### PR TITLE
Module S0: Freeze CodeGraph repo access contract

### DIFF
--- a/assets/mcp/general-repo-reader-tools.v1.schema.json
+++ b/assets/mcp/general-repo-reader-tools.v1.schema.json
@@ -1,0 +1,504 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://repo-harness.local/schemas/mcp/general-repo-reader-tools.v1.schema.json",
+  "title": "repo-harness general repo reader MCP tools v1",
+  "type": "object",
+  "required": [
+    "version",
+    "policy",
+    "tools",
+    "common_response_fields",
+    "error_codes"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "const": "1"
+    },
+    "policy": {
+      "type": "object",
+      "required": [
+        "repo_authorization",
+        "content_exclusion",
+        "path_representation",
+        "snapshot_required",
+        "implicit_redaction"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "repo_authorization": {
+          "const": "registered_repo_whitelist"
+        },
+        "content_exclusion": {
+          "const": ".ignore"
+        },
+        "path_representation": {
+          "const": "repo_relative"
+        },
+        "snapshot_required": {
+          "const": true
+        },
+        "implicit_redaction": {
+          "const": false
+        }
+      }
+    },
+    "tools": {
+      "type": "array",
+      "minItems": 7,
+      "items": {
+        "$ref": "#/$defs/tool"
+      }
+    },
+    "common_response_fields": {
+      "type": "array",
+      "items": {
+        "enum": [
+          "repo_id",
+          "snapshot_id",
+          "index_revision",
+          "ignore_digest",
+          "stale",
+          "partial",
+          "next_cursor"
+        ]
+      },
+      "uniqueItems": true
+    },
+    "error_codes": {
+      "type": "array",
+      "items": {
+        "enum": [
+          "REPO_NOT_ALLOWED",
+          "WRITE_DISABLED",
+          "INVALID_RELATIVE_PATH",
+          "PATH_OUTSIDE_REPO",
+          "SYMLINK_ESCAPE",
+          "PATH_IGNORED",
+          "NOT_FOUND",
+          "NOT_A_FILE",
+          "BINARY_CONTENT",
+          "INVALID_RANGE",
+          "PAYLOAD_LIMIT_REACHED",
+          "SNAPSHOT_STALE",
+          "INDEX_UNAVAILABLE",
+          "INDEX_STALE",
+          "REVISION_CONFLICT",
+          "TARGET_EXISTS",
+          "PARTIAL_FAILURE",
+          "INTERNAL_ADAPTER_ERROR"
+        ]
+      },
+      "uniqueItems": true
+    }
+  },
+  "$defs": {
+    "tool": {
+      "type": "object",
+      "required": [
+        "name",
+        "description",
+        "annotations",
+        "input_schema",
+        "output_schema"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "enum": [
+            "get_repo_capabilities",
+            "repo_manifest",
+            "list_tree",
+            "search_text",
+            "read_file",
+            "read_files",
+            "stat_file"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "annotations": {
+          "type": "object",
+          "required": [
+            "readOnlyHint",
+            "destructiveHint",
+            "idempotentHint",
+            "openWorldHint"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "readOnlyHint": {
+              "const": true
+            },
+            "destructiveHint": {
+              "const": false
+            },
+            "idempotentHint": {
+              "const": true
+            },
+            "openWorldHint": {
+              "const": false
+            }
+          }
+        },
+        "input_schema": {
+          "$ref": "#/$defs/object_schema"
+        },
+        "output_schema": {
+          "$ref": "#/$defs/object_schema"
+        }
+      }
+    },
+    "object_schema": {
+      "type": "object",
+      "required": [
+        "type",
+        "additionalProperties"
+      ],
+      "properties": {
+        "type": {
+          "const": "object"
+        },
+        "required": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "properties": {
+          "type": "object"
+        },
+        "additionalProperties": {
+          "const": false
+        }
+      }
+    }
+  },
+  "x-repo-harness-tools": [
+    {
+      "name": "get_repo_capabilities",
+      "description": "Return read/write mode, index capabilities, and limits for a registered repo.",
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "input_schema": {
+        "type": "object",
+        "required": [
+          "repo_id"
+        ],
+        "properties": {
+          "repo_id": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "required": [
+          "repo_id",
+          "access_mode",
+          "read_tools",
+          "write_tools",
+          "limits"
+        ],
+        "properties": {},
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "repo_manifest",
+      "description": "Return the complete non-.ignore repo inventory with indexed/readable metadata.",
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "input_schema": {
+        "type": "object",
+        "required": [
+          "repo_id"
+        ],
+        "properties": {
+          "repo_id": {
+            "type": "string"
+          },
+          "snapshot_id": {
+            "type": "string"
+          },
+          "cursor": {
+            "type": "string"
+          },
+          "page_size": {
+            "type": "number",
+            "minimum": 1
+          }
+        },
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "required": [
+          "repo_id",
+          "snapshot_id",
+          "ignore_digest",
+          "entries",
+          "complete"
+        ],
+        "properties": {},
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "list_tree",
+      "description": "List non-.ignore children under a repo-relative directory with stable pagination.",
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "input_schema": {
+        "type": "object",
+        "required": [
+          "repo_id"
+        ],
+        "properties": {
+          "repo_id": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string",
+            "default": "."
+          },
+          "depth": {
+            "type": "number",
+            "minimum": 0
+          },
+          "snapshot_id": {
+            "type": "string"
+          },
+          "cursor": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "required": [
+          "repo_id",
+          "snapshot_id",
+          "ignore_digest",
+          "entries"
+        ],
+        "properties": {},
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "search_text",
+      "description": "Search allowed repo text using CodeGraph first and policy-consistent fallback when needed.",
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "input_schema": {
+        "type": "object",
+        "required": [
+          "repo_id",
+          "query"
+        ],
+        "properties": {
+          "repo_id": {
+            "type": "string"
+          },
+          "query": {
+            "type": "string",
+            "minLength": 1
+          },
+          "mode": {
+            "enum": [
+              "literal",
+              "regex"
+            ]
+          },
+          "paths": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "snapshot_id": {
+            "type": "string"
+          },
+          "cursor": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "required": [
+          "repo_id",
+          "snapshot_id",
+          "ignore_digest",
+          "matches"
+        ],
+        "properties": {},
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "read_file",
+      "description": "Read one allowed file by line or byte range with hash and continuation metadata.",
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "input_schema": {
+        "type": "object",
+        "required": [
+          "repo_id",
+          "path"
+        ],
+        "properties": {
+          "repo_id": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "line_range": {
+            "type": "array",
+            "minItems": 2,
+            "maxItems": 2
+          },
+          "byte_range": {
+            "type": "array",
+            "minItems": 2,
+            "maxItems": 2
+          },
+          "snapshot_id": {
+            "type": "string"
+          },
+          "cursor": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "required": [
+          "repo_id",
+          "snapshot_id",
+          "ignore_digest",
+          "path",
+          "sha256"
+        ],
+        "properties": {},
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "read_files",
+      "description": "Read a bounded batch of allowed files with per-item success or failure.",
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "input_schema": {
+        "type": "object",
+        "required": [
+          "repo_id",
+          "requests"
+        ],
+        "properties": {
+          "repo_id": {
+            "type": "string"
+          },
+          "requests": {
+            "type": "array"
+          },
+          "snapshot_id": {
+            "type": "string"
+          },
+          "byte_budget": {
+            "type": "number",
+            "minimum": 1
+          }
+        },
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "required": [
+          "repo_id",
+          "snapshot_id",
+          "ignore_digest",
+          "results"
+        ],
+        "properties": {},
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "stat_file",
+      "description": "Return metadata for one allowed file, directory, or symlink.",
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "input_schema": {
+        "type": "object",
+        "required": [
+          "repo_id",
+          "path"
+        ],
+        "properties": {
+          "repo_id": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "snapshot_id": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "required": [
+          "repo_id",
+          "snapshot_id",
+          "ignore_digest",
+          "path",
+          "type",
+          "indexed",
+          "readable"
+        ],
+        "properties": {},
+        "additionalProperties": false
+      }
+    }
+  ]
+}

--- a/assets/mcp/general-repo-reader-tools.v1.schema.json
+++ b/assets/mcp/general-repo-reader-tools.v1.schema.json
@@ -154,8 +154,7 @@
     "object_schema": {
       "type": "object",
       "required": [
-        "type",
-        "additionalProperties"
+        "type"
       ],
       "properties": {
         "type": {
@@ -172,12 +171,34 @@
           "type": "object"
         },
         "additionalProperties": {
-          "const": false
+          "type": "boolean"
+        },
+        "oneOf": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          },
+          "minItems": 1
+        },
+        "anyOf": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          },
+          "minItems": 1
+        },
+        "allOf": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          },
+          "minItems": 1
         }
-      }
+      },
+      "additionalProperties": true
     }
   },
-  "x-repo-harness-tools": [
+  "tools": [
     {
       "name": "get_repo_capabilities",
       "description": "Return read/write mode, index capabilities, and limits for a registered repo.",
@@ -201,15 +222,66 @@
       },
       "output_schema": {
         "type": "object",
-        "required": [
-          "repo_id",
-          "access_mode",
-          "read_tools",
-          "write_tools",
-          "limits"
-        ],
-        "properties": {},
-        "additionalProperties": false
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "repo_id",
+              "access_mode",
+              "read_tools",
+              "write_tools",
+              "limits"
+            ],
+            "properties": {
+              "repo_id": {
+                "type": "string"
+              },
+              "access_mode": {
+                "type": "string"
+              },
+              "read_tools": {
+                "type": "array"
+              },
+              "write_tools": {
+                "type": "array"
+              },
+              "limits": {
+                "type": "object"
+              }
+            },
+            "additionalProperties": true
+          },
+          {
+            "type": "object",
+            "required": [
+              "error"
+            ],
+            "properties": {
+              "error": {
+                "type": "object",
+                "required": [
+                  "code",
+                  "message",
+                  "retryable"
+                ],
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  },
+                  "retryable": {
+                    "type": "boolean"
+                  },
+                  "details": {}
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
       }
     },
     {
@@ -245,15 +317,66 @@
       },
       "output_schema": {
         "type": "object",
-        "required": [
-          "repo_id",
-          "snapshot_id",
-          "ignore_digest",
-          "entries",
-          "complete"
-        ],
-        "properties": {},
-        "additionalProperties": false
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "repo_id",
+              "snapshot_id",
+              "ignore_digest",
+              "entries",
+              "complete"
+            ],
+            "properties": {
+              "repo_id": {
+                "type": "string"
+              },
+              "snapshot_id": {
+                "type": "string"
+              },
+              "ignore_digest": {
+                "type": "string"
+              },
+              "entries": {
+                "type": "array"
+              },
+              "complete": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": true
+          },
+          {
+            "type": "object",
+            "required": [
+              "error"
+            ],
+            "properties": {
+              "error": {
+                "type": "object",
+                "required": [
+                  "code",
+                  "message",
+                  "retryable"
+                ],
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  },
+                  "retryable": {
+                    "type": "boolean"
+                  },
+                  "details": {}
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
       }
     },
     {
@@ -293,14 +416,62 @@
       },
       "output_schema": {
         "type": "object",
-        "required": [
-          "repo_id",
-          "snapshot_id",
-          "ignore_digest",
-          "entries"
-        ],
-        "properties": {},
-        "additionalProperties": false
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "repo_id",
+              "snapshot_id",
+              "ignore_digest",
+              "entries"
+            ],
+            "properties": {
+              "repo_id": {
+                "type": "string"
+              },
+              "snapshot_id": {
+                "type": "string"
+              },
+              "ignore_digest": {
+                "type": "string"
+              },
+              "entries": {
+                "type": "array"
+              }
+            },
+            "additionalProperties": true
+          },
+          {
+            "type": "object",
+            "required": [
+              "error"
+            ],
+            "properties": {
+              "error": {
+                "type": "object",
+                "required": [
+                  "code",
+                  "message",
+                  "retryable"
+                ],
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  },
+                  "retryable": {
+                    "type": "boolean"
+                  },
+                  "details": {}
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
       }
     },
     {
@@ -349,14 +520,62 @@
       },
       "output_schema": {
         "type": "object",
-        "required": [
-          "repo_id",
-          "snapshot_id",
-          "ignore_digest",
-          "matches"
-        ],
-        "properties": {},
-        "additionalProperties": false
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "repo_id",
+              "snapshot_id",
+              "ignore_digest",
+              "matches"
+            ],
+            "properties": {
+              "repo_id": {
+                "type": "string"
+              },
+              "snapshot_id": {
+                "type": "string"
+              },
+              "ignore_digest": {
+                "type": "string"
+              },
+              "matches": {
+                "type": "array"
+              }
+            },
+            "additionalProperties": true
+          },
+          {
+            "type": "object",
+            "required": [
+              "error"
+            ],
+            "properties": {
+              "error": {
+                "type": "object",
+                "required": [
+                  "code",
+                  "message",
+                  "retryable"
+                ],
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  },
+                  "retryable": {
+                    "type": "boolean"
+                  },
+                  "details": {}
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
       }
     },
     {
@@ -402,15 +621,66 @@
       },
       "output_schema": {
         "type": "object",
-        "required": [
-          "repo_id",
-          "snapshot_id",
-          "ignore_digest",
-          "path",
-          "sha256"
-        ],
-        "properties": {},
-        "additionalProperties": false
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "repo_id",
+              "snapshot_id",
+              "ignore_digest",
+              "path",
+              "sha256"
+            ],
+            "properties": {
+              "repo_id": {
+                "type": "string"
+              },
+              "snapshot_id": {
+                "type": "string"
+              },
+              "ignore_digest": {
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              },
+              "sha256": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": true
+          },
+          {
+            "type": "object",
+            "required": [
+              "error"
+            ],
+            "properties": {
+              "error": {
+                "type": "object",
+                "required": [
+                  "code",
+                  "message",
+                  "retryable"
+                ],
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  },
+                  "retryable": {
+                    "type": "boolean"
+                  },
+                  "details": {}
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
       }
     },
     {
@@ -447,14 +717,62 @@
       },
       "output_schema": {
         "type": "object",
-        "required": [
-          "repo_id",
-          "snapshot_id",
-          "ignore_digest",
-          "results"
-        ],
-        "properties": {},
-        "additionalProperties": false
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "repo_id",
+              "snapshot_id",
+              "ignore_digest",
+              "results"
+            ],
+            "properties": {
+              "repo_id": {
+                "type": "string"
+              },
+              "snapshot_id": {
+                "type": "string"
+              },
+              "ignore_digest": {
+                "type": "string"
+              },
+              "results": {
+                "type": "array"
+              }
+            },
+            "additionalProperties": true
+          },
+          {
+            "type": "object",
+            "required": [
+              "error"
+            ],
+            "properties": {
+              "error": {
+                "type": "object",
+                "required": [
+                  "code",
+                  "message",
+                  "retryable"
+                ],
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  },
+                  "retryable": {
+                    "type": "boolean"
+                  },
+                  "details": {}
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
       }
     },
     {
@@ -487,17 +805,74 @@
       },
       "output_schema": {
         "type": "object",
-        "required": [
-          "repo_id",
-          "snapshot_id",
-          "ignore_digest",
-          "path",
-          "type",
-          "indexed",
-          "readable"
-        ],
-        "properties": {},
-        "additionalProperties": false
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "repo_id",
+              "snapshot_id",
+              "ignore_digest",
+              "path",
+              "type",
+              "indexed",
+              "readable"
+            ],
+            "properties": {
+              "repo_id": {
+                "type": "string"
+              },
+              "snapshot_id": {
+                "type": "string"
+              },
+              "ignore_digest": {
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "indexed": {
+                "type": "boolean"
+              },
+              "readable": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": true
+          },
+          {
+            "type": "object",
+            "required": [
+              "error"
+            ],
+            "properties": {
+              "error": {
+                "type": "object",
+                "required": [
+                  "code",
+                  "message",
+                  "retryable"
+                ],
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  },
+                  "retryable": {
+                    "type": "boolean"
+                  },
+                  "details": {}
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
       }
     }
   ]

--- a/docs/architecture/decisions/20260622-general-repo-codegraph-access.md
+++ b/docs/architecture/decisions/20260622-general-repo-codegraph-access.md
@@ -1,0 +1,111 @@
+# General Repo Access Through CodeGraph
+
+> Status: Accepted for Sprint 0 contract freeze
+> Source PRD: `plans/prds/20260622-1700-gpt-codegraph.prd.md`
+> Source sprint: `plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md`
+> Date: 2026-06-22
+
+## Context
+
+The existing MCP reader was built for repo-harness planning surfaces and guarded
+workflow artifacts. The new product boundary is broader: a user-approved repo
+should be available to GPT for complete analysis, except paths excluded by that
+repo's `.ignore` file.
+
+The critical risk is mixing authorization with indexing. CodeGraph is the read
+and search backend, but it is not the policy engine. A stale or incomplete
+CodeGraph index must never become the access-control decision, and CodeGraph
+omissions must never be treated as proof that a file is inaccessible.
+
+## Decision
+
+Repo-harness owns authorization, path policy, ignore policy, snapshot semantics,
+mutation safety, and audit boundaries. CodeGraph owns indexed code discovery and
+symbol/text retrieval where it can provide them.
+
+The external MCP contract uses `repo_id` plus repo-relative paths. Local
+absolute paths are server-side registry data and are not accepted by GPT-facing
+tools.
+
+For a registered repo:
+
+- The repo whitelist is the repo-level authorization boundary.
+- `.ignore` is the only content-level exclusion source for the general repo API.
+- `.gitignore`, `.rgignore`, dotfile status, file extension, hidden directory
+  status, workflow-artifact status, and CodeGraph's own indexing filters are not
+  implicit policy.
+- Canonical root containment and symlink containment are always enforced before
+  CodeGraph calls and again on CodeGraph-returned paths.
+- CodeGraph-unindexed ordinary text files remain manifest-visible and use secure
+  filesystem read fallback when policy allows them.
+- Authorized file content is not implicitly redacted in tool responses for this
+  API. Logs, traces, metrics, errors, and audit records must not include file
+  content.
+- Write tools are not registered for read-only repos. Write access requires an
+  explicit repo-level `read_write` capability.
+- Every overwriting write, patch, move, or delete operation requires a revision
+  precondition such as `expected_sha256`; new file creation requires an explicit
+  must-not-exist precondition.
+
+## Tool Boundary
+
+Sprint 0 freezes the read contract for:
+
+- `get_repo_capabilities`
+- `repo_manifest`
+- `list_tree`
+- `stat_file`
+- `read_file`
+- `read_files`
+- `search_text`
+
+The write contract remains design-frozen but implementation-gated until the
+read plane and snapshot behavior are proven.
+
+## Snapshot Contract
+
+Every read response carries the same public consistency fields:
+
+- `repo_id`
+- `snapshot_id`
+- `index_revision`
+- `ignore_digest`
+- `stale`
+- `partial`
+- `next_cursor`
+
+If a request cannot be served from one coherent snapshot, the tool returns a
+stale or partial state instead of silently mixing manifest, search, and read
+results from different versions.
+
+## Invariants
+
+- A path is authorized before CodeGraph is called.
+- Every path returned by CodeGraph is checked again against canonical root
+  containment and `.ignore`.
+- `repo_manifest` is the visible file-set authority. Search results cannot be
+  used as a completeness proof.
+- Transport limits produce pagination, chunking, or explicit errors. They do not
+  remove files from the manifest.
+- Binary and unsupported files remain visible through metadata even when text
+  content is unavailable.
+
+## Tradeoffs
+
+This decision deliberately keeps the first production implementation smaller
+than the final product surface. It accepts a secure filesystem walker fallback
+for manifest parity because local CodeGraph 1.0.1 does not expose enough stable
+inventory and snapshot metadata to make CodeGraph the only source of truth.
+
+The cost is more server-side policy code in Sprint 1 and Sprint 2. The benefit
+is that repo-harness keeps a single authorization model and can prove that GPT
+analysis is not limited to whatever CodeGraph happened to index.
+
+## Out Of Scope
+
+- Arbitrary local filesystem access outside registered repos.
+- Shell, process execution, remote Codex execution, or browser automation.
+- MCP mutation of the repo whitelist itself.
+- Full binary parsing.
+- Production write tools before read-plane parity, snapshot behavior, and index
+  lag handling are verified.

--- a/docs/researches/20260622-codegraph-capability-matrix.md
+++ b/docs/researches/20260622-codegraph-capability-matrix.md
@@ -1,0 +1,97 @@
+# CodeGraph Capability Matrix For General Repo Access
+
+> Scope: Sprint 0 spike evidence for the general repo access PRD.
+> Local version checked: `@colbymchenry/codegraph` 1.0.1.
+> Checked from: `/Users/ancienttwo/Projects/repo-harness`.
+
+## Local Evidence
+
+Commands run:
+
+```bash
+./node_modules/.bin/codegraph --version
+./node_modules/.bin/codegraph --help
+./node_modules/.bin/codegraph status .
+./node_modules/.bin/codegraph files --help
+./node_modules/.bin/codegraph query --help
+./node_modules/.bin/codegraph node --help
+./node_modules/.bin/codegraph sync --help
+./node_modules/.bin/codegraph files --path . --format flat --json
+```
+
+Temporary fixture mutation spike:
+
+```bash
+codegraph init <temp-repo>
+codegraph files --path <temp-repo> --format flat --json
+# create src/added.ts, modify src/app.ts, move docs/guide.md, delete file.widget
+codegraph sync <temp-repo>
+codegraph files --path <temp-repo> --format flat --json
+```
+
+Observed state:
+
+- Version: `1.0.1`.
+- Indexed files in this repo: `844`.
+- Indexed nodes: `13,132`.
+- Indexed edges: `46,333`.
+- Status: up to date.
+- Warning: index was built by an earlier version and should be rebuilt with
+  `codegraph index -f` or `codegraph sync`.
+- JSON-capable CLI surfaces: `files --json`, `query --json`.
+- Source/file read surface: `node --file`, line-numbered text output.
+- Refresh surface: `sync`; full rebuild through `index`.
+- Temp fixture result: initial inventory reported only indexed TypeScript
+  source; after `sync`, newly created and modified TypeScript paths were
+  visible, deleted unknown-extension paths stayed absent, and Markdown/dotfile
+  paths were not inventory-visible.
+
+## Capability Matrix
+
+| Requirement | Status | Evidence | Repo-harness handling |
+|---|---|---|---|
+| Enumerate indexed files | native | `codegraph files --format flat --json` returns path, language, node count, and size | Use through adapter when available |
+| Enumerate every non-ignored repo path | filesystem-fallback | local `files` output is index inventory, not a complete filesystem manifest | Secure walker is manifest source of truth; merge CodeGraph metadata |
+| Include dotfiles by policy | filesystem-fallback | CodeGraph indexes some hidden paths such as `.github`, but it is not the policy source | Walker applies `.ignore` only; dotfiles are visible unless ignored |
+| Include unknown extensions and non-code text | filesystem-fallback | CodeGraph file inventory is language/index oriented | Walker lists them; read fallback handles allowed text |
+| Literal symbol/code search | native | `query --json` and MCP search surfaces exist for indexed symbols/code | Adapter calls CodeGraph first |
+| Stable full-text literal search over all allowed files | adapter-emulated | current CLI search is index scoped and not tied to `.ignore` policy | Use filesystem search fallback for unindexed allowed text |
+| Regex search | adapter-emulated | no verified stable regex search contract in CLI help | Implement bounded server-side fallback until CodeGraph supports it |
+| Read indexed source by file | native | `codegraph node --file` returns line-numbered source | Use for indexed text reads where snapshot permits |
+| Read arbitrary allowed text not indexed by CodeGraph | filesystem-fallback | unindexed ordinary files are outside CodeGraph read guarantee | Secure direct read with path guard and `.ignore` policy |
+| File hash/revision from CodeGraph | unsupported | CLI help does not expose hash or revision fields | Compute sha256 in repo-harness |
+| Index revision | unsupported | status output has counts but no stable revision token | Use adapter-reported best effort plus repo-harness snapshot state |
+| Snapshot ID shared by manifest/search/read | unsupported | local CodeGraph CLI does not expose stable snapshot handles | Snapshot Coordinator is a repo-harness responsibility |
+| Incremental refresh | native for indexed files | `sync [path]` is available; temp spike saw new/modified/deleted TypeScript path updates | Index Sync Coordinator may call it after mutations |
+| New/modify/move/delete visibility for non-indexed files | filesystem-fallback | temp spike did not expose Markdown, dotfile, or unknown-extension paths in inventory | Manifest/read must use secure walker and direct metadata |
+| Per-path invalidation | unsupported | CLI help does not expose an invalidate command | Use repo refresh/sync fallback |
+| Write/edit/delete | unsupported | CodeGraph CLI is read/index oriented | Mutation plane stays in repo-harness |
+| Path authorization | unsupported by design | CodeGraph resolves projects and files, not repo-harness policy | Guard before and after adapter calls |
+| `.ignore` as sole policy source | unsupported by design | CodeGraph has its own indexing behavior | Repo-harness applies `.ignore` consistently |
+
+## Source Of Truth Decision
+
+`repo_manifest` must be produced by secure filesystem walking plus CodeGraph
+metadata merge. CodeGraph inventory alone is insufficient for a complete visible
+file-set proof because Sprint 0 requires dotfiles, unknown extensions, allowed
+unindexed text, binary metadata, and transport-limit visibility.
+
+## Fallback Rules
+
+- If CodeGraph inventory omits an allowed path, manifest still includes it with
+  `indexed: false`.
+- If CodeGraph read/search is unavailable for an allowed text file, filesystem
+  fallback may serve it and must return `indexed: false` or equivalent metadata.
+- If a file is binary, unsupported, or too large for one response, it remains in
+  manifest and returns metadata plus continuation or a typed error.
+- If CodeGraph returns a path that is outside the repo or now ignored by
+  `.ignore`, repo-harness filters it and records a policy rejection without
+  exposing the path content.
+
+## Sprint 1 Pressure Points
+
+The current production MCP reader still has legacy behavior that conflicts with
+the new PRD: common deny globs, `.gitignore`-based ignore handling, hidden-file
+defaults, and response redaction. Those are intentionally left unchanged in this
+Sprint 0 contract PR and must be replaced only after the new registry, guard,
+ignore, and schema surfaces are in place.

--- a/plans/prds/20260622-1700-gpt-codegraph.prd.md
+++ b/plans/prds/20260622-1700-gpt-codegraph.prd.md
@@ -1,0 +1,73 @@
+# GPT CodeGraph General Repo Access PRD
+
+**Status**: Approved
+**Date**: 2026-06-22
+
+## AI Quick-Read Card
+
+- Goal: expose registered repo content to GPT through repo-harness MCP using CodeGraph as the primary indexed backend.
+- Authorization: the repo whitelist is the repo boundary; `.ignore` is the only content-level exclusion rule.
+- Read tools: `repo_manifest`, `list_tree`, `search_text`, `read_file`, `read_files`, and `stat_file`.
+- Completeness rule: CodeGraph omissions are not authorization failures; allowed unindexed files remain visible through secure filesystem fallback.
+- Write rule: write tools stay repo-capability gated and require revision preconditions, atomic writes, and post-write index state.
+- First delivery slice: freeze the contract, CodeGraph capability matrix, schema, fixture, and CI contract test before changing production reader behavior.
+
+## Problem
+
+The current repo-harness MCP reader was designed around workflow artifacts and safe planning surfaces. That is too narrow for full GPT repository analysis. Files can disappear from the model's view because they are hidden, ignored by a non-policy ignore file, unindexed by CodeGraph, or filtered by legacy deny and redaction behavior.
+
+The product needs a single repo access contract where users authorize repos explicitly and repo-harness can prove which files were visible, searchable, readable, indexed, or deliberately excluded.
+
+## Goals
+
+- Use registered repos, represented externally by `repo_id`, as the only repo-level authorization source.
+- Use `.ignore` as the only content-level exclusion source for the general repo API.
+- Keep external paths repo-relative; never expose local absolute roots in GPT-facing requests.
+- Use CodeGraph for indexed inventory, search, and source reads when it can serve them.
+- Use secure filesystem walking and direct-read fallback when CodeGraph cannot prove complete coverage.
+- Return common consistency fields: `repo_id`, `snapshot_id`, `index_revision`, `ignore_digest`, `stale`, `partial`, and `next_cursor`.
+- Keep write tools disabled unless the registered repo is explicitly `read_write`.
+- Protect writes with `expected_sha256` or equivalent revision preconditions and atomic same-directory writes.
+
+## Non-Goals
+
+- Do not expose arbitrary local filesystem paths.
+- Do not expose shell, process execution, browser automation, or remote Codex execution.
+- Do not let MCP mutate the repo whitelist.
+- Do not treat CodeGraph `not indexed` as `not allowed`.
+- Do not silently redact authorized file responses for this API; instead, prevent file content from entering logs, traces, metrics, errors, and audit records.
+- Do not parse every binary format in the first release. Binary files still need metadata visibility.
+
+## Acceptance Scenarios
+
+1. Given a registered repo, GPT can enumerate every path not matched by that repo's `.ignore`, including dotfiles, unknown extensions, and `.gitignore` matches that are not also `.ignore` matches.
+2. Given a CodeGraph index that omits an allowed text file, `repo_manifest` still returns the file with `indexed: false`, and `read_file` can use secure direct-read fallback.
+3. Given an external symlink or a `..` path attempt, every tool rejects access before reading content and returns a stable path-policy error.
+4. Given a write-enabled repo, overwrites, patches, moves, and deletes require revision preconditions; stale hashes return `REVISION_CONFLICT` instead of overwriting local changes.
+5. Given a large repo or large result set, tools return pagination, continuation, or typed payload-limit errors without removing files from the manifest.
+6. Given CodeGraph returns a path that is now ignored or outside the repo, repo-harness filters it after the adapter call and does not expose file content.
+
+## Design Notes
+
+The original comparison with CodexPro led to this implementation stance:
+
+- Borrow canonical root checks, repo-relative paths, traversal rejection, symlink containment, read/write capability separation, and diff/hash-style write results.
+- Do not copy fixed blocked globs, hidden-file filtering, extension allowlists, implicit `.gitignore` policy, or authorized-content redaction.
+- Treat CodeGraph as the indexed read/search plane and repo-harness as the authorization, snapshot, manifest, fallback-read, mutation, and audit plane.
+
+The manifest source of truth is secure filesystem walking plus CodeGraph metadata merge. CodeGraph inventory alone is not complete enough because it can omit non-code text, dotfiles, unknown extensions, binary metadata, or files created before the next sync.
+
+## Sprint 0 Evidence
+
+- ADR: `docs/architecture/decisions/20260622-general-repo-codegraph-access.md`
+- CodeGraph capability matrix: `docs/researches/20260622-codegraph-capability-matrix.md`
+- Tool schema: `assets/mcp/general-repo-reader-tools.v1.schema.json`
+- Fixture and contract test: `tests/fixtures/mcp-codegraph-access/`, `tests/cli/mcp-codegraph-contract.test.ts`
+
+## Risks
+
+- CodeGraph inventory incompleteness could make GPT analysis miss files unless `repo_manifest` is walker-backed.
+- CodeGraph's own ignore/index policy could diverge from `.ignore`; every adapter result needs repo-harness post-filtering.
+- Snapshot-less reads can mix manifest, search, and read versions; Sprint 2 must make stale state explicit.
+- Write tools can lose local changes unless revision preconditions are mandatory.
+- Logs, traces, and errors can leak authorized file content unless the logging allowlist is strict.

--- a/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
+++ b/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
@@ -1,0 +1,804 @@
+# Repo-Harness 通用仓库访问与 CodeGraph 集成 Sprint 方案
+
+**版本：** v1.0  
+**建议周期：** Sprint 0（1 周）+ Sprint 1–4（每个 2 周），共 9 周  
+**适用范围：** 在现有 repo 白名单机制之上，为 GPT/MCP 提供白名单仓库内、除 `.ignore` 排除项外的完整文件枚举、搜索、读取与受控写入能力。  
+**建议团队：** 2 名后端/平台工程师、1 名测试工程师、0.5 名 DevOps/SRE；Tech Lead 兼任架构评审。
+
+---
+
+## 1. 项目目标
+
+### 1.1 核心目标
+
+- [ ] 白名单 repo 是首要授权边界。
+- [ ] 白名单 repo 内，除 `.ignore` 命中的路径外，默认允许枚举、搜索、读取。
+- [ ] 不按文件扩展名、隐藏目录、dotfile、`.gitignore`、`.rgignore` 或“是否属于 workflow artifact”增加额外拒绝规则。
+- [ ] MCP 至少提供：
+  - `repo_manifest`
+  - `list_tree`
+  - `search_text`
+  - `read_file`
+  - `read_files`
+  - `stat_file`
+- [ ] CodeGraph 作为索引、检索和仓库内容服务的主要后端。
+- [ ] CodeGraph 未索引但授权允许的普通文件，仍可通过安全直读 fallback 获取。
+- [ ] 所有读取工具共享同一套 repo、路径、ignore 和 snapshot 语义。
+- [ ] 写能力按 repo capability 单独启用，默认只读。
+- [ ] 写入使用版本前置条件、原子提交和写后索引同步，避免覆盖并发修改。
+- [ ] 返回结果可证明完整性、版本一致性和索引状态。
+
+### 1.2 明确不做
+
+- [ ] 不开放任意本机文件系统路径。
+- [ ] 不开放 shell、进程执行或远程 Codex 执行。
+- [ ] 不通过 MCP 修改 repo 白名单配置本身。
+- [ ] 不把 CodeGraph 的“未索引”解释为“无权限”。
+- [ ] 不在已授权文件正文上做隐式 secret redaction；但日志中不得记录正文。
+- [ ] 首版不承诺解析任意二进制格式，只提供 stat、类型、哈希及可选字节分块能力。
+
+---
+
+## 2. 关键架构原则
+
+1. **授权与索引分离**  
+   repo-harness 决定“是否允许访问”；CodeGraph 决定“如何索引和搜索”。不得用 CodeGraph 是否返回结果代替权限判断。
+
+2. **单一 ignore 语义**  
+   所有工具共用同一个 IgnorePolicy 实例和 `ignore_digest`。默认只认仓库约定的 `.ignore`，不隐式继承其他 ignore 文件。
+
+3. **完整性优先**  
+   `repo_manifest` 是仓库可见内容的权威清单。CodeGraph 若不能完整枚举未索引文件，则由安全文件系统 walker 补齐。
+
+4. **路径以 repo-relative 为唯一外部表示**  
+   GPT 不接触本机绝对路径。所有请求使用 `repo_id + relative_path`。
+
+5. **一致性可观察**  
+   所有响应返回 `snapshot_id`、`ignore_digest`、`index_revision` 和 `stale` 状态，避免 manifest、search、read 混用不同版本。
+
+6. **传输限制不等于权限拒绝**  
+   大文件、深目录和大结果集采用分页、分块和 continuation token，不因体积大而从 manifest 中消失。
+
+7. **写入无丢失更新**  
+   覆盖、编辑、移动和删除必须携带 `expected_sha256` 或等价 revision 前置条件。
+
+---
+
+## 3. 目标架构
+
+```mermaid
+flowchart TD
+    GPT[ChatGPT / MCP Client] --> GW[MCP Tool Gateway]
+
+    GW --> AUTH[Auth & Capability Service]
+    AUTH --> REG[Repo Registry / Existing Whitelist]
+    GW --> CTX[Request Context]
+
+    CTX --> GUARD[Canonical Path Guard]
+    GUARD --> IGNORE[Ignore Policy Engine]
+    IGNORE --> SNAP[Snapshot Coordinator]
+
+    SNAP --> MANIFEST[Manifest & Tree Service]
+    SNAP --> SEARCH[Search Service]
+    SNAP --> READ[Read & Stat Service]
+    SNAP --> MUTATE[Mutation Service]
+
+    MANIFEST --> CG[CodeGraph Adapter]
+    SEARCH --> CG
+    READ --> CG
+    READ --> FSREAD[Secure FS Read Fallback]
+
+    MUTATE --> FSWRITE[Atomic FS Mutation Layer]
+    FSWRITE --> INDEX[Index Sync / Reindex Coordinator]
+    INDEX --> CG
+
+    MANIFEST --> CACHE[Metadata / Manifest Cache]
+    SEARCH --> CACHE
+    READ --> CACHE
+
+    GW --> ERR[Unified Error Mapper]
+    GW --> OBS[Audit, Metrics, Tracing]
+    MUTATE --> OBS
+    INDEX --> OBS
+```
+
+### 3.1 读取主流程
+
+```text
+MCP 请求
+→ 用户与 repo capability 校验
+→ repo_id 解析为 canonical root
+→ relative path 规范化
+→ 路径穿越与 symlink 越界检查
+→ .ignore 判定
+→ 绑定或创建 snapshot
+→ 调用 CodeGraph
+→ 对返回路径再次进行 guard + ignore 过滤
+→ 必要时安全直读 fallback
+→ 分页/分块序列化
+→ 返回 snapshot、hash、index 状态
+```
+
+### 3.2 写入主流程
+
+```text
+MCP 写请求
+→ 校验 repo 为 read_write
+→ 路径和 .ignore 校验
+→ 校验 expected_sha256 / must_not_exist
+→ 在同目录创建临时文件或执行安全变更
+→ fsync
+→ atomic rename / commit
+→ 生成 before/after hash 与 diff
+→ 通知 CodeGraph invalidate/reindex
+→ 产生新 snapshot
+→ 返回写入结果和索引状态
+```
+
+---
+
+## 4. 完整架构模块
+
+| ID | 模块 | 核心职责 | 主要接口/产物 | 所属 Sprint |
+|---|---|---|---|---|
+| ARC-01 | MCP Tool Gateway | 注册工具、参数校验、超时、分页、响应序列化 | Tool schemas、handler registry | S0–S2 |
+| ARC-02 | Auth & Capability Service | 用户身份、repo 访问模式、读写 capability | `canReadRepo`、`canWriteRepo` | S1、S3 |
+| ARC-03 | Repo Registry | 对接现有白名单；`repo_id → canonical root` | RepoRecord、registry API | S1 |
+| ARC-04 | Canonical Path Guard | 防 `..`、绝对路径、symlink escape、TOCTOU | `resolveAllowedPath` | S1 |
+| ARC-05 | Ignore Policy Engine | 解析 `.ignore`，统一所有工具的排除逻辑 | matcher、`ignore_digest` | S1 |
+| ARC-06 | Snapshot Coordinator | 绑定文件系统、ignore 和 CodeGraph 版本 | SnapshotRecord、stale 检测 | S2 |
+| ARC-07 | CodeGraph Adapter | 封装本机 CodeGraph；能力探测、错误映射 | adapter interface | S0、S2 |
+| ARC-08 | Manifest Service | 返回全部非忽略文件的权威清单 | `repo_manifest` | S2 |
+| ARC-09 | Tree Service | 目录树、depth、分页、排序 | `list_tree` | S1–S2 |
+| ARC-10 | Search Service | 文本/正则/路径搜索，稳定分页和上下文 | `search_text` | S2 |
+| ARC-11 | Read & Stat Service | 单文件、批量、范围读取、元数据 | `read_file(s)`、`stat_file` | S1–S2 |
+| ARC-12 | Secure FS Read Fallback | 读取 CodeGraph 未索引但被授权的文件 | fd-relative read API | S2 |
+| ARC-13 | Mutation Service | create/write/patch/move/delete，版本前置条件 | mutation tools | S3 |
+| ARC-14 | Atomic FS Mutation Layer | 临时文件、fsync、rename、回滚边界 | atomic mutation API | S3 |
+| ARC-15 | Index Sync Coordinator | invalidate、增量索引、index lag 状态 | reindex events/status | S3 |
+| ARC-16 | Cache Layer | manifest、stat、hash 缓存；按 snapshot 失效 | cache keys、TTL | S2–S4 |
+| ARC-17 | Unified Error Model | 稳定错误码、可重试标记、部分失败 | error schema | S1 |
+| ARC-18 | Audit & Observability | 调用审计、指标、trace；不记录正文 | dashboards、alerts | S3–S4 |
+| ARC-19 | Feature Flags & Rollout | 并行模式、canary、回滚 | config/flags | S4 |
+| ARC-20 | Test Harness | fixture repo、竞态、越界、ignore、性能测试 | CI suites | S0–S4 |
+| ARC-21 | Documentation & ADR | 权限契约、工具说明、运维手册 | docs/ADR/runbook | S0–S4 |
+
+---
+
+## 5. MCP 工具契约
+
+### 5.1 读取工具
+
+| 工具 | 关键输入 | 关键输出 | 必要约束 |
+|---|---|---|---|
+| `repo_manifest` | `repo_id`, `snapshot_id?`, `cursor?`, `page_size?` | entries、counts、manifest digest、snapshot | 必须覆盖全部非忽略路径 |
+| `list_tree` | `repo_id`, `path`, `depth`, `cursor?` | tree nodes、next cursor | hidden/dotfile 默认包含 |
+| `search_text` | `repo_id`, `query`, `mode`, `paths?`, `cursor?`, `snapshot_id?` | matches、line context、file hash | 返回路径必须二次过滤 |
+| `read_file` | `repo_id`, `path`, `line_range?`/`byte_range?`, `snapshot_id?` | content/chunk、sha256、continuation | 大文件分块，不静默拒绝 |
+| `read_files` | `repo_id`, `requests[]`, `snapshot_id?`, `byte_budget?` | per-item result、partial failures | 单项错误不应使整批失败 |
+| `stat_file` | `repo_id`, `path`, `snapshot_id?` | type、size、mtime、sha256、indexed、binary | 区分 stat/lstat 信息 |
+| `get_repo_capabilities` | `repo_id` | read/write、CodeGraph 能力、限制 | 不返回本机绝对路径 |
+
+### 5.2 写入工具
+
+| 工具 | 关键输入 | 并发前置条件 | 输出 |
+|---|---|---|---|
+| `write_file` | path、content | 覆盖时 `expected_sha256`；新建时 `must_not_exist` | before/after hash、diff、index state |
+| `apply_patch` | path、structured edits/unified diff | `expected_sha256` 必填 | applied hunks、diff、new hash |
+| `move_path` | from、to | source hash、target must-not-exist | moved entries、index state |
+| `delete_path` | path | `expected_sha256` 或 tree revision | deleted metadata、index state |
+| `refresh_repo_index` | repo_id、paths? | write capability 或 admin capability | new index revision、snapshot |
+
+### 5.3 建议响应公共字段
+
+```json
+{
+  "repo_id": "repo_123",
+  "snapshot_id": "snap_abc",
+  "index_revision": 42,
+  "ignore_digest": "sha256:...",
+  "stale": false,
+  "partial": false,
+  "next_cursor": null
+}
+```
+
+### 5.4 建议错误码
+
+- `REPO_NOT_ALLOWED`
+- `WRITE_DISABLED`
+- `INVALID_RELATIVE_PATH`
+- `PATH_OUTSIDE_REPO`
+- `SYMLINK_ESCAPE`
+- `PATH_IGNORED`
+- `NOT_FOUND`
+- `NOT_A_FILE`
+- `BINARY_CONTENT`
+- `INVALID_RANGE`
+- `PAYLOAD_LIMIT_REACHED`
+- `SNAPSHOT_STALE`
+- `INDEX_UNAVAILABLE`
+- `INDEX_STALE`
+- `REVISION_CONFLICT`
+- `TARGET_EXISTS`
+- `PARTIAL_FAILURE`
+- `INTERNAL_ADAPTER_ERROR`
+
+错误对象必须包含：
+
+```json
+{
+  "code": "REVISION_CONFLICT",
+  "message": "File changed after it was read.",
+  "retryable": false,
+  "details": {
+    "expected_sha256": "...",
+    "actual_sha256": "..."
+  }
+}
+```
+
+---
+
+## 6. 核心数据模型
+
+### RepoRecord
+
+```text
+repo_id
+owner_id
+root_realpath                 // 仅服务端保存
+access_mode                   // read_only | read_write
+enabled
+codegraph_project_id
+ignore_policy_version
+created_at
+updated_at
+registry_revision
+```
+
+### SnapshotRecord
+
+```text
+snapshot_id
+repo_id
+fs_revision
+codegraph_revision
+ignore_digest
+manifest_digest
+created_at
+state                         // ready | index_lagging | stale | failed
+```
+
+### ManifestEntry
+
+```text
+path                          // repo-relative
+type                          // file | dir | symlink
+size
+mtime
+sha256
+mime
+binary
+indexed
+readable
+writable
+symlink_target_kind           // internal | external | none
+```
+
+### MutationRecord
+
+```text
+mutation_id
+repo_id
+operation
+paths
+expected_hashes
+before_hashes
+after_hashes
+actor_id
+committed_at
+index_state                   // pending | ready | failed
+new_snapshot_id
+```
+
+---
+
+# 7. Sprint 0：契约冻结与 CodeGraph 技术验证
+
+**周期：** 1 周  
+**目标：** 在进入生产开发前冻结权限语义、CodeGraph 能力边界和工具契约，避免后续因“索引不完整”“ignore 不一致”返工。
+
+## 7.1 架构与产品契约
+
+- [x] **S0-ARC-001** 编写 ADR：repo 白名单是授权边界，`.ignore` 是唯一内容级排除规则。
+- [x] **S0-ARC-002** 明确 `.ignore` 语法：建议采用 gitignore pattern 语义，但不自动加载 `.gitignore`/`.rgignore`。
+- [x] **S0-ARC-003** 明确隐藏文件、dotfile 和未知扩展名默认可见。
+- [x] **S0-ARC-004** 明确 symlink 规则：目标仍在同一 canonical repo root 内时允许；越界拒绝。
+- [x] **S0-ARC-005** 明确读写 capability：repo 默认 `read_only`，显式升级为 `read_write`。
+- [x] **S0-ARC-006** 明确传输限制策略：分页/分块，不将大小限制解释为内容拒绝。
+- [x] **S0-ARC-007** 明确已授权正文不做隐式脱敏；日志严禁记录正文。
+- [x] **S0-ARC-008** 冻结公共错误模型、分页模型和 snapshot 字段。
+
+## 7.2 CodeGraph Spike
+
+- [x] **S0-CG-001** 列出本机 CodeGraph 当前 API/CLI/SDK 能力。
+- [x] **S0-CG-002** 验证 CodeGraph 是否能枚举“全部文件”，包括未索引文件、dotfile 和未知扩展名。
+- [x] **S0-CG-003** 验证 literal、regex、path search 能力和分页稳定性。
+- [x] **S0-CG-004** 验证能否按行/字节读取，是否能返回文件 hash/revision。
+- [x] **S0-CG-005** 验证索引 revision、刷新、invalidate 和增量 reindex 能力。
+- [x] **S0-CG-006** 验证新建、修改、移动、删除后的索引可见延迟。
+- [x] **S0-CG-007** 形成 capability matrix：native / adapter-emulated / filesystem-fallback / unsupported。
+- [x] **S0-CG-008** 决定 manifest 的 source of truth：CodeGraph 全量 inventory 或 secure walker + CodeGraph metadata merge。
+
+## 7.3 测试基线
+
+- [x] **S0-TST-001** 建立 fixture repo，包含普通文件、dotfile、空文件、超大文件、二进制、未知扩展名。
+- [x] **S0-TST-002** 加入 `.ignore` 的包含、排除、否定规则和嵌套目录案例。
+- [x] **S0-TST-003** 加入 `../`、绝对路径、内部 symlink、外部 symlink、symlink chain。
+- [x] **S0-TST-004** 加入并发修改、删除后读取、写入时 rename 的竞态用例。
+- [x] **S0-TST-005** 建立大仓库基准：10k、100k、500k entries。
+- [x] **S0-TST-006** 在 CI 中提供可重复启动的 fake CodeGraph 或 adapter contract test double。
+
+## 7.4 Sprint 0 退出标准
+
+- [ ] 所有 ADR 经架构评审通过。
+- [x] CodeGraph capability matrix 无未知关键项。
+- [x] 已明确何时启用安全文件系统 fallback。
+- [x] MCP 工具 JSON Schema 进入版本控制。
+- [x] Fixture repo 和最小 adapter spike 可在 CI 运行。
+- [x] 无 P0/P1 未决权限问题。
+
+Sprint 0 evidence:
+
+- ADR: `docs/architecture/decisions/20260622-general-repo-codegraph-access.md`
+- Capability matrix and local spike: `docs/researches/20260622-codegraph-capability-matrix.md`
+- MCP schema: `assets/mcp/general-repo-reader-tools.v1.schema.json`
+- Fixture and contract tests: `tests/fixtures/mcp-codegraph-access/`, `tests/cli/mcp-codegraph-contract.test.ts`
+- Verification: `bun test tests/cli/mcp-codegraph-contract.test.ts`
+- Remaining exit gate: architecture reviewer sign-off through the Sprint 0 PR.
+
+---
+
+# 8. Sprint 1：安全边界与基础读取 MVP
+
+**周期：** 2 周  
+**目标：** 打通现有白名单、路径守卫、`.ignore`、基础 tree/stat/read，并证明“不额外阻拦”。
+
+## 8.1 Repo Registry 与 capability
+
+- [ ] **S1-REG-001** 对接现有 repo 白名单，不复制第二份授权源。
+- [ ] **S1-REG-002** 使用稳定 `repo_id`，外部 API 禁止提交本机绝对路径。
+- [ ] **S1-REG-003** 在 Registry 中支持 `read_only | read_write`，初始默认 `read_only`。
+- [ ] **S1-REG-004** 为 repo root 建立 canonical realpath，并检测 root 被移动/替换。
+- [ ] **S1-REG-005** 实现 registry revision 和配置变更审计。
+
+## 8.2 Path Guard
+
+- [ ] **S1-GRD-001** 拒绝绝对路径、NUL、非法编码和 `..` 越界。
+- [ ] **S1-GRD-002** 路径标准化后再次验证仍在 repo root 内。
+- [ ] **S1-GRD-003** 支持内部 symlink；拒绝 external symlink 和 symlink chain escape。
+- [ ] **S1-GRD-004** 写路径对不存在目标检查最近的已存在父目录。
+- [ ] **S1-GRD-005** 使用 fd-relative/openat 等机制降低 check-then-open TOCTOU 风险。
+- [ ] **S1-GRD-006** 对 CodeGraph 返回的每个 path 执行二次 guard。
+- [ ] **S1-GRD-007** 增加 Windows/macOS/Linux 路径差异测试；若首版只支持单平台，在 capability 中显式声明。
+
+## 8.3 Ignore Policy
+
+- [ ] **S1-IGN-001** 实现 `.ignore` parser 和 matcher。
+- [ ] **S1-IGN-002** 计算稳定 `ignore_digest`。
+- [ ] **S1-IGN-003** 所有服务注入同一个 IgnorePolicy，不允许各模块自行解析。
+- [ ] **S1-IGN-004** 不自动继承 `.gitignore`、`.rgignore` 或 CodeGraph 默认 ignore。
+- [ ] **S1-IGN-005** dotfile 和隐藏目录默认包含。
+- [ ] **S1-IGN-006** `.ignore` 变化时使 manifest/cache/snapshot 失效。
+- [ ] **S1-IGN-007** 为否定规则、目录规则、尾部斜杠、转义和 Unicode 路径建立测试。
+
+## 8.4 基础工具
+
+- [ ] **S1-API-001** 实现 `get_repo_capabilities`。
+- [ ] **S1-API-002** 实现 `stat_file`，返回 type、size、mtime、hash、indexed 状态。
+- [ ] **S1-API-003** 实现 `read_file` 首版，支持 line range 和 byte range。
+- [ ] **S1-API-004** 实现 `list_tree` 首版，支持 path、depth、分页。
+- [ ] **S1-API-005** 确保 `.env`、dotfile、未知扩展名在未被 `.ignore` 命中时可以 stat/read/list。
+- [ ] **S1-API-006** 为超出单次响应预算的内容返回 continuation token。
+- [ ] **S1-API-007** 实现统一 error mapper 和 retryable 标记。
+- [ ] **S1-API-008** 在响应中加入 repo、ignore 和初步 revision 元数据。
+
+## 8.5 测试与文档
+
+- [ ] **S1-TST-001** 路径穿越、symlink escape、大小写、Unicode、长路径单测。
+- [ ] **S1-TST-002** `.ignore` golden tests。
+- [ ] **S1-TST-003** 白名单 repo 与非白名单 repo 的访问隔离测试。
+- [ ] **S1-TST-004** 验证不再存在 artifact-only、extension allowlist、hidden-file block。
+- [ ] **S1-DOC-001** 编写权限契约和基础工具使用文档。
+- [ ] **S1-DOC-002** 更新 MCP server instructions，移除“只读 workflow artifacts”的旧描述。
+
+## 8.6 Sprint 1 退出标准
+
+- [ ] 任意白名单 fixture repo 的全部非忽略普通文件均可通过 tree → stat → read 访问。
+- [ ] 非白名单 repo 和 repo 外 symlink 100% 拒绝。
+- [ ] `.ignore` 在 tree、stat、read 三个工具中的结果完全一致。
+- [ ] 所有响应不暴露绝对路径。
+- [ ] 单元测试覆盖率达到团队门槛；路径和 ignore 核心模块建议 ≥ 90%。
+- [ ] 无高危路径逃逸问题。
+
+---
+
+# 9. Sprint 2：CodeGraph、完整 Manifest、搜索与 Snapshot
+
+**周期：** 2 周  
+**目标：** 建立生产级 CodeGraph Adapter，提供全面分析所需的完整 inventory、搜索、批量读取与一致 snapshot。
+
+## 9.1 CodeGraph Adapter
+
+- [ ] **S2-CG-001** 定义稳定 adapter interface，隔离 CodeGraph 具体版本和调用方式。
+- [ ] **S2-CG-002** 启动时执行 capability discovery，并缓存结果。
+- [ ] **S2-CG-003** 统一 CodeGraph timeout、取消、重试和错误映射。
+- [ ] **S2-CG-004** 所有返回路径执行 canonical guard 和 `.ignore` 二次过滤。
+- [ ] **S2-CG-005** 记录 adapter latency、failure 和 index revision 指标。
+- [ ] **S2-CG-006** 对 CodeGraph 不支持的能力提供明确 fallback，而非静默缺失。
+- [ ] **S2-CG-007** 建立 adapter contract tests，可替换 fake/real CodeGraph。
+
+## 9.2 Snapshot Coordinator
+
+- [ ] **S2-SNP-001** 定义 `snapshot_id` 生命周期。
+- [ ] **S2-SNP-002** snapshot 绑定 `fs_revision + codegraph_revision + ignore_digest`。
+- [ ] **S2-SNP-003** manifest、tree、search、read、batch read 可复用同一 snapshot。
+- [ ] **S2-SNP-004** 文件或 ignore 变化时标记 snapshot stale。
+- [ ] **S2-SNP-005** stale 时返回显式状态；禁止静默混合版本。
+- [ ] **S2-SNP-006** 定义 snapshot TTL、最大并发数和清理策略。
+- [ ] **S2-SNP-007** 为“索引落后于文件系统”提供 `index_lagging` 状态。
+
+## 9.3 Repo Manifest
+
+- [ ] **S2-MAN-001** 实现 `repo_manifest`，覆盖所有非忽略 entries。
+- [ ] **S2-MAN-002** 每项包含 `indexed/readable/binary/size/mtime/hash/type`。
+- [ ] **S2-MAN-003** CodeGraph inventory 不完整时，由 secure walker 补齐。
+- [ ] **S2-MAN-004** 合并 CodeGraph metadata 和文件系统 metadata，定义冲突优先级。
+- [ ] **S2-MAN-005** 支持稳定排序、分页、cursor 和 manifest digest。
+- [ ] **S2-MAN-006** 返回总文件数、目录数、文本/二进制数、未索引数。
+- [ ] **S2-MAN-007** 仅在完整遍历成功时返回 `complete: true`。
+- [ ] **S2-MAN-008** 对遍历中发生的变化返回 stale/partial，而不是伪造完整性。
+- [ ] **S2-MAN-009** 建立 manifest parity test：期望集合与实际集合逐项对比。
+
+## 9.4 搜索与批量读取
+
+- [ ] **S2-SRC-001** 实现 `search_text` literal 模式。
+- [ ] **S2-SRC-002** 实现 regex 模式；限制复杂度但不按路径或扩展名过滤。
+- [ ] **S2-SRC-003** 支持 path include filter；filter 只能缩小用户主动请求，不得成为隐式 policy。
+- [ ] **S2-SRC-004** 返回行号、上下文、文件 hash、snapshot。
+- [ ] **S2-SRC-005** 支持稳定分页和 continuation。
+- [ ] **S2-SRC-006** CodeGraph 搜索不可用时提供受限 filesystem search fallback，并保持同一 ignore 语义。
+- [ ] **S2-RD-001** 实现 `read_files`。
+- [ ] **S2-RD-002** 支持 per-file range、全局 byte budget 和 partial success。
+- [ ] **S2-RD-003** CodeGraph 未索引但授权允许的文本使用 secure read fallback。
+- [ ] **S2-RD-004** 二进制文件默认返回 metadata；可选开放 byte chunk。
+- [ ] **S2-RD-005** 为读取结果返回 sha256，供后续写前置条件使用。
+
+## 9.5 性能与缓存
+
+- [ ] **S2-PERF-001** manifest 流式生成，不将全仓库一次性载入内存。
+- [ ] **S2-PERF-002** cache key 包含 repo、snapshot、ignore digest 和路径。
+- [ ] **S2-PERF-003** 文件变化、ignore 变化、registry 变化时精确失效。
+- [ ] **S2-PERF-004** 在 10k/100k/500k entries fixture 上记录基线。
+- [ ] **S2-PERF-005** 建议初始目标：100k 文件 warm manifest 首屏 p95 < 2s；普通 read 首块 p95 < 500ms；warm search p95 < 2s。最终以环境基线调整。
+
+## 9.6 Sprint 2 退出标准
+
+- [ ] Manifest 与真实非忽略文件集合在 fixture 中达到 100% parity。
+- [ ] 未索引文件仍会出现在 manifest，并可在授权条件下读取。
+- [ ] 同一 snapshot 中 manifest/search/read 的 hash 一致。
+- [ ] CodeGraph 返回越界或已忽略路径时被二次过滤。
+- [ ] search 不因 dotfile、扩展名或 `.gitignore` 漏结果。
+- [ ] 100k 文件规模下无 OOM，所有大结果均可分页恢复。
+- [ ] CodeGraph 故障时错误清晰；允许 fallback 的路径可降级运行。
+
+---
+
+# 10. Sprint 3：写入平面、并发控制与索引同步
+
+**周期：** 2 周  
+**目标：** 在 repo 级 `read_write` capability 下提供可审计、无丢失更新、写后可检索的变更能力。
+
+## 10.1 写 capability 与 API
+
+- [ ] **S3-CAP-001** repo 默认保持 `read_only`。
+- [ ] **S3-CAP-002** 只有现有授权系统显式配置 `read_write` 时才注册/允许写工具。
+- [ ] **S3-CAP-003** 写请求复用同一 Path Guard 和 IgnorePolicy。
+- [ ] **S3-API-001** 实现 `write_file` create/replace。
+- [ ] **S3-API-002** 实现 `apply_patch`，优先结构化 edits，必要时支持 unified diff。
+- [ ] **S3-API-003** 实现 `move_path`。
+- [ ] **S3-API-004** 实现 `delete_path`。
+- [ ] **S3-API-005** 定义目录创建、空目录和递归删除策略；递归删除建议首版默认关闭或要求显式参数。
+- [ ] **S3-API-006** 写响应返回 before/after hash、diff、mutation id 和 index state。
+
+## 10.2 乐观并发与原子写
+
+- [ ] **S3-MUT-001** 覆盖已有文件必须提交 `expected_sha256`。
+- [ ] **S3-MUT-002** 新建必须提交 `must_not_exist: true`。
+- [ ] **S3-MUT-003** hash 不匹配返回 `REVISION_CONFLICT`，禁止自动覆盖。
+- [ ] **S3-MUT-004** 临时文件必须位于目标同一文件系统/目录边界。
+- [ ] **S3-MUT-005** 写临时文件 → fsync → atomic rename。
+- [ ] **S3-MUT-006** 保留原文件权限和必要 metadata，策略写入 ADR。
+- [ ] **S3-MUT-007** patch 应验证每个 hunk 或精确文本 precondition。
+- [ ] **S3-MUT-008** move/delete 同样进行版本和目标存在性检查。
+- [ ] **S3-MUT-009** 写失败不得留下半文件或跨 repo 临时文件。
+- [ ] **S3-MUT-010** 对写入过程进行故障注入测试：磁盘满、权限变化、进程中断、rename 失败。
+
+## 10.3 Index Sync
+
+- [ ] **S3-IDX-001** 每次成功 mutation 产生 index invalidation event。
+- [ ] **S3-IDX-002** 能按 path 增量 reindex 时优先使用；否则明确使用 repo refresh。
+- [ ] **S3-IDX-003** 写后返回 `index_state: pending|ready|failed`。
+- [ ] **S3-IDX-004** 索引完成后生成新 `codegraph_revision` 和 snapshot。
+- [ ] **S3-IDX-005** 在索引 pending 时，changed path 的 read/stat 走安全直读并返回最新 hash。
+- [ ] **S3-IDX-006** search 必须明确使用旧索引还是等待新索引；禁止假装已可搜。
+- [ ] **S3-IDX-007** 实现 `refresh_repo_index` 或内部等价管理接口。
+- [ ] **S3-IDX-008** 定义 reindex retry、dead-letter 和人工恢复流程。
+- [ ] **S3-IDX-009** 监控 mutation commit 到 CodeGraph 可搜索的 index lag。
+
+## 10.4 审计
+
+- [ ] **S3-AUD-001** 审计 actor、repo_id、operation、relative paths、hash、结果和耗时。
+- [ ] **S3-AUD-002** 不记录文件正文、patch 全文或 secret。
+- [ ] **S3-AUD-003** 审计日志与应用日志分离并设置保留策略。
+- [ ] **S3-AUD-004** mutation id 可追踪到索引刷新状态。
+- [ ] **S3-AUD-005** 对拒绝的写请求记录错误码，不记录内容。
+
+## 10.5 Sprint 3 退出标准
+
+- [ ] 所有写工具在 read-only repo 中可靠拒绝。
+- [ ] 100% 检测并发覆盖冲突，无 lost update。
+- [ ] 原子写故障注入不产生半写文件。
+- [ ] 写后 stat/read 立即可见最新内容。
+- [ ] 写后 search 在定义的 index lag SLO 内可见，或明确返回 pending。
+- [ ] move/delete 后 manifest 与索引最终一致。
+- [ ] 所有写操作可通过 mutation id 审计。
+
+---
+
+# 11. Sprint 4：安全加固、可观测性、迁移与发布
+
+**周期：** 2 周  
+**目标：** 在真实仓库上完成兼容验证、性能调优、灰度、文档和生产发布。
+
+## 11.1 安全与一致性加固
+
+- [ ] **S4-SEC-001** 独立安全评审：path traversal、symlink、TOCTOU、权限提升、日志泄露。
+- [ ] **S4-SEC-002** Fuzz path parser、ignore parser 和 patch parser。
+- [ ] **S4-SEC-003** 测试 repo root 在运行期间被替换、卸载或权限变化。
+- [ ] **S4-SEC-004** 测试 CodeGraph 返回恶意/异常 path。
+- [ ] **S4-SEC-005** 测试 manifest 生成期间文件大量变更。
+- [ ] **S4-SEC-006** 确认所有内容大小限制均返回 continuation 或明确错误，不造成隐式文件消失。
+- [ ] **S4-SEC-007** 确认内容不进入 trace、metrics label 或 error stack。
+
+## 11.2 可观测性
+
+- [ ] **S4-OBS-001** 指标：tool calls、latency、bytes、errors、partial、fallback rate。
+- [ ] **S4-OBS-002** 指标：manifest parity failures、snapshot stale rate、index lag。
+- [ ] **S4-OBS-003** 指标：write conflicts、atomic write failures、reindex failures。
+- [ ] **S4-OBS-004** Dashboard：按 repo、tool、CodeGraph revision 聚合。
+- [ ] **S4-OBS-005** 告警：路径逃逸尝试突增、index lag 超阈值、manifest incomplete、reindex dead-letter。
+- [ ] **S4-OBS-006** tracing：MCP → policy → CodeGraph/FS → response，全链路 correlation id。
+
+## 11.3 兼容与迁移
+
+- [ ] **S4-MIG-001** 保留旧 artifact-only 工具的兼容 wrapper，内部转调新服务。
+- [ ] **S4-MIG-002** 增加 feature flag：`general_repo_read`、`repo_write`、`fs_fallback`。
+- [ ] **S4-MIG-003** 影子模式比较旧结果与新 manifest/tree/search 结果。
+- [ ] **S4-MIG-004** 选择 1–3 个 canary repo，包含小、中、大规模。
+- [ ] **S4-MIG-005** canary 首阶段只读；验证后再启用单个 read_write repo。
+- [ ] **S4-MIG-006** 准备一键回退到旧工具面；回退不得破坏白名单数据。
+- [ ] **S4-MIG-007** 删除或禁用旧的隐藏文件、扩展名、artifact-only 固定过滤器。
+- [ ] **S4-MIG-008** 对 CodeGraph 自带 ignore 设置进行审计，确保不会在 adapter 层静默丢文件。
+
+## 11.4 文档与运维
+
+- [ ] **S4-DOC-001** MCP tool reference 和完整 JSON examples。
+- [ ] **S4-DOC-002** Repo 管理员文档：白名单、read/write 模式、`.ignore`。
+- [ ] **S4-DOC-003** CodeGraph 安装、版本兼容和 health check。
+- [ ] **S4-DOC-004** Runbook：index stale、CodeGraph down、manifest incomplete、mutation conflict。
+- [ ] **S4-DOC-005** 数据和隐私说明：可读范围、无正文日志、审计范围。
+- [ ] **S4-DOC-006** 开发者迁移指南：从 workflow artifact API 到通用 repo API。
+- [ ] **S4-DOC-007** 发布说明和已知限制。
+
+## 11.5 Sprint 4 退出标准
+
+- [ ] 安全评审无未关闭 P0/P1。
+- [ ] Canary repo 连续运行达到团队设定观察窗口，无 manifest 缺失。
+- [ ] CodeGraph 故障、索引延迟和 fallback 行为符合 runbook。
+- [ ] 性能达到批准后的 SLO。
+- [ ] 旧过滤逻辑已移除或仅在关闭的新 feature flag 后存在。
+- [ ] 文档、dashboard、alerts、回滚步骤全部完成。
+- [ ] 发布负责人、测试负责人和安全负责人签字。
+
+---
+
+## 12. 全局 Definition of Done
+
+每个 backlog item 只有同时满足以下条件才可关闭：
+
+- [ ] 实现通过 code review。
+- [ ] 单元测试、集成测试和必要的 contract tests 通过。
+- [ ] 对外 schema 和错误码有文档。
+- [ ] 不增加 extension、dotfile、`.gitignore` 或内容类别过滤。
+- [ ] 结果经过 Path Guard 和 IgnorePolicy。
+- [ ] 不在日志和 trace 中记录文件正文。
+- [ ] 关键路径有 metrics/tracing。
+- [ ] 对大结果支持分页或分块。
+- [ ] 对 snapshot/index 语义有明确行为。
+- [ ] 变更兼容 feature flag 和回滚方案。
+- [ ] 验收标准由非实现者复核。
+
+---
+
+## 13. 测试矩阵
+
+| 维度 | 必测案例 |
+|---|---|
+| 授权 | 白名单、非白名单、disabled repo、read-only、read-write |
+| 路径 | 正常相对路径、`..`、绝对路径、Unicode、超长路径、大小写差异 |
+| Symlink | 内部目标、外部目标、多级链、循环、检查后替换 |
+| Ignore | 文件、目录、通配符、否定规则、转义、嵌套、ignore 文件变化 |
+| 文件类型 | 文本、空文件、dotfile、未知扩展名、二进制、超大文件、稀疏文件 |
+| CodeGraph | 正常、未索引、旧索引、超时、崩溃、返回异常 path |
+| Snapshot | 同版本、stale、索引落后、manifest 中途变化 |
+| Search | literal、regex、无结果、大量结果、分页、上下文边界 |
+| Read | 行范围、字节范围、UTF-8 边界、分块、批量部分失败 |
+| Write | create、replace、patch、move、delete、冲突、磁盘满、权限变化 |
+| 一致性 | 写后 read、写后 manifest、写后 search、move/delete 后索引 |
+| 性能 | 10k/100k/500k 文件、并发调用、大文件、高 match 数 |
+| 隐私 | 正文不进入日志、metrics、trace、错误栈 |
+
+---
+
+## 14. 建议 SLO 与发布门禁
+
+以下为初始目标，Sprint 0 基线完成后可调整：
+
+- [ ] `repo_manifest` 对 fixture 的可见文件集合准确率：**100%**。
+- [ ] `search_text` 对已索引文本的召回准确率：**100%**。
+- [ ] 路径逃逸成功数：**0**。
+- [ ] 未经 read_write capability 的成功写入数：**0**。
+- [ ] 乐观并发冲突漏检数：**0**。
+- [ ] 普通文件 `read_file` 首块 p95：**< 500 ms**。
+- [ ] warm `search_text` p95：**< 2 s**。
+- [ ] 100k 文件 manifest 首屏 p95：**< 2 s**。
+- [ ] 成功写入到可搜索的 index lag p95：建议 **< 5 s**，若 CodeGraph 不支持则返回显式 pending。
+- [ ] CodeGraph down 时，支持 fallback 的 read/stat 可用性：**≥ 99.9%**。
+- [ ] 审计记录覆盖率：所有写操作 **100%**。
+
+---
+
+## 15. 风险登记表
+
+| 风险 | 影响 | 缓解措施 | Owner |
+|---|---|---|---|
+| CodeGraph 不枚举未索引文件 | Manifest 不完整，GPT 分析遗漏 | secure walker 补齐；manifest parity gate | Platform |
+| CodeGraph 自带 ignore 隐式过滤 | 搜索遗漏 dotfile/未知文件 | capability audit；adapter 二次策略；FS fallback | Platform |
+| manifest/search/read 版本不一致 | 结论基于混合版本 | Snapshot Coordinator；stale 状态 | Backend |
+| symlink/TOCTOU 越界 | 读取或写入 repo 外 | canonical guard + fd-relative I/O + race tests | Security |
+| 大 repo 导致 OOM/超时 | 工具不可用 | 流式遍历、分页、缓存、可取消 | Backend |
+| 写覆盖开发者新修改 | 数据丢失 | `expected_sha256` 强制前置条件 | Backend |
+| 写后索引延迟 | read 与 search 不一致 | index state、增量 reindex、最新文件直读 | Platform |
+| 正文进入日志 | 隐私/密钥泄露 | structured logging allowlist；测试扫描 | SRE |
+| 旧 artifact-only 逻辑残留 | 文件仍被额外阻拦 | shadow parity、代码搜索、迁移 gate | Tech Lead |
+| `.ignore` 语义不清 | 工具结果不一致 | ADR、单一 parser、digest、golden tests | Tech Lead |
+
+---
+
+## 16. 开发跟踪模板
+
+每个 issue 建议使用以下格式：
+
+```markdown
+### ID
+S2-MAN-003
+
+### 目标
+当 CodeGraph inventory 不完整时，由 secure walker 补齐 manifest。
+
+### 依赖
+S1-GRD-001, S1-IGN-001, S2-CG-001
+
+### 验收标准
+- [ ] CodeGraph 未返回的授权文件仍出现在 manifest
+- [ ] `.ignore` 命中的文件不出现
+- [ ] dotfile 和未知扩展名可出现
+- [ ] external symlink 不出现且产生审计事件
+- [ ] 100k 文件 fixture 不 OOM
+- [ ] 返回 `complete`、`partial` 和 snapshot 状态
+
+### 测试
+- [ ] Unit
+- [ ] Contract
+- [ ] Integration
+- [ ] Performance
+- [ ] Security/race
+
+### 发布
+- [ ] Feature flag
+- [ ] Metrics
+- [ ] Docs
+- [ ] Rollback
+```
+
+建议看板列：
+
+```text
+Backlog
+→ Ready
+→ In Development
+→ In Review
+→ QA / Contract Test
+→ Canary
+→ Done
+```
+
+建议标签：
+
+```text
+area:mcp
+area:registry
+area:path-guard
+area:ignore
+area:codegraph
+area:manifest
+area:search
+area:read
+area:write
+area:index-sync
+type:security
+type:performance
+priority:P0/P1/P2
+```
+
+---
+
+## 17. 最终发布 Checklist
+
+### 权限与内容范围
+
+- [ ] repo 白名单是唯一仓库授权源。
+- [ ] `.ignore` 是唯一内容级排除源。
+- [ ] 未启用 `.gitignore`、`.rgignore`、扩展名或 dotfile 隐式过滤。
+- [ ] 未保留 artifact-only 读取限制。
+- [ ] 未经授权的 repo 无法通过 repo_id、path、symlink 或 CodeGraph 结果绕过。
+
+### 读取完整性
+
+- [ ] Manifest 能证明完整遍历。
+- [ ] 未索引文件仍有 metadata，授权文本可 fallback 读取。
+- [ ] Tree、search、read、stat 和 manifest 使用同一 ignore digest。
+- [ ] 所有工具支持 snapshot 或明确说明 current-state 语义。
+- [ ] 大文件和大结果通过 continuation 完成读取。
+
+### 写入安全
+
+- [ ] 默认只读。
+- [ ] 写入需要 repo 级 read_write capability。
+- [ ] 覆盖、patch、move、delete 均有 revision precondition。
+- [ ] 写操作为原子提交。
+- [ ] 写后索引状态可观察并可恢复。
+- [ ] 无 lost update 测试通过。
+
+### 运维与上线
+
+- [ ] Dashboard 和 alerts 已启用。
+- [ ] Runbook 已演练。
+- [ ] Canary 验证通过。
+- [ ] 回滚已演练。
+- [ ] 安全评审通过。
+- [ ] 发布说明已完成。
+
+---
+
+## 18. 推荐实施顺序总结
+
+1. 先冻结权限与 `.ignore` 语义，不急于写工具。
+2. 先实现 Registry、Path Guard 和 IgnorePolicy，再接 CodeGraph。
+3. 用 manifest parity 证明“全部可见”，不能只靠搜索结果推测完整性。
+4. 用 snapshot 解决 manifest/search/read 的版本混合。
+5. 读取稳定后再开放写入。
+6. 写入必须先完成 hash precondition、atomic commit 和 index sync。
+7. 最后通过 shadow、canary 和 feature flag 替换旧 artifact-only 能力。

--- a/tasks/notes/20260622-repo-harness-codegraph.notes.md
+++ b/tasks/notes/20260622-repo-harness-codegraph.notes.md
@@ -1,0 +1,34 @@
+# 20260622 repo-harness CodeGraph general repo access notes
+
+## Slice
+
+Sprint 0 contract freeze for `plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md`.
+
+## Decisions
+
+- Do not change the production MCP reader in this slice. Its legacy deny globs,
+  `.gitignore` handling, hidden-file defaults, and redaction behavior are known
+  conflicts with the new PRD and belong to Sprint 1 after the contract is
+  frozen.
+- Add a versioned schema and a CI contract test before adding runtime adapter
+  code. This keeps Sprint 0 reviewable and prevents a partial implementation
+  from accidentally widening access without manifest parity.
+- Treat CodeGraph 1.0.1 as the indexed metadata/search backend, not the manifest
+  source of truth. Local CLI evidence does not expose complete repo inventory,
+  stable snapshot handles, file hashes, or mutation APIs.
+
+## Tradeoffs
+
+- The S0 test uses a local fake CodeGraph inventory in the test file instead of
+  adding a production adapter abstraction. This avoids committing an interface
+  before Sprint 1/S2 implementation pressure is clearer.
+- The tracked fixture uses ordinary text files for portability; the CI contract
+  test materializes empty, large, binary, internal symlink, external symlink, and
+  symlink-chain cases at runtime. Race/fault cases remain Sprint 1/S2/S3 test
+  work because they require the production guard and mutation planes.
+
+## Open Follow-up
+
+- Sprint 1 must replace legacy MCP reader filtering with the general repo
+  Registry, Path Guard, and `.ignore` policy rather than layering the new API on
+  top of current `COMMON_DENY_GLOBS`.

--- a/tests/cli/mcp-codegraph-contract.test.ts
+++ b/tests/cli/mcp-codegraph-contract.test.ts
@@ -46,6 +46,124 @@ function readJson(path: string) {
   return JSON.parse(readFileSync(path, 'utf-8'));
 }
 
+interface SchemaValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+function schemaTypeMatches(value: unknown, type: string): boolean {
+  if (type === 'array') return Array.isArray(value);
+  if (type === 'object') return typeof value === 'object' && value !== null && !Array.isArray(value);
+  if (type === 'number') return typeof value === 'number' && Number.isFinite(value);
+  return typeof value === type;
+}
+
+function resolveSchemaRef(root: Record<string, unknown>, ref: string): unknown {
+  if (!ref.startsWith('#/')) throw new Error(`Unsupported schema ref: ${ref}`);
+  return ref.slice(2).split('/').reduce<unknown>((node, part) => {
+    if (typeof node !== 'object' || node === null) throw new Error(`Invalid schema ref: ${ref}`);
+    return (node as Record<string, unknown>)[part];
+  }, root);
+}
+
+function validateJsonSchema(schema: unknown, value: unknown, root: Record<string, unknown>, path = '$'): SchemaValidationResult {
+  if (typeof schema !== 'object' || schema === null) return { valid: true, errors: [] };
+  const schemaObject = schema as Record<string, unknown>;
+  if (typeof schemaObject.$ref === 'string') {
+    return validateJsonSchema(resolveSchemaRef(root, schemaObject.$ref), value, root, path);
+  }
+
+  const errors: string[] = [];
+  if (schemaObject.const !== undefined && value !== schemaObject.const) {
+    errors.push(`${path} expected const ${JSON.stringify(schemaObject.const)}`);
+  }
+  if (Array.isArray(schemaObject.enum) && !schemaObject.enum.includes(value)) {
+    errors.push(`${path} expected enum member`);
+  }
+  if (typeof schemaObject.type === 'string' && !schemaTypeMatches(value, schemaObject.type)) {
+    errors.push(`${path} expected type ${schemaObject.type}`);
+    return { valid: false, errors };
+  }
+  if (Array.isArray(schemaObject.required)) {
+    const valueObject = value as Record<string, unknown>;
+    for (const key of schemaObject.required) {
+      if (typeof key === 'string' && !(key in valueObject)) errors.push(`${path}.${key} is required`);
+    }
+  }
+  if (Array.isArray(schemaObject.oneOf)) {
+    const matches = schemaObject.oneOf.filter((candidate) => validateJsonSchema(candidate, value, root, path).valid);
+    if (matches.length !== 1) errors.push(`${path} expected exactly one oneOf match, got ${matches.length}`);
+  }
+  if (schemaObject.properties && typeof value === 'object' && value !== null && !Array.isArray(value)) {
+    const properties = schemaObject.properties as Record<string, unknown>;
+    const valueObject = value as Record<string, unknown>;
+    for (const [key, childSchema] of Object.entries(properties)) {
+      if (key in valueObject) {
+        errors.push(...validateJsonSchema(childSchema, valueObject[key], root, `${path}.${key}`).errors);
+      }
+    }
+    if (schemaObject.additionalProperties === false) {
+      for (const key of Object.keys(valueObject)) {
+        if (!(key in properties)) errors.push(`${path}.${key} is not allowed`);
+      }
+    }
+  }
+  if (schemaObject.items && Array.isArray(value)) {
+    value.forEach((entry, index) => {
+      errors.push(...validateJsonSchema(schemaObject.items, entry, root, `${path}[${index}]`).errors);
+    });
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+function sampleSuccessPayload(toolName: string): Record<string, unknown> {
+  const common = {
+    repo_id: 'repo_fixture',
+    snapshot_id: 'snap_fixture',
+    index_revision: 1,
+    ignore_digest: `sha256:${'a'.repeat(64)}`,
+    stale: false,
+    partial: false,
+    next_cursor: null,
+  };
+  switch (toolName) {
+    case 'get_repo_capabilities':
+      return {
+        repo_id: 'repo_fixture',
+        access_mode: 'read_only',
+        read_tools: TOOL_NAMES,
+        write_tools: [],
+        limits: { max_read_bytes: 1024 },
+      };
+    case 'repo_manifest':
+      return { ...common, entries: [], complete: true };
+    case 'list_tree':
+      return { ...common, entries: [] };
+    case 'search_text':
+      return { ...common, matches: [] };
+    case 'read_file':
+      return { ...common, path: 'README.md', sha256: 'b'.repeat(64), content: 'ok' };
+    case 'read_files':
+      return { ...common, results: [] };
+    case 'stat_file':
+      return { ...common, path: 'README.md', type: 'file', indexed: true, readable: true };
+    default:
+      throw new Error(`Missing sample payload for ${toolName}`);
+  }
+}
+
+function sampleErrorPayload(): Record<string, unknown> {
+  return {
+    error: {
+      code: 'REPO_NOT_ALLOWED',
+      message: 'repo_id is not in the registered repo whitelist',
+      retryable: false,
+      details: { repo_id: 'missing' },
+    },
+  };
+}
+
 function toPosixPath(path: string): string {
   return path.split(sep).join('/');
 }
@@ -165,10 +283,12 @@ describe('general repo CodeGraph contract', () => {
     expect(schema.properties.version.const).toBe('1');
     expect(schema.properties.policy.properties.content_exclusion.const).toBe('.ignore');
     expect(schema.properties.policy.properties.implicit_redaction.const).toBe(false);
-    expect(schema['x-repo-harness-tools'].map((tool: { name: string }) => tool.name)).toEqual(TOOL_NAMES);
+    expect(schema['x-repo-harness-tools']).toBeUndefined();
+    expect(schema.tools.map((tool: { name: string }) => tool.name)).toEqual(TOOL_NAMES);
     expect(schema.properties.common_response_fields.items.enum).toEqual(COMMON_RESPONSE_FIELDS);
 
-    for (const tool of schema['x-repo-harness-tools']) {
+    for (const tool of schema.tools) {
+      expect(validateJsonSchema(schema.$defs.tool, tool, schema).errors).toEqual([]);
       expect(tool.annotations).toEqual({
         readOnlyHint: true,
         destructiveHint: false,
@@ -176,8 +296,9 @@ describe('general repo CodeGraph contract', () => {
         openWorldHint: false,
       });
       expect(tool.input_schema.additionalProperties).toBe(false);
-      expect(tool.output_schema.additionalProperties).toBe(false);
       expect(tool.input_schema.properties.repo_id).toEqual({ type: 'string' });
+      expect(validateJsonSchema(tool.output_schema, sampleSuccessPayload(tool.name), schema).errors).toEqual([]);
+      expect(validateJsonSchema(tool.output_schema, sampleErrorPayload(), schema).errors).toEqual([]);
     }
   });
 

--- a/tests/cli/mcp-codegraph-contract.test.ts
+++ b/tests/cli/mcp-codegraph-contract.test.ts
@@ -1,0 +1,294 @@
+import { describe, expect, test } from 'bun:test';
+import { createHash } from 'crypto';
+import { copyFileSync, existsSync, lstatSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, symlinkSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { dirname, isAbsolute, join, relative, sep } from 'path';
+
+const ROOT = join(import.meta.dir, '..', '..');
+const SCHEMA_PATH = join(ROOT, 'assets/mcp/general-repo-reader-tools.v1.schema.json');
+const FIXTURE_ROOT = join(ROOT, 'tests/fixtures/mcp-codegraph-access/repo');
+const FIXTURE_OUTSIDE = join(ROOT, 'tests/fixtures/mcp-codegraph-access/outside/outside.txt');
+
+const TOOL_NAMES = [
+  'get_repo_capabilities',
+  'repo_manifest',
+  'list_tree',
+  'search_text',
+  'read_file',
+  'read_files',
+  'stat_file',
+];
+
+const COMMON_RESPONSE_FIELDS = [
+  'repo_id',
+  'snapshot_id',
+  'index_revision',
+  'ignore_digest',
+  'stale',
+  'partial',
+  'next_cursor',
+];
+
+interface IgnoreRule {
+  pattern: string;
+  negated: boolean;
+}
+
+interface ManifestEntry {
+  path: string;
+  type: 'file' | 'dir' | 'symlink' | 'other';
+  indexed: boolean;
+  readable: boolean;
+  symlinkTargetKind: 'internal' | 'external' | 'none';
+}
+
+function readJson(path: string) {
+  return JSON.parse(readFileSync(path, 'utf-8'));
+}
+
+function toPosixPath(path: string): string {
+  return path.split(sep).join('/');
+}
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function fileSha256(path: string): string {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+function validateRepoRelativePath(path: string): 'ok' | 'INVALID_RELATIVE_PATH' {
+  const trimmed = path.trim();
+  if (trimmed.length === 0) return 'INVALID_RELATIVE_PATH';
+  if (isAbsolute(trimmed) || /^[a-zA-Z]:[\\/]/.test(trimmed) || trimmed.startsWith('\\\\')) {
+    return 'INVALID_RELATIVE_PATH';
+  }
+  if (trimmed.split(/[\\/]+/).some((part) => part === '..')) return 'INVALID_RELATIVE_PATH';
+  return 'ok';
+}
+
+function copyFixture(source: string, target: string): void {
+  mkdirSync(target, { recursive: true });
+  for (const entry of readdirSync(source, { withFileTypes: true })) {
+    const from = join(source, entry.name);
+    const to = join(target, entry.name);
+    if (entry.isDirectory()) {
+      copyFixture(from, to);
+    } else if (entry.isFile()) {
+      mkdirSync(dirname(to), { recursive: true });
+      copyFileSync(from, to);
+    }
+  }
+}
+
+function readIgnoreRules(root: string): IgnoreRule[] {
+  return readFileSync(join(root, '.ignore'), 'utf-8')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith('#'))
+    .map((line) => ({
+      pattern: line.startsWith('!') ? line.slice(1) : line,
+      negated: line.startsWith('!'),
+    }));
+}
+
+function matchesIgnorePattern(pattern: string, path: string): boolean {
+  if (pattern.endsWith('/**')) {
+    const prefix = pattern.slice(0, -3);
+    return path === prefix || path.startsWith(`${prefix}/`);
+  }
+  if (!pattern.includes('/')) {
+    return path.split('/').includes(pattern);
+  }
+  return path === pattern;
+}
+
+function isIgnored(path: string, rules: IgnoreRule[]): boolean {
+  let ignored = false;
+  for (const rule of rules) {
+    if (matchesIgnorePattern(rule.pattern, path)) ignored = !rule.negated;
+  }
+  return ignored;
+}
+
+function walk(root: string, dir = root): string[] {
+  const paths: string[] = [];
+  for (const child of readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+    const absolute = join(dir, child.name);
+    const relativePath = toPosixPath(relative(root, absolute));
+    paths.push(relativePath);
+    if (child.isDirectory()) paths.push(...walk(root, absolute));
+  }
+  return paths;
+}
+
+function manifestFromSecureWalker(root: string, indexedPaths: Set<string>): { ignoreDigest: string; entries: ManifestEntry[] } {
+  const canonicalRoot = realpathSync(root);
+  const ignoreText = readFileSync(join(root, '.ignore'), 'utf-8');
+  const rules = readIgnoreRules(root);
+  const entries: ManifestEntry[] = [];
+
+  for (const path of walk(root)) {
+    if (path === '.ignore') continue;
+    if (isIgnored(path, rules)) continue;
+
+    const absolutePath = join(root, path);
+    const lstat = lstatSync(absolutePath);
+    let symlinkTargetKind: ManifestEntry['symlinkTargetKind'] = 'none';
+    let readable = true;
+
+    if (lstat.isSymbolicLink()) {
+      const target = realpathSync(absolutePath);
+      const relation = relative(canonicalRoot, target);
+      const inside = relation === '' || (relation !== '..' && !relation.startsWith(`..${sep}`) && !isAbsolute(relation));
+      symlinkTargetKind = inside ? 'internal' : 'external';
+      readable = inside;
+    }
+
+    entries.push({
+      path,
+      type: lstat.isDirectory() ? 'dir' : lstat.isSymbolicLink() ? 'symlink' : lstat.isFile() ? 'file' : 'other',
+      indexed: indexedPaths.has(path),
+      readable,
+      symlinkTargetKind,
+    });
+  }
+
+  entries.sort((a, b) => a.path.localeCompare(b.path));
+  return { ignoreDigest: `sha256:${sha256(ignoreText)}`, entries };
+}
+
+describe('general repo CodeGraph contract', () => {
+  test('versioned schema freezes the Sprint 0 reader tool surface', () => {
+    const schema = readJson(SCHEMA_PATH);
+    expect(schema.properties.version.const).toBe('1');
+    expect(schema.properties.policy.properties.content_exclusion.const).toBe('.ignore');
+    expect(schema.properties.policy.properties.implicit_redaction.const).toBe(false);
+    expect(schema['x-repo-harness-tools'].map((tool: { name: string }) => tool.name)).toEqual(TOOL_NAMES);
+    expect(schema.properties.common_response_fields.items.enum).toEqual(COMMON_RESPONSE_FIELDS);
+
+    for (const tool of schema['x-repo-harness-tools']) {
+      expect(tool.annotations).toEqual({
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      });
+      expect(tool.input_schema.additionalProperties).toBe(false);
+      expect(tool.output_schema.additionalProperties).toBe(false);
+      expect(tool.input_schema.properties.repo_id).toEqual({ type: 'string' });
+    }
+  });
+
+  test('fixture manifest uses .ignore only and treats CodeGraph inventory as metadata', () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'repo-harness-codegraph-contract-'));
+    const repoRoot = join(tempRoot, 'repo');
+    try {
+      copyFixture(FIXTURE_ROOT, repoRoot);
+      writeFileSync(join(repoRoot, 'empty.txt'), '');
+      writeFileSync(join(repoRoot, 'large.txt'), `${'large-line\n'.repeat(4096)}`);
+      writeFileSync(join(repoRoot, 'binary.bin'), Buffer.from([0, 1, 2, 3, 255]));
+      symlinkSync(join(repoRoot, 'docs/nested/guide.md'), join(repoRoot, 'internal-link.md'));
+      symlinkSync(join(repoRoot, 'internal-link.md'), join(repoRoot, 'internal-chain.md'));
+      symlinkSync(FIXTURE_OUTSIDE, join(repoRoot, 'external-link.txt'));
+
+      const fakeCodeGraphIndexed = new Set([
+        'README.md',
+        'src/app.ts',
+        'docs/nested/guide.md',
+      ]);
+      const manifest = manifestFromSecureWalker(repoRoot, fakeCodeGraphIndexed);
+      const visiblePaths = manifest.entries.map((entry) => entry.path);
+
+      expect(manifest.ignoreDigest).toMatch(/^sha256:[a-f0-9]{64}$/);
+      expect(visiblePaths).toContain('.env.allowed');
+      expect(visiblePaths).toContain('.gitignore');
+      expect(visiblePaths).toContain('.config');
+      expect(visiblePaths).toContain('.config/settings.json');
+      expect(visiblePaths).toContain('docs/.hidden.md');
+      expect(visiblePaths).toContain('gitignored-but-visible.txt');
+      expect(visiblePaths).toContain('generated/keep/gitignored-visible.txt');
+      expect(visiblePaths).toContain('generated/drop/keep-visible.txt');
+      expect(visiblePaths).toContain('unknown.widget');
+      expect(visiblePaths).toContain('empty.txt');
+      expect(visiblePaths).toContain('large.txt');
+      expect(visiblePaths).toContain('binary.bin');
+      expect(visiblePaths).not.toContain('ignored-secret.txt');
+      expect(visiblePaths).not.toContain('generated/drop/ignored.txt');
+
+      const unindexedVisible = manifest.entries.filter((entry) => entry.path === 'unknown.widget' || entry.path === 'docs/.hidden.md');
+      expect(unindexedVisible.every((entry) => entry.indexed === false && entry.readable === true)).toBe(true);
+
+      const externalLink = manifest.entries.find((entry) => entry.path === 'external-link.txt');
+      expect(externalLink).toMatchObject({
+        type: 'symlink',
+        readable: false,
+        symlinkTargetKind: 'external',
+      });
+      const internalLink = manifest.entries.find((entry) => entry.path === 'internal-link.md');
+      expect(internalLink).toMatchObject({
+        type: 'symlink',
+        readable: true,
+        symlinkTargetKind: 'internal',
+      });
+      const internalChain = manifest.entries.find((entry) => entry.path === 'internal-chain.md');
+      expect(internalChain).toMatchObject({
+        type: 'symlink',
+        readable: true,
+        symlinkTargetKind: 'internal',
+      });
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('fixture models path and race cases required by the write/read contract', () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'repo-harness-codegraph-race-contract-'));
+    const repoRoot = join(tempRoot, 'repo');
+    try {
+      copyFixture(FIXTURE_ROOT, repoRoot);
+
+      expect(validateRepoRelativePath('../outside.txt')).toBe('INVALID_RELATIVE_PATH');
+      expect(validateRepoRelativePath('/tmp/outside.txt')).toBe('INVALID_RELATIVE_PATH');
+      expect(validateRepoRelativePath('C:\\Users\\me\\repo')).toBe('INVALID_RELATIVE_PATH');
+      expect(validateRepoRelativePath('docs/nested/guide.md')).toBe('ok');
+
+      const target = join(repoRoot, 'src/app.ts');
+      const expectedSha = fileSha256(target);
+      writeFileSync(target, 'export const fixtureValue = "changed concurrently";\n');
+      expect(fileSha256(target)).not.toBe(expectedSha);
+
+      const deleted = join(repoRoot, 'docs/nested/guide.md');
+      rmSync(deleted);
+      expect(existsSync(deleted)).toBe(false);
+
+      const renameTarget = join(repoRoot, 'generated/keep/renamed.txt');
+      const tempWrite = join(repoRoot, 'generated/keep/.renamed.tmp');
+      writeFileSync(tempWrite, 'atomic rename candidate\n');
+      renameSync(tempWrite, renameTarget);
+      expect(readFileSync(renameTarget, 'utf-8')).toBe('atomic rename candidate\n');
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('fixture keeps the expected S0 edge cases in version control', () => {
+    const required = [
+      '.ignore',
+      '.env.allowed',
+      '.gitignore',
+      '.config/settings.json',
+      'docs/.hidden.md',
+      'docs/nested/guide.md',
+      'unknown.widget',
+      'gitignored-but-visible.txt',
+      'generated/drop/ignored.txt',
+      'generated/drop/keep-visible.txt',
+    ];
+
+    for (const path of required) {
+      expect(existsSync(join(FIXTURE_ROOT, path))).toBe(true);
+    }
+  });
+});

--- a/tests/fixtures/mcp-codegraph-access/benchmark-plan.json
+++ b/tests/fixtures/mcp-codegraph-access/benchmark-plan.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "entry_counts": [10000, 100000, 500000],
+  "purpose": "Sprint 0 large-repo baseline shape for repo_manifest/list_tree/search_text performance work.",
+  "required_measurements": [
+    "cold manifest first page latency",
+    "warm manifest first page latency",
+    "warm literal search latency",
+    "read_file first chunk latency",
+    "peak resident memory",
+    "manifest parity count"
+  ],
+  "generation_rules": {
+    "include_dotfiles": true,
+    "include_unknown_extensions": true,
+    "include_binary_placeholders": true,
+    "include_nested_ignore_rules": true,
+    "include_reincluded_ignore_paths": true
+  },
+  "acceptance": {
+    "manifest_parity": "100%",
+    "no_oom": true,
+    "results_paginated": true
+  }
+}

--- a/tests/fixtures/mcp-codegraph-access/outside/outside.txt
+++ b/tests/fixtures/mcp-codegraph-access/outside/outside.txt
@@ -1,0 +1,1 @@
+Outside repo symlink target.

--- a/tests/fixtures/mcp-codegraph-access/repo/.config/settings.json
+++ b/tests/fixtures/mcp-codegraph-access/repo/.config/settings.json
@@ -1,0 +1,3 @@
+{
+  "visible": true
+}

--- a/tests/fixtures/mcp-codegraph-access/repo/.env.allowed
+++ b/tests/fixtures/mcp-codegraph-access/repo/.env.allowed
@@ -1,0 +1,1 @@
+VISIBLE_ENV_EXAMPLE=allowed-by-general-repo-contract

--- a/tests/fixtures/mcp-codegraph-access/repo/.gitignore
+++ b/tests/fixtures/mcp-codegraph-access/repo/.gitignore
@@ -1,0 +1,3 @@
+# This file must not affect the general repo API visible set.
+gitignored-but-visible.txt
+generated/keep/gitignored-visible.txt

--- a/tests/fixtures/mcp-codegraph-access/repo/.ignore
+++ b/tests/fixtures/mcp-codegraph-access/repo/.ignore
@@ -1,0 +1,4 @@
+# General repo API policy fixture. Only this file is a content exclusion source.
+generated/drop/**
+!generated/drop/keep-visible.txt
+ignored-secret.txt

--- a/tests/fixtures/mcp-codegraph-access/repo/README.md
+++ b/tests/fixtures/mcp-codegraph-access/repo/README.md
@@ -1,0 +1,3 @@
+# MCP CodeGraph Access Fixture
+
+This fixture proves that `.ignore`, not `.gitignore`, is the content policy.

--- a/tests/fixtures/mcp-codegraph-access/repo/docs/.hidden.md
+++ b/tests/fixtures/mcp-codegraph-access/repo/docs/.hidden.md
@@ -1,0 +1,3 @@
+# Hidden But Visible
+
+Dotfiles are visible unless `.ignore` excludes them.

--- a/tests/fixtures/mcp-codegraph-access/repo/docs/nested/guide.md
+++ b/tests/fixtures/mcp-codegraph-access/repo/docs/nested/guide.md
@@ -1,0 +1,3 @@
+# Nested Guide
+
+General repo access must walk nested directories.

--- a/tests/fixtures/mcp-codegraph-access/repo/generated/drop/ignored.txt
+++ b/tests/fixtures/mcp-codegraph-access/repo/generated/drop/ignored.txt
@@ -1,0 +1,1 @@
+This file is hidden by .ignore.

--- a/tests/fixtures/mcp-codegraph-access/repo/generated/drop/keep-visible.txt
+++ b/tests/fixtures/mcp-codegraph-access/repo/generated/drop/keep-visible.txt
@@ -1,0 +1,1 @@
+This file is re-included by a .ignore negation rule.

--- a/tests/fixtures/mcp-codegraph-access/repo/generated/keep/gitignored-visible.txt
+++ b/tests/fixtures/mcp-codegraph-access/repo/generated/keep/gitignored-visible.txt
@@ -1,0 +1,1 @@
+Nested .gitignore match remains visible.

--- a/tests/fixtures/mcp-codegraph-access/repo/gitignored-but-visible.txt
+++ b/tests/fixtures/mcp-codegraph-access/repo/gitignored-but-visible.txt
@@ -1,0 +1,1 @@
+This path is listed in .gitignore but remains visible because only .ignore is policy.

--- a/tests/fixtures/mcp-codegraph-access/repo/ignored-secret.txt
+++ b/tests/fixtures/mcp-codegraph-access/repo/ignored-secret.txt
@@ -1,0 +1,1 @@
+This file is hidden by .ignore.

--- a/tests/fixtures/mcp-codegraph-access/repo/src/app.ts
+++ b/tests/fixtures/mcp-codegraph-access/repo/src/app.ts
@@ -1,0 +1,1 @@
+export const fixtureValue = "indexed by fake CodeGraph";

--- a/tests/fixtures/mcp-codegraph-access/repo/unknown.widget
+++ b/tests/fixtures/mcp-codegraph-access/repo/unknown.widget
@@ -1,0 +1,1 @@
+unknown extension should remain visible


### PR DESCRIPTION
## Summary
- Add the approved PRD and Sprint 0 checklist for general repo access through CodeGraph.
- Freeze the authorization contract: registered repo whitelist plus .ignore-only content exclusion, with CodeGraph as indexed backend rather than policy authority.
- Add a versioned MCP reader schema, CodeGraph capability matrix, fixture repo, benchmark plan, and CI contract test.

## P1 Map
- Entry point for this slice is the planning/contract surface, not production MCP handlers.
- Authoritative files: plans/prds/20260622-1700-gpt-codegraph.prd.md, plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md, docs/architecture/decisions/20260622-general-repo-codegraph-access.md, assets/mcp/general-repo-reader-tools.v1.schema.json.
- Runtime implementation remains out of scope for Sprint 0; current reader behavior is intentionally unchanged.

## P2 Trace
- PRD -> ADR/schema/matrix -> fixture -> tests/cli/mcp-codegraph-contract.test.ts.
- The contract test walks a fixture repo, applies .ignore only, merges fake CodeGraph indexed metadata, and verifies dotfiles, .gitignore matches, unknown extensions, symlink boundaries, path rejection, and stale-write precondition cases.

## P3 Decision
- CodeGraph 1.0.1 can serve indexed files/search/read surfaces, but local spike showed it does not provide complete inventory, stable snapshot handles, hash/revision fields, or mutation APIs.
- Smallest coherent change is to freeze the contract and test pressure first; Sprint 1 can replace legacy filtering without widening access accidentally.

## Verification
- bun test tests/cli/mcp-codegraph-contract.test.ts tests/cli/mcp-reader-tools.test.ts tests/cli/mcp-workspaces.test.ts tests/cli/codegraph.test.ts tests/tooling/codegraph-integration.test.ts
- bun test
- bash scripts/check-deploy-sql-order.sh
- bash scripts/check-architecture-sync.sh
- bash scripts/check-task-sync.sh
- bash scripts/prepare-codex-handoff.sh --reason codegraph-sprint0 >/tmp/repo-harness-prepare-codex-handoff.log && bash scripts/check-task-workflow.sh --strict
- bun scripts/inspect-project-state.ts --repo . --format text
- bash scripts/migrate-project-template.sh --repo . --dry-run
- bash scripts/ensure-codegraph.sh --sync
- bun src/cli/index.ts status --json
- bun src/cli/index.ts doctor --json
- bun src/cli/index.ts setup check --target codex --check-updates --json

## Notes
- No new runtime dependencies, no package/lockfile changes.
- The only remaining Sprint 0 exit gate is human architecture review of the ADR through this PR.