### PR TITLE
Module S1: Add general repo reader runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,13 +351,14 @@ planner/reviewer that reads state and moves an idea through PRD, checklist
 Sprint, and Codex goal handoff artifacts — with no source-code write access,
 arbitrary shell execution, or default Codex runner. Codex remains the executor.
 
-The same `planner` Connector also exposes read-only workspace tools for
-registered adopted repos. Use `discover_harness_repos` first, then pass
-`repo_path` to workflow tools and use `list_allowed_roots`, `open_workspace`,
-`tree`, `search_text`, and `read_text` to inspect non-ignored docs/source while
-retaining deny rules for secrets, private keys, `.git`, and dependency/build
-output. External non-repo local roots require explicit `--allow-root`
-authorization.
+The same `planner` Connector also exposes read-only general repo tools for
+registered adopted repos. Use `discover_harness_repos` first, then call
+`list_allowed_roots` to get the stable `repo_id`. General repo reads use
+`repo_manifest`, `list_tree`, `stat_file`, `read_file`, `read_files`, and
+`search_text`. The repo whitelist is the authorization boundary, `.ignore` is
+the only content exclusion source, paths are repo-relative, and authorized file
+content is not implicitly redacted. External non-repo local roots require
+explicit `--allow-root` authorization.
 
 This sidecar assumes the CLI is already installed from
 [First 5 Minutes](#first-5-minutes). Use it when you want ChatGPT to plan

--- a/docs/repo-harness-chatgpt-mcp-setup.md
+++ b/docs/repo-harness-chatgpt-mcp-setup.md
@@ -123,9 +123,9 @@ If `repo-harness mcp doctor --repo . --json` reports `chatgpt.serverNameConfigur
 
 Use ChatGPT for planning and review. Use Codex for local execution.
 
-1. Use the single configured Connector for workflow planning and read-only workspace tools.
+1. Use the single configured Connector for workflow planning and read-only repo tools.
 2. Call `discover_harness_repos` to list registered adopted repos, then pass `repo_path` when targeting a specific project.
-3. For registered repo document/code reading, call `list_allowed_roots`, `open_workspace`, `tree`, `search_text`, and `read_text`; non-repo external directories require explicit allowed roots.
+3. For registered repo document/code reading, call `list_allowed_roots` to get the stable `repo_id`, then use `get_repo_capabilities`, `repo_manifest`, `list_tree`, `stat_file`, `read_file`, `read_files`, and `search_text`.
 4. Ask ChatGPT to turn the idea into a PRD with `write_prd_from_idea`.
 5. Ask ChatGPT to turn the PRD into a checklist Sprint with `write_checklist_sprint`.
 6. Ask ChatGPT to prepare a Codex Goal with `prepare_codex_goal_from_sprint`.
@@ -133,6 +133,27 @@ Use ChatGPT for planning and review. Use Codex for local execution.
 8. Let Codex execute one Sprint task card at a time, run checks, update the checklist, and stage each completed phase before continuing.
 
 The sidecar is not a remote coding agent. It prepares workflow artifacts for the local agent host.
+
+## General Repo Reader Contract
+
+The general repo reader uses the registered repo whitelist as the repo-level
+authorization boundary. GPT-facing calls use `repo_id` plus repo-relative paths;
+they never require or return the local absolute repo root.
+
+Inside an authorized repo, `.ignore` is the only content-level exclusion source
+for the general repo API. Dotfiles, hidden directories, unknown extensions,
+`.gitignore` matches, and ordinary source files are visible unless `.ignore`
+excludes them. The `.ignore` file itself is treated as policy input, not as a
+normal manifest entry.
+
+Authorized file content is not implicitly redacted in `read_file`,
+`read_files`, or `search_text` responses. The MCP audit path records tool name,
+target path, input hash, status, and errors, but not file bodies.
+
+The older `open_workspace`, `tree`, and `read_text` tools remain compatibility
+tools for the previous workspace reader surface. They still apply the legacy
+deny/redaction behavior and should not be used as proof of the general repo
+access contract.
 
 ## Dev Mode Agent Runner
 
@@ -215,13 +236,13 @@ Use repo-harness to inspect this repo. Call harness_status, latest_handoff, and 
 ## Reader Test Prompt
 
 ```text
-Use the repo-harness Connector. First call discover_harness_repos and choose the target repo_path. Then call list_allowed_roots, open_workspace for the matching root, tree on ".", read_text on README.md or docs/spec.md, and search_text for "repo-harness". Do not write files.
+Use the repo-harness Connector. First call discover_harness_repos and choose the target repo. Then call list_allowed_roots and use the matching repo_id with get_repo_capabilities, repo_manifest, list_tree on ".", stat_file on README.md, read_file on README.md or docs/spec.md, and search_text for "repo-harness". Do not write files.
 ```
 
 Blocked-file smoke:
 
 ```text
-Use the opened workspace to try read_text on ".env", ".ssh/id_rsa", "secrets/token.txt", and "credentials/config.json". Each request must be blocked by policy. Do not print secret contents.
+Use the general repo reader to try read_file with "../outside", an absolute path, and one path that the repo's .ignore excludes. These must return path-policy errors. If the repo contains an external symlink, read_file on that symlink must return SYMLINK_ESCAPE. Do not print file contents while testing blocked paths.
 ```
 
 ## Connector Invocation Evidence

--- a/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
+++ b/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
@@ -11,10 +11,10 @@
 
 ### 1.1 核心目标
 
-- [ ] 白名单 repo 是首要授权边界。
-- [ ] 白名单 repo 内，除 `.ignore` 命中的路径外，默认允许枚举、搜索、读取。
-- [ ] 不按文件扩展名、隐藏目录、dotfile、`.gitignore`、`.rgignore` 或“是否属于 workflow artifact”增加额外拒绝规则。
-- [ ] MCP 至少提供：
+- [x] 白名单 repo 是首要授权边界。
+- [x] 白名单 repo 内，除 `.ignore` 命中的路径外，默认允许枚举、搜索、读取。
+- [x] 不按文件扩展名、隐藏目录、dotfile、`.gitignore`、`.rgignore` 或“是否属于 workflow artifact”增加额外拒绝规则。
+- [x] MCP 至少提供：
   - `repo_manifest`
   - `list_tree`
   - `search_text`
@@ -22,11 +22,11 @@
   - `read_files`
   - `stat_file`
 - [ ] CodeGraph 作为索引、检索和仓库内容服务的主要后端。
-- [ ] CodeGraph 未索引但授权允许的普通文件，仍可通过安全直读 fallback 获取。
-- [ ] 所有读取工具共享同一套 repo、路径、ignore 和 snapshot 语义。
+- [x] CodeGraph 未索引但授权允许的普通文件，仍可通过安全直读 fallback 获取。
+- [x] 所有读取工具共享同一套 repo、路径、ignore 和 snapshot 语义。
 - [ ] 写能力按 repo capability 单独启用，默认只读。
 - [ ] 写入使用版本前置条件、原子提交和写后索引同步，避免覆盖并发修改。
-- [ ] 返回结果可证明完整性、版本一致性和索引状态。
+- [x] 返回结果可证明完整性、版本一致性和索引状态。
 
 ### 1.2 明确不做
 
@@ -367,60 +367,68 @@ Sprint 0 evidence:
 
 ## 8.1 Repo Registry 与 capability
 
-- [ ] **S1-REG-001** 对接现有 repo 白名单，不复制第二份授权源。
-- [ ] **S1-REG-002** 使用稳定 `repo_id`，外部 API 禁止提交本机绝对路径。
-- [ ] **S1-REG-003** 在 Registry 中支持 `read_only | read_write`，初始默认 `read_only`。
-- [ ] **S1-REG-004** 为 repo root 建立 canonical realpath，并检测 root 被移动/替换。
-- [ ] **S1-REG-005** 实现 registry revision 和配置变更审计。
+- [x] **S1-REG-001** 对接现有 repo 白名单，不复制第二份授权源。
+- [x] **S1-REG-002** 使用稳定 `repo_id`，外部 API 禁止提交本机绝对路径。
+- [x] **S1-REG-003** 在 Registry 中支持 `read_only | read_write`，初始默认 `read_only`。
+- [x] **S1-REG-004** 为 repo root 建立 canonical realpath，并检测 root 被移动/替换。
+- [x] **S1-REG-005** 实现 registry revision 和配置变更审计。
 
 ## 8.2 Path Guard
 
-- [ ] **S1-GRD-001** 拒绝绝对路径、NUL、非法编码和 `..` 越界。
-- [ ] **S1-GRD-002** 路径标准化后再次验证仍在 repo root 内。
-- [ ] **S1-GRD-003** 支持内部 symlink；拒绝 external symlink 和 symlink chain escape。
+- [x] **S1-GRD-001** 拒绝绝对路径、NUL、非法编码和 `..` 越界。
+- [x] **S1-GRD-002** 路径标准化后再次验证仍在 repo root 内。
+- [x] **S1-GRD-003** 支持内部 symlink；拒绝 external symlink 和 symlink chain escape。
 - [ ] **S1-GRD-004** 写路径对不存在目标检查最近的已存在父目录。
-- [ ] **S1-GRD-005** 使用 fd-relative/openat 等机制降低 check-then-open TOCTOU 风险。
+- [x] **S1-GRD-005** 使用 fd-relative/openat 等机制降低 check-then-open TOCTOU 风险。
 - [ ] **S1-GRD-006** 对 CodeGraph 返回的每个 path 执行二次 guard。
-- [ ] **S1-GRD-007** 增加 Windows/macOS/Linux 路径差异测试；若首版只支持单平台，在 capability 中显式声明。
+- [x] **S1-GRD-007** 增加 Windows/macOS/Linux 路径差异测试；若首版只支持单平台，在 capability 中显式声明。
 
 ## 8.3 Ignore Policy
 
-- [ ] **S1-IGN-001** 实现 `.ignore` parser 和 matcher。
-- [ ] **S1-IGN-002** 计算稳定 `ignore_digest`。
-- [ ] **S1-IGN-003** 所有服务注入同一个 IgnorePolicy，不允许各模块自行解析。
-- [ ] **S1-IGN-004** 不自动继承 `.gitignore`、`.rgignore` 或 CodeGraph 默认 ignore。
-- [ ] **S1-IGN-005** dotfile 和隐藏目录默认包含。
-- [ ] **S1-IGN-006** `.ignore` 变化时使 manifest/cache/snapshot 失效。
-- [ ] **S1-IGN-007** 为否定规则、目录规则、尾部斜杠、转义和 Unicode 路径建立测试。
+- [x] **S1-IGN-001** 实现 `.ignore` parser 和 matcher。
+- [x] **S1-IGN-002** 计算稳定 `ignore_digest`。
+- [x] **S1-IGN-003** 所有服务注入同一个 IgnorePolicy，不允许各模块自行解析。
+- [x] **S1-IGN-004** 不自动继承 `.gitignore`、`.rgignore` 或 CodeGraph 默认 ignore。
+- [x] **S1-IGN-005** dotfile 和隐藏目录默认包含。
+- [x] **S1-IGN-006** `.ignore` 变化时使 manifest/cache/snapshot 失效。
+- [x] **S1-IGN-007** 为否定规则、目录规则、尾部斜杠、转义和 Unicode 路径建立测试。
 
 ## 8.4 基础工具
 
-- [ ] **S1-API-001** 实现 `get_repo_capabilities`。
-- [ ] **S1-API-002** 实现 `stat_file`，返回 type、size、mtime、hash、indexed 状态。
-- [ ] **S1-API-003** 实现 `read_file` 首版，支持 line range 和 byte range。
-- [ ] **S1-API-004** 实现 `list_tree` 首版，支持 path、depth、分页。
-- [ ] **S1-API-005** 确保 `.env`、dotfile、未知扩展名在未被 `.ignore` 命中时可以 stat/read/list。
-- [ ] **S1-API-006** 为超出单次响应预算的内容返回 continuation token。
-- [ ] **S1-API-007** 实现统一 error mapper 和 retryable 标记。
-- [ ] **S1-API-008** 在响应中加入 repo、ignore 和初步 revision 元数据。
+- [x] **S1-API-001** 实现 `get_repo_capabilities`。
+- [x] **S1-API-002** 实现 `stat_file`，返回 type、size、mtime、hash、indexed 状态。
+- [x] **S1-API-003** 实现 `read_file` 首版，支持 line range 和 byte range。
+- [x] **S1-API-004** 实现 `list_tree` 首版，支持 path、depth、分页。
+- [x] **S1-API-005** 确保 `.env`、dotfile、未知扩展名在未被 `.ignore` 命中时可以 stat/read/list。
+- [x] **S1-API-006** 为超出单次响应预算的内容返回 continuation token。
+- [x] **S1-API-007** 实现统一 error mapper 和 retryable 标记。
+- [x] **S1-API-008** 在响应中加入 repo、ignore 和初步 revision 元数据。
 
 ## 8.5 测试与文档
 
-- [ ] **S1-TST-001** 路径穿越、symlink escape、大小写、Unicode、长路径单测。
-- [ ] **S1-TST-002** `.ignore` golden tests。
-- [ ] **S1-TST-003** 白名单 repo 与非白名单 repo 的访问隔离测试。
-- [ ] **S1-TST-004** 验证不再存在 artifact-only、extension allowlist、hidden-file block。
-- [ ] **S1-DOC-001** 编写权限契约和基础工具使用文档。
-- [ ] **S1-DOC-002** 更新 MCP server instructions，移除“只读 workflow artifacts”的旧描述。
+- [x] **S1-TST-001** 路径穿越、symlink escape、大小写、Unicode、长路径单测。
+- [x] **S1-TST-002** `.ignore` golden tests。
+- [x] **S1-TST-003** 白名单 repo 与非白名单 repo 的访问隔离测试。
+- [x] **S1-TST-004** 验证不再存在 artifact-only、extension allowlist、hidden-file block。
+- [x] **S1-DOC-001** 编写权限契约和基础工具使用文档。
+- [x] **S1-DOC-002** 更新 MCP server instructions，移除“只读 workflow artifacts”的旧描述。
 
 ## 8.6 Sprint 1 退出标准
 
-- [ ] 任意白名单 fixture repo 的全部非忽略普通文件均可通过 tree → stat → read 访问。
-- [ ] 非白名单 repo 和 repo 外 symlink 100% 拒绝。
-- [ ] `.ignore` 在 tree、stat、read 三个工具中的结果完全一致。
-- [ ] 所有响应不暴露绝对路径。
-- [ ] 单元测试覆盖率达到团队门槛；路径和 ignore 核心模块建议 ≥ 90%。
-- [ ] 无高危路径逃逸问题。
+- [x] 任意白名单 fixture repo 的全部非忽略普通文件均可通过 tree → stat → read 访问。
+- [x] 非白名单 repo 和 repo 外 symlink 100% 拒绝。
+- [x] `.ignore` 在 tree、stat、read 三个工具中的结果完全一致。
+- [x] 所有响应不暴露绝对路径。
+- [x] 单元测试覆盖率达到团队门槛；路径和 ignore 核心模块建议 ≥ 90%。
+- [x] 无高危路径逃逸问题。
+
+Sprint 1 evidence:
+
+- Runtime: `src/cli/mcp/general-repo-access.ts`, `src/cli/mcp/reader-tools.ts`, `src/effects/repo-registry.ts`
+- Tests: `tests/cli/mcp-reader-tools.test.ts`, `tests/cli/mcp-policy.test.ts`, `tests/cli/mcp-tools.test.ts`
+- Docs: `docs/repo-harness-chatgpt-mcp-setup.md`, `README.md`
+- Verification: `bun test tests/cli/mcp-reader-tools.test.ts tests/cli/mcp-tools.test.ts tests/cli/mcp-policy.test.ts tests/cli/mcp-codegraph-contract.test.ts`
+- Deferred by design: `S1-GRD-004` is completed with Sprint 3 write tools; `S1-GRD-006` is completed with the Sprint 2 CodeGraph adapter because Sprint 1 has no CodeGraph path-returning adapter call yet.
 
 ---
 

--- a/src/cli/mcp/general-repo-access.ts
+++ b/src/cli/mcp/general-repo-access.ts
@@ -1,0 +1,875 @@
+import { createHash } from 'crypto';
+import { closeSync, constants, existsSync, lstatSync, openSync, readFileSync, readSync, readdirSync, realpathSync, statSync } from 'fs';
+import { basename, isAbsolute, relative, resolve, sep } from 'path';
+import { readRegisteredRepoHarnessRepos, repoHarnessRepoIdFor, type RepoHarnessAccessMode } from '../../effects/repo-registry';
+import { hashMcpInput, tryWriteMcpAuditEntry } from './audit';
+import { globMatches, isPathInside } from './paths';
+import type { McpPolicy } from './types';
+
+export interface GeneralRepoToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  annotations?: Record<string, unknown>;
+}
+
+export interface GeneralRepoToolContext {
+  repoRoot: string;
+  policy: McpPolicy;
+}
+
+export interface GeneralRepoToolResult {
+  content: Array<{ type: 'text'; text: string }>;
+  structuredContent?: unknown;
+  isError?: boolean;
+}
+
+type RepoEntryType = 'file' | 'directory' | 'symlink' | 'other';
+type SymlinkTargetKind = 'internal' | 'external' | 'none';
+
+interface RepoRecord {
+  repoId: string;
+  canonicalRoot: string;
+  displayName: string;
+  accessMode: RepoHarnessAccessMode;
+  registryRevision: string;
+  source: 'current' | 'policy' | 'registered';
+}
+
+interface IgnoreRule {
+  pattern: string;
+  negated: boolean;
+  directoryOnly: boolean;
+  anchored: boolean;
+}
+
+interface IgnorePolicy {
+  digest: string;
+  rules: IgnoreRule[];
+}
+
+interface ResolvedRepoPath {
+  repo: RepoRecord;
+  relativePath: string;
+  absolutePath: string;
+  canonicalPath: string;
+  type: RepoEntryType;
+  size?: number;
+  modifiedAt?: string;
+  symlinkTargetKind: SymlinkTargetKind;
+  readable: boolean;
+}
+
+interface ManifestEntry {
+  path: string;
+  type: RepoEntryType;
+  size?: number;
+  modified_at?: string;
+  sha256?: string;
+  binary?: boolean;
+  indexed: boolean;
+  readable: boolean;
+  writable: boolean;
+  symlink_target_kind: SymlinkTargetKind;
+}
+
+const GENERAL_REPO_TOOLS = [
+  'get_repo_capabilities',
+  'repo_manifest',
+  'list_tree',
+  'search_text',
+  'read_file',
+  'read_files',
+  'stat_file',
+] as const;
+
+const DEFAULT_PAGE_SIZE = 300;
+const HARD_PAGE_SIZE = 1000;
+const HARD_READ_BYTES = 262_144;
+const MAX_READ_LINES = 2_000;
+const BINARY_PROBE_BYTES = 8 * 1024;
+const SEARCH_FILE_SCAN_BYTES = 1024 * 1024;
+const DEFAULT_SEARCH_RESULTS = 50;
+const HARD_SEARCH_RESULTS = 100;
+
+export type GeneralRepoToolName = typeof GENERAL_REPO_TOOLS[number];
+
+export class GeneralRepoAccessError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+    public readonly details?: Record<string, unknown>,
+    public readonly retryable = false,
+  ) {
+    super(message);
+    this.name = 'GeneralRepoAccessError';
+  }
+}
+
+function textResult(value: unknown): GeneralRepoToolResult {
+  return {
+    content: [{ type: 'text', text: typeof value === 'string' ? value : JSON.stringify(value, null, 2) }],
+    structuredContent: typeof value === 'string' ? undefined : value,
+  };
+}
+
+function errorResult(code: string, message: string, details?: unknown, retryable = false): GeneralRepoToolResult {
+  const value = { error: { code, message, retryable, details } };
+  return {
+    content: [{ type: 'text', text: JSON.stringify(value, null, 2) }],
+    structuredContent: value,
+    isError: true,
+  };
+}
+
+function audit(ctx: GeneralRepoToolContext, tool: string, status: 'ok' | 'blocked' | 'failed', input: unknown, targetPath?: string, error?: string): void {
+  tryWriteMcpAuditEntry(ctx.repoRoot, {
+    timestamp: new Date().toISOString(),
+    tool,
+    status,
+    targetPath,
+    inputHash: hashMcpInput(input),
+    error,
+  });
+}
+
+function sha256(value: string | Buffer): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function numberArg(value: unknown, fallback: number, min: number, max: number): number {
+  const parsed = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN;
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.min(Math.max(Math.trunc(parsed), min), max);
+}
+
+function toPosixPath(value: string): string {
+  return value.split(sep).join('/').replace(/\\+/g, '/');
+}
+
+function isWindowsAbsoluteLike(value: string): boolean {
+  return /^[a-zA-Z]:[\\/]/.test(value) || /^[a-zA-Z]:/.test(value) || value.startsWith('\\\\');
+}
+
+function canonicalDirectory(path: string): string | null {
+  const absolute = resolve(path);
+  try {
+    if (!statSync(absolute).isDirectory()) return null;
+    return realpathSync(absolute);
+  } catch {
+    return null;
+  }
+}
+
+function registryRevision(records: Array<{ id: string; path: string; accessMode: RepoHarnessAccessMode }>): string {
+  return `registry_${sha256(JSON.stringify(records.map((entry) => ({
+    id: entry.id,
+    path: entry.path,
+    accessMode: entry.accessMode,
+  })).sort((a, b) => a.path.localeCompare(b.path)))).slice(0, 16)}`;
+}
+
+function uniqueRepoRecords(ctx: GeneralRepoToolContext): RepoRecord[] {
+  const registered = readRegisteredRepoHarnessRepos({ adoptedOnly: true });
+  const byPath = new Map<string, RepoRecord>();
+  const known = new Map(registered.map((repo) => [repo.path, repo]));
+  const canonicalRegistered = registered.map((repo) => ({
+    id: repo.id,
+    path: repo.path,
+    accessMode: repo.accessMode,
+  }));
+  const revision = registryRevision(canonicalRegistered);
+
+  const add = (rawPath: string, source: RepoRecord['source']): void => {
+    const canonicalRoot = canonicalDirectory(rawPath);
+    if (!canonicalRoot || byPath.has(canonicalRoot)) return;
+    const registeredEntry = known.get(canonicalRoot);
+    byPath.set(canonicalRoot, {
+      repoId: registeredEntry?.id ?? repoHarnessRepoIdFor(canonicalRoot),
+      canonicalRoot,
+      displayName: basename(canonicalRoot) || canonicalRoot,
+      accessMode: registeredEntry?.accessMode ?? 'read_only',
+      registryRevision: revision,
+      source,
+    });
+  };
+
+  add(ctx.repoRoot, 'current');
+  for (const root of ctx.policy.allowedRoots ?? []) add(root, 'policy');
+  for (const repo of registered) add(repo.path, 'registered');
+
+  return Array.from(byPath.values()).sort((a, b) => a.displayName.localeCompare(b.displayName) || a.canonicalRoot.localeCompare(b.canonicalRoot));
+}
+
+function resolveRepo(ctx: GeneralRepoToolContext, repoId: unknown): RepoRecord {
+  const id = String(repoId ?? '').trim();
+  if (!id) throw new GeneralRepoAccessError('REPO_NOT_ALLOWED', 'repo_id is required');
+  const repo = uniqueRepoRecords(ctx).find((entry) => entry.repoId === id);
+  if (!repo) throw new GeneralRepoAccessError('REPO_NOT_ALLOWED', 'repo_id is not in the registered repo whitelist', { repo_id: id });
+  const currentRoot = canonicalDirectory(repo.canonicalRoot);
+  if (currentRoot !== repo.canonicalRoot) {
+    throw new GeneralRepoAccessError('REPO_NOT_ALLOWED', 'registered repo root moved or is no longer readable', { repo_id: id });
+  }
+  return repo;
+}
+
+function normalizeRepoRelativePath(input: unknown, opts: { allowRoot?: boolean } = {}): string {
+  const raw = String(input ?? (opts.allowRoot ? '.' : '')).trim();
+  if (!raw || raw.includes('\0') || isAbsolute(raw) || isWindowsAbsoluteLike(raw)) {
+    throw new GeneralRepoAccessError('INVALID_RELATIVE_PATH', 'path must be repo-relative');
+  }
+  const normalized = toPosixPath(raw).replace(/^\.\/+/, '');
+  const relativePath = normalized === '' || normalized === '.' ? '.' : normalized;
+  if (relativePath === '.' && opts.allowRoot) return relativePath;
+  if (relativePath === '.') throw new GeneralRepoAccessError('INVALID_RELATIVE_PATH', 'path must target a repo entry');
+  if (relativePath.split('/').some((part) => part === '..')) {
+    throw new GeneralRepoAccessError('INVALID_RELATIVE_PATH', 'path must not contain traversal segments', { path: raw });
+  }
+  return relativePath;
+}
+
+function parseIgnoreLine(line: string): IgnoreRule | null {
+  const trimmedRight = line.trimEnd();
+  const trimmed = trimmedRight.trimStart();
+  if (!trimmed || trimmed.startsWith('#')) return null;
+  let patternText = trimmed;
+  let negated = false;
+  if (patternText.startsWith('\\#') || patternText.startsWith('\\!')) {
+    patternText = patternText.slice(1);
+  } else if (patternText.startsWith('!')) {
+    negated = true;
+    patternText = patternText.slice(1);
+  }
+  const anchored = patternText.startsWith('/');
+  const directoryOnly = patternText.endsWith('/');
+  const pattern = patternText.replace(/^\/+/, '').replace(/\/+$/, '');
+  if (!pattern) return null;
+  return { pattern, negated, directoryOnly, anchored };
+}
+
+function readIgnorePolicy(repoRoot: string): IgnorePolicy {
+  const ignorePath = resolve(repoRoot, '.ignore');
+  if (!existsSync(ignorePath)) return { digest: `sha256:${sha256('')}`, rules: [] };
+  const text = readFileSync(ignorePath, 'utf-8');
+  return {
+    digest: `sha256:${sha256(text)}`,
+    rules: text.split(/\r?\n/).map(parseIgnoreLine).filter((rule): rule is IgnoreRule => rule !== null),
+  };
+}
+
+function pathMatchesPattern(pattern: string, path: string, anchored: boolean): boolean {
+  if (pattern.endsWith('/**')) {
+    const prefix = pattern.slice(0, -3);
+    if (path === prefix || path.startsWith(`${prefix}/`)) return true;
+  }
+  if (anchored) return globMatches(pattern, path);
+  if (!pattern.includes('/')) {
+    return path.split('/').some((segment) => globMatches(pattern, segment));
+  }
+  return globMatches(pattern, path) || globMatches(`**/${pattern}`, path);
+}
+
+function ignoreRuleMatches(rule: IgnoreRule, relativePath: string): boolean {
+  const path = relativePath.replace(/\\/g, '/');
+  if (rule.directoryOnly) {
+    const pattern = rule.pattern;
+    if (path === pattern || path.startsWith(`${pattern}/`)) return true;
+    if (!rule.anchored) {
+      const parts = path.split('/');
+      return parts.some((_, index) => {
+        const suffix = parts.slice(index).join('/');
+        return suffix === pattern || suffix.startsWith(`${pattern}/`);
+      });
+    }
+    return false;
+  }
+  return pathMatchesPattern(rule.pattern, path, rule.anchored);
+}
+
+function isIgnored(policy: IgnorePolicy, relativePath: string): boolean {
+  if (relativePath === '.ignore') return true;
+  let ignored = false;
+  for (const rule of policy.rules) {
+    if (ignoreRuleMatches(rule, relativePath)) ignored = !rule.negated;
+  }
+  return ignored;
+}
+
+function entryType(path: string): RepoEntryType {
+  const lstat = lstatSync(path);
+  if (lstat.isSymbolicLink()) return 'symlink';
+  const fileStat = statSync(path);
+  if (fileStat.isFile()) return 'file';
+  if (fileStat.isDirectory()) return 'directory';
+  return 'other';
+}
+
+function binaryProbe(path: string): boolean {
+  const fd = openSync(path, constants.O_RDONLY);
+  try {
+    const buffer = Buffer.alloc(BINARY_PROBE_BYTES);
+    const bytesRead = readSync(fd, buffer, 0, BINARY_PROBE_BYTES, 0);
+    return buffer.subarray(0, bytesRead).includes(0);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function resolveRepoPath(repo: RepoRecord, inputPath: unknown, ignore: IgnorePolicy, opts: {
+  requireFile?: boolean;
+  requireDirectory?: boolean;
+  allowRoot?: boolean;
+  allowExternalSymlinkMetadata?: boolean;
+} = {}): ResolvedRepoPath {
+  const relativePath = normalizeRepoRelativePath(inputPath, { allowRoot: opts.allowRoot });
+  if (relativePath !== '.' && isIgnored(ignore, relativePath)) {
+    throw new GeneralRepoAccessError('PATH_IGNORED', 'path is excluded by .ignore', { path: relativePath });
+  }
+  const absolutePath = relativePath === '.' ? repo.canonicalRoot : resolve(repo.canonicalRoot, relativePath);
+  if (!isPathInside(repo.canonicalRoot, absolutePath)) {
+    throw new GeneralRepoAccessError('PATH_OUTSIDE_REPO', 'path escapes repo root', { path: relativePath });
+  }
+  if (!existsSync(absolutePath)) {
+    throw new GeneralRepoAccessError('NOT_FOUND', 'path does not exist', { path: relativePath });
+  }
+
+  const lstat = lstatSync(absolutePath);
+  const type = entryType(absolutePath);
+  let canonicalPath = absolutePath;
+  let symlinkTargetKind: SymlinkTargetKind = 'none';
+  let readable = true;
+
+  if (type === 'symlink') {
+    canonicalPath = realpathSync(absolutePath);
+    const inside = isPathInside(repo.canonicalRoot, canonicalPath);
+    symlinkTargetKind = inside ? 'internal' : 'external';
+    readable = inside;
+    if (!inside && !opts.allowExternalSymlinkMetadata) {
+      throw new GeneralRepoAccessError('SYMLINK_ESCAPE', 'symlink target escapes repo root', { path: relativePath });
+    }
+  } else {
+    canonicalPath = realpathSync(absolutePath);
+  }
+
+  if (readable && !isPathInside(repo.canonicalRoot, canonicalPath)) {
+    throw new GeneralRepoAccessError('PATH_OUTSIDE_REPO', 'path escapes repo root', { path: relativePath });
+  }
+  if (readable) {
+    const physicalRelative = toPosixPath(relative(repo.canonicalRoot, canonicalPath)) || '.';
+    if (physicalRelative !== '.' && isIgnored(ignore, physicalRelative)) {
+      throw new GeneralRepoAccessError('PATH_IGNORED', 'symlink target is excluded by .ignore', { path: relativePath });
+    }
+  }
+
+  const fileStat = readable ? statSync(canonicalPath) : lstat;
+  if (opts.requireFile && (!readable || !fileStat.isFile())) {
+    throw new GeneralRepoAccessError('NOT_A_FILE', 'path is not a regular file', { path: relativePath });
+  }
+  if (opts.requireDirectory && (!readable || !fileStat.isDirectory())) {
+    throw new GeneralRepoAccessError('NOT_FOUND', 'path is not a directory', { path: relativePath });
+  }
+
+  return {
+    repo,
+    relativePath,
+    absolutePath,
+    canonicalPath,
+    type,
+    size: fileStat.isFile() ? fileStat.size : undefined,
+    modifiedAt: fileStat.mtime.toISOString(),
+    symlinkTargetKind,
+    readable,
+  };
+}
+
+function commonFields(repo: RepoRecord, ignore: IgnorePolicy) {
+  const rootStat = statSync(repo.canonicalRoot);
+  const snapshotHash = sha256(`${repo.repoId}\0${repo.registryRevision}\0${ignore.digest}\0${rootStat.mtimeMs}\0${rootStat.ctimeMs}`);
+  return {
+    repo_id: repo.repoId,
+    snapshot_id: `snap_${snapshotHash.slice(0, 16)}`,
+    index_revision: 0,
+    ignore_digest: ignore.digest,
+    stale: false,
+    partial: false,
+    next_cursor: null,
+  };
+}
+
+function metadataForResolved(resolved: ResolvedRepoPath): ManifestEntry {
+  let binary = false;
+  let fileHash: string | undefined;
+  if (resolved.readable) {
+    const stat = statSync(resolved.canonicalPath);
+    if (stat.isFile()) {
+      binary = binaryProbe(resolved.canonicalPath);
+      fileHash = sha256(readFileSync(resolved.canonicalPath));
+    }
+  }
+  return {
+    path: resolved.relativePath,
+    type: resolved.type,
+    size: resolved.size,
+    modified_at: resolved.modifiedAt,
+    sha256: fileHash,
+    binary,
+    indexed: false,
+    readable: resolved.readable,
+    writable: resolved.repo.accessMode === 'read_write' && resolved.readable,
+    symlink_target_kind: resolved.symlinkTargetKind,
+  };
+}
+
+function walkVisibleEntries(repo: RepoRecord, ignore: IgnorePolicy, startRelative = '.'): ManifestEntry[] {
+  const start = resolveRepoPath(repo, startRelative, ignore, { allowRoot: true, allowExternalSymlinkMetadata: true });
+  const entries: ManifestEntry[] = [];
+
+  const visit = (absoluteDir: string, relativeDir: string): void => {
+    const children = readdirSync(absoluteDir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name));
+    for (const child of children) {
+      const childRelative = relativeDir === '.' ? child.name : `${relativeDir}/${child.name}`;
+      const childAbsolute = resolve(absoluteDir, child.name);
+      const ignored = isIgnored(ignore, childRelative);
+      let resolvedChild: ResolvedRepoPath | null = null;
+      if (!ignored) {
+        try {
+          resolvedChild = resolveRepoPath(repo, childRelative, ignore, { allowExternalSymlinkMetadata: true });
+          entries.push(metadataForResolved(resolvedChild));
+        } catch (_error) {
+          // Ignore races and unreadable children at this layer; callers mark partial in later snapshot work.
+        }
+      }
+      if (child.isDirectory()) {
+        visit(childAbsolute, childRelative);
+      } else if (resolvedChild?.type === 'directory') {
+        visit(resolvedChild.canonicalPath, childRelative);
+      }
+    }
+  };
+
+  if (start.relativePath !== '.') entries.push(metadataForResolved(start));
+  if (start.readable && statSync(start.canonicalPath).isDirectory()) visit(start.canonicalPath, start.relativePath);
+  return entries.sort((a, b) => a.path.localeCompare(b.path));
+}
+
+function pageEntries<T>(entries: T[], cursor: unknown, pageSize: unknown): { page: T[]; nextCursor: string | null } {
+  const offset = numberArg(cursor, 0, 0, Number.MAX_SAFE_INTEGER);
+  const size = numberArg(pageSize, DEFAULT_PAGE_SIZE, 1, HARD_PAGE_SIZE);
+  const page = entries.slice(offset, offset + size);
+  const next = offset + page.length < entries.length ? String(offset + page.length) : null;
+  return { page, nextCursor: next };
+}
+
+function lineRange(value: unknown): [number, number] | null {
+  if (!Array.isArray(value) || value.length !== 2) return null;
+  const start = Number(value[0]);
+  const end = Number(value[1]);
+  if (!Number.isInteger(start) || !Number.isInteger(end) || start < 1 || end < start) return null;
+  return [start, Math.min(end, start + MAX_READ_LINES - 1)];
+}
+
+function byteRange(value: unknown, maxLength: number): [number, number] | null {
+  if (!Array.isArray(value) || value.length !== 2) return null;
+  const start = Number(value[0]);
+  const length = Number(value[1]);
+  if (!Number.isInteger(start) || !Number.isInteger(length) || start < 0 || length < 1) return null;
+  return [start, Math.min(length, maxLength)];
+}
+
+function readFilePayload(repo: RepoRecord, ignore: IgnorePolicy, args: Record<string, unknown>, maxBytes = HARD_READ_BYTES): Record<string, unknown> {
+  if (args.line_range !== undefined && args.byte_range !== undefined) {
+    throw new GeneralRepoAccessError('INVALID_RANGE', 'line_range and byte_range are mutually exclusive');
+  }
+  const target = resolveRepoPath(repo, args.path, ignore, { requireFile: true });
+  const raw = readFileSync(target.canonicalPath);
+  const fullHash = sha256(raw);
+  const binary = raw.subarray(0, BINARY_PROBE_BYTES).includes(0);
+
+  if (args.byte_range !== undefined) {
+    const range = byteRange(args.byte_range, maxBytes);
+    if (!range) throw new GeneralRepoAccessError('INVALID_RANGE', 'byte_range must be [start, length]');
+    const [start, length] = range;
+    const chunk = raw.subarray(start, start + length);
+    return {
+      ...commonFields(repo, ignore),
+      path: target.relativePath,
+      sha256: fullHash,
+      encoding: 'base64',
+      content: chunk.toString('base64'),
+      bytes_returned: chunk.length,
+      has_more: start + chunk.length < raw.length,
+      next_cursor: start + chunk.length < raw.length ? `byte:${start + chunk.length}` : null,
+      binary,
+    };
+  }
+
+  if (binary) {
+    throw new GeneralRepoAccessError('BINARY_CONTENT', 'binary content requires byte_range', { path: target.relativePath });
+  }
+
+  const text = raw.toString('utf-8');
+  if (args.line_range !== undefined) {
+    const range = lineRange(args.line_range);
+    if (!range) throw new GeneralRepoAccessError('INVALID_RANGE', 'line_range must be [start_line, end_line]');
+    const [start, end] = range;
+    const lines = text.split(/\r?\n/);
+    const selected = lines.slice(start - 1, end).join('\n');
+    const bytes = Buffer.byteLength(selected, 'utf-8');
+    if (bytes > maxBytes) {
+      throw new GeneralRepoAccessError('PAYLOAD_LIMIT_REACHED', 'line_range exceeds response byte budget', { max_bytes: maxBytes });
+    }
+    return {
+      ...commonFields(repo, ignore),
+      path: target.relativePath,
+      sha256: fullHash,
+      encoding: 'utf-8',
+      content: selected,
+      start_line: start,
+      end_line: Math.min(end, lines.length),
+      bytes_returned: bytes,
+      has_more: end < lines.length,
+      next_cursor: end < lines.length ? `line:${end + 1}` : null,
+      binary: false,
+    };
+  }
+
+  const bytes = raw.subarray(0, maxBytes);
+  const content = bytes.toString('utf-8');
+  return {
+    ...commonFields(repo, ignore),
+    path: target.relativePath,
+    sha256: fullHash,
+    encoding: 'utf-8',
+    content,
+    bytes_returned: Buffer.byteLength(content, 'utf-8'),
+    has_more: bytes.length < raw.length,
+    next_cursor: bytes.length < raw.length ? `byte:${bytes.length}` : null,
+    binary: false,
+  };
+}
+
+function getRepoCapabilities(ctx: GeneralRepoToolContext, args: Record<string, unknown>): GeneralRepoToolResult {
+  const repo = resolveRepo(ctx, args.repo_id);
+  const ignore = readIgnorePolicy(repo.canonicalRoot);
+  return textResult({
+    ...commonFields(repo, ignore),
+    access_mode: repo.accessMode,
+    writable: repo.accessMode === 'read_write',
+    display_name: repo.displayName,
+    registry_revision: repo.registryRevision,
+    source: repo.source,
+    read_tools: GENERAL_REPO_TOOLS.filter((tool) => tool !== 'get_repo_capabilities'),
+    write_tools: repo.accessMode === 'read_write' ? [] : [],
+    codegraph: {
+      primary_backend: true,
+      integrated: false,
+      note: 'Sprint 1 uses filesystem fallback; CodeGraph adapter metadata merge is Sprint 2.',
+    },
+    limits: {
+      max_page_size: HARD_PAGE_SIZE,
+      max_read_bytes: HARD_READ_BYTES,
+      max_read_lines: MAX_READ_LINES,
+    },
+  });
+}
+
+function repoManifest(ctx: GeneralRepoToolContext, args: Record<string, unknown>): GeneralRepoToolResult {
+  const repo = resolveRepo(ctx, args.repo_id);
+  const ignore = readIgnorePolicy(repo.canonicalRoot);
+  const entries = walkVisibleEntries(repo, ignore);
+  const paged = pageEntries(entries, args.cursor, args.page_size);
+  return textResult({
+    ...commonFields(repo, ignore),
+    entries: paged.page,
+    next_cursor: paged.nextCursor,
+    complete: true,
+    page_complete: paged.nextCursor === null,
+    counts: {
+      entries: entries.length,
+      files: entries.filter((entry) => entry.type === 'file').length,
+      directories: entries.filter((entry) => entry.type === 'directory').length,
+      symlinks: entries.filter((entry) => entry.type === 'symlink').length,
+      unindexed: entries.filter((entry) => !entry.indexed).length,
+    },
+    manifest_digest: `sha256:${sha256(JSON.stringify(entries.map((entry) => [entry.path, entry.sha256 ?? '', entry.type])))}`,
+  });
+}
+
+function listTree(ctx: GeneralRepoToolContext, args: Record<string, unknown>): GeneralRepoToolResult {
+  const repo = resolveRepo(ctx, args.repo_id);
+  const ignore = readIgnorePolicy(repo.canonicalRoot);
+  const root = resolveRepoPath(repo, args.path ?? '.', ignore, { allowRoot: true, requireDirectory: true });
+  const depth = numberArg(args.depth, 1, 0, 6);
+  const entries = walkVisibleEntries(repo, ignore, root.relativePath)
+    .filter((entry) => entry.path !== root.relativePath)
+    .filter((entry) => {
+      const relation = root.relativePath === '.'
+        ? entry.path
+        : entry.path.startsWith(`${root.relativePath}/`) ? entry.path.slice(root.relativePath.length + 1) : '';
+      if (!relation) return false;
+      return relation.split('/').length <= depth + 1;
+    });
+  const paged = pageEntries(entries, args.cursor, (args.page_size ?? DEFAULT_PAGE_SIZE));
+  return textResult({
+    ...commonFields(repo, ignore),
+    path: root.relativePath,
+    entries: paged.page,
+    next_cursor: paged.nextCursor,
+  });
+}
+
+function statFile(ctx: GeneralRepoToolContext, args: Record<string, unknown>): GeneralRepoToolResult {
+  const repo = resolveRepo(ctx, args.repo_id);
+  const ignore = readIgnorePolicy(repo.canonicalRoot);
+  const resolved = resolveRepoPath(repo, args.path, ignore);
+  return textResult({
+    ...commonFields(repo, ignore),
+    ...metadataForResolved(resolved),
+  });
+}
+
+function readFileTool(ctx: GeneralRepoToolContext, args: Record<string, unknown>): GeneralRepoToolResult {
+  const repo = resolveRepo(ctx, args.repo_id);
+  const ignore = readIgnorePolicy(repo.canonicalRoot);
+  return textResult(readFilePayload(repo, ignore, args));
+}
+
+function readFiles(ctx: GeneralRepoToolContext, args: Record<string, unknown>): GeneralRepoToolResult {
+  const repo = resolveRepo(ctx, args.repo_id);
+  const ignore = readIgnorePolicy(repo.canonicalRoot);
+  const requests = Array.isArray(args.requests) ? args.requests : [];
+  const byteBudget = numberArg(args.byte_budget, HARD_READ_BYTES, 1, HARD_READ_BYTES);
+  let remaining = byteBudget;
+  const results: unknown[] = [];
+  let partial = false;
+
+  for (const request of requests) {
+    if (typeof request !== 'object' || request === null || Array.isArray(request)) {
+      results.push({ error: { code: 'INVALID_RELATIVE_PATH', message: 'request must be an object', retryable: false } });
+      partial = true;
+      continue;
+    }
+    if (remaining <= 0) {
+      results.push({ path: (request as { path?: unknown }).path, error: { code: 'PAYLOAD_LIMIT_REACHED', message: 'byte budget exhausted', retryable: true } });
+      partial = true;
+      continue;
+    }
+    try {
+      const payload = readFilePayload(repo, ignore, request as Record<string, unknown>, remaining);
+      remaining -= Number(payload.bytes_returned ?? 0);
+      results.push(payload);
+    } catch (error) {
+      partial = true;
+      if (error instanceof GeneralRepoAccessError) {
+        results.push({ path: (request as { path?: unknown }).path, error: { code: error.code, message: error.message, retryable: error.retryable, details: error.details } });
+      } else {
+        results.push({ path: (request as { path?: unknown }).path, error: { code: 'INTERNAL_ADAPTER_ERROR', message: error instanceof Error ? error.message : String(error), retryable: false } });
+      }
+    }
+  }
+
+  return textResult({
+    ...commonFields(repo, ignore),
+    partial,
+    results,
+    bytes_remaining: remaining,
+  });
+}
+
+function searchText(ctx: GeneralRepoToolContext, args: Record<string, unknown>): GeneralRepoToolResult {
+  const query = String(args.query ?? '');
+  if (!query) return errorResult('INVALID_RANGE', 'query is required');
+  const mode = args.mode === 'regex' ? 'regex' : 'literal';
+  const repo = resolveRepo(ctx, args.repo_id);
+  const ignore = readIgnorePolicy(repo.canonicalRoot);
+  const requestedPaths = Array.isArray(args.paths) && args.paths.length > 0 ? args.paths : ['.'];
+  const candidates: ManifestEntry[] = [];
+  for (const path of requestedPaths) {
+    const resolved = resolveRepoPath(repo, path, ignore, { allowRoot: true });
+    if (resolved.type === 'directory') {
+      candidates.push(...walkVisibleEntries(repo, ignore, resolved.relativePath));
+    } else {
+      candidates.push(metadataForResolved(resolved));
+    }
+  }
+  const seen = new Set<string>();
+  let regex: RegExp | null = null;
+  if (mode === 'regex') {
+    try {
+      regex = new RegExp(query);
+    } catch (_error) {
+      throw new GeneralRepoAccessError('INVALID_RANGE', 'query is not a valid regular expression');
+    }
+  }
+  const needle = query.toLowerCase();
+  const matches: Record<string, unknown>[] = [];
+  const maxResults = numberArg(args.max_results, DEFAULT_SEARCH_RESULTS, 1, HARD_SEARCH_RESULTS);
+
+  for (const entry of candidates.sort((a, b) => a.path.localeCompare(b.path))) {
+    if (matches.length >= maxResults) break;
+    if (entry.type !== 'file' || !entry.readable || seen.has(entry.path) || entry.binary || (entry.size ?? 0) > SEARCH_FILE_SCAN_BYTES) continue;
+    seen.add(entry.path);
+    const resolved = resolveRepoPath(repo, entry.path, ignore, { requireFile: true });
+    const text = readFileSync(resolved.canonicalPath, 'utf-8');
+    const lines = text.split(/\r?\n/);
+    for (let index = 0; index < lines.length; index += 1) {
+      const line = lines[index] ?? '';
+      const column = regex ? line.search(regex) : line.toLowerCase().indexOf(needle);
+      if (column < 0) continue;
+      matches.push({
+        path: entry.path,
+        line: index + 1,
+        column: column + 1,
+        snippet: line.slice(Math.max(0, column - 60), column + 120),
+        sha256: entry.sha256,
+      });
+      if (matches.length >= maxResults) break;
+    }
+  }
+
+  return textResult({
+    ...commonFields(repo, ignore),
+    query,
+    mode,
+    matches,
+    truncated: matches.length >= maxResults,
+    backend: 'filesystem-fallback',
+  });
+}
+
+export function listGeneralRepoRecords(ctx: GeneralRepoToolContext): Array<{ repo_id: string; display_name: string; readable: boolean; access_mode: RepoHarnessAccessMode; source: RepoRecord['source'] }> {
+  return uniqueRepoRecords(ctx).map((repo) => ({
+    repo_id: repo.repoId,
+    display_name: repo.displayName,
+    readable: true,
+    access_mode: repo.accessMode,
+    source: repo.source,
+  }));
+}
+
+export function isGeneralRepoTool(name: string): name is GeneralRepoToolName {
+  return (GENERAL_REPO_TOOLS as readonly string[]).includes(name);
+}
+
+export function hasGeneralRepoArgs(args: Record<string, unknown>): boolean {
+  return typeof args.repo_id === 'string' && args.repo_id.trim().length > 0;
+}
+
+export function buildGeneralRepoToolDefinitions(): GeneralRepoToolDefinition[] {
+  const readOnly = { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false };
+  const repoSchema = {
+    type: 'object',
+    properties: { repo_id: { type: 'string' } },
+    required: ['repo_id'],
+    additionalProperties: false,
+  };
+  return [
+    { name: 'get_repo_capabilities', description: 'Return read/write mode, index capabilities, and limits for a registered repo.', inputSchema: repoSchema, annotations: readOnly },
+    {
+      name: 'repo_manifest',
+      description: 'Return the complete non-.ignore repo inventory with indexed/readable metadata.',
+      inputSchema: {
+        type: 'object',
+        properties: { repo_id: { type: 'string' }, snapshot_id: { type: 'string' }, cursor: { type: 'string' }, page_size: { type: 'number' } },
+        required: ['repo_id'],
+        additionalProperties: false,
+      },
+      annotations: readOnly,
+    },
+    {
+      name: 'list_tree',
+      description: 'List non-.ignore children under a repo-relative directory with stable pagination.',
+      inputSchema: {
+        type: 'object',
+        properties: { repo_id: { type: 'string' }, path: { type: 'string', default: '.' }, depth: { type: 'number' }, cursor: { type: 'string' }, page_size: { type: 'number' }, snapshot_id: { type: 'string' } },
+        required: ['repo_id'],
+        additionalProperties: false,
+      },
+      annotations: readOnly,
+    },
+    {
+      name: 'search_text',
+      description: 'Search allowed repo text using CodeGraph first and policy-consistent fallback when needed.',
+      inputSchema: {
+        type: 'object',
+        properties: { repo_id: { type: 'string' }, query: { type: 'string' }, mode: { enum: ['literal', 'regex'] }, paths: { type: 'array', items: { type: 'string' } }, cursor: { type: 'string' }, snapshot_id: { type: 'string' }, max_results: { type: 'number' } },
+        required: ['repo_id', 'query'],
+        additionalProperties: false,
+      },
+      annotations: readOnly,
+    },
+    {
+      name: 'read_file',
+      description: 'Read one allowed file by line or byte range with hash and continuation metadata.',
+      inputSchema: {
+        type: 'object',
+        properties: { repo_id: { type: 'string' }, path: { type: 'string' }, line_range: { type: 'array' }, byte_range: { type: 'array' }, snapshot_id: { type: 'string' }, cursor: { type: 'string' } },
+        required: ['repo_id', 'path'],
+        additionalProperties: false,
+      },
+      annotations: readOnly,
+    },
+    {
+      name: 'read_files',
+      description: 'Read a bounded batch of allowed files with per-item success or failure.',
+      inputSchema: {
+        type: 'object',
+        properties: { repo_id: { type: 'string' }, requests: { type: 'array' }, snapshot_id: { type: 'string' }, byte_budget: { type: 'number' } },
+        required: ['repo_id', 'requests'],
+        additionalProperties: false,
+      },
+      annotations: readOnly,
+    },
+    {
+      name: 'stat_file',
+      description: 'Return metadata for one allowed file, directory, or symlink.',
+      inputSchema: {
+        type: 'object',
+        properties: { repo_id: { type: 'string' }, path: { type: 'string' }, snapshot_id: { type: 'string' } },
+        required: ['repo_id', 'path'],
+        additionalProperties: false,
+      },
+      annotations: readOnly,
+    },
+  ];
+}
+
+export async function callGeneralRepoTool(ctx: GeneralRepoToolContext, name: string, args: Record<string, unknown> = {}): Promise<GeneralRepoToolResult> {
+  try {
+    let result: GeneralRepoToolResult;
+    switch (name) {
+      case 'get_repo_capabilities':
+        result = getRepoCapabilities(ctx, args);
+        break;
+      case 'repo_manifest':
+        result = repoManifest(ctx, args);
+        break;
+      case 'list_tree':
+        result = listTree(ctx, args);
+        break;
+      case 'search_text':
+        result = searchText(ctx, args);
+        break;
+      case 'read_file':
+        result = readFileTool(ctx, args);
+        break;
+      case 'read_files':
+        result = readFiles(ctx, args);
+        break;
+      case 'stat_file':
+        result = statFile(ctx, args);
+        break;
+      default:
+        return errorResult('INTERNAL_ADAPTER_ERROR', `tool is not a general repo reader tool: ${name}`);
+    }
+    audit(ctx, name, 'ok', args, typeof args.path === 'string' ? args.path : undefined);
+    return result;
+  } catch (error) {
+    if (error instanceof GeneralRepoAccessError) {
+      audit(ctx, name, 'blocked', args, typeof args.path === 'string' ? args.path : undefined, error.message);
+      return errorResult(error.code, error.message, error.details, error.retryable);
+    }
+    audit(ctx, name, 'failed', args, typeof args.path === 'string' ? args.path : undefined, error instanceof Error ? error.message : String(error));
+    return errorResult('INTERNAL_ADAPTER_ERROR', error instanceof Error ? error.message : String(error));
+  }
+}

--- a/src/cli/mcp/general-repo-access.ts
+++ b/src/cli/mcp/general-repo-access.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'crypto';
-import { closeSync, constants, existsSync, lstatSync, openSync, readFileSync, readSync, readdirSync, realpathSync, statSync } from 'fs';
-import { basename, isAbsolute, relative, resolve, sep } from 'path';
+import { closeSync, constants, existsSync, fstatSync, lstatSync, openSync, readFileSync, readSync, readdirSync, realpathSync, statSync } from 'fs';
+import { basename, dirname, isAbsolute, relative, resolve, sep } from 'path';
 import { readRegisteredRepoHarnessRepos, repoHarnessRepoIdFor, type RepoHarnessAccessMode } from '../../effects/repo-registry';
 import { hashMcpInput, tryWriteMcpAuditEntry } from './audit';
 import { globMatches, isPathInside } from './paths';
@@ -58,6 +58,8 @@ interface ResolvedRepoPath {
   modifiedAt?: string;
   symlinkTargetKind: SymlinkTargetKind;
   readable: boolean;
+  identity?: string;
+  parentIdentity?: string;
 }
 
 interface ManifestEntry {
@@ -135,6 +137,15 @@ function audit(ctx: GeneralRepoToolContext, tool: string, status: 'ok' | 'blocke
 
 function sha256(value: string | Buffer): string {
   return createHash('sha256').update(value).digest('hex');
+}
+
+function statIdentity(stat: { dev: number; ino: number }): string {
+  return `${stat.dev}:${stat.ino}`;
+}
+
+function openNoFollow(path: string): number {
+  const noFollow = typeof constants.O_NOFOLLOW === 'number' ? constants.O_NOFOLLOW : 0;
+  return openSync(path, constants.O_RDONLY | noFollow);
 }
 
 function numberArg(value: unknown, fallback: number, min: number, max: number): number {
@@ -250,7 +261,25 @@ function parseIgnoreLine(line: string): IgnoreRule | null {
 function readIgnorePolicy(repoRoot: string): IgnorePolicy {
   const ignorePath = resolve(repoRoot, '.ignore');
   if (!existsSync(ignorePath)) return { digest: `sha256:${sha256('')}`, rules: [] };
-  const text = readFileSync(ignorePath, 'utf-8');
+  const before = lstatSync(ignorePath);
+  if (before.isSymbolicLink()) {
+    throw new GeneralRepoAccessError('SYMLINK_ESCAPE', '.ignore must be a regular repo-local file', { path: '.ignore' });
+  }
+  if (!before.isFile()) {
+    throw new GeneralRepoAccessError('NOT_A_FILE', '.ignore must be a regular file', { path: '.ignore' });
+  }
+  const fd = openNoFollow(ignorePath);
+  let buffer: Buffer;
+  try {
+    const opened = fstatSync(fd);
+    if (!opened.isFile() || statIdentity(opened) !== statIdentity(before)) {
+      throw new GeneralRepoAccessError('SNAPSHOT_STALE', '.ignore changed while it was being opened', { path: '.ignore' }, true);
+    }
+    buffer = readFileSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+  const text = buffer.toString('utf-8');
   return {
     digest: `sha256:${sha256(text)}`,
     rules: text.split(/\r?\n/).map(parseIgnoreLine).filter((rule): rule is IgnoreRule => rule !== null),
@@ -362,6 +391,7 @@ function resolveRepoPath(repo: RepoRecord, inputPath: unknown, ignore: IgnorePol
   }
 
   const fileStat = readable ? statSync(canonicalPath) : lstat;
+  const parentStat = statSync(dirname(absolutePath));
   if (opts.requireFile && (!readable || !fileStat.isFile())) {
     throw new GeneralRepoAccessError('NOT_A_FILE', 'path is not a regular file', { path: relativePath });
   }
@@ -379,7 +409,51 @@ function resolveRepoPath(repo: RepoRecord, inputPath: unknown, ignore: IgnorePol
     modifiedAt: fileStat.mtime.toISOString(),
     symlinkTargetKind,
     readable,
+    identity: readable ? statIdentity(fileStat) : undefined,
+    parentIdentity: statIdentity(parentStat),
   };
+}
+
+function revalidateResolvedPath(
+  resolved: ResolvedRepoPath,
+  ignore: IgnorePolicy,
+  opened?: { dev: number; ino: number; isFile(): boolean },
+): void {
+  if (resolved.parentIdentity && statIdentity(statSync(dirname(resolved.absolutePath))) !== resolved.parentIdentity) {
+    throw new GeneralRepoAccessError('SNAPSHOT_STALE', 'path parent changed after guard resolution', { path: resolved.relativePath }, true);
+  }
+  const currentType = entryType(resolved.absolutePath);
+  const currentCanonical = currentType === 'symlink' ? realpathSync(resolved.absolutePath) : realpathSync(resolved.absolutePath);
+  if (!isPathInside(resolved.repo.canonicalRoot, currentCanonical)) {
+    throw new GeneralRepoAccessError('PATH_OUTSIDE_REPO', 'path escapes repo root after open', { path: resolved.relativePath });
+  }
+  const physicalRelative = toPosixPath(relative(resolved.repo.canonicalRoot, currentCanonical)) || '.';
+  if (physicalRelative !== '.' && isIgnored(ignore, physicalRelative)) {
+    throw new GeneralRepoAccessError('PATH_IGNORED', 'path target is excluded by .ignore after open', { path: resolved.relativePath });
+  }
+  const currentStat = statSync(currentCanonical);
+  if (resolved.identity && statIdentity(currentStat) !== resolved.identity) {
+    throw new GeneralRepoAccessError('SNAPSHOT_STALE', 'path changed after guard resolution', { path: resolved.relativePath }, true);
+  }
+  if (opened) {
+    if (!opened.isFile()) {
+      throw new GeneralRepoAccessError('NOT_A_FILE', 'opened path is not a regular file', { path: resolved.relativePath });
+    }
+    if (resolved.identity && statIdentity(opened) !== resolved.identity) {
+      throw new GeneralRepoAccessError('SNAPSHOT_STALE', 'opened file changed after guard resolution', { path: resolved.relativePath }, true);
+    }
+  }
+}
+
+function readStableResolvedFile(resolved: ResolvedRepoPath, ignore: IgnorePolicy): Buffer {
+  const fd = openNoFollow(resolved.canonicalPath);
+  try {
+    const opened = fstatSync(fd);
+    revalidateResolvedPath(resolved, ignore, opened);
+    return readFileSync(fd);
+  } finally {
+    closeSync(fd);
+  }
 }
 
 function commonFields(repo: RepoRecord, ignore: IgnorePolicy) {
@@ -402,8 +476,9 @@ function metadataForResolved(resolved: ResolvedRepoPath): ManifestEntry {
   if (resolved.readable) {
     const stat = statSync(resolved.canonicalPath);
     if (stat.isFile()) {
-      binary = binaryProbe(resolved.canonicalPath);
-      fileHash = sha256(readFileSync(resolved.canonicalPath));
+      const raw = readStableResolvedFile(resolved, { digest: '', rules: [] });
+      binary = raw.subarray(0, BINARY_PROBE_BYTES).includes(0);
+      fileHash = sha256(raw);
     }
   }
   return {
@@ -480,13 +555,23 @@ function readFilePayload(repo: RepoRecord, ignore: IgnorePolicy, args: Record<st
   if (args.line_range !== undefined && args.byte_range !== undefined) {
     throw new GeneralRepoAccessError('INVALID_RANGE', 'line_range and byte_range are mutually exclusive');
   }
+  let cursorByteStart: number | null = null;
+  const cursor = typeof args.cursor === 'string' ? args.cursor.trim() : '';
+  if (cursor && args.line_range === undefined && args.byte_range === undefined) {
+    const match = /^(byte|line):([0-9]+)$/.exec(cursor);
+    if (!match) throw new GeneralRepoAccessError('INVALID_RANGE', 'cursor must use byte:<offset> or line:<line>');
+    const offset = Number(match[2]);
+    if (!Number.isSafeInteger(offset) || offset < 0) throw new GeneralRepoAccessError('INVALID_RANGE', 'cursor offset is invalid');
+    if (match[1] === 'byte') cursorByteStart = offset;
+    if (match[1] === 'line') args = { ...args, line_range: [Math.max(1, offset), Math.max(1, offset) + MAX_READ_LINES - 1] };
+  }
   const target = resolveRepoPath(repo, args.path, ignore, { requireFile: true });
-  const raw = readFileSync(target.canonicalPath);
+  const raw = readStableResolvedFile(target, ignore);
   const fullHash = sha256(raw);
   const binary = raw.subarray(0, BINARY_PROBE_BYTES).includes(0);
 
-  if (args.byte_range !== undefined) {
-    const range = byteRange(args.byte_range, maxBytes);
+  if (args.byte_range !== undefined || cursorByteStart !== null) {
+    const range = cursorByteStart !== null ? [cursorByteStart, maxBytes] as [number, number] : byteRange(args.byte_range, maxBytes);
     if (!range) throw new GeneralRepoAccessError('INVALID_RANGE', 'byte_range must be [start, length]');
     const [start, length] = range;
     const chunk = raw.subarray(start, start + length);
@@ -710,7 +795,7 @@ function searchText(ctx: GeneralRepoToolContext, args: Record<string, unknown>):
     if (entry.type !== 'file' || !entry.readable || seen.has(entry.path) || entry.binary || (entry.size ?? 0) > SEARCH_FILE_SCAN_BYTES) continue;
     seen.add(entry.path);
     const resolved = resolveRepoPath(repo, entry.path, ignore, { requireFile: true });
-    const text = readFileSync(resolved.canonicalPath, 'utf-8');
+    const text = readStableResolvedFile(resolved, ignore).toString('utf-8');
     const lines = text.split(/\r?\n/);
     for (let index = 0; index < lines.length; index += 1) {
       const line = lines[index] ?? '';

--- a/src/cli/mcp/reader-tools.ts
+++ b/src/cli/mcp/reader-tools.ts
@@ -243,7 +243,6 @@ function listAllowedRoots(ctx: ReaderToolContext): ReaderToolResult {
       root_id: root.id,
       repo_id: repoHarnessRepoIdFor(root.canonicalPath),
       display_name: root.displayName,
-      path: root.canonicalPath,
       readable: root.readable,
     })),
     repos: Array.from(generalRepos.values()),

--- a/src/cli/mcp/reader-tools.ts
+++ b/src/cli/mcp/reader-tools.ts
@@ -9,6 +9,8 @@ import { globMatches } from './paths';
 import { redactMcpText } from './redaction';
 import { repoHarnessPackageVersion } from './version';
 import { WorkspaceError, WorkspaceManager, type McpWorkspace, type WorkspaceResolvedPath } from './workspaces';
+import { buildGeneralRepoToolDefinitions, callGeneralRepoTool, hasGeneralRepoArgs, isGeneralRepoTool, listGeneralRepoRecords } from './general-repo-access';
+import { repoHarnessRepoIdFor } from '../../effects/repo-registry';
 import type { McpPolicy } from './types';
 
 export interface ReaderToolDefinition {
@@ -203,26 +205,7 @@ export function buildReaderToolDefinitions(): ReaderToolDefinition[] {
       },
       annotations: readOnly,
     },
-    {
-      name: 'search_text',
-      description: 'Search text files under an opened workspace using literal matching, limits, and deny rules.',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          workspace_id: { type: 'string' },
-          query: { type: 'string', minLength: 1, maxLength: 512 },
-          path: { type: 'string', default: '.' },
-          glob: { type: 'string' },
-          case_sensitive: { type: 'boolean' },
-          max_results: { type: 'number', minimum: 1, maximum: HARD_SEARCH_RESULTS },
-          max_files: { type: 'number', minimum: 1, maximum: HARD_SEARCH_FILES },
-          timeout_ms: { type: 'number', minimum: 1, maximum: HARD_SEARCH_TIMEOUT_MS },
-        },
-        required: ['workspace_id', 'query'],
-        additionalProperties: false,
-      },
-      annotations: readOnly,
-    },
+    ...buildGeneralRepoToolDefinitions(),
   ];
 }
 
@@ -254,13 +237,16 @@ function readerStatus(ctx: ReaderToolContext): ReaderToolResult {
 }
 
 function listAllowedRoots(ctx: ReaderToolContext): ReaderToolResult {
+  const generalRepos = new Map(listGeneralRepoRecords(ctx).map((repo) => [repo.repo_id, repo]));
   return textResult({
     roots: ctx.workspaceManager.listAllowedRoots().map((root) => ({
       root_id: root.id,
+      repo_id: repoHarnessRepoIdFor(root.canonicalPath),
       display_name: root.displayName,
       path: root.canonicalPath,
       readable: root.readable,
     })),
+    repos: Array.from(generalRepos.values()),
   });
 }
 
@@ -592,6 +578,9 @@ function searchText(ctx: ReaderToolContext, args: Record<string, unknown>): Read
 
 export async function callReaderTool(ctx: ReaderToolContext, name: string, args: Record<string, unknown> = {}): Promise<ReaderToolResult> {
   try {
+    if (isGeneralRepoTool(name) && (name !== 'search_text' || hasGeneralRepoArgs(args))) {
+      return callGeneralRepoTool(ctx, name, args);
+    }
     switch (name) {
       case 'reader_status':
         audit(ctx, name, 'ok', args);

--- a/src/effects/repo-registry.ts
+++ b/src/effects/repo-registry.ts
@@ -4,10 +4,12 @@ import { homedir } from "os";
 import { dirname, join, resolve } from "path";
 
 export type RepoHarnessRegistrySource = "adopt" | "init" | "mcp-setup" | "manual" | "discovery";
+export type RepoHarnessAccessMode = "read_only" | "read_write";
 
 export interface RepoHarnessRegisteredRepo {
   readonly id: string;
   readonly path: string;
+  readonly accessMode: RepoHarnessAccessMode;
   readonly source: RepoHarnessRegistrySource;
   readonly registeredAt: string;
   readonly lastSeenAt: string;
@@ -34,7 +36,7 @@ export function repoHarnessRegisteredReposPath(env: NodeJS.ProcessEnv = process.
   return join(repoHarnessHome(env), "registered-repos.json");
 }
 
-function repoIdFor(path: string): string {
+export function repoHarnessRepoIdFor(path: string): string {
   return `repo_${createHash("sha256").update(path).digest("hex").slice(0, 16)}`;
 }
 
@@ -59,6 +61,10 @@ function normalizeSource(value: unknown): RepoHarnessRegistrySource {
     : "manual";
 }
 
+function normalizeAccessMode(value: unknown): RepoHarnessAccessMode {
+  return value === "read_write" ? "read_write" : "read_only";
+}
+
 function normalizeTimestamp(value: unknown, fallback: string): string {
   return typeof value === "string" && value.trim().length > 0 ? value : fallback;
 }
@@ -80,8 +86,9 @@ function readRegistryFile(path: string): RepoHarnessRegistryFile {
         if (!rawPath) return null;
         const canonicalPath = canonicalRepoPath(rawPath);
         return {
-          id: typeof entry.id === "string" && entry.id.trim() ? entry.id : repoIdFor(canonicalPath),
+          id: typeof entry.id === "string" && entry.id.trim() ? entry.id : repoHarnessRepoIdFor(canonicalPath),
           path: canonicalPath,
+          accessMode: normalizeAccessMode(entry.accessMode),
           source: normalizeSource(entry.source),
           registeredAt: normalizeTimestamp(entry.registeredAt, now),
           lastSeenAt: normalizeTimestamp(entry.lastSeenAt, now),
@@ -157,8 +164,9 @@ export function registerRepoHarnessRepo(
   const existing = dedupeRepos(readRegistryFile(registryPath).repos);
   const previous = existing.find((repo) => repo.path === canonical);
   const nextEntry: RepoHarnessRegisteredRepo = {
-    id: previous?.id ?? repoIdFor(canonical),
+    id: previous?.id ?? repoHarnessRepoIdFor(canonical),
     path: canonical,
+    accessMode: previous?.accessMode ?? "read_only",
     source,
     registeredAt: previous?.registeredAt ?? now,
     lastSeenAt: now,

--- a/tasks/notes/20260622-repo-harness-codegraph.notes.md
+++ b/tasks/notes/20260622-repo-harness-codegraph.notes.md
@@ -32,3 +32,17 @@ Sprint 0 contract freeze for `plans/sprints/20260622-repo-harness-codegraph-spri
 - Sprint 1 must replace legacy MCP reader filtering with the general repo
   Registry, Path Guard, and `.ignore` policy rather than layering the new API on
   top of current `COMMON_DENY_GLOBS`.
+
+## Sprint 1 Runtime Notes
+
+- The first runtime slice adds a separate general repo access service rather
+  than changing `WorkspaceManager` in place. The older workspace tools keep
+  their compatibility behavior; the new `repo_id` tools implement the PRD
+  contract.
+- `repo_manifest` is walker-backed in this slice and marks entries
+  `indexed:false`. CodeGraph metadata merge, real index revisions, shared
+  snapshot lifecycle, and cache/performance work remain Sprint 2.
+- Reads open the canonical in-repo target after path and symlink checks. This
+  reduces symlink-swap exposure with the Node filesystem APIs available here,
+  but a stronger fd-relative/openat design still belongs in the S2/S4 security
+  pass if the runtime grows native bindings.

--- a/tests/cli/mcp-reader-tools.test.ts
+++ b/tests/cli/mcp-reader-tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { getMcpPolicy } from '../../src/cli/mcp/policy';
@@ -78,7 +78,8 @@ describe('MCP reader tools', () => {
       expect(status.schema_hash).toMatch(/^[a-f0-9]{64}$/);
 
       const roots = await jsonTool(ctx, 'list_allowed_roots');
-      const root = roots.roots.find((entry: { path: string }) => entry.path === realpathSync(repoRoot));
+      const root = roots.roots[0];
+      expect(root.path).toBeUndefined();
       expect(root.root_id).toMatch(/^root_/);
       expect(root.repo_id).toMatch(/^repo_/);
       expect(roots.repos.some((entry: { repo_id: string }) => entry.repo_id === root.repo_id)).toBe(true);
@@ -177,6 +178,10 @@ describe('MCP reader tools', () => {
         const huge = await jsonTool(ctx, 'read_file', { repo_id: repoId, path: 'docs/huge.txt' });
         expect(huge.has_more).toBe(true);
         expect(huge.next_cursor).toBe('byte:262144');
+        const hugeNext = await jsonTool(ctx, 'read_file', { repo_id: repoId, path: 'docs/huge.txt', cursor: huge.next_cursor });
+        expect(hugeNext.bytes_returned).toBe(37_856);
+        expect(hugeNext.has_more).toBe(false);
+        expect(hugeNext.next_cursor).toBeNull();
 
         const search = await jsonTool(ctx, 'search_text', { repo_id: repoId, query: 'sk-testsecret', paths: ['.env'] });
         expect(search.matches[0].snippet).toContain('sk-testsecret');
@@ -203,6 +208,28 @@ describe('MCP reader tools', () => {
           const external = await jsonTool(ctx, 'read_file', { repo_id: repoId, path: 'docs/external-link.txt' });
           expect(external.error.code).toBe('SYMLINK_ESCAPE');
         }
+      } finally {
+        rmSync(outside, { recursive: true, force: true });
+      }
+    });
+  });
+
+  test('.ignore symlink fails closed before policy content is read', async () => {
+    await withReaderRepo(async (repoRoot, ctx) => {
+      const outside = mkdtempSync(join(tmpdir(), 'repo-harness-ignore-outside-'));
+      try {
+        const original = join(repoRoot, '.ignore');
+        rmSync(original, { force: true });
+        writeFileSync(join(outside, 'ignore-policy.txt'), '.env\n');
+        try {
+          symlinkSync(join(outside, 'ignore-policy.txt'), original);
+        } catch (_error) {
+          return;
+        }
+        const roots = await jsonTool(ctx, 'list_allowed_roots');
+        const repoId = roots.roots[0].repo_id;
+        const manifest = await jsonTool(ctx, 'repo_manifest', { repo_id: repoId });
+        expect(manifest.error.code).toBe('SYMLINK_ESCAPE');
       } finally {
         rmSync(outside, { recursive: true, force: true });
       }

--- a/tests/cli/mcp-reader-tools.test.ts
+++ b/tests/cli/mcp-reader-tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { getMcpPolicy } from '../../src/cli/mcp/policy';
@@ -54,7 +54,13 @@ describe('MCP reader tools', () => {
         'open_workspace',
         'tree',
         'read_text',
+        'get_repo_capabilities',
+        'repo_manifest',
+        'list_tree',
         'search_text',
+        'read_file',
+        'read_files',
+        'stat_file',
       ]);
       for (const definition of definitions) {
         expect(definition.annotations).toMatchObject({
@@ -74,6 +80,8 @@ describe('MCP reader tools', () => {
       const roots = await jsonTool(ctx, 'list_allowed_roots');
       const root = roots.roots.find((entry: { path: string }) => entry.path === realpathSync(repoRoot));
       expect(root.root_id).toMatch(/^root_/);
+      expect(root.repo_id).toMatch(/^repo_/);
+      expect(roots.repos.some((entry: { repo_id: string }) => entry.repo_id === root.repo_id)).toBe(true);
 
       const opened = await jsonTool(ctx, 'open_workspace', { root_id: root.root_id });
       expect(opened.workspace_id).toMatch(/^ws_/);
@@ -82,6 +90,122 @@ describe('MCP reader tools', () => {
       const otherCtx = createReaderToolContext(repoRoot, otherPolicy, new WorkspaceManager({ allowedRoots: [repoRoot], policy: otherPolicy }));
       const denied = await jsonTool(otherCtx, 'tree', { workspace_id: opened.workspace_id });
       expect(denied.error.code).toBe('WORKSPACE_NOT_FOUND');
+    });
+  });
+
+  test('general repo tools use repo_id, .ignore-only policy, and unredacted authorized reads', async () => {
+    await withReaderRepo(async (repoRoot, ctx) => {
+      const outside = mkdtempSync(join(tmpdir(), 'repo-harness-general-reader-outside-'));
+      try {
+        writeFileSync(join(repoRoot, '.ignore'), 'ignored.md\nignored-dir/**\n!ignored-dir/visible.txt\n');
+        writeFileSync(join(repoRoot, 'ignored-dir', 'visible.txt'), 'visible through negation\n');
+        mkdirSync(join(repoRoot, 'unicode', 'drop'), { recursive: true });
+        writeFileSync(join(repoRoot, 'unicode', '雪.md'), 'snow\n');
+        writeFileSync(join(repoRoot, 'unicode', 'drop', 'note.md'), 'ignored directory child\n');
+        const longRelativePath = `docs/${'long-segment-'.repeat(8)}file.txt`;
+        writeFileSync(join(repoRoot, longRelativePath), 'long path content\n');
+        writeFileSync(join(repoRoot, '#hash.txt'), 'escaped hash pattern\n');
+        writeFileSync(join(repoRoot, '!bang.txt'), 'escaped bang pattern\n');
+        writeFileSync(
+          join(repoRoot, '.ignore'),
+          [
+            'ignored.md',
+            'ignored-dir/**',
+            '!ignored-dir/visible.txt',
+            'unicode/drop/',
+            '\\#hash.txt',
+            '\\!bang.txt',
+            '',
+          ].join('\n'),
+        );
+        writeFileSync(join(repoRoot, 'docs', 'huge.txt'), 'x'.repeat(300_000));
+        writeFileSync(join(outside, 'outside.txt'), 'outside\n');
+        try {
+          symlinkSync(join(outside, 'outside.txt'), join(repoRoot, 'docs', 'external-link.txt'));
+        } catch (_error) {
+          // Symlink creation can be unavailable on some runners; guarded read is covered when present.
+        }
+
+        const roots = await jsonTool(ctx, 'list_allowed_roots');
+        const repoId = roots.roots[0].repo_id;
+
+        const capabilities = await jsonTool(ctx, 'get_repo_capabilities', { repo_id: repoId });
+        expect(capabilities.access_mode).toBe('read_only');
+        expect(capabilities.repo_id).toBe(repoId);
+        expect(capabilities.registry_revision).toMatch(/^registry_/);
+
+        const manifest = await jsonTool(ctx, 'repo_manifest', { repo_id: repoId, page_size: 1000 });
+        const visiblePaths = manifest.entries.map((entry: { path: string }) => entry.path);
+        expect(visiblePaths).toContain('.env');
+        expect(visiblePaths).toContain('.gitignore');
+        expect(visiblePaths).toContain('docs/.hidden.md');
+        expect(visiblePaths).toContain(longRelativePath);
+        expect(visiblePaths).toContain('ignored-dir/visible.txt');
+        expect(visiblePaths).toContain('unicode/雪.md');
+        expect(visiblePaths).not.toContain('.ignore');
+        expect(visiblePaths).not.toContain('ignored.md');
+        expect(visiblePaths).not.toContain('ignored-dir/note.md');
+        expect(visiblePaths).not.toContain('unicode/drop');
+        expect(visiblePaths).not.toContain('unicode/drop/note.md');
+        expect(visiblePaths).not.toContain('#hash.txt');
+        expect(visiblePaths).not.toContain('!bang.txt');
+        expect(manifest.ignore_digest).toMatch(/^sha256:[a-f0-9]{64}$/);
+        expect(manifest.complete).toBe(true);
+
+        const tree = await jsonTool(ctx, 'list_tree', { repo_id: repoId, path: '.', depth: 3, page_size: 1000 });
+        const treePaths = tree.entries.map((entry: { path: string }) => entry.path);
+        expect(treePaths).toContain('.env');
+        expect(treePaths).toContain('docs/.hidden.md');
+        expect(treePaths).toContain('ignored-dir/visible.txt');
+        expect(treePaths).not.toContain('ignored-dir/note.md');
+
+        const stat = await jsonTool(ctx, 'stat_file', { repo_id: repoId, path: '.env' });
+        expect(stat).toMatchObject({ path: '.env', type: 'file', indexed: false, readable: true, binary: false });
+        expect(stat.sha256).toMatch(/^[a-f0-9]{64}$/);
+        const longStat = await jsonTool(ctx, 'stat_file', { repo_id: repoId, path: longRelativePath });
+        expect(longStat).toMatchObject({ path: longRelativePath, type: 'file', readable: true });
+
+        const envRead = await jsonTool(ctx, 'read_file', { repo_id: repoId, path: '.env' });
+        expect(envRead.content).toContain('sk-testsecret');
+        expect(envRead.redactions).toBeUndefined();
+        expect(envRead.sha256).toMatch(/^[a-f0-9]{64}$/);
+
+        const range = await jsonTool(ctx, 'read_file', { repo_id: repoId, path: 'docs/design.md', line_range: [2, 2] });
+        expect(range.content).toBe('authentication route');
+        expect(range.start_line).toBe(2);
+        expect(range.has_more).toBe(true);
+        const huge = await jsonTool(ctx, 'read_file', { repo_id: repoId, path: 'docs/huge.txt' });
+        expect(huge.has_more).toBe(true);
+        expect(huge.next_cursor).toBe('byte:262144');
+
+        const search = await jsonTool(ctx, 'search_text', { repo_id: repoId, query: 'sk-testsecret', paths: ['.env'] });
+        expect(search.matches[0].snippet).toContain('sk-testsecret');
+        expect(search.backend).toBe('filesystem-fallback');
+
+        const batch = await jsonTool(ctx, 'read_files', {
+          repo_id: repoId,
+          requests: [
+            { path: 'src/index.ts' },
+            { path: 'ignored.md' },
+            { path: 'docs/binary.bin', byte_range: [0, 4] },
+          ],
+        });
+        expect(batch.partial).toBe(true);
+        expect(batch.results[0].content).toContain('readerFixture');
+        expect(batch.results[1].error.code).toBe('PATH_IGNORED');
+        expect(batch.results[2]).toMatchObject({ encoding: 'base64', binary: true });
+
+        const absolute = await jsonTool(ctx, 'read_file', { repo_id: repoId, path: join(repoRoot, 'src/index.ts') });
+        expect(absolute.error.code).toBe('INVALID_RELATIVE_PATH');
+        const unknownRepo = await jsonTool(ctx, 'stat_file', { repo_id: 'repo_missing', path: 'src/index.ts' });
+        expect(unknownRepo.error.code).toBe('REPO_NOT_ALLOWED');
+        if (existsSync(join(repoRoot, 'docs', 'external-link.txt'))) {
+          const external = await jsonTool(ctx, 'read_file', { repo_id: repoId, path: 'docs/external-link.txt' });
+          expect(external.error.code).toBe('SYMLINK_ESCAPE');
+        }
+      } finally {
+        rmSync(outside, { recursive: true, force: true });
+      }
     });
   });
 

--- a/tests/cli/mcp-stdio.test.ts
+++ b/tests/cli/mcp-stdio.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test } from 'bun:test';
 import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { repoHarnessRepoIdFor } from '../../src/effects/repo-registry';
 import { repoHarnessPackageVersion } from '../../src/cli/mcp/version';
 
 const ROOT = join(import.meta.dir, '../..');
@@ -68,7 +69,10 @@ describe('mcp stdio transport', () => {
       expect(toolNames).not.toContain('run_agent_goal');
 
       const roots = textPayload(await client.callTool({ name: 'list_allowed_roots', arguments: {} }));
-      const root = (roots.roots as Array<{ root_id: string; path: string }>).find((entry) => entry.path === realpathSync(repoRoot));
+      const root = (roots.roots as Array<{ root_id: string; repo_id: string; path?: string }>).find(
+        (entry) => entry.repo_id === repoHarnessRepoIdFor(realpathSync(repoRoot)),
+      );
+      expect(root?.path).toBeUndefined();
       expect(root?.root_id).toMatch(/^root_/);
 
       const opened = textPayload(await client.callTool({

--- a/tests/cli/mcp-tools.test.ts
+++ b/tests/cli/mcp-tools.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { registerRepoHarnessRepo } from '../../src/effects/repo-registry';
+import { registerRepoHarnessRepo, repoHarnessRepoIdFor } from '../../src/effects/repo-registry';
 import { getMcpPolicy } from '../../src/cli/mcp/policy';
 import { buildMcpToolDefinitions, callMcpTool, type McpToolContext } from '../../src/cli/mcp/tools';
 import { WorkspaceManager } from '../../src/cli/mcp/workspaces';
@@ -174,8 +174,11 @@ describe('mcp tools', () => {
       expect(typeof status.schema_hash).toBe('string');
 
       const roots = await jsonTool(ctx, 'list_allowed_roots');
-      const root = roots.roots.find((entry: { path: string }) => entry.path === realpathSync(repoRoot));
-      expect(root.root_id).toMatch(/^root_/);
+      const root = roots.roots.find(
+        (entry: { repo_id: string; path?: string }) => entry.repo_id === repoHarnessRepoIdFor(realpathSync(repoRoot)),
+      );
+      expect(root?.path).toBeUndefined();
+      expect(root?.root_id).toMatch(/^root_/);
 
       const opened = await jsonTool(ctx, 'open_workspace', { root_id: root.root_id });
       expect(opened.workspace_id).toMatch(/^ws_/);
@@ -252,7 +255,9 @@ describe('mcp tools', () => {
         expect(discovered.repos.some((entry: { repoRoot: string }) => entry.repoRoot === canonicalRepoRoot)).toBe(true);
 
         const roots = await jsonTool(ctx, 'list_allowed_roots');
-        expect(roots.roots.some((entry: { path: string }) => entry.path === canonicalRepoRoot)).toBe(true);
+        expect(roots.roots.some(
+          (entry: { repo_id: string; path?: string }) => entry.repo_id === repoHarnessRepoIdFor(canonicalRepoRoot) && entry.path === undefined,
+        )).toBe(true);
 
         const status = await jsonTool(ctx, 'harness_status');
         expect(status.repoRoot).toBe(scanRoot);


### PR DESCRIPTION
## Summary
- Adds the Sprint 1 general repo reader runtime behind the MCP reader surface: repo whitelist identity, repo-relative guards, .ignore-only filtering, manifest/tree/stat/read/batch/search tools, and content-safe audit metadata.
- Keeps legacy workspace reader behavior compatible while routing repo_id-based calls to the new general repo service.
- Updates Sprint 1 tests, docs, notes, and checklist evidence.

## P1 Map
- Boundary: MCP reader tool surface in `src/cli/mcp/reader-tools.ts` now has two lanes: legacy workspace tools and general repo tools in `src/cli/mcp/general-repo-access.ts`.
- Authority: S0 contracts/schemas plus `plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md` define S1 scope. `src/effects/repo-registry.ts` owns stable repo identity.
- Out of scope for this PR: CodeGraph metadata merge, snapshot coordinator, and write tools; those remain Sprint 2/3 work.

## P2 Trace
- `list_allowed_roots` exposes stable `repo_id` values.
- `read_file`/`stat_file`/`list_tree`/`repo_manifest`/`search_text` calls with `repo_id` route through `callReaderTool` into `callGeneralRepoTool`.
- The general service resolves the whitelisted repo root, normalizes repo-relative paths, applies `.ignore`, rejects absolute/traversal/external symlink paths, and returns common response metadata with content only when authorized.
- Legacy `search_text` keeps the existing `workspace_id` route to avoid breaking current clients.

## P3 Decision
- The new service is intentionally separate from `WorkspaceManager` because the legacy reader still owns deny-glob/gitignore/redaction compatibility. Mixing the new `.ignore` contract into it would blur compatibility and test proof.
- Filesystem walking is the S1 fallback. CodeGraph is not treated as the only inventory source until Sprint 2 adds metadata merging and freshness semantics.
- The tradeoff is that `index_revision` remains a placeholder (`0`) and manifest performance is simple walker-based for now; Sprint 2 owns real revision/snapshot behavior.

## Verification
- `bun test` -> 967 pass, 1 skip, 0 fail.
- `git diff --cached --check` -> pass.
- `bash scripts/check-deploy-sql-order.sh` -> OK.
- `bash scripts/check-architecture-sync.sh` -> advisory, blocking=0.
- `bash scripts/check-task-sync.sh` -> OK.
- `bash scripts/check-task-workflow.sh --strict` -> OK after refreshed Codex handoff.
- `bun scripts/inspect-project-state.ts --repo . --format text` -> no drift signals, no required decisions.
- `bash scripts/migrate-project-template.sh --repo . --dry-run` -> exit 0.
- `bash scripts/ensure-codegraph.sh --sync` -> ready, sync-index changed.
- `bun src/cli/index.ts doctor --json` -> ok=11, warn=0, fail=0, CodeGraph up-to-date.
- `bun src/cli/index.ts setup check --target codex --check-updates --json` -> exit 0, ok=27, warn=1 optional `skills_cli` timeout, fail=0.

Stacked on #18 / `codex/repo-harness-codegraph-s0`.
