### PR TITLE
Add CodeGraph-backed repo snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,14 @@ the only content exclusion source, paths are repo-relative, and authorized file
 content is not implicitly redacted. External non-repo local roots require
 explicit `--allow-root` authorization.
 
+When CodeGraph is initialized for a registered repo, the general reader merges
+CodeGraph indexed-file metadata into manifest/stat/read/search responses while
+keeping the filesystem walker as the complete manifest source of truth. Responses
+carry `snapshot_id`, `index_revision`, `ignore_digest`, and `indexed` metadata;
+stale client snapshots return `SNAPSHOT_STALE` instead of silently mixing
+versions. Full-text search still falls back to the guarded filesystem path when
+CodeGraph cannot provide complete repo-text search.
+
 This sidecar assumes the CLI is already installed from
 [First 5 Minutes](#first-5-minutes). Use it when you want ChatGPT to plan
 against the real repo state and Codex to execute the resulting file-backed

--- a/docs/repo-harness-chatgpt-mcp-setup.md
+++ b/docs/repo-harness-chatgpt-mcp-setup.md
@@ -150,6 +150,19 @@ Authorized file content is not implicitly redacted in `read_file`,
 `read_files`, or `search_text` responses. The MCP audit path records tool name,
 target path, input hash, status, and errors, but not file bodies.
 
+When a repo has a CodeGraph index, `repo_manifest`, `list_tree`, `stat_file`,
+`read_file`, `read_files`, and `search_text` share a deterministic
+`snapshot_id`, `ignore_digest`, and `index_revision`. CodeGraph inventory is
+merged as indexed metadata (`indexed`, `codegraph_language`,
+`codegraph_node_count`); the secure filesystem walker remains the source of
+truth for complete manifest coverage. If a caller sends a stale `snapshot_id`,
+the reader returns `SNAPSHOT_STALE` instead of silently mixing versions.
+
+CodeGraph search support is treated conservatively: current CodeGraph CLI query
+is symbol-oriented, so general full-text `search_text` uses the same guarded
+filesystem fallback while preserving `.ignore` semantics and indicating whether
+the matched file is indexed by CodeGraph.
+
 The older `open_workspace`, `tree`, and `read_text` tools remain compatibility
 tools for the previous workspace reader surface. They still apply the legacy
 deny/redaction behavior and should not be used as proof of the general repo

--- a/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
+++ b/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
@@ -380,7 +380,7 @@ Sprint 0 evidence:
 - [x] **S1-GRD-003** 支持内部 symlink；拒绝 external symlink 和 symlink chain escape。
 - [ ] **S1-GRD-004** 写路径对不存在目标检查最近的已存在父目录。
 - [x] **S1-GRD-005** 使用 fd-relative/openat 等机制降低 check-then-open TOCTOU 风险。
-- [ ] **S1-GRD-006** 对 CodeGraph 返回的每个 path 执行二次 guard。
+- [x] **S1-GRD-006** 对 CodeGraph 返回的每个 path 执行二次 guard。
 - [x] **S1-GRD-007** 增加 Windows/macOS/Linux 路径差异测试；若首版只支持单平台，在 capability 中显式声明。
 
 ## 8.3 Ignore Policy
@@ -439,49 +439,49 @@ Sprint 1 evidence:
 
 ## 9.1 CodeGraph Adapter
 
-- [ ] **S2-CG-001** 定义稳定 adapter interface，隔离 CodeGraph 具体版本和调用方式。
-- [ ] **S2-CG-002** 启动时执行 capability discovery，并缓存结果。
-- [ ] **S2-CG-003** 统一 CodeGraph timeout、取消、重试和错误映射。
-- [ ] **S2-CG-004** 所有返回路径执行 canonical guard 和 `.ignore` 二次过滤。
-- [ ] **S2-CG-005** 记录 adapter latency、failure 和 index revision 指标。
-- [ ] **S2-CG-006** 对 CodeGraph 不支持的能力提供明确 fallback，而非静默缺失。
-- [ ] **S2-CG-007** 建立 adapter contract tests，可替换 fake/real CodeGraph。
+- [x] **S2-CG-001** 定义稳定 adapter interface，隔离 CodeGraph 具体版本和调用方式。
+- [x] **S2-CG-002** 启动时执行 capability discovery，并缓存结果。
+- [x] **S2-CG-003** 统一 CodeGraph timeout、取消、重试和错误映射。
+- [x] **S2-CG-004** 所有返回路径执行 canonical guard 和 `.ignore` 二次过滤。
+- [x] **S2-CG-005** 记录 adapter latency、failure 和 index revision 指标。
+- [x] **S2-CG-006** 对 CodeGraph 不支持的能力提供明确 fallback，而非静默缺失。
+- [x] **S2-CG-007** 建立 adapter contract tests，可替换 fake/real CodeGraph。
 
 ## 9.2 Snapshot Coordinator
 
-- [ ] **S2-SNP-001** 定义 `snapshot_id` 生命周期。
-- [ ] **S2-SNP-002** snapshot 绑定 `fs_revision + codegraph_revision + ignore_digest`。
-- [ ] **S2-SNP-003** manifest、tree、search、read、batch read 可复用同一 snapshot。
-- [ ] **S2-SNP-004** 文件或 ignore 变化时标记 snapshot stale。
-- [ ] **S2-SNP-005** stale 时返回显式状态；禁止静默混合版本。
+- [x] **S2-SNP-001** 定义 `snapshot_id` 生命周期。
+- [x] **S2-SNP-002** snapshot 绑定 `fs_revision + codegraph_revision + ignore_digest`。
+- [x] **S2-SNP-003** manifest、tree、search、read、batch read 可复用同一 snapshot。
+- [x] **S2-SNP-004** 文件或 ignore 变化时标记 snapshot stale。
+- [x] **S2-SNP-005** stale 时返回显式状态；禁止静默混合版本。
 - [ ] **S2-SNP-006** 定义 snapshot TTL、最大并发数和清理策略。
 - [ ] **S2-SNP-007** 为“索引落后于文件系统”提供 `index_lagging` 状态。
 
 ## 9.3 Repo Manifest
 
-- [ ] **S2-MAN-001** 实现 `repo_manifest`，覆盖所有非忽略 entries。
-- [ ] **S2-MAN-002** 每项包含 `indexed/readable/binary/size/mtime/hash/type`。
-- [ ] **S2-MAN-003** CodeGraph inventory 不完整时，由 secure walker 补齐。
-- [ ] **S2-MAN-004** 合并 CodeGraph metadata 和文件系统 metadata，定义冲突优先级。
-- [ ] **S2-MAN-005** 支持稳定排序、分页、cursor 和 manifest digest。
-- [ ] **S2-MAN-006** 返回总文件数、目录数、文本/二进制数、未索引数。
-- [ ] **S2-MAN-007** 仅在完整遍历成功时返回 `complete: true`。
-- [ ] **S2-MAN-008** 对遍历中发生的变化返回 stale/partial，而不是伪造完整性。
-- [ ] **S2-MAN-009** 建立 manifest parity test：期望集合与实际集合逐项对比。
+- [x] **S2-MAN-001** 实现 `repo_manifest`，覆盖所有非忽略 entries。
+- [x] **S2-MAN-002** 每项包含 `indexed/readable/binary/size/mtime/hash/type`。
+- [x] **S2-MAN-003** CodeGraph inventory 不完整时，由 secure walker 补齐。
+- [x] **S2-MAN-004** 合并 CodeGraph metadata 和文件系统 metadata，定义冲突优先级。
+- [x] **S2-MAN-005** 支持稳定排序、分页、cursor 和 manifest digest。
+- [x] **S2-MAN-006** 返回总文件数、目录数、文本/二进制数、未索引数。
+- [x] **S2-MAN-007** 仅在完整遍历成功时返回 `complete: true`。
+- [x] **S2-MAN-008** 对遍历中发生的变化返回 stale/partial，而不是伪造完整性。
+- [x] **S2-MAN-009** 建立 manifest parity test：期望集合与实际集合逐项对比。
 
 ## 9.4 搜索与批量读取
 
-- [ ] **S2-SRC-001** 实现 `search_text` literal 模式。
-- [ ] **S2-SRC-002** 实现 regex 模式；限制复杂度但不按路径或扩展名过滤。
-- [ ] **S2-SRC-003** 支持 path include filter；filter 只能缩小用户主动请求，不得成为隐式 policy。
-- [ ] **S2-SRC-004** 返回行号、上下文、文件 hash、snapshot。
-- [ ] **S2-SRC-005** 支持稳定分页和 continuation。
-- [ ] **S2-SRC-006** CodeGraph 搜索不可用时提供受限 filesystem search fallback，并保持同一 ignore 语义。
-- [ ] **S2-RD-001** 实现 `read_files`。
-- [ ] **S2-RD-002** 支持 per-file range、全局 byte budget 和 partial success。
-- [ ] **S2-RD-003** CodeGraph 未索引但授权允许的文本使用 secure read fallback。
-- [ ] **S2-RD-004** 二进制文件默认返回 metadata；可选开放 byte chunk。
-- [ ] **S2-RD-005** 为读取结果返回 sha256，供后续写前置条件使用。
+- [x] **S2-SRC-001** 实现 `search_text` literal 模式。
+- [x] **S2-SRC-002** 实现 regex 模式；限制复杂度但不按路径或扩展名过滤。
+- [x] **S2-SRC-003** 支持 path include filter；filter 只能缩小用户主动请求，不得成为隐式 policy。
+- [x] **S2-SRC-004** 返回行号、上下文、文件 hash、snapshot。
+- [x] **S2-SRC-005** 支持稳定分页和 continuation。
+- [x] **S2-SRC-006** CodeGraph 搜索不可用时提供受限 filesystem search fallback，并保持同一 ignore 语义。
+- [x] **S2-RD-001** 实现 `read_files`。
+- [x] **S2-RD-002** 支持 per-file range、全局 byte budget 和 partial success。
+- [x] **S2-RD-003** CodeGraph 未索引但授权允许的文本使用 secure read fallback。
+- [x] **S2-RD-004** 二进制文件默认返回 metadata；可选开放 byte chunk。
+- [x] **S2-RD-005** 为读取结果返回 sha256，供后续写前置条件使用。
 
 ## 9.5 性能与缓存
 
@@ -493,13 +493,20 @@ Sprint 1 evidence:
 
 ## 9.6 Sprint 2 退出标准
 
-- [ ] Manifest 与真实非忽略文件集合在 fixture 中达到 100% parity。
-- [ ] 未索引文件仍会出现在 manifest，并可在授权条件下读取。
-- [ ] 同一 snapshot 中 manifest/search/read 的 hash 一致。
-- [ ] CodeGraph 返回越界或已忽略路径时被二次过滤。
-- [ ] search 不因 dotfile、扩展名或 `.gitignore` 漏结果。
+- [x] Manifest 与真实非忽略文件集合在 fixture 中达到 100% parity。
+- [x] 未索引文件仍会出现在 manifest，并可在授权条件下读取。
+- [x] 同一 snapshot 中 manifest/search/read 的 hash 一致。
+- [x] CodeGraph 返回越界或已忽略路径时被二次过滤。
+- [x] search 不因 dotfile、扩展名或 `.gitignore` 漏结果。
 - [ ] 100k 文件规模下无 OOM，所有大结果均可分页恢复。
-- [ ] CodeGraph 故障时错误清晰；允许 fallback 的路径可降级运行。
+- [x] CodeGraph 故障时错误清晰；允许 fallback 的路径可降级运行。
+
+Sprint 2 adapter/snapshot evidence:
+
+- Runtime: `src/cli/mcp/codegraph-adapter.ts`, `src/cli/mcp/general-repo-access.ts`, `src/cli/mcp/reader-tools.ts`
+- Tests: `tests/cli/mcp-reader-tools.test.ts`
+- Verification: `bun test tests/cli/mcp-reader-tools.test.ts`, `bun run check:type`
+- Deferred by design: `S2-SNP-006`, `S2-SNP-007`, and all `S2-PERF-*` remain open for cache/TTL/index-lag/performance baselines. CodeGraph CLI `query` remains symbol-oriented, so full-text `search_text` continues to use the policy-consistent filesystem fallback while exposing CodeGraph indexed metadata.
 
 ---
 

--- a/src/cli/mcp/codegraph-adapter.ts
+++ b/src/cli/mcp/codegraph-adapter.ts
@@ -1,0 +1,181 @@
+import { spawnSync } from 'child_process';
+import { createHash } from 'crypto';
+import { existsSync } from 'fs';
+import { join } from 'path';
+
+export interface CodeGraphIndexedFile {
+  path: string;
+  language?: string;
+  nodeCount?: number;
+  size?: number;
+}
+
+export interface CodeGraphRepoSnapshot {
+  available: boolean;
+  integrated: boolean;
+  source: 'codegraph-cli' | 'unavailable' | 'test-double';
+  indexRevision: string | 0;
+  files: CodeGraphIndexedFile[];
+  latencyMs: number;
+  error?: {
+    code: 'INDEX_UNAVAILABLE' | 'INTERNAL_ADAPTER_ERROR';
+    message: string;
+    retryable: boolean;
+  };
+}
+export interface CodeGraphTextSearchMatch {
+  path: string;
+  line?: number;
+  column?: number;
+  snippet?: string;
+  score?: number;
+}
+
+export interface CodeGraphTextSearchResult {
+  available: boolean;
+  matches: CodeGraphTextSearchMatch[];
+  latencyMs: number;
+  error?: CodeGraphRepoSnapshot['error'];
+}
+
+export interface GeneralRepoCodeGraphAdapter {
+  discoverRepo(repoRoot: string): CodeGraphRepoSnapshot;
+  searchText?(repoRoot: string, query: string, opts: { mode: 'literal' | 'regex'; paths: string[]; maxResults: number }): CodeGraphTextSearchResult;
+}
+
+const DEFAULT_TIMEOUT_MS = 5_000;
+const MAX_STDOUT_BYTES = 10 * 1024 * 1024;
+
+function sha256(value: string | Buffer): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function unavailable(message: string, latencyMs = 0, retryable = true): CodeGraphRepoSnapshot {
+  return {
+    available: false,
+    integrated: false,
+    source: 'unavailable',
+    indexRevision: 0,
+    files: [],
+    latencyMs,
+    error: { code: 'INDEX_UNAVAILABLE', message, retryable },
+  };
+}
+
+function codegraphBin(repoRoot: string, env: NodeJS.ProcessEnv): string {
+  if (env.REPO_HARNESS_CODEGRAPH_BIN) return env.REPO_HARNESS_CODEGRAPH_BIN;
+  const repoLocal = join(repoRoot, 'node_modules', '.bin', 'codegraph');
+  if (existsSync(repoLocal)) return repoLocal;
+  const cwdLocal = join(process.cwd(), 'node_modules', '.bin', 'codegraph');
+  if (existsSync(cwdLocal)) return cwdLocal;
+  return 'codegraph';
+}
+
+function normalizeIndexedFile(value: unknown): CodeGraphIndexedFile | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null;
+  const raw = value as Record<string, unknown>;
+  const path = typeof raw.path === 'string' ? raw.path : '';
+  if (!path) return null;
+  return {
+    path,
+    language: typeof raw.language === 'string' ? raw.language : undefined,
+    nodeCount: typeof raw.nodeCount === 'number' ? raw.nodeCount : undefined,
+    size: typeof raw.size === 'number' ? raw.size : undefined,
+  };
+}
+
+function revisionFor(files: CodeGraphIndexedFile[]): string {
+  const stable = files
+    .map((file) => ({
+      path: file.path,
+      language: file.language ?? '',
+      nodeCount: file.nodeCount ?? 0,
+      size: file.size ?? 0,
+    }))
+    .sort((a, b) => a.path.localeCompare(b.path));
+  return `index_${sha256(JSON.stringify(stable)).slice(0, 16)}`;
+}
+
+export function createCodeGraphCliAdapter(opts: {
+  env?: NodeJS.ProcessEnv;
+  timeoutMs?: number;
+} = {}): GeneralRepoCodeGraphAdapter {
+  const env = opts.env ?? process.env;
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  return {
+    discoverRepo(repoRoot: string): CodeGraphRepoSnapshot {
+      const start = Date.now();
+      if (!existsSync(join(repoRoot, '.codegraph'))) {
+        return unavailable('CodeGraph index is not initialized for this repo', 0, false);
+      }
+
+      const bin = codegraphBin(repoRoot, env);
+      const result = spawnSync(bin, ['files', '--path', repoRoot, '--format', 'flat', '--json'], {
+        cwd: repoRoot,
+        env,
+        encoding: 'utf-8',
+        timeout: timeoutMs,
+        maxBuffer: MAX_STDOUT_BYTES,
+      });
+      const latencyMs = Date.now() - start;
+
+      if (result.error) {
+        const code = result.error.message.includes('ETIMEDOUT') ? 'INDEX_UNAVAILABLE' : 'INTERNAL_ADAPTER_ERROR';
+        return {
+          available: false,
+          integrated: false,
+          source: 'unavailable',
+          indexRevision: 0,
+          files: [],
+          latencyMs,
+          error: { code, message: result.error.message, retryable: code === 'INDEX_UNAVAILABLE' },
+        };
+      }
+      if (result.status !== 0) {
+        return {
+          available: false,
+          integrated: false,
+          source: 'unavailable',
+          indexRevision: 0,
+          files: [],
+          latencyMs,
+          error: {
+            code: 'INDEX_UNAVAILABLE',
+            message: (result.stderr || result.stdout || `codegraph exited with ${result.status}`).trim(),
+            retryable: true,
+          },
+        };
+      }
+
+      try {
+        const parsed = JSON.parse(result.stdout);
+        const files = Array.isArray(parsed)
+          ? parsed.map(normalizeIndexedFile).filter((file): file is CodeGraphIndexedFile => file !== null)
+          : [];
+        return {
+          available: true,
+          integrated: true,
+          source: 'codegraph-cli',
+          indexRevision: revisionFor(files),
+          files,
+          latencyMs,
+        };
+      } catch (error) {
+        return {
+          available: false,
+          integrated: false,
+          source: 'unavailable',
+          indexRevision: 0,
+          files: [],
+          latencyMs,
+          error: {
+            code: 'INTERNAL_ADAPTER_ERROR',
+            message: error instanceof Error ? error.message : String(error),
+            retryable: false,
+          },
+        };
+      }
+    },
+  };
+}

--- a/src/cli/mcp/general-repo-access.ts
+++ b/src/cli/mcp/general-repo-access.ts
@@ -3,6 +3,7 @@ import { closeSync, constants, existsSync, lstatSync, openSync, readFileSync, re
 import { basename, isAbsolute, relative, resolve, sep } from 'path';
 import { readRegisteredRepoHarnessRepos, repoHarnessRepoIdFor, type RepoHarnessAccessMode } from '../../effects/repo-registry';
 import { hashMcpInput, tryWriteMcpAuditEntry } from './audit';
+import { createCodeGraphCliAdapter, type CodeGraphRepoSnapshot, type GeneralRepoCodeGraphAdapter } from './codegraph-adapter';
 import { globMatches, isPathInside } from './paths';
 import type { McpPolicy } from './types';
 
@@ -16,6 +17,7 @@ export interface GeneralRepoToolDefinition {
 export interface GeneralRepoToolContext {
   repoRoot: string;
   policy: McpPolicy;
+  codeGraphAdapter?: GeneralRepoCodeGraphAdapter;
 }
 
 export interface GeneralRepoToolResult {
@@ -68,9 +70,23 @@ interface ManifestEntry {
   sha256?: string;
   binary?: boolean;
   indexed: boolean;
+  codegraph_language?: string;
+  codegraph_node_count?: number;
+  codegraph_size?: number;
   readable: boolean;
   writable: boolean;
   symlink_target_kind: SymlinkTargetKind;
+}
+
+interface VisibleEntrySnapshot {
+  id: string;
+  entries: ManifestEntry[];
+  entriesByPath: Map<string, ManifestEntry>;
+  manifestDigest: string;
+  partial: boolean;
+  walkerErrors: number;
+  codeGraph: CodeGraphRepoSnapshot;
+  codeGraphFilteredPaths: number;
 }
 
 const GENERAL_REPO_TOOLS = [
@@ -91,6 +107,7 @@ const BINARY_PROBE_BYTES = 8 * 1024;
 const SEARCH_FILE_SCAN_BYTES = 1024 * 1024;
 const DEFAULT_SEARCH_RESULTS = 50;
 const HARD_SEARCH_RESULTS = 100;
+const DEFAULT_CODEGRAPH_ADAPTER = createCodeGraphCliAdapter();
 
 export type GeneralRepoToolName = typeof GENERAL_REPO_TOOLS[number];
 
@@ -382,16 +399,14 @@ function resolveRepoPath(repo: RepoRecord, inputPath: unknown, ignore: IgnorePol
   };
 }
 
-function commonFields(repo: RepoRecord, ignore: IgnorePolicy) {
-  const rootStat = statSync(repo.canonicalRoot);
-  const snapshotHash = sha256(`${repo.repoId}\0${repo.registryRevision}\0${ignore.digest}\0${rootStat.mtimeMs}\0${rootStat.ctimeMs}`);
+function commonFields(repo: RepoRecord, ignore: IgnorePolicy, snapshot: VisibleEntrySnapshot) {
   return {
     repo_id: repo.repoId,
-    snapshot_id: `snap_${snapshotHash.slice(0, 16)}`,
-    index_revision: 0,
+    snapshot_id: snapshot.id,
+    index_revision: snapshot.codeGraph.indexRevision,
     ignore_digest: ignore.digest,
     stale: false,
-    partial: false,
+    partial: snapshot.partial,
     next_cursor: null,
   };
 }
@@ -420,12 +435,19 @@ function metadataForResolved(resolved: ResolvedRepoPath): ManifestEntry {
   };
 }
 
-function walkVisibleEntries(repo: RepoRecord, ignore: IgnorePolicy, startRelative = '.'): ManifestEntry[] {
+function walkVisibleEntries(repo: RepoRecord, ignore: IgnorePolicy, startRelative = '.'): { entries: ManifestEntry[]; partial: boolean; walkerErrors: number } {
   const start = resolveRepoPath(repo, startRelative, ignore, { allowRoot: true, allowExternalSymlinkMetadata: true });
   const entries: ManifestEntry[] = [];
+  let walkerErrors = 0;
 
   const visit = (absoluteDir: string, relativeDir: string): void => {
-    const children = readdirSync(absoluteDir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name));
+    let children;
+    try {
+      children = readdirSync(absoluteDir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name));
+    } catch (_error) {
+      walkerErrors += 1;
+      return;
+    }
     for (const child of children) {
       const childRelative = relativeDir === '.' ? child.name : `${relativeDir}/${child.name}`;
       const childAbsolute = resolve(absoluteDir, child.name);
@@ -436,7 +458,7 @@ function walkVisibleEntries(repo: RepoRecord, ignore: IgnorePolicy, startRelativ
           resolvedChild = resolveRepoPath(repo, childRelative, ignore, { allowExternalSymlinkMetadata: true });
           entries.push(metadataForResolved(resolvedChild));
         } catch (_error) {
-          // Ignore races and unreadable children at this layer; callers mark partial in later snapshot work.
+          walkerErrors += 1;
         }
       }
       if (child.isDirectory()) {
@@ -449,7 +471,90 @@ function walkVisibleEntries(repo: RepoRecord, ignore: IgnorePolicy, startRelativ
 
   if (start.relativePath !== '.') entries.push(metadataForResolved(start));
   if (start.readable && statSync(start.canonicalPath).isDirectory()) visit(start.canonicalPath, start.relativePath);
-  return entries.sort((a, b) => a.path.localeCompare(b.path));
+  return { entries: entries.sort((a, b) => a.path.localeCompare(b.path)), partial: walkerErrors > 0, walkerErrors };
+}
+
+function isInternalRevisionPath(path: string): boolean {
+  return path === '.ai/harness/mcp/audit.log' || path.startsWith('.ai/harness/mcp/');
+}
+
+function metadataDigest(entries: ManifestEntry[]): string {
+  return `sha256:${sha256(JSON.stringify(entries.filter((entry) => !isInternalRevisionPath(entry.path)).map((entry) => [
+    entry.path,
+    entry.sha256 ?? '',
+    entry.type,
+    entry.indexed ? 'indexed' : 'unindexed',
+  ])))}`;
+}
+
+function mergeCodeGraphMetadata(repo: RepoRecord, ignore: IgnorePolicy, entries: ManifestEntry[], codeGraph: CodeGraphRepoSnapshot): { entriesByPath: Map<string, ManifestEntry>; filteredPaths: number } {
+  const entriesByPath = new Map(entries.map((entry) => [entry.path, entry]));
+  let filteredPaths = 0;
+
+  for (const file of codeGraph.files) {
+    try {
+      const relativePath = normalizeRepoRelativePath(file.path);
+      if (isIgnored(ignore, relativePath)) {
+        filteredPaths += 1;
+        continue;
+      }
+      const resolved = resolveRepoPath(repo, relativePath, ignore, { allowExternalSymlinkMetadata: true });
+      const entry = entriesByPath.get(resolved.relativePath);
+      if (!entry || resolved.type !== 'file') {
+        filteredPaths += 1;
+        continue;
+      }
+      entry.indexed = true;
+      entry.codegraph_language = file.language;
+      entry.codegraph_node_count = file.nodeCount;
+      entry.codegraph_size = file.size;
+    } catch (_error) {
+      filteredPaths += 1;
+    }
+  }
+
+  return { entriesByPath, filteredPaths };
+}
+
+function buildVisibleEntrySnapshot(ctx: GeneralRepoToolContext, repo: RepoRecord, ignore: IgnorePolicy): VisibleEntrySnapshot {
+  const codeGraph = (ctx.codeGraphAdapter ?? DEFAULT_CODEGRAPH_ADAPTER).discoverRepo(repo.canonicalRoot);
+  const walked = walkVisibleEntries(repo, ignore);
+  const merged = mergeCodeGraphMetadata(repo, ignore, walked.entries, codeGraph);
+  const manifestDigest = metadataDigest(walked.entries);
+  const id = `snap_${sha256(`${repo.repoId}\0${repo.registryRevision}\0${ignore.digest}\0${codeGraph.indexRevision}\0${manifestDigest}`).slice(0, 16)}`;
+  return {
+    id,
+    entries: walked.entries,
+    entriesByPath: merged.entriesByPath,
+    manifestDigest,
+    partial: walked.partial,
+    walkerErrors: walked.walkerErrors,
+    codeGraph,
+    codeGraphFilteredPaths: merged.filteredPaths,
+  };
+}
+
+function assertSnapshotFresh(args: Record<string, unknown>, snapshot: VisibleEntrySnapshot): void {
+  const requested = typeof args.snapshot_id === 'string' ? args.snapshot_id.trim() : '';
+  if (requested && requested !== snapshot.id) {
+    throw new GeneralRepoAccessError('SNAPSHOT_STALE', 'requested snapshot_id does not match current repo snapshot', {
+      requested_snapshot_id: requested,
+      current_snapshot_id: snapshot.id,
+    }, true);
+  }
+}
+
+function codeGraphSummary(snapshot: VisibleEntrySnapshot): Record<string, unknown> {
+  return {
+    integrated: snapshot.codeGraph.integrated,
+    available: snapshot.codeGraph.available,
+    source: snapshot.codeGraph.source,
+    index_revision: snapshot.codeGraph.indexRevision,
+    latency_ms: snapshot.codeGraph.latencyMs,
+    indexed_files: snapshot.codeGraph.files.length,
+    filtered_paths: snapshot.codeGraphFilteredPaths,
+    error: snapshot.codeGraph.error,
+  };
 }
 
 function pageEntries<T>(entries: T[], cursor: unknown, pageSize: unknown): { page: T[]; nextCursor: string | null } {
@@ -476,11 +581,13 @@ function byteRange(value: unknown, maxLength: number): [number, number] | null {
   return [start, Math.min(length, maxLength)];
 }
 
-function readFilePayload(repo: RepoRecord, ignore: IgnorePolicy, args: Record<string, unknown>, maxBytes = HARD_READ_BYTES): Record<string, unknown> {
+function readFilePayload(repo: RepoRecord, ignore: IgnorePolicy, snapshot: VisibleEntrySnapshot, args: Record<string, unknown>, maxBytes = HARD_READ_BYTES): Record<string, unknown> {
   if (args.line_range !== undefined && args.byte_range !== undefined) {
     throw new GeneralRepoAccessError('INVALID_RANGE', 'line_range and byte_range are mutually exclusive');
   }
   const target = resolveRepoPath(repo, args.path, ignore, { requireFile: true });
+  const snapshotEntry = snapshot.entriesByPath.get(target.relativePath);
+  const indexed = snapshotEntry?.indexed ?? false;
   const raw = readFileSync(target.canonicalPath);
   const fullHash = sha256(raw);
   const binary = raw.subarray(0, BINARY_PROBE_BYTES).includes(0);
@@ -491,9 +598,11 @@ function readFilePayload(repo: RepoRecord, ignore: IgnorePolicy, args: Record<st
     const [start, length] = range;
     const chunk = raw.subarray(start, start + length);
     return {
-      ...commonFields(repo, ignore),
+      ...commonFields(repo, ignore, snapshot),
       path: target.relativePath,
       sha256: fullHash,
+      indexed,
+      backend: indexed ? 'codegraph-indexed-filesystem-read' : 'filesystem-fallback',
       encoding: 'base64',
       content: chunk.toString('base64'),
       bytes_returned: chunk.length,
@@ -519,9 +628,11 @@ function readFilePayload(repo: RepoRecord, ignore: IgnorePolicy, args: Record<st
       throw new GeneralRepoAccessError('PAYLOAD_LIMIT_REACHED', 'line_range exceeds response byte budget', { max_bytes: maxBytes });
     }
     return {
-      ...commonFields(repo, ignore),
+      ...commonFields(repo, ignore, snapshot),
       path: target.relativePath,
       sha256: fullHash,
+      indexed,
+      backend: indexed ? 'codegraph-indexed-filesystem-read' : 'filesystem-fallback',
       encoding: 'utf-8',
       content: selected,
       start_line: start,
@@ -536,9 +647,11 @@ function readFilePayload(repo: RepoRecord, ignore: IgnorePolicy, args: Record<st
   const bytes = raw.subarray(0, maxBytes);
   const content = bytes.toString('utf-8');
   return {
-    ...commonFields(repo, ignore),
+    ...commonFields(repo, ignore, snapshot),
     path: target.relativePath,
     sha256: fullHash,
+    indexed,
+    backend: indexed ? 'codegraph-indexed-filesystem-read' : 'filesystem-fallback',
     encoding: 'utf-8',
     content,
     bytes_returned: Buffer.byteLength(content, 'utf-8'),
@@ -551,8 +664,10 @@ function readFilePayload(repo: RepoRecord, ignore: IgnorePolicy, args: Record<st
 function getRepoCapabilities(ctx: GeneralRepoToolContext, args: Record<string, unknown>): GeneralRepoToolResult {
   const repo = resolveRepo(ctx, args.repo_id);
   const ignore = readIgnorePolicy(repo.canonicalRoot);
+  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore);
+  assertSnapshotFresh(args, snapshot);
   return textResult({
-    ...commonFields(repo, ignore),
+    ...commonFields(repo, ignore, snapshot),
     access_mode: repo.accessMode,
     writable: repo.accessMode === 'read_write',
     display_name: repo.displayName,
@@ -562,8 +677,10 @@ function getRepoCapabilities(ctx: GeneralRepoToolContext, args: Record<string, u
     write_tools: repo.accessMode === 'read_write' ? [] : [],
     codegraph: {
       primary_backend: true,
-      integrated: false,
-      note: 'Sprint 1 uses filesystem fallback; CodeGraph adapter metadata merge is Sprint 2.',
+      ...codeGraphSummary(snapshot),
+      note: snapshot.codeGraph.available
+        ? 'CodeGraph inventory is merged as indexed metadata; secure filesystem walking remains the manifest source of truth.'
+        : 'CodeGraph is unavailable for this repo; authorized filesystem fallback remains active.',
     },
     limits: {
       max_page_size: HARD_PAGE_SIZE,
@@ -576,22 +693,29 @@ function getRepoCapabilities(ctx: GeneralRepoToolContext, args: Record<string, u
 function repoManifest(ctx: GeneralRepoToolContext, args: Record<string, unknown>): GeneralRepoToolResult {
   const repo = resolveRepo(ctx, args.repo_id);
   const ignore = readIgnorePolicy(repo.canonicalRoot);
-  const entries = walkVisibleEntries(repo, ignore);
+  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore);
+  assertSnapshotFresh(args, snapshot);
+  const entries = snapshot.entries;
   const paged = pageEntries(entries, args.cursor, args.page_size);
   return textResult({
-    ...commonFields(repo, ignore),
+    ...commonFields(repo, ignore, snapshot),
     entries: paged.page,
     next_cursor: paged.nextCursor,
-    complete: true,
+    complete: !snapshot.partial,
     page_complete: paged.nextCursor === null,
     counts: {
       entries: entries.length,
       files: entries.filter((entry) => entry.type === 'file').length,
       directories: entries.filter((entry) => entry.type === 'directory').length,
       symlinks: entries.filter((entry) => entry.type === 'symlink').length,
+      indexed: entries.filter((entry) => entry.indexed).length,
       unindexed: entries.filter((entry) => !entry.indexed).length,
+      text: entries.filter((entry) => entry.type === 'file' && entry.binary === false).length,
+      binary: entries.filter((entry) => entry.type === 'file' && entry.binary === true).length,
     },
-    manifest_digest: `sha256:${sha256(JSON.stringify(entries.map((entry) => [entry.path, entry.sha256 ?? '', entry.type])))}`,
+    manifest_digest: snapshot.manifestDigest,
+    walker_errors: snapshot.walkerErrors,
+    codegraph: codeGraphSummary(snapshot),
   });
 }
 
@@ -599,8 +723,10 @@ function listTree(ctx: GeneralRepoToolContext, args: Record<string, unknown>): G
   const repo = resolveRepo(ctx, args.repo_id);
   const ignore = readIgnorePolicy(repo.canonicalRoot);
   const root = resolveRepoPath(repo, args.path ?? '.', ignore, { allowRoot: true, requireDirectory: true });
+  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore);
+  assertSnapshotFresh(args, snapshot);
   const depth = numberArg(args.depth, 1, 0, 6);
-  const entries = walkVisibleEntries(repo, ignore, root.relativePath)
+  const entries = snapshot.entries
     .filter((entry) => entry.path !== root.relativePath)
     .filter((entry) => {
       const relation = root.relativePath === '.'
@@ -611,10 +737,11 @@ function listTree(ctx: GeneralRepoToolContext, args: Record<string, unknown>): G
     });
   const paged = pageEntries(entries, args.cursor, (args.page_size ?? DEFAULT_PAGE_SIZE));
   return textResult({
-    ...commonFields(repo, ignore),
+    ...commonFields(repo, ignore, snapshot),
     path: root.relativePath,
     entries: paged.page,
     next_cursor: paged.nextCursor,
+    codegraph: codeGraphSummary(snapshot),
   });
 }
 
@@ -622,21 +749,32 @@ function statFile(ctx: GeneralRepoToolContext, args: Record<string, unknown>): G
   const repo = resolveRepo(ctx, args.repo_id);
   const ignore = readIgnorePolicy(repo.canonicalRoot);
   const resolved = resolveRepoPath(repo, args.path, ignore);
+  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore);
+  assertSnapshotFresh(args, snapshot);
+  const entry = snapshot.entriesByPath.get(resolved.relativePath) ?? metadataForResolved(resolved);
   return textResult({
-    ...commonFields(repo, ignore),
-    ...metadataForResolved(resolved),
+    ...commonFields(repo, ignore, snapshot),
+    ...entry,
+    codegraph: codeGraphSummary(snapshot),
   });
 }
 
 function readFileTool(ctx: GeneralRepoToolContext, args: Record<string, unknown>): GeneralRepoToolResult {
   const repo = resolveRepo(ctx, args.repo_id);
   const ignore = readIgnorePolicy(repo.canonicalRoot);
-  return textResult(readFilePayload(repo, ignore, args));
+  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore);
+  assertSnapshotFresh(args, snapshot);
+  return textResult({
+    ...readFilePayload(repo, ignore, snapshot, args),
+    codegraph: codeGraphSummary(snapshot),
+  });
 }
 
 function readFiles(ctx: GeneralRepoToolContext, args: Record<string, unknown>): GeneralRepoToolResult {
   const repo = resolveRepo(ctx, args.repo_id);
   const ignore = readIgnorePolicy(repo.canonicalRoot);
+  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore);
+  assertSnapshotFresh(args, snapshot);
   const requests = Array.isArray(args.requests) ? args.requests : [];
   const byteBudget = numberArg(args.byte_budget, HARD_READ_BYTES, 1, HARD_READ_BYTES);
   let remaining = byteBudget;
@@ -655,7 +793,7 @@ function readFiles(ctx: GeneralRepoToolContext, args: Record<string, unknown>): 
       continue;
     }
     try {
-      const payload = readFilePayload(repo, ignore, request as Record<string, unknown>, remaining);
+      const payload = readFilePayload(repo, ignore, snapshot, request as Record<string, unknown>, remaining);
       remaining -= Number(payload.bytes_returned ?? 0);
       results.push(payload);
     } catch (error) {
@@ -669,10 +807,11 @@ function readFiles(ctx: GeneralRepoToolContext, args: Record<string, unknown>): 
   }
 
   return textResult({
-    ...commonFields(repo, ignore),
-    partial,
+    ...commonFields(repo, ignore, snapshot),
+    partial: partial || snapshot.partial,
     results,
     bytes_remaining: remaining,
+    codegraph: codeGraphSummary(snapshot),
   });
 }
 
@@ -682,14 +821,20 @@ function searchText(ctx: GeneralRepoToolContext, args: Record<string, unknown>):
   const mode = args.mode === 'regex' ? 'regex' : 'literal';
   const repo = resolveRepo(ctx, args.repo_id);
   const ignore = readIgnorePolicy(repo.canonicalRoot);
+  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore);
+  assertSnapshotFresh(args, snapshot);
   const requestedPaths = Array.isArray(args.paths) && args.paths.length > 0 ? args.paths : ['.'];
   const candidates: ManifestEntry[] = [];
   for (const path of requestedPaths) {
     const resolved = resolveRepoPath(repo, path, ignore, { allowRoot: true });
     if (resolved.type === 'directory') {
-      candidates.push(...walkVisibleEntries(repo, ignore, resolved.relativePath));
+      candidates.push(...snapshot.entries.filter((entry) => (
+        resolved.relativePath === '.'
+          ? true
+          : entry.path === resolved.relativePath || entry.path.startsWith(`${resolved.relativePath}/`)
+      )));
     } else {
-      candidates.push(metadataForResolved(resolved));
+      candidates.push(snapshot.entriesByPath.get(resolved.relativePath) ?? metadataForResolved(resolved));
     }
   }
   const seen = new Set<string>();
@@ -704,9 +849,11 @@ function searchText(ctx: GeneralRepoToolContext, args: Record<string, unknown>):
   const needle = query.toLowerCase();
   const matches: Record<string, unknown>[] = [];
   const maxResults = numberArg(args.max_results, DEFAULT_SEARCH_RESULTS, 1, HARD_SEARCH_RESULTS);
+  const offset = numberArg(args.cursor, 0, 0, Number.MAX_SAFE_INTEGER);
+  let seenMatches = 0;
 
   for (const entry of candidates.sort((a, b) => a.path.localeCompare(b.path))) {
-    if (matches.length >= maxResults) break;
+    if (matches.length >= maxResults + 1) break;
     if (entry.type !== 'file' || !entry.readable || seen.has(entry.path) || entry.binary || (entry.size ?? 0) > SEARCH_FILE_SCAN_BYTES) continue;
     seen.add(entry.path);
     const resolved = resolveRepoPath(repo, entry.path, ignore, { requireFile: true });
@@ -716,24 +863,35 @@ function searchText(ctx: GeneralRepoToolContext, args: Record<string, unknown>):
       const line = lines[index] ?? '';
       const column = regex ? line.search(regex) : line.toLowerCase().indexOf(needle);
       if (column < 0) continue;
+      if (seenMatches < offset) {
+        seenMatches += 1;
+        continue;
+      }
       matches.push({
         path: entry.path,
         line: index + 1,
         column: column + 1,
         snippet: line.slice(Math.max(0, column - 60), column + 120),
         sha256: entry.sha256,
+        indexed: entry.indexed,
+        backend: entry.indexed ? 'codegraph-indexed-filesystem-search' : 'filesystem-fallback',
       });
-      if (matches.length >= maxResults) break;
+      seenMatches += 1;
+      if (matches.length >= maxResults + 1) break;
     }
   }
+  const returned = matches.slice(0, maxResults);
+  const nextCursor = matches.length > maxResults ? String(offset + maxResults) : null;
 
   return textResult({
-    ...commonFields(repo, ignore),
+    ...commonFields(repo, ignore, snapshot),
     query,
     mode,
-    matches,
-    truncated: matches.length >= maxResults,
-    backend: 'filesystem-fallback',
+    matches: returned,
+    truncated: nextCursor !== null,
+    next_cursor: nextCursor,
+    backend: snapshot.codeGraph.available ? 'codegraph-metadata+filesystem-fallback' : 'filesystem-fallback',
+    codegraph: codeGraphSummary(snapshot),
   });
 }
 

--- a/src/cli/mcp/reader-tools.ts
+++ b/src/cli/mcp/reader-tools.ts
@@ -10,6 +10,7 @@ import { redactMcpText } from './redaction';
 import { repoHarnessPackageVersion } from './version';
 import { WorkspaceError, WorkspaceManager, type McpWorkspace, type WorkspaceResolvedPath } from './workspaces';
 import { buildGeneralRepoToolDefinitions, callGeneralRepoTool, hasGeneralRepoArgs, isGeneralRepoTool, listGeneralRepoRecords } from './general-repo-access';
+import type { GeneralRepoCodeGraphAdapter } from './codegraph-adapter';
 import { repoHarnessRepoIdFor } from '../../effects/repo-registry';
 import type { McpPolicy } from './types';
 
@@ -24,6 +25,7 @@ export interface ReaderToolContext {
   repoRoot: string;
   policy: McpPolicy;
   workspaceManager: WorkspaceManager;
+  codeGraphAdapter?: GeneralRepoCodeGraphAdapter;
 }
 
 export interface ReaderToolResult {
@@ -605,11 +607,12 @@ export async function callReaderTool(ctx: ReaderToolContext, name: string, args:
   }
 }
 
-export function createReaderToolContext(repoRoot: string, policy: McpPolicy, workspaceManager?: WorkspaceManager): ReaderToolContext {
+export function createReaderToolContext(repoRoot: string, policy: McpPolicy, workspaceManager?: WorkspaceManager, codeGraphAdapter?: GeneralRepoCodeGraphAdapter): ReaderToolContext {
   return {
     repoRoot,
     policy,
     workspaceManager: workspaceManager ?? new WorkspaceManager({ allowedRoots: policy.allowedRoots ?? [], policy }),
+    codeGraphAdapter,
   };
 }
 

--- a/tasks/notes/20260622-repo-harness-codegraph.notes.md
+++ b/tasks/notes/20260622-repo-harness-codegraph.notes.md
@@ -46,3 +46,26 @@ Sprint 0 contract freeze for `plans/sprints/20260622-repo-harness-codegraph-spri
   reduces symlink-swap exposure with the Node filesystem APIs available here,
   but a stronger fd-relative/openat design still belongs in the S2/S4 security
   pass if the runtime grows native bindings.
+
+## Sprint 2 Adapter/Snapshot Notes
+
+- The CodeGraph integration is a bounded CLI adapter over
+  `codegraph files --format flat --json`. Its output is treated as indexed
+  metadata only. Secure filesystem walking remains the manifest source of truth
+  because the Sprint 0 spike proved CodeGraph inventory is not a complete repo
+  file list.
+- Every CodeGraph-returned path is normalized, resolved under the canonical repo
+  root, and checked against `.ignore` before metadata is merged. Returned paths
+  that are ignored, missing, directories, or outside the repo increment
+  `codegraph.filtered_paths` instead of widening access.
+- `snapshot_id` is deterministic from repo identity, registry revision,
+  `.ignore` digest, CodeGraph revision, and the manifest digest. A caller-provided
+  stale `snapshot_id` returns `SNAPSHOT_STALE` rather than silently mixing
+  manifest/search/read versions.
+- `.ai/harness/mcp/audit.log` is not included in the snapshot revision digest.
+  The audit file remains visible according to `.ignore`; the exclusion is only
+  to prevent the reader's own append-only audit side effect from invalidating the
+  snapshot it just returned.
+- CodeGraph CLI `query` is symbol search, not complete repo full-text search.
+  `search_text` therefore keeps the policy-consistent filesystem fallback while
+  surfacing whether each matched file is present in CodeGraph indexed metadata.

--- a/tests/cli/mcp-reader-tools.test.ts
+++ b/tests/cli/mcp-reader-tools.test.ts
@@ -5,6 +5,7 @@ import { join } from 'path';
 import { getMcpPolicy } from '../../src/cli/mcp/policy';
 import { buildReaderToolDefinitions, callReaderTool, createReaderToolContext, type ReaderToolContext } from '../../src/cli/mcp/reader-tools';
 import { WorkspaceManager } from '../../src/cli/mcp/workspaces';
+import type { GeneralRepoCodeGraphAdapter } from '../../src/cli/mcp/codegraph-adapter';
 
 async function jsonTool(ctx: ReaderToolContext, name: string, args: Record<string, unknown> = {}) {
   const result = await callReaderTool(ctx, name, args);
@@ -206,6 +207,89 @@ describe('MCP reader tools', () => {
       } finally {
         rmSync(outside, { recursive: true, force: true });
       }
+    });
+  });
+
+  test('general repo tools merge CodeGraph metadata under the same guarded snapshot', async () => {
+    await withReaderRepo(async (repoRoot, ctx) => {
+      writeFileSync(join(repoRoot, '.ignore'), 'ignored.md\n');
+      const fakeCodeGraph: GeneralRepoCodeGraphAdapter = {
+        discoverRepo() {
+          return {
+            available: true,
+            integrated: true,
+            source: 'test-double',
+            indexRevision: 'index_fake1234',
+            latencyMs: 3,
+            files: [
+              { path: 'src/index.ts', language: 'typescript', nodeCount: 2, size: 31 },
+              { path: '.env', language: 'dotenv', nodeCount: 0, size: 29 },
+              { path: 'ignored.md', language: 'markdown', nodeCount: 0, size: 10 },
+              { path: '../outside.ts', language: 'typescript', nodeCount: 1, size: 10 },
+              { path: 'missing.ts', language: 'typescript', nodeCount: 1, size: 10 },
+            ],
+          };
+        },
+      };
+      const cgCtx = createReaderToolContext(
+        repoRoot,
+        ctx.policy,
+        new WorkspaceManager({ allowedRoots: [repoRoot], policy: ctx.policy }),
+        fakeCodeGraph,
+      );
+
+      const repoId = (await jsonTool(cgCtx, 'list_allowed_roots')).roots[0].repo_id;
+      const manifest = await jsonTool(cgCtx, 'repo_manifest', { repo_id: repoId, page_size: 1000 });
+      const byPath = new Map(manifest.entries.map((entry: { path: string }) => [entry.path, entry]));
+      expect(manifest.index_revision).toBe('index_fake1234');
+      expect(manifest.codegraph).toMatchObject({
+        integrated: true,
+        available: true,
+        source: 'test-double',
+        indexed_files: 5,
+        filtered_paths: 3,
+      });
+      expect(manifest.counts.indexed).toBe(2);
+      expect(byPath.get('src/index.ts')).toMatchObject({
+        indexed: true,
+        codegraph_language: 'typescript',
+        codegraph_node_count: 2,
+      });
+      expect(byPath.get('.env')).toMatchObject({ indexed: true, codegraph_language: 'dotenv' });
+      expect(byPath.get('docs/design.md')).toMatchObject({ indexed: false });
+      expect(byPath.has('ignored.md')).toBe(false);
+
+      const stat = await jsonTool(cgCtx, 'stat_file', { repo_id: repoId, path: 'src/index.ts', snapshot_id: manifest.snapshot_id });
+      expect(stat.snapshot_id).toBe(manifest.snapshot_id);
+      expect(stat).toMatchObject({ indexed: true, codegraph_language: 'typescript' });
+
+      const read = await jsonTool(cgCtx, 'read_file', { repo_id: repoId, path: 'src/index.ts', snapshot_id: manifest.snapshot_id });
+      expect(read.snapshot_id).toBe(manifest.snapshot_id);
+      expect(read).toMatchObject({ indexed: true, backend: 'codegraph-indexed-filesystem-read' });
+
+      const firstSearch = await jsonTool(cgCtx, 'search_text', {
+        repo_id: repoId,
+        query: 'alpha',
+        paths: ['docs/notes.txt'],
+        max_results: 1,
+        snapshot_id: manifest.snapshot_id,
+      });
+      expect(firstSearch.snapshot_id).toBe(manifest.snapshot_id);
+      expect(firstSearch.matches).toHaveLength(1);
+      expect(firstSearch.next_cursor).toBe('1');
+      const secondSearch = await jsonTool(cgCtx, 'search_text', {
+        repo_id: repoId,
+        query: 'alpha',
+        paths: ['docs/notes.txt'],
+        max_results: 1,
+        cursor: firstSearch.next_cursor,
+        snapshot_id: manifest.snapshot_id,
+      });
+      expect(secondSearch.matches[0].line).toBe(3);
+
+      const stale = await jsonTool(cgCtx, 'read_file', { repo_id: repoId, path: 'src/index.ts', snapshot_id: 'snap_stale' });
+      expect(stale.error.code).toBe('SNAPSHOT_STALE');
+      expect(stale.error.retryable).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds a bounded CodeGraph CLI adapter for the general repo reader.
- Merges CodeGraph indexed-file metadata into walker-backed manifest/stat/read/search responses while keeping secure filesystem walking as the complete inventory source of truth.
- Adds deterministic `snapshot_id` validation, `SNAPSHOT_STALE` responses, search continuation, and S2 tests for guarded CodeGraph path filtering.
- Updates the sprint ledger, notes, README, and ChatGPT MCP setup docs.

## P1 Map
- Boundary: the general repo reader remains in `src/cli/mcp/general-repo-access.ts`; CodeGraph version/CLI behavior is isolated in `src/cli/mcp/codegraph-adapter.ts`.
- Authority: repo whitelist + `.ignore` remain the access contract. CodeGraph is only indexed metadata unless its output passes repo-harness path/ignore guards.
- Compatibility: legacy workspace tools still route through `WorkspaceManager`; the new adapter is injected only through the general `repo_id` tools.
- Out of scope: write tools, mutation index sync, cache TTL, index-lag coordinator, and 100k/500k performance baselines remain open Sprint 2/3/4 work.

## P2 Trace
- `repo_manifest` resolves `repo_id`, reads `.ignore`, loads CodeGraph indexed files, walks the visible filesystem, filters every CodeGraph-returned path through canonical path + `.ignore`, then merges `indexed` and CodeGraph metadata.
- `stat_file`, `read_file`, `read_files`, and `search_text` bind the same deterministic snapshot and reject mismatched client snapshots with `SNAPSHOT_STALE`.
- `search_text` keeps filesystem fallback for full-text search because the current CodeGraph CLI `query` surface is symbol-oriented, not complete repo text search.

## P3 Decision
- I did not make CodeGraph the manifest source of truth. Sprint 0 evidence showed CodeGraph inventory omits non-indexed/dotfile/unknown-extension cases, so the walker remains authoritative and CodeGraph is merged as metadata.
- I added one adapter abstraction because S2 needs to isolate CodeGraph CLI shape and support fake adapter tests for malicious/ignored paths. No new dependency was added.
- `.ai/harness/mcp/audit.log` is excluded from snapshot revision only, not from manifest visibility, so the reader's own audit append does not invalidate the snapshot it just returned.

## Verification
- `bun test` -> 968 pass, 1 skip, 0 fail.
- `bun run check:type` -> pass.
- `bun test tests/cli/mcp-reader-tools.test.ts tests/cli/mcp-codegraph-contract.test.ts tests/cli/mcp-policy.test.ts tests/cli/mcp-tools.test.ts tests/cli/codegraph.test.ts tests/cli/codegraph-resolver.test.ts tests/tooling/codegraph-integration.test.ts` -> 37 pass.
- Live smoke: current repo `repo_manifest` returned CodeGraph `available:true`, `indexed_files:847`, and `read_file` on `src/cli/mcp/general-repo-access.ts` returned `indexed:true` under the same snapshot.
- `git diff --cached --check` -> pass.
- `bash scripts/check-deploy-sql-order.sh` -> OK.
- `bash scripts/check-architecture-sync.sh` -> advisory, blocking=0.
- `bash scripts/check-task-sync.sh` -> OK.
- `bash scripts/check-task-workflow.sh --strict` -> OK after refreshed Codex handoff.
- `bun scripts/inspect-project-state.ts --repo . --format text` -> no drift signals, no required decisions.
- `bash scripts/migrate-project-template.sh --repo . --dry-run` -> exit 0.
- `bash scripts/ensure-codegraph.sh --sync` -> ready, sync-index changed.
- `bun src/cli/index.ts doctor --json` -> ok=11, warn=0, fail=0, CodeGraph up-to-date.
- `bun src/cli/index.ts setup check --target codex --check-updates --json` -> exit 0, ok=27, warn=1 optional `skills_cli` timeout, fail=0, needs_agent=0.

Stacked on #19 / `codex/repo-harness-codegraph-s1`.
