### PR TITLE
Harden ChatGPT connector readback flow

### DIFF
--- a/assets/skill-commands/repo-harness-gptpro/SKILL.md
+++ b/assets/skill-commands/repo-harness-gptpro/SKILL.md
@@ -36,21 +36,44 @@ Use GPT Pro language with the user. Treat the `browser-*` command names as imple
    `stamp="$(date -u +%Y%m%dT%H%M%SZ)"; slug="<short-purpose>"; mkdir -p .ai/harness/handoff/gptpro; out=".ai/harness/handoff/gptpro/gptpro-${stamp}-${slug}.md"; repo-harness chatgpt browser-consult --repo <repo> --provider oracle --model gpt-5.5-pro --heartbeat 59 --title "gptpro-${stamp}-${slug}" --prompt <prompt> --write-output "$out"`
 10. Use `--dry-run` first when attaching files, then run the real consult only after the prompt bundle and allowed paths are clear.
 11. For GPT Pro reviews or acceptance checks, resolve the recorded ChatGPT MCP server name from `repo-harness mcp doctor --repo <repo> --json` or `.repo-harness/mcp.local.json` (`chatgpt.serverName`). Treat `chatgpt.serverNameConfigured:false` or a missing `chatgpt.serverName` as setup-incomplete, then route to `repo-harness:gptpro_setup` before an MCP read-back review. Do not substitute a user-specific hard-coded MCP name.
-12. When the user asks for a reasoning mode, pass repo-harness `--thinking <light|standard|extended|heavy>` only after `browser-doctor --provider oracle` reports `browserThinkingTime:true`; repo-harness maps it to Oracle `--browser-thinking-time`.
-13. For long GPT Pro analysis tasks, keep Oracle heartbeat enabled at 59 seconds unless the user explicitly disables it; repo-harness streams heartbeat/diagnostic lines to stderr and reserves stdout for final JSON.
-14. Report the GPT Pro result with: session id, timestamped output path, conversation URL if present, whether it was a new consult or follow-up, and any visible-browser blocker.
+12. When MCP read-back is required, pass the recorded server name as an explicit ChatGPT app preselect: `serverName="$(repo-harness mcp doctor --repo <repo> --json | jq -r '.chatgpt.serverName // empty')"` and add `--chatgpt-app "$serverName"` to `browser-consult` or `browser-followup`. If the command fails with `ORACLE_APP_PRESELECT_UNSUPPORTED`, the selected Oracle binary cannot click the ChatGPT app selector yet; report that as a browser-trigger blocker instead of relying on prompt text like `@serverName`.
+13. When the user asks for a reasoning mode, pass repo-harness `--thinking <light|standard|extended|heavy>` only after `browser-doctor --provider oracle` reports `browserThinkingTime:true`; repo-harness maps it to Oracle `--browser-thinking-time`.
+14. For long GPT Pro analysis tasks, expect detailed Pro Extended planning/review runs to take 15 minutes or more. Do not treat elapsed time as failure while the session is still alive; wait for a final answer or a concrete browser, login, capture, or tool-call failure.
+15. Keep Oracle heartbeat enabled at 59 seconds unless the user explicitly disables it; repo-harness streams heartbeat/diagnostic lines to stderr and reserves stdout for final JSON. Heartbeat lines like `no thinking status detected yet` are progress diagnostics, not a blocker by themselves.
+16. Report the GPT Pro result with: session id, timestamped output path, conversation URL if present, whether it was a new consult or follow-up, and any visible-browser blocker.
 
 ## MCP Read-Back Acceptance
 
 When asking GPT Pro to review repo updates, include an explicit acceptance requirement in the prompt:
 
 - Use the recorded ChatGPT MCP server name from `chatgpt.serverName` to read the current repo state before producing findings or a merge/readiness verdict.
+- Before a Pro MCP attempt, open ChatGPT Settings -> Connectors for the recorded server name, run Refresh or Scan Tools, verify the expected Action is listed, then start a fresh chat and select the Connector from `+` -> More.
 - Read at least the changed-file list or status, the relevant diffs or changed files, and any requested session/handoff artifacts through that recorded MCP server; pasted summaries are context, not sufficient evidence.
 - Include a short `MCP Read Evidence` section in the final answer naming the recorded MCP server, the reads performed, and the files, diffs, or artifacts inspected.
 - If the recorded MCP server name is missing, or `mcp doctor --json` reports `chatgpt.serverNameConfigured:false`, route to `repo-harness:gptpro_setup` so initialization can record it before review.
 - If the recorded MCP server is unavailable, blocked, stale, or cannot read the requested paths, classify the result as blocked or partial instead of issuing a merge-ready verdict.
 - A prompt that asks ChatGPT to use the recorded MCP server is not sufficient by itself; the ChatGPT conversation must expose the app/action schema. If the conversation reports that the app is not exposed, use a fresh app-enabled conversation or a GitHub PR/diff evidence source instead of claiming MCP read-back evidence.
+- For Pro runs, the normal tool-call runtime UI may not appear the way it does for other models because Pro uses a sandbox/process flow. In the visible ChatGPT Web UI, click the assistant's `Thinking` / `Thought for ...` disclosure to open the right-side process pane. Use that pane to confirm whether Pro actually emitted a `Called tool` event for the selected app, which action it chose, or whether it only reasoned inside the sandbox without invoking MCP.
+- Treat `Called tool` with an action/result, or an equivalent captured tool-call transcript, as the only accepted MCP invocation evidence. Reject connector selection, assistant self-report, plausible JSON, and sandbox shell exploration as proof.
+- Classify Pro outcomes explicitly: `invocation_verified` for a real tool call, `approval_pending` for a real confirmation prompt, `surface_blocked` for sandbox-only reasoning or `app_unavailable` with no tool event, and `bundle_fallback` when Pro reviews a local evidence bundle instead of reading through MCP.
 - Do not ask GPT Pro to retrieve secrets, cookies, browser storage, ignored private operations state, or other denied paths through the recorded MCP server.
+
+## Pro Surface Fallback
+
+- When Pro is `surface_blocked`, stop retrying the same connector prompt after one explicit-tool retry. Do not delete/recreate the Connector as the first response to a Pro-only dispatch failure.
+- Reuse the existing local GPT Pro/Oracle handoff path. Build a bounded evidence bundle from local files, diffs, checks, and known external findings, then ask Pro for a plan or review over that bundle.
+- The fallback prompt must include a provenance header:
+
+```yaml
+source: local_repo_harness_bundle
+pro_invoked_mcp: false
+working_tree: clean | dirty
+included_paths: [...]
+omitted_or_truncated: [...]
+```
+
+- Tell Pro that anything outside the bundle is unknown. Codex executes and verifies locally, then creates a fresh post-change bundle for another Pro review if needed.
+- Distinguish permissions: repo-scope setup is repo-bound; broad repo discovery requires explicit user-scope setup with full-disk read. Do not recommend full-disk read by default.
 
 ## Research Promotion
 

--- a/assets/skill-version.json
+++ b/assets/skill-version.json
@@ -158,7 +158,7 @@
     },
     {
       "version": "0.7.4",
-      "description": "Stops compact adopt from restoring retired root helper wrappers and lets package-dispatched architecture helpers run without repo-local scripts"
+      "description": "Adds user-scope ChatGPT MCP full-disk repo discovery, GPT Pro Connector read-back safeguards, and package-dispatched architecture helper fixes while retiring compact adopt root wrappers"
     }
   ],
   "generatedProjectStamp": {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,12 +4,6 @@ All notable changes to this skill are documented here.
 
 ## [Unreleased]
 
-### Added
-
-- Added explicit ChatGPT app preselection for Oracle browser consults via
-  `--chatgpt-app`, so GPT Pro MCP read-back prompts can select the recorded
-  Connector app before submitting instead of relying on prompt text mentions.
-
 ## [0.7.4] - 2026-06-20
 
 ### Added
@@ -21,6 +15,11 @@ All notable changes to this skill are documented here.
 - Added `discover_harness_repos` plus `repo_path` targeting for MCP read tools,
   so a user-authorized full-disk ChatGPT Connector can find adopted repos before
   reading workflow state.
+- Added explicit ChatGPT app preselection for Oracle browser consults via
+  `--chatgpt-app`, so GPT Pro MCP read-back prompts can select the recorded
+  Connector app before submitting instead of relying on prompt text mentions.
+- Added ChatGPT Connector invocation-evidence metadata to `mcp doctor`, making
+  local setup readiness distinct from per-chat/model tool invocation proof.
 
 ### Fixed
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this skill are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- Added explicit ChatGPT app preselection for Oracle browser consults via
+  `--chatgpt-app`, so GPT Pro MCP read-back prompts can select the recorded
+  Connector app before submitting instead of relying on prompt text mentions.
+
 ## [0.7.4] - 2026-06-20
 
 ### Added
@@ -12,6 +18,9 @@ All notable changes to this skill are documented here.
   explicit `--allow-full-disk-read` opt-in that stores local MCP config and auth
   under `~/.repo-harness/` and lets read tools inspect any OS-readable file when
   the server is launched from `/`.
+- Added `discover_harness_repos` plus `repo_path` targeting for MCP read tools,
+  so a user-authorized full-disk ChatGPT Connector can find adopted repos before
+  reading workflow state.
 
 ### Fixed
 

--- a/docs/repo-harness-chatgpt-browser-engine.md
+++ b/docs/repo-harness-chatgpt-browser-engine.md
@@ -101,6 +101,15 @@ The wrapper maps repo-harness input to `oracle --engine browser --browser-archiv
 
 The oracle binary is resolved in a fixed, auditable order — `--oracle-bin`, then `REPO_HARNESS_ORACLE_BIN`, then repo-local `node_modules/.bin/oracle`, then `oracle` on `PATH`. A missing binary fails with `ORACLE_NOT_INSTALLED`; explicitly configured binaries (`--oracle-bin` or `REPO_HARNESS_ORACLE_BIN`) fail closed when invalid and do not silently fall through to the next source. repo-harness never implicitly downloads or `npx`-executes an unpinned oracle. `browser-doctor --provider oracle --json` runs `--help`, `--debug-help`, `--version`, plus an isolated `--browser-thinking-time` dry-run parser probe, and reports `installed`, resolved `binary`, `version`, `nodeCompatible`, a `capabilities` map (`browserEngine`, `writeOutput`, `browserFollowup`, `sessionFollowup`, `browserArchive`, `browserModelStrategy`, `browserCookiePath`, `browserThinkingTime`, `chatgptUrl`, `heartbeat`), and opt-in `agent_actions` when a GPT Pro setup repair can install, upgrade, or re-point the selected pinned external CLI; `status:"ready"` requires every capability for every flag repo-harness may send at runtime.
 
+When a ChatGPT MCP Connector app must be active for read-back, use `--chatgpt-app <serverName>` with the server name recorded by `repo-harness mcp doctor --repo <repo> --json` under `chatgpt.serverName`. repo-harness maps that to Oracle `--browser-app <serverName>` so Oracle selects the composer app before submitting the prompt. This is an opt-in capability: it is reported under `oracle.optionalCapabilities.browserAppPreselect` and is required only when `--chatgpt-app` is present. If the selected Oracle binary lacks `--browser-app`, the run fails before prompt submission with `ORACLE_APP_PRESELECT_UNSUPPORTED`; do not rely on plain prompt text such as `@serverName` as evidence that ChatGPT exposed MCP tools.
+
+App selection and tool availability are separate gates. `--chatgpt-app` only
+selects the Connector in the composer; ChatGPT can still see a stale scanned
+tool schema. If a run proves the app is selected but ChatGPT reports a specific
+tool unavailable, compare the live MCP `/mcp` `tools/list` against the
+Connector's visible tools and use ChatGPT Connector **Scan Tools** to refresh the
+schema.
+
 Long Oracle browser runs default to `--heartbeat 59`. repo-harness streams Oracle diagnostics and heartbeat lines to stderr while preserving stdout for the final JSON payload, so humans and agents get a periodic liveness signal without breaking automation that parses command output.
 
 Oracle browser mode supports model selection through `--model` and thinking intensity through `--browser-thinking-time <light|standard|extended|heavy>`. repo-harness maps its `--thinking` value directly to that Oracle browser flag after doctor has verified parser support. Oracle also supports `--browser-manual-login`, but repo-harness intentionally does not send it on the bound-profile path because it skips cookie copy and would make the selected Chrome profile cookie DB non-authoritative.

--- a/docs/repo-harness-chatgpt-mcp-setup.md
+++ b/docs/repo-harness-chatgpt-mcp-setup.md
@@ -24,6 +24,12 @@ repo-harness mcp setup chatgpt --scope user --repo / --allow-full-disk-read --en
 repo-harness mcp serve --repo / --transport http --host 127.0.0.1 --port 8765 --profile planner
 ```
 
+In user-scope mode, ChatGPT should first call `discover_harness_repos` to find
+adopted repositories, then pass the selected `repoRoot` as `repo_path` to
+`harness_status`, `latest_handoff`, `latest_checks`, and other read tools. Read
+tools without `repo_path` report the configured server root; they do not
+auto-select a discovered repo.
+
 Health check:
 
 ```bash
@@ -181,9 +187,89 @@ repo-harness mcp prepare-goal --repo . --prd plans/prds/<feature>.prd.md --sprin
 
 ## Test Prompt
 
-```text
-Use repo-harness to inspect this repo. Call harness_status, latest_handoff, and list_workflow_files. Do not write files.
+When testing through `repo-harness-gptpro`, pass the configured Connector name
+as an explicit browser app selector instead of relying on prompt text:
+
+```bash
+serverName="$(repo-harness mcp doctor --repo . --json | jq -r '.chatgpt.serverName // empty')"
+repo-harness chatgpt browser-consult --repo . --provider oracle --chatgpt-app "$serverName" --prompt "Call harness_doctor and report MCP Read Evidence."
 ```
+
+If the selected Oracle binary does not support app preselection yet,
+repo-harness fails before prompt submission with `ORACLE_APP_PRESELECT_UNSUPPORTED`.
+In that case, manually select the Connector from ChatGPT's composer `+` menu or
+upgrade/pin an Oracle binary with `--browser-app` support before treating the
+run as MCP read-back evidence.
+
+```text
+Use repo-harness to inspect my local development repos. First call discover_harness_repos. Pick the repoRoot that matches the user's target, then call harness_status, latest_handoff, and list_workflow_files with repo_path set to that repoRoot. Do not write files.
+```
+
+ChatGPT can only call tools present in the Connector schema it scanned. Selecting
+the app in the composer exposes that scanned schema to the conversation; it does
+not force ChatGPT to refresh the server's current `tools/list`. After adding a
+tool or changing the sidecar scope, restart `repo-harness mcp serve`, verify the
+local `/mcp` `tools/list`, then open the ChatGPT Connector settings and run
+**Scan Tools** again. If ChatGPT says the app is selected but a tool is
+unavailable while local `tools/list` includes it, the ChatGPT Connector schema is
+stale.
+
+## Connector Invocation Evidence
+
+Treat Connector readiness as four independent checks:
+
+1. Endpoint: the sidecar and public HTTPS `/mcp` endpoint respond.
+2. Schema: ChatGPT Connector settings show the expected Action after Refresh.
+3. Selection: a fresh chat has the recorded Connector selected from `+` -> More.
+4. Invocation: the current model surface emits a real tool call.
+
+Only a visible `Called tool` event with the selected Action/result, or an
+equivalent captured tool-call transcript, proves MCP invocation. Connector
+selection, assistant self-report, plausible JSON, or sandbox shell commands do
+not prove that ChatGPT called MCP.
+
+For Pro runs, the normal tool-call runtime UI may not appear the way it does for
+other models because Pro uses a sandbox/process flow. In the visible ChatGPT Web
+UI, click the assistant's `Thinking` / `Thought for ...` disclosure to open the
+right-side process pane. Use that pane to confirm whether Pro actually emitted a
+`Called tool` event for the selected app, which action it chose, or whether it
+only reasoned inside the sandbox without invoking MCP. If the pane shows
+sandbox-only exploration, or the answer reports `app_unavailable` without a tool
+event, classify the outcome as `surface_blocked`, not as a broken repo or
+sidecar.
+
+Detailed Pro Extended planning and review tasks commonly take 15 minutes or
+more. When driving Pro through the browser path, do not treat elapsed time as
+failure while the session is still alive; wait for a final answer or a concrete
+browser, login, capture, or tool-call failure. Keep the Oracle heartbeat enabled;
+heartbeat diagnostics such as `no thinking status detected yet` are progress
+signals, not blockers by themselves.
+
+Outcome labels:
+
+- `invocation_verified`: real `Called tool` event or captured tool-call transcript.
+- `approval_pending`: a real tool request produced a confirmation prompt.
+- `surface_blocked`: schema is current, but the current model surface did not call MCP.
+- `bundle_fallback`: Pro is reviewing a local evidence bundle and did not read through MCP.
+
+When Pro is `surface_blocked`, use `repo-harness-gptpro` to send a bounded local
+evidence bundle through the existing Oracle/browser handoff. The bundle must say
+it was produced locally, list included and omitted/truncated material, and
+include:
+
+```yaml
+source: local_repo_harness_bundle
+pro_invoked_mcp: false
+working_tree: clean | dirty
+```
+
+Do not claim MCP read-back evidence for fallback output. Pro can plan or review
+the supplied bundle, while Codex still executes and verifies locally.
+
+Permission scope is separate from invocation evidence. Repo-scope setup is bound
+to the configured repo and does not imply arbitrary repo discovery. User-scope
+setup with explicit full-disk read is required before broad repo discovery is
+authorized.
 
 ## PRD Prompt
 
@@ -219,7 +305,7 @@ Use repo-harness-chatgpt-bridge. Execute the latest ChatGPT-generated Codex goal
 
 - If ChatGPT cannot connect, verify the tunnel URL is HTTPS and ends in `/mcp`.
 - If ChatGPT returns unauthorized, verify OAuth discovery works and re-run the authorization passphrase flow.
-- If tools are missing, restart `repo-harness mcp serve` and rescan tools.
+- If tools are missing in ChatGPT but present in local `tools/list`, restart `repo-harness mcp serve`, then run **Scan Tools** in the ChatGPT Connector settings so ChatGPT refreshes its cached schema.
 - If writes fail, verify the target path is a PRD, sprint, plan, or approved handoff file.
 - If ChatGPT generated prose instead of checklist Sprint task cards, ask it to use write_checklist_sprint.
 - If Codex cannot see the server, run `repo-harness mcp setup codex --repo . --scope project`.

--- a/src/cli/chatgpt-browser/engine.ts
+++ b/src/cli/chatgpt-browser/engine.ts
@@ -12,7 +12,7 @@ import {
 } from './binding';
 import { resolveBrowserOutputPath } from './file-policy';
 import { checkNativeChatgptSession, nativeDebuggingBlockedByDefaultProfile, nativeProviderAvailable, runNativeProvider } from './native-provider';
-import { buildOracleCommand, probeOracle, resolveOracleBin, runOracleProvider } from './oracle-provider';
+import { buildOracleCommand, probeOracle, resolveOracleBin, runOracleProvider, supportsBrowserAppPreselect } from './oracle-provider';
 import { assemblePromptBundle } from './prompt-assembler';
 import {
   cleanupBrowserSessions,
@@ -290,6 +290,9 @@ export async function browserDoctor(
   const oraclePresent = Boolean(oracleResolution.binary);
   const oracleProbe = oracleResolution.binary ? probeOracle(oracleResolution.binary) : undefined;
   const oracleCapabilities = oracleProbe?.capabilities ?? EMPTY_ORACLE_CAPABILITIES;
+  const oracleOptionalCapabilities = {
+    browserAppPreselect: oracleProbe ? supportsBrowserAppPreselect(oracleProbe.helpText) : false,
+  };
   const missingOracleCapabilities = Object.entries(oracleCapabilities)
     .filter(([, supported]) => supported !== true)
     .map(([capability]) => capability);
@@ -399,6 +402,7 @@ export async function browserDoctor(
       version: oracleProbe?.version,
       nodeCompatible: oracleProbe?.nodeCompatible ?? false,
       capabilities: oracleCapabilities,
+      optionalCapabilities: oracleOptionalCapabilities,
       missingCapabilities: missingOracleCapabilities,
       error: oracleError,
     },
@@ -464,6 +468,20 @@ export async function runBrowserConsult(input: BrowserConsultInput): Promise<Bro
   const effectiveInput = withBrowserBinding(input, provider);
   assertOutputTarget(effectiveInput);
   const bundle = assemblePromptBundle(effectiveInput);
+  if (effectiveInput.chatgptApp && provider !== 'oracle') {
+    return writeBrowserSession({
+      input: effectiveInput,
+      provider,
+      status: 'failed',
+      bundle,
+      output: `ChatGPT app preselection requires the oracle provider; ${provider} does not select composer apps.`,
+      error: {
+        code: 'CHATGPT_APP_PRESELECT_PROVIDER_UNSUPPORTED',
+        message: `ChatGPT app preselection is not supported by provider "${provider}"`,
+        recovery: 'Use --provider oracle with an Oracle binary that supports --browser-app, or omit --chatgpt-app and select the app manually.',
+      },
+    });
+  }
   if (effectiveInput.dryRun !== true) {
     if (provider === 'oracle') {
       const oracle = await runOracleProvider(effectiveInput, bundle);
@@ -548,6 +566,7 @@ export async function runBrowserFollowup(input: Omit<BrowserConsultInput, 'sourc
     thinking: input.thinking ?? existing.meta.model.thinking,
     provider,
     chatgptUrl: input.chatgptUrl ?? existing.meta.browser.conversationUrl ?? existing.meta.browser.chatgptUrl,
+    chatgptApp: input.chatgptApp ?? existing.meta.browser.chatgptApp,
     profileDir: input.profileDir ?? existing.meta.browser.profileDir,
     profileDirectory: input.profileDirectory ?? existing.meta.browser.profileDirectory,
     browserChannel: input.browserChannel ?? existing.meta.browser.channel,

--- a/src/cli/chatgpt-browser/oracle-provider.ts
+++ b/src/cli/chatgpt-browser/oracle-provider.ts
@@ -54,6 +54,10 @@ export interface OracleProbe {
   helpText: string;
 }
 
+export function supportsBrowserAppPreselect(helpText: string): boolean {
+  return helpText.includes('--browser-app');
+}
+
 /**
  * Resolve the oracle binary through a fixed, auditable order. We never implicitly
  * download or `npx`-execute an unpinned oracle; a missing binary is a hard,
@@ -193,6 +197,7 @@ export function buildOracleCommand(input: BrowserConsultInput, answerPath?: stri
   if (input.model) args.push('--model', input.model, '--browser-model-strategy', 'select');
   else args.push('--browser-model-strategy', 'current');
   if (input.thinking) args.push('--browser-thinking-time', input.thinking);
+  if (input.chatgptApp) args.push('--browser-app', input.chatgptApp);
   if (input.chatgptUrl) args.push('--chatgpt-url', input.chatgptUrl);
   args.push('--heartbeat', String(input.heartbeatSeconds ?? 59));
   const cookiePath = resolveOracleCookiePath(input);
@@ -333,6 +338,23 @@ export async function runOracleProvider(input: BrowserConsultInput, _bundle: Pro
         recovery: resolution.error?.recovery ?? 'Install oracle (pin the version; do not auto-download), or pass --oracle-bin / set REPO_HARNESS_ORACLE_BIN, or rerun with --dry-run.',
       },
     };
+  }
+  if (input.chatgptApp) {
+    const probe = probeOracle(resolution.binary);
+    if (!supportsBrowserAppPreselect(probe.helpText)) {
+      return {
+        status: 'failed',
+        output: `Oracle binary does not support ChatGPT app preselection for "${input.chatgptApp}".`,
+        command: [resolution.binary, ...buildOracleCommand(input)],
+        oracleBinary: resolution.binary,
+        oracleVersion: probe.version,
+        error: {
+          code: 'ORACLE_APP_PRESELECT_UNSUPPORTED',
+          message: 'oracle binary did not report --browser-app support',
+          recovery: 'Upgrade or point repo-harness at an Oracle binary that supports --browser-app, omit --chatgpt-app, or manually select the ChatGPT app in the composer before relying on MCP tools.',
+        },
+      };
+    }
   }
   if (input.profileDir && !resolveOracleCookiePath(input)) {
     const selectedProfilePath = input.profileDirectory

--- a/src/cli/chatgpt-browser/session-store.ts
+++ b/src/cli/chatgpt-browser/session-store.ts
@@ -76,6 +76,7 @@ function renderTranscript(meta: BrowserSessionMeta, bundle: PromptBundle, output
     `- Provider: ${meta.provider}`,
     `- Model: ${meta.model.requested ?? 'current'}`,
     `- Thinking: ${meta.model.thinking ?? 'unspecified'}`,
+    ...(meta.browser.chatgptApp ? [`- ChatGPT App: ${meta.browser.chatgptApp}`] : []),
     ...(meta.sourceSessionId ? [`- Source Session: ${meta.sourceSessionId}`] : []),
     ...(meta.browser.conversationUrl ? [`- Conversation: ${meta.browser.conversationUrl}`] : []),
     `- Created: ${meta.createdAt}`,
@@ -162,6 +163,7 @@ export function writeBrowserSession(opts: {
     browser: {
       mode: 'manual-login',
       chatgptUrl: opts.input.chatgptUrl ?? 'https://chatgpt.com/',
+      chatgptApp: opts.input.chatgptApp,
       channel: opts.input.browserChannel,
       profileDir: opts.input.profileDir,
       profileDirectory: opts.input.profileDirectory,

--- a/src/cli/chatgpt-browser/types.ts
+++ b/src/cli/chatgpt-browser/types.ts
@@ -25,6 +25,7 @@ export interface BrowserConsultInput {
   followups?: string[];
   model?: string;
   thinking?: ThinkingLevel;
+  chatgptApp?: string;
   provider?: BrowserProviderName;
   chatgptUrl?: string;
   timeoutMs?: number;
@@ -93,6 +94,7 @@ export interface BrowserSessionMeta {
   browser: {
     mode: 'manual-login';
     chatgptUrl: string;
+    chatgptApp?: string;
     channel?: NativeBrowserChannel;
     profileDir?: string;
     profileDirectory?: string;

--- a/src/cli/commands/chatgpt.ts
+++ b/src/cli/commands/chatgpt.ts
@@ -56,6 +56,7 @@ interface BrowserConsultOptions extends BrowserCommonOptions {
   followUp?: string[];
   model?: string;
   thinking?: string;
+  chatgptApp?: string;
   provider?: string;
   chatgptUrl?: string;
   timeoutMs?: string;
@@ -81,6 +82,7 @@ interface BrowserFollowupOptions extends BrowserCommonOptions {
   followUp?: string[];
   model?: string;
   thinking?: string;
+  chatgptApp?: string;
   provider?: string;
   timeoutMs?: string;
   heartbeat?: string;
@@ -237,6 +239,7 @@ export function buildChatgptCommand(): Command {
     .option('--follow-up <text>', 'Follow-up prompt for the same conversation', (value, previous: string[] = []) => [...previous, value], [])
     .option('--model <label>', 'Requested ChatGPT model label')
     .option('--thinking <level>', 'Thinking level: light|standard|extended|heavy')
+    .option('--chatgpt-app <name>', 'Select a ChatGPT app/connector by name before submitting the prompt')
     .option('--provider <provider>', 'Browser provider: oracle|native|bridge', 'oracle')
     .option('--chatgpt-url <url>', 'ChatGPT URL to open')
     .option('--timeout-ms <ms>', 'Assistant timeout in milliseconds')
@@ -264,6 +267,7 @@ export function buildChatgptCommand(): Command {
           followups: rawOpts.followUp,
           model: rawOpts.model,
           thinking: parseThinking(rawOpts.thinking),
+          chatgptApp: rawOpts.chatgptApp,
           provider: parseProvider(rawOpts.provider),
           chatgptUrl: rawOpts.chatgptUrl,
           timeoutMs: parsePositiveInteger('timeout-ms', rawOpts.timeoutMs),
@@ -314,6 +318,7 @@ export function buildChatgptCommand(): Command {
     .option('--follow-up <text>', 'Additional follow-up prompt', (value, previous: string[] = []) => [...previous, value], [])
     .option('--model <label>', 'Override requested ChatGPT model label')
     .option('--thinking <level>', 'Thinking level: light|standard|extended|heavy')
+    .option('--chatgpt-app <name>', 'Select a ChatGPT app/connector by name before submitting the follow-up')
     .option('--provider <provider>', 'Browser provider: oracle|native|bridge')
     .option('--timeout-ms <ms>', 'Assistant timeout in milliseconds')
     .option('--heartbeat <seconds>', 'Oracle provider heartbeat interval in seconds; 0 disables Oracle heartbeat (default: 59)')
@@ -338,6 +343,7 @@ export function buildChatgptCommand(): Command {
           followups: rawOpts.followUp,
           model: rawOpts.model,
           thinking: parseThinking(rawOpts.thinking),
+          chatgptApp: rawOpts.chatgptApp,
           provider: rawOpts.provider ? parseProvider(rawOpts.provider) : undefined,
           timeoutMs: parsePositiveInteger('timeout-ms', rawOpts.timeoutMs),
           heartbeatSeconds: parseNonNegativeInteger('heartbeat', rawOpts.heartbeat),

--- a/src/cli/mcp/setup.ts
+++ b/src/cli/mcp/setup.ts
@@ -334,6 +334,63 @@ repo-harness mcp prepare-goal --repo . --prd plans/prds/<feature>.prd.md --sprin
 Use repo-harness to inspect this repo. Call harness_status, latest_handoff, and list_workflow_files. Do not write files.
 \`\`\`
 
+## Connector Invocation Evidence
+
+Treat Connector readiness as four independent checks:
+
+1. Endpoint: the sidecar and public HTTPS \`/mcp\` endpoint respond.
+2. Schema: ChatGPT Connector settings show the expected Action after Refresh.
+3. Selection: a fresh chat has the recorded Connector selected from \`+\` -> More.
+4. Invocation: the current model surface emits a real tool call.
+
+Only a visible \`Called tool\` event with the selected Action/result, or an
+equivalent captured tool-call transcript, proves MCP invocation. Connector
+selection, assistant self-report, plausible JSON, or sandbox shell commands do
+not prove that ChatGPT called MCP.
+
+For Pro runs, the normal tool-call runtime UI may not appear the way it does for
+other models because Pro uses a sandbox/process flow. In the visible ChatGPT Web
+UI, click the assistant's \`Thinking\` / \`Thought for ...\` disclosure to open
+the right-side process pane. Use that pane to confirm whether Pro actually
+emitted a \`Called tool\` event for the selected app, which action it chose, or
+whether it only reasoned inside the sandbox without invoking MCP. If the pane
+shows sandbox-only exploration, or the answer reports \`app_unavailable\` without
+a tool event, classify the outcome as \`surface_blocked\`, not as a broken repo
+or sidecar.
+
+Detailed Pro Extended planning and review tasks commonly take 15 minutes or
+more. When driving Pro through the browser path, do not treat elapsed time as
+failure while the session is still alive; wait for a final answer or a concrete
+browser, login, capture, or tool-call failure. Keep the Oracle heartbeat enabled;
+heartbeat diagnostics such as \`no thinking status detected yet\` are progress
+signals, not blockers by themselves.
+
+Outcome labels:
+
+- \`invocation_verified\`: real \`Called tool\` event or captured tool-call transcript.
+- \`approval_pending\`: a real tool request produced a confirmation prompt.
+- \`surface_blocked\`: schema is current, but the current model surface did not call MCP.
+- \`bundle_fallback\`: Pro is reviewing a local evidence bundle and did not read through MCP.
+
+When Pro is \`surface_blocked\`, use \`repo-harness-gptpro\` to send a bounded
+local evidence bundle through the existing Oracle/browser handoff. The bundle
+must say it was produced locally, list included and omitted/truncated material,
+and include:
+
+\`\`\`yaml
+source: local_repo_harness_bundle
+pro_invoked_mcp: false
+working_tree: clean | dirty
+\`\`\`
+
+Do not claim MCP read-back evidence for fallback output. Pro can plan or review
+the supplied bundle, while Codex still executes and verifies locally.
+
+Permission scope is separate from invocation evidence. Repo-scope setup is bound
+to the configured repo and does not imply arbitrary repo discovery. User-scope
+setup with explicit full-disk read is required before broad repo discovery is
+authorized.
+
 ## PRD Prompt
 
 \`\`\`text
@@ -837,6 +894,7 @@ export function runMcpDoctor(opts: { repo?: string; json?: boolean }): McpSetupR
       guide: existsSync(join(repoRoot, 'docs', 'repo-harness-chatgpt-mcp-setup.md')),
       authConfigured,
       permissions: {
+        configurationScope: configScope,
         fullDiskRead: localConfig?.scope === 'user' && localConfig.permissions?.fullDiskRead === true,
       },
       devMode: {
@@ -861,6 +919,15 @@ export function runMcpDoctor(opts: { repo?: string; json?: boolean }): McpSetupR
       publicEndpoint: localConfig?.chatgpt?.endpoint,
       authMode,
       manualStepsRequired: true,
+      invocationVerification: {
+        status: 'manual_required',
+        checkableByDoctor: false,
+        scope: 'per_chat_model_surface',
+        acceptedEvidence: [
+          'called_tool_event',
+          'captured_tool_call_transcript',
+        ],
+      },
       setup: configScope === 'user'
         ? `repo-harness mcp setup chatgpt --repo ${repoRoot} --scope user`
         : 'repo-harness mcp setup chatgpt --repo .',
@@ -874,10 +941,11 @@ export function runMcpDoctor(opts: { repo?: string; json?: boolean }): McpSetupR
       `[repo-harness mcp] Repo: ${repoRoot}`,
       `[repo-harness mcp] Status: ${report.status}`,
       `[repo-harness mcp] Config scope: ${configScope}`,
-      `[repo-harness mcp] Full-disk read: ${report.mcp.permissions.fullDiskRead ? 'enabled' : 'disabled'}`,
+      `[repo-harness mcp] Full-disk read: ${report.mcp.permissions.fullDiskRead ? 'enabled' : 'disabled'} (configuration scope: ${report.mcp.permissions.configurationScope})`,
       `[repo-harness mcp] ChatGPT MCP server name: ${
         configuredServerName ?? `missing (run setup; default is ${DEFAULT_CHATGPT_MCP_SERVER_NAME})`
       }`,
+      '[repo-harness mcp] ChatGPT tool invocation: manual verification required (doctor checks local MCP health, not per-chat/model dispatch)',
       `[repo-harness mcp] ChatGPT guide: ${report.mcp.guide ? 'present' : 'missing'}`,
       `[repo-harness mcp] ChatGPT auth: ${report.mcp.authConfigured ? `${authMode} present` : 'missing'}`,
       `[repo-harness mcp] Dev runner: ${report.mcp.devMode.agentRunner ? `enabled (${report.mcp.devMode.allowedAgents.join(',')})` : 'disabled'}`,

--- a/src/cli/mcp/tools.ts
+++ b/src/cli/mcp/tools.ts
@@ -1,13 +1,14 @@
 import { createHash } from 'crypto';
 import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync, appendFileSync } from 'fs';
-import { basename, dirname, join } from 'path';
+import { homedir } from 'os';
+import { basename, dirname, isAbsolute, join, resolve } from 'path';
 import { runProcess } from '../../effects/process-runner';
 import { runHelper } from '../runtime/helper-runner';
 import { listSessions, openSession, readSession, runBrowserConsult, runBrowserFollowup } from '../chatgpt-browser/engine';
 import type { BrowserProviderName, NativeBrowserChannel, ThinkingLevel } from '../chatgpt-browser/types';
 import { hashMcpInput, tryWriteMcpAuditEntry } from './audit';
 import { resolveMcpPath } from './paths';
-import { currentGitBranch, isRepoHarnessAdopted } from './repo';
+import { currentGitBranch, isRepoHarnessAdopted, resolveMcpRepoRoot } from './repo';
 import { redactMcpText } from './redaction';
 import type { McpAgentRunnerName, McpPolicy } from './types';
 
@@ -31,6 +32,40 @@ interface CallToolResult {
 }
 
 const EMPTY_SCHEMA = { type: 'object', additionalProperties: false };
+const DEFAULT_DISCOVERY_DEPTH = 7;
+const DEFAULT_DISCOVERY_LIMIT = 12;
+const DISCOVERY_SKIP_DIRS = new Set([
+  '.bun',
+  '.codegraph',
+  '.local',
+  '.Trash',
+  '.worktrees',
+  '.cache',
+  '.git',
+  '.npm',
+  '.pnpm-store',
+  '.repo-harness',
+  '.rustup',
+  'Applications',
+  'Caches',
+  'Library',
+  'Movies',
+  'Music',
+  'Pictures',
+  'System',
+  'Volumes',
+  'bin',
+  'build',
+  'coverage',
+  'codex-backups',
+  'dev',
+  'dist',
+  'node_modules',
+  'private',
+  'proc',
+  'sbin',
+  'usr',
+]);
 
 function textResult(value: unknown): CallToolResult {
   return {
@@ -52,6 +87,127 @@ function audit(ctx: McpToolContext, tool: string, status: 'ok' | 'blocked' | 'fa
     inputHash: hashMcpInput(input),
     error,
   });
+}
+
+function repoSummary(repoRoot: string): { repoRoot: string; adopted: boolean; branch: string | null; workflowRoots: Array<{ path: string; exists: boolean }> } {
+  const roots = ['docs/spec.md', 'plans', 'tasks/current.md', '.ai/harness/handoff', '.ai/harness/checks'];
+  return {
+    repoRoot,
+    adopted: isRepoHarnessAdopted(repoRoot),
+    branch: currentGitBranch(repoRoot),
+    workflowRoots: roots.map((path) => ({ path, exists: existsSync(join(repoRoot, path)) })),
+  };
+}
+
+function isFullDiskRead(ctx: McpToolContext): boolean {
+  return ctx.policy.allowAbsoluteRead === true && ctx.policy.readGlobs.includes('**');
+}
+
+function isDiscoverableHarnessRepo(path: string): boolean {
+  return existsSync(join(path, '.ai', 'harness', 'policy.json'));
+}
+
+function discoveryDefaultRoots(ctx: McpToolContext): string[] {
+  if (ctx.repoRoot !== '/') return [ctx.repoRoot];
+  const home = homedir();
+  const candidates = [
+    join(home, 'Projects'),
+    join(home, 'Documents'),
+    join(home, 'Developer'),
+    home,
+    '/Users',
+    '/Volumes',
+    '/opt',
+    '/tmp',
+  ];
+  return Array.from(new Set(candidates.map((path) => resolve(path)))).filter((path) => existsSync(path));
+}
+
+function discoverySortWeight(repoRoot: string): string {
+  const home = homedir();
+  const projects = join(home, 'Projects');
+  if (repoRoot.startsWith(`${projects}/`) || repoRoot === projects) return `0:${repoRoot}`;
+  if (repoRoot.startsWith(`${home}/`) || repoRoot === home) return `1:${repoRoot}`;
+  if (repoRoot.startsWith('/Volumes/')) return `2:${repoRoot}`;
+  if (repoRoot.startsWith('/tmp/') || repoRoot.startsWith('/private/tmp/')) return `9:${repoRoot}`;
+  return `5:${repoRoot}`;
+}
+
+function numberArg(value: unknown, fallback: number, min: number, max: number): number {
+  const parsed = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN;
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.min(Math.max(Math.trunc(parsed), min), max);
+}
+
+function stringArgList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((entry) => String(entry).trim()).filter(Boolean);
+}
+
+function discoverHarnessRepos(ctx: McpToolContext, args: Record<string, unknown> = {}): { scannedRoots: string[]; repos: ReturnType<typeof repoSummary>[]; truncated: boolean } {
+  if (!isFullDiskRead(ctx)) return { scannedRoots: [], repos: [], truncated: false };
+  const roots = (stringArgList(args.roots).length > 0 ? stringArgList(args.roots) : discoveryDefaultRoots(ctx))
+    .map((path) => resolve(path))
+    .filter((path) => existsSync(path));
+  const maxDepth = numberArg(args.max_depth, DEFAULT_DISCOVERY_DEPTH, 1, 12);
+  const limit = numberArg(args.limit, DEFAULT_DISCOVERY_LIMIT, 1, 100);
+  const repos = new Map<string, ReturnType<typeof repoSummary>>();
+  const queue = roots.map((path) => ({ path, depth: 0 }));
+  let truncated = false;
+
+  for (let index = 0; index < queue.length; index += 1) {
+    const current = queue[index];
+    if (!current) continue;
+    if (repos.size >= limit) {
+      truncated = true;
+      break;
+    }
+    let currentStat;
+    try {
+      currentStat = statSync(current.path);
+    } catch (_error) {
+      continue;
+    }
+    if (!currentStat.isDirectory()) continue;
+    if (isDiscoverableHarnessRepo(current.path)) {
+      const root = resolveMcpRepoRoot(current.path);
+      if (!repos.has(root)) repos.set(root, repoSummary(root));
+      continue;
+    }
+    if (current.depth >= maxDepth) continue;
+    let entries;
+    try {
+      entries = readdirSync(current.path, { withFileTypes: true });
+    } catch (_error) {
+      continue;
+    }
+    for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+      if (!entry.isDirectory() || DISCOVERY_SKIP_DIRS.has(entry.name)) continue;
+      queue.push({ path: join(current.path, entry.name), depth: current.depth + 1 });
+    }
+  }
+
+  return {
+    scannedRoots: roots,
+    repos: Array.from(repos.values()).sort((a, b) => discoverySortWeight(a.repoRoot).localeCompare(discoverySortWeight(b.repoRoot))),
+    truncated,
+  };
+}
+
+function targetRepoRoot(ctx: McpToolContext, args: Record<string, unknown>): { ok: true; repoRoot: string } | { ok: false; result: CallToolResult } {
+  const raw = typeof args.repo_path === 'string' ? args.repo_path.trim() : '';
+  if (!raw) {
+    return { ok: true, repoRoot: ctx.repoRoot };
+  }
+  if (isAbsolute(raw) && !isFullDiskRead(ctx)) {
+    return { ok: false, result: errorResult('POLICY_DENIED', 'repo_path absolute paths require user-scope full-disk read authorization.', { repo_path: raw }) };
+  }
+  const candidate = isAbsolute(raw) ? raw : resolve(ctx.repoRoot, raw);
+  const repoRoot = resolveMcpRepoRoot(candidate);
+  if (!isFullDiskRead(ctx) && repoRoot !== ctx.repoRoot) {
+    return { ok: false, result: errorResult('POLICY_DENIED', 'repo_path outside the configured repo requires user-scope full-disk read authorization.', { repo_path: raw }) };
+  }
+  return { ok: true, repoRoot };
 }
 
 function isProbablyBinary(bytes: Buffer): boolean {
@@ -477,9 +633,23 @@ function parseNativeBrowserChannel(value: unknown): NativeBrowserChannel | undef
 export function buildMcpToolDefinitions(policy: McpPolicy, opts: { enableChatgptBrowser?: boolean } = {}): McpToolDefinition[] {
   const readOnly = { readOnlyHint: true, openWorldHint: false };
   const write = { readOnlyHint: false, openWorldHint: false, destructiveHint: false };
+  const optionalRepoSchema = {
+    type: 'object',
+    properties: { repo_path: { type: 'string' } },
+    additionalProperties: false,
+  };
+  const discoverySchema = {
+    type: 'object',
+    properties: {
+      roots: { type: 'array', items: { type: 'string' } },
+      max_depth: { type: 'number' },
+      limit: { type: 'number' },
+    },
+    additionalProperties: false,
+  };
   const stringPathSchema = {
     type: 'object',
-    properties: { path: { type: 'string' } },
+    properties: { path: { type: 'string' }, repo_path: { type: 'string' } },
     required: ['path'],
     additionalProperties: false,
   };
@@ -588,15 +758,16 @@ export function buildMcpToolDefinitions(policy: McpPolicy, opts: { enableChatgpt
   };
 
   const tools: McpToolDefinition[] = [
-    { name: 'harness_status', description: 'Return repo-harness adoption and workflow status.', inputSchema: EMPTY_SCHEMA, annotations: readOnly },
-    { name: 'harness_doctor', description: 'Return compact MCP setup diagnostics.', inputSchema: EMPTY_SCHEMA, annotations: readOnly },
-    { name: 'list_workflow_files', description: 'List policy-readable workflow files.', inputSchema: EMPTY_SCHEMA, annotations: readOnly },
+    { name: 'harness_status', description: 'Return repo-harness adoption and workflow status. Pass repo_path after discover_harness_repos when targeting another adopted repo.', inputSchema: optionalRepoSchema, annotations: readOnly },
+    { name: 'harness_doctor', description: 'Return compact MCP setup diagnostics.', inputSchema: optionalRepoSchema, annotations: readOnly },
+    { name: 'discover_harness_repos', description: 'Discover repo-harness adopted repositories from authorized local disk roots. Requires user-scope full-disk read.', inputSchema: discoverySchema, annotations: readOnly },
+    { name: 'list_workflow_files', description: 'List policy-readable workflow files.', inputSchema: optionalRepoSchema, annotations: readOnly },
     { name: 'read_workflow_file', description: 'Read one policy-allowed file path. Absolute paths require user-scope full-disk read authorization.', inputSchema: stringPathSchema, annotations: readOnly },
-    { name: 'latest_handoff', description: 'Return latest repo-harness handoff artifacts.', inputSchema: EMPTY_SCHEMA, annotations: readOnly },
-    { name: 'latest_checks', description: 'Return latest repo-harness check artifacts.', inputSchema: EMPTY_SCHEMA, annotations: readOnly },
-    { name: 'list_prds', description: 'List PRD artifacts under plans/prds.', inputSchema: EMPTY_SCHEMA, annotations: readOnly },
-    { name: 'list_sprints', description: 'List sprint artifacts under plans/sprints.', inputSchema: EMPTY_SCHEMA, annotations: readOnly },
-    { name: 'summarize_repo_harness_state', description: 'Return a compact planning state summary.', inputSchema: EMPTY_SCHEMA, annotations: readOnly },
+    { name: 'latest_handoff', description: 'Return latest repo-harness handoff artifacts.', inputSchema: optionalRepoSchema, annotations: readOnly },
+    { name: 'latest_checks', description: 'Return latest repo-harness check artifacts.', inputSchema: optionalRepoSchema, annotations: readOnly },
+    { name: 'list_prds', description: 'List PRD artifacts under plans/prds.', inputSchema: optionalRepoSchema, annotations: readOnly },
+    { name: 'list_sprints', description: 'List sprint artifacts under plans/sprints.', inputSchema: optionalRepoSchema, annotations: readOnly },
+    { name: 'summarize_repo_harness_state', description: 'Return a compact planning state summary.', inputSchema: optionalRepoSchema, annotations: readOnly },
     { name: 'write_prd', description: 'Write a PRD under plans/prds/*.prd.md.', inputSchema: markdownWriterSchema, annotations: write },
     { name: 'write_prd_from_idea', description: 'Turn a product idea into a strict-compatible draft PRD under plans/prds/*.prd.md.', inputSchema: ideaPrdSchema, annotations: write },
     { name: 'write_sprint', description: 'Write a sprint under plans/sprints/*.sprint.md.', inputSchema: markdownWriterSchema, annotations: write },
@@ -692,23 +863,27 @@ export async function callMcpTool(ctx: McpToolContext, name: string, args: Recor
   try {
     switch (name) {
       case 'harness_status': {
-        const roots = ['docs/spec.md', 'plans', 'tasks/current.md', '.ai/harness/handoff', '.ai/harness/checks'];
+        const target = targetRepoRoot(ctx, args);
+        if (!target.ok) return target.result;
+        const summary = repoSummary(target.repoRoot);
         audit(ctx, name, 'ok', args);
         return textResult({
-          repoRoot: ctx.repoRoot,
-          adopted: isRepoHarnessAdopted(ctx.repoRoot),
+          repoRoot: summary.repoRoot,
+          adopted: summary.adopted,
           profile: ctx.policy.profile,
-          branch: currentGitBranch(ctx.repoRoot),
-          workflowRoots: roots.map((path) => ({ path, exists: existsSync(join(ctx.repoRoot, path)) })),
+          branch: summary.branch,
+          workflowRoots: summary.workflowRoots,
         });
       }
       case 'harness_doctor': {
-        const localConfig = existsSync(join(ctx.repoRoot, '.repo-harness', 'mcp.local.json'));
-        const codexConfig = existsSync(join(ctx.repoRoot, '.codex', 'config.toml'));
+        const target = targetRepoRoot(ctx, args);
+        if (!target.ok) return target.result;
+        const localConfig = existsSync(join(target.repoRoot, '.repo-harness', 'mcp.local.json'));
+        const codexConfig = existsSync(join(target.repoRoot, '.codex', 'config.toml'));
         audit(ctx, name, 'ok', args);
         return textResult({
-          status: isRepoHarnessAdopted(ctx.repoRoot) ? 'ready_local' : ctx.policy.allowAbsoluteRead ? 'ready_user' : 'not_adopted',
-          repo: ctx.repoRoot,
+          status: isRepoHarnessAdopted(target.repoRoot) ? 'ready_local' : ctx.policy.allowAbsoluteRead ? 'ready_user' : 'not_adopted',
+          repo: target.repoRoot,
           profile: ctx.policy.profile,
           mcp: {
             localConfig,
@@ -726,18 +901,31 @@ export async function callMcpTool(ctx: McpToolContext, name: string, args: Recor
           },
         });
       }
+      case 'discover_harness_repos': {
+        if (!isFullDiskRead(ctx)) {
+          audit(ctx, name, 'blocked', args, undefined, 'full-disk read is not enabled');
+          return errorResult('FULL_DISK_READ_REQUIRED', 'discover_harness_repos requires user-scope full-disk read authorization.');
+        }
+        const discovery = discoverHarnessRepos(ctx, args);
+        audit(ctx, name, 'ok', args);
+        return textResult(discovery);
+      }
       case 'list_workflow_files': {
-        const files = workflowFileCandidates(ctx.repoRoot)
-          .filter((path) => resolveMcpPath(ctx.repoRoot, path, ctx.policy, 'read').ok)
-          .map((path) => fileSummary(path, ctx.repoRoot))
+        const target = targetRepoRoot(ctx, args);
+        if (!target.ok) return target.result;
+        const files = workflowFileCandidates(target.repoRoot)
+          .filter((path) => resolveMcpPath(target.repoRoot, path, ctx.policy, 'read').ok)
+          .map((path) => fileSummary(path, target.repoRoot))
           .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
           .filter((entry) => entry.size <= ctx.policy.maxFileBytes);
         audit(ctx, name, 'ok', args);
         return textResult({ files });
       }
       case 'read_workflow_file': {
+        const target = targetRepoRoot(ctx, args);
+        if (!target.ok) return target.result;
         const path = typeof args.path === 'string' ? args.path : '';
-        const decision = resolveMcpPath(ctx.repoRoot, path, ctx.policy, 'read');
+        const decision = resolveMcpPath(target.repoRoot, path, ctx.policy, 'read');
         if (!decision.ok || !decision.absolutePath || !decision.relativePath) {
           audit(ctx, name, 'blocked', args, path, decision.reason);
           return errorResult('POLICY_DENIED', decision.reason ?? 'path denied', { path });
@@ -759,21 +947,25 @@ export async function callMcpTool(ctx: McpToolContext, name: string, args: Recor
         });
       }
       case 'latest_handoff': {
+        const target = targetRepoRoot(ctx, args);
+        if (!target.ok) return target.result;
         const paths = ['.ai/harness/handoff/resume.md', '.ai/harness/handoff/codex-goal.md', '.ai/harness/handoff/chatgpt-plan.md'];
         const handoff = paths.map((path) => {
-          const decision = resolveMcpPath(ctx.repoRoot, path, ctx.policy, 'read');
+          const decision = resolveMcpPath(target.repoRoot, path, ctx.policy, 'read');
           if (!decision.ok || !decision.absolutePath || !existsSync(decision.absolutePath)) return { path, exists: false };
           const content = redactMcpText(readFileSync(decision.absolutePath, 'utf-8')).text;
-          return { path, exists: true, preview: content.split(/\r?\n/).slice(0, 24).join('\n') };
+          return { path, exists: true, preview: content.split(/\r?\n/).slice(0, 10).join('\n').slice(0, 1600) };
         });
         audit(ctx, name, 'ok', args);
         return textResult({ handoff });
       }
       case 'latest_checks': {
-        const files = workflowFileCandidates(ctx.repoRoot)
+        const target = targetRepoRoot(ctx, args);
+        if (!target.ok) return target.result;
+        const files = workflowFileCandidates(target.repoRoot)
           .filter((path) => path.startsWith('.ai/harness/checks/'))
-          .filter((path) => resolveMcpPath(ctx.repoRoot, path, ctx.policy, 'read').ok)
-          .map((path) => fileSummary(path, ctx.repoRoot))
+          .filter((path) => resolveMcpPath(target.repoRoot, path, ctx.policy, 'read').ok)
+          .map((path) => fileSummary(path, target.repoRoot))
           .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
           .sort((a, b) => b.modifiedAt.localeCompare(a.modifiedAt))
           .slice(0, 20);
@@ -782,21 +974,25 @@ export async function callMcpTool(ctx: McpToolContext, name: string, args: Recor
       }
       case 'list_prds':
       case 'list_sprints': {
+        const target = targetRepoRoot(ctx, args);
+        if (!target.ok) return target.result;
         const root = name === 'list_prds' ? 'plans/prds' : 'plans/sprints';
         const files: string[] = [];
-        listFilesUnder(ctx.repoRoot, root, 200, files);
+        listFilesUnder(target.repoRoot, root, 200, files);
         audit(ctx, name, 'ok', args);
-        return textResult({ files: files.map((path) => fileSummary(path, ctx.repoRoot)).filter(Boolean) });
+        return textResult({ files: files.map((path) => fileSummary(path, target.repoRoot)).filter(Boolean) });
       }
       case 'summarize_repo_harness_state': {
-        const current = existsSync(join(ctx.repoRoot, 'tasks/current.md'))
-          ? readFileSync(join(ctx.repoRoot, 'tasks/current.md'), 'utf-8').split(/\r?\n/).slice(0, 50).join('\n')
+        const target = targetRepoRoot(ctx, args);
+        if (!target.ok) return target.result;
+        const current = existsSync(join(target.repoRoot, 'tasks/current.md'))
+          ? readFileSync(join(target.repoRoot, 'tasks/current.md'), 'utf-8').split(/\r?\n/).slice(0, 50).join('\n')
           : null;
         audit(ctx, name, 'ok', args);
         return textResult({
           status: {
-            adopted: isRepoHarnessAdopted(ctx.repoRoot),
-            branch: currentGitBranch(ctx.repoRoot),
+            adopted: isRepoHarnessAdopted(target.repoRoot),
+            branch: currentGitBranch(target.repoRoot),
             profile: ctx.policy.profile,
           },
           current: current ? redactMcpText(current).text : null,

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,16 +1,16 @@
 # Current Status Snapshot
 
 <!-- generated-by: repo-harness refresh-current-status v1 -->
-<!-- updated_at: 2026-06-20T14:05:59+0800 -->
+<!-- updated_at: 2026-06-20T16:27:16+0800 -->
 <!-- stale_after: 24h -->
 
 > **Status**: Active
-> **Updated At**: 2026-06-20T14:05:59+0800
+> **Updated At**: 2026-06-20T16:27:16+0800
 > **Source Branch**: main
-> **Source Commit**: 02231d8
+> **Source Commit**: ed34dfe
 > **Target Branch**: main
 > **Stale After**: 24h
-> **Reason**: mcp-user-scope-full-disk-read
+> **Reason**: chatgpt-app-preselect
 > **Derived From**: active-plan, active-sprint, workstreams, handoff, checks, git status
 
 This file is a tracked mainline snapshot derived from repo artifacts. It is not a live lock, not a kanban board, and not an implementation gate. If it is stale, read the source artifacts below.
@@ -49,22 +49,21 @@ This file is a tracked mainline snapshot derived from repo artifacts. It is not 
 
 ## Git Status
 
-- Summary: 14 changed/untracked path(s)
+- Summary: 13 changed/untracked path(s)
 
 ```
+ M assets/skill-commands/repo-harness-gptpro/SKILL.md
+ M docs/CHANGELOG.md
+ M docs/repo-harness-chatgpt-browser-engine.md
  M docs/repo-harness-chatgpt-mcp-setup.md
- M src/cli/commands/mcp.ts
- M src/cli/mcp/auth.ts
- M src/cli/mcp/paths.ts
- M src/cli/mcp/policy.ts
- M src/cli/mcp/server.ts
- M src/cli/mcp/setup.ts
+ M src/cli/chatgpt-browser/engine.ts
+ M src/cli/chatgpt-browser/oracle-provider.ts
+ M src/cli/chatgpt-browser/session-store.ts
+ M src/cli/chatgpt-browser/types.ts
+ M src/cli/commands/chatgpt.ts
  M src/cli/mcp/tools.ts
- M src/cli/mcp/transports/http.ts
- M src/cli/mcp/types.ts
  M tasks/current.md
- M tests/cli/mcp-policy.test.ts
- M tests/cli/mcp-setup.test.ts
+ M tests/cli/chatgpt-browser.test.ts
  M tests/cli/mcp-tools.test.ts
 ```
 

--- a/tasks/notes/20260620-gptpro-mcp-release-readiness.notes.md
+++ b/tasks/notes/20260620-gptpro-mcp-release-readiness.notes.md
@@ -1,0 +1,5 @@
+# 2026-06-20 GPT Pro MCP release readiness notes
+
+- Release prep moved the ChatGPT Oracle app preselection and MCP invocation-evidence entries from `Unreleased` into the `0.7.4` changelog surface.
+- `assets/skill-version.json` now describes the full `0.7.4` release scope: user-scope ChatGPT MCP repo discovery, GPT Pro Connector read-back safeguards, package-dispatched architecture helper fixes, and retired compact-adopt root wrappers.
+- Publish must happen only after PR #12 is merged to `main`; npm `repo-harness@0.7.4`, tag `v0.7.4`, and the GitHub release are intentionally absent during this prep slice.

--- a/tests/action-command-skills.test.ts
+++ b/tests/action-command-skills.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
+import { assertChatGptMcpContract } from "./helpers/chatgpt-mcp-contract";
 
 const ROOT = join(import.meta.dir, "..");
 const COMMAND_ROOT = join(ROOT, "assets", "skill-commands");
@@ -311,9 +312,15 @@ describe("repo-harness action command skills", () => {
     expect(gptpro).toContain("chatgpt.serverName");
     expect(gptpro).toContain(".repo-harness/mcp.local.json");
     expect(gptpro).toContain("MCP Read Evidence");
+    expect(gptpro).toContain("right-side process pane");
+    expect(gptpro).toContain("Called tool");
+    expect(gptpro).toContain("sandbox/process flow");
+    expect(gptpro).toContain("15 minutes or more");
+    expect(gptpro).toContain("Do not treat elapsed time as failure");
+    expect(gptpro).toContain("no thinking status detected yet");
     expect(gptpro).toContain("blocked or partial");
     expect(gptpro).toContain("route to `repo-harness:gptpro_setup`");
     expect(gptpro).toContain("Does not rename or replace the underlying");
-    expect(gptpro).not.toContain("kito-mcp");
+    assertChatGptMcpContract(gptpro);
   });
 });

--- a/tests/cli/chatgpt-browser.test.ts
+++ b/tests/cli/chatgpt-browser.test.ts
@@ -7,6 +7,7 @@ import { inspectBridgeExtensionInstall, renderBrowserAuthorizePage } from '../..
 import { writeChatgptBridgeExtension } from '../../src/cli/chatgpt-browser/bridge-extension';
 import { runBridgeProvider } from '../../src/cli/chatgpt-browser/bridge-provider';
 import type { PromptBundle } from '../../src/cli/chatgpt-browser/types';
+import { assertChatGptMcpContract } from '../helpers/chatgpt-mcp-contract';
 
 const ROOT = join(import.meta.dir, '../..');
 const CLI = join(ROOT, 'src/cli/index.ts');
@@ -87,6 +88,7 @@ describe('chatgpt browser command', () => {
     expect(consult.stdout).toContain('--keep-browser');
     expect(consult.stdout).toContain('--allow-absolute-output');
     expect(consult.stdout).toContain('--heartbeat');
+    expect(consult.stdout).toContain('--chatgpt-app');
   });
 
   test('dry-run consult writes a repo-local session with inline files', () => {
@@ -108,6 +110,8 @@ describe('chatgpt browser command', () => {
         'GPT-5.5 Pro',
         '--thinking',
         'heavy',
+        '--chatgpt-app',
+        'team-review-mcp',
       ]);
       expect(result.status).toBe(0);
       const payload = JSON.parse(result.stdout);
@@ -121,6 +125,9 @@ describe('chatgpt browser command', () => {
       expect(meta.engine).toBe('chatgpt-browser');
       expect(meta.provider).toBe('oracle');
       expect(meta.browser.profileDir).toBeUndefined();
+      expect(meta.browser.chatgptApp).toBe('team-review-mcp');
+      expect(payload.dryRun.command).toContain('--browser-app');
+      expect(payload.dryRun.command).toContain('team-review-mcp');
 
       const read = runChatgpt(['browser-session', '--repo', repoRoot, payload.sessionId]);
       expect(read.status).toBe(0);
@@ -145,6 +152,7 @@ describe('chatgpt browser command', () => {
       expect(followupPayload.sourceSessionId).toBe(payload.sessionId);
       const followupMeta = JSON.parse(readFileSync(join(repoRoot, '.ai/harness/chatgpt/sessions', followupPayload.sessionId, 'meta.json'), 'utf-8'));
       expect(followupMeta.sourceSessionId).toBe(payload.sessionId);
+      expect(followupMeta.browser.chatgptApp).toBe('team-review-mcp');
 
       const cleanupPlan = runChatgpt(['browser-cleanup', '--repo', repoRoot, '--status', 'dry_run', '--limit', '1', '--json']);
       expect(cleanupPlan.status).toBe(0);
@@ -274,6 +282,23 @@ describe('chatgpt browser command', () => {
       expect(meta.provider).toBe('native');
       expect(meta.status).toBe('dry_run');
       expect(meta.browser.profileDir).toBeUndefined();
+
+      const appPreselectDryRun = runChatgpt([
+        'browser-consult',
+        '--repo',
+        repoRoot,
+        '--provider',
+        'native',
+        '--dry-run',
+        '--prompt',
+        'Reply exactly OK',
+        '--chatgpt-app',
+        'team-review-mcp',
+      ]);
+      expect(appPreselectDryRun.status).toBe(0);
+      const appPreselectPayload = JSON.parse(appPreselectDryRun.stdout);
+      expect(appPreselectPayload.status).toBe('failed');
+      expect(appPreselectPayload.error.code).toBe('CHATGPT_APP_PRESELECT_PROVIDER_UNSUPPORTED');
 
       const unsupported = runChatgpt([
         'browser-consult',
@@ -939,6 +964,99 @@ describe('chatgpt browser command', () => {
     });
   });
 
+  test('oracle app preselection fails closed when the binary lacks browser-app support', () => {
+    withRepo((repoRoot) => {
+      const binDir = mkdtempSync(join(tmpdir(), 'repo-harness-fake-oracle-no-app-'));
+      try {
+        const oraclePath = join(binDir, 'oracle');
+        writeFileSync(
+          oraclePath,
+          [
+            '#!/bin/sh',
+            'case "$1" in',
+            '  --version) printf "%s\\n" "0.14.1"; exit 0;;',
+            '  --help|--debug-help) printf "%s\\n" "Usage: oracle --engine browser --write-output <p> --browser-thinking-time <level>"; exit 0;;',
+            'esac',
+            'for a in "$@"; do',
+            '  if [ "$a" = "--dry-run" ]; then exit 0; fi',
+            'done',
+            'printf "%s\\n" "unexpected oracle execution" >&2',
+            'exit 23',
+          ].join('\n'),
+        );
+        chmodSync(oraclePath, 0o755);
+        const result = runChatgpt([
+          'browser-consult',
+          '--repo',
+          repoRoot,
+          '--prompt',
+          'Review this.',
+          '--chatgpt-app',
+          'team-review-mcp',
+          '--oracle-bin',
+          oraclePath,
+        ]);
+        expect(result.status).toBe(0);
+        const payload = JSON.parse(result.stdout);
+        expect(payload.status).toBe('failed');
+        expect(payload.error.code).toBe('ORACLE_APP_PRESELECT_UNSUPPORTED');
+        const output = readFileSync(payload.paths.output, 'utf-8');
+        expect(output).toContain('does not support ChatGPT app preselection');
+        expect(output).not.toContain('unexpected oracle execution');
+      } finally {
+        rmSync(binDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  test('oracle provider passes ChatGPT app preselection to Oracle when supported', () => {
+    withRepo((repoRoot) => {
+      const binDir = mkdtempSync(join(tmpdir(), 'repo-harness-fake-oracle-app-'));
+      try {
+        const oraclePath = join(binDir, 'oracle');
+        writeFileSync(
+          oraclePath,
+          [
+            '#!/bin/sh',
+            'case "$1" in',
+            '  --version) printf "%s\\n" "0.14.2"; exit 0;;',
+            '  --help|--debug-help) printf "%s\\n" "Usage: oracle --engine browser --write-output <p> --browser-app <name> --browser-thinking-time <level>"; exit 0;;',
+            'esac',
+            'ARGS="$*"',
+            'OUT=""',
+            'PREV=""',
+            'for a in "$@"; do',
+            '  if [ "$PREV" = "--write-output" ]; then OUT="$a"; fi',
+            '  PREV="$a"',
+            'done',
+            'if [ -n "$OUT" ]; then printf "%s\\n" "Oracle saw: $ARGS" > "$OUT"; fi',
+          ].join('\n'),
+        );
+        chmodSync(oraclePath, 0o755);
+        const result = runChatgpt([
+          'browser-consult',
+          '--repo',
+          repoRoot,
+          '--prompt',
+          'Review this.',
+          '--chatgpt-app',
+          'team-review-mcp',
+          '--oracle-bin',
+          oraclePath,
+        ]);
+        expect(result.status).toBe(0);
+        const payload = JSON.parse(result.stdout);
+        expect(payload.status).toBe('completed');
+        const output = readFileSync(payload.paths.output, 'utf-8');
+        expect(output).toContain('--browser-app team-review-mcp');
+        const meta = JSON.parse(readFileSync(join(repoRoot, '.ai/harness/chatgpt/sessions', payload.sessionId, 'meta.json'), 'utf-8'));
+        expect(meta.browser.chatgptApp).toBe('team-review-mcp');
+      } finally {
+        rmSync(binDir, { recursive: true, force: true });
+      }
+    });
+  });
+
   test('oracle doctor probes binary capabilities and reports ready', () => {
     withRepo((repoRoot) => {
       const binDir = mkdtempSync(join(tmpdir(), 'repo-harness-fake-oracle-doctor-'));
@@ -974,6 +1092,9 @@ describe('chatgpt browser command', () => {
           browserThinkingTime: true,
           chatgptUrl: true,
           heartbeat: true,
+        });
+        expect(readiness.oracle.optionalCapabilities).toEqual({
+          browserAppPreselect: false,
         });
         expect(readiness.oracle.missingCapabilities).toEqual([]);
 
@@ -1203,6 +1324,7 @@ describe('chatgpt browser command', () => {
     expect(readFileSync(guide, 'utf-8')).toContain('Oracle CLI package currently requires `node >=24`');
     expect(readFileSync(guide, 'utf-8')).toContain('agent_actions');
     expect(readFileSync(guide, 'utf-8')).toContain('chatgpt-oracle-install-pinned');
+    expect(readFileSync(guide, 'utf-8')).toContain('--chatgpt-app <serverName>');
     const browserSkillText = readFileSync(skill, 'utf-8');
     expect(browserSkillText).toContain('repo-harness-chatgpt-browser');
     expect(browserSkillText).toContain('--provider oracle --json');
@@ -1216,9 +1338,16 @@ describe('chatgpt browser command', () => {
     expect(gptproSkillText).toContain('--model gpt-5.5-pro');
     expect(gptproSkillText).toContain('MCP Read-Back Acceptance');
     expect(gptproSkillText).toContain('chatgpt.serverName');
+    expect(gptproSkillText).toContain('--chatgpt-app "$serverName"');
     expect(gptproSkillText).toContain('.repo-harness/mcp.local.json');
     expect(gptproSkillText).toContain('MCP Read Evidence');
-    expect(gptproSkillText).not.toContain('kito-mcp');
+    expect(gptproSkillText).toContain('right-side process pane');
+    expect(gptproSkillText).toContain('Called tool');
+    expect(gptproSkillText).toContain('sandbox/process flow');
+    expect(gptproSkillText).toContain('15 minutes or more');
+    expect(gptproSkillText).toContain('Do not treat elapsed time as failure');
+    expect(gptproSkillText).toContain('no thinking status detected yet');
     expect(gptproSkillText).not.toContain('gptpro-consult.md');
+    assertChatGptMcpContract(gptproSkillText);
   });
 });

--- a/tests/cli/mcp-setup.test.ts
+++ b/tests/cli/mcp-setup.test.ts
@@ -13,6 +13,7 @@ import {
   runMcpSetupCodex,
 } from '../../src/cli/mcp/setup';
 import { createMcpToolContext } from '../../src/cli/mcp/server';
+import { assertChatGptMcpContract } from '../helpers/chatgpt-mcp-contract';
 
 const CLI = join(import.meta.dir, '../..', 'src/cli/index.ts');
 
@@ -63,9 +64,21 @@ describe('mcp setup', () => {
 
       const doctor = JSON.parse(runMcpDoctor({ repo: repoRoot, json: true }).lines[0]);
       expect(doctor.mcp.authConfigured).toBe(true);
+      expect(doctor.mcp.permissions.configurationScope).toBe('repo');
       expect(doctor.mcp.devMode.agentRunner).toBe(false);
       expect(doctor.chatgpt.serverName).toBe('repo-harness');
       expect(doctor.chatgpt.localEndpoint).toBe('http://127.0.0.1:8765/mcp');
+      expect(doctor.chatgpt.invocationVerification).toMatchObject({
+        status: 'manual_required',
+        checkableByDoctor: false,
+        scope: 'per_chat_model_surface',
+      });
+      expect(doctor.chatgpt.invocationVerification.acceptedEvidence).toEqual([
+        'called_tool_event',
+        'captured_tool_call_transcript',
+      ]);
+      const humanDoctor = runMcpDoctor({ repo: repoRoot }).lines.join('\n');
+      expect(humanDoctor).toContain('ChatGPT tool invocation: manual verification required');
     });
   });
 
@@ -132,6 +145,7 @@ describe('mcp setup', () => {
         expect(doctor.mcp.configScope).toBe('user');
         expect(doctor.mcp.localConfig).toBe(true);
         expect(doctor.mcp.authConfigured).toBe(true);
+        expect(doctor.mcp.permissions.configurationScope).toBe('user');
         expect(doctor.mcp.permissions.fullDiskRead).toBe(true);
         expect(doctor.codex.configured).toBe(false);
         expect(doctor.chatgpt.serverName).toBe('team-review-mcp');
@@ -174,6 +188,7 @@ describe('mcp setup', () => {
       const doctor = JSON.parse(runMcpDoctor({ repo: root, json: true }).lines[0]);
       expect(doctor.status).toBe('ready_user');
       expect(doctor.mcp.configScope).toBe('user');
+      expect(doctor.mcp.permissions.configurationScope).toBe('user');
       expect(doctor.mcp.permissions.fullDiskRead).toBe(true);
     } finally {
       if (previousHome === undefined) {
@@ -358,6 +373,13 @@ describe('mcp setup', () => {
     expect(guide).toContain('cloudflared tunnel create repo-harness-mcp');
     expect(guide).toContain('quick tunnel');
     expect(guide).toContain('chatgpt.serverName');
+    expect(guide).toContain('right-side process pane');
+    expect(guide).toContain('Called tool');
+    expect(guide).toContain('sandbox/process flow');
+    expect(guide).toContain('15 minutes or');
+    expect(guide).toContain('do not treat elapsed time as');
+    expect(guide).toContain('no thinking status detected yet');
+    assertChatGptMcpContract(guide);
   });
 
   test('patches Codex config while preserving unrelated content', () => {

--- a/tests/cli/mcp-tools.test.ts
+++ b/tests/cli/mcp-tools.test.ts
@@ -114,6 +114,56 @@ describe('mcp tools', () => {
     });
   });
 
+  test('discovers adopted repos under full-disk authorization and reads a target repo', async () => {
+    const scanRoot = mkdtempSync(join(tmpdir(), 'repo-harness-mcp-discovery-'));
+    const repoRoot = join(scanRoot, 'workspace', 'agentic-dev');
+    try {
+      mkdirSync(join(repoRoot, '.ai/harness/handoff'), { recursive: true });
+      mkdirSync(join(repoRoot, 'tasks'), { recursive: true });
+      writeFileSync(join(repoRoot, '.ai/harness/policy.json'), '{}\n');
+      writeFileSync(join(repoRoot, '.ai/harness/handoff/resume.md'), '# Resume\n\nready\n');
+      writeFileSync(join(repoRoot, 'tasks/current.md'), 'status=Active\n');
+
+      const fullDiskCtx = { repoRoot: scanRoot, policy: getMcpPolicy('planner', { fullDiskRead: true }) };
+      expect(buildMcpToolDefinitions(fullDiskCtx.policy).some((tool) => tool.name === 'discover_harness_repos')).toBe(true);
+
+      const discovered = await jsonTool(fullDiskCtx, 'discover_harness_repos', { roots: [scanRoot], max_depth: 4 });
+      expect(discovered.repos.some((entry: { repoRoot: string }) => entry.repoRoot === repoRoot)).toBe(true);
+
+      const status = await jsonTool(fullDiskCtx, 'harness_status');
+      expect(status.repoRoot).toBe(scanRoot);
+      expect(status.adopted).toBe(false);
+
+      const targetedStatus = await jsonTool(fullDiskCtx, 'harness_status', { repo_path: repoRoot });
+      expect(targetedStatus.repoRoot).toBe(repoRoot);
+      expect(targetedStatus.adopted).toBe(true);
+
+      const handoff = await jsonTool(fullDiskCtx, 'latest_handoff', { repo_path: repoRoot });
+      const resume = handoff.handoff.find((entry: { path: string }) => entry.path === '.ai/harness/handoff/resume.md');
+      expect(resume).toMatchObject({ exists: true });
+      expect(resume.preview).toContain('# Resume');
+
+      const current = await jsonTool(fullDiskCtx, 'read_workflow_file', { repo_path: repoRoot, path: 'tasks/current.md' });
+      expect(current.content).toContain('status=Active');
+
+      const absoluteCurrent = await jsonTool(fullDiskCtx, 'read_workflow_file', { path: join(repoRoot, 'tasks/current.md') });
+      expect(absoluteCurrent.content).toContain('status=Active');
+
+      const repoLocalCtx = { repoRoot: scanRoot, policy: getMcpPolicy('planner') };
+      const denied = await jsonTool(repoLocalCtx, 'discover_harness_repos', { roots: [scanRoot] });
+      expect(denied.error.code).toBe('FULL_DISK_READ_REQUIRED');
+      const deniedAbsoluteTarget = await jsonTool(repoLocalCtx, 'latest_handoff', { repo_path: repoRoot });
+      expect(deniedAbsoluteTarget.error.code).toBe('POLICY_DENIED');
+      const siblingRoot = join(scanRoot, 'sibling');
+      mkdirSync(join(siblingRoot, '.ai/harness/handoff'), { recursive: true });
+      writeFileSync(join(siblingRoot, '.ai/harness/policy.json'), '{}\n');
+      const deniedRelativeTarget = await jsonTool(repoLocalCtx, 'latest_handoff', { repo_path: 'sibling' });
+      expect(deniedRelativeTarget.error.code).toBe('POLICY_DENIED');
+    } finally {
+      rmSync(scanRoot, { recursive: true, force: true });
+    }
+  });
+
   test('writes planning artifacts and blocks overwrite by default', async () => {
     await withRepo(async (repoRoot, ctx) => {
       const prd = await jsonTool(ctx, 'write_prd', {

--- a/tests/helpers/chatgpt-mcp-contract.ts
+++ b/tests/helpers/chatgpt-mcp-contract.ts
@@ -1,0 +1,22 @@
+import { expect } from 'bun:test';
+
+export function assertChatGptMcpContract(text: string): void {
+  const lower = text.toLowerCase();
+  expect(text).toContain('chatgpt.serverName');
+  expect(text).toContain('Refresh');
+  expect(text).toContain('Action');
+  expect(text).toContain('fresh chat');
+  expect(text).toContain('Called tool');
+  expect(text).toContain('captured tool-call transcript');
+  expect(text).toContain('assistant self-report');
+  expect(text).toContain('sandbox');
+  expect(text).toContain('app_unavailable');
+  expect(text).toContain('surface_blocked');
+  expect(text).toContain('bundle_fallback');
+  expect(text).toContain('source: local_repo_harness_bundle');
+  expect(text).toContain('pro_invoked_mcp: false');
+  expect(lower).toContain('repo-scope');
+  expect(lower).toContain('user-scope');
+  expect(text).not.toMatch(/asdk_app_[a-f0-9]{32}/);
+  expect(text).not.toMatch(/\/Users\/[A-Za-z0-9._-]+/);
+}


### PR DESCRIPTION
## Summary
- Add explicit full-disk MCP repo discovery plus `repo_path` targeting while preserving absolute reads against the configured user-scope root.
- Add Oracle `--chatgpt-app` preselection support with fail-closed capability/provider checks.
- Add ChatGPT connector invocation-evidence metadata to `mcp doctor` and document GPT Pro manual readback/fallback rules.
- Share ChatGPT MCP contract assertions across docs, skills, generated setup guide, and tests.

## Review Notes
- `$check` review included a Claude read-only cross-review because this touches MCP read permissions and CLI dispatch.
- Claude found a P1 regression where default full-disk reads could silently retarget to the first discovered repo. Fixed by removing auto-retargeting from default reads and adding coverage for absolute full-disk reads without `repo_path`.

## Verification
- `bun test` -> 885 pass, 0 fail
- `bun run check:type` -> pass
- `git diff --check` -> pass
- `git diff --cached --check` -> pass
- `bash scripts/check-deploy-sql-order.sh` -> pass
- `bash scripts/check-architecture-sync.sh` -> pass
- `bash scripts/check-task-sync.sh` -> pass
- `bash scripts/check-task-workflow.sh --strict` -> pass after refreshing Codex handoff/resume
- `bun scripts/inspect-project-state.ts --repo . --format text` -> pass
- `bash scripts/migrate-project-template.sh --repo . --dry-run` -> pass
- `repo-harness mcp doctor --repo /Users/kito/Projects/agentic-dev --json | jq ...` -> reports `invocationVerification.status=manual_required`
