### PR TITLE
Fix MCP goal language policy for 0.7.0

### DIFF
--- a/.agents/skills/repo-harness-chatgpt-bridge/SKILL.md
+++ b/.agents/skills/repo-harness-chatgpt-bridge/SKILL.md
@@ -55,10 +55,11 @@ The generated `/goal` prompt should preserve this shape when absolute paths are 
 
 ```text
 /goal
-阅读： <prd-path>
-开worktree完整执行：<sprint-path>
-完成阶段性任务，要staging再继续
-参考repo: <optional-reference-repo>
+Read: <prd-path>
+Open or use a worktree and complete: <sprint-path>
+After each completed phase, stage the result before continuing.
+Use the user's language for status reports unless repo-local instructions require otherwise.
+Reference repo: <optional-reference-repo>
 ```
 
 ## Safety Boundaries

--- a/.ai/harness/handoff/codex-goal.md
+++ b/.ai/harness/handoff/codex-goal.md
@@ -49,8 +49,9 @@ Codex is the executor. ChatGPT/repo-harness may prepare planning artifacts, but 
 
 ```text
 /goal
-阅读： /Users/ancienttwo/Projects/agentic-dev-wt-mcp-connector/plans/prds/20260617-repo-harness-mcp-prd.md
-开worktree完整执行：/Users/ancienttwo/Projects/agentic-dev-wt-mcp-connector/plans/sprints/20260617-repo-harness-mcp-sprint.md
-完成阶段性任务，要staging再继续
-参考repo: /Users/ancienttwo/Projects/agentic-dev/_ref/local-dev-mcp
+Read: /Users/ancienttwo/Projects/agentic-dev-wt-mcp-connector/plans/prds/20260617-repo-harness-mcp-prd.md
+Open or use a worktree and complete: /Users/ancienttwo/Projects/agentic-dev-wt-mcp-connector/plans/sprints/20260617-repo-harness-mcp-sprint.md
+After each completed phase, stage the result before continuing.
+Use the user's language for status reports unless repo-local instructions require otherwise.
+Reference repo: /Users/ancienttwo/Projects/agentic-dev/_ref/local-dev-mcp
 ```

--- a/assets/skill-commands/repo-harness-goal/SKILL.md
+++ b/assets/skill-commands/repo-harness-goal/SKILL.md
@@ -32,7 +32,7 @@ Non-goals: <explicit exclusions>
 Execution route: <repo-harness-sprint row, repo-harness-plan, or contract worktree path>
 Acceptance checks: <commands or machine-checkable assertions>
 Stop condition: <verified completion or blocker evidence>
-Reporting: concise Chinese status, include changed files, tradeoffs, checks, and next bottleneck only if verified
+Reporting: use the user's language unless repo-local instructions require otherwise; include changed files, tradeoffs, checks, and next bottleneck only if verified
 ```
 
 ## Failure Modes

--- a/deploy/release-checklists/260618-repo-harness-0.7.0.md
+++ b/deploy/release-checklists/260618-repo-harness-0.7.0.md
@@ -29,6 +29,8 @@ session cleanup remains dry-run unless `--force` is passed.
 - `assets/skill-version.json`
 - README current release/stamp references, including localized READMEs
 - `docs/CHANGELOG.md`
+- ChatGPT Connector goal handoff and `repo-harness-goal` reporting language
+  policy
 - version expectation tests
 - release checklist and task notes
 
@@ -55,6 +57,10 @@ session cleanup remains dry-run unless `--force` is passed.
 - Focused release/browser checks passed:
   `bun test tests/bootstrap-files.test.ts tests/skill-version.test.ts tests/readme-dx.test.ts tests/cli/chatgpt-browser.test.ts tests/cli/mcp-tools.test.ts`
   returned `56 pass`, `0 fail`.
+- Focused MCP/Skill language checks passed:
+  `bun test tests/cli/mcp.test.ts tests/cli/mcp-tools.test.ts tests/cli/mcp-setup.test.ts tests/action-command-skills.test.ts`
+  returned `33 pass`, `0 fail`, and the old Chinese `/goal` tokens are absent
+  from non-test release surfaces.
 - Full release gate passed:
   `BUN_TEST_TIMEOUT_MS=180000 BUN_TEST_MAX_CONCURRENCY=1 bun run check:release`
   returned `840 pass`, `0 fail`, then completed deploy SQL order,
@@ -63,12 +69,12 @@ session cleanup remains dry-run unless `--force` is passed.
   `[release] OK: npm package gate passed`.
 - `npm pack --dry-run --json` returned:
   - filename: `repo-harness-0.7.0.tgz`
-  - package size: `4774929`
-  - unpacked size: `6898693`
+  - package size: `4774793`
+  - unpacked size: `6898999`
   - total files: `325`
-  - shasum: `5a3c69ac2cecab8265a7392e5e4f5ea31879b90d`
+  - shasum: `bbc8f22e4f9e4e7d3b3e39de91f530092fa1d872`
   - integrity:
-    `sha512-Ya0Y/KCxUdtYfzWW9Bsgslb4bthZnAeejXS0Lq5VuB3pIPR8zu8DB+KaaIEbfM+LD4/+flJuwqjTJqDko7OQTQ==`
+    `sha512-Gc6AiRtGgHfgYK2zdOA3MoMNzAKPBXVXcii6wyc+FImV/aO0ooUIk5E79rjOiBUA4wvUz8AZ/BVgWBxhJfbaLg==`
 - The package dry-run includes
   `.agents/skills/repo-harness-chatgpt-browser/SKILL.md`,
   `docs/repo-harness-chatgpt-browser-engine.md`, and

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -45,6 +45,10 @@ All notable changes to this skill are documented here.
 
 ### Fixed
 
+- Made generated ChatGPT Connector `/goal` prompts and `repo-harness-goal`
+  reporting guidance language-neutral, so installed skills and MCP goal handoff
+  output follow the user's language or repo-local instructions instead of
+  hard-coding Chinese prompt lines.
 - Made non-standard `repo-harness adopt --mode minimal|self-host` fail closed
   unless it routes to ordinary TypeScript `--dry-run` or
   `--experimental-ts-apply`,

--- a/plans/sprints/20260617-repo-harness-mcp-sprint.md
+++ b/plans/sprints/20260617-repo-harness-mcp-sprint.md
@@ -1649,7 +1649,7 @@ Checklist:
 * [x] Implement `prepare_codex_goal_from_sprint` for Sprint -> Goal.
 * [x] Implement `repo-harness mcp prepare-goal` as the local CLI equivalent.
 * [x] Ensure generated Sprint task cards include checklist items and staging gates.
-* [x] Ensure generated Goal includes the user's `阅读 / 开worktree完整执行 / 完成阶段性任务，要staging再继续 / 参考repo` shape.
+* [x] Ensure generated Goal uses a language-neutral `/goal` shape with read, worktree execution, stage-before-continue, user-language reporting, and optional reference repo lines.
 * [x] Keep direct Codex execution out of MCP; local Codex owns `/goal` execution.
 * [x] Add tests for the full chain and CLI handoff.
 * [x] Update guide and bridge Skill references.

--- a/src/cli/mcp/setup.ts
+++ b/src/cli/mcp/setup.ts
@@ -418,10 +418,11 @@ The generated \`/goal\` prompt should preserve this shape when absolute paths ar
 
 \`\`\`text
 /goal
-阅读： <prd-path>
-开worktree完整执行：<sprint-path>
-完成阶段性任务，要staging再继续
-参考repo: <optional-reference-repo>
+Read: <prd-path>
+Open or use a worktree and complete: <sprint-path>
+After each completed phase, stage the result before continuing.
+Use the user's language for status reports unless repo-local instructions require otherwise.
+Reference repo: <optional-reference-repo>
 \`\`\`
 
 ## Safety Boundaries

--- a/src/cli/mcp/tools.ts
+++ b/src/cli/mcp/tools.ts
@@ -398,10 +398,11 @@ function renderCodexGoalFromSprint(args: Record<string, unknown>): { body: strin
   const extraInstructions = String(args.extra_instructions ?? '').trim();
   const prompt = [
     '/goal',
-    `阅读： ${goalPrdPath}`,
-    `开worktree完整执行：${goalSprintPath}`,
-    '完成阶段性任务，要staging再继续',
-    referenceRepo ? `参考repo: ${referenceRepo}` : '',
+    `Read: ${goalPrdPath}`,
+    `Open or use a worktree and complete: ${goalSprintPath}`,
+    'After each completed phase, stage the result before continuing.',
+    'Use the user\'s language for status reports unless repo-local instructions require otherwise.',
+    referenceRepo ? `Reference repo: ${referenceRepo}` : '',
   ].filter(Boolean).join('\n');
   const body = [
     '# Codex Goal',

--- a/tasks/notes/repo-harness-0.7.0-release-prep.notes.md
+++ b/tasks/notes/repo-harness-0.7.0-release-prep.notes.md
@@ -10,6 +10,7 @@ ChatGPT browser engine PR.
 | Use `0.7.0` | The merged PR adds a new public CLI/MCP browser-engine feature line, not a patch-only fix. | `package.json`, `assets/skill-version.json`, `.claude/.skill-version`, README release surfaces, changelog, and version tests move together to `0.7.0`. |
 | Keep one package/template version line | The 0.4.0 release retired the separate generated-workflow compatibility line, and this release does not introduce a compatibility split. | Downstream generated stamps move together to `repo-harness@0.7.0+template@0.7.0`. |
 | Keep browser tools opt-in | The browser engine can create real ChatGPT Web conversations and write repo-local session records. | MCP tools are exposed only with `--enable-chatgpt-browser`; cleanup defaults to dry-run; native provider fails closed for unsupported model/thinking selection. |
+| Keep generated Goal prompts language-neutral | The ChatGPT Connector and installed skills can be used outside Chinese-language repos, while repo-local AGENTS/CLAUDE files may still require a language. | `/goal` prompt generation now tells agents to use the user's language unless repo-local instructions require otherwise. |
 | Stop before publish/tag/release | The current request is release preparation. Publishing npm, creating `v0.7.0`, and creating the GitHub release are irreversible public actions. | Release checklist records the hold and the required readback path. |
 
 ## Preflight Evidence
@@ -31,13 +32,17 @@ ChatGPT browser engine PR.
 - Focused release/browser checks passed:
   `bun test tests/bootstrap-files.test.ts tests/skill-version.test.ts tests/readme-dx.test.ts tests/cli/chatgpt-browser.test.ts tests/cli/mcp-tools.test.ts`
   returned `56 pass`, `0 fail`.
+- Focused MCP/Skill language checks passed:
+  `bun test tests/cli/mcp.test.ts tests/cli/mcp-tools.test.ts tests/cli/mcp-setup.test.ts tests/action-command-skills.test.ts`
+  returned `33 pass`, `0 fail`, and the old Chinese `/goal` tokens are absent
+  from non-test release surfaces.
 - Full release gate passed:
   `BUN_TEST_TIMEOUT_MS=180000 BUN_TEST_MAX_CONCURRENCY=1 bun run check:release`
   returned `840 pass`, `0 fail`, then completed workflow checks, repository
   inspection, package dry-run, tarball install smoke, and `[release] OK`.
 - `npm pack --dry-run --json` returned `repo-harness-0.7.0.tgz`, package size
-  `4774929`, unpacked size `6898693`, `325` files, and shasum
-  `5a3c69ac2cecab8265a7392e5e4f5ea31879b90d`.
+  `4774793`, unpacked size `6898999`, `325` files, and shasum
+  `bbc8f22e4f9e4e7d3b3e39de91f530092fa1d872`.
 - `bash scripts/check-tarball-install-smoke.sh` passed for
   `repo-harness-0.7.0.tgz`.
 

--- a/tests/action-command-skills.test.ts
+++ b/tests/action-command-skills.test.ts
@@ -256,5 +256,7 @@ describe("repo-harness action command skills", () => {
     expect(goal).toContain("If no detailed PRD/Sprint artifact is attached or named");
     expect(goal).toContain("Does not create, approve, or execute a Goal session without detailed PRD/Sprint context");
     expect(goal).toContain("Preserve host-native `/goal` ownership");
+    expect(goal).toContain("use the user's language unless repo-local instructions require otherwise");
+    expect(goal).not.toContain("concise Chinese status");
   });
 });

--- a/tests/cli/mcp-setup.test.ts
+++ b/tests/cli/mcp-setup.test.ts
@@ -110,7 +110,12 @@ describe('mcp setup', () => {
       expect(protectedResult.changed).toHaveLength(0);
       expect(readFileSync(skill, 'utf-8')).toBe('custom\n');
       runMcpInstallSkill({ repo: repoRoot, overwrite: true });
-      expect(readFileSync(skill, 'utf-8')).toContain('repo-harness-chatgpt-bridge');
+      const installed = readFileSync(skill, 'utf-8');
+      expect(installed).toContain('repo-harness-chatgpt-bridge');
+      expect(installed).toContain("Use the user's language for status reports unless repo-local instructions require otherwise.");
+      expect(installed).not.toContain('阅读：');
+      expect(installed).not.toContain('开worktree完整执行');
+      expect(installed).not.toContain('完成阶段性任务，要staging再继续');
     });
   });
 });

--- a/tests/cli/mcp-tools.test.ts
+++ b/tests/cli/mcp-tools.test.ts
@@ -223,9 +223,12 @@ describe('mcp tools', () => {
       expect(goal.status).toBe('written');
       expect(goal.path).toBe('.ai/harness/handoff/codex-goal.md');
       expect(goal.prompt).toContain('/goal');
-      expect(goal.prompt).toContain(`阅读： ${prd.path}`);
-      expect(goal.prompt).toContain(`开worktree完整执行：${sprint.path}`);
-      expect(goal.prompt).toContain('完成阶段性任务，要staging再继续');
+      expect(goal.prompt).toContain(`Read: ${prd.path}`);
+      expect(goal.prompt).toContain(`Open or use a worktree and complete: ${sprint.path}`);
+      expect(goal.prompt).toContain('After each completed phase, stage the result before continuing.');
+      expect(goal.prompt).toContain("Use the user's language for status reports unless repo-local instructions require otherwise.");
+      expect(goal.prompt).not.toContain('阅读：');
+      expect(goal.prompt).not.toContain('开worktree完整执行');
       const goalContent = readFileSync(join(repoRoot, '.ai/harness/handoff/codex-goal.md'), 'utf-8');
       expect(goalContent).toContain('## Host-native /goal prompt');
       expect(goalContent).toContain('No commit is created unless the user explicitly asks for commit.');

--- a/tests/cli/mcp.test.ts
+++ b/tests/cli/mcp.test.ts
@@ -69,9 +69,12 @@ describe('mcp command', () => {
       ]);
       expect(result.status).toBe(0);
       expect(result.stdout).toContain('/goal');
-      expect(result.stdout).toContain(`阅读： ${join(repoRoot, 'plans/prds/example.prd.md')}`);
-      expect(result.stdout).toContain(`开worktree完整执行：${join(repoRoot, 'plans/sprints/example.sprint.md')}`);
-      expect(result.stdout).toContain('完成阶段性任务，要staging再继续');
+      expect(result.stdout).toContain(`Read: ${join(repoRoot, 'plans/prds/example.prd.md')}`);
+      expect(result.stdout).toContain(`Open or use a worktree and complete: ${join(repoRoot, 'plans/sprints/example.sprint.md')}`);
+      expect(result.stdout).toContain('After each completed phase, stage the result before continuing.');
+      expect(result.stdout).toContain("Use the user's language for status reports unless repo-local instructions require otherwise.");
+      expect(result.stdout).not.toContain('阅读：');
+      expect(result.stdout).not.toContain('开worktree完整执行');
       const goalPath = join(repoRoot, '.ai/harness/handoff/codex-goal.md');
       expect(existsSync(goalPath)).toBe(true);
       expect(readFileSync(goalPath, 'utf-8')).toContain('## Host-native /goal prompt');


### PR DESCRIPTION
## Summary

- replace hard-coded Chinese ChatGPT Connector /goal prompt lines with language-neutral instructions
- make repo-harness-goal reporting follow the user's language unless repo-local instructions require otherwise
- update MCP setup templates, installed bridge skill, current handoff example, sprint filing, changelog, and release filing
- add regression assertions so the old Chinese /goal tokens do not return in generated skill/prompt surfaces

## Verification

- bun test tests/cli/mcp.test.ts tests/cli/mcp-tools.test.ts tests/cli/mcp-setup.test.ts tests/action-command-skills.test.ts
- BUN_TEST_TIMEOUT_MS=180000 BUN_TEST_MAX_CONCURRENCY=1 bun run check:release
- npm pack --dry-run --json
- git diff --check
- bash scripts/check-task-sync.sh && bash scripts/check-task-workflow.sh --strict
- rg --hidden -n "阅读：|开worktree完整执行|完成阶段性任务，要staging再继续|参考repo|concise Chinese status" --glob '!node_modules/**' --glob '!.git/**' --glob '!tests/**'