### PR TITLE
fix(mcp): resolve repo alias discovery

### DIFF
--- a/assets/skill-commands/repo-harness-gptpro/SKILL.md
+++ b/assets/skill-commands/repo-harness-gptpro/SKILL.md
@@ -47,7 +47,8 @@ Use GPT Pro language with the user. Treat the `browser-*` command names as imple
 When asking GPT Pro to review repo updates, include an explicit acceptance requirement in the prompt:
 
 - Use the recorded ChatGPT MCP server name from `chatgpt.serverName` to read the current repo state before producing findings or a merge/readiness verdict.
-- Before a Pro MCP attempt, open ChatGPT Settings -> Connectors for the recorded server name, run Refresh or Scan Tools, verify the expected Action is listed, then start a fresh chat and select the Connector from `+` -> More.
+- Before a Pro MCP attempt, open ChatGPT Settings -> Connectors for the recorded server name, run Refresh or Scan Tools, verify the expected Action is listed, then start a fresh chat with Deep research enabled when the review requires Pro research, and select the Connector from `+` -> More.
+- For multi-repo or user-scope reads, first call `discover_harness_repos` with `query`, `name`, or `repo_path` for repo-like text such as `my-app/`; use the returned exact target for follow-up workflow reads. Do not rely on a literal relative path guess.
 - Read at least the changed-file list or status, the relevant diffs or changed files, and any requested session/handoff artifacts through that recorded MCP server; pasted summaries are context, not sufficient evidence.
 - Include a short `MCP Read Evidence` section in the final answer naming the recorded MCP server, the reads performed, and the files, diffs, or artifacts inspected.
 - If the recorded MCP server name is missing, or `mcp doctor --json` reports `chatgpt.serverNameConfigured:false`, route to `repo-harness:gptpro_setup` so initialization can record it before review.

--- a/docs/repo-harness-chatgpt-mcp-setup.md
+++ b/docs/repo-harness-chatgpt-mcp-setup.md
@@ -124,7 +124,7 @@ If `repo-harness mcp doctor --repo . --json` reports `chatgpt.serverNameConfigur
 Use ChatGPT for planning and review. Use Codex for local execution.
 
 1. Use the single configured Connector for workflow planning and repo tools.
-2. Call `discover_harness_repos` to list registered adopted repos, then pass `repo_path` when targeting a specific project.
+2. Call `discover_harness_repos` to list registered adopted repos, or pass `query`/`name`/`repo_path` for repo-like user text such as `my-app/`; then pass the selected exact `repo_path` when targeting a specific project. Registered repo aliases are resolved through the same authorized discovery surface, not by widening filesystem access.
 3. For registered repo document/code reading, call `list_allowed_roots` to get the stable `repo_id`, then use `get_repo_capabilities`, `repo_manifest`, `list_tree`, `stat_file`, `read_file`, `read_files`, and `search_text`.
 4. For registered repo writes, first check `get_repo_capabilities.write_tools`; only repos explicitly configured as `read_write` expose `write_file`, `apply_patch`, `move_path`, `delete_path`, and `refresh_repo_index`.
 5. Ask ChatGPT to turn the idea into a PRD with `write_prd_from_idea`.
@@ -309,7 +309,7 @@ Use repo-harness to inspect this repo. Call harness_status, latest_handoff, and 
 ## Reader Test Prompt
 
 ```text
-Use the repo-harness Connector. First call discover_harness_repos and choose the target repo. Then call list_allowed_roots and use the matching repo_id with get_repo_capabilities, repo_manifest, list_tree on ".", stat_file on README.md, read_file on README.md or docs/spec.md, and search_text for "repo-harness". Do not write files.
+Use the repo-harness Connector. First call discover_harness_repos with query/name/repo_path when the user gives repo-like text such as "my-app/", then choose the exact target repo_path. Then call list_allowed_roots and use the matching repo_id with get_repo_capabilities, repo_manifest, list_tree on ".", stat_file on README.md, read_file on README.md or docs/spec.md, and search_text for "repo-harness". Do not write files.
 ```
 
 Blocked-file smoke:
@@ -380,7 +380,7 @@ the recommended ChatGPT Connector shape for users working across projects.
 ## PRD Prompt
 
 ```text
-Use repo-harness discover_harness_repos first, choose the target repo_path, inspect docs/spec.md, tasks/current.md, latest handoff, and existing plans in that repo, then convert this idea into a PRD with write_prd_from_idea using the same repo_path. Do not edit source code.
+Use repo-harness discover_harness_repos first, pass query/name/repo_path when the user gives repo-like text such as "my-app/", choose the exact target repo_path, inspect docs/spec.md, tasks/current.md, latest handoff, and existing plans in that repo, then convert this idea into a PRD with write_prd_from_idea using the same repo_path. Do not edit source code.
 ```
 
 ## Checklist Sprint Prompt

--- a/src/cli/mcp/setup.ts
+++ b/src/cli/mcp/setup.ts
@@ -300,7 +300,7 @@ If \`repo-harness mcp doctor --repo . --json\` reports \`chatgpt.serverNameConfi
 Use ChatGPT for planning and review. Use Codex for local execution.
 
 1. Use the single configured Connector for workflow planning and repo tools.
-2. Call \`discover_harness_repos\` to list registered adopted repos, then pass \`repo_path\` when targeting a specific project.
+2. Call \`discover_harness_repos\` to list registered adopted repos, or pass \`query\`/\`name\`/\`repo_path\` for repo-like user text such as \`my-app/\`; then pass the selected exact \`repo_path\` when targeting a specific project. Registered repo aliases are resolved through the same authorized discovery surface, not by widening filesystem access.
 3. For registered repo document/code reading, call \`list_allowed_roots\` to get the stable \`repo_id\`, then use \`get_repo_capabilities\`, \`repo_manifest\`, \`list_tree\`, \`stat_file\`, \`read_file\`, \`read_files\`, and \`search_text\`.
 4. For registered repo writes, first check \`get_repo_capabilities.write_tools\`; mutation tools stay hidden and rejected unless the repo is read-write and rollout write is enabled.
 5. Ask ChatGPT to turn the idea into a PRD with \`write_prd_from_idea\`.
@@ -414,7 +414,7 @@ Use repo-harness to inspect this repo. Call harness_status, latest_handoff, and 
 ## Reader Test Prompt
 
 \`\`\`text
-Use the repo-harness Connector. First call discover_harness_repos and choose the target repo_path. Then call list_allowed_roots, capture the stable repo_id, call get_repo_capabilities, repo_manifest, list_tree on ".", read_file on README.md or docs/spec.md, and search_text for "repo-harness". Do not write files.
+Use the repo-harness Connector. First call discover_harness_repos with query/name/repo_path when the user gives repo-like text such as "my-app/", then choose the exact target repo_path. Then call list_allowed_roots, capture the stable repo_id, call get_repo_capabilities, repo_manifest, list_tree on ".", read_file on README.md or docs/spec.md, and search_text for "repo-harness". Do not write files.
 \`\`\`
 
 Blocked-file smoke:
@@ -485,7 +485,7 @@ the recommended ChatGPT Connector shape for users working across projects.
 ## PRD Prompt
 
 \`\`\`text
-Use repo-harness discover_harness_repos first, choose the target repo_path, inspect docs/spec.md, tasks/current.md, latest handoff, and existing plans in that repo, then convert this idea into a PRD with write_prd_from_idea using the same repo_path. Do not edit source code.
+Use repo-harness discover_harness_repos first, pass query/name/repo_path when the user gives repo-like text such as "my-app/", choose the exact target repo_path, inspect docs/spec.md, tasks/current.md, latest handoff, and existing plans in that repo, then convert this idea into a PRD with write_prd_from_idea using the same repo_path. Do not edit source code.
 \`\`\`
 
 ## Checklist Sprint Prompt

--- a/src/cli/mcp/tools.ts
+++ b/src/cli/mcp/tools.ts
@@ -43,7 +43,7 @@ interface CallToolResult {
 }
 
 const DEFAULT_DISCOVERY_DEPTH = 7;
-const DEFAULT_DISCOVERY_LIMIT = 12;
+const DEFAULT_DISCOVERY_LIMIT = 25;
 const GENERAL_REPO_READ_SINGLE_CHUNK_BYTES = 262_144;
 const DISCOVERY_SKIP_DIRS = new Set([
   '.bun',
@@ -118,6 +118,40 @@ function isDiscoverableHarnessRepo(path: string): boolean {
   return existsSync(join(path, '.ai', 'harness', 'policy.json')) || existsSync(join(path, 'tasks', 'current.md'));
 }
 
+function normalizeRepoSearchTerm(value: unknown): string {
+  if (typeof value !== 'string') return '';
+  const normalized = value.trim()
+    .replace(/\\/g, '/')
+    .replace(/^\/+/, '')
+    .replace(/\/+$/, '')
+    .replace(/\/+/g, '/')
+    .toLowerCase();
+  if (normalized === '.' || normalized === '..') return '';
+  return normalized;
+}
+
+function repoMatchesQuery(repoRoot: string, query: string): boolean {
+  const normalizedQuery = normalizeRepoSearchTerm(query);
+  if (!normalizedQuery) return true;
+  const normalizedRoot = repoRoot.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
+  const repoName = basename(repoRoot).toLowerCase();
+  return repoName === normalizedQuery ||
+    repoName.includes(normalizedQuery) ||
+    normalizedRoot === normalizedQuery ||
+    normalizedRoot.endsWith(`/${normalizedQuery}`) ||
+    normalizedRoot.includes(`/${normalizedQuery}/`) ||
+    normalizedRoot.includes(normalizedQuery);
+}
+
+function repoMatchesAliasExactly(repoRoot: string, query: string): boolean {
+  const normalizedQuery = normalizeRepoSearchTerm(query);
+  if (!normalizedQuery) return false;
+  const normalizedRoot = repoRoot.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
+  return basename(repoRoot).toLowerCase() === normalizedQuery ||
+    normalizedRoot === normalizedQuery ||
+    normalizedRoot.endsWith(`/${normalizedQuery}`);
+}
+
 function discoveryDefaultRoots(ctx: McpToolContext): string[] {
   const configured = [...(ctx.policy.discoveryRoots ?? []), ...(ctx.policy.allowedRoots ?? [])]
     .map((path) => resolve(path))
@@ -138,14 +172,33 @@ function discoveryDefaultRoots(ctx: McpToolContext): string[] {
   return Array.from(new Set(candidates.map((path) => resolve(path)))).filter((path) => existsSync(path));
 }
 
-function discoverySortWeight(repoRoot: string): string {
+function discoverySortWeight(repoRoot: string, query = ''): string {
+  const normalizedQuery = normalizeRepoSearchTerm(query);
+  const repoName = basename(repoRoot).toLowerCase();
+  const normalizedRoot = repoRoot.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
+  const queryWeight = !normalizedQuery
+    ? '0'
+    : repoName === normalizedQuery || normalizedRoot.endsWith(`/${normalizedQuery}`)
+      ? '0'
+      : repoName.startsWith(normalizedQuery)
+        ? '1'
+        : repoName.includes(normalizedQuery)
+          ? '2'
+          : normalizedRoot.includes(normalizedQuery)
+            ? '3'
+            : '4';
   const home = homedir();
   const projects = join(home, 'Projects');
-  if (repoRoot.startsWith(`${projects}/`) || repoRoot === projects) return `0:${repoRoot}`;
-  if (repoRoot.startsWith(`${home}/`) || repoRoot === home) return `1:${repoRoot}`;
-  if (repoRoot.startsWith('/Volumes/')) return `2:${repoRoot}`;
-  if (repoRoot.startsWith('/tmp/') || repoRoot.startsWith('/private/tmp/')) return `9:${repoRoot}`;
-  return `5:${repoRoot}`;
+  const locationWeight = repoRoot.startsWith(`${projects}/`) || repoRoot === projects
+    ? '0'
+    : repoRoot.startsWith(`${home}/`) || repoRoot === home
+      ? '1'
+      : repoRoot.startsWith('/Volumes/')
+        ? '2'
+        : repoRoot.startsWith('/tmp/') || repoRoot.startsWith('/private/tmp/')
+          ? '9'
+          : '5';
+  return `${queryWeight}:${locationWeight}:${repoRoot}`;
 }
 
 function numberArg(value: unknown, fallback: number, min: number, max: number): number {
@@ -184,9 +237,10 @@ function isAuthorizedDiscoveryRoot(ctx: McpToolContext, root: string): boolean {
   return authorizedDiscoveryRoots(ctx).some((authorized) => isPathInside(authorized, canonical));
 }
 
-function addDiscoveredRepo(ctx: McpToolContext, repos: Map<string, ReturnType<typeof repoSummary>>, repoRoot: string): void {
+function addDiscoveredRepo(ctx: McpToolContext, repos: Map<string, ReturnType<typeof repoSummary>>, repoRoot: string, query = ''): void {
   const root = canonicalDirectory(resolveMcpRepoRoot(repoRoot));
   if (!root || !isRepoHarnessAdopted(root)) return;
+  if (!repoMatchesQuery(root, query)) return;
   if (!repos.has(root)) repos.set(root, repoSummary(root));
   try {
     ctx.workspaceManager?.ensureAllowedRoot(root);
@@ -196,7 +250,8 @@ function addDiscoveredRepo(ctx: McpToolContext, repos: Map<string, ReturnType<ty
   }
 }
 
-function discoverHarnessRepos(ctx: McpToolContext, args: Record<string, unknown> = {}): { scannedRoots: string[]; repos: ReturnType<typeof repoSummary>[]; truncated: boolean } {
+function discoverHarnessRepos(ctx: McpToolContext, args: Record<string, unknown> = {}): { scannedRoots: string[]; query: string | null; repos: ReturnType<typeof repoSummary>[]; truncated: boolean } {
+  const query = normalizeRepoSearchTerm(args.query) || normalizeRepoSearchTerm(args.name) || normalizeRepoSearchTerm(args.repo_path);
   const requestedRoots = stringArgList(args.roots);
   const roots = (requestedRoots.length > 0 ? requestedRoots : discoveryDefaultRoots(ctx))
     .map((path) => resolve(path))
@@ -206,7 +261,7 @@ function discoverHarnessRepos(ctx: McpToolContext, args: Record<string, unknown>
   const limit = numberArg(args.limit, DEFAULT_DISCOVERY_LIMIT, 1, 100);
   const repos = new Map<string, ReturnType<typeof repoSummary>>();
   for (const entry of readRegisteredRepoHarnessRepos({ adoptedOnly: true })) {
-    addDiscoveredRepo(ctx, repos, entry.path);
+    addDiscoveredRepo(ctx, repos, entry.path, query);
     if (repos.size >= limit) break;
   }
   const queue = roots.map((path) => ({ path, depth: 0 }));
@@ -227,8 +282,8 @@ function discoverHarnessRepos(ctx: McpToolContext, args: Record<string, unknown>
     }
     if (!currentStat.isDirectory()) continue;
     if (isDiscoverableHarnessRepo(current.path)) {
-      addDiscoveredRepo(ctx, repos, current.path);
-      continue;
+      addDiscoveredRepo(ctx, repos, current.path, query);
+      if (!query) continue;
     }
     if (current.depth >= maxDepth) continue;
     let entries;
@@ -245,9 +300,36 @@ function discoverHarnessRepos(ctx: McpToolContext, args: Record<string, unknown>
 
   return {
     scannedRoots: roots,
-    repos: Array.from(repos.values()).sort((a, b) => discoverySortWeight(a.repoRoot).localeCompare(discoverySortWeight(b.repoRoot))),
+    query: query || null,
+    repos: Array.from(repos.values()).sort((a, b) => discoverySortWeight(a.repoRoot, query).localeCompare(discoverySortWeight(b.repoRoot, query))),
     truncated,
   };
+}
+
+function resolveAuthorizedRepoAlias(ctx: McpToolContext, raw: string): { ok: true; repoRoot: string } | { ok: false; result: CallToolResult } | null {
+  const rawSegments = raw.replace(/\\/g, '/').split('/').filter(Boolean);
+  if (isAbsolute(raw) || rawSegments.includes('.') || rawSegments.includes('..')) return null;
+  const candidate = resolve(ctx.repoRoot, raw);
+  if (existsSync(candidate)) return null;
+  const query = normalizeRepoSearchTerm(raw);
+  if (!query) return null;
+  const discovery = discoverHarnessRepos(ctx, { query, limit: 10 });
+  const exact = discovery.repos.filter((repo) => repoMatchesAliasExactly(repo.repoRoot, query));
+  const candidates = exact.length > 0 ? exact : discovery.repos;
+  if (candidates.length === 1) {
+    return { ok: true, repoRoot: candidates[0].repoRoot };
+  }
+  if (candidates.length > 1) {
+    return {
+      ok: false,
+      result: errorResult(
+        'REPO_ALIAS_AMBIGUOUS',
+        'repo_path matched multiple adopted repositories; call discover_harness_repos with query and pass an exact repo_path.',
+        { repo_path: raw, matches: candidates.map((repo) => repo.repoRoot) },
+      ),
+    };
+  }
+  return null;
 }
 
 function targetRepoRoot(ctx: McpToolContext, args: Record<string, unknown>): { ok: true; repoRoot: string } | { ok: false; result: CallToolResult } {
@@ -255,6 +337,8 @@ function targetRepoRoot(ctx: McpToolContext, args: Record<string, unknown>): { o
   if (!raw) {
     return { ok: true, repoRoot: ctx.repoRoot };
   }
+  const alias = resolveAuthorizedRepoAlias(ctx, raw);
+  if (alias) return alias;
   const candidate = isAbsolute(raw) ? raw : resolve(ctx.repoRoot, raw);
   const repoRoot = canonicalDirectory(resolveMcpRepoRoot(candidate)) ?? resolveMcpRepoRoot(candidate);
   const currentRoot = canonicalDirectory(ctx.repoRoot) ?? ctx.repoRoot;
@@ -745,6 +829,9 @@ export function buildMcpToolDefinitions(policy: McpPolicy, opts: { enableChatgpt
   const discoverySchema = {
     type: 'object',
     properties: {
+      query: { type: 'string' },
+      name: { type: 'string' },
+      repo_path: { type: 'string' },
       roots: { type: 'array', items: { type: 'string' } },
       max_depth: { type: 'number' },
       limit: { type: 'number' },
@@ -868,7 +955,7 @@ export function buildMcpToolDefinitions(policy: McpPolicy, opts: { enableChatgpt
   const tools: McpToolDefinition[] = [
     { name: 'harness_status', description: 'Return repo-harness adoption and workflow status. Pass repo_path after discover_harness_repos when targeting another adopted repo.', inputSchema: optionalRepoSchema, annotations: readOnly },
     { name: 'harness_doctor', description: 'Return compact MCP setup diagnostics.', inputSchema: optionalRepoSchema, annotations: readOnly },
-    { name: 'discover_harness_repos', description: 'Discover repo-harness adopted repositories from the global registry and explicit allowed discovery roots.', inputSchema: discoverySchema, annotations: readOnly },
+    { name: 'discover_harness_repos', description: 'Discover repo-harness adopted repositories from the global registry and explicit allowed discovery roots. Pass query, name, or repo_path for repo-like user inputs such as "my-app/".', inputSchema: discoverySchema, annotations: readOnly },
     { name: 'list_workflow_files', description: 'List policy-readable workflow files. Pass repo_path to target a registered adopted repo.', inputSchema: optionalRepoSchema, annotations: readOnly },
     { name: 'read_workflow_file', description: 'Read one policy-allowed workflow file path from the current or target registered repo.', inputSchema: stringPathSchema, annotations: readOnly },
     { name: 'latest_handoff', description: 'Return latest repo-harness handoff artifacts.', inputSchema: optionalRepoSchema, annotations: readOnly },

--- a/tasks/notes/mcp-repo-alias-discovery.notes.md
+++ b/tasks/notes/mcp-repo-alias-discovery.notes.md
@@ -1,0 +1,22 @@
+# MCP Repo Alias Discovery Notes
+
+> **Date**: 2026-06-29
+> **Slice**: mcp-repo-alias-discovery
+
+## Decision
+
+Allow `discover_harness_repos` to accept `query`, `name`, or `repo_path` filters,
+and resolve repo-like `repo_path` values such as `my-app/` through authorized
+discovery before falling back to literal path handling.
+
+## Boundary
+
+Alias resolution does not widen filesystem access. Candidates must still come
+from the registered repo index or explicit allowed/discovery roots, and
+ambiguous aliases fail closed.
+
+## Verification
+
+- `bun test tests/cli/mcp-tools.test.ts`
+- `bun test tests/cli/mcp-setup.test.ts tests/action-command-skills.test.ts tests/cli/chatgpt-browser.test.ts`
+- `bun test`

--- a/tests/cli/mcp-tools.test.ts
+++ b/tests/cli/mcp-tools.test.ts
@@ -261,6 +261,10 @@ describe('mcp tools', () => {
         const discovered = await jsonTool(ctx, 'discover_harness_repos');
         expect(discovered.repos.some((entry: { repoRoot: string }) => entry.repoRoot === canonicalRepoRoot)).toBe(true);
 
+        const queried = await jsonTool(ctx, 'discover_harness_repos', { query: 'agentic-dev/' });
+        expect(queried.query).toBe('agentic-dev');
+        expect(queried.repos.map((entry: { repoRoot: string }) => entry.repoRoot)).toContain(canonicalRepoRoot);
+
         const roots = await jsonTool(ctx, 'list_allowed_roots');
         expect(roots.roots.some(
           (entry: { repo_id: string; path?: string }) => entry.repo_id === repoHarnessRepoIdFor(canonicalRepoRoot) && entry.path === undefined,
@@ -274,13 +278,24 @@ describe('mcp tools', () => {
         expect(targetedStatus.repoRoot).toBe(canonicalRepoRoot);
         expect(targetedStatus.adopted).toBe(true);
 
+        const aliasStatus = await jsonTool(ctx, 'harness_status', { repo_path: 'agentic-dev/' });
+        expect(aliasStatus.repoRoot).toBe(canonicalRepoRoot);
+        expect(aliasStatus.adopted).toBe(true);
+
         const handoff = await jsonTool(ctx, 'latest_handoff', { repo_path: repoRoot });
         const resume = handoff.handoff.find((entry: { path: string }) => entry.path === '.ai/harness/handoff/resume.md');
         expect(resume).toMatchObject({ exists: true });
         expect(resume.preview).toContain('# Resume');
 
+        const aliasHandoff = await jsonTool(ctx, 'latest_handoff', { repo_path: 'agentic-dev/' });
+        const aliasResume = aliasHandoff.handoff.find((entry: { path: string }) => entry.path === '.ai/harness/handoff/resume.md');
+        expect(aliasResume).toMatchObject({ exists: true });
+
         const current = await jsonTool(ctx, 'read_workflow_file', { repo_path: repoRoot, path: 'tasks/current.md' });
         expect(current.content).toContain('status=Active');
+
+        const aliasCurrent = await jsonTool(ctx, 'read_workflow_file', { repo_path: 'agentic-dev/', path: 'tasks/current.md' });
+        expect(aliasCurrent.content).toContain('status=Active');
 
         const prd = await jsonTool(ctx, 'write_prd', {
           repo_path: repoRoot,


### PR DESCRIPTION
## Summary
- Resolve repo-like MCP inputs through authorized repository discovery instead of treating them as literal relative paths.
- Add `query`/`name`/`repo_path` filters to `discover_harness_repos`, increase the default discovery limit, and fail ambiguous aliases closed.
- Document GPT Pro Deep research + Connector activation with generic repo alias guidance and no local project paths.

## Verification
- `bun test tests/cli/mcp-tools.test.ts`
- `bun test tests/cli/mcp-setup.test.ts tests/action-command-skills.test.ts tests/cli/chatgpt-browser.test.ts`
- `bun test`
- `git diff --check`
- `bash scripts/check-deploy-sql-order.sh`
- `bash scripts/check-architecture-sync.sh`
- `bash scripts/check-task-sync.sh`
- `bash scripts/check-task-workflow.sh --strict`
- `bun scripts/inspect-project-state.ts --repo . --format text`
- `bash scripts/migrate-project-template.sh --repo . --dry-run`
- GitHub CI: `Test` plus MCP path matrix on ubuntu, macos, and windows all passed.

## Notes
- Alias resolution does not widen filesystem access. Candidates must come from the registered repo index or explicit allowed/discovery roots.
- The branch was rebased/rebuilt on current `origin/main`; the PR is now mergeable.