### PR TITLE
Add repo-harness MCP connector

### DIFF
--- a/.agents/skills/repo-harness-chatgpt-bridge/SKILL.md
+++ b/.agents/skills/repo-harness-chatgpt-bridge/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: repo-harness-chatgpt-bridge
+description: Use when setting up or operating the repo-harness ChatGPT MCP Connector, bridging ChatGPT planning artifacts into Codex execution through repo-harness PRDs, sprints, checks, and handoffs.
+---
+
+# repo-harness-chatgpt-bridge
+
+You are operating inside a repo-harness adopted repository.
+
+Responsibilities:
+
+1. Treat ChatGPT as planner/reviewer and Codex as executor.
+2. Do not store or print secrets, OAuth passphrases, tunnel tokens, or ~/.codex/auth.json.
+3. Prefer repo-harness CLI commands over manual file edits.
+4. Keep ChatGPT write access limited to PRD, sprint, plan, and handoff artifacts.
+5. Before execution, read docs/spec.md, tasks/current.md, .ai/harness/handoff/resume.md, and .ai/harness/handoff/codex-goal.md when present.
+6. If setting up ChatGPT Connector, run repo-harness mcp doctor, then repo-harness mcp setup chatgpt --repo ., and do not log into ChatGPT unless explicitly asked for assisted setup.
+7. If assisted browser setup is requested, never type passwords, 2FA codes, OAuth passphrases, or admin approvals without user instruction.
+8. For planning, preserve the chain: idea -> PRD -> checklist Sprint -> Codex Goal.
+9. Checklist Sprints must use task cards with stage gates; Codex should stage each completed phase before continuing.
+10. MCP may prepare .ai/harness/handoff/codex-goal.md, but it must not run Codex remotely or expose a default codex exec runner.
+11. If executing the latest ChatGPT plan, read .ai/harness/handoff/codex-goal.md, run repo-harness workflow checks, execute only the scoped task, and update review evidence plus handoff.

--- a/.agents/skills/repo-harness-chatgpt-bridge/references/chatgpt-connector-manual.md
+++ b/.agents/skills/repo-harness-chatgpt-bridge/references/chatgpt-connector-manual.md
@@ -1,0 +1,113 @@
+# repo-harness ChatGPT MCP Connector Setup
+
+## Prerequisites
+
+- A repo-harness adopted repository.
+- A local `repo-harness` CLI on PATH.
+- ChatGPT workspace access to Developer Mode and custom MCP Connectors.
+- A public HTTPS tunnel for ChatGPT Web. Local Codex can use stdio without a tunnel.
+
+## Start Local MCP Server
+
+```bash
+repo-harness mcp serve --repo . --transport http --host 127.0.0.1 --port 8765 --profile planner
+```
+
+Health check:
+
+```bash
+curl http://127.0.0.1:8765/health
+```
+
+The ChatGPT path uses OAuth with a local passphrase. The passphrase is stored in an ignored local file:
+
+```bash
+jq -r .passphrase .repo-harness/mcp.oauth.json
+```
+
+Do not commit or paste this passphrase into issue trackers, PRs, or shared logs.
+
+OAuth discovery smoke:
+
+```bash
+curl http://127.0.0.1:8765/.well-known/oauth-protected-resource/mcp
+```
+
+## Start Tunnel
+
+```bash
+cloudflared tunnel --url http://127.0.0.1:8765
+```
+
+Use this Connector URL:
+
+```text
+<https-tunnel-url>/mcp
+```
+
+## Create ChatGPT Connector
+
+1. Open ChatGPT Settings.
+2. Enable Developer Mode if your workspace exposes it.
+3. Go to Connectors.
+4. Create a Connector named `repo-harness`.
+5. Paste the HTTPS Connector URL ending in `/mcp`.
+6. Configure Connector authentication as OAuth.
+7. Click Scan Tools.
+8. When the authorization page opens, enter the passphrase from `.repo-harness/mcp.oauth.json`.
+9. Wait for the tool scan to finish, then create the Connector.
+10. Keep write confirmations enabled.
+
+## Test Prompt
+
+```text
+Use repo-harness to inspect this repo. Call harness_status, latest_handoff, and list_workflow_files. Do not write files.
+```
+
+## PRD Prompt
+
+```text
+Use repo-harness to inspect docs/spec.md, tasks/current.md, latest handoff, and existing plans. Convert this idea into a PRD with write_prd_from_idea. Do not edit source code.
+```
+
+## Checklist Sprint Prompt
+
+```text
+Use repo-harness to read the PRD. Convert it into an ordered checklist Sprint with write_checklist_sprint. Every task card must include a stage gate that requires Codex to stage the completed phase before continuing.
+```
+
+## Codex Goal Prompt
+
+```text
+Use repo-harness prepare_codex_goal_from_sprint with the PRD path and checklist Sprint path. Return the host-native /goal prompt. Do not run Codex remotely.
+```
+
+Equivalent local CLI:
+
+```bash
+repo-harness mcp prepare-goal --repo . --prd plans/prds/<feature>.prd.md --sprint plans/sprints/<feature>.sprint.md --reference-repo <optional-readonly-reference>
+```
+
+## Codex Executor Prompt
+
+```text
+Use repo-harness-chatgpt-bridge. Execute the latest ChatGPT-generated Codex goal from .ai/harness/handoff/codex-goal.md.
+```
+
+## Troubleshooting
+
+- If ChatGPT cannot connect, verify the tunnel URL is HTTPS and ends in `/mcp`.
+- If ChatGPT returns unauthorized, verify OAuth discovery works and re-run the authorization passphrase flow.
+- If tools are missing, restart `repo-harness mcp serve` and rescan tools.
+- If writes fail, verify the target path is a PRD, sprint, plan, or approved handoff file.
+- If ChatGPT generated prose instead of checklist Sprint task cards, ask it to use write_checklist_sprint.
+- If Codex cannot see the server, run `repo-harness mcp setup codex --repo . --scope project`.
+
+## Security Notes
+
+- This MCP server exposes workflow artifacts, not general filesystem access.
+- The `/mcp` endpoint requires OAuth-issued Bearer tokens by default. Do not expose it through a tunnel without Connector auth configured.
+- `repo-harness mcp serve --auth bearer` is available for non-ChatGPT clients that can send a static bearer token.
+- Planner profile cannot write application source files, package manifests, lockfiles, CI config, secrets, or files outside the repo root.
+- MCP does not expose a default Codex runner. It prepares `.ai/harness/handoff/codex-goal.md`; the local Codex host owns `/goal` execution.
+- Do not put tunnel tokens, OAuth tokens, passphrases, or ChatGPT/Codex credentials in git.

--- a/.agents/skills/repo-harness-chatgpt-bridge/references/workflow.md
+++ b/.agents/skills/repo-harness-chatgpt-bridge/references/workflow.md
@@ -1,0 +1,51 @@
+# Workflow
+
+ChatGPT plans through MCP; Codex executes through repo-harness checks and handoff.
+
+## Planning Chain
+
+Use this chain for execution-ready planning:
+
+1. idea -> PRD: call `write_prd_from_idea`.
+2. PRD -> checklist Sprint: call `write_checklist_sprint`.
+3. Sprint -> Goal: call `prepare_codex_goal_from_sprint` or run `repo-harness mcp prepare-goal`.
+
+The MCP server prepares artifacts only. The local Codex host owns `/goal` execution.
+
+## Sprint Format
+
+When ChatGPT writes a sprint for Codex execution, use checklist task cards rather than prose-only plans.
+
+Each execution phase should include:
+
+- `[ ]` checklist items for concrete implementation steps.
+- Acceptance criteria for the phase.
+- Verification commands or evidence expected before the phase is considered done.
+- A staging gate that tells Codex to stage the completed phase before continuing.
+
+Preferred task card shape:
+
+```markdown
+## Task Card N: <phase name>
+
+status: pending
+
+Tasks:
+
+- [ ] <step>
+- [ ] <step>
+
+Acceptance criteria:
+
+- [ ] <observable outcome>
+
+Verification:
+
+- [ ] `<command or evidence surface>`
+
+Stage gate:
+
+- [ ] Stage all files for this completed phase before starting the next task card.
+```
+
+Codex should update checklist status as work completes and stop at staging gates long enough to verify `git status --short` shows the intended staged files.

--- a/.ai/harness/handoff/codex-goal.md
+++ b/.ai/harness/handoff/codex-goal.md
@@ -1,0 +1,56 @@
+---
+title: "Codex Goal"
+kind: "codex-goal"
+created_at: "2026-06-16T21:25:03.011Z"
+source: "repo-harness-mcp"
+---
+# Codex Goal
+
+## Source of truth
+
+- PRD: `/Users/ancienttwo/Projects/agentic-dev-wt-mcp-connector/plans/prds/20260617-repo-harness-mcp-prd.md`
+- Checklist Sprint: `/Users/ancienttwo/Projects/agentic-dev-wt-mcp-connector/plans/sprints/20260617-repo-harness-mcp-sprint.md`
+- Reference repo: `/Users/ancienttwo/Projects/agentic-dev/_ref/local-dev-mcp` (read-only comparison source)
+
+## Role
+
+Codex is the executor. ChatGPT/repo-harness may prepare planning artifacts, but implementation ownership stays in the local Codex session.
+
+## Scope
+
+- Open or use an isolated worktree for the sprint implementation.
+- Execute the checklist Sprint task cards in order.
+- Update the Sprint checklist as phases complete.
+- Stage each completed phase before continuing to the next phase.
+- Do not modify the reference repo or ignored secrets/ops state.
+
+## Required workflow
+
+1. Read the PRD and Sprint paths above before editing.
+2. Build the P1/P2/P3 map required by repo-local AGENTS.md for non-trivial changes.
+3. Execute one checklist task card at a time.
+4. After each phase, run the relevant focused checks, update the checklist, and stage the completed slice.
+5. Continue until the Sprint checklist is complete or a real blocker is reached.
+6. Leave a concise handoff with staged state and verification evidence.
+
+## Required checks
+
+- Run the checks named by the Sprint task card.
+- At sprint closeout, run repo-required checks unless the Sprint narrows the verification surface with a stated reason.
+
+## Done when
+
+- The checklist Sprint is complete.
+- Every completed phase is staged.
+- Checks pass or failures are documented with exact blocker evidence.
+- No commit is created unless the user explicitly asks for commit.
+
+## Host-native /goal prompt
+
+```text
+/goal
+阅读： /Users/ancienttwo/Projects/agentic-dev-wt-mcp-connector/plans/prds/20260617-repo-harness-mcp-prd.md
+开worktree完整执行：/Users/ancienttwo/Projects/agentic-dev-wt-mcp-connector/plans/sprints/20260617-repo-harness-mcp-sprint.md
+完成阶段性任务，要staging再继续
+参考repo: /Users/ancienttwo/Projects/agentic-dev/_ref/local-dev-mcp
+```

--- a/.ai/harness/handoff/mcp-connector-sprint-closeout.md
+++ b/.ai/harness/handoff/mcp-connector-sprint-closeout.md
@@ -1,0 +1,73 @@
+# Sprint Closeout: repo-harness ChatGPT MCP Connector MVP
+
+Updated: 2026-06-17
+
+## Completed
+
+- Added `repo-harness mcp` CLI group with `serve`, `doctor`, `setup chatgpt`, `setup codex`, `install-skill`, and `print-chatgpt-guide`.
+- Added planner/executor/orchestrator policy model, allow/deny path enforcement, repo-root confinement, traversal blocking, symlink escape blocking, max file size enforcement, redaction, and hash-only audit logging.
+- Added MCP server factory with workflow-scoped read tools, planning writer tools, and fixed `run_workflow_check`.
+- Added stdio and HTTP transports. HTTP exposes `/health`, OAuth discovery, passphrase-backed authorization, token/registration endpoints, and authenticated `/mcp`; it binds to `127.0.0.1` by default, has request size limiting, and logs startup to stderr.
+- Added ChatGPT setup config/guide generation, Codex MCP config patching with backup/dry-run/idempotency, and repo-local bridge Skill installation with overwrite/dry-run protection.
+- Added the execution-planning chain: `write_prd_from_idea`, `write_checklist_sprint`, `prepare_codex_goal_from_sprint`, and local `repo-harness mcp prepare-goal` for host-native `/goal` handoff.
+- Tightened Sprint generation to checklist task cards with explicit per-phase staging gates.
+- Added README mention and generated `docs/repo-harness-chatgpt-mcp-setup.md`.
+
+## Not completed
+
+- No default `run_codex_goal` / orchestrator runner was implemented; this remains intentionally out of MVP scope.
+- ChatGPT persistent `allow always` approval reuse loops back through authorization in the observed UI. `allow once` works and completed the MVP E2E.
+- ChatGPT cannot launch local Codex CLI in the MVP. The supported handoff is explicit: MCP writes `.ai/harness/handoff/codex-goal.md` and returns a host-native `/goal` prompt for the local Codex host/user to execute.
+
+## Tests run
+
+- `bun test tests/cli/mcp.test.ts tests/cli/mcp-policy.test.ts tests/cli/mcp-tools.test.ts tests/cli/mcp-setup.test.ts tests/cli/mcp-http.test.ts`
+- `bun test tests/cli/mcp-tools.test.ts tests/cli/mcp.test.ts tests/cli/mcp-setup.test.ts`
+- `bun test` (`810 pass`, `0 fail`, `7724 expect() calls`; captured in `/tmp/repo-harness-bun-test.log`)
+- `bun run check:type`
+- `git diff --check`
+- `bash scripts/check-task-sync.sh`
+- `bash scripts/check-task-workflow.sh --strict`
+- `bash scripts/check-architecture-sync.sh`
+- `bash scripts/check-deploy-sql-order.sh`
+- `bun scripts/inspect-project-state.ts --repo . --format text`
+- `bash scripts/migrate-project-template.sh --repo . --dry-run`
+- `repo-harness setup check --target codex --check-updates --json` (`27 ok`, `1 warn`, `0 fail`, `0 needs_agent`; warning is optional `skills_cli` timeout)
+- `repo-harness mcp prepare-goal --repo . --prd /Users/ancienttwo/Projects/agentic-dev-wt-mcp-connector/plans/prds/20260617-repo-harness-mcp-prd.md --sprint /Users/ancienttwo/Projects/agentic-dev-wt-mcp-connector/plans/sprints/20260617-repo-harness-mcp-sprint.md --reference-repo /Users/ancienttwo/Projects/agentic-dev/_ref/local-dev-mcp --overwrite`
+- `curl http://127.0.0.1:8765/health`
+- HTTP `/mcp` JSON-RPC initialize smoke.
+- HTTP auth smoke: unauthenticated initialize returns 401, OAuth dynamic registration plus passphrase authorization returns an access token, authenticated initialize returns 200, and static bearer fallback remains covered.
+- Official MCP `StdioClientTransport` smoke listing 15 tools from `repo-harness mcp serve --transport stdio --profile planner`.
+- Claude read-only cross-review was run. The P1 unauthenticated tunnel exposure finding was fixed first with bearer-token HTTP auth, then aligned with the reference repo and ChatGPT UI by adding OAuth/passphrase auth and regenerated setup docs.
+- Local Codex-goal bridge read path is covered: `write_codex_goal` -> `latest_handoff` -> `read_workflow_file`.
+
+## Manual E2E result
+
+- Local MCP E2E passed on this worktree. Details are in `.ai/harness/handoff/mcp-e2e-result.md`.
+- ChatGPT UI manual connector E2E passed through OAuth with `allow once`: `harness_status`, `latest_handoff`, `write_prd`, and `write_codex_goal` reached the local server. The write smoke artifacts are `tasks/notes/20260617-chatgpt-mcp-smoke-prd.notes.md` and `.ai/harness/handoff/codex-goal.md`.
+
+## Security review
+
+- Denied paths tested: `.env`, `.git/**`, traversal, symlink escape, source-write paths.
+- Source write blocking tested: planner profile rejects `src/**`, package manifests, lockfiles, and CI config through policy.
+- Secrets redaction tested: bearer token, OpenAI-style key, private key, JWT/database/secret-like assignment patterns.
+- Audit log checked: stores metadata and input hash, not raw prompt/body or token values.
+- HTTP auth checked: `/mcp` fails closed without OAuth-issued bearer auth by default; setup writes passphrase/token state only to ignored `.repo-harness/*` files.
+
+## Known limitations
+
+- Tool files are currently implemented in one `src/cli/mcp/tools.ts` module rather than one file per tool to keep the first slice compact.
+- `mcp doctor` checks local files and Codex config, but does not yet probe a user-supplied public HTTPS endpoint.
+- ChatGPT persistent `allow always` approval reuse needs a follow-up OAuth/session compatibility investigation.
+
+## Follow-up sprint candidates
+
+- Add better MCP client integration tests.
+- Add optional tunnel helper.
+- Split MCP tool handlers into per-tool files if the module grows.
+- Add optional orchestrator profile behind explicit user confirmation.
+- Add richer ChatGPT review tools.
+
+## Next recommended task
+
+- Investigate ChatGPT persistent `allow always` approval reuse against the OAuth token/session flow. `allow once` is sufficient for MVP, but persistent approval looping is the next real compatibility gap.

--- a/.ai/harness/handoff/mcp-discovery.md
+++ b/.ai/harness/handoff/mcp-discovery.md
@@ -1,0 +1,48 @@
+# repo-harness MCP Discovery
+
+Updated: 2026-06-17
+Sprint: `plans/sprints/20260617-repo-harness-mcp-sprint.md`
+PRD: `plans/prds/20260617-repo-harness-mcp-prd.md`
+
+## P1 Map
+
+- CLI entrypoint is `src/cli/index.ts`; top-level commands are registered in `buildProgram()` with small command builders imported from `src/cli/commands/*`.
+- Existing command-builder pattern is represented by `buildRunCommand()`, `buildToolsCommand()`, `buildBrainCommand()`, and `buildDocsCommand()`.
+- Runtime helper execution is centralized in `src/cli/runtime/helper-runner.ts`; fixed workflow checks should reuse `runHelper()` instead of exposing arbitrary shell.
+- Repo-local workflow authority for this sprint is `plans/**`, `tasks/**`, `.ai/context/**`, `.ai/harness/**`, `docs/spec.md`, and root agent context files.
+- Reference repo `_ref/local-dev-mcp` is read-only input. It proves useful patterns for MCP transport, denied paths, redaction, OAuth/passphrase, and audit logs, but its broad local-dev filesystem/shell surface is explicitly out of scope for repo-harness MVP.
+
+## P2 Trace
+
+Concrete CLI route:
+
+`bun src/cli/index.ts <command>` -> `runCli()` -> `buildProgram().parseAsync()` -> command builder action -> command module implementation -> process exit code.
+
+Expected MCP route:
+
+`repo-harness mcp serve --repo . --transport stdio|http --profile planner` -> `buildMcpCommand()` -> `startMcpServer()` -> policy-scoped tools -> workflow artifact read/write helpers -> JSON MCP content or structured CLI result.
+
+Fixed workflow check route:
+
+MCP tool `run_workflow_check` -> repo root resolution -> `runHelper({ helper: "check-task-workflow", args: ["--strict"], stdio: "pipe" })` -> redacted stdout/stderr -> audit metadata.
+
+## P3 Decision
+
+- Add `src/cli/commands/mcp.ts` for command registration, mirroring existing command-builder style.
+- Put reusable MCP policy, path, redaction, audit, tool, and setup logic under `src/cli/mcp/` so command parsing stays thin.
+- Use least-privilege workflow artifacts as the compatibility boundary. Planner profile can write planning and handoff files only; it cannot write `src/**`, app/package code, package manifests, lockfiles, CI, secrets, or files outside repo root.
+- Preserve repo-harness' current design: it coordinates workflow artifacts and checks; it does not become a general local development gateway.
+
+## Preferred Test Surface
+
+- Focused CLI scaffold: `bun test tests/cli/mcp.test.ts`
+- Policy/path core: `bun test tests/cli/mcp-policy.test.ts`
+- Full repo gate: `bun run check:ci`
+- Required sprint smoke: `repo-harness mcp --help`, `repo-harness mcp serve --help`, `repo-harness mcp doctor --help`, `repo-harness mcp setup --help`
+
+## Risk Notes
+
+- Path handling must normalize to repo-relative POSIX paths and block traversal, absolute paths, symlink escapes, denied globs, and oversized reads.
+- Config patching must preserve unrelated TOML content and create a backup before mutation.
+- HTTP `/mcp` must not print secrets or bind to `0.0.0.0` unless explicitly requested.
+- Audit logging must record metadata and input hashes, not raw prompts or secret-like content.

--- a/.ai/harness/handoff/mcp-e2e-result.md
+++ b/.ai/harness/handoff/mcp-e2e-result.md
@@ -1,0 +1,49 @@
+# repo-harness MCP E2E Result
+
+Updated: 2026-06-17
+Worktree: `/Users/ancienttwo/Projects/agentic-dev-wt-mcp-connector`
+Branch: `codex/repo-harness-mcp-connector`
+
+## Local Setup
+
+- `bun src/cli/index.ts mcp setup chatgpt --repo .` generated `.repo-harness/mcp.local.json` and `docs/repo-harness-chatgpt-mcp-setup.md`.
+- `.repo-harness/mcp.local.json` uses `auth.mode=oauth`; `.repo-harness/mcp.oauth.json`, `.repo-harness/mcp.oauth-tokens.json`, and `.repo-harness/mcp.tokens.json` are ignored local runtime state.
+- `bun src/cli/index.ts mcp setup codex --repo . --scope project` generated ignored `.codex/config.toml` with `repo_harness` MCP server and required enabled tools.
+- `bun src/cli/index.ts mcp install-skill --repo . --overwrite` installed `.agents/skills/repo-harness-chatgpt-bridge/`.
+- `bun src/cli/index.ts mcp doctor --repo . --json` returned `status=ready_local`, `codex.configured=true`, and `missingTools=[]`.
+
+## Transport Smoke
+
+- HTTP server started with `bun src/cli/index.ts mcp serve --repo . --transport http --host 127.0.0.1 --port 8765 --profile planner`.
+- `curl http://127.0.0.1:8765/health` returned `{"status":"ok","server":"repo-harness-mcp","auth":"oauth"}` in default ChatGPT mode.
+- OAuth discovery at `/.well-known/oauth-protected-resource/mcp` returned the `/mcp` resource and authorization server metadata.
+- Unauthenticated POST initialize to `http://127.0.0.1:8765/mcp` returned HTTP 401 with a `www-authenticate` header pointing to the OAuth protected-resource metadata.
+- Dynamic client registration, passphrase-backed `/authorize`, `/token` exchange, and authenticated MCP initialize were covered by the focused HTTP transport test.
+- Static bearer fallback remains available through `repo-harness mcp serve --auth bearer`; the bearer fallback smoke returns 401 without auth, 400 for malformed authenticated JSON, and 200 for authenticated initialize.
+- Official MCP `StdioClientTransport` connected to `repo-harness mcp serve --transport stdio --profile planner` and listed 15 tools, starting with `harness_status`, `harness_doctor`, `list_workflow_files`, `read_workflow_file`, and `latest_handoff`.
+
+## Tool Smoke
+
+- Unit tests exercised allowed reads, denied `.env` reads, traversal rejection, symlink escape rejection, planner write allowlist, PRD write, Codex goal validation, overwrite prevention, redaction, audit hash-only logging, and Codex config patching.
+- Unit tests also cover nested deny globs, prefixed secret assignments, OAuth setup config, bearer fallback config, and latest-checks listing when earlier workflow roots exceed the per-root listing cap.
+- Unit tests cover the local Codex bridge read path: after MCP writes `.ai/harness/handoff/codex-goal.md`, `latest_handoff` and `read_workflow_file` expose the goal through policy-allowed workflow reads.
+- No arbitrary shell MCP tool exists. The only execution tool is fixed to `check-task-workflow --strict`.
+- Planner profile cannot write `src/**`, package manifests, lockfiles, or CI config.
+- HTTP `/mcp` fails closed without OAuth-issued bearer auth by default.
+
+## External Manual Step
+
+ChatGPT Web Connector manual E2E completed on 2026-06-17 using a Cloudflare quick tunnel and OAuth auth. The user opened the ChatGPT New App modal and the available authentication options were OAuth, No Auth, and Mixed. That confirmed the correct ChatGPT path is OAuth, matching `_ref/local-dev-mcp`, not a static customer-provided bearer token. The generated guide now documents the OAuth path and the local HTTP test covers the OAuth flow end to end.
+
+Observed ChatGPT tool calls:
+
+- `harness_status` succeeded and returned repo path `/Users/ancienttwo/Projects/agentic-dev-wt-mcp-connector`, `adopted=true`, `profile=planner`, and branch `codex/repo-harness-mcp-connector`.
+- `latest_handoff` succeeded.
+- `write_prd` succeeded and wrote a smoke PRD. Because the smoke body is E2E evidence rather than a real product PRD, the content was retained under `tasks/notes/20260617-chatgpt-mcp-smoke-prd.notes.md` instead of the formal PRD ledger.
+- An incomplete `write_codex_goal` was blocked by required-section validation, then a corrected `write_codex_goal` succeeded and wrote `.ai/harness/handoff/codex-goal.md`.
+
+Notes:
+
+- ChatGPT `allow once` worked for manual approvals.
+- The user observed that `allow always` loops back through authorization. Persistent approval reuse is outside the MVP acceptance criteria and should be treated as a follow-up compatibility issue.
+- The quick tunnel and local MCP server were stopped after the E2E run.

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ tasks/.current.md.tmp.*
 .ai/harness/sprint/
 .ai/harness/worktrees/
 .ai/harness/runs/
+.ai/harness/mcp/audit.log
 .ai/harness/triage/*
 !.ai/harness/triage/.gitkeep
 .codex/*
@@ -64,6 +65,8 @@ autoresearch/
 *.tgz
 _ref/
 _ops/
+.repo-harness/mcp.local.json
+.repo-harness/mcp.tokens.json
 .codegraph/
 .understand-anything/
 # Environment
@@ -75,3 +78,5 @@ _ops/
 # Operations
 # Local operations state
 .claude/worktrees/
+.repo-harness/mcp.oauth.json
+.repo-harness/mcp.oauth-tokens.json

--- a/README.md
+++ b/README.md
@@ -77,10 +77,17 @@ target repository so Claude, Codex, and humans can agree on:
 - which checks and review evidence prove the work is done
 - how hooks should warn, block, trace, and hand off work across sessions
 
-It is not an agent gateway, product runtime, database service, or MCP server.
 The product boundary is deliberately boring: inspect a repo, install or refresh
 workflow files, route host events through repo-local hooks, and verify that the
 workflow surfaces stay consistent.
+
+As an optional sidecar, `repo-harness mcp` exposes only workflow artifacts to
+MCP clients. ChatGPT can use it as a planner/reviewer to read state and move an
+idea through PRD, checklist Sprint, and Codex goal handoff artifacts; it does
+not get source-code write access, arbitrary shell execution, or a default Codex
+runner. Codex remains the executor. The generated manual setup guide lives at
+`docs/repo-harness-chatgpt-mcp-setup.md`, and the local CLI handoff is
+`repo-harness mcp prepare-goal --prd <prd> --sprint <sprint>`.
 
 ## How It Works
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,11 +5,15 @@
     "": {
       "name": "repo-harness",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.28.0",
         "commander": "^14.0.3",
+        "express": "^5.2.1",
       },
       "devDependencies": {
         "@colbymchenry/codegraph": "^1.0.1",
         "@types/bun": "latest",
+        "@types/cors": "^2.8.17",
+        "@types/express": "^5.0.0",
         "typescript": "^6.0.3",
       },
     },
@@ -29,16 +33,222 @@
 
     "@colbymchenry/codegraph-win32-x64": ["@colbymchenry/codegraph-win32-x64@1.0.1", "", { "os": "win32", "cpu": "x64" }, "sha512-qU6jjyma635qKJ0aaL8XU8QtYUGkWly0Mu4Wm2cSWRcNDL1v6sVoHMElgfUY7E9tK0gnU+/LbZW3MfmtqLG1GA=="],
 
+    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
+    "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
+
     "@types/bun": ["@types/bun@1.3.14", "https://registry.npmmirror.com/@types/bun/-/bun-1.3.14.tgz", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
+
+    "@types/cors": ["@types/cors@2.8.19", "", { "dependencies": { "@types/node": "*" } }, "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg=="],
+
+    "@types/express": ["@types/express@5.0.6", "", { "dependencies": { "@types/body-parser": "*", "@types/express-serve-static-core": "^5.0.0", "@types/serve-static": "^2" } }, "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA=="],
+
+    "@types/express-serve-static-core": ["@types/express-serve-static-core@5.1.1", "", { "dependencies": { "@types/node": "*", "@types/qs": "*", "@types/range-parser": "*", "@types/send": "*" } }, "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A=="],
+
+    "@types/http-errors": ["@types/http-errors@2.0.5", "", {}, "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg=="],
 
     "@types/node": ["@types/node@25.9.1", "https://registry.npmmirror.com/@types/node/-/node-25.9.1.tgz", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
 
+    "@types/qs": ["@types/qs@6.15.1", "", {}, "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw=="],
+
+    "@types/range-parser": ["@types/range-parser@1.2.7", "", {}, "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="],
+
+    "@types/send": ["@types/send@1.2.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ=="],
+
+    "@types/serve-static": ["@types/serve-static@2.2.0", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*" } }, "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ=="],
+
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
+
     "bun-types": ["bun-types@1.3.14", "https://registry.npmmirror.com/bun-types/-/bun-types-1.3.14.tgz", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
     "commander": ["commander@14.0.3", "https://registry.npmmirror.com/commander/-/commander-14.0.3.tgz", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
+
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.5.2", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
+
+    "hono": ["hono@4.12.25", "", {}, "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.15.2", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "undici-types": ["undici-types@7.24.6", "https://registry.npmmirror.com/undici-types/-/undici-types-7.24.6.tgz", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
   }
 }

--- a/docs/repo-harness-chatgpt-mcp-setup.md
+++ b/docs/repo-harness-chatgpt-mcp-setup.md
@@ -1,0 +1,113 @@
+# repo-harness ChatGPT MCP Connector Setup
+
+## Prerequisites
+
+- A repo-harness adopted repository.
+- A local `repo-harness` CLI on PATH.
+- ChatGPT workspace access to Developer Mode and custom MCP Connectors.
+- A public HTTPS tunnel for ChatGPT Web. Local Codex can use stdio without a tunnel.
+
+## Start Local MCP Server
+
+```bash
+repo-harness mcp serve --repo . --transport http --host 127.0.0.1 --port 8765 --profile planner
+```
+
+Health check:
+
+```bash
+curl http://127.0.0.1:8765/health
+```
+
+The ChatGPT path uses OAuth with a local passphrase. The passphrase is stored in an ignored local file:
+
+```bash
+jq -r .passphrase .repo-harness/mcp.oauth.json
+```
+
+Do not commit or paste this passphrase into issue trackers, PRs, or shared logs.
+
+OAuth discovery smoke:
+
+```bash
+curl http://127.0.0.1:8765/.well-known/oauth-protected-resource/mcp
+```
+
+## Start Tunnel
+
+```bash
+cloudflared tunnel --url http://127.0.0.1:8765
+```
+
+Use this Connector URL:
+
+```text
+<https-tunnel-url>/mcp
+```
+
+## Create ChatGPT Connector
+
+1. Open ChatGPT Settings.
+2. Enable Developer Mode if your workspace exposes it.
+3. Go to Connectors.
+4. Create a Connector named `repo-harness`.
+5. Paste the HTTPS Connector URL ending in `/mcp`.
+6. Configure Connector authentication as OAuth.
+7. Click Scan Tools.
+8. When the authorization page opens, enter the passphrase from `.repo-harness/mcp.oauth.json`.
+9. Wait for the tool scan to finish, then create the Connector.
+10. Keep write confirmations enabled.
+
+## Test Prompt
+
+```text
+Use repo-harness to inspect this repo. Call harness_status, latest_handoff, and list_workflow_files. Do not write files.
+```
+
+## PRD Prompt
+
+```text
+Use repo-harness to inspect docs/spec.md, tasks/current.md, latest handoff, and existing plans. Convert this idea into a PRD with write_prd_from_idea. Do not edit source code.
+```
+
+## Checklist Sprint Prompt
+
+```text
+Use repo-harness to read the PRD. Convert it into an ordered checklist Sprint with write_checklist_sprint. Every task card must include a stage gate that requires Codex to stage the completed phase before continuing.
+```
+
+## Codex Goal Prompt
+
+```text
+Use repo-harness prepare_codex_goal_from_sprint with the PRD path and checklist Sprint path. Return the host-native /goal prompt. Do not run Codex remotely.
+```
+
+Equivalent local CLI:
+
+```bash
+repo-harness mcp prepare-goal --repo . --prd plans/prds/<feature>.prd.md --sprint plans/sprints/<feature>.sprint.md --reference-repo <optional-readonly-reference>
+```
+
+## Codex Executor Prompt
+
+```text
+Use repo-harness-chatgpt-bridge. Execute the latest ChatGPT-generated Codex goal from .ai/harness/handoff/codex-goal.md.
+```
+
+## Troubleshooting
+
+- If ChatGPT cannot connect, verify the tunnel URL is HTTPS and ends in `/mcp`.
+- If ChatGPT returns unauthorized, verify OAuth discovery works and re-run the authorization passphrase flow.
+- If tools are missing, restart `repo-harness mcp serve` and rescan tools.
+- If writes fail, verify the target path is a PRD, sprint, plan, or approved handoff file.
+- If ChatGPT generated prose instead of checklist Sprint task cards, ask it to use write_checklist_sprint.
+- If Codex cannot see the server, run `repo-harness mcp setup codex --repo . --scope project`.
+
+## Security Notes
+
+- This MCP server exposes workflow artifacts, not general filesystem access.
+- The `/mcp` endpoint requires OAuth-issued Bearer tokens by default. Do not expose it through a tunnel without Connector auth configured.
+- `repo-harness mcp serve --auth bearer` is available for non-ChatGPT clients that can send a static bearer token.
+- Planner profile cannot write application source files, package manifests, lockfiles, CI config, secrets, or files outside the repo root.
+- MCP does not expose a default Codex runner. It prepares `.ai/harness/handoff/codex-goal.md`; the local Codex host owns `/goal` execution.
+- Do not put tunnel tokens, OAuth tokens, passphrases, or ChatGPT/Codex credentials in git.

--- a/package.json
+++ b/package.json
@@ -50,9 +50,13 @@
   "devDependencies": {
     "@colbymchenry/codegraph": "1.0.1",
     "@types/bun": "latest",
+    "@types/cors": "^2.8.17",
+    "@types/express": "^5.0.0",
     "typescript": "^6.0.3"
   },
   "dependencies": {
-    "commander": "^14.0.3"
+    "@modelcontextprotocol/sdk": "^1.28.0",
+    "commander": "^14.0.3",
+    "express": "^5.2.1"
   }
 }

--- a/plans/prds/20260617-repo-harness-mcp-prd.md
+++ b/plans/prds/20260617-repo-harness-mcp-prd.md
@@ -15,13 +15,7 @@ repo-harness 应该做的：
 
 `local-dev-mcp` 当前就是“让 ChatGPT 通过 MCP 操作选定本地项目”的本地 MCP server，带项目 registry、denied paths、shell 风险分类、OAuth、redaction、localhost + HTTPS tunnel 这些安全控制；这些设计可以直接借鉴。([GitHub][1]) 但 `repo-harness` README 明确说它现在不是 agent gateway 或 MCP server，而是 repo-local workflow、hooks、checks、handoff 的协调层；所以这个功能最好作为可选 sidecar，而不是改变主产品边界。([GitHub][2])
 
-下面是一份可以直接放进：
-
-```text
-plans/prds/repo-harness-chatgpt-mcp-connector.prd.md
-```
-
-的详细 PRD。
+本 PRD 的当前仓库路径是 `plans/prds/20260617-repo-harness-mcp-prd.md`。
 
 ---
 

--- a/plans/sprints/20260617-repo-harness-mcp-sprint.md
+++ b/plans/sprints/20260617-repo-harness-mcp-sprint.md
@@ -1,18 +1,12 @@
-下面内容可直接保存为：
-
-```text
-plans/sprints/repo-harness-chatgpt-mcp-connector-mvp.sprint.md
-```
-
 # Sprint: repo-harness ChatGPT MCP Connector MVP
 
 ## 0. Metadata
 
 ```yaml
 id: sprint-repo-harness-chatgpt-mcp-connector-mvp
-status: planned
-prd: plans/prds/repo-harness-chatgpt-mcp-connector.prd.md
-target_branch: feature/repo-harness-mcp-connector
+status: active
+prd: plans/prds/20260617-repo-harness-mcp-prd.md
+target_branch: codex/repo-harness-mcp-connector
 primary_agent: codex
 secondary_agent: chatgpt-planner
 risk_level: medium
@@ -31,6 +25,7 @@ The sprint should deliver:
 * ChatGPT setup guide generation
 * Codex MCP config helper
 * Codex Skill installation
+* idea -> PRD -> checklist Sprint -> Codex Goal chain
 * security guardrails
 * tests and manual E2E checklist
 
@@ -42,13 +37,13 @@ The MVP must **not** expose arbitrary shell, direct source-code editing, or auto
 
 Do not implement these in this sprint:
 
-* [ ] Do not make ChatGPT Web Pro available as a Codex model.
-* [ ] Do not implement general-purpose local filesystem MCP access.
-* [ ] Do not expose `run_shell` as a public MCP tool.
-* [ ] Do not allow ChatGPT to modify application source files through MCP.
-* [ ] Do not implement default `run_codex_goal` / `codex exec` runner.
-* [ ] Do not automate ChatGPT login, 2FA, admin approval, or browser account actions.
-* [ ] Do not store OpenAI, ChatGPT, Codex, tunnel, OAuth, or workspace secrets in git.
+* [x] Do not make ChatGPT Web Pro available as a Codex model.
+* [x] Do not implement general-purpose local filesystem MCP access.
+* [x] Do not expose `run_shell` as a public MCP tool.
+* [x] Do not allow ChatGPT to modify application source files through MCP.
+* [x] Do not implement default `run_codex_goal` / `codex exec` runner.
+* [x] Do not automate ChatGPT login, 2FA, admin approval, or browser account actions.
+* [x] Do not store OpenAI, ChatGPT, Codex, tunnel, OAuth, or workspace secrets in git.
 
 ---
 
@@ -56,23 +51,27 @@ Do not implement these in this sprint:
 
 The sprint is complete when all of the following are true:
 
-* [ ] `repo-harness mcp serve --transport stdio --profile planner` starts successfully.
-* [ ] `repo-harness mcp serve --transport http --port 8765 --profile planner` starts successfully.
-* [ ] HTTP server exposes `/health`.
-* [ ] HTTP server exposes `/mcp`.
-* [ ] MCP server exposes safe read-only tools.
-* [ ] MCP server exposes planning-only write tools.
-* [ ] Planner profile cannot read denied paths.
-* [ ] Planner profile cannot write application source files.
-* [ ] `repo-harness mcp doctor --repo .` reports actionable setup status.
-* [ ] `repo-harness mcp setup chatgpt --repo .` generates local config and manual setup guide.
-* [ ] `repo-harness mcp setup codex --repo . --scope project` safely patches `.codex/config.toml`.
-* [ ] `repo-harness mcp install-skill --repo .` installs the Codex Skill.
-* [ ] Unit tests cover path policy, writes, redaction, and config patching.
-* [ ] Manual E2E has been run on a sample repo.
-* [ ] `.gitignore` prevents local MCP secrets and audit logs from being committed.
-* [ ] README or generated guide explains the ChatGPT Connector setup flow.
-* [ ] No secrets, local tokens, tunnel URLs, OAuth passphrases, or user auth files are committed.
+* [x] `repo-harness mcp serve --transport stdio --profile planner` starts successfully.
+* [x] `repo-harness mcp serve --transport http --port 8765 --profile planner` starts successfully.
+* [x] HTTP server exposes `/health`.
+* [x] HTTP server exposes `/mcp`.
+* [x] MCP server exposes safe read-only tools.
+* [x] MCP server exposes planning-only write tools.
+* [x] Planner profile cannot read denied paths.
+* [x] Planner profile cannot write application source files.
+* [x] `repo-harness mcp doctor --repo .` reports actionable setup status.
+* [x] `repo-harness mcp setup chatgpt --repo .` generates local config and manual setup guide.
+* [x] `repo-harness mcp setup codex --repo . --scope project` safely patches `.codex/config.toml`.
+* [x] `repo-harness mcp install-skill --repo .` installs the Codex Skill.
+* [x] MCP exposes `write_prd_from_idea`.
+* [x] MCP exposes `write_checklist_sprint` with per-task staging gates.
+* [x] MCP exposes `prepare_codex_goal_from_sprint`.
+* [x] `repo-harness mcp prepare-goal --repo . --prd <prd> --sprint <sprint>` writes `.ai/harness/handoff/codex-goal.md` and prints a host-native `/goal` prompt.
+* [x] Unit tests cover path policy, writes, redaction, and config patching.
+* [x] Manual E2E has been run on a sample repo.
+* [x] `.gitignore` prevents local MCP secrets and audit logs from being committed.
+* [x] README or generated guide explains the ChatGPT Connector setup flow.
+* [x] No secrets, local tokens, tunnel URLs, OAuth passphrases, or user auth files are committed.
 
 ---
 
@@ -80,15 +79,15 @@ The sprint is complete when all of the following are true:
 
 Agents working on this sprint must follow these rules:
 
-* [ ] Prefer small, reviewable changes.
-* [ ] Preserve existing CLI style and command registration patterns.
-* [ ] Do not rewrite unrelated repo-harness architecture.
-* [ ] Do not introduce source-code editing through MCP in MVP.
-* [ ] Do not bypass repo-harness workflow files.
-* [ ] Add tests with each functional module where practical.
-* [ ] Keep generated local secrets out of git.
-* [ ] Update this sprint checklist as work completes.
-* [ ] If blocked, write a blocker note under `.ai/harness/handoff/`.
+* [x] Prefer small, reviewable changes.
+* [x] Preserve existing CLI style and command registration patterns.
+* [x] Do not rewrite unrelated repo-harness architecture.
+* [x] Do not introduce source-code editing through MCP in MVP.
+* [x] Do not bypass repo-harness workflow files.
+* [x] Add tests with each functional module where practical.
+* [x] Keep generated local secrets out of git.
+* [x] Update this sprint checklist as work completes.
+* [x] If blocked, write a blocker note under `.ai/harness/handoff/`.
 
 ---
 
@@ -111,13 +110,14 @@ In ChatGPT:
 Use repo-harness to inspect this repo.
 Create a PRD for <feature>.
 Do not edit source code.
-Write the PRD and prepare a Codex goal prompt.
+Write the PRD, convert it to a checklist Sprint, and prepare a Codex goal prompt.
 ```
 
 Expected written artifacts:
 
 ```text
 plans/prds/<feature>.prd.md
+plans/sprints/<feature>.sprint.md
 .ai/harness/handoff/codex-goal.md
 ```
 
@@ -149,6 +149,12 @@ tasks/current.md
 
 Codex then implements, runs checks, writes review evidence, and updates handoff.
 
+Local CLI equivalent for Sprint to Goal:
+
+```bash
+repo-harness mcp prepare-goal --repo . --prd plans/prds/<feature>.prd.md --sprint plans/sprints/<feature>.sprint.md --reference-repo <optional-readonly-reference>
+```
+
 ---
 
 # Sprint Backlog
@@ -157,21 +163,21 @@ Codex then implements, runs checks, writes review evidence, and updates handoff.
 
 ### A1. Inspect existing CLI architecture
 
-* [ ] Inspect `src/cli/index.ts`.
-* [ ] Inspect existing command builders under `src/cli/commands/`.
-* [ ] Inspect `run`, `tools`, `brain`, `docs`, `install`, and `adopt` command patterns.
-* [ ] Identify current test runner and test layout.
-* [ ] Identify package manager and script commands.
-* [ ] Confirm how repo root is resolved today.
-* [ ] Confirm how repo-harness adopted state is detected today.
-* [ ] Confirm how helper scripts are invoked today.
+* [x] Inspect `src/cli/index.ts`.
+* [x] Inspect existing command builders under `src/cli/commands/`.
+* [x] Inspect `run`, `tools`, `brain`, `docs`, `install`, and `adopt` command patterns.
+* [x] Identify current test runner and test layout.
+* [x] Identify package manager and script commands.
+* [x] Confirm how repo root is resolved today.
+* [x] Confirm how repo-harness adopted state is detected today.
+* [x] Confirm how helper scripts are invoked today.
 
 Acceptance criteria:
 
-* [ ] Agent has a short implementation note in `.ai/harness/handoff/mcp-discovery.md`.
-* [ ] Note includes command registration pattern.
-* [ ] Note includes preferred test command.
-* [ ] Note includes risk notes for path handling and config patching.
+* [x] Agent has a short implementation note in `.ai/harness/handoff/mcp-discovery.md`.
+* [x] Note includes command registration pattern.
+* [x] Note includes preferred test command.
+* [x] Note includes risk notes for path handling and config patching.
 
 ---
 
@@ -188,14 +194,14 @@ src/cli/index.ts
 
 Tasks:
 
-* [ ] Create `buildMcpCommand()`.
-* [ ] Add top-level `mcp` command.
-* [ ] Register `mcp` in CLI entrypoint.
-* [ ] Add `mcp --help`.
-* [ ] Add `mcp serve --help`.
-* [ ] Add `mcp doctor --help`.
-* [ ] Add `mcp setup --help`.
-* [ ] Add `mcp install-skill --help`.
+* [x] Create `buildMcpCommand()`.
+* [x] Add top-level `mcp` command.
+* [x] Register `mcp` in CLI entrypoint.
+* [x] Add `mcp --help`.
+* [x] Add `mcp serve --help`.
+* [x] Add `mcp doctor --help`.
+* [x] Add `mcp setup --help`.
+* [x] Add `mcp install-skill --help`.
 
 Initial command shape:
 
@@ -210,11 +216,11 @@ repo-harness mcp print-chatgpt-guide
 
 Acceptance criteria:
 
-* [ ] `repo-harness mcp --help` works.
-* [ ] `repo-harness mcp serve --help` works.
-* [ ] `repo-harness mcp doctor --help` works.
-* [ ] Invalid subcommands produce useful errors.
-* [ ] No existing CLI command behavior regresses.
+* [x] `repo-harness mcp --help` works.
+* [x] `repo-harness mcp serve --help` works.
+* [x] `repo-harness mcp doctor --help` works.
+* [x] Invalid subcommands produce useful errors.
+* [x] No existing CLI command behavior regresses.
 
 ---
 
@@ -232,19 +238,19 @@ src/cli/mcp/types.ts
 
 Tasks:
 
-* [ ] Define `McpProfileName`.
-* [ ] Define `McpPolicy`.
-* [ ] Define planner profile.
-* [ ] Define executor profile.
-* [ ] Define future orchestrator profile but keep disabled.
-* [ ] Add read allowlist globs.
-* [ ] Add write allowlist globs.
-* [ ] Add deny globs.
-* [ ] Add max file size limit.
-* [ ] Add path traversal prevention.
-* [ ] Add symlink escape prevention.
-* [ ] Add repo-root confinement.
-* [ ] Add normalized POSIX-style path matching.
+* [x] Define `McpProfileName`.
+* [x] Define `McpPolicy`.
+* [x] Define planner profile.
+* [x] Define executor profile.
+* [x] Define future orchestrator profile but keep disabled.
+* [x] Add read allowlist globs.
+* [x] Add write allowlist globs.
+* [x] Add deny globs.
+* [x] Add max file size limit.
+* [x] Add path traversal prevention.
+* [x] Add symlink escape prevention.
+* [x] Add repo-root confinement.
+* [x] Add normalized POSIX-style path matching.
 
 Planner read allowlist:
 
@@ -298,12 +304,12 @@ private/**
 
 Acceptance criteria:
 
-* [ ] Allowed workflow files can be read.
-* [ ] Denied files cannot be read.
-* [ ] Files outside repo root cannot be read.
-* [ ] Symlink escape is blocked.
-* [ ] Planner writes are restricted to planning/handoff files.
-* [ ] Planner cannot write `src/**`, `app/**`, `packages/**`, `package.json`, lockfiles, or CI config.
+* [x] Allowed workflow files can be read.
+* [x] Denied files cannot be read.
+* [x] Files outside repo root cannot be read.
+* [x] Symlink escape is blocked.
+* [x] Planner writes are restricted to planning/handoff files.
+* [x] Planner cannot write `src/**`, `app/**`, `packages/**`, `package.json`, lockfiles, or CI config.
 
 ---
 
@@ -317,19 +323,19 @@ src/cli/mcp/redaction.ts
 
 Tasks:
 
-* [ ] Add basic secret-like pattern redaction.
-* [ ] Redact obvious API keys.
-* [ ] Redact bearer tokens.
-* [ ] Redact private key blocks.
-* [ ] Redact OAuth-style tokens.
-* [ ] Apply redaction to tool output errors.
-* [ ] Avoid storing raw sensitive content in audit logs.
+* [x] Add basic secret-like pattern redaction.
+* [x] Redact obvious API keys.
+* [x] Redact bearer tokens.
+* [x] Redact private key blocks.
+* [x] Redact OAuth-style tokens.
+* [x] Apply redaction to tool output errors.
+* [x] Avoid storing raw sensitive content in audit logs.
 
 Acceptance criteria:
 
-* [ ] Tool outputs do not expose redacted patterns.
-* [ ] Errors do not print full local secret values.
-* [ ] Audit log stores hashes or metadata, not raw prompts/secrets.
+* [x] Tool outputs do not expose redacted patterns.
+* [x] Errors do not print full local secret values.
+* [x] Audit log stores hashes or metadata, not raw prompts/secrets.
 
 ---
 
@@ -343,22 +349,22 @@ src/cli/mcp/audit.ts
 
 Tasks:
 
-* [ ] Create `.ai/harness/mcp/` when needed.
-* [ ] Write `.ai/harness/mcp/audit.log`.
-* [ ] Log timestamp.
-* [ ] Log tool name.
-* [ ] Log target path when applicable.
-* [ ] Log result status.
-* [ ] Log input hash instead of raw input.
-* [ ] Redact errors.
-* [ ] Ensure audit log path is gitignored.
+* [x] Create `.ai/harness/mcp/` when needed.
+* [x] Write `.ai/harness/mcp/audit.log`.
+* [x] Log timestamp.
+* [x] Log tool name.
+* [x] Log target path when applicable.
+* [x] Log result status.
+* [x] Log input hash instead of raw input.
+* [x] Redact errors.
+* [x] Ensure audit log path is gitignored.
 
 Acceptance criteria:
 
-* [ ] Read tools can log access metadata.
-* [ ] Write tools log writes.
-* [ ] No raw secret content appears in audit log.
-* [ ] Audit logging failure does not crash normal tool execution.
+* [x] Read tools can log access metadata.
+* [x] Write tools log writes.
+* [x] No raw secret content appears in audit log.
+* [x] Audit logging failure does not crash normal tool execution.
 
 ---
 
@@ -375,16 +381,16 @@ src/cli/mcp/instructions.ts
 
 Tasks:
 
-* [ ] Add MCP server construction.
-* [ ] Add server name.
-* [ ] Add server version.
-* [ ] Add server instructions.
-* [ ] Register read-only tools.
-* [ ] Register write tools.
-* [ ] Apply profile filtering.
-* [ ] Add structured error handling.
-* [ ] Add JSON-safe outputs.
-* [ ] Add tests or smoke tests for server creation.
+* [x] Add MCP server construction.
+* [x] Add server name.
+* [x] Add server version.
+* [x] Add server instructions.
+* [x] Register read-only tools.
+* [x] Register write tools.
+* [x] Apply profile filtering.
+* [x] Add structured error handling.
+* [x] Add JSON-safe outputs.
+* [x] Add tests or smoke tests for server creation.
 
 Server instruction text should communicate:
 
@@ -398,11 +404,11 @@ Before writing a plan, inspect docs/spec.md, tasks/current.md, latest handoff, a
 
 Acceptance criteria:
 
-* [ ] Server can be created with planner profile.
-* [ ] Server can be created with executor profile.
-* [ ] Server rejects unknown profile.
-* [ ] Tool list changes according to profile.
-* [ ] Instructions are present and concise.
+* [x] Server can be created with planner profile.
+* [x] Server can be created with executor profile.
+* [x] Server rejects unknown profile.
+* [x] Tool list changes according to profile.
+* [x] Instructions are present and concise.
 
 ---
 
@@ -416,12 +422,12 @@ src/cli/mcp/transports/stdio.ts
 
 Tasks:
 
-* [ ] Add `--transport stdio`.
-* [ ] Wire MCP server to STDIO transport.
-* [ ] Suppress noisy logs on stdout.
-* [ ] Send operational logs to stderr.
-* [ ] Ensure process exits cleanly.
-* [ ] Add smoke test or manual test command.
+* [x] Add `--transport stdio`.
+* [x] Wire MCP server to STDIO transport.
+* [x] Suppress noisy logs on stdout.
+* [x] Send operational logs to stderr.
+* [x] Ensure process exits cleanly.
+* [x] Add smoke test or manual test command.
 
 Command:
 
@@ -431,10 +437,10 @@ repo-harness mcp serve --repo . --transport stdio --profile planner
 
 Acceptance criteria:
 
-* [ ] STDIO transport starts.
-* [ ] STDIO transport works with local MCP-compatible clients.
-* [ ] No human-readable logs corrupt JSON-RPC stdout.
-* [ ] Errors are printed to stderr.
+* [x] STDIO transport starts.
+* [x] STDIO transport works with local MCP-compatible clients.
+* [x] No human-readable logs corrupt JSON-RPC stdout.
+* [x] Errors are printed to stderr.
 
 ---
 
@@ -448,17 +454,17 @@ src/cli/mcp/transports/http.ts
 
 Tasks:
 
-* [ ] Add `--transport http`.
-* [ ] Add `--host`.
-* [ ] Add `--port`.
-* [ ] Add `/health`.
-* [ ] Add `/mcp`.
-* [ ] Bind to `127.0.0.1` by default.
-* [ ] Avoid binding to `0.0.0.0` unless explicitly requested.
-* [ ] Add basic request size limit.
-* [ ] Add graceful shutdown.
-* [ ] Add CORS behavior only if needed.
-* [ ] Add useful startup output.
+* [x] Add `--transport http`.
+* [x] Add `--host`.
+* [x] Add `--port`.
+* [x] Add `/health`.
+* [x] Add `/mcp`.
+* [x] Bind to `127.0.0.1` by default.
+* [x] Avoid binding to `0.0.0.0` unless explicitly requested.
+* [x] Add basic request size limit.
+* [x] Add graceful shutdown.
+* [x] Add CORS behavior only if needed.
+* [x] Add useful startup output.
 
 Command:
 
@@ -468,11 +474,11 @@ repo-harness mcp serve --repo . --transport http --host 127.0.0.1 --port 8765 --
 
 Acceptance criteria:
 
-* [ ] `curl http://127.0.0.1:8765/health` returns healthy JSON.
-* [ ] `/mcp` endpoint is available.
-* [ ] Default host is localhost.
-* [ ] Startup message includes local endpoint.
-* [ ] Startup message does not print secrets.
+* [x] `curl http://127.0.0.1:8765/health` returns healthy JSON.
+* [x] `/mcp` endpoint is available.
+* [x] Default host is localhost.
+* [x] Startup message includes local endpoint.
+* [x] Startup message does not print secrets.
 
 ---
 
@@ -482,19 +488,19 @@ Acceptance criteria:
 
 Tasks:
 
-* [ ] Implement `harness_status`.
-* [ ] Return repo root.
-* [ ] Return adopted state.
-* [ ] Return available workflow roots.
-* [ ] Return active profile.
-* [ ] Return current git branch when available.
-* [ ] Mark as read-only.
+* [x] Implement `harness_status`.
+* [x] Return repo root.
+* [x] Return adopted state.
+* [x] Return available workflow roots.
+* [x] Return active profile.
+* [x] Return current git branch when available.
+* [x] Mark as read-only.
 
 Acceptance criteria:
 
-* [ ] Tool works in adopted repo.
-* [ ] Tool returns useful error in non-adopted repo.
-* [ ] Tool does not leak denied paths.
+* [x] Tool works in adopted repo.
+* [x] Tool returns useful error in non-adopted repo.
+* [x] Tool does not leak denied paths.
 
 ---
 
@@ -502,17 +508,17 @@ Acceptance criteria:
 
 Tasks:
 
-* [ ] Implement `harness_doctor`.
-* [ ] Reuse existing doctor logic if available.
-* [ ] Return structured JSON.
-* [ ] Mark as read-only.
-* [ ] Redact local paths if needed only for remote clients.
+* [x] Implement `harness_doctor`.
+* [x] Reuse existing doctor logic if available.
+* [x] Return structured JSON.
+* [x] Mark as read-only.
+* [x] Redact local paths if needed only for remote clients.
 
 Acceptance criteria:
 
-* [ ] Tool returns pass/warn/fail sections.
-* [ ] Tool handles missing repo-harness artifacts.
-* [ ] Tool output is compact enough for model consumption.
+* [x] Tool returns pass/warn/fail sections.
+* [x] Tool handles missing repo-harness artifacts.
+* [x] Tool output is compact enough for model consumption.
 
 ---
 
@@ -520,21 +526,21 @@ Acceptance criteria:
 
 Tasks:
 
-* [ ] Implement allowlist-based workflow file listing.
-* [ ] Include relative paths.
-* [ ] Include file size.
-* [ ] Include modified time if simple.
-* [ ] Exclude denied paths.
-* [ ] Exclude files above configured max size.
-* [ ] Mark as read-only.
+* [x] Implement allowlist-based workflow file listing.
+* [x] Include relative paths.
+* [x] Include file size.
+* [x] Include modified time if simple.
+* [x] Exclude denied paths.
+* [x] Exclude files above configured max size.
+* [x] Mark as read-only.
 
 Acceptance criteria:
 
-* [ ] Lists `docs/spec.md` when present.
-* [ ] Lists `plans/**` when present.
-* [ ] Lists `.ai/harness/handoff/**` when present.
-* [ ] Does not list `.env`.
-* [ ] Does not list `.git/**`.
+* [x] Lists `docs/spec.md` when present.
+* [x] Lists `plans/**` when present.
+* [x] Lists `.ai/harness/handoff/**` when present.
+* [x] Does not list `.env`.
+* [x] Does not list `.git/**`.
 
 ---
 
@@ -542,24 +548,24 @@ Acceptance criteria:
 
 Tasks:
 
-* [ ] Implement file read by relative path.
-* [ ] Enforce allowlist.
-* [ ] Enforce denylist.
-* [ ] Enforce max file size.
-* [ ] Normalize path.
-* [ ] Block `../`.
-* [ ] Block symlink escape.
-* [ ] Redact output.
-* [ ] Mark as read-only.
+* [x] Implement file read by relative path.
+* [x] Enforce allowlist.
+* [x] Enforce denylist.
+* [x] Enforce max file size.
+* [x] Normalize path.
+* [x] Block `../`.
+* [x] Block symlink escape.
+* [x] Redact output.
+* [x] Mark as read-only.
 
 Acceptance criteria:
 
-* [ ] Can read `docs/spec.md`.
-* [ ] Can read files under `plans/`.
-* [ ] Can read `.ai/harness/handoff/resume.md`.
-* [ ] Cannot read `.env`.
-* [ ] Cannot read `../outside`.
-* [ ] Cannot read symlink to outside repo.
+* [x] Can read `docs/spec.md`.
+* [x] Can read files under `plans/`.
+* [x] Can read `.ai/harness/handoff/resume.md`.
+* [x] Cannot read `.env`.
+* [x] Cannot read `../outside`.
+* [x] Cannot read symlink to outside repo.
 
 ---
 
@@ -567,18 +573,18 @@ Acceptance criteria:
 
 Tasks:
 
-* [ ] Implement latest handoff discovery.
-* [ ] Prefer `.ai/harness/handoff/resume.md`.
-* [ ] Include `codex-goal.md` status.
-* [ ] Include `chatgpt-plan.md` status.
-* [ ] Return concise summary.
-* [ ] Mark as read-only.
+* [x] Implement latest handoff discovery.
+* [x] Prefer `.ai/harness/handoff/resume.md`.
+* [x] Include `codex-goal.md` status.
+* [x] Include `chatgpt-plan.md` status.
+* [x] Return concise summary.
+* [x] Mark as read-only.
 
 Acceptance criteria:
 
-* [ ] Tool works when handoff exists.
-* [ ] Tool gives useful empty state when missing.
-* [ ] Tool does not fail if optional files are absent.
+* [x] Tool works when handoff exists.
+* [x] Tool gives useful empty state when missing.
+* [x] Tool does not fail if optional files are absent.
 
 ---
 
@@ -586,17 +592,17 @@ Acceptance criteria:
 
 Tasks:
 
-* [ ] Implement checks summary.
-* [ ] Read `.ai/harness/checks/**`.
-* [ ] Return latest check files.
-* [ ] Include timestamps and relative paths.
-* [ ] Mark as read-only.
+* [x] Implement checks summary.
+* [x] Read `.ai/harness/checks/**`.
+* [x] Return latest check files.
+* [x] Include timestamps and relative paths.
+* [x] Mark as read-only.
 
 Acceptance criteria:
 
-* [ ] Tool works with no check files.
-* [ ] Tool returns latest check artifacts when present.
-* [ ] Tool output stays concise.
+* [x] Tool works with no check files.
+* [x] Tool returns latest check artifacts when present.
+* [x] Tool output stays concise.
 
 ---
 
@@ -606,18 +612,18 @@ Acceptance criteria:
 
 Tasks:
 
-* [ ] Implement PRD writer.
-* [ ] Accept title.
-* [ ] Accept slug.
-* [ ] Accept markdown body.
-* [ ] Slugify filename.
-* [ ] Write to `plans/prds/<slug>.prd.md`.
-* [ ] Create directory if needed.
-* [ ] Prevent overwrite by default.
-* [ ] Support explicit overwrite flag.
-* [ ] Add frontmatter.
-* [ ] Audit write.
-* [ ] Run content validation.
+* [x] Implement PRD writer.
+* [x] Accept title.
+* [x] Accept slug.
+* [x] Accept markdown body.
+* [x] Slugify filename.
+* [x] Write to strict-compatible `plans/prds/<YYYYMMDD>-<HHMM>-<slug>.prd.md`.
+* [x] Create directory if needed.
+* [x] Prevent overwrite by default.
+* [x] Support explicit overwrite flag.
+* [x] Add frontmatter.
+* [x] Audit write.
+* [x] Run content validation.
 
 Input shape:
 
@@ -632,11 +638,11 @@ Input shape:
 
 Acceptance criteria:
 
-* [ ] Valid PRD writes to `plans/prds/*.prd.md`.
-* [ ] Invalid path is rejected.
-* [ ] Overwrite is blocked by default.
-* [ ] Audit log records write.
-* [ ] Output returns relative path and status.
+* [x] Valid PRD writes to `plans/prds/*.prd.md`.
+* [x] Invalid path is rejected.
+* [x] Overwrite is blocked by default.
+* [x] Audit log records write.
+* [x] Output returns relative path and status.
 
 ---
 
@@ -644,22 +650,22 @@ Acceptance criteria:
 
 Tasks:
 
-* [ ] Implement sprint writer.
-* [ ] Accept title.
-* [ ] Accept slug.
-* [ ] Accept markdown body.
-* [ ] Write to `plans/sprints/<slug>.sprint.md`.
-* [ ] Create directory if needed.
-* [ ] Prevent overwrite by default.
-* [ ] Add frontmatter.
-* [ ] Audit write.
+* [x] Implement sprint writer.
+* [x] Accept title.
+* [x] Accept slug.
+* [x] Accept markdown body.
+* [x] Write to `plans/sprints/<slug>.sprint.md`.
+* [x] Create directory if needed.
+* [x] Prevent overwrite by default.
+* [x] Add frontmatter.
+* [x] Audit write.
 
 Acceptance criteria:
 
-* [ ] Valid sprint writes to `plans/sprints/*.sprint.md`.
-* [ ] Overwrite requires explicit flag.
-* [ ] Planner profile can write sprint.
-* [ ] Planner profile cannot write outside `plans/sprints/**`.
+* [x] Valid sprint writes to `plans/sprints/*.sprint.md`.
+* [x] Overwrite requires explicit flag.
+* [x] Planner profile can write sprint.
+* [x] Planner profile cannot write outside `plans/sprints/**`.
 
 ---
 
@@ -667,20 +673,20 @@ Acceptance criteria:
 
 Tasks:
 
-* [ ] Implement implementation plan writer.
-* [ ] Accept title.
-* [ ] Accept slug.
-* [ ] Accept markdown body.
-* [ ] Write to `plans/plan-<slug>.md`.
-* [ ] Prevent overwrite by default.
-* [ ] Add frontmatter.
-* [ ] Audit write.
+* [x] Implement implementation plan writer.
+* [x] Accept title.
+* [x] Accept slug.
+* [x] Accept markdown body.
+* [x] Write to `plans/plan-<slug>.md`.
+* [x] Prevent overwrite by default.
+* [x] Add frontmatter.
+* [x] Audit write.
 
 Acceptance criteria:
 
-* [ ] Writes only `plans/plan-*.md`.
-* [ ] Rejects nested arbitrary paths.
-* [ ] Output includes relative path.
+* [x] Writes only `plans/plan-*.md`.
+* [x] Rejects nested arbitrary paths.
+* [x] Output includes relative path.
 
 ---
 
@@ -688,17 +694,17 @@ Acceptance criteria:
 
 Tasks:
 
-* [ ] Implement Codex goal writer.
-* [ ] Write only `.ai/harness/handoff/codex-goal.md`.
-* [ ] Accept markdown body.
-* [ ] Validate required sections.
-* [ ] Prevent empty or tiny goals.
-* [ ] Include source-of-truth references.
-* [ ] Include scope.
-* [ ] Include required checks.
-* [ ] Include done criteria.
-* [ ] Include handoff update requirement.
-* [ ] Audit write.
+* [x] Implement Codex goal writer.
+* [x] Write only `.ai/harness/handoff/codex-goal.md`.
+* [x] Accept markdown body.
+* [x] Validate required sections.
+* [x] Prevent empty or tiny goals.
+* [x] Include source-of-truth references.
+* [x] Include scope.
+* [x] Include required checks.
+* [x] Include done criteria.
+* [x] Include handoff update requirement.
+* [x] Audit write.
 
 Required sections:
 
@@ -714,10 +720,10 @@ Required sections:
 
 Acceptance criteria:
 
-* [ ] Valid goal writes successfully.
-* [ ] Missing required sections are rejected with actionable error.
-* [ ] Goal path is fixed and cannot be changed by model input.
-* [ ] Audit log records write.
+* [x] Valid goal writes successfully.
+* [x] Missing required sections are rejected with actionable error.
+* [x] Goal path is fixed and cannot be changed by model input.
+* [x] Audit log records write.
 
 ---
 
@@ -725,18 +731,18 @@ Acceptance criteria:
 
 Tasks:
 
-* [ ] Implement handoff note appender.
-* [ ] Append to `.ai/harness/handoff/chatgpt-plan.md`.
-* [ ] Add timestamp header.
-* [ ] Add actor field.
-* [ ] Add concise note body.
-* [ ] Audit write.
+* [x] Implement handoff note appender.
+* [x] Append to `.ai/harness/handoff/chatgpt-plan.md`.
+* [x] Add timestamp header.
+* [x] Add actor field.
+* [x] Add concise note body.
+* [x] Audit write.
 
 Acceptance criteria:
 
-* [ ] Notes append without overwriting existing content.
-* [ ] Notes are timestamped.
-* [ ] Notes remain inside allowed handoff path.
+* [x] Notes append without overwriting existing content.
+* [x] Notes are timestamped.
+* [x] Notes remain inside allowed handoff path.
 
 ---
 
@@ -744,14 +750,14 @@ Acceptance criteria:
 
 Tasks:
 
-* [ ] Implement fixed workflow check runner.
-* [ ] Do not expose arbitrary command input.
-* [ ] Run existing repo-harness workflow check helper.
-* [ ] Capture stdout/stderr.
-* [ ] Redact output.
-* [ ] Return exit code.
-* [ ] Apply timeout.
-* [ ] Audit execution.
+* [x] Implement fixed workflow check runner.
+* [x] Do not expose arbitrary command input.
+* [x] Run existing repo-harness workflow check helper.
+* [x] Capture stdout/stderr.
+* [x] Redact output.
+* [x] Return exit code.
+* [x] Apply timeout.
+* [x] Audit execution.
 
 Allowed command should be fixed, for example:
 
@@ -761,10 +767,10 @@ repo-harness run check-task-workflow -- --strict
 
 Acceptance criteria:
 
-* [ ] Tool runs only the fixed workflow check.
-* [ ] Tool does not accept arbitrary shell.
-* [ ] Tool returns structured success/failure.
-* [ ] Timeout is enforced.
+* [x] Tool runs only the fixed workflow check.
+* [x] Tool does not accept arbitrary shell.
+* [x] Tool returns structured success/failure.
+* [x] Timeout is enforced.
 
 ---
 
@@ -781,14 +787,16 @@ src/cli/mcp/config.ts
 
 Tasks:
 
-* [ ] Create `.repo-harness/` if missing.
-* [ ] Generate `.repo-harness/mcp.local.json`.
-* [ ] Generate auth passphrase or token if selected.
-* [ ] Store secret only in local ignored file or environment instruction.
-* [ ] Add `.repo-harness/mcp.local.json` to `.gitignore`.
-* [ ] Add `.repo-harness/mcp.tokens.json` to `.gitignore`.
-* [ ] Add `.ai/harness/mcp/audit.log` to `.gitignore`.
-* [ ] Print next-step commands.
+* [x] Create `.repo-harness/` if missing.
+* [x] Generate `.repo-harness/mcp.local.json`.
+* [x] Generate auth passphrase or token if selected.
+* [x] Store secret only in local ignored file or environment instruction.
+* [x] Add `.repo-harness/mcp.local.json` to `.gitignore`.
+* [x] Add `.repo-harness/mcp.tokens.json` to `.gitignore`.
+* [x] Add `.repo-harness/mcp.oauth.json` to `.gitignore`.
+* [x] Add `.repo-harness/mcp.oauth-tokens.json` to `.gitignore`.
+* [x] Add `.ai/harness/mcp/audit.log` to `.gitignore`.
+* [x] Print next-step commands.
 
 Command:
 
@@ -798,11 +806,11 @@ repo-harness mcp setup chatgpt --repo .
 
 Acceptance criteria:
 
-* [ ] Setup creates local config.
-* [ ] Setup does not commit secrets.
-* [ ] Setup prints server start command.
-* [ ] Setup prints tunnel instruction.
-* [ ] Setup prints guide path.
+* [x] Setup creates local config.
+* [x] Setup does not commit secrets.
+* [x] Setup prints server start command.
+* [x] Setup prints tunnel instruction.
+* [x] Setup prints guide path.
 
 ---
 
@@ -817,24 +825,24 @@ docs/repo-harness-chatgpt-mcp-setup.md
 
 Tasks:
 
-* [ ] Generate `docs/repo-harness-chatgpt-mcp-setup.md`.
-* [ ] Include prerequisites.
-* [ ] Include server start command.
-* [ ] Include tunnel example.
-* [ ] Include ChatGPT Connector steps.
-* [ ] Include test prompt.
-* [ ] Include PRD-generation prompt.
-* [ ] Include Codex handoff prompt.
-* [ ] Include troubleshooting.
-* [ ] Include security notes.
-* [ ] Avoid embedding secrets in guide.
+* [x] Generate `docs/repo-harness-chatgpt-mcp-setup.md`.
+* [x] Include prerequisites.
+* [x] Include server start command.
+* [x] Include tunnel example.
+* [x] Include ChatGPT Connector steps.
+* [x] Include test prompt.
+* [x] Include PRD-generation prompt.
+* [x] Include Codex handoff prompt.
+* [x] Include troubleshooting.
+* [x] Include security notes.
+* [x] Avoid embedding secrets in guide.
 
 Acceptance criteria:
 
-* [ ] Guide is generated.
-* [ ] Guide is safe to commit.
-* [ ] Guide includes copy-paste commands.
-* [ ] Guide clearly marks manual ChatGPT UI steps.
+* [x] Guide is generated.
+* [x] Guide is safe to commit.
+* [x] Guide includes copy-paste commands.
+* [x] Guide clearly marks manual ChatGPT UI steps.
 
 ---
 
@@ -842,23 +850,23 @@ Acceptance criteria:
 
 Tasks:
 
-* [ ] Add command:
+* [x] Add command:
 
 ```bash
 repo-harness mcp print-chatgpt-guide --repo .
 ```
 
-* [ ] Print the same instructions to stdout.
-* [ ] Support `--write` to write guide file.
-* [ ] Support `--endpoint <url>` to include known tunnel endpoint.
-* [ ] Do not print auth secret unless explicit `--show-secret` is provided.
-* [ ] Prefer not to implement `--show-secret` unless necessary.
+* [x] Print the same instructions to stdout.
+* [x] Support `--write` to write guide file.
+* [x] Support `--endpoint <url>` to include known tunnel endpoint.
+* [x] Do not print auth secret unless explicit `--show-secret` is provided.
+* [x] Prefer not to implement `--show-secret` unless necessary.
 
 Acceptance criteria:
 
-* [ ] Command works without tunnel.
-* [ ] Command works with provided endpoint.
-* [ ] Output is usable as human tutorial.
+* [x] Command works without tunnel.
+* [x] Command works with provided endpoint.
+* [x] Output is usable as human tutorial.
 
 ---
 
@@ -875,17 +883,17 @@ src/cli/mcp/setup/toml.ts
 
 Tasks:
 
-* [ ] Detect existing `.codex/config.toml`.
-* [ ] Create `.codex/` if missing.
-* [ ] Preserve unrelated config.
-* [ ] Add or update `[mcp_servers.repo_harness]`.
-* [ ] Use STDIO by default.
-* [ ] Add `enabled_tools`.
-* [ ] Add approval mode.
-* [ ] Create backup before patching.
-* [ ] Support `--dry-run`.
-* [ ] Support `--scope project`.
-* [ ] Optionally support `--scope user` later.
+* [x] Detect existing `.codex/config.toml`.
+* [x] Create `.codex/` if missing.
+* [x] Preserve unrelated config.
+* [x] Add or update `[mcp_servers.repo_harness]`.
+* [x] Use STDIO by default.
+* [x] Add `enabled_tools`.
+* [x] Add approval mode.
+* [x] Create backup before patching.
+* [x] Support `--dry-run`.
+* [x] Support `--scope project`.
+* [x] Optionally support `--scope user` later.
 
 Default config:
 
@@ -915,12 +923,12 @@ default_tools_approval_mode = "prompt"
 
 Acceptance criteria:
 
-* [ ] `.codex/config.toml` is created if absent.
-* [ ] Existing config is preserved.
-* [ ] Backup is created before modification.
-* [ ] Dry run prints planned patch.
-* [ ] Config uses relative repo path when safe.
-* [ ] No secrets are written.
+* [x] `.codex/config.toml` is created if absent.
+* [x] Existing config is preserved.
+* [x] Backup is created before modification.
+* [x] Dry run prints planned patch.
+* [x] Config uses relative repo path when safe.
+* [x] No secrets are written.
 
 ---
 
@@ -928,18 +936,18 @@ Acceptance criteria:
 
 Tasks:
 
-* [ ] Add Codex checks to `mcp doctor`.
-* [ ] Check `codex` command availability.
-* [ ] Check `.codex/config.toml` presence.
-* [ ] Check `repo_harness` MCP server entry.
-* [ ] Check required enabled tools.
-* [ ] Provide next-step command.
+* [x] Add Codex checks to `mcp doctor`.
+* [x] Check `codex` command availability.
+* [x] Check `.codex/config.toml` presence.
+* [x] Check `repo_harness` MCP server entry.
+* [x] Check required enabled tools.
+* [x] Provide next-step command.
 
 Acceptance criteria:
 
-* [ ] Doctor reports Codex configured/unconfigured.
-* [ ] Doctor provides exact fix command.
-* [ ] Doctor does not fail if Codex is not installed.
+* [x] Doctor reports Codex configured/unconfigured.
+* [x] Doctor provides exact fix command.
+* [x] Doctor does not fail if Codex is not installed.
 
 ---
 
@@ -957,15 +965,15 @@ src/cli/mcp/skill/templates/references/workflow.md
 
 Tasks:
 
-* [ ] Create Skill template.
-* [ ] Include frontmatter.
-* [ ] Define when to use.
-* [ ] Define planner/executor boundary.
-* [ ] Define setup behavior.
-* [ ] Define execution behavior.
-* [ ] Define computer-use safety rules.
-* [ ] Define handoff update requirements.
-* [ ] Define secrets handling rules.
+* [x] Create Skill template.
+* [x] Include frontmatter.
+* [x] Define when to use.
+* [x] Define planner/executor boundary.
+* [x] Define setup behavior.
+* [x] Define execution behavior.
+* [x] Define computer-use safety rules.
+* [x] Define handoff update requirements.
+* [x] Define secrets handling rules.
 
 Skill frontmatter:
 
@@ -978,11 +986,11 @@ description: Use when setting up or operating the repo-harness ChatGPT MCP Conne
 
 Acceptance criteria:
 
-* [ ] Skill has clear trigger description.
-* [ ] Skill tells Codex to read `codex-goal.md`.
-* [ ] Skill tells Codex not to handle secrets.
-* [ ] Skill tells Codex not to automate ChatGPT login unless explicitly requested.
-* [ ] Skill tells Codex to update review evidence and handoff.
+* [x] Skill has clear trigger description.
+* [x] Skill tells Codex to read `codex-goal.md`.
+* [x] Skill tells Codex not to handle secrets.
+* [x] Skill tells Codex not to automate ChatGPT login unless explicitly requested.
+* [x] Skill tells Codex to update review evidence and handoff.
 
 ---
 
@@ -990,29 +998,29 @@ Acceptance criteria:
 
 Tasks:
 
-* [ ] Add command:
+* [x] Add command:
 
 ```bash
 repo-harness mcp install-skill --repo .
 ```
 
-* [ ] Install to:
+* [x] Install to:
 
 ```text
 .agents/skills/repo-harness-chatgpt-bridge/
 ```
 
-* [ ] Create directories if needed.
-* [ ] Preserve existing skill unless `--overwrite`.
-* [ ] Support `--dry-run`.
-* [ ] Print installed files.
+* [x] Create directories if needed.
+* [x] Preserve existing skill unless `--overwrite`.
+* [x] Support `--dry-run`.
+* [x] Print installed files.
 
 Acceptance criteria:
 
-* [ ] Skill installs into repo.
-* [ ] Existing skill is not overwritten by default.
-* [ ] Dry run works.
-* [ ] No secrets are written.
+* [x] Skill installs into repo.
+* [x] Existing skill is not overwritten by default.
+* [x] Dry run works.
+* [x] No secrets are written.
 
 ---
 
@@ -1020,20 +1028,20 @@ Acceptance criteria:
 
 Tasks:
 
-* [ ] Add a reference doc for optional computer-use assisted setup.
-* [ ] Clearly mark as experimental.
-* [ ] Require user confirmation for browser/account actions.
-* [ ] Instruct agent not to type passwords.
-* [ ] Instruct agent not to type 2FA codes.
-* [ ] Instruct agent not to approve workspace/admin prompts without user confirmation.
-* [ ] Instruct agent to stop before final connector creation if unsure.
-* [ ] Include manual fallback path.
+* [x] Add a reference doc for optional computer-use assisted setup.
+* [x] Clearly mark as experimental.
+* [x] Require user confirmation for browser/account actions.
+* [x] Instruct agent not to type passwords.
+* [x] Instruct agent not to type 2FA codes.
+* [x] Instruct agent not to approve workspace/admin prompts without user confirmation.
+* [x] Instruct agent to stop before final connector creation if unsure.
+* [x] Include manual fallback path.
 
 Acceptance criteria:
 
-* [ ] Skill supports assisted setup safely.
-* [ ] Skill does not imply full automation is guaranteed.
-* [ ] Manual path remains primary.
+* [x] Skill supports assisted setup safely.
+* [x] Skill does not imply full automation is guaranteed.
+* [x] Manual path remains primary.
 
 ---
 
@@ -1055,21 +1063,21 @@ repo-harness mcp doctor --repo .
 
 Tasks:
 
-* [ ] Check git repo.
-* [ ] Check repo-harness adoption.
-* [ ] Check `docs/spec.md`.
-* [ ] Check `plans/`.
-* [ ] Check `tasks/`.
-* [ ] Check `.ai/context/`.
-* [ ] Check `.ai/harness/handoff/`.
-* [ ] Check `.ai/harness/checks/`.
-* [ ] Check local MCP config.
-* [ ] Check `.gitignore` entries.
-* [ ] Check Codex config.
-* [ ] Check Skill installation.
-* [ ] Check HTTP server if `--endpoint` is passed.
-* [ ] Print human-readable output by default.
-* [ ] Support `--json`.
+* [x] Check git repo.
+* [x] Check repo-harness adoption.
+* [x] Check `docs/spec.md`.
+* [x] Check `plans/`.
+* [x] Check `tasks/`.
+* [x] Check `.ai/context/`.
+* [x] Check `.ai/harness/handoff/`.
+* [x] Check `.ai/harness/checks/`.
+* [x] Check local MCP config.
+* [x] Check `.gitignore` entries.
+* [x] Check Codex config.
+* [x] Check Skill installation.
+* [x] Check HTTP server if `--endpoint` is passed.
+* [x] Print human-readable output by default.
+* [x] Support `--json`.
 
 Example JSON shape:
 
@@ -1098,10 +1106,10 @@ Example JSON shape:
 
 Acceptance criteria:
 
-* [ ] Human output is readable.
-* [ ] JSON output is machine-readable.
-* [ ] Warnings include exact next command.
-* [ ] Doctor does not require server to be running unless endpoint check requested.
+* [x] Human output is readable.
+* [x] JSON output is machine-readable.
+* [x] Warnings include exact next command.
+* [x] Doctor does not require server to be running unless endpoint check requested.
 
 ---
 
@@ -1111,19 +1119,19 @@ Acceptance criteria:
 
 Tasks:
 
-* [ ] Test allowed read path.
-* [ ] Test denied read path.
-* [ ] Test path traversal.
-* [ ] Test symlink escape.
-* [ ] Test allowed write path.
-* [ ] Test denied source write.
-* [ ] Test max file size.
-* [ ] Test slug generation.
+* [x] Test allowed read path.
+* [x] Test denied read path.
+* [x] Test path traversal.
+* [x] Test symlink escape.
+* [x] Test allowed write path.
+* [x] Test denied source write.
+* [x] Test max file size.
+* [x] Test slug generation.
 
 Acceptance criteria:
 
-* [ ] All policy tests pass.
-* [ ] Tests cover Unix-style and platform-native path separators.
+* [x] All policy tests pass.
+* [x] Tests cover Unix-style and platform-native path separators.
 
 ---
 
@@ -1131,19 +1139,19 @@ Acceptance criteria:
 
 Tasks:
 
-* [ ] Test `write_prd`.
-* [ ] Test `write_sprint`.
-* [ ] Test `write_plan`.
-* [ ] Test `write_codex_goal`.
-* [ ] Test overwrite prevention.
-* [ ] Test validation error messages.
-* [ ] Test audit entries.
+* [x] Test `write_prd`.
+* [x] Test `write_sprint`.
+* [x] Test `write_plan`.
+* [x] Test `write_codex_goal`.
+* [x] Test overwrite prevention.
+* [x] Test validation error messages.
+* [x] Test audit entries.
 
 Acceptance criteria:
 
-* [ ] Writer tools only write allowed paths.
-* [ ] Invalid inputs produce actionable errors.
-* [ ] Audit log is written without secrets.
+* [x] Writer tools only write allowed paths.
+* [x] Invalid inputs produce actionable errors.
+* [x] Audit log is written without secrets.
 
 ---
 
@@ -1151,18 +1159,18 @@ Acceptance criteria:
 
 Tasks:
 
-* [ ] Test new `.codex/config.toml`.
-* [ ] Test patch existing config.
-* [ ] Test preserve unrelated config.
-* [ ] Test backup creation.
-* [ ] Test dry run.
-* [ ] Test repeated setup idempotency.
+* [x] Test new `.codex/config.toml`.
+* [x] Test patch existing config.
+* [x] Test preserve unrelated config.
+* [x] Test backup creation.
+* [x] Test dry run.
+* [x] Test repeated setup idempotency.
 
 Acceptance criteria:
 
-* [ ] Running setup twice does not duplicate config.
-* [ ] Existing config remains valid.
-* [ ] Dry run does not write files.
+* [x] Running setup twice does not duplicate config.
+* [x] Existing config remains valid.
+* [x] Dry run does not write files.
 
 ---
 
@@ -1170,19 +1178,19 @@ Acceptance criteria:
 
 Tasks:
 
-* [ ] Start STDIO server smoke test.
-* [ ] Start HTTP server smoke test.
-* [ ] Check `/health`.
-* [ ] Check MCP tool listing if test harness supports it.
-* [ ] Call read-only tool.
-* [ ] Call writer tool against temp repo.
-* [ ] Verify denied paths remain blocked.
+* [x] Start STDIO server smoke test.
+* [x] Start HTTP server smoke test.
+* [x] Check `/health`.
+* [x] Check MCP tool listing if test harness supports it.
+* [x] Call read-only tool.
+* [x] Call writer tool against temp repo.
+* [x] Verify denied paths remain blocked.
 
 Acceptance criteria:
 
-* [ ] HTTP server starts and stops cleanly.
-* [ ] STDIO server does not print logs to stdout.
-* [ ] Tool calls work in temp repo.
+* [x] HTTP server starts and stops cleanly.
+* [x] STDIO server does not print logs to stdout.
+* [x] Tool calls work in temp repo.
 
 ---
 
@@ -1192,31 +1200,31 @@ Use a disposable repo.
 
 Steps:
 
-* [ ] Create or select sample repo.
-* [ ] Run `repo-harness adopt --repo .` if needed.
-* [ ] Run `repo-harness mcp setup chatgpt --repo .`.
-* [ ] Run `repo-harness mcp setup codex --repo . --scope project`.
-* [ ] Run `repo-harness mcp install-skill --repo .`.
-* [ ] Start HTTP MCP server.
-* [ ] Start tunnel manually.
-* [ ] Add ChatGPT Connector manually.
-* [ ] Ask ChatGPT to call `harness_status`.
-* [ ] Ask ChatGPT to read latest handoff.
-* [ ] Ask ChatGPT to write a test PRD.
-* [ ] Ask ChatGPT to write Codex goal.
-* [ ] Open Codex.
-* [ ] Ask Codex to use the Skill and read latest goal.
-* [ ] Confirm Codex can follow goal.
-* [ ] Confirm review evidence and handoff are updated.
+* [x] Create or select sample repo.
+* [x] Run `repo-harness adopt --repo .` if needed.
+* [x] Run `repo-harness mcp setup chatgpt --repo .`.
+* [x] Run `repo-harness mcp setup codex --repo . --scope project`.
+* [x] Run `repo-harness mcp install-skill --repo .`.
+* [x] Start HTTP MCP server.
+* [x] Start tunnel manually.
+* [x] Add ChatGPT Connector manually.
+* [x] Ask ChatGPT to call `harness_status`.
+* [x] Ask ChatGPT to read latest handoff.
+* [x] Ask ChatGPT to write a test PRD.
+* [x] Ask ChatGPT to write Codex goal.
+* [x] Open Codex.
+* [x] Ask Codex to use the Skill and read latest goal.
+* [x] Confirm Codex can follow goal.
+* [x] Confirm review evidence and handoff are updated.
 
 Acceptance criteria:
 
-* [ ] ChatGPT can read workflow state.
-* [ ] ChatGPT can write PRD.
-* [ ] ChatGPT can write Codex goal.
-* [ ] Codex can consume the goal.
-* [ ] No source files are modified by ChatGPT MCP tools.
-* [ ] No secrets appear in logs.
+* [x] ChatGPT can read workflow state.
+* [x] ChatGPT can write PRD.
+* [x] ChatGPT can write Codex goal.
+* [x] Codex can consume the goal.
+* [x] No source files are modified by ChatGPT MCP tools.
+* [x] No secrets appear in logs.
 
 ---
 
@@ -1226,20 +1234,20 @@ Acceptance criteria:
 
 Tasks:
 
-* [ ] Add guide template.
-* [ ] Include setup commands.
-* [ ] Include ChatGPT Connector manual steps.
-* [ ] Include tunnel explanation.
-* [ ] Include test prompts.
-* [ ] Include common errors.
-* [ ] Include security warnings.
-* [ ] Include fallback workflow when ChatGPT MCP is unavailable.
+* [x] Add guide template.
+* [x] Include setup commands.
+* [x] Include ChatGPT Connector manual steps.
+* [x] Include tunnel explanation.
+* [x] Include test prompts.
+* [x] Include common errors.
+* [x] Include security warnings.
+* [x] Include fallback workflow when ChatGPT MCP is unavailable.
 
 Acceptance criteria:
 
-* [ ] Guide can be generated by CLI.
-* [ ] Guide can be committed safely.
-* [ ] Guide is enough for manual setup without reading source code.
+* [x] Guide can be generated by CLI.
+* [x] Guide can be committed safely.
+* [x] Guide is enough for manual setup without reading source code.
 
 ---
 
@@ -1247,18 +1255,18 @@ Acceptance criteria:
 
 Tasks:
 
-* [ ] Add short README mention.
-* [ ] Link to generated guide.
-* [ ] Explain planner/executor split.
-* [ ] Explain that ChatGPT does not execute code in MVP.
-* [ ] Explain Codex remains executor.
-* [ ] Explain MCP support depends on user ChatGPT workspace availability.
+* [x] Add short README mention.
+* [x] Link to generated guide.
+* [x] Explain planner/executor split.
+* [x] Explain that ChatGPT does not execute code in MVP.
+* [x] Explain Codex remains executor.
+* [x] Explain MCP support depends on user ChatGPT workspace availability.
 
 Acceptance criteria:
 
-* [ ] README update is concise.
-* [ ] README does not overpromise automatic ChatGPT configuration.
-* [ ] README positions MCP as optional sidecar.
+* [x] README update is concise.
+* [x] README does not overpromise automatic ChatGPT configuration.
+* [x] README positions MCP as optional sidecar.
 
 ---
 
@@ -1268,18 +1276,20 @@ Acceptance criteria:
 
 Tasks:
 
-* [ ] Ensure `.repo-harness/mcp.local.json` is ignored.
-* [ ] Ensure `.repo-harness/mcp.tokens.json` is ignored.
-* [ ] Ensure `.ai/harness/mcp/audit.log` is ignored.
-* [ ] Ensure generated guide does not contain secrets.
-* [ ] Ensure test fixtures do not contain fake realistic secrets unless redacted.
-* [ ] Review `git diff` for accidental local paths or tokens.
+* [x] Ensure `.repo-harness/mcp.local.json` is ignored.
+* [x] Ensure `.repo-harness/mcp.tokens.json` is ignored.
+* [x] Ensure `.repo-harness/mcp.oauth.json` is ignored.
+* [x] Ensure `.repo-harness/mcp.oauth-tokens.json` is ignored.
+* [x] Ensure `.ai/harness/mcp/audit.log` is ignored.
+* [x] Ensure generated guide does not contain secrets.
+* [x] Ensure test fixtures do not contain fake realistic secrets unless redacted.
+* [x] Review `git diff` for accidental local paths or tokens.
 
 Acceptance criteria:
 
-* [ ] `git status` contains only intended files.
-* [ ] No local machine secrets or private paths are committed.
-* [ ] No tunnel URL is committed unless it is clearly placeholder text.
+* [x] `git status` contains only intended files.
+* [x] No local machine secrets or private paths are committed.
+* [x] No tunnel URL is committed unless it is clearly placeholder text.
 
 ---
 
@@ -1306,10 +1316,10 @@ If commands differ, record actual commands in handoff.
 
 Acceptance criteria:
 
-* [ ] All available tests pass.
-* [ ] Typecheck passes.
-* [ ] Lint passes or known unrelated failures are documented.
-* [ ] Manual smoke test result is documented.
+* [x] All available tests pass.
+* [x] Typecheck passes.
+* [x] Lint passes or known unrelated failures are documented.
+* [x] Manual smoke test result is documented.
 
 ---
 
@@ -1317,22 +1327,23 @@ Acceptance criteria:
 
 Agents should follow this sequence unless blocked:
 
-1. [ ] Discovery and baseline.
-2. [ ] CLI scaffold.
-3. [ ] Policy and path security.
-4. [ ] MCP server core.
-5. [ ] STDIO transport.
-6. [ ] HTTP transport.
-7. [ ] Read-only tools.
-8. [ ] Writer tools.
-9. [ ] `mcp doctor`.
-10. [ ] ChatGPT setup and guide generation.
-11. [ ] Codex config setup.
-12. [ ] Codex Skill installation.
-13. [ ] Tests.
-14. [ ] Documentation.
-15. [ ] Manual E2E.
-16. [ ] Final cleanup and handoff.
+1. [x] Discovery and baseline.
+2. [x] CLI scaffold.
+3. [x] Policy and path security.
+4. [x] MCP server core.
+5. [x] STDIO transport.
+6. [x] HTTP transport.
+7. [x] Read-only tools.
+8. [x] Writer tools.
+9. [x] `mcp doctor`.
+10. [x] ChatGPT setup and guide generation.
+11. [x] Codex config setup.
+12. [x] Codex Skill installation.
+13. [x] Tests.
+14. [x] Documentation.
+15. [x] Manual E2E.
+16. [x] Final cleanup and handoff.
+17. [x] idea -> PRD -> checklist Sprint -> Goal chain.
 
 ---
 
@@ -1343,24 +1354,24 @@ Agents should follow this sequence unless blocked:
 ```yaml
 id: mcp-cli-scaffold
 priority: P0
-status: todo
+status: done
 owner: codex
 ```
 
 Checklist:
 
-* [ ] Create `src/cli/commands/mcp.ts`.
-* [ ] Add `buildMcpCommand()`.
-* [ ] Register command in CLI entrypoint.
-* [ ] Add subcommands with placeholder actions.
-* [ ] Verify help output.
-* [ ] Add basic smoke test if test framework exists.
+* [x] Create `src/cli/commands/mcp.ts`.
+* [x] Add `buildMcpCommand()`.
+* [x] Register command in CLI entrypoint.
+* [x] Add subcommands with placeholder actions.
+* [x] Verify help output.
+* [x] Add basic smoke test if test framework exists.
 
 Done when:
 
-* [ ] `repo-harness mcp --help` works.
-* [ ] `repo-harness mcp serve --help` works.
-* [ ] Existing commands still work.
+* [x] `repo-harness mcp --help` works.
+* [x] `repo-harness mcp serve --help` works.
+* [x] Existing commands still work.
 
 ---
 
@@ -1369,27 +1380,27 @@ Done when:
 ```yaml
 id: mcp-policy-engine
 priority: P0
-status: todo
+status: done
 owner: codex
 ```
 
 Checklist:
 
-* [ ] Implement profile types.
-* [ ] Implement planner profile.
-* [ ] Implement executor profile.
-* [ ] Implement denylist.
-* [ ] Implement allowlist matching.
-* [ ] Implement path normalization.
-* [ ] Implement repo-root confinement.
-* [ ] Implement symlink escape check.
-* [ ] Add tests.
+* [x] Implement profile types.
+* [x] Implement planner profile.
+* [x] Implement executor profile.
+* [x] Implement denylist.
+* [x] Implement allowlist matching.
+* [x] Implement path normalization.
+* [x] Implement repo-root confinement.
+* [x] Implement symlink escape check.
+* [x] Add tests.
 
 Done when:
 
-* [ ] Planner can read workflow files.
-* [ ] Planner cannot read secrets.
-* [ ] Planner cannot write source files.
+* [x] Planner can read workflow files.
+* [x] Planner cannot read secrets.
+* [x] Planner cannot write source files.
 
 ---
 
@@ -1398,26 +1409,26 @@ Done when:
 ```yaml
 id: mcp-server-core
 priority: P0
-status: todo
+status: done
 owner: codex
 ```
 
 Checklist:
 
-* [ ] Add server factory.
-* [ ] Add instructions.
-* [ ] Register placeholder tools.
-* [ ] Add STDIO transport.
-* [ ] Add HTTP transport.
-* [ ] Add `/health`.
-* [ ] Add structured errors.
+* [x] Add server factory.
+* [x] Add instructions.
+* [x] Register placeholder tools.
+* [x] Add STDIO transport.
+* [x] Add HTTP transport.
+* [x] Add `/health`.
+* [x] Add structured errors.
 
 Done when:
 
-* [ ] STDIO server starts.
-* [ ] HTTP server starts.
-* [ ] `/health` responds.
-* [ ] Tools are listed by MCP client.
+* [x] STDIO server starts.
+* [x] HTTP server starts.
+* [x] `/health` responds.
+* [x] Tools are listed by MCP client.
 
 ---
 
@@ -1426,25 +1437,25 @@ Done when:
 ```yaml
 id: mcp-read-tools
 priority: P0
-status: todo
+status: done
 owner: codex
 ```
 
 Checklist:
 
-* [ ] Implement `harness_status`.
-* [ ] Implement `harness_doctor`.
-* [ ] Implement `list_workflow_files`.
-* [ ] Implement `read_workflow_file`.
-* [ ] Implement `latest_handoff`.
-* [ ] Implement `latest_checks`.
-* [ ] Add tests.
+* [x] Implement `harness_status`.
+* [x] Implement `harness_doctor`.
+* [x] Implement `list_workflow_files`.
+* [x] Implement `read_workflow_file`.
+* [x] Implement `latest_handoff`.
+* [x] Implement `latest_checks`.
+* [x] Add tests.
 
 Done when:
 
-* [ ] ChatGPT can inspect workflow state.
-* [ ] Denied paths remain blocked.
-* [ ] Outputs are concise and redacted.
+* [x] ChatGPT can inspect workflow state.
+* [x] Denied paths remain blocked.
+* [x] Outputs are concise and redacted.
 
 ---
 
@@ -1453,28 +1464,28 @@ Done when:
 ```yaml
 id: mcp-planning-writers
 priority: P0
-status: todo
+status: done
 owner: codex
 ```
 
 Checklist:
 
-* [ ] Implement `write_prd`.
-* [ ] Implement `write_sprint`.
-* [ ] Implement `write_plan`.
-* [ ] Implement `write_codex_goal`.
-* [ ] Implement `append_handoff_note`.
-* [ ] Implement `run_workflow_check`.
-* [ ] Add validation.
-* [ ] Add audit logging.
-* [ ] Add tests.
+* [x] Implement `write_prd`.
+* [x] Implement `write_sprint`.
+* [x] Implement `write_plan`.
+* [x] Implement `write_codex_goal`.
+* [x] Implement `append_handoff_note`.
+* [x] Implement `run_workflow_check`.
+* [x] Add validation.
+* [x] Add audit logging.
+* [x] Add tests.
 
 Done when:
 
-* [ ] ChatGPT can write PRD.
-* [ ] ChatGPT can write Codex goal.
-* [ ] ChatGPT cannot write source files.
-* [ ] Workflow check can be run through fixed command only.
+* [x] ChatGPT can write PRD.
+* [x] ChatGPT can write Codex goal.
+* [x] ChatGPT cannot write source files.
+* [x] Workflow check can be run through fixed command only.
 
 ---
 
@@ -1483,26 +1494,26 @@ Done when:
 ```yaml
 id: mcp-chatgpt-setup
 priority: P1
-status: todo
+status: done
 owner: codex
 ```
 
 Checklist:
 
-* [ ] Implement `mcp setup chatgpt`.
-* [ ] Generate local config.
-* [ ] Update `.gitignore`.
-* [ ] Generate guide.
-* [ ] Print server start command.
-* [ ] Print tunnel command example.
-* [ ] Print ChatGPT Connector steps.
-* [ ] Add dry-run if practical.
+* [x] Implement `mcp setup chatgpt`.
+* [x] Generate local config.
+* [x] Update `.gitignore`.
+* [x] Generate guide.
+* [x] Print server start command.
+* [x] Print tunnel command example.
+* [x] Print ChatGPT Connector steps.
+* [x] Add dry-run if practical.
 
 Done when:
 
-* [ ] User can run one command and receive all local setup artifacts.
-* [ ] ChatGPT UI steps are documented.
-* [ ] No secrets are written to tracked files.
+* [x] User can run one command and receive all local setup artifacts.
+* [x] ChatGPT UI steps are documented.
+* [x] No secrets are written to tracked files.
 
 ---
 
@@ -1511,25 +1522,25 @@ Done when:
 ```yaml
 id: mcp-codex-setup
 priority: P1
-status: todo
+status: done
 owner: codex
 ```
 
 Checklist:
 
-* [ ] Implement `mcp setup codex`.
-* [ ] Create `.codex/config.toml` if missing.
-* [ ] Preserve existing config.
-* [ ] Add `repo_harness` MCP server.
-* [ ] Add backup.
-* [ ] Add dry-run.
-* [ ] Add doctor validation.
+* [x] Implement `mcp setup codex`.
+* [x] Create `.codex/config.toml` if missing.
+* [x] Preserve existing config.
+* [x] Add `repo_harness` MCP server.
+* [x] Add backup.
+* [x] Add dry-run.
+* [x] Add doctor validation.
 
 Done when:
 
-* [ ] Project-level Codex MCP config is generated safely.
-* [ ] Running setup twice is idempotent.
-* [ ] Existing user config is preserved.
+* [x] Project-level Codex MCP config is generated safely.
+* [x] Running setup twice is idempotent.
+* [x] Existing user config is preserved.
 
 ---
 
@@ -1538,26 +1549,26 @@ Done when:
 ```yaml
 id: mcp-codex-skill
 priority: P1
-status: todo
+status: done
 owner: codex
 ```
 
 Checklist:
 
-* [ ] Create Skill template.
-* [ ] Add `SKILL.md`.
-* [ ] Add manual setup reference.
-* [ ] Add workflow reference.
-* [ ] Add computer-use safety rules.
-* [ ] Implement `install-skill`.
-* [ ] Add dry-run.
-* [ ] Add overwrite protection.
+* [x] Create Skill template.
+* [x] Add `SKILL.md`.
+* [x] Add manual setup reference.
+* [x] Add workflow reference.
+* [x] Add computer-use safety rules.
+* [x] Implement `install-skill`.
+* [x] Add dry-run.
+* [x] Add overwrite protection.
 
 Done when:
 
-* [ ] Skill installs into `.agents/skills/repo-harness-chatgpt-bridge/`.
-* [ ] Skill tells Codex how to consume `codex-goal.md`.
-* [ ] Skill does not encourage unsafe browser automation.
+* [x] Skill installs into `.agents/skills/repo-harness-chatgpt-bridge/`.
+* [x] Skill tells Codex how to consume `codex-goal.md`.
+* [x] Skill does not encourage unsafe browser automation.
 
 ---
 
@@ -1566,25 +1577,25 @@ Done when:
 ```yaml
 id: mcp-doctor
 priority: P1
-status: todo
+status: done
 owner: codex
 ```
 
 Checklist:
 
-* [ ] Implement repo checks.
-* [ ] Implement MCP config checks.
-* [ ] Implement Codex config checks.
-* [ ] Implement Skill checks.
-* [ ] Implement guide checks.
-* [ ] Add `--json`.
-* [ ] Add actionable next steps.
+* [x] Implement repo checks.
+* [x] Implement MCP config checks.
+* [x] Implement Codex config checks.
+* [x] Implement Skill checks.
+* [x] Implement guide checks.
+* [x] Add `--json`.
+* [x] Add actionable next steps.
 
 Done when:
 
-* [ ] Doctor explains what is ready.
-* [ ] Doctor explains what is missing.
-* [ ] Doctor gives exact commands to fix missing setup.
+* [x] Doctor explains what is ready.
+* [x] Doctor explains what is missing.
+* [x] Doctor gives exact commands to fix missing setup.
 
 ---
 
@@ -1593,32 +1604,62 @@ Done when:
 ```yaml
 id: mcp-final-e2e
 priority: P0
-status: todo
+status: done
 owner: codex
 ```
 
 Checklist:
 
-* [ ] Create disposable test repo.
-* [ ] Adopt repo-harness.
-* [ ] Run ChatGPT setup.
-* [ ] Run Codex setup.
-* [ ] Install Skill.
-* [ ] Start HTTP MCP server.
-* [ ] Verify `/health`.
-* [ ] Connect through local MCP test client if available.
-* [ ] Manually connect ChatGPT if available.
-* [ ] Write sample PRD.
-* [ ] Write sample Codex goal.
-* [ ] Confirm Codex can read latest goal.
-* [ ] Run checks.
-* [ ] Update handoff.
+* [x] Create disposable test repo.
+* [x] Adopt repo-harness.
+* [x] Run ChatGPT setup.
+* [x] Run Codex setup.
+* [x] Install Skill.
+* [x] Start HTTP MCP server.
+* [x] Verify `/health`.
+* [x] Connect through local MCP test client if available.
+* [x] Manually connect ChatGPT if available.
+* [x] Write sample PRD.
+* [x] Write sample Codex goal.
+* [x] Confirm Codex can read latest goal.
+* [x] Run checks.
+* [x] Update handoff.
 
 Done when:
 
-* [ ] E2E result is documented in `.ai/harness/handoff/mcp-e2e-result.md`.
-* [ ] Known limitations are documented.
-* [ ] Sprint checklist is updated.
+* [x] E2E result is documented in `.ai/harness/handoff/mcp-e2e-result.md`.
+* [x] Known limitations are documented.
+* [x] Sprint checklist is updated.
+
+---
+
+## Task Card 11: Goal Chain Surface
+
+```yaml
+id: mcp-goal-chain
+priority: P0
+status: done
+owner: codex
+```
+
+Checklist:
+
+* [x] Implement `write_prd_from_idea` for idea -> PRD.
+* [x] Implement `write_checklist_sprint` for PRD -> checklist Sprint.
+* [x] Implement `prepare_codex_goal_from_sprint` for Sprint -> Goal.
+* [x] Implement `repo-harness mcp prepare-goal` as the local CLI equivalent.
+* [x] Ensure generated Sprint task cards include checklist items and staging gates.
+* [x] Ensure generated Goal includes the user's `阅读 / 开worktree完整执行 / 完成阶段性任务，要staging再继续 / 参考repo` shape.
+* [x] Keep direct Codex execution out of MCP; local Codex owns `/goal` execution.
+* [x] Add tests for the full chain and CLI handoff.
+* [x] Update guide and bridge Skill references.
+
+Done when:
+
+* [x] ChatGPT can move from idea to PRD to checklist Sprint to Codex Goal through MCP tools.
+* [x] A local user can run `repo-harness mcp prepare-goal --repo . --prd <prd> --sprint <sprint>` and receive a host-native `/goal` prompt.
+* [x] The stage-gate contract is explicit in generated Sprint and Goal artifacts.
+* [x] No default `codex exec` or remote runner is exposed.
 
 ---
 
@@ -1672,6 +1713,8 @@ Local ignored files:
 ```text
 .repo-harness/mcp.local.json
 .repo-harness/mcp.tokens.json
+.repo-harness/mcp.oauth.json
+.repo-harness/mcp.oauth-tokens.json
 .ai/harness/mcp/audit.log
 ```
 
@@ -1681,22 +1724,22 @@ Local ignored files:
 
 Before closing the sprint:
 
-* [ ] All P0 task cards are complete.
-* [ ] P1 task cards are complete or explicitly deferred.
-* [ ] Tests pass.
-* [ ] Typecheck passes.
-* [ ] Lint passes or unrelated failures are documented.
-* [ ] Manual E2E result is documented.
-* [ ] README/docs are updated.
-* [ ] Generated guide is safe to commit.
-* [ ] Codex Skill is safe to commit.
-* [ ] `.gitignore` covers local MCP config and audit logs.
-* [ ] No secret-like content appears in git diff.
-* [ ] No arbitrary shell MCP tool exists.
-* [ ] No default Codex runner exists.
-* [ ] ChatGPT planner can only write planning/handoff artifacts.
-* [ ] Codex executor remains responsible for implementation.
-* [ ] Handoff file summarizes completed work, checks, blockers, and next step.
+* [x] All P0 task cards are complete.
+* [x] P1 task cards are complete or explicitly deferred.
+* [x] Tests pass.
+* [x] Typecheck passes.
+* [x] Lint passes or unrelated failures are documented.
+* [x] Local MCP E2E result is documented.
+* [x] README/docs are updated.
+* [x] Generated guide is safe to commit.
+* [x] Codex Skill is safe to commit.
+* [x] `.gitignore` covers local MCP config and audit logs.
+* [x] No secret-like content appears in git diff.
+* [x] No arbitrary shell MCP tool exists.
+* [x] No default Codex runner exists.
+* [x] ChatGPT planner can only write planning/handoff artifacts.
+* [x] Codex executor remains responsible for implementation.
+* [x] Handoff files summarize completed work, checks, and the ChatGPT UI manual E2E result.
 
 ---
 
@@ -1713,19 +1756,19 @@ At the end of the sprint, write this to:
 
 ## Completed
 
-- TBD
+-
 
 ## Not completed
 
-- TBD
+-
 
 ## Tests run
 
-- TBD
+-
 
 ## Manual E2E result
 
-- TBD
+-
 
 ## Security review
 
@@ -1736,7 +1779,7 @@ At the end of the sprint, write this to:
 
 ## Known limitations
 
-- TBD
+-
 
 ## Follow-up sprint candidates
 
@@ -1750,5 +1793,5 @@ At the end of the sprint, write this to:
 
 ## Next recommended task
 
-- TBD
+-
 ```

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -1,0 +1,217 @@
+import { Command } from 'commander';
+import { isAbsolute, relative } from 'path';
+import { createMcpToolContext } from '../mcp/server';
+import { startMcpHttp } from '../mcp/transports/http';
+import { startMcpStdio } from '../mcp/transports/stdio';
+import { callMcpTool } from '../mcp/tools';
+import {
+  runMcpDoctor,
+  runMcpInstallSkill,
+  runMcpPrintGuide,
+  runMcpSetupChatgpt,
+  runMcpSetupCodex,
+} from '../mcp/setup';
+
+export interface McpServeOptions {
+  repo?: string;
+  transport: string;
+  host: string;
+  port: string;
+  profile: string;
+  auth?: string;
+}
+
+interface McpSetupChatgptOptions {
+  repo?: string;
+  host?: string;
+  port?: string;
+}
+
+interface McpSetupCodexOptions {
+  repo?: string;
+  scope?: string;
+  dryRun?: boolean;
+}
+
+interface McpInstallSkillOptions {
+  repo?: string;
+  overwrite?: boolean;
+  dryRun?: boolean;
+}
+
+interface McpPrepareGoalOptions {
+  repo?: string;
+  prd: string;
+  sprint: string;
+  referenceRepo?: string;
+  extraInstructions?: string;
+  overwrite?: boolean;
+}
+
+function parsePort(value: string): number {
+  const port = Number(value);
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+    throw new Error(`invalid --port "${value}"`);
+  }
+  return port;
+}
+
+async function runMcpAction(action: () => void | Promise<void>): Promise<void> {
+  try {
+    await action();
+  } catch (error) {
+    console.error(`repo-harness mcp: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(2);
+  }
+}
+
+async function prepareCodexGoalFromSprint(rawOpts: McpPrepareGoalOptions): Promise<string[]> {
+  const ctx = createMcpToolContext({ repo: rawOpts.repo ?? '.', profile: 'planner' });
+  const prdPath = toRepoRelativeInput(ctx.repoRoot, rawOpts.prd);
+  const sprintPath = toRepoRelativeInput(ctx.repoRoot, rawOpts.sprint);
+  const result = await callMcpTool(ctx, 'prepare_codex_goal_from_sprint', {
+    prd_path: prdPath,
+    sprint_path: sprintPath,
+    goal_prd_path: rawOpts.prd,
+    goal_sprint_path: rawOpts.sprint,
+    reference_repo: rawOpts.referenceRepo,
+    extra_instructions: rawOpts.extraInstructions,
+    overwrite: rawOpts.overwrite === true,
+  });
+  const payload = JSON.parse(result.content[0]?.text ?? '{}');
+  if (payload.error) {
+    throw new Error(`${payload.error.code}: ${payload.error.message}`);
+  }
+  return [
+    `[repo-harness mcp] Codex goal: ${payload.path}`,
+    '[repo-harness mcp] Host-native /goal prompt:',
+    '',
+    String(payload.prompt ?? '').trimEnd(),
+  ];
+}
+
+function toRepoRelativeInput(repoRoot: string, path: string): string {
+  if (!isAbsolute(path)) return path;
+  const relativePath = relative(repoRoot, path).split('\\').join('/');
+  if (relativePath === '' || relativePath.startsWith('../') || relativePath === '..') return path;
+  return relativePath;
+}
+
+export function buildMcpCommand(): Command {
+  const mcp = new Command('mcp').description('Run and configure the repo-harness MCP workflow sidecar');
+
+  mcp
+    .command('serve')
+    .description('Start the repo-harness MCP server')
+    .option('--repo <path>', 'Repository root to expose through workflow-scoped MCP tools', '.')
+    .option('--transport <transport>', 'Transport: stdio|http', 'stdio')
+    .option('--host <host>', 'HTTP bind host', '127.0.0.1')
+    .option('--port <port>', 'HTTP bind port', '8765')
+    .option('--profile <profile>', 'MCP profile: planner|executor|orchestrator', 'planner')
+    .option('--auth <mode>', 'HTTP auth mode: oauth|bearer', 'oauth')
+    .action(async (rawOpts: McpServeOptions) => {
+      await runMcpAction(async () => {
+        if (rawOpts.transport === 'stdio') {
+          await startMcpStdio({ repo: rawOpts.repo, profile: rawOpts.profile });
+          return;
+        }
+        if (rawOpts.transport === 'http') {
+          await startMcpHttp({
+            repo: rawOpts.repo,
+            profile: rawOpts.profile,
+            host: rawOpts.host,
+            port: parsePort(rawOpts.port),
+            auth: rawOpts.auth,
+          });
+          return;
+        }
+        throw new Error(`serve: invalid --transport "${rawOpts.transport}" (expected: stdio, http)`);
+      });
+    });
+
+  mcp
+    .command('doctor')
+    .description('Check repo-harness MCP setup status')
+    .option('--repo <path>', 'Repository root to inspect', '.')
+    .option('--json', 'Output JSON instead of human-readable text')
+    .action((rawOpts: { repo?: string; json?: boolean }) => {
+      void runMcpAction(() => {
+        const result = runMcpDoctor(rawOpts);
+        console.log(result.lines.join('\n'));
+      });
+    });
+
+  const setup = new Command('setup').description('Generate MCP setup files for ChatGPT or Codex');
+
+  setup
+    .command('chatgpt')
+    .description('Generate ChatGPT Connector local config and manual setup guide')
+    .option('--repo <path>', 'Repository root to configure', '.')
+    .option('--host <host>', 'Local MCP HTTP bind host', '127.0.0.1')
+    .option('--port <port>', 'Local MCP HTTP bind port', '8765')
+    .action((rawOpts: McpSetupChatgptOptions) => {
+      void runMcpAction(() => {
+        const result = runMcpSetupChatgpt(rawOpts);
+        console.log(result.lines.join('\n'));
+      });
+    });
+
+  setup
+    .command('codex')
+    .description('Patch Codex MCP config for repo-harness')
+    .option('--repo <path>', 'Repository root to configure', '.')
+    .option('--scope <scope>', 'Config scope: project|user', 'project')
+    .option('--dry-run', 'Print planned changes without writing files')
+    .action((rawOpts: McpSetupCodexOptions) => {
+      void runMcpAction(() => {
+        const result = runMcpSetupCodex(rawOpts);
+        console.log(result.lines.join('\n'));
+      });
+    });
+
+  mcp.addCommand(setup);
+
+  mcp
+    .command('install-skill')
+    .description('Install the repo-harness ChatGPT bridge Codex Skill')
+    .option('--repo <path>', 'Repository root to configure', '.')
+    .option('--overwrite', 'Replace an existing repo-local bridge Skill')
+    .option('--dry-run', 'Print planned installation without writing files')
+    .action((rawOpts: McpInstallSkillOptions) => {
+      void runMcpAction(() => {
+        const result = runMcpInstallSkill(rawOpts);
+        console.log(result.lines.join('\n'));
+      });
+    });
+
+  mcp
+    .command('prepare-goal')
+    .description('Prepare .ai/harness/handoff/codex-goal.md and print a host-native /goal prompt from a PRD and checklist Sprint')
+    .option('--repo <path>', 'Repository root to configure', '.')
+    .requiredOption('--prd <path>', 'PRD path to read')
+    .requiredOption('--sprint <path>', 'Checklist Sprint path to execute')
+    .option('--reference-repo <path>', 'Read-only reference repo path to include in the Goal')
+    .option('--extra-instructions <text>', 'Additional bounded execution instruction for Codex')
+    .option('--overwrite', 'Replace an existing Codex goal handoff')
+    .action((rawOpts: McpPrepareGoalOptions) => {
+      void runMcpAction(async () => {
+        const lines = await prepareCodexGoalFromSprint(rawOpts);
+        console.log(lines.join('\n'));
+      });
+    });
+
+  mcp
+    .command('print-chatgpt-guide')
+    .description('Print the ChatGPT Connector setup guide')
+    .option('--repo <path>', 'Repository root to inspect', '.')
+    .option('--endpoint <url>', 'Public HTTPS /mcp endpoint to include in the guide')
+    .option('--write', 'Write docs/repo-harness-chatgpt-mcp-setup.md')
+    .action((rawOpts: { repo?: string; endpoint?: string; write?: boolean }) => {
+      void runMcpAction(() => {
+        const result = runMcpPrintGuide(rawOpts);
+        console.log(result.lines.join('\n'));
+      });
+    });
+
+  return mcp;
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -18,6 +18,7 @@ import { buildToolsCommand } from './commands/tools';
 import { buildBrainCommand } from './commands/brain';
 import { buildCapabilityContextCommand } from './commands/capability-context';
 import { buildDocsCommand } from './commands/docs';
+import { buildMcpCommand } from './commands/mcp';
 import { buildRunCommand } from './commands/run';
 import { formatSecurityScan, runSecurityScan } from './commands/security';
 import { runGlobalRuntimeSetup } from './commands/global-runtime';
@@ -47,6 +48,7 @@ export const SUBCOMMANDS = [
   'brain',
   'capability-context',
   'docs',
+  'mcp',
 ] as const;
 export type Subcommand = (typeof SUBCOMMANDS)[number];
 
@@ -513,6 +515,7 @@ export function buildProgram(): Command {
   program.addCommand(buildBrainCommand());
   program.addCommand(buildCapabilityContextCommand());
   program.addCommand(buildDocsCommand());
+  program.addCommand(buildMcpCommand());
   program.addCommand(buildRunCommand());
   program
     .command('prompt-guard-decide', { hidden: true })

--- a/src/cli/mcp/audit.ts
+++ b/src/cli/mcp/audit.ts
@@ -1,0 +1,32 @@
+import { createHash } from 'crypto';
+import { appendFileSync, mkdirSync } from 'fs';
+import { dirname, join } from 'path';
+import { redactMcpText } from './redaction';
+import type { McpAuditEntry } from './types';
+
+export function hashMcpInput(value: unknown): string {
+  return createHash('sha256').update(JSON.stringify(value)).digest('hex');
+}
+
+export function mcpAuditLogPath(repoRoot: string): string {
+  return join(repoRoot, '.ai', 'harness', 'mcp', 'audit.log');
+}
+
+export function writeMcpAuditEntry(repoRoot: string, entry: McpAuditEntry): void {
+  const logPath = mcpAuditLogPath(repoRoot);
+  mkdirSync(dirname(logPath), { recursive: true });
+  const safeEntry = {
+    ...entry,
+    error: entry.error ? redactMcpText(entry.error).text : undefined,
+  };
+  appendFileSync(logPath, `${JSON.stringify(safeEntry)}\n`, 'utf-8');
+}
+
+export function tryWriteMcpAuditEntry(repoRoot: string, entry: McpAuditEntry): boolean {
+  try {
+    writeMcpAuditEntry(repoRoot, entry);
+    return true;
+  } catch (_error) {
+    return false;
+  }
+}

--- a/src/cli/mcp/auth.ts
+++ b/src/cli/mcp/auth.ts
@@ -1,0 +1,101 @@
+import { randomBytes } from 'crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
+
+export interface McpLocalConfig {
+  version?: number;
+  repo?: string;
+  server?: {
+    host?: string;
+    port?: number;
+    transport?: string;
+  };
+  auth?: {
+    mode?: string;
+    tokenFile?: string;
+    oauthFile?: string;
+  };
+  profile?: string;
+}
+
+export type McpHttpAuthMode = 'oauth' | 'bearer';
+
+export function mcpLocalConfigPath(repoRoot: string): string {
+  return join(repoRoot, '.repo-harness', 'mcp.local.json');
+}
+
+export function mcpTokenPath(repoRoot: string): string {
+  return join(repoRoot, '.repo-harness', 'mcp.tokens.json');
+}
+
+export function mcpOAuthPath(repoRoot: string): string {
+  return join(repoRoot, '.repo-harness', 'mcp.oauth.json');
+}
+
+export function mcpOAuthTokenStorePath(repoRoot: string): string {
+  return join(repoRoot, '.repo-harness', 'mcp.oauth-tokens.json');
+}
+
+export function loadMcpLocalConfig(repoRoot: string): McpLocalConfig | null {
+  const path = mcpLocalConfigPath(repoRoot);
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8')) as McpLocalConfig;
+  } catch (_error) {
+    return null;
+  }
+}
+
+export function readMcpBearerToken(repoRoot: string): string | null {
+  if (process.env.REPO_HARNESS_MCP_TOKEN?.trim()) return process.env.REPO_HARNESS_MCP_TOKEN.trim();
+  const path = mcpTokenPath(repoRoot);
+  if (!existsSync(path)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf-8')) as { bearerToken?: unknown };
+    return typeof parsed.bearerToken === 'string' && parsed.bearerToken.trim().length > 0 ? parsed.bearerToken.trim() : null;
+  } catch (_error) {
+    return null;
+  }
+}
+
+export function ensureMcpBearerToken(repoRoot: string): { token: string; path: string; changed: boolean } {
+  const path = mcpTokenPath(repoRoot);
+  const existing = readMcpBearerToken(repoRoot);
+  if (existing) return { token: existing, path, changed: false };
+
+  const token = randomBytes(32).toString('base64url');
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify({ version: 1, bearerToken: token }, null, 2)}\n`, { encoding: 'utf-8', mode: 0o600 });
+  return { token, path, changed: true };
+}
+
+export function parseMcpHttpAuthMode(value: string | undefined): McpHttpAuthMode {
+  const mode = (value ?? 'oauth').trim().toLowerCase();
+  if (mode === 'oauth' || mode === 'bearer') return mode;
+  throw new Error(`invalid --auth "${value}" (expected: oauth, bearer)`);
+}
+
+export function readMcpOAuthPassphrase(repoRoot: string): string | null {
+  if (process.env.REPO_HARNESS_MCP_OAUTH_PASSPHRASE?.trim()) {
+    return process.env.REPO_HARNESS_MCP_OAUTH_PASSPHRASE.trim();
+  }
+  const path = mcpOAuthPath(repoRoot);
+  if (!existsSync(path)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf-8')) as { passphrase?: unknown };
+    return typeof parsed.passphrase === 'string' && parsed.passphrase.trim().length > 0 ? parsed.passphrase.trim() : null;
+  } catch (_error) {
+    return null;
+  }
+}
+
+export function ensureMcpOAuthPassphrase(repoRoot: string): { passphrase: string; path: string; changed: boolean } {
+  const path = mcpOAuthPath(repoRoot);
+  const existing = readMcpOAuthPassphrase(repoRoot);
+  if (existing) return { passphrase: existing, path, changed: false };
+
+  const passphrase = randomBytes(24).toString('base64url');
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify({ version: 1, passphrase }, null, 2)}\n`, { encoding: 'utf-8', mode: 0o600 });
+  return { passphrase, path, changed: true };
+}

--- a/src/cli/mcp/instructions.ts
+++ b/src/cli/mcp/instructions.ts
@@ -1,0 +1,8 @@
+export const MCP_SERVER_INSTRUCTIONS = [
+  'repo-harness exposes repo-local workflow artifacts, not general filesystem access.',
+  'Use it to read product intent, plans, contracts, checks, reviews, and handoff.',
+  'For ChatGPT, act as planner/reviewer: move ideas through PRDs, checklist Sprints with staging gates, and Codex goal prompts.',
+  'Do not edit application source through this server. Codex is the executor.',
+  'Do not run Codex remotely through MCP; prepare .ai/harness/handoff/codex-goal.md for the local Codex host instead.',
+  'Before writing a plan, inspect docs/spec.md, tasks/current.md, latest handoff, and existing plans.',
+].join(' ');

--- a/src/cli/mcp/oauth.ts
+++ b/src/cli/mcp/oauth.ts
@@ -1,0 +1,214 @@
+import { randomUUID } from 'crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, chmodSync } from 'fs';
+import { dirname } from 'path';
+import type { OAuthRegisteredClientsStore } from '@modelcontextprotocol/sdk/server/auth/clients.js';
+import { InvalidGrantError, InvalidTokenError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
+import type { AuthorizationParams, OAuthServerProvider } from '@modelcontextprotocol/sdk/server/auth/provider.js';
+import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
+import type {
+  OAuthClientInformationFull,
+  OAuthTokenRevocationRequest,
+  OAuthTokens,
+} from '@modelcontextprotocol/sdk/shared/auth.js';
+
+interface TokenData {
+  accessTokens?: Record<string, AuthInfo>;
+  refreshTokens?: Record<string, string>;
+  clients?: Record<string, OAuthClientInformationFull>;
+}
+
+function nowSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+function issueToken(): string {
+  return randomUUID();
+}
+
+export class McpOAuthTokenStore implements OAuthRegisteredClientsStore {
+  private accessTokens = new Map<string, AuthInfo>();
+  private refreshTokens = new Map<string, string>();
+  private clients = new Map<string, OAuthClientInformationFull>();
+
+  constructor(private readonly path: string) {}
+
+  load(): void {
+    if (!existsSync(this.path)) return;
+    try {
+      const data = JSON.parse(readFileSync(this.path, 'utf-8')) as TokenData;
+      const refreshTargets = new Set(Object.values(data.refreshTokens ?? {}));
+      for (const [token, info] of Object.entries(data.accessTokens ?? {})) {
+        if (!info.expiresAt || info.expiresAt > nowSeconds() || refreshTargets.has(token)) {
+          this.accessTokens.set(token, info);
+        }
+      }
+      for (const [token, accessToken] of Object.entries(data.refreshTokens ?? {})) {
+        this.refreshTokens.set(token, accessToken);
+      }
+      for (const [clientId, client] of Object.entries(data.clients ?? {})) {
+        this.clients.set(clientId, client);
+      }
+    } catch (_error) {
+      // Corrupt local auth state should not prevent starting the server.
+    }
+  }
+
+  flush(): void {
+    mkdirSync(dirname(this.path), { recursive: true, mode: 0o700 });
+    chmodSync(dirname(this.path), 0o700);
+    const data: TokenData = {
+      accessTokens: Object.fromEntries(this.accessTokens),
+      refreshTokens: Object.fromEntries(this.refreshTokens),
+      clients: Object.fromEntries(this.clients),
+    };
+    writeFileSync(this.path, `${JSON.stringify(data, null, 2)}\n`, { encoding: 'utf-8', mode: 0o600 });
+    chmodSync(this.path, 0o600);
+  }
+
+  getClient(clientId: string): OAuthClientInformationFull | undefined {
+    return this.clients.get(clientId);
+  }
+
+  registerClient(client: Omit<OAuthClientInformationFull, 'client_id' | 'client_id_issued_at'>): OAuthClientInformationFull {
+    const candidate = client as Partial<OAuthClientInformationFull>;
+    const full: OAuthClientInformationFull = {
+      ...client,
+      client_id: candidate.client_id ?? randomUUID(),
+      client_id_issued_at: candidate.client_id_issued_at ?? nowSeconds(),
+    };
+    this.clients.set(full.client_id, full);
+    this.flush();
+    return full;
+  }
+
+  getAccessToken(token: string): AuthInfo | undefined {
+    return this.accessTokens.get(token);
+  }
+
+  setAccessToken(token: string, info: AuthInfo): void {
+    this.accessTokens.set(token, info);
+    this.flush();
+  }
+
+  deleteAccessToken(token: string): void {
+    this.accessTokens.delete(token);
+    this.flush();
+  }
+
+  getRefreshToken(token: string): string | undefined {
+    return this.refreshTokens.get(token);
+  }
+
+  setRefreshToken(token: string, accessToken: string): void {
+    this.refreshTokens.set(token, accessToken);
+    this.flush();
+  }
+
+  deleteRefreshToken(token: string): void {
+    this.refreshTokens.delete(token);
+    this.flush();
+  }
+
+  findRefreshTokenByAccessToken(accessToken: string): string | undefined {
+    for (const [refreshToken, storedAccessToken] of this.refreshTokens) {
+      if (storedAccessToken === accessToken) return refreshToken;
+    }
+    return undefined;
+  }
+}
+
+export function createMcpOAuthProvider(store: McpOAuthTokenStore): OAuthServerProvider {
+  const authCodes = new Map<string, { challenge: string; clientId: string }>();
+
+  return {
+    get clientsStore(): OAuthRegisteredClientsStore {
+      return store;
+    },
+
+    async authorize(client: OAuthClientInformationFull, params: AuthorizationParams, res): Promise<void> {
+      const code = issueToken();
+      authCodes.set(code, {
+        challenge: params.codeChallenge,
+        clientId: client.client_id,
+      });
+      const redirectUrl = new URL(params.redirectUri);
+      redirectUrl.searchParams.set('code', code);
+      if (params.state) redirectUrl.searchParams.set('state', params.state);
+      res.redirect(302, redirectUrl.toString());
+    },
+
+    async challengeForAuthorizationCode(_client: OAuthClientInformationFull, authorizationCode: string): Promise<string> {
+      const stored = authCodes.get(authorizationCode);
+      if (!stored) throw new InvalidGrantError('Invalid authorization code');
+      return stored.challenge;
+    },
+
+    async exchangeAuthorizationCode(
+      client: OAuthClientInformationFull,
+      authorizationCode: string,
+      _codeVerifier?: string,
+    ): Promise<OAuthTokens> {
+      const stored = authCodes.get(authorizationCode);
+      if (!stored || stored.clientId !== client.client_id) {
+        throw new InvalidGrantError('Invalid authorization code');
+      }
+      authCodes.delete(authorizationCode);
+      const accessToken = issueToken();
+      const refreshToken = issueToken();
+      const expiresIn = 30 * 24 * 60 * 60;
+      const expiresAt = nowSeconds() + expiresIn;
+      store.setAccessToken(accessToken, {
+        token: accessToken,
+        clientId: client.client_id,
+        scopes: ['repo-harness'],
+        expiresAt,
+      });
+      store.setRefreshToken(refreshToken, accessToken);
+      return {
+        access_token: accessToken,
+        token_type: 'Bearer',
+        expires_in: expiresIn,
+        refresh_token: refreshToken,
+        scope: 'repo-harness',
+      };
+    },
+
+    async exchangeRefreshToken(client: OAuthClientInformationFull, refreshToken: string): Promise<OAuthTokens> {
+      const accessToken = store.getRefreshToken(refreshToken);
+      const existing = accessToken ? store.getAccessToken(accessToken) : undefined;
+      if (!accessToken || !existing || existing.clientId !== client.client_id) {
+        throw new InvalidGrantError('Invalid refresh token');
+      }
+      store.deleteRefreshToken(refreshToken);
+      const nextRefreshToken = issueToken();
+      const expiresIn = 30 * 24 * 60 * 60;
+      store.setAccessToken(accessToken, { ...existing, expiresAt: nowSeconds() + expiresIn });
+      store.setRefreshToken(nextRefreshToken, accessToken);
+      return {
+        access_token: accessToken,
+        token_type: 'Bearer',
+        expires_in: expiresIn,
+        refresh_token: nextRefreshToken,
+        scope: existing.scopes.join(' '),
+      };
+    },
+
+    async verifyAccessToken(token: string): Promise<AuthInfo> {
+      const info = store.getAccessToken(token);
+      if (!info) throw new InvalidTokenError('Token not found');
+      if (info.expiresAt && info.expiresAt < nowSeconds()) {
+        if (!store.findRefreshTokenByAccessToken(token)) {
+          store.deleteAccessToken(token);
+        }
+        throw new InvalidTokenError('Token has expired');
+      }
+      return info;
+    },
+
+    async revokeToken(_client: OAuthClientInformationFull, request: OAuthTokenRevocationRequest): Promise<void> {
+      store.deleteAccessToken(request.token);
+      const refreshToken = store.findRefreshTokenByAccessToken(request.token);
+      if (refreshToken) store.deleteRefreshToken(refreshToken);
+    },
+  };
+}

--- a/src/cli/mcp/paths.ts
+++ b/src/cli/mcp/paths.ts
@@ -1,0 +1,102 @@
+import { existsSync, lstatSync, realpathSync } from 'fs';
+import { dirname, isAbsolute, resolve, sep } from 'path';
+import type { McpPathDecision, McpPathIntent, McpPolicy } from './types';
+
+function toPosixPath(value: string): string {
+  return value.split(sep).join('/').replace(/\\+/g, '/');
+}
+
+export function normalizeMcpRelativePath(input: string): McpPathDecision {
+  const trimmed = input.trim();
+  if (trimmed.length === 0) return { ok: false, reason: 'path is required' };
+  if (isAbsolute(trimmed)) return { ok: false, reason: 'absolute paths are not allowed' };
+  const normalized = toPosixPath(trimmed).replace(/^\.\/+/, '');
+  if (normalized === '' || normalized === '.') return { ok: false, reason: 'path must target a file' };
+  if (normalized.split('/').some((part) => part === '..')) {
+    return { ok: false, reason: 'path traversal is not allowed' };
+  }
+  return { ok: true, relativePath: normalized };
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+}
+
+export function globMatches(pattern: string, relativePath: string): boolean {
+  if (pattern === '**') return true;
+  let expression = '';
+  for (let index = 0; index < pattern.length; index += 1) {
+    const char = pattern[index];
+    const next = pattern[index + 1];
+    if (char === '*' && next === '*') {
+      expression += '.*';
+      index += 1;
+    } else if (char === '*') {
+      expression += '[^/]*';
+    } else {
+      expression += escapeRegex(char);
+    }
+  }
+  return new RegExp(`^${expression}$`).test(relativePath);
+}
+
+function anyGlobMatches(patterns: string[], relativePath: string): boolean {
+  return patterns.some((pattern) => globMatches(pattern, relativePath));
+}
+
+function denyGlobMatches(pattern: string, relativePath: string): boolean {
+  if (globMatches(pattern, relativePath)) return true;
+  if (!pattern.includes('/')) {
+    return relativePath.split('/').some((segment) => globMatches(pattern, segment));
+  }
+  if (!pattern.startsWith('**/')) {
+    return globMatches(`**/${pattern}`, relativePath);
+  }
+  return false;
+}
+
+function anyDenyGlobMatches(patterns: string[], relativePath: string): boolean {
+  return patterns.some((pattern) => denyGlobMatches(pattern, relativePath));
+}
+
+function realpathInside(child: string, parent: string): boolean {
+  const normalizedParent = parent.endsWith(sep) ? parent : `${parent}${sep}`;
+  return child === parent || child.startsWith(normalizedParent);
+}
+
+export function resolveMcpPath(repoRoot: string, inputPath: string, policy: McpPolicy, intent: McpPathIntent): McpPathDecision {
+  const normalized = normalizeMcpRelativePath(inputPath);
+  if (!normalized.ok || !normalized.relativePath) return normalized;
+
+  const relativePath = normalized.relativePath;
+  if (anyDenyGlobMatches(policy.denyGlobs, relativePath)) {
+    return { ok: false, relativePath, reason: `path is denied by MCP policy: ${relativePath}` };
+  }
+
+  const allowGlobs = intent === 'read' ? policy.readGlobs : policy.writeGlobs;
+  if (!anyGlobMatches(allowGlobs, relativePath)) {
+    return { ok: false, relativePath, reason: `path is not allowed for ${intent}: ${relativePath}` };
+  }
+
+  const repoRealpath = realpathSync(repoRoot);
+  const absolutePath = resolve(repoRealpath, relativePath);
+  const existingPath = existsSync(absolutePath) ? absolutePath : dirname(absolutePath);
+  if (!existsSync(existingPath)) {
+    if (intent === 'read') return { ok: false, relativePath, reason: `path does not exist: ${relativePath}` };
+    return { ok: true, relativePath, absolutePath };
+  }
+
+  const realExistingPath = realpathSync(existingPath);
+  if (!realpathInside(realExistingPath, repoRealpath)) {
+    return { ok: false, relativePath, reason: `path escapes repository root: ${relativePath}` };
+  }
+
+  if (existsSync(absolutePath) && lstatSync(absolutePath).isSymbolicLink()) {
+    const realTarget = realpathSync(absolutePath);
+    if (!realpathInside(realTarget, repoRealpath)) {
+      return { ok: false, relativePath, reason: `symlink escapes repository root: ${relativePath}` };
+    }
+  }
+
+  return { ok: true, relativePath, absolutePath };
+}

--- a/src/cli/mcp/policy.ts
+++ b/src/cli/mcp/policy.ts
@@ -1,0 +1,107 @@
+import type { McpPolicy, McpProfileName } from './types';
+
+const COMMON_DENY_GLOBS = [
+  '.env',
+  '.env.*',
+  '*.pem',
+  '*.key',
+  '*.p12',
+  '*.pfx',
+  '.ssh/**',
+  '.git/**',
+  'node_modules/**',
+  'dist/**',
+  'build/**',
+  'coverage/**',
+  'secrets/**',
+  'credentials/**',
+  'private/**',
+  '.cache/**',
+  '.DS_Store',
+];
+
+export const PLANNER_READ_GLOBS = [
+  'AGENTS.md',
+  'CLAUDE.md',
+  'SKILL.md',
+  'docs/spec.md',
+  'docs/reference-configs/**',
+  'plans/**',
+  'tasks/current.md',
+  'tasks/contracts/**',
+  'tasks/reviews/**',
+  'tasks/notes/**',
+  '.ai/context/**',
+  '.ai/harness/handoff/**',
+  '.ai/harness/checks/**',
+];
+
+export const PLANNER_WRITE_GLOBS = [
+  'plans/prds/**',
+  'plans/sprints/**',
+  'plans/plan-*.md',
+  '.ai/harness/handoff/codex-goal.md',
+  '.ai/harness/handoff/chatgpt-plan.md',
+];
+
+export function getMcpPolicy(profile: McpProfileName): McpPolicy {
+  if (profile === 'planner') {
+    return {
+      profile,
+      readGlobs: PLANNER_READ_GLOBS,
+      writeGlobs: PLANNER_WRITE_GLOBS,
+      denyGlobs: [
+        ...COMMON_DENY_GLOBS,
+        'src/**',
+        'app/**',
+        'packages/**',
+        'package.json',
+        'bun.lock',
+        'package-lock.json',
+        'pnpm-lock.yaml',
+        'yarn.lock',
+        '.github/workflows/**',
+      ],
+      maxFileBytes: 512 * 1024,
+      execution: {
+        fixedWorkflowCheck: true,
+        codexRunner: false,
+      },
+    };
+  }
+
+  if (profile === 'executor') {
+    return {
+      profile,
+      readGlobs: ['plans/**', 'tasks/**', 'docs/spec.md', '.ai/context/**', '.ai/harness/**'],
+      writeGlobs: ['tasks/reviews/**', '.ai/harness/checks/**', '.ai/harness/handoff/**'],
+      denyGlobs: COMMON_DENY_GLOBS,
+      maxFileBytes: 512 * 1024,
+      execution: {
+        fixedWorkflowCheck: true,
+        codexRunner: false,
+      },
+    };
+  }
+
+  if (profile === 'orchestrator') {
+    return {
+      profile,
+      readGlobs: [],
+      writeGlobs: [],
+      denyGlobs: ['**'],
+      maxFileBytes: 0,
+      execution: {
+        fixedWorkflowCheck: false,
+        codexRunner: false,
+      },
+    };
+  }
+
+  throw new Error(`unknown MCP profile: ${String(profile)}`);
+}
+
+export function parseMcpProfile(value: string): McpProfileName {
+  if (value === 'planner' || value === 'executor' || value === 'orchestrator') return value;
+  throw new Error(`invalid MCP profile "${value}" (expected: planner, executor, orchestrator)`);
+}

--- a/src/cli/mcp/redaction.ts
+++ b/src/cli/mcp/redaction.ts
@@ -1,0 +1,53 @@
+export interface McpRedaction {
+  type: string;
+  count: number;
+}
+
+export interface McpRedactionResult {
+  text: string;
+  redactions: McpRedaction[];
+}
+
+interface RedactionPattern {
+  type: string;
+  pattern: RegExp;
+  replacement: string;
+}
+
+const REDACTION_PATTERNS: RedactionPattern[] = [
+  { type: 'bearer_token', pattern: /Authorization:\s*Bearer\s+\S+/gi, replacement: 'Authorization: Bearer [REDACTED]' },
+  { type: 'openai_key', pattern: /sk-[A-Za-z0-9]{20,}/g, replacement: 'sk-[REDACTED]' },
+  { type: 'github_pat', pattern: /ghp_[A-Za-z0-9]{20,}/g, replacement: 'ghp_[REDACTED]' },
+  { type: 'github_pat_v2', pattern: /github_pat_[A-Za-z0-9_]{30,}/g, replacement: 'github_pat_[REDACTED]' },
+  { type: 'aws_key', pattern: /AKIA[0-9A-Z]{16}/g, replacement: 'AKIA[REDACTED]' },
+  {
+    type: 'secret_assignment',
+    pattern: /(^|[^\w])([A-Z0-9_]*(?:API_KEY|SECRET|TOKEN|PASSWORD|PASSWD|CREDENTIALS)[A-Z0-9_]*)\s*([:=])\s*\S+/gi,
+    replacement: '$1$2$3[REDACTED]',
+  },
+  {
+    type: 'database_url',
+    pattern: /(^|[^\w])((?:DATABASE_URL|POSTGRES_URL|MONGODB_URI|REDIS_URL))\s*([:=])\s*\S+/gi,
+    replacement: '$1$2$3[REDACTED]',
+  },
+  { type: 'jwt_token', pattern: /eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}/g, replacement: '[JWT REDACTED]' },
+  {
+    type: 'private_key',
+    pattern: /-----BEGIN\s+(?:RSA\s+|OPENSSH\s+)?PRIVATE\s+KEY-----[\s\S]*?-----END\s+(?:RSA\s+|OPENSSH\s+)?PRIVATE\s+KEY-----/g,
+    replacement: '[PRIVATE KEY REDACTED]',
+  },
+];
+
+export function redactMcpText(input: string): McpRedactionResult {
+  const redactions: McpRedaction[] = [];
+  let text = input;
+
+  for (const entry of REDACTION_PATTERNS) {
+    const matches = text.match(entry.pattern);
+    if (!matches) continue;
+    redactions.push({ type: entry.type, count: matches.length });
+    text = text.replace(entry.pattern, entry.replacement);
+  }
+
+  return { text, redactions };
+}

--- a/src/cli/mcp/repo.ts
+++ b/src/cli/mcp/repo.ts
@@ -1,0 +1,24 @@
+import { existsSync } from 'fs';
+import { join, resolve } from 'path';
+import { runProcess } from '../../effects/process-runner';
+
+export function resolveMcpRepoRoot(repo = '.'): string {
+  const candidate = resolve(repo);
+  const result = runProcess('git', ['-C', candidate, 'rev-parse', '--show-toplevel'], {
+    timeoutMs: 5000,
+    stdio: 'pipe',
+  });
+  return result.status === 0 && result.stdout.trim() ? result.stdout.trim() : candidate;
+}
+
+export function isRepoHarnessAdopted(repoRoot: string): boolean {
+  return existsSync(join(repoRoot, '.ai', 'harness', 'policy.json')) || existsSync(join(repoRoot, 'tasks', 'current.md'));
+}
+
+export function currentGitBranch(repoRoot: string): string | null {
+  const result = runProcess('git', ['-C', repoRoot, 'branch', '--show-current'], {
+    timeoutMs: 5000,
+    stdio: 'pipe',
+  });
+  return result.status === 0 && result.stdout.trim() ? result.stdout.trim() : null;
+}

--- a/src/cli/mcp/server.ts
+++ b/src/cli/mcp/server.ts
@@ -1,0 +1,42 @@
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { MCP_SERVER_INSTRUCTIONS } from './instructions';
+import { getMcpPolicy, parseMcpProfile } from './policy';
+import { resolveMcpRepoRoot } from './repo';
+import { buildMcpToolDefinitions, callMcpTool, type McpToolContext } from './tools';
+
+export interface McpServerOptions {
+  repo?: string;
+  profile?: string;
+}
+
+export function createMcpToolContext(opts: McpServerOptions): McpToolContext {
+  const profile = parseMcpProfile(opts.profile ?? 'planner');
+  return {
+    repoRoot: resolveMcpRepoRoot(opts.repo ?? '.'),
+    policy: getMcpPolicy(profile),
+  };
+}
+
+export function createRepoHarnessMcpServer(opts: McpServerOptions): Server {
+  const ctx = createMcpToolContext(opts);
+  const server = new Server(
+    { name: 'repo-harness-mcp', version: '0.1.0' },
+    {
+      capabilities: { tools: {} },
+      instructions: MCP_SERVER_INSTRUCTIONS,
+    },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: buildMcpToolDefinitions(ctx.policy),
+  }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const name = request.params.name;
+    const args = (request.params.arguments ?? {}) as Record<string, unknown>;
+    return callMcpTool(ctx, name, args);
+  });
+
+  return server;
+}

--- a/src/cli/mcp/setup.ts
+++ b/src/cli/mcp/setup.ts
@@ -1,0 +1,443 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { dirname, join, relative } from 'path';
+import { ensureMcpBearerToken, ensureMcpOAuthPassphrase, loadMcpLocalConfig, mcpOAuthPath, mcpTokenPath } from './auth';
+import { resolveMcpRepoRoot } from './repo';
+
+export interface McpSetupResult {
+  status: 'ok';
+  repoRoot: string;
+  changed: string[];
+  lines: string[];
+}
+
+const REQUIRED_CODEX_TOOLS = [
+  'harness_status',
+  'read_workflow_file',
+  'latest_handoff',
+  'latest_checks',
+  'prepare_codex_goal_from_sprint',
+  'write_codex_goal',
+  'run_workflow_check',
+];
+
+function writeFileIfChanged(path: string, content: string, changed: string[]): void {
+  if (existsSync(path) && readFileSync(path, 'utf-8') === content) return;
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content, 'utf-8');
+  changed.push(path);
+}
+
+function ensureGitignoreEntries(repoRoot: string, entries: string[], changed: string[]): void {
+  const path = join(repoRoot, '.gitignore');
+  const current = existsSync(path) ? readFileSync(path, 'utf-8') : '';
+  const lines = current.split(/\r?\n/);
+  let next = current.trimEnd();
+  for (const entry of entries) {
+    if (lines.includes(entry)) continue;
+    next += `${next.length > 0 ? '\n' : ''}${entry}`;
+  }
+  next += '\n';
+  writeFileIfChanged(path, next, changed);
+}
+
+export function chatgptGuideMarkdown(endpoint = '<https-tunnel-url>/mcp'): string {
+  return `# repo-harness ChatGPT MCP Connector Setup
+
+## Prerequisites
+
+- A repo-harness adopted repository.
+- A local \`repo-harness\` CLI on PATH.
+- ChatGPT workspace access to Developer Mode and custom MCP Connectors.
+- A public HTTPS tunnel for ChatGPT Web. Local Codex can use stdio without a tunnel.
+
+## Start Local MCP Server
+
+\`\`\`bash
+repo-harness mcp serve --repo . --transport http --host 127.0.0.1 --port 8765 --profile planner
+\`\`\`
+
+Health check:
+
+\`\`\`bash
+curl http://127.0.0.1:8765/health
+\`\`\`
+
+The ChatGPT path uses OAuth with a local passphrase. The passphrase is stored in an ignored local file:
+
+\`\`\`bash
+jq -r .passphrase .repo-harness/mcp.oauth.json
+\`\`\`
+
+Do not commit or paste this passphrase into issue trackers, PRs, or shared logs.
+
+OAuth discovery smoke:
+
+\`\`\`bash
+curl http://127.0.0.1:8765/.well-known/oauth-protected-resource/mcp
+\`\`\`
+
+## Start Tunnel
+
+\`\`\`bash
+cloudflared tunnel --url http://127.0.0.1:8765
+\`\`\`
+
+Use this Connector URL:
+
+\`\`\`text
+${endpoint}
+\`\`\`
+
+## Create ChatGPT Connector
+
+1. Open ChatGPT Settings.
+2. Enable Developer Mode if your workspace exposes it.
+3. Go to Connectors.
+4. Create a Connector named \`repo-harness\`.
+5. Paste the HTTPS Connector URL ending in \`/mcp\`.
+6. Configure Connector authentication as OAuth.
+7. Click Scan Tools.
+8. When the authorization page opens, enter the passphrase from \`.repo-harness/mcp.oauth.json\`.
+9. Wait for the tool scan to finish, then create the Connector.
+10. Keep write confirmations enabled.
+
+## Test Prompt
+
+\`\`\`text
+Use repo-harness to inspect this repo. Call harness_status, latest_handoff, and list_workflow_files. Do not write files.
+\`\`\`
+
+## PRD Prompt
+
+\`\`\`text
+Use repo-harness to inspect docs/spec.md, tasks/current.md, latest handoff, and existing plans. Convert this idea into a PRD with write_prd_from_idea. Do not edit source code.
+\`\`\`
+
+## Checklist Sprint Prompt
+
+\`\`\`text
+Use repo-harness to read the PRD. Convert it into an ordered checklist Sprint with write_checklist_sprint. Every task card must include a stage gate that requires Codex to stage the completed phase before continuing.
+\`\`\`
+
+## Codex Goal Prompt
+
+\`\`\`text
+Use repo-harness prepare_codex_goal_from_sprint with the PRD path and checklist Sprint path. Return the host-native /goal prompt. Do not run Codex remotely.
+\`\`\`
+
+Equivalent local CLI:
+
+\`\`\`bash
+repo-harness mcp prepare-goal --repo . --prd plans/prds/<feature>.prd.md --sprint plans/sprints/<feature>.sprint.md --reference-repo <optional-readonly-reference>
+\`\`\`
+
+## Codex Executor Prompt
+
+\`\`\`text
+Use repo-harness-chatgpt-bridge. Execute the latest ChatGPT-generated Codex goal from .ai/harness/handoff/codex-goal.md.
+\`\`\`
+
+## Troubleshooting
+
+- If ChatGPT cannot connect, verify the tunnel URL is HTTPS and ends in \`/mcp\`.
+- If ChatGPT returns unauthorized, verify OAuth discovery works and re-run the authorization passphrase flow.
+- If tools are missing, restart \`repo-harness mcp serve\` and rescan tools.
+- If writes fail, verify the target path is a PRD, sprint, plan, or approved handoff file.
+- If ChatGPT generated prose instead of checklist Sprint task cards, ask it to use write_checklist_sprint.
+- If Codex cannot see the server, run \`repo-harness mcp setup codex --repo . --scope project\`.
+
+## Security Notes
+
+- This MCP server exposes workflow artifacts, not general filesystem access.
+- The \`/mcp\` endpoint requires OAuth-issued Bearer tokens by default. Do not expose it through a tunnel without Connector auth configured.
+- \`repo-harness mcp serve --auth bearer\` is available for non-ChatGPT clients that can send a static bearer token.
+- Planner profile cannot write application source files, package manifests, lockfiles, CI config, secrets, or files outside the repo root.
+- MCP does not expose a default Codex runner. It prepares \`.ai/harness/handoff/codex-goal.md\`; the local Codex host owns \`/goal\` execution.
+- Do not put tunnel tokens, OAuth tokens, passphrases, or ChatGPT/Codex credentials in git.
+`;
+}
+
+export function runMcpSetupChatgpt(opts: { repo?: string; host?: string; port?: string; endpoint?: string }): McpSetupResult {
+  const repoRoot = resolveMcpRepoRoot(opts.repo ?? '.');
+  const changed: string[] = [];
+  const host = opts.host ?? '127.0.0.1';
+  const port = opts.port ?? '8765';
+  const configPath = join(repoRoot, '.repo-harness', 'mcp.local.json');
+  const guidePath = join(repoRoot, 'docs', 'repo-harness-chatgpt-mcp-setup.md');
+  const token = ensureMcpBearerToken(repoRoot);
+  const oauth = ensureMcpOAuthPassphrase(repoRoot);
+  if (token.changed) changed.push(token.path);
+  if (oauth.changed) changed.push(oauth.path);
+  const config = {
+    version: 1,
+    repo: repoRoot,
+    server: { host, port: Number(port), transport: 'http' },
+    auth: { mode: 'oauth', oauthFile: '.repo-harness/mcp.oauth.json', tokenFile: '.repo-harness/mcp.tokens.json' },
+    profile: 'planner',
+  };
+  writeFileIfChanged(configPath, `${JSON.stringify(config, null, 2)}\n`, changed);
+  writeFileIfChanged(guidePath, chatgptGuideMarkdown(opts.endpoint), changed);
+  ensureGitignoreEntries(repoRoot, [
+    '.repo-harness/mcp.local.json',
+    '.repo-harness/mcp.tokens.json',
+    '.repo-harness/mcp.oauth.json',
+    '.repo-harness/mcp.oauth-tokens.json',
+    '.ai/harness/mcp/audit.log',
+  ], changed);
+
+  return {
+    status: 'ok',
+    repoRoot,
+    changed,
+    lines: [
+      `[repo-harness mcp] Repo: ${repoRoot}`,
+      '[repo-harness mcp] Profile: planner',
+      `[repo-harness mcp] Local endpoint: http://${host}:${port}/mcp`,
+      '[repo-harness mcp] ChatGPT endpoint: requires HTTPS tunnel',
+      `[repo-harness mcp] Auth: OAuth passphrase (${relative(repoRoot, oauth.path)})`,
+      `[repo-harness mcp] Bearer fallback token: ${relative(repoRoot, token.path)}`,
+      `[repo-harness mcp] Config: ${relative(repoRoot, configPath)}`,
+      `[repo-harness mcp] Guide: ${relative(repoRoot, guidePath)}`,
+      `Next: repo-harness mcp serve --repo . --transport http --host ${host} --port ${port} --profile planner`,
+    ],
+  };
+}
+
+const CODEX_MCP_BLOCK = `[mcp_servers.repo_harness]
+command = "repo-harness"
+args = [
+  "mcp",
+  "serve",
+  "--repo",
+  ".",
+  "--transport",
+  "stdio",
+  "--profile",
+  "executor"
+]
+enabled_tools = [
+  "harness_status",
+  "read_workflow_file",
+  "latest_handoff",
+  "latest_checks",
+  "prepare_codex_goal_from_sprint",
+  "write_codex_goal",
+  "run_workflow_check"
+]
+default_tools_approval_mode = "prompt"
+`;
+
+export function patchCodexConfigToml(current: string): string {
+  const normalized = current.trimEnd();
+  const blockPattern = /\n?\[mcp_servers\.repo_harness\][\s\S]*?(?=\n\[|$)/;
+  const prefix = normalized.length > 0 ? `${normalized}\n\n` : '';
+  if (!blockPattern.test(normalized)) return `${prefix}${CODEX_MCP_BLOCK}`;
+  return `${normalized.replace(blockPattern, `\n${CODEX_MCP_BLOCK}`.trimEnd())}\n`;
+}
+
+export function runMcpSetupCodex(opts: { repo?: string; scope?: string; dryRun?: boolean }): McpSetupResult {
+  if ((opts.scope ?? 'project') !== 'project') {
+    throw new Error('repo-harness mcp setup codex currently supports --scope project only');
+  }
+  const repoRoot = resolveMcpRepoRoot(opts.repo ?? '.');
+  const configPath = join(repoRoot, '.codex', 'config.toml');
+  const changed: string[] = [];
+  const current = existsSync(configPath) ? readFileSync(configPath, 'utf-8') : '';
+  const next = patchCodexConfigToml(current);
+  if (opts.dryRun === true) {
+    return {
+      status: 'ok',
+      repoRoot,
+      changed: [],
+      lines: [`[repo-harness mcp] Dry run: would patch ${relative(repoRoot, configPath)}`, next],
+    };
+  }
+  if (existsSync(configPath) && current !== next) {
+    const backupPath = `${configPath}.bak`;
+    writeFileIfChanged(backupPath, current, changed);
+  }
+  writeFileIfChanged(configPath, next, changed);
+  return {
+    status: 'ok',
+    repoRoot,
+    changed,
+    lines: [
+      `[repo-harness mcp] Codex config: ${relative(repoRoot, configPath)}`,
+      '[repo-harness mcp] Server: repo_harness',
+      '[repo-harness mcp] Transport: stdio',
+    ],
+  };
+}
+
+const SKILL_MD = `---
+name: repo-harness-chatgpt-bridge
+description: Use when setting up or operating the repo-harness ChatGPT MCP Connector, bridging ChatGPT planning artifacts into Codex execution through repo-harness PRDs, sprints, checks, and handoffs.
+---
+
+# repo-harness-chatgpt-bridge
+
+You are operating inside a repo-harness adopted repository.
+
+Responsibilities:
+
+1. Treat ChatGPT as planner/reviewer and Codex as executor.
+2. Do not store or print secrets, OAuth passphrases, tunnel tokens, or ~/.codex/auth.json.
+3. Prefer repo-harness CLI commands over manual file edits.
+4. Keep ChatGPT write access limited to PRD, sprint, plan, and handoff artifacts.
+5. Before execution, read docs/spec.md, tasks/current.md, .ai/harness/handoff/resume.md, and .ai/harness/handoff/codex-goal.md when present.
+6. If setting up ChatGPT Connector, run repo-harness mcp doctor, then repo-harness mcp setup chatgpt --repo ., and do not log into ChatGPT unless explicitly asked for assisted setup.
+7. If assisted browser setup is requested, never type passwords, 2FA codes, OAuth passphrases, or admin approvals without user instruction.
+8. For planning, preserve the chain: idea -> PRD -> checklist Sprint -> Codex Goal.
+9. Checklist Sprints must use task cards with stage gates; Codex should stage each completed phase before continuing.
+10. MCP may prepare .ai/harness/handoff/codex-goal.md, but it must not run Codex remotely or expose a default codex exec runner.
+11. If executing the latest ChatGPT plan, read .ai/harness/handoff/codex-goal.md, run repo-harness workflow checks, execute only the scoped task, and update review evidence plus handoff.
+`;
+
+export function runMcpInstallSkill(opts: { repo?: string; overwrite?: boolean; dryRun?: boolean }): McpSetupResult {
+  const repoRoot = resolveMcpRepoRoot(opts.repo ?? '.');
+  const changed: string[] = [];
+  const skillRoot = join(repoRoot, '.agents', 'skills', 'repo-harness-chatgpt-bridge');
+  const skillPath = join(skillRoot, 'SKILL.md');
+  if (existsSync(skillPath) && opts.overwrite !== true) {
+    return {
+      status: 'ok',
+      repoRoot,
+      changed,
+      lines: [`[repo-harness mcp] Skill already exists: ${relative(repoRoot, skillPath)}`, '[repo-harness mcp] Use --overwrite to replace it.'],
+    };
+  }
+  if (opts.dryRun === true) {
+    return {
+      status: 'ok',
+      repoRoot,
+      changed,
+      lines: [`[repo-harness mcp] Dry run: would install ${relative(repoRoot, skillRoot)}`],
+    };
+  }
+  writeFileIfChanged(join(skillRoot, 'SKILL.md'), SKILL_MD, changed);
+  writeFileIfChanged(join(skillRoot, 'references', 'workflow.md'), `# Workflow
+
+ChatGPT plans through MCP; Codex executes through repo-harness checks and handoff.
+
+## Planning Chain
+
+Use this chain for execution-ready planning:
+
+1. idea -> PRD: call \`write_prd_from_idea\`.
+2. PRD -> checklist Sprint: call \`write_checklist_sprint\`.
+3. Sprint -> Goal: call \`prepare_codex_goal_from_sprint\` or run \`repo-harness mcp prepare-goal\`.
+
+The MCP server prepares artifacts only. The local Codex host owns \`/goal\` execution.
+
+## Sprint Format
+
+When ChatGPT writes a sprint for Codex execution, use checklist task cards rather than prose-only plans.
+
+Each execution phase should include:
+
+- \`[ ]\` checklist items for concrete implementation steps.
+- Acceptance criteria for the phase.
+- Verification commands or evidence expected before the phase is considered done.
+- A staging gate that tells Codex to stage the completed phase before continuing.
+
+Preferred task card shape:
+
+\`\`\`markdown
+## Task Card N: <phase name>
+
+status: pending
+
+Tasks:
+
+- [ ] <step>
+- [ ] <step>
+
+Acceptance criteria:
+
+- [ ] <observable outcome>
+
+Verification:
+
+- [ ] \`<command or evidence surface>\`
+
+Stage gate:
+
+- [ ] Stage all files for this completed phase before starting the next task card.
+\`\`\`
+
+Codex should update checklist status as work completes and stop at staging gates long enough to verify \`git status --short\` shows the intended staged files.
+`, changed);
+  writeFileIfChanged(join(skillRoot, 'references', 'chatgpt-connector-manual.md'), chatgptGuideMarkdown(), changed);
+  return {
+    status: 'ok',
+    repoRoot,
+    changed,
+    lines: [`[repo-harness mcp] Skill installed: ${relative(repoRoot, skillRoot)}`],
+  };
+}
+
+export function runMcpPrintGuide(opts: { repo?: string; endpoint?: string; write?: boolean }): McpSetupResult {
+  const repoRoot = resolveMcpRepoRoot(opts.repo ?? '.');
+  const changed: string[] = [];
+  const content = chatgptGuideMarkdown(opts.endpoint);
+  if (opts.write === true) {
+    writeFileIfChanged(join(repoRoot, 'docs', 'repo-harness-chatgpt-mcp-setup.md'), content, changed);
+  }
+  return {
+    status: 'ok',
+    repoRoot,
+    changed,
+    lines: [content.trimEnd()],
+  };
+}
+
+export function runMcpDoctor(opts: { repo?: string; json?: boolean }): McpSetupResult {
+  const repoRoot = resolveMcpRepoRoot(opts.repo ?? '.');
+  const localConfig = loadMcpLocalConfig(repoRoot);
+  const host = localConfig?.server?.host ?? '127.0.0.1';
+  const port = localConfig?.server?.port ?? 8765;
+  const authMode = localConfig?.auth?.mode ?? 'missing';
+  const codexConfigPath = join(repoRoot, '.codex', 'config.toml');
+  const codexConfig = existsSync(codexConfigPath) ? readFileSync(codexConfigPath, 'utf-8') : '';
+  const codexHasServer = codexConfig.includes('[mcp_servers.repo_harness]');
+  const missingTools = REQUIRED_CODEX_TOOLS.filter((tool) => !codexConfig.includes(`"${tool}"`));
+  const codexCommand = Bun.which('codex');
+  const report = {
+    status: existsSync(join(repoRoot, '.ai', 'harness', 'policy.json')) ? 'ready_local' : 'not_adopted',
+    repo: repoRoot,
+    mcp: {
+      localConfig: existsSync(join(repoRoot, '.repo-harness', 'mcp.local.json')),
+      guide: existsSync(join(repoRoot, 'docs', 'repo-harness-chatgpt-mcp-setup.md')),
+      authConfigured: (authMode === 'oauth' && existsSync(mcpOAuthPath(repoRoot))) ||
+        (authMode === 'bearer' && existsSync(mcpTokenPath(repoRoot))),
+    },
+    codex: {
+      cliAvailable: codexCommand !== null,
+      configured: codexHasServer && missingTools.length === 0,
+      configPath: '.codex/config.toml',
+      hasServer: codexHasServer,
+      missingTools,
+      fix: 'repo-harness mcp setup codex --repo . --scope project',
+    },
+    chatgpt: {
+      localEndpoint: `http://${host}:${port}/mcp`,
+      authMode,
+      manualStepsRequired: true,
+      setup: 'repo-harness mcp setup chatgpt --repo .',
+    },
+  };
+  return {
+    status: 'ok',
+    repoRoot,
+    changed: [],
+    lines: opts.json === true ? [JSON.stringify(report, null, 2)] : [
+      `[repo-harness mcp] Repo: ${repoRoot}`,
+      `[repo-harness mcp] Status: ${report.status}`,
+      `[repo-harness mcp] ChatGPT guide: ${report.mcp.guide ? 'present' : 'missing'}`,
+      `[repo-harness mcp] ChatGPT auth: ${report.mcp.authConfigured ? `${authMode} present` : 'missing'}`,
+      `[repo-harness mcp] Codex config: ${report.codex.configured ? 'present' : 'missing'}`,
+      `[repo-harness mcp] Codex CLI: ${report.codex.cliAvailable ? 'present' : 'missing'}`,
+      `[repo-harness mcp] Next ChatGPT setup: ${report.chatgpt.setup}`,
+    ],
+  };
+}

--- a/src/cli/mcp/tools.ts
+++ b/src/cli/mcp/tools.ts
@@ -1,0 +1,722 @@
+import { createHash } from 'crypto';
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync, appendFileSync } from 'fs';
+import { basename, dirname, join } from 'path';
+import { runHelper } from '../runtime/helper-runner';
+import { hashMcpInput, tryWriteMcpAuditEntry } from './audit';
+import { resolveMcpPath } from './paths';
+import { currentGitBranch, isRepoHarnessAdopted } from './repo';
+import { redactMcpText } from './redaction';
+import type { McpPolicy } from './types';
+
+export interface McpToolContext {
+  repoRoot: string;
+  policy: McpPolicy;
+}
+
+export interface McpToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  annotations?: Record<string, unknown>;
+}
+
+interface CallToolResult {
+  content: Array<{ type: 'text'; text: string }>;
+  isError?: boolean;
+}
+
+const EMPTY_SCHEMA = { type: 'object', additionalProperties: false };
+
+function textResult(value: unknown): CallToolResult {
+  return {
+    content: [{ type: 'text', text: typeof value === 'string' ? value : JSON.stringify(value, null, 2) }],
+  };
+}
+
+function errorResult(code: string, message: string, details?: unknown): CallToolResult {
+  return textResult({ error: { code, message: redactMcpText(message).text, details } });
+}
+
+function audit(ctx: McpToolContext, tool: string, status: 'ok' | 'blocked' | 'failed', input: unknown, targetPath?: string, error?: string): void {
+  tryWriteMcpAuditEntry(ctx.repoRoot, {
+    timestamp: new Date().toISOString(),
+    tool,
+    status,
+    targetPath,
+    inputHash: hashMcpInput(input),
+    error,
+  });
+}
+
+function isProbablyBinary(bytes: Buffer): boolean {
+  return bytes.subarray(0, Math.min(bytes.length, 8000)).includes(0);
+}
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function fileSummary(path: string, repoRoot: string): { path: string; size: number; modifiedAt: string } | null {
+  try {
+    const fileStat = statSync(join(repoRoot, path));
+    if (!fileStat.isFile()) return null;
+    return { path, size: fileStat.size, modifiedAt: fileStat.mtime.toISOString() };
+  } catch (_error) {
+    return null;
+  }
+}
+
+function listFilesUnder(repoRoot: string, root: string, maxFiles: number, out: string[]): void {
+  if (out.length >= maxFiles) return;
+  const absoluteRoot = join(repoRoot, root);
+  if (!existsSync(absoluteRoot)) return;
+  const rootStat = statSync(absoluteRoot);
+  if (rootStat.isFile()) {
+    out.push(root);
+    return;
+  }
+  if (!rootStat.isDirectory()) return;
+  for (const entry of readdirSync(absoluteRoot, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+    if (out.length >= maxFiles) return;
+    const child = `${root}/${entry.name}`;
+    if (entry.isDirectory()) {
+      listFilesUnder(repoRoot, child, maxFiles, out);
+    } else if (entry.isFile() || entry.isSymbolicLink()) {
+      out.push(child);
+    }
+  }
+}
+
+function workflowFileCandidates(repoRoot: string): string[] {
+  const roots = [
+    'AGENTS.md',
+    'CLAUDE.md',
+    'SKILL.md',
+    'docs/spec.md',
+    'docs/reference-configs',
+    'plans',
+    'tasks',
+    '.ai/context',
+    '.ai/harness/handoff',
+    '.ai/harness/checks',
+  ];
+  const files: string[] = [];
+  for (const root of roots) {
+    const rootFiles: string[] = [];
+    listFilesUnder(repoRoot, root, 700, rootFiles);
+    files.push(...rootFiles);
+  }
+  return Array.from(new Set(files)).sort();
+}
+
+function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80) || 'artifact';
+}
+
+function timestampPrefix(date = new Date()): string {
+  const yyyy = String(date.getFullYear());
+  const mm = String(date.getMonth() + 1).padStart(2, '0');
+  const dd = String(date.getDate()).padStart(2, '0');
+  const hh = String(date.getHours()).padStart(2, '0');
+  const min = String(date.getMinutes()).padStart(2, '0');
+  return `${yyyy}${mm}${dd}-${hh}${min}`;
+}
+
+function prdArtifactPath(slug: string): string {
+  const normalized = slugify(slug);
+  const prefixed = /^\d{8}-\d{4}-/.test(normalized) ? normalized : `${timestampPrefix()}-${normalized}`;
+  return `plans/prds/${prefixed}.prd.md`;
+}
+
+function sprintArtifactPath(slug: string): string {
+  const normalized = slugify(slug);
+  const prefixed = /^\d{8}-\d{4}-/.test(normalized) ? normalized : `${timestampPrefix()}-${normalized}`;
+  return `plans/sprints/${prefixed}.sprint.md`;
+}
+
+function frontmatter(title: string, kind: string): string {
+  return [
+    '---',
+    `title: ${JSON.stringify(title)}`,
+    `kind: ${JSON.stringify(kind)}`,
+    `created_at: ${JSON.stringify(new Date().toISOString())}`,
+    `source: "repo-harness-mcp"`,
+    '---',
+    '',
+  ].join('\n');
+}
+
+function bodyWithFrontmatter(title: string, kind: string, body: string): string {
+  return body.trimStart().startsWith('---') ? body.trimEnd() + '\n' : `${frontmatter(title, kind)}${body.trimEnd()}\n`;
+}
+
+function writeMarkdownArtifact(
+  ctx: McpToolContext,
+  tool: string,
+  relativePath: string,
+  title: string,
+  kind: string,
+  body: string,
+  overwrite: boolean,
+  input: unknown,
+  extra?: Record<string, unknown>,
+): CallToolResult {
+  const decision = resolveMcpPath(ctx.repoRoot, relativePath, ctx.policy, 'write');
+  if (!decision.ok || !decision.absolutePath) {
+    audit(ctx, tool, 'blocked', input, relativePath, decision.reason);
+    return errorResult('POLICY_DENIED', decision.reason ?? 'path denied', { path: relativePath });
+  }
+  if (existsSync(decision.absolutePath) && !overwrite) {
+    audit(ctx, tool, 'blocked', input, relativePath, 'target exists and overwrite was not requested');
+    return errorResult('WOULD_OVERWRITE', `target already exists: ${relativePath}`);
+  }
+  mkdirSync(dirname(decision.absolutePath), { recursive: true });
+  writeFileSync(decision.absolutePath, bodyWithFrontmatter(title, kind, body), 'utf-8');
+  audit(ctx, tool, 'ok', input, relativePath);
+  return textResult({ status: 'written', path: relativePath, ...(extra ?? {}) });
+}
+
+function validateGoal(body: string): string[] {
+  return [
+    '# Codex Goal',
+    '## Source of truth',
+    '## Role',
+    '## Scope',
+    '## Required workflow',
+    '## Required checks',
+    '## Done when',
+  ].filter((section) => !body.includes(section));
+}
+
+function stringList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((entry) => String(entry).trim()).filter((entry) => entry.length > 0);
+}
+
+function taskObjects(value: unknown): Array<Record<string, unknown>> {
+  if (!Array.isArray(value)) return [];
+  return value.filter((entry): entry is Record<string, unknown> => typeof entry === 'object' && entry !== null && !Array.isArray(entry));
+}
+
+function renderPrdFromIdeaBody(args: Record<string, unknown>): string {
+  const title = String(args.title ?? 'Untitled PRD').trim() || 'Untitled PRD';
+  const idea = String(args.idea ?? '').trim();
+  const problem = String(args.problem ?? '').trim() || 'TBD: clarify the concrete user or workflow pain.';
+  const users = stringList(args.users);
+  const goals = stringList(args.goals);
+  const nonGoals = stringList(args.non_goals);
+  const success = stringList(args.success_criteria);
+  const notes = String(args.notes ?? '').trim();
+  return [
+    `# ${title}`,
+    '',
+    '> **Status**: Draft',
+    '',
+    '## Idea',
+    '',
+    idea || 'TBD: summarize the originating idea.',
+    '',
+    '## Problem',
+    '',
+    problem,
+    '',
+    '## Users',
+    '',
+    ...(users.length > 0 ? users.map((entry) => `- ${entry}`) : ['- TBD']),
+    '',
+    '## Goals',
+    '',
+    ...(goals.length > 0 ? goals.map((entry) => `- ${entry}`) : ['- Turn the idea into a reviewable repo-harness PRD.']),
+    '',
+    '## Non-goals',
+    '',
+    ...(nonGoals.length > 0 ? nonGoals.map((entry) => `- ${entry}`) : ['- Directly executing implementation work from ChatGPT.']),
+    '',
+    '## Acceptance Criteria',
+    '',
+    ...(success.length > 0 ? success.map((entry) => `- [ ] ${entry}`) : ['- [ ] The PRD can be converted into a checklist Sprint with staged verification gates.']),
+    '',
+    '## Workflow Contract',
+    '',
+    '- PRD is the source of product intent.',
+    '- Sprint must be generated as ordered checklist task cards.',
+    '- Codex execution must happen through a host-native `/goal` prompt or local Codex session, not through remote MCP execution.',
+    '',
+    '## Handoff Notes',
+    '',
+    notes || '- Generated from an idea through repo-harness MCP.',
+  ].join('\n');
+}
+
+function renderChecklistSprintBody(args: Record<string, unknown>): string {
+  const title = String(args.title ?? 'Checklist Sprint').trim() || 'Checklist Sprint';
+  const prdPath = String(args.prd_path ?? '').trim();
+  const tasks = taskObjects(args.tasks);
+  const taskBlocks = tasks.length > 0 ? tasks.map((task, index) => {
+    const taskTitle = String(task.title ?? `Task ${index + 1}`).trim() || `Task ${index + 1}`;
+    const objective = String(task.objective ?? '').trim() || 'Complete the scoped implementation slice.';
+    const files = stringList(task.files);
+    const checks = stringList(task.checks);
+    const stageGate = String(task.stage_gate ?? '').trim() || 'Update this checklist, run relevant checks, and stage the completed slice before continuing.';
+    return [
+      `### Task Card ${index + 1}: ${taskTitle}`,
+      '',
+      `- [ ] Objective: ${objective}`,
+      `- [ ] Files/entrypoints: ${files.length > 0 ? files.map((entry) => `\`${entry}\``).join(', ') : 'TBD during execution'}`,
+      `- [ ] Verification: ${checks.length > 0 ? checks.map((entry) => `\`${entry}\``).join(', ') : 'Focused check for this slice'}`,
+      `- [ ] Stage gate: ${stageGate}`,
+    ].join('\n');
+  }) : [
+    [
+      '### Task Card 1: Plan the first implementation slice',
+      '',
+      '- [ ] Objective: Derive the first concrete implementation slice from the PRD.',
+      '- [ ] Files/entrypoints: TBD during execution',
+      '- [ ] Verification: Focused check for this slice',
+      '- [ ] Stage gate: Update this checklist, run relevant checks, and stage the completed slice before continuing.',
+    ].join('\n'),
+  ];
+
+  return [
+    `# ${title}`,
+    '',
+    '> **Status**: Draft',
+    '',
+    '## Source',
+    '',
+    `- PRD: \`${prdPath || 'TBD'}\``,
+    '',
+    '## Execution Rule',
+    '',
+    '- Execute task cards in order.',
+    '- Keep each task card reviewable as one staged slice.',
+    '- After every completed phase, update the checklist and stage the result before continuing.',
+    '- Do not treat unstaged work as a completed phase.',
+    '',
+    '## Checklist',
+    '',
+    ...taskBlocks.flatMap((block) => [block, '']),
+    '## Final Acceptance',
+    '',
+    '- [ ] All task cards are checked.',
+    '- [ ] Required checks pass.',
+    '- [ ] Handoff explains staged state, residual risks, and next bottleneck if any.',
+  ].join('\n').trimEnd() + '\n';
+}
+
+function renderCodexGoalFromSprint(args: Record<string, unknown>): { body: string; prompt: string } {
+  const prdPath = String(args.prd_path ?? '').trim();
+  const sprintPath = String(args.sprint_path ?? '').trim();
+  const goalPrdPath = String(args.goal_prd_path ?? prdPath).trim() || prdPath;
+  const goalSprintPath = String(args.goal_sprint_path ?? sprintPath).trim() || sprintPath;
+  const referenceRepo = String(args.reference_repo ?? '').trim();
+  const extraInstructions = String(args.extra_instructions ?? '').trim();
+  const prompt = [
+    '/goal',
+    `阅读： ${goalPrdPath}`,
+    `开worktree完整执行：${goalSprintPath}`,
+    '完成阶段性任务，要staging再继续',
+    referenceRepo ? `参考repo: ${referenceRepo}` : '',
+  ].filter(Boolean).join('\n');
+  const body = [
+    '# Codex Goal',
+    '',
+    '## Source of truth',
+    '',
+    `- PRD: \`${goalPrdPath}\``,
+    `- Checklist Sprint: \`${goalSprintPath}\``,
+    ...(referenceRepo ? [`- Reference repo: \`${referenceRepo}\` (read-only comparison source)`] : []),
+    '',
+    '## Role',
+    '',
+    'Codex is the executor. ChatGPT/repo-harness may prepare planning artifacts, but implementation ownership stays in the local Codex session.',
+    '',
+    '## Scope',
+    '',
+    '- Open or use an isolated worktree for the sprint implementation.',
+    '- Execute the checklist Sprint task cards in order.',
+    '- Update the Sprint checklist as phases complete.',
+    '- Stage each completed phase before continuing to the next phase.',
+    '- Do not modify the reference repo or ignored secrets/ops state.',
+    '',
+    '## Required workflow',
+    '',
+    '1. Read the PRD and Sprint paths above before editing.',
+    '2. Build the P1/P2/P3 map required by repo-local AGENTS.md for non-trivial changes.',
+    '3. Execute one checklist task card at a time.',
+    '4. After each phase, run the relevant focused checks, update the checklist, and stage the completed slice.',
+    '5. Continue until the Sprint checklist is complete or a real blocker is reached.',
+    '6. Leave a concise handoff with staged state and verification evidence.',
+    ...(extraInstructions ? ['', extraInstructions] : []),
+    '',
+    '## Required checks',
+    '',
+    '- Run the checks named by the Sprint task card.',
+    '- At sprint closeout, run repo-required checks unless the Sprint narrows the verification surface with a stated reason.',
+    '',
+    '## Done when',
+    '',
+    '- The checklist Sprint is complete.',
+    '- Every completed phase is staged.',
+    '- Checks pass or failures are documented with exact blocker evidence.',
+    '- No commit is created unless the user explicitly asks for commit.',
+    '',
+    '## Host-native /goal prompt',
+    '',
+    '```text',
+    prompt,
+    '```',
+  ].join('\n');
+  return { body, prompt };
+}
+
+export function buildMcpToolDefinitions(policy: McpPolicy): McpToolDefinition[] {
+  const readOnly = { readOnlyHint: true, openWorldHint: false };
+  const write = { readOnlyHint: false, openWorldHint: false, destructiveHint: false };
+  const stringPathSchema = {
+    type: 'object',
+    properties: { path: { type: 'string' } },
+    required: ['path'],
+    additionalProperties: false,
+  };
+  const markdownWriterSchema = {
+    type: 'object',
+    properties: {
+      title: { type: 'string' },
+      slug: { type: 'string' },
+      body: { type: 'string' },
+      overwrite: { type: 'boolean' },
+    },
+    required: ['title', 'slug', 'body'],
+    additionalProperties: false,
+  };
+  const ideaPrdSchema = {
+    type: 'object',
+    properties: {
+      title: { type: 'string' },
+      slug: { type: 'string' },
+      idea: { type: 'string' },
+      problem: { type: 'string' },
+      users: { type: 'array', items: { type: 'string' } },
+      goals: { type: 'array', items: { type: 'string' } },
+      non_goals: { type: 'array', items: { type: 'string' } },
+      success_criteria: { type: 'array', items: { type: 'string' } },
+      notes: { type: 'string' },
+      overwrite: { type: 'boolean' },
+    },
+    required: ['title', 'slug', 'idea'],
+    additionalProperties: false,
+  };
+  const checklistSprintSchema = {
+    type: 'object',
+    properties: {
+      title: { type: 'string' },
+      slug: { type: 'string' },
+      prd_path: { type: 'string' },
+      tasks: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            title: { type: 'string' },
+            objective: { type: 'string' },
+            files: { type: 'array', items: { type: 'string' } },
+            checks: { type: 'array', items: { type: 'string' } },
+            stage_gate: { type: 'string' },
+          },
+          required: ['title', 'objective'],
+          additionalProperties: false,
+        },
+      },
+      overwrite: { type: 'boolean' },
+    },
+    required: ['title', 'slug', 'prd_path', 'tasks'],
+    additionalProperties: false,
+  };
+  const goalFromSprintSchema = {
+    type: 'object',
+    properties: {
+      prd_path: { type: 'string' },
+      sprint_path: { type: 'string' },
+      goal_prd_path: { type: 'string' },
+      goal_sprint_path: { type: 'string' },
+      reference_repo: { type: 'string' },
+      extra_instructions: { type: 'string' },
+      overwrite: { type: 'boolean' },
+    },
+    required: ['prd_path', 'sprint_path'],
+    additionalProperties: false,
+  };
+
+  const tools: McpToolDefinition[] = [
+    { name: 'harness_status', description: 'Return repo-harness adoption and workflow status.', inputSchema: EMPTY_SCHEMA, annotations: readOnly },
+    { name: 'harness_doctor', description: 'Return compact MCP setup diagnostics.', inputSchema: EMPTY_SCHEMA, annotations: readOnly },
+    { name: 'list_workflow_files', description: 'List policy-readable workflow files.', inputSchema: EMPTY_SCHEMA, annotations: readOnly },
+    { name: 'read_workflow_file', description: 'Read one policy-allowed workflow file by repo-relative path.', inputSchema: stringPathSchema, annotations: readOnly },
+    { name: 'latest_handoff', description: 'Return latest repo-harness handoff artifacts.', inputSchema: EMPTY_SCHEMA, annotations: readOnly },
+    { name: 'latest_checks', description: 'Return latest repo-harness check artifacts.', inputSchema: EMPTY_SCHEMA, annotations: readOnly },
+    { name: 'list_prds', description: 'List PRD artifacts under plans/prds.', inputSchema: EMPTY_SCHEMA, annotations: readOnly },
+    { name: 'list_sprints', description: 'List sprint artifacts under plans/sprints.', inputSchema: EMPTY_SCHEMA, annotations: readOnly },
+    { name: 'summarize_repo_harness_state', description: 'Return a compact planning state summary.', inputSchema: EMPTY_SCHEMA, annotations: readOnly },
+    { name: 'write_prd', description: 'Write a PRD under plans/prds/*.prd.md.', inputSchema: markdownWriterSchema, annotations: write },
+    { name: 'write_prd_from_idea', description: 'Turn a product idea into a strict-compatible draft PRD under plans/prds/*.prd.md.', inputSchema: ideaPrdSchema, annotations: write },
+    { name: 'write_sprint', description: 'Write a sprint under plans/sprints/*.sprint.md.', inputSchema: markdownWriterSchema, annotations: write },
+    { name: 'write_checklist_sprint', description: 'Turn a PRD into an ordered checklist Sprint with per-phase staging gates.', inputSchema: checklistSprintSchema, annotations: write },
+    { name: 'write_plan', description: 'Write an implementation plan under plans/plan-*.md.', inputSchema: markdownWriterSchema, annotations: write },
+    { name: 'prepare_codex_goal_from_sprint', description: 'Prepare .ai/harness/handoff/codex-goal.md and a host-native /goal prompt from PRD + checklist Sprint.', inputSchema: goalFromSprintSchema, annotations: write },
+    {
+      name: 'write_codex_goal',
+      description: 'Write .ai/harness/handoff/codex-goal.md after required section validation.',
+      inputSchema: {
+        type: 'object',
+        properties: { body: { type: 'string' }, overwrite: { type: 'boolean' } },
+        required: ['body'],
+        additionalProperties: false,
+      },
+      annotations: write,
+    },
+    {
+      name: 'append_handoff_note',
+      description: 'Append a timestamped planner handoff note.',
+      inputSchema: {
+        type: 'object',
+        properties: { actor: { type: 'string' }, body: { type: 'string' } },
+        required: ['body'],
+        additionalProperties: false,
+      },
+      annotations: write,
+    },
+  ];
+
+  if (policy.execution.fixedWorkflowCheck) {
+    tools.push({ name: 'run_workflow_check', description: 'Run the fixed repo-harness strict workflow check.', inputSchema: EMPTY_SCHEMA, annotations: write });
+  }
+  return tools;
+}
+
+export async function callMcpTool(ctx: McpToolContext, name: string, args: Record<string, unknown> = {}): Promise<CallToolResult> {
+  try {
+    switch (name) {
+      case 'harness_status': {
+        const roots = ['docs/spec.md', 'plans', 'tasks/current.md', '.ai/harness/handoff', '.ai/harness/checks'];
+        audit(ctx, name, 'ok', args);
+        return textResult({
+          repoRoot: ctx.repoRoot,
+          adopted: isRepoHarnessAdopted(ctx.repoRoot),
+          profile: ctx.policy.profile,
+          branch: currentGitBranch(ctx.repoRoot),
+          workflowRoots: roots.map((path) => ({ path, exists: existsSync(join(ctx.repoRoot, path)) })),
+        });
+      }
+      case 'harness_doctor': {
+        const localConfig = existsSync(join(ctx.repoRoot, '.repo-harness', 'mcp.local.json'));
+        const codexConfig = existsSync(join(ctx.repoRoot, '.codex', 'config.toml'));
+        audit(ctx, name, 'ok', args);
+        return textResult({
+          status: isRepoHarnessAdopted(ctx.repoRoot) ? 'ready_local' : 'not_adopted',
+          repo: ctx.repoRoot,
+          profile: ctx.policy.profile,
+          mcp: {
+            localConfig,
+            policy: 'builtin',
+            deniedPaths: ctx.policy.denyGlobs.length,
+          },
+          codex: {
+            configured: codexConfig,
+            fix: codexConfig ? null : 'repo-harness mcp setup codex --repo . --scope project',
+          },
+          chatgpt: {
+            localEndpoint: 'http://127.0.0.1:8765/mcp',
+            manualStepsRequired: true,
+            guide: 'docs/repo-harness-chatgpt-mcp-setup.md',
+          },
+        });
+      }
+      case 'list_workflow_files': {
+        const files = workflowFileCandidates(ctx.repoRoot)
+          .filter((path) => resolveMcpPath(ctx.repoRoot, path, ctx.policy, 'read').ok)
+          .map((path) => fileSummary(path, ctx.repoRoot))
+          .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
+          .filter((entry) => entry.size <= ctx.policy.maxFileBytes);
+        audit(ctx, name, 'ok', args);
+        return textResult({ files });
+      }
+      case 'read_workflow_file': {
+        const path = typeof args.path === 'string' ? args.path : '';
+        const decision = resolveMcpPath(ctx.repoRoot, path, ctx.policy, 'read');
+        if (!decision.ok || !decision.absolutePath || !decision.relativePath) {
+          audit(ctx, name, 'blocked', args, path, decision.reason);
+          return errorResult('POLICY_DENIED', decision.reason ?? 'path denied', { path });
+        }
+        const fileStat = statSync(decision.absolutePath);
+        if (!fileStat.isFile()) return errorResult('NOT_A_FILE', `path is not a file: ${decision.relativePath}`);
+        if (fileStat.size > ctx.policy.maxFileBytes) return errorResult('FILE_TOO_LARGE', `file exceeds ${ctx.policy.maxFileBytes} bytes`);
+        const bytes = readFileSync(decision.absolutePath);
+        if (isProbablyBinary(bytes)) return errorResult('BINARY_FILE', 'binary files are not supported');
+        const raw = bytes.toString('utf-8');
+        const redacted = redactMcpText(raw);
+        audit(ctx, name, 'ok', args, decision.relativePath);
+        return textResult({
+          path: decision.relativePath,
+          size: fileStat.size,
+          sha256: sha256(raw),
+          redactions: redacted.redactions,
+          content: redacted.text,
+        });
+      }
+      case 'latest_handoff': {
+        const paths = ['.ai/harness/handoff/resume.md', '.ai/harness/handoff/codex-goal.md', '.ai/harness/handoff/chatgpt-plan.md'];
+        const handoff = paths.map((path) => {
+          const decision = resolveMcpPath(ctx.repoRoot, path, ctx.policy, 'read');
+          if (!decision.ok || !decision.absolutePath || !existsSync(decision.absolutePath)) return { path, exists: false };
+          const content = redactMcpText(readFileSync(decision.absolutePath, 'utf-8')).text;
+          return { path, exists: true, preview: content.split(/\r?\n/).slice(0, 24).join('\n') };
+        });
+        audit(ctx, name, 'ok', args);
+        return textResult({ handoff });
+      }
+      case 'latest_checks': {
+        const files = workflowFileCandidates(ctx.repoRoot)
+          .filter((path) => path.startsWith('.ai/harness/checks/'))
+          .filter((path) => resolveMcpPath(ctx.repoRoot, path, ctx.policy, 'read').ok)
+          .map((path) => fileSummary(path, ctx.repoRoot))
+          .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
+          .sort((a, b) => b.modifiedAt.localeCompare(a.modifiedAt))
+          .slice(0, 20);
+        audit(ctx, name, 'ok', args);
+        return textResult({ files });
+      }
+      case 'list_prds':
+      case 'list_sprints': {
+        const root = name === 'list_prds' ? 'plans/prds' : 'plans/sprints';
+        const files: string[] = [];
+        listFilesUnder(ctx.repoRoot, root, 200, files);
+        audit(ctx, name, 'ok', args);
+        return textResult({ files: files.map((path) => fileSummary(path, ctx.repoRoot)).filter(Boolean) });
+      }
+      case 'summarize_repo_harness_state': {
+        const current = existsSync(join(ctx.repoRoot, 'tasks/current.md'))
+          ? readFileSync(join(ctx.repoRoot, 'tasks/current.md'), 'utf-8').split(/\r?\n/).slice(0, 50).join('\n')
+          : null;
+        audit(ctx, name, 'ok', args);
+        return textResult({
+          status: {
+            adopted: isRepoHarnessAdopted(ctx.repoRoot),
+            branch: currentGitBranch(ctx.repoRoot),
+            profile: ctx.policy.profile,
+          },
+          current: current ? redactMcpText(current).text : null,
+        });
+      }
+      case 'write_prd': {
+        const title = String(args.title ?? '').trim();
+        const slug = slugify(String(args.slug ?? title));
+        return writeMarkdownArtifact(ctx, name, prdArtifactPath(slug), title, 'prd', String(args.body ?? ''), args.overwrite === true, args);
+      }
+      case 'write_prd_from_idea': {
+        const title = String(args.title ?? '').trim();
+        const slug = slugify(String(args.slug ?? title));
+        const body = renderPrdFromIdeaBody(args);
+        return writeMarkdownArtifact(ctx, name, prdArtifactPath(slug), title, 'prd', body, args.overwrite === true, args);
+      }
+      case 'write_sprint': {
+        const title = String(args.title ?? '').trim();
+        const slug = slugify(String(args.slug ?? title));
+        return writeMarkdownArtifact(ctx, name, sprintArtifactPath(slug), title, 'sprint', String(args.body ?? ''), args.overwrite === true, args);
+      }
+      case 'write_checklist_sprint': {
+        const title = String(args.title ?? '').trim();
+        const slug = slugify(String(args.slug ?? title));
+        const prdPath = String(args.prd_path ?? '').trim();
+        const prdDecision = resolveMcpPath(ctx.repoRoot, prdPath, ctx.policy, 'read');
+        if (!prdDecision.ok || !prdDecision.absolutePath || !existsSync(prdDecision.absolutePath)) {
+          audit(ctx, name, 'blocked', args, prdPath, prdDecision.reason ?? 'PRD path does not exist or is not readable');
+          return errorResult('PRD_NOT_READABLE', 'PRD path does not exist or is not policy-readable.', { path: prdPath });
+        }
+        const body = renderChecklistSprintBody(args);
+        return writeMarkdownArtifact(ctx, name, sprintArtifactPath(slug), title, 'sprint', body, args.overwrite === true, args);
+      }
+      case 'write_plan': {
+        const title = String(args.title ?? '').trim();
+        const slug = slugify(String(args.slug ?? title));
+        return writeMarkdownArtifact(ctx, name, `plans/plan-${slug}.md`, title, 'plan', String(args.body ?? ''), args.overwrite === true, args);
+      }
+      case 'prepare_codex_goal_from_sprint': {
+        const prdPath = String(args.prd_path ?? '').trim();
+        const sprintPath = String(args.sprint_path ?? '').trim();
+        const missingInputs = [
+          { label: 'PRD', path: prdPath },
+          { label: 'Sprint', path: sprintPath },
+        ].filter((entry) => {
+          const decision = resolveMcpPath(ctx.repoRoot, entry.path, ctx.policy, 'read');
+          return !decision.ok || !decision.absolutePath || !existsSync(decision.absolutePath);
+        });
+        if (missingInputs.length > 0) {
+          audit(ctx, name, 'blocked', args, missingInputs[0]?.path, `${missingInputs.map((entry) => entry.label).join(', ')} path does not exist or is not readable`);
+          return errorResult('SOURCE_NOT_READABLE', 'PRD or Sprint path does not exist or is not policy-readable.', { missing: missingInputs });
+        }
+        const goal = renderCodexGoalFromSprint(args);
+        const missing = validateGoal(goal.body);
+        if (missing.length > 0) {
+          audit(ctx, name, 'blocked', args, '.ai/harness/handoff/codex-goal.md', `missing required goal sections: ${missing.join(', ')}`);
+          return errorResult('INVALID_GOAL', 'Generated Codex goal is missing required sections.', { missing });
+        }
+        return writeMarkdownArtifact(ctx, name, '.ai/harness/handoff/codex-goal.md', 'Codex Goal', 'codex-goal', goal.body, args.overwrite === true, args, {
+          prompt: goal.prompt,
+        });
+      }
+      case 'write_codex_goal': {
+        const body = String(args.body ?? '');
+        const missing = validateGoal(body);
+        if (body.trim().length < 120 || missing.length > 0) {
+          audit(ctx, name, 'blocked', args, '.ai/harness/handoff/codex-goal.md', `missing required goal sections: ${missing.join(', ')}`);
+          return errorResult('INVALID_GOAL', 'Codex goal is missing required sections or is too small.', { missing });
+        }
+        return writeMarkdownArtifact(ctx, name, '.ai/harness/handoff/codex-goal.md', 'Codex Goal', 'codex-goal', body, args.overwrite === true, args);
+      }
+      case 'append_handoff_note': {
+        const path = '.ai/harness/handoff/chatgpt-plan.md';
+        const decision = resolveMcpPath(ctx.repoRoot, path, ctx.policy, 'write');
+        if (!decision.ok || !decision.absolutePath) return errorResult('POLICY_DENIED', decision.reason ?? 'path denied');
+        mkdirSync(dirname(decision.absolutePath), { recursive: true });
+        const actor = String(args.actor ?? 'chatgpt-planner').trim() || 'chatgpt-planner';
+        const body = String(args.body ?? '').trim();
+        const block = [``, `## ${new Date().toISOString()}`, ``, `Actor: ${actor}`, ``, body, ``].join('\n');
+        appendFileSync(decision.absolutePath, block, 'utf-8');
+        audit(ctx, name, 'ok', args, path);
+        return textResult({ status: 'appended', path });
+      }
+      case 'run_workflow_check': {
+        const result = runHelper({
+          helper: 'check-task-workflow',
+          args: ['--strict'],
+          cwd: ctx.repoRoot,
+          stdio: 'pipe',
+          timeoutMs: 60_000,
+          maxOutputBytes: 96 * 1024,
+        });
+        const stdout = redactMcpText(result.stdout ?? '');
+        const stderr = redactMcpText(result.stderr ?? '');
+        audit(ctx, name, result.exitCode === 0 ? 'ok' : 'failed', args, undefined, stderr.text);
+        return textResult({
+          exitCode: result.exitCode,
+          reason: result.reason,
+          stdout: stdout.text,
+          stderr: stderr.text,
+          helper: result.resolved ? { source: result.resolved.source, fileName: basename(result.resolved.path) } : null,
+        });
+      }
+      default:
+        return errorResult('UNKNOWN_TOOL', `unknown MCP tool: ${name}`);
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    audit(ctx, name, 'failed', args, undefined, message);
+    return errorResult('TOOL_FAILED', message);
+  }
+}

--- a/src/cli/mcp/transports/http.ts
+++ b/src/cli/mcp/transports/http.ts
@@ -1,0 +1,372 @@
+import { randomUUID, timingSafeEqual } from 'crypto';
+import express, { type Request, type Response, type NextFunction } from 'express';
+import { tokenHandler } from '@modelcontextprotocol/sdk/server/auth/handlers/token.js';
+import { revocationHandler } from '@modelcontextprotocol/sdk/server/auth/handlers/revoke.js';
+import { clientRegistrationHandler } from '@modelcontextprotocol/sdk/server/auth/handlers/register.js';
+import { redirectUriMatches } from '@modelcontextprotocol/sdk/server/auth/handlers/authorize.js';
+import { InvalidTokenError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
+import type { OAuthClientInformationFull } from '@modelcontextprotocol/sdk/shared/auth.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { createRepoHarnessMcpServer, type McpServerOptions } from '../server';
+import {
+  mcpOAuthTokenStorePath,
+  parseMcpHttpAuthMode,
+  readMcpBearerToken,
+  readMcpOAuthPassphrase,
+  type McpHttpAuthMode,
+} from '../auth';
+import { createMcpOAuthProvider, McpOAuthTokenStore } from '../oauth';
+import { resolveMcpRepoRoot } from '../repo';
+
+export interface McpHttpOptions extends McpServerOptions {
+  host?: string;
+  port?: number;
+  authToken?: string;
+  auth?: string;
+}
+
+function bearerFromRequest(req: Request): string | null {
+  const header = req.headers.authorization;
+  if (typeof header !== 'string') return null;
+  const match = /^Bearer\s+(.+)$/i.exec(header.trim());
+  return match ? match[1].trim() : null;
+}
+
+export function isAuthorizedMcpHttpRequest(req: Request, expectedToken: string | null): boolean {
+  if (!expectedToken) return false;
+  return bearerFromRequest(req) === expectedToken;
+}
+
+function rawBodyToJson(body: Buffer): unknown | undefined {
+  if (body.length === 0) return undefined;
+  return JSON.parse(body.toString('utf-8'));
+}
+
+function isInitializeRequest(body: unknown): boolean {
+  return typeof body === 'object' && body !== null && (body as Record<string, unknown>).method === 'initialize';
+}
+
+function getPublicOrigin(req: Request): string {
+  const configured = process.env.REPO_HARNESS_MCP_PUBLIC_ORIGIN?.trim();
+  if (configured) {
+    try {
+      return new URL(configured).origin;
+    } catch (_error) {
+      // Fall through to request-derived origin.
+    }
+  }
+  const proto = (req.headers['x-forwarded-proto'] as string | undefined) ?? 'https';
+  const host = (req.headers['x-forwarded-host'] as string | undefined) ?? req.headers.host ?? '127.0.0.1:8765';
+  return `${proto}://${host}`;
+}
+
+export function isAllowedMcpOAuthRedirectUri(redirectUri: string): boolean {
+  try {
+    const url = new URL(redirectUri);
+    if (url.protocol === 'http:' && ['localhost', '127.0.0.1', '[::1]'].includes(url.hostname)) {
+      return true;
+    }
+    if (
+      url.protocol === 'https:' &&
+      (url.origin === 'https://chatgpt.com' || url.origin === 'https://chat.openai.com') &&
+      url.pathname.startsWith('/connector/oauth/')
+    ) {
+      return true;
+    }
+    return false;
+  } catch (_error) {
+    return false;
+  }
+}
+
+function isRegisteredRedirectUri(redirectUri: string, client: { redirect_uris?: string[] }): boolean {
+  return (client.redirect_uris ?? []).some((registered) => redirectUriMatches(redirectUri, registered));
+}
+
+function escapeHtmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function renderPassphrasePage(params: URLSearchParams): string {
+  const hiddenFields = Array.from(params.entries())
+    .filter(([key]) => key !== 'passphrase')
+    .map(([key, value]) => `<input type="hidden" name="${escapeHtmlAttribute(key)}" value="${escapeHtmlAttribute(value)}">`)
+    .join('\n');
+
+  return `<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Authorize repo-harness</title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+body{font-family:-apple-system,BlinkMacSystemFont,sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0;background:#f6f6f3;color:#1f2328}
+.card{width:min(420px,92vw);background:#fff;border:1px solid #d8d8d0;border-radius:12px;padding:32px;box-shadow:0 12px 40px rgba(0,0,0,.08)}
+h1{font-size:20px;margin:0 0 8px}p{margin:0 0 20px;color:#60666d;line-height:1.45}
+input{width:100%;box-sizing:border-box;border:1px solid #bfc4c9;border-radius:8px;padding:12px;font-size:16px}
+button{width:100%;margin-top:14px;border:0;border-radius:8px;padding:12px;background:#1f2328;color:#fff;font-size:16px;font-weight:600}
+</style></head>
+<body><main class="card">
+<h1>Authorize repo-harness</h1>
+<p>Enter the local MCP passphrase to let ChatGPT use this workflow-scoped connector.</p>
+<form method="POST" action="/authorize">
+${hiddenFields}
+<input type="password" name="passphrase" placeholder="Passphrase" autofocus>
+<button type="submit">Authorize</button>
+</form>
+</main></body></html>`;
+}
+
+function requirePassphrase(passphrase: string): (req: Request, res: Response, next: NextFunction) => void {
+  return (req, res, next) => {
+    const provided = typeof req.body?.passphrase === 'string' ? req.body.passphrase : undefined;
+    if (provided) {
+      const a = Buffer.from(provided);
+      const b = Buffer.from(passphrase);
+      if (a.length === b.length && timingSafeEqual(a, b)) {
+        next();
+        return;
+      }
+    }
+    const params = new URLSearchParams(req.url.includes('?') ? req.url.slice(req.url.indexOf('?')) : '');
+    res.type('html').send(renderPassphrasePage(params));
+  };
+}
+
+function oauthAuthorizationHandler(provider: ReturnType<typeof createMcpOAuthProvider>) {
+  return async (req: Request, res: Response) => {
+    const query = req.method === 'POST' ? req.body : req.query;
+    const clientId = typeof query.client_id === 'string' ? query.client_id : '';
+    const responseType = typeof query.response_type === 'string' ? query.response_type : '';
+    const codeChallenge = typeof query.code_challenge === 'string' ? query.code_challenge : '';
+    const codeChallengeMethod = typeof query.code_challenge_method === 'string' ? query.code_challenge_method : '';
+    const state = typeof query.state === 'string' ? query.state : undefined;
+    const scope = typeof query.scope === 'string' ? query.scope : undefined;
+    let redirectUri = typeof query.redirect_uri === 'string' ? query.redirect_uri : undefined;
+
+    if (responseType !== 'code') {
+      res.status(400).json({ error: 'unsupported_response_type', error_description: 'Only code response type is supported' });
+      return;
+    }
+    if (!codeChallenge || codeChallengeMethod !== 'S256') {
+      res.status(400).json({ error: 'invalid_request', error_description: 'PKCE S256 is required' });
+      return;
+    }
+
+    const client = await provider.clientsStore.getClient(clientId);
+    if (!client) {
+      res.status(400).json({ error: 'invalid_client', error_description: 'Unknown client_id' });
+      return;
+    }
+    if (!redirectUri && client.redirect_uris.length === 1) {
+      redirectUri = client.redirect_uris[0];
+    }
+    if (!redirectUri || !isAllowedMcpOAuthRedirectUri(redirectUri)) {
+      res.status(400).json({
+        error: 'invalid_request',
+        error_description: 'redirect_uri must be localhost or a ChatGPT connector callback URL',
+      });
+      return;
+    }
+    if (!isRegisteredRedirectUri(redirectUri, client)) {
+      res.status(400).json({
+        error: 'invalid_request',
+        error_description: 'redirect_uri must match a registered client redirect_uri',
+      });
+      return;
+    }
+
+    await provider.authorize(client as OAuthClientInformationFull, {
+      state,
+      scopes: scope ? scope.split(' ') : [],
+      redirectUri,
+      codeChallenge,
+    }, res);
+  };
+}
+
+function sendOAuthUnauthorized(req: Request, res: Response, description: string): void {
+  const resourceMetadataUrl = `${getPublicOrigin(req)}/.well-known/oauth-protected-resource/mcp`;
+  res.setHeader(
+    'www-authenticate',
+    `Bearer error="invalid_token", error_description="${description}", resource_metadata="${resourceMetadataUrl}"`,
+  );
+  res.status(401).json({ error: 'invalid_token', message: description });
+}
+
+function requireMcpHttpAuth(mode: McpHttpAuthMode, bearerToken: string | null, provider: ReturnType<typeof createMcpOAuthProvider> | null) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (mode === 'bearer') {
+      if (!isAuthorizedMcpHttpRequest(req, bearerToken)) {
+        res.setHeader('www-authenticate', 'Bearer realm="repo-harness-mcp"');
+        res.status(bearerToken ? 401 : 503).json({ error: bearerToken ? 'unauthorized' : 'auth_not_configured' });
+        return;
+      }
+      next();
+      return;
+    }
+
+    const token = bearerFromRequest(req);
+    if (!token || !provider) {
+      sendOAuthUnauthorized(req, res, token ? 'OAuth is not configured' : 'Missing Authorization header');
+      return;
+    }
+    provider.verifyAccessToken(token)
+      .then((authInfo) => {
+        (req as unknown as Record<string, unknown>).auth = authInfo;
+        next();
+      })
+      .catch((error: unknown) => {
+        if (error instanceof InvalidTokenError) {
+          sendOAuthUnauthorized(req, res, error.message);
+        } else {
+          res.status(500).json({ error: 'server_error', message: 'Internal Server Error' });
+        }
+      });
+  };
+}
+
+async function handleMcpPost(req: Request, res: Response, opts: McpHttpOptions, transports: Map<string, StreamableHTTPServerTransport>): Promise<void> {
+  let body: unknown;
+  try {
+    body = rawBodyToJson(req.body as Buffer);
+  } catch (_error) {
+    res.status(400).json({ error: 'invalid JSON request body' });
+    return;
+  }
+  const sessionId = req.headers['mcp-session-id'] as string | undefined;
+  if (!sessionId && isInitializeRequest(body)) {
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+      onsessioninitialized: (newSessionId) => transports.set(newSessionId, transport),
+    });
+    transport.onclose = () => {
+      if (transport.sessionId) transports.delete(transport.sessionId);
+    };
+    const server = createRepoHarnessMcpServer(opts);
+    await server.connect(transport);
+    await transport.handleRequest(req, res, body);
+    return;
+  }
+  if (sessionId) {
+    const transport = transports.get(sessionId);
+    if (transport) {
+      await transport.handleRequest(req, res, body);
+      return;
+    }
+  }
+  res.status(400).json({ error: 'No valid session' });
+}
+
+async function handleMcpGet(req: Request, res: Response, transports: Map<string, StreamableHTTPServerTransport>): Promise<void> {
+  const sessionId = req.headers['mcp-session-id'] as string | undefined;
+  const transport = sessionId ? transports.get(sessionId) : undefined;
+  if (!transport) {
+    res.status(400).json({ error: 'No valid session' });
+    return;
+  }
+  await transport.handleRequest(req, res);
+}
+
+export async function startMcpHttp(opts: McpHttpOptions): Promise<void> {
+  const host = opts.host ?? '127.0.0.1';
+  const port = opts.port ?? 8765;
+  const repoRoot = resolveMcpRepoRoot(opts.repo ?? '.');
+  const authMode = parseMcpHttpAuthMode(opts.auth);
+  const authToken = authMode === 'bearer' ? opts.authToken ?? readMcpBearerToken(repoRoot) : null;
+  const oauthPassphrase = authMode === 'oauth' ? readMcpOAuthPassphrase(repoRoot) : null;
+  const tokenStore = authMode === 'oauth' ? new McpOAuthTokenStore(mcpOAuthTokenStorePath(repoRoot)) : null;
+  tokenStore?.load();
+  const oauthProvider = tokenStore ? createMcpOAuthProvider(tokenStore) : null;
+  const transports = new Map<string, StreamableHTTPServerTransport>();
+  const app = express();
+  app.set('trust proxy', 1);
+
+  app.get('/health', (_req, res) => {
+    res.json({
+      status: 'ok',
+      server: 'repo-harness-mcp',
+      auth: authMode === 'oauth' ? (oauthPassphrase ? 'oauth' : 'missing') : (authToken ? 'required' : 'missing'),
+    });
+  });
+
+  if (authMode === 'oauth' && oauthProvider) {
+    app.use('/authorize', express.urlencoded({ extended: false, limit: '10kb' }));
+    app.use('/authorize', requirePassphrase(oauthPassphrase ?? ''));
+    app.use('/authorize', oauthAuthorizationHandler(oauthProvider));
+    app.use('/token', tokenHandler({ provider: oauthProvider, rateLimit: false }));
+    app.use('/revoke', revocationHandler({ provider: oauthProvider, rateLimit: false }));
+    app.use('/register', clientRegistrationHandler({ clientsStore: oauthProvider.clientsStore, rateLimit: false }));
+    app.get('/.well-known/oauth-authorization-server', (req, res) => {
+      const origin = getPublicOrigin(req);
+      res.json({
+        issuer: origin,
+        authorization_endpoint: `${origin}/authorize`,
+        token_endpoint: `${origin}/token`,
+        revocation_endpoint: `${origin}/revoke`,
+        registration_endpoint: `${origin}/register`,
+        response_types_supported: ['code'],
+        grant_types_supported: ['authorization_code', 'refresh_token'],
+        code_challenge_methods_supported: ['S256'],
+        token_endpoint_auth_methods_supported: ['client_secret_post', 'none'],
+        scopes_supported: ['repo-harness'],
+      });
+    });
+    app.get('/.well-known/openid-configuration', (req, res) => {
+      const origin = getPublicOrigin(req);
+      res.json({
+        issuer: origin,
+        authorization_endpoint: `${origin}/authorize`,
+        token_endpoint: `${origin}/token`,
+        registration_endpoint: `${origin}/register`,
+        response_types_supported: ['code'],
+        grant_types_supported: ['authorization_code', 'refresh_token'],
+        code_challenge_methods_supported: ['S256'],
+        token_endpoint_auth_methods_supported: ['client_secret_post', 'none'],
+        scopes_supported: ['repo-harness'],
+      });
+    });
+    app.get('/.well-known/oauth-protected-resource/mcp', (req, res) => {
+      const origin = getPublicOrigin(req);
+      res.json({
+        resource: `${origin}/mcp`,
+        authorization_servers: [origin],
+        scopes_supported: ['repo-harness'],
+        bearer_methods_supported: ['header'],
+      });
+    });
+  }
+
+  app.post('/mcp', requireMcpHttpAuth(authMode, authToken, oauthProvider), express.raw({ type: '*/*', limit: '1mb' }), (req, res) => {
+    handleMcpPost(req, res, { ...opts, repo: repoRoot }, transports).catch((error: unknown) => {
+      if (!res.headersSent) res.status(500).json({ error: error instanceof Error ? error.message : String(error) });
+    });
+  });
+  app.get('/mcp', requireMcpHttpAuth(authMode, authToken, oauthProvider), (req, res) => {
+    handleMcpGet(req, res, transports).catch((error: unknown) => {
+      if (!res.headersSent) res.status(500).json({ error: error instanceof Error ? error.message : String(error) });
+    });
+  });
+  app.use((_req, res) => res.status(404).json({ error: 'not_found' }));
+
+  const httpServer = app.listen(port, host);
+
+  await new Promise<void>((resolve) => {
+    httpServer.once('listening', resolve);
+  });
+  const authLabel = authMode === 'oauth' ? (oauthPassphrase ? 'oauth' : 'oauth-missing') : (authToken ? 'bearer' : 'missing');
+  console.error(`repo-harness mcp http listening on http://${host}:${port}/mcp (auth: ${authLabel})`);
+
+  const shutdown = () => {
+    for (const transport of transports.values()) {
+      void transport.close().catch(() => undefined);
+    }
+    tokenStore?.flush();
+    httpServer.close(() => process.exit(0));
+  };
+  process.once('SIGINT', shutdown);
+  process.once('SIGTERM', shutdown);
+}

--- a/src/cli/mcp/transports/stdio.ts
+++ b/src/cli/mcp/transports/stdio.ts
@@ -1,0 +1,8 @@
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { createRepoHarnessMcpServer, type McpServerOptions } from '../server';
+
+export async function startMcpStdio(opts: McpServerOptions): Promise<void> {
+  const server = createRepoHarnessMcpServer(opts);
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}

--- a/src/cli/mcp/types.ts
+++ b/src/cli/mcp/types.ts
@@ -1,0 +1,30 @@
+export type McpProfileName = 'planner' | 'executor' | 'orchestrator';
+export type McpPathIntent = 'read' | 'write';
+
+export interface McpPolicy {
+  profile: McpProfileName;
+  readGlobs: string[];
+  writeGlobs: string[];
+  denyGlobs: string[];
+  maxFileBytes: number;
+  execution: {
+    fixedWorkflowCheck: boolean;
+    codexRunner: boolean;
+  };
+}
+
+export interface McpPathDecision {
+  ok: boolean;
+  relativePath?: string;
+  absolutePath?: string;
+  reason?: string;
+}
+
+export interface McpAuditEntry {
+  timestamp: string;
+  tool: string;
+  status: 'ok' | 'blocked' | 'failed';
+  targetPath?: string;
+  inputHash?: string;
+  error?: string;
+}

--- a/tasks/notes/20260617-chatgpt-mcp-smoke-prd.notes.md
+++ b/tasks/notes/20260617-chatgpt-mcp-smoke-prd.notes.md
@@ -1,0 +1,7 @@
+---
+title: "ChatGPT MCP Smoke PRD"
+kind: "prd"
+created_at: "2026-06-16T20:58:45.228Z"
+source: "repo-harness-mcp"
+---
+This PRD is only a smoke-test artifact proving ChatGPT MCP write access to repo-harness planning files. It does not request source changes, dependency changes, release changes, or implementation work.

--- a/tests/cli/mcp-http.test.ts
+++ b/tests/cli/mcp-http.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, test } from 'bun:test';
+import { createHash, randomBytes } from 'crypto';
+import { createServer } from 'net';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { runMcpSetupChatgpt } from '../../src/cli/mcp/setup';
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (typeof address !== 'object' || address === null) {
+        server.close(() => reject(new Error('unable to allocate test port')));
+        return;
+      }
+      server.close(() => resolve(address.port));
+    });
+  });
+}
+
+async function waitForHealth(port: number): Promise<void> {
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/health`);
+      if (response.ok) return;
+    } catch (_error) {
+      // Server is still starting.
+    }
+    await Bun.sleep(50);
+  }
+  throw new Error('MCP HTTP server did not become healthy');
+}
+
+function initializeBody(): string {
+  return JSON.stringify({
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'repo-harness-test', version: '0' },
+    },
+  });
+}
+
+describe('mcp http transport', () => {
+  test('requires bearer auth and accepts authenticated initialize requests', async () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'repo-harness-mcp-http-'));
+    const port = await freePort();
+    let proc: Bun.Subprocess<'ignore', 'pipe', 'pipe'> | null = null;
+    try {
+      mkdirSync(join(repoRoot, '.ai/harness'), { recursive: true });
+      writeFileSync(join(repoRoot, '.ai/harness/policy.json'), '{}\n');
+      runMcpSetupChatgpt({ repo: repoRoot, port: String(port) });
+      const token = (await Bun.file(join(repoRoot, '.repo-harness/mcp.tokens.json')).json()).bearerToken;
+
+      proc = Bun.spawn(
+        [
+          'bun',
+          'src/cli/index.ts',
+          'mcp',
+          'serve',
+          '--repo',
+          repoRoot,
+          '--transport',
+          'http',
+          '--host',
+          '127.0.0.1',
+          '--port',
+          String(port),
+          '--profile',
+          'planner',
+          '--auth',
+          'bearer',
+        ],
+        { cwd: process.cwd(), stdout: 'ignore', stderr: 'pipe' },
+      );
+      await waitForHealth(port);
+
+      const health = await fetch(`http://127.0.0.1:${port}/health`);
+      expect(await health.json()).toMatchObject({ status: 'ok', auth: 'required' });
+
+      const noAuth = await fetch(`http://127.0.0.1:${port}/mcp`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: initializeBody(),
+      });
+      expect(noAuth.status).toBe(401);
+
+      const badJson = await fetch(`http://127.0.0.1:${port}/mcp`, {
+        method: 'POST',
+        headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+        body: '{bad',
+      });
+      expect(badJson.status).toBe(400);
+
+      const initialized = await fetch(`http://127.0.0.1:${port}/mcp`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${token}`,
+          'content-type': 'application/json',
+          accept: 'application/json, text/event-stream',
+        },
+        body: initializeBody(),
+      });
+      expect(initialized.status).toBe(200);
+      expect(await initialized.text()).toContain('repo-harness-mcp');
+    } finally {
+      proc?.kill();
+      await proc?.exited.catch(() => undefined);
+      rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('supports ChatGPT-compatible OAuth authorization flow', async () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'repo-harness-mcp-oauth-'));
+    const port = await freePort();
+    let proc: Bun.Subprocess<'ignore', 'pipe', 'pipe'> | null = null;
+    try {
+      mkdirSync(join(repoRoot, '.ai/harness'), { recursive: true });
+      writeFileSync(join(repoRoot, '.ai/harness/policy.json'), '{}\n');
+      runMcpSetupChatgpt({ repo: repoRoot, port: String(port) });
+      const passphrase = (await Bun.file(join(repoRoot, '.repo-harness/mcp.oauth.json')).json()).passphrase;
+
+      proc = Bun.spawn(
+        [
+          'bun',
+          'src/cli/index.ts',
+          'mcp',
+          'serve',
+          '--repo',
+          repoRoot,
+          '--transport',
+          'http',
+          '--host',
+          '127.0.0.1',
+          '--port',
+          String(port),
+          '--profile',
+          'planner',
+        ],
+        { cwd: process.cwd(), stdout: 'ignore', stderr: 'pipe' },
+      );
+      await waitForHealth(port);
+
+      const health = await fetch(`http://127.0.0.1:${port}/health`);
+      expect(await health.json()).toMatchObject({ status: 'ok', auth: 'oauth' });
+
+      const metadata = await fetch(`http://127.0.0.1:${port}/.well-known/oauth-protected-resource/mcp`, {
+        headers: { 'x-forwarded-proto': 'https', 'x-forwarded-host': 'example.test' },
+      });
+      expect(await metadata.json()).toMatchObject({
+        resource: 'https://example.test/mcp',
+        authorization_servers: ['https://example.test'],
+      });
+
+      const registered = await fetch(`http://127.0.0.1:${port}/register`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          redirect_uris: ['http://localhost/callback'],
+          token_endpoint_auth_method: 'none',
+          grant_types: ['authorization_code', 'refresh_token'],
+          response_types: ['code'],
+          client_name: 'repo-harness-test',
+        }),
+      });
+      expect(registered.status).toBe(201);
+      const client = await registered.json() as { client_id: string };
+      expect(typeof client.client_id).toBe('string');
+
+      const verifier = randomBytes(32).toString('base64url');
+      const challenge = createHash('sha256').update(verifier).digest('base64url');
+      const authorizeBody = new URLSearchParams({
+        passphrase,
+        client_id: client.client_id,
+        redirect_uri: 'http://localhost/callback',
+        response_type: 'code',
+        code_challenge: challenge,
+        code_challenge_method: 'S256',
+        state: 'state-1',
+      });
+      const authorized = await fetch(`http://127.0.0.1:${port}/authorize`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: authorizeBody,
+        redirect: 'manual',
+      });
+      expect(authorized.status).toBe(302);
+      const redirect = new URL(authorized.headers.get('location') ?? '');
+      const code = redirect.searchParams.get('code');
+      expect(code).toBeTruthy();
+
+      const token = await fetch(`http://127.0.0.1:${port}/token`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          grant_type: 'authorization_code',
+          client_id: client.client_id,
+          code: code ?? '',
+          code_verifier: verifier,
+          redirect_uri: 'http://localhost/callback',
+        }),
+      });
+      expect(token.status).toBe(200);
+      const tokenJson = await token.json() as { access_token: string; token_type: string };
+      expect(tokenJson.token_type).toBe('Bearer');
+
+      const noAuth = await fetch(`http://127.0.0.1:${port}/mcp`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: initializeBody(),
+      });
+      expect(noAuth.status).toBe(401);
+      expect(noAuth.headers.get('www-authenticate')).toContain('/.well-known/oauth-protected-resource/mcp');
+
+      const initialized = await fetch(`http://127.0.0.1:${port}/mcp`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${tokenJson.access_token}`,
+          'content-type': 'application/json',
+          accept: 'application/json, text/event-stream',
+        },
+        body: initializeBody(),
+      });
+      expect(initialized.status).toBe(200);
+      expect(await initialized.text()).toContain('repo-harness-mcp');
+    } finally {
+      proc?.kill();
+      await proc?.exited.catch(() => undefined);
+      rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/cli/mcp-policy.test.ts
+++ b/tests/cli/mcp-policy.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { hashMcpInput, mcpAuditLogPath, tryWriteMcpAuditEntry, writeMcpAuditEntry } from '../../src/cli/mcp/audit';
+import { getMcpPolicy } from '../../src/cli/mcp/policy';
+import { redactMcpText } from '../../src/cli/mcp/redaction';
+import { globMatches, normalizeMcpRelativePath, resolveMcpPath } from '../../src/cli/mcp/paths';
+
+describe('mcp policy and paths', () => {
+  test('matches repo-harness workflow globs without matching sibling paths', () => {
+    expect(globMatches('plans/**', 'plans/prds/example.prd.md')).toBe(true);
+    expect(globMatches('plans/plan-*.md', 'plans/plan-test.md')).toBe(true);
+    expect(globMatches('plans/plan-*.md', 'plans/archive/plan-test.md')).toBe(false);
+    expect(globMatches('*.pem', 'secret.pem')).toBe(true);
+    expect(globMatches('*.pem', 'nested/secret.pem')).toBe(false);
+  });
+
+  test('normalizes relative paths and rejects traversal or absolute input', () => {
+    expect(normalizeMcpRelativePath('./plans/prds/test.md')).toMatchObject({
+      ok: true,
+      relativePath: 'plans/prds/test.md',
+    });
+    expect(normalizeMcpRelativePath('plans\\prds\\test.md')).toMatchObject({
+      ok: true,
+      relativePath: 'plans/prds/test.md',
+    });
+    expect(normalizeMcpRelativePath('../outside').ok).toBe(false);
+    expect(normalizeMcpRelativePath('/tmp/outside').ok).toBe(false);
+  });
+
+  test('planner profile permits workflow reads and blocks denied or source writes', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'repo-harness-mcp-policy-'));
+    try {
+      mkdirSync(join(tmp, 'plans/prds'), { recursive: true });
+      mkdirSync(join(tmp, 'src'), { recursive: true });
+      writeFileSync(join(tmp, 'plans/prds/test.prd.md'), '# Test\n');
+      writeFileSync(join(tmp, '.env'), 'TOKEN=secret\n');
+      mkdirSync(join(tmp, 'tasks/secrets'), { recursive: true });
+      writeFileSync(join(tmp, 'tasks/secrets/token.txt'), 'TOKEN=secret\n');
+      mkdirSync(join(tmp, '.ai/harness/nested'), { recursive: true });
+      writeFileSync(join(tmp, '.ai/harness/nested/private.key'), 'SECRET=secret\n');
+
+      const policy = getMcpPolicy('planner');
+      expect(resolveMcpPath(tmp, 'plans/prds/test.prd.md', policy, 'read')).toMatchObject({
+        ok: true,
+        relativePath: 'plans/prds/test.prd.md',
+      });
+      expect(resolveMcpPath(tmp, '.env', policy, 'read')).toMatchObject({ ok: false });
+      expect(resolveMcpPath(tmp, 'src/index.ts', policy, 'write')).toMatchObject({ ok: false });
+      expect(resolveMcpPath(tmp, 'plans/prds/new.prd.md', policy, 'write')).toMatchObject({
+        ok: true,
+        relativePath: 'plans/prds/new.prd.md',
+      });
+
+      const executor = getMcpPolicy('executor');
+      expect(resolveMcpPath(tmp, 'tasks/secrets/token.txt', executor, 'read')).toMatchObject({ ok: false });
+      expect(resolveMcpPath(tmp, '.ai/harness/nested/private.key', executor, 'read')).toMatchObject({ ok: false });
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('blocks symlink escapes from allowed workflow roots', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'repo-harness-mcp-symlink-'));
+    const outside = mkdtempSync(join(tmpdir(), 'repo-harness-mcp-outside-'));
+    try {
+      mkdirSync(join(tmp, 'plans'), { recursive: true });
+      writeFileSync(join(outside, 'secret.md'), '# outside\n');
+      symlinkSync(join(outside, 'secret.md'), join(tmp, 'plans', 'linked.md'));
+
+      const policy = getMcpPolicy('planner');
+      const decision = resolveMcpPath(tmp, 'plans/linked.md', policy, 'read');
+      expect(decision.ok).toBe(false);
+      expect(decision.reason).toContain('escapes repository root');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('mcp redaction and audit', () => {
+  test('redacts common token and private key patterns', () => {
+    const input = [
+      'Authorization: Bearer token-value',
+      'OPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwxyz',
+      'MY_API_KEY=plain-secret',
+      'APP_SECRET: another-secret',
+      '-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----',
+    ].join('\n');
+    const result = redactMcpText(input);
+    expect(result.text).toContain('Authorization: Bearer [REDACTED]');
+    expect(result.text).toContain('OPENAI_API_KEY=[REDACTED]');
+    expect(result.text).toContain('MY_API_KEY=[REDACTED]');
+    expect(result.text).toContain('APP_SECRET:[REDACTED]');
+    expect(result.text).toContain('[PRIVATE KEY REDACTED]');
+    expect(result.text).not.toContain('token-value');
+    expect(result.text).not.toContain('abcdefghijklmnopqrstuvwxyz');
+    expect(result.text).not.toContain('plain-secret');
+    expect(result.text).not.toContain('another-secret');
+  });
+
+  test('audit log stores input hash and redacted errors', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'repo-harness-mcp-audit-'));
+    try {
+      const inputHash = hashMcpInput({ body: 'secret body' });
+      writeMcpAuditEntry(tmp, {
+        timestamp: '2026-06-17T00:00:00.000Z',
+        tool: 'write_prd',
+        status: 'failed',
+        targetPath: 'plans/prds/test.prd.md',
+        inputHash,
+        error: 'Authorization: Bearer token-value',
+      });
+
+      const line = readFileSync(mcpAuditLogPath(tmp), 'utf-8').trim();
+      expect(line).toContain(inputHash);
+      expect(line).toContain('Authorization: Bearer [REDACTED]');
+      expect(line).not.toContain('secret body');
+      expect(line).not.toContain('token-value');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('safe audit write reports failure without throwing', () => {
+    expect(tryWriteMcpAuditEntry('/dev/null/not-a-dir', {
+      timestamp: '2026-06-17T00:00:00.000Z',
+      tool: 'read_workflow_file',
+      status: 'ok',
+      inputHash: hashMcpInput({ path: 'plans/test.md' }),
+    })).toBe(false);
+  });
+});

--- a/tests/cli/mcp-setup.test.ts
+++ b/tests/cli/mcp-setup.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from 'bun:test';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  chatgptGuideMarkdown,
+  patchCodexConfigToml,
+  runMcpDoctor,
+  runMcpInstallSkill,
+  runMcpSetupChatgpt,
+  runMcpSetupCodex,
+} from '../../src/cli/mcp/setup';
+
+function withTmpRepo<T>(fn: (repoRoot: string) => T): T {
+  const repoRoot = mkdtempSync(join(tmpdir(), 'repo-harness-mcp-setup-'));
+  try {
+    mkdirSync(join(repoRoot, '.ai/harness'), { recursive: true });
+    writeFileSync(join(repoRoot, '.ai/harness/policy.json'), '{}\n');
+    return fn(repoRoot);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+}
+
+describe('mcp setup', () => {
+  test('generates ChatGPT local config, guide, and ignore entries', () => {
+    withTmpRepo((repoRoot) => {
+      const result = runMcpSetupChatgpt({ repo: repoRoot });
+      expect(result.changed.length).toBeGreaterThan(0);
+      expect(existsSync(join(repoRoot, '.repo-harness/mcp.local.json'))).toBe(true);
+      expect(existsSync(join(repoRoot, '.repo-harness/mcp.tokens.json'))).toBe(true);
+      expect(existsSync(join(repoRoot, '.repo-harness/mcp.oauth.json'))).toBe(true);
+      expect(existsSync(join(repoRoot, 'docs/repo-harness-chatgpt-mcp-setup.md'))).toBe(true);
+      const config = JSON.parse(readFileSync(join(repoRoot, '.repo-harness/mcp.local.json'), 'utf-8'));
+      expect(config.auth).toMatchObject({
+        mode: 'oauth',
+        oauthFile: '.repo-harness/mcp.oauth.json',
+        tokenFile: '.repo-harness/mcp.tokens.json',
+      });
+      const token = JSON.parse(readFileSync(join(repoRoot, '.repo-harness/mcp.tokens.json'), 'utf-8')).bearerToken;
+      expect(typeof token).toBe('string');
+      expect(token.length).toBeGreaterThan(30);
+      const passphrase = JSON.parse(readFileSync(join(repoRoot, '.repo-harness/mcp.oauth.json'), 'utf-8')).passphrase;
+      expect(typeof passphrase).toBe('string');
+      expect(passphrase.length).toBeGreaterThan(20);
+      const ignore = readFileSync(join(repoRoot, '.gitignore'), 'utf-8');
+      expect(ignore).toContain('.repo-harness/mcp.local.json');
+      expect(ignore).toContain('.repo-harness/mcp.tokens.json');
+      expect(ignore).toContain('.repo-harness/mcp.oauth.json');
+      expect(ignore).toContain('.repo-harness/mcp.oauth-tokens.json');
+      expect(ignore).toContain('.ai/harness/mcp/audit.log');
+
+      const doctor = JSON.parse(runMcpDoctor({ repo: repoRoot, json: true }).lines[0]);
+      expect(doctor.mcp.authConfigured).toBe(true);
+      expect(doctor.chatgpt.localEndpoint).toBe('http://127.0.0.1:8765/mcp');
+    });
+  });
+
+  test('ChatGPT guide uses OAuth for ChatGPT and documents bearer fallback', () => {
+    const guide = chatgptGuideMarkdown('https://example.test/mcp');
+    expect(guide).toContain('Configure Connector authentication as OAuth');
+    expect(guide).toContain('.repo-harness/mcp.oauth.json');
+    expect(guide).toContain('oauth-protected-resource');
+    expect(guide).toContain('--auth bearer');
+    expect(guide).toContain('https://example.test/mcp');
+  });
+
+  test('patches Codex config while preserving unrelated content', () => {
+    const patched = patchCodexConfigToml('[profiles.default]\nmodel = "gpt-5"\n');
+    expect(patched).toContain('[profiles.default]');
+    expect(patched).toContain('[mcp_servers.repo_harness]');
+    expect(patched).toContain('"mcp"');
+
+    withTmpRepo((repoRoot) => {
+      mkdirSync(join(repoRoot, '.codex'), { recursive: true });
+      writeFileSync(join(repoRoot, '.codex/config.toml'), '[profiles.default]\nmodel = "gpt-5"\n');
+      const dryRun = runMcpSetupCodex({ repo: repoRoot, scope: 'project', dryRun: true });
+      expect(dryRun.changed).toHaveLength(0);
+      expect(readFileSync(join(repoRoot, '.codex/config.toml'), 'utf-8')).not.toContain('[mcp_servers.repo_harness]');
+
+      const result = runMcpSetupCodex({ repo: repoRoot, scope: 'project' });
+      expect(result.changed.some((path) => path.endsWith('.codex/config.toml'))).toBe(true);
+      expect(existsSync(join(repoRoot, '.codex/config.toml.bak'))).toBe(true);
+      const config = readFileSync(join(repoRoot, '.codex/config.toml'), 'utf-8');
+      expect(config).toContain('[profiles.default]');
+      expect(config).toContain('[mcp_servers.repo_harness]');
+
+      const again = runMcpSetupCodex({ repo: repoRoot, scope: 'project' });
+      expect(again.changed).toHaveLength(0);
+    });
+  });
+
+  test('installs bridge skill template with overwrite protection', () => {
+    withTmpRepo((repoRoot) => {
+      runMcpInstallSkill({ repo: repoRoot });
+      const skill = join(repoRoot, '.agents/skills/repo-harness-chatgpt-bridge/SKILL.md');
+      expect(existsSync(skill)).toBe(true);
+      expect(readFileSync(skill, 'utf-8')).toContain('repo-harness-chatgpt-bridge');
+      writeFileSync(skill, 'custom\n');
+      const protectedResult = runMcpInstallSkill({ repo: repoRoot });
+      expect(protectedResult.changed).toHaveLength(0);
+      expect(readFileSync(skill, 'utf-8')).toBe('custom\n');
+      runMcpInstallSkill({ repo: repoRoot, overwrite: true });
+      expect(readFileSync(skill, 'utf-8')).toContain('repo-harness-chatgpt-bridge');
+    });
+  });
+});

--- a/tests/cli/mcp-tools.test.ts
+++ b/tests/cli/mcp-tools.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, test } from 'bun:test';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { getMcpPolicy } from '../../src/cli/mcp/policy';
+import { callMcpTool, type McpToolContext } from '../../src/cli/mcp/tools';
+
+async function withRepo<T>(fn: (repoRoot: string, ctx: McpToolContext) => Promise<T>): Promise<T> {
+  const repoRoot = mkdtempSync(join(tmpdir(), 'repo-harness-mcp-tools-'));
+  try {
+    mkdirSync(join(repoRoot, '.ai/harness/handoff'), { recursive: true });
+    mkdirSync(join(repoRoot, '.ai/harness/checks'), { recursive: true });
+    mkdirSync(join(repoRoot, 'plans/prds'), { recursive: true });
+    mkdirSync(join(repoRoot, 'plans/sprints'), { recursive: true });
+    mkdirSync(join(repoRoot, 'tasks'), { recursive: true });
+    writeFileSync(join(repoRoot, '.ai/harness/policy.json'), '{}\n');
+    writeFileSync(join(repoRoot, 'tasks/current.md'), 'status=Active\n');
+    writeFileSync(join(repoRoot, 'plans/prds/existing.prd.md'), '# Existing\n');
+    return await fn(repoRoot, { repoRoot, policy: getMcpPolicy('planner') });
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+}
+
+async function jsonTool(ctx: McpToolContext, name: string, args: Record<string, unknown> = {}) {
+  const result = await callMcpTool(ctx, name, args);
+  return JSON.parse(result.content[0].text);
+}
+
+describe('mcp tools', () => {
+  test('lists and reads allowed workflow files with redaction', async () => {
+    await withRepo(async (_repoRoot, ctx) => {
+      const listed = await jsonTool(ctx, 'list_workflow_files');
+      expect(listed.files.some((entry: { path: string }) => entry.path === 'tasks/current.md')).toBe(true);
+
+      const read = await jsonTool(ctx, 'read_workflow_file', { path: 'tasks/current.md' });
+      expect(read.path).toBe('tasks/current.md');
+      expect(read.content).toContain('status=Active');
+
+      const denied = await jsonTool(ctx, 'read_workflow_file', { path: '.env' });
+      expect(denied.error.code).toBe('POLICY_DENIED');
+    });
+  });
+
+  test('writes planning artifacts and blocks overwrite by default', async () => {
+    await withRepo(async (repoRoot, ctx) => {
+      const prd = await jsonTool(ctx, 'write_prd', {
+        title: 'New Feature',
+        slug: 'new-feature',
+        body: '# New Feature\n\nBody.',
+      });
+      expect(prd.status).toBe('written');
+      expect(prd.path).toMatch(/^plans\/prds\/\d{8}-\d{4}-new-feature\.prd\.md$/);
+      expect(existsSync(join(repoRoot, prd.path))).toBe(true);
+
+      const blocked = await jsonTool(ctx, 'write_prd', {
+        title: 'New Feature',
+        slug: prd.path.replace(/^plans\/prds\//, '').replace(/\.prd\.md$/, ''),
+        body: '# New Feature\n\nBody.',
+      });
+      expect(blocked.error.code).toBe('WOULD_OVERWRITE');
+
+      const sprint = await jsonTool(ctx, 'write_sprint', {
+        title: 'Sprint',
+        slug: 'sprint-one',
+        body: '# Sprint\n\nBody.',
+      });
+      expect(sprint.path).toMatch(/^plans\/sprints\/\d{8}-\d{4}-sprint-one\.sprint\.md$/);
+
+      const plan = await jsonTool(ctx, 'write_plan', {
+        title: 'Plan',
+        slug: 'plan-one',
+        body: '# Plan\n\nBody.',
+      });
+      expect(plan.path).toBe('plans/plan-plan-one.md');
+
+      const handoff = await jsonTool(ctx, 'append_handoff_note', { actor: 'test', body: 'handoff note' });
+      expect(handoff.path).toBe('.ai/harness/handoff/chatgpt-plan.md');
+      expect(readFileSync(join(repoRoot, '.ai/harness/handoff/chatgpt-plan.md'), 'utf-8')).toContain('handoff note');
+    });
+  });
+
+  test('blocks oversized workflow reads', async () => {
+    await withRepo(async (repoRoot, ctx) => {
+      writeFileSync(join(repoRoot, 'plans/prds/large.prd.md'), 'x'.repeat(32));
+      const smallLimit = { ...ctx, policy: { ...ctx.policy, maxFileBytes: 8 } };
+      const result = await jsonTool(smallLimit, 'read_workflow_file', { path: 'plans/prds/large.prd.md' });
+      expect(result.error.code).toBe('FILE_TOO_LARGE');
+    });
+  });
+
+  test('validates fixed Codex goal path and required sections', async () => {
+    await withRepo(async (repoRoot, ctx) => {
+      const invalid = await jsonTool(ctx, 'write_codex_goal', { body: '# Codex Goal\nshort' });
+      expect(invalid.error.code).toBe('INVALID_GOAL');
+
+      const validBody = [
+        '# Codex Goal',
+        '## Source of truth',
+        'plans/prds/example.prd.md',
+        '## Role',
+        'Codex executor.',
+        '## Scope',
+        'Only workflow artifacts.',
+        '## Required workflow',
+        'Read PRD and sprint.',
+        '## Required checks',
+        'bun test tests/cli/mcp.test.ts',
+        '## Done when',
+        'Checks pass and handoff is updated.',
+      ].join('\n\n');
+      const written = await jsonTool(ctx, 'write_codex_goal', { body: validBody });
+      expect(written.status).toBe('written');
+      expect(readFileSync(join(repoRoot, '.ai/harness/handoff/codex-goal.md'), 'utf-8')).toContain('# Codex Goal');
+    });
+  });
+
+  test('supports idea to PRD to checklist Sprint to Codex goal handoff', async () => {
+    await withRepo(async (repoRoot, ctx) => {
+      const prd = await jsonTool(ctx, 'write_prd_from_idea', {
+        title: 'Goal Chain',
+        slug: 'goal-chain',
+        idea: 'Convert idea to PRD, checklist Sprint, and host-native Codex /goal handoff.',
+        users: ['ChatGPT planner', 'Codex executor'],
+        goals: ['Generate reviewable workflow artifacts'],
+        success_criteria: ['Codex receives a staged checklist Sprint execution prompt'],
+      });
+      expect(prd.path).toMatch(/^plans\/prds\/\d{8}-\d{4}-goal-chain\.prd\.md$/);
+      const prdContent = readFileSync(join(repoRoot, prd.path), 'utf-8');
+      expect(prdContent).toContain('> **Status**: Draft');
+      expect(prdContent).toContain('## Workflow Contract');
+
+      const sprint = await jsonTool(ctx, 'write_checklist_sprint', {
+        title: 'Goal Chain Sprint',
+        slug: 'goal-chain-sprint',
+        prd_path: prd.path,
+        tasks: [
+          {
+            title: 'Implement chain surface',
+            objective: 'Expose the idea to PRD to checklist Sprint to Goal route.',
+            files: ['src/cli/mcp/tools.ts'],
+            checks: ['bun test tests/cli/mcp-tools.test.ts'],
+            stage_gate: 'Stage MCP tool changes before continuing.',
+          },
+        ],
+      });
+      expect(sprint.path).toMatch(/^plans\/sprints\/\d{8}-\d{4}-goal-chain-sprint\.sprint\.md$/);
+      const sprintContent = readFileSync(join(repoRoot, sprint.path), 'utf-8');
+      expect(sprintContent).toContain('### Task Card 1: Implement chain surface');
+      expect(sprintContent).toContain('- [ ] Stage gate: Stage MCP tool changes before continuing.');
+
+      const goal = await jsonTool(ctx, 'prepare_codex_goal_from_sprint', {
+        prd_path: prd.path,
+        sprint_path: sprint.path,
+        reference_repo: '/tmp/reference-repo',
+      });
+      expect(goal.status).toBe('written');
+      expect(goal.path).toBe('.ai/harness/handoff/codex-goal.md');
+      expect(goal.prompt).toContain('/goal');
+      expect(goal.prompt).toContain(`阅读： ${prd.path}`);
+      expect(goal.prompt).toContain(`开worktree完整执行：${sprint.path}`);
+      expect(goal.prompt).toContain('完成阶段性任务，要staging再继续');
+      const goalContent = readFileSync(join(repoRoot, '.ai/harness/handoff/codex-goal.md'), 'utf-8');
+      expect(goalContent).toContain('## Host-native /goal prompt');
+      expect(goalContent).toContain('No commit is created unless the user explicitly asks for commit.');
+    });
+  });
+
+  test('exposes a written Codex goal through the handoff read path', async () => {
+    await withRepo(async (repoRoot, ctx) => {
+      const validBody = [
+        '# Codex Goal',
+        '## Source of truth',
+        'plans/prds/example.prd.md',
+        '## Role',
+        'Codex executor.',
+        '## Scope',
+        'Only workflow artifacts.',
+        '## Required workflow',
+        'Read PRD and sprint.',
+        '## Required checks',
+        'bun test tests/cli/mcp.test.ts',
+        '## Done when',
+        'Checks pass and handoff is updated.',
+      ].join('\n\n');
+
+      await jsonTool(ctx, 'write_codex_goal', { body: validBody });
+
+      const handoff = await jsonTool(ctx, 'latest_handoff');
+      const goal = handoff.handoff.find((entry: { path: string }) => entry.path === '.ai/harness/handoff/codex-goal.md');
+      expect(goal).toMatchObject({ exists: true });
+      expect(goal.preview).toContain('# Codex Goal');
+
+      const readGoal = await jsonTool(ctx, 'read_workflow_file', { path: '.ai/harness/handoff/codex-goal.md' });
+      expect(readGoal.content).toContain('## Required checks');
+      expect(readFileSync(join(repoRoot, '.ai/harness/handoff/codex-goal.md'), 'utf-8')).toContain('source: "repo-harness-mcp"');
+    });
+  });
+
+  test('latest_checks is not starved by large earlier workflow roots', async () => {
+    await withRepo(async (repoRoot, ctx) => {
+      for (let index = 0; index < 720; index += 1) {
+        writeFileSync(join(repoRoot, 'plans/prds', `bulk-${String(index).padStart(3, '0')}.prd.md`), '# Bulk\n');
+      }
+      writeFileSync(join(repoRoot, '.ai/harness/checks/latest.json'), '{"ok":true}\n');
+
+      const result = await jsonTool(ctx, 'latest_checks');
+      expect(result.files.some((entry: { path: string }) => entry.path === '.ai/harness/checks/latest.json')).toBe(true);
+    });
+  });
+});

--- a/tests/cli/mcp.test.ts
+++ b/tests/cli/mcp.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'bun:test';
+import { spawnSync } from 'child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const ROOT = join(import.meta.dir, '../..');
+const CLI = join(ROOT, 'src/cli/index.ts');
+
+function runMcp(args: string[]) {
+  return spawnSync('bun', [CLI, 'mcp', ...args], {
+    cwd: ROOT,
+    encoding: 'utf-8',
+  });
+}
+
+describe('mcp command', () => {
+  test('prints help for command group and subcommands', () => {
+    const root = runMcp(['--help']);
+    expect(root.status).toBe(0);
+    expect(root.stdout).toContain('Run and configure the repo-harness MCP workflow sidecar');
+    expect(root.stdout).toContain('serve');
+    expect(root.stdout).toContain('doctor');
+    expect(root.stdout).toContain('setup');
+
+    const serve = runMcp(['serve', '--help']);
+    expect(serve.status).toBe(0);
+    expect(serve.stdout).toContain('--transport <transport>');
+    expect(serve.stdout).toContain('--profile <profile>');
+
+    const doctor = runMcp(['doctor', '--help']);
+    expect(doctor.status).toBe(0);
+    expect(doctor.stdout).toContain('Check repo-harness MCP setup status');
+
+    const setup = runMcp(['setup', '--help']);
+    expect(setup.status).toBe(0);
+    expect(setup.stdout).toContain('chatgpt');
+    expect(setup.stdout).toContain('codex');
+    expect(root.stdout).toContain('prepare-goal');
+  });
+
+  test('rejects invalid subcommands with a useful error', () => {
+    const result = runMcp(['missing']);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("unknown command 'missing'");
+  });
+
+  test('prepare-goal writes Codex handoff and prints host-native /goal prompt', () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'repo-harness-mcp-goal-'));
+    try {
+      mkdirSync(join(repoRoot, '.ai/harness'), { recursive: true });
+      mkdirSync(join(repoRoot, 'plans/prds'), { recursive: true });
+      mkdirSync(join(repoRoot, 'plans/sprints'), { recursive: true });
+      writeFileSync(join(repoRoot, '.ai/harness/policy.json'), '{}\n');
+      writeFileSync(join(repoRoot, 'plans/prds/example.prd.md'), '# Example PRD\n');
+      writeFileSync(join(repoRoot, 'plans/sprints/example.sprint.md'), '# Example Sprint\n\n- [ ] Task\n');
+
+      const result = runMcp([
+        'prepare-goal',
+        '--repo',
+        repoRoot,
+        '--prd',
+        join(repoRoot, 'plans/prds/example.prd.md'),
+        '--sprint',
+        join(repoRoot, 'plans/sprints/example.sprint.md'),
+        '--reference-repo',
+        '/tmp/reference-repo',
+      ]);
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('/goal');
+      expect(result.stdout).toContain(`阅读： ${join(repoRoot, 'plans/prds/example.prd.md')}`);
+      expect(result.stdout).toContain(`开worktree完整执行：${join(repoRoot, 'plans/sprints/example.sprint.md')}`);
+      expect(result.stdout).toContain('完成阶段性任务，要staging再继续');
+      const goalPath = join(repoRoot, '.ai/harness/handoff/codex-goal.md');
+      expect(existsSync(goalPath)).toBe(true);
+      expect(readFileSync(goalPath, 'utf-8')).toContain('## Host-native /goal prompt');
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- add `repo-harness mcp` serve/setup/doctor/install-skill/prepare-goal surfaces
- add workflow-scoped MCP read/write tools, OAuth HTTP transport, stdio transport, audit/redaction/path policy guards
- add idea -> PRD -> checklist Sprint -> Codex Goal chain with staged phase gates
- add ChatGPT Connector guide, Codex bridge Skill, PRD/Sprint artifacts, and handoff evidence

## Safety boundary

- no default `codex exec` runner
- no arbitrary shell MCP tool
- planner profile cannot write source files, package manifests, lockfiles, CI config, secrets, or paths outside the repo root
- ChatGPT prepares `.ai/harness/handoff/codex-goal.md`; local Codex owns `/goal` execution

## Verification

- `bun test` (`810 pass`, `0 fail`)
- `bun test tests/cli/mcp-tools.test.ts tests/cli/mcp.test.ts tests/cli/mcp-setup.test.ts`
- `bun run check:type`
- `git diff --check`
- `bash scripts/check-task-sync.sh`
- `bash scripts/check-task-workflow.sh --strict`
- `bash scripts/check-architecture-sync.sh`
- `bash scripts/check-deploy-sql-order.sh`
- `bun scripts/inspect-project-state.ts --repo . --format text`
- `bash scripts/migrate-project-template.sh --repo . --dry-run`
- `repo-harness setup check --target codex --check-updates --json` (`27 ok`, `1 warn`, `0 fail`, `0 needs_agent`; warning is optional `skills_cli` timeout)
- `repo-harness mcp prepare-goal --repo . --prd /Users/ancienttwo/Projects/agentic-dev-wt-mcp-connector/plans/prds/20260617-repo-harness-mcp-prd.md --sprint /Users/ancienttwo/Projects/agentic-dev-wt-mcp-connector/plans/sprints/20260617-repo-harness-mcp-sprint.md --reference-repo /Users/ancienttwo/Projects/agentic-dev/_ref/local-dev-mcp --overwrite`