### PR TITLE
Add snapshot TTL and index lag state

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,8 +365,15 @@ CodeGraph indexed-file metadata into manifest/stat/read/search responses while
 keeping the filesystem walker as the complete manifest source of truth. Responses
 carry `snapshot_id`, `index_revision`, `ignore_digest`, and `indexed` metadata;
 stale client snapshots return `SNAPSHOT_STALE` instead of silently mixing
-versions. Full-text search still falls back to the guarded filesystem path when
-CodeGraph cannot provide complete repo-text search.
+versions. Responses also expose `snapshot_state`, snapshot TTL/expiry, and a
+bounded in-process snapshot cache marker. The cache key includes repo identity,
+registry revision, `.ignore` digest, and the validated snapshot id; a cache hit
+is returned only after the current manifest digest still matches, so file,
+registry, and `.ignore` changes keep producing a new snapshot. If CodeGraph
+reports a now-missing indexed path or metadata that no longer matches the
+filesystem, the snapshot becomes `index_lagging` while authorized read/stat
+fallback stays available. Full-text search still falls back to the guarded
+filesystem path when CodeGraph cannot provide complete repo-text search.
 
 This sidecar assumes the CLI is already installed from
 [First 5 Minutes](#first-5-minutes). Use it when you want ChatGPT to plan

--- a/assets/mcp/general-repo-reader-tools.v1.schema.json
+++ b/assets/mcp/general-repo-reader-tools.v1.schema.json
@@ -56,6 +56,11 @@
         "enum": [
           "repo_id",
           "snapshot_id",
+          "snapshot_state",
+          "snapshot_created_at",
+          "snapshot_expires_at",
+          "snapshot_ttl_ms",
+          "snapshot_cache",
           "index_revision",
           "ignore_digest",
           "stale",

--- a/docs/repo-harness-chatgpt-mcp-setup.md
+++ b/docs/repo-harness-chatgpt-mcp-setup.md
@@ -157,6 +157,13 @@ merged as indexed metadata (`indexed`, `codegraph_language`,
 `codegraph_node_count`); the secure filesystem walker remains the source of
 truth for complete manifest coverage. If a caller sends a stale `snapshot_id`,
 the reader returns `SNAPSHOT_STALE` instead of silently mixing versions.
+Each response also reports `snapshot_state`, creation/expiry time, TTL, and a
+bounded snapshot cache marker. The cache is revalidated by the current manifest
+digest before it can be reported as a hit; it does not let stale file or
+`.ignore` changes masquerade as current state. If CodeGraph still references a
+deleted indexed path or returns metadata that no longer matches the filesystem,
+the response uses `snapshot_state: "index_lagging"` and includes lagging paths
+under the `codegraph` object.
 
 CodeGraph search support is treated conservatively: current CodeGraph CLI query
 is symbol-oriented, so general full-text `search_text` uses the same guarded

--- a/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
+++ b/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
@@ -454,8 +454,8 @@ Sprint 1 evidence:
 - [x] **S2-SNP-003** manifest、tree、search、read、batch read 可复用同一 snapshot。
 - [x] **S2-SNP-004** 文件或 ignore 变化时标记 snapshot stale。
 - [x] **S2-SNP-005** stale 时返回显式状态；禁止静默混合版本。
-- [ ] **S2-SNP-006** 定义 snapshot TTL、最大并发数和清理策略。
-- [ ] **S2-SNP-007** 为“索引落后于文件系统”提供 `index_lagging` 状态。
+- [x] **S2-SNP-006** 定义 snapshot TTL、最大并发数和清理策略。
+- [x] **S2-SNP-007** 为“索引落后于文件系统”提供 `index_lagging` 状态。
 
 ## 9.3 Repo Manifest
 
@@ -506,7 +506,8 @@ Sprint 2 adapter/snapshot evidence:
 - Runtime: `src/cli/mcp/codegraph-adapter.ts`, `src/cli/mcp/general-repo-access.ts`, `src/cli/mcp/reader-tools.ts`
 - Tests: `tests/cli/mcp-reader-tools.test.ts`
 - Verification: `bun test tests/cli/mcp-reader-tools.test.ts`, `bun run check:type`
-- Deferred by design: `S2-SNP-006`, `S2-SNP-007`, and all `S2-PERF-*` remain open for cache/TTL/index-lag/performance baselines. CodeGraph CLI `query` remains symbol-oriented, so full-text `search_text` continues to use the policy-consistent filesystem fallback while exposing CodeGraph indexed metadata.
+- Snapshot cache/index-lag update: responses now expose `snapshot_state`, creation/expiry, TTL, bounded snapshot metadata, and CodeGraph lagging path summaries. Snapshot memoization is repo-wide and revalidated by the current manifest digest, so it closes `S2-SNP-006/007` but does not claim the per-path cache requirements in `S2-PERF-002/003`.
+- Deferred by design: all `S2-PERF-*` items and the 100k/OOM exit gate remain open for true streaming inventory, per-path cache keys, precise cache invalidation, and measured large-repo baselines. CodeGraph CLI `query` remains symbol-oriented, so full-text `search_text` continues to use the policy-consistent filesystem fallback while exposing CodeGraph indexed metadata.
 
 ---
 

--- a/src/cli/mcp/general-repo-access.ts
+++ b/src/cli/mcp/general-repo-access.ts
@@ -28,6 +28,7 @@ export interface GeneralRepoToolResult {
 
 type RepoEntryType = 'file' | 'directory' | 'symlink' | 'other';
 type SymlinkTargetKind = 'internal' | 'external' | 'none';
+type SnapshotState = 'ready' | 'index_lagging' | 'failed';
 
 interface RepoRecord {
   repoId: string;
@@ -73,6 +74,7 @@ interface ManifestEntry {
   codegraph_language?: string;
   codegraph_node_count?: number;
   codegraph_size?: number;
+  codegraph_index_lagging?: boolean;
   readable: boolean;
   writable: boolean;
   symlink_target_kind: SymlinkTargetKind;
@@ -80,6 +82,14 @@ interface ManifestEntry {
 
 interface VisibleEntrySnapshot {
   id: string;
+  state: SnapshotState;
+  createdAtMs: number;
+  createdAt: string;
+  expiresAt: string;
+  ttlMs: number;
+  cacheKey: string;
+  cacheHit: boolean;
+  cacheSize: number;
   entries: ManifestEntry[];
   entriesByPath: Map<string, ManifestEntry>;
   manifestDigest: string;
@@ -87,6 +97,7 @@ interface VisibleEntrySnapshot {
   walkerErrors: number;
   codeGraph: CodeGraphRepoSnapshot;
   codeGraphFilteredPaths: number;
+  codeGraphLaggingPaths: string[];
 }
 
 const GENERAL_REPO_TOOLS = [
@@ -107,7 +118,11 @@ const BINARY_PROBE_BYTES = 8 * 1024;
 const SEARCH_FILE_SCAN_BYTES = 1024 * 1024;
 const DEFAULT_SEARCH_RESULTS = 50;
 const HARD_SEARCH_RESULTS = 100;
+const SNAPSHOT_TTL_MS = 30_000;
+const MAX_SNAPSHOT_CACHE_ENTRIES = 16;
+const MAX_LAGGING_PATHS_RETURNED = 50;
 const DEFAULT_CODEGRAPH_ADAPTER = createCodeGraphCliAdapter();
+const SNAPSHOT_CACHE = new Map<string, VisibleEntrySnapshot>();
 
 export type GeneralRepoToolName = typeof GENERAL_REPO_TOOLS[number];
 
@@ -403,6 +418,16 @@ function commonFields(repo: RepoRecord, ignore: IgnorePolicy, snapshot: VisibleE
   return {
     repo_id: repo.repoId,
     snapshot_id: snapshot.id,
+    snapshot_state: snapshot.state,
+    snapshot_created_at: snapshot.createdAt,
+    snapshot_expires_at: snapshot.expiresAt,
+    snapshot_ttl_ms: snapshot.ttlMs,
+    snapshot_cache: {
+      key: snapshot.cacheKey,
+      hit: snapshot.cacheHit,
+      size: snapshot.cacheSize,
+      max_entries: MAX_SNAPSHOT_CACHE_ENTRIES,
+    },
     index_revision: snapshot.codeGraph.indexRevision,
     ignore_digest: ignore.digest,
     stale: false,
@@ -487,13 +512,15 @@ function metadataDigest(entries: ManifestEntry[]): string {
   ])))}`;
 }
 
-function mergeCodeGraphMetadata(repo: RepoRecord, ignore: IgnorePolicy, entries: ManifestEntry[], codeGraph: CodeGraphRepoSnapshot): { entriesByPath: Map<string, ManifestEntry>; filteredPaths: number } {
+function mergeCodeGraphMetadata(repo: RepoRecord, ignore: IgnorePolicy, entries: ManifestEntry[], codeGraph: CodeGraphRepoSnapshot): { entriesByPath: Map<string, ManifestEntry>; filteredPaths: number; laggingPaths: string[] } {
   const entriesByPath = new Map(entries.map((entry) => [entry.path, entry]));
   let filteredPaths = 0;
+  const laggingPaths = new Set<string>();
 
   for (const file of codeGraph.files) {
+    let relativePath = '';
     try {
-      const relativePath = normalizeRepoRelativePath(file.path);
+      relativePath = normalizeRepoRelativePath(file.path);
       if (isIgnored(ignore, relativePath)) {
         filteredPaths += 1;
         continue;
@@ -508,22 +535,43 @@ function mergeCodeGraphMetadata(repo: RepoRecord, ignore: IgnorePolicy, entries:
       entry.codegraph_language = file.language;
       entry.codegraph_node_count = file.nodeCount;
       entry.codegraph_size = file.size;
-    } catch (_error) {
+      if (typeof file.size === 'number' && typeof entry.size === 'number' && file.size !== entry.size) {
+        entry.codegraph_index_lagging = true;
+        laggingPaths.add(resolved.relativePath);
+      }
+    } catch (error) {
       filteredPaths += 1;
+      if (error instanceof GeneralRepoAccessError && error.code === 'NOT_FOUND' && relativePath) {
+        laggingPaths.add(relativePath);
+      }
     }
   }
 
-  return { entriesByPath, filteredPaths };
+  return { entriesByPath, filteredPaths, laggingPaths: [...laggingPaths].sort((a, b) => a.localeCompare(b)) };
 }
 
 function buildVisibleEntrySnapshot(ctx: GeneralRepoToolContext, repo: RepoRecord, ignore: IgnorePolicy): VisibleEntrySnapshot {
+  const createdAtMs = Date.now();
   const codeGraph = (ctx.codeGraphAdapter ?? DEFAULT_CODEGRAPH_ADAPTER).discoverRepo(repo.canonicalRoot);
   const walked = walkVisibleEntries(repo, ignore);
   const merged = mergeCodeGraphMetadata(repo, ignore, walked.entries, codeGraph);
   const manifestDigest = metadataDigest(walked.entries);
   const id = `snap_${sha256(`${repo.repoId}\0${repo.registryRevision}\0${ignore.digest}\0${codeGraph.indexRevision}\0${manifestDigest}`).slice(0, 16)}`;
-  return {
+  const cacheKey = `cache_${sha256(`${repo.repoId}\0${repo.registryRevision}\0${ignore.digest}\0${id}`).slice(0, 16)}`;
+  const state: SnapshotState = codeGraph.available && merged.laggingPaths.length > 0
+    ? 'index_lagging'
+    : 'ready';
+  const expiresAtMs = createdAtMs + SNAPSHOT_TTL_MS;
+  const snapshot: VisibleEntrySnapshot = {
     id,
+    state,
+    createdAtMs,
+    createdAt: new Date(createdAtMs).toISOString(),
+    expiresAt: new Date(expiresAtMs).toISOString(),
+    ttlMs: SNAPSHOT_TTL_MS,
+    cacheKey,
+    cacheHit: false,
+    cacheSize: SNAPSHOT_CACHE.size,
     entries: walked.entries,
     entriesByPath: merged.entriesByPath,
     manifestDigest,
@@ -531,6 +579,45 @@ function buildVisibleEntrySnapshot(ctx: GeneralRepoToolContext, repo: RepoRecord
     walkerErrors: walked.walkerErrors,
     codeGraph,
     codeGraphFilteredPaths: merged.filteredPaths,
+    codeGraphLaggingPaths: merged.laggingPaths,
+  };
+  return rememberSnapshot(snapshot);
+}
+
+function rememberSnapshot(snapshot: VisibleEntrySnapshot): VisibleEntrySnapshot {
+  const now = Date.now();
+  for (const [key, cached] of SNAPSHOT_CACHE) {
+    if (Date.parse(cached.expiresAt) <= now) SNAPSHOT_CACHE.delete(key);
+  }
+
+  const cached = SNAPSHOT_CACHE.get(snapshot.cacheKey);
+  if (cached && cached.id === snapshot.id && Date.parse(cached.expiresAt) > now) {
+    const cacheHit = {
+      ...cached,
+      cacheHit: true,
+      cacheSize: SNAPSHOT_CACHE.size,
+    };
+    SNAPSHOT_CACHE.set(snapshot.cacheKey, cacheHit);
+    return cacheHit;
+  }
+
+  SNAPSHOT_CACHE.set(snapshot.cacheKey, snapshot);
+  while (SNAPSHOT_CACHE.size > MAX_SNAPSHOT_CACHE_ENTRIES) {
+    let oldestKey: string | null = null;
+    let oldestCreatedAt = Number.POSITIVE_INFINITY;
+    for (const [key, cachedSnapshot] of SNAPSHOT_CACHE) {
+      if (cachedSnapshot.createdAtMs < oldestCreatedAt) {
+        oldestCreatedAt = cachedSnapshot.createdAtMs;
+        oldestKey = key;
+      }
+    }
+    if (!oldestKey) break;
+    SNAPSHOT_CACHE.delete(oldestKey);
+  }
+
+  return {
+    ...snapshot,
+    cacheSize: SNAPSHOT_CACHE.size,
   };
 }
 
@@ -553,6 +640,9 @@ function codeGraphSummary(snapshot: VisibleEntrySnapshot): Record<string, unknow
     latency_ms: snapshot.codeGraph.latencyMs,
     indexed_files: snapshot.codeGraph.files.length,
     filtered_paths: snapshot.codeGraphFilteredPaths,
+    index_lagging: snapshot.codeGraphLaggingPaths.length > 0,
+    lagging_path_count: snapshot.codeGraphLaggingPaths.length,
+    lagging_paths: snapshot.codeGraphLaggingPaths.slice(0, MAX_LAGGING_PATHS_RETURNED),
     error: snapshot.codeGraph.error,
   };
 }
@@ -710,6 +800,7 @@ function repoManifest(ctx: GeneralRepoToolContext, args: Record<string, unknown>
       symlinks: entries.filter((entry) => entry.type === 'symlink').length,
       indexed: entries.filter((entry) => entry.indexed).length,
       unindexed: entries.filter((entry) => !entry.indexed).length,
+      index_lagging: entries.filter((entry) => entry.codegraph_index_lagging).length,
       text: entries.filter((entry) => entry.type === 'file' && entry.binary === false).length,
       binary: entries.filter((entry) => entry.type === 'file' && entry.binary === true).length,
     },

--- a/tasks/notes/20260622-repo-harness-codegraph.notes.md
+++ b/tasks/notes/20260622-repo-harness-codegraph.notes.md
@@ -69,3 +69,23 @@ Sprint 0 contract freeze for `plans/sprints/20260622-repo-harness-codegraph-spri
 - CodeGraph CLI `query` is symbol search, not complete repo full-text search.
   `search_text` therefore keeps the policy-consistent filesystem fallback while
   surfacing whether each matched file is present in CodeGraph indexed metadata.
+
+## Sprint 2 Snapshot Cache/Index-Lag Notes
+
+- Snapshot TTL is currently a bounded in-process memoization contract:
+  30 seconds, at most 16 snapshots. The cache key includes repo id, registry
+  revision, `.ignore` digest, and the validated snapshot id. A hit is only
+  reported after the reader recomputes the current manifest digest and confirms
+  the snapshot id still matches; this preserves stale detection for file,
+  registry, and `.ignore` changes.
+- `snapshot_state` is `ready` when the filesystem-backed snapshot can be served,
+  and `index_lagging` when CodeGraph metadata proves the index is behind the
+  filesystem. Secure walker traversal errors remain represented by the existing
+  `partial` and `walker_errors` fields, because a partial manifest can still be
+  served with explicit completeness metadata. CodeGraph lag evidence is limited
+  to stale indexed paths that no longer resolve and indexed files whose
+  CodeGraph size differs from the current filesystem size.
+- This slice does not claim the full S2 performance target. Manifest generation
+  still walks the complete visible tree to compute counts, hashes, and the
+  manifest digest. The remaining performance slice must measure 10k/100k/500k
+  fixtures and decide whether to introduce a true streaming inventory structure.

--- a/tests/cli/mcp-codegraph-contract.test.ts
+++ b/tests/cli/mcp-codegraph-contract.test.ts
@@ -22,6 +22,11 @@ const TOOL_NAMES = [
 const COMMON_RESPONSE_FIELDS = [
   'repo_id',
   'snapshot_id',
+  'snapshot_state',
+  'snapshot_created_at',
+  'snapshot_expires_at',
+  'snapshot_ttl_ms',
+  'snapshot_cache',
   'index_revision',
   'ignore_digest',
   'stale',

--- a/tests/cli/mcp-reader-tools.test.ts
+++ b/tests/cli/mcp-reader-tools.test.ts
@@ -222,7 +222,7 @@ describe('MCP reader tools', () => {
             indexRevision: 'index_fake1234',
             latencyMs: 3,
             files: [
-              { path: 'src/index.ts', language: 'typescript', nodeCount: 2, size: 31 },
+              { path: 'src/index.ts', language: 'typescript', nodeCount: 2, size: 1 },
               { path: '.env', language: 'dotenv', nodeCount: 0, size: 29 },
               { path: 'ignored.md', language: 'markdown', nodeCount: 0, size: 10 },
               { path: '../outside.ts', language: 'typescript', nodeCount: 1, size: 10 },
@@ -242,18 +242,31 @@ describe('MCP reader tools', () => {
       const manifest = await jsonTool(cgCtx, 'repo_manifest', { repo_id: repoId, page_size: 1000 });
       const byPath = new Map(manifest.entries.map((entry: { path: string }) => [entry.path, entry]));
       expect(manifest.index_revision).toBe('index_fake1234');
+      expect(manifest.snapshot_state).toBe('index_lagging');
+      expect(manifest.snapshot_ttl_ms).toBe(30_000);
+      expect(manifest.snapshot_created_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+      expect(manifest.snapshot_expires_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+      expect(manifest.snapshot_cache).toMatchObject({
+        hit: false,
+        max_entries: 16,
+      });
       expect(manifest.codegraph).toMatchObject({
         integrated: true,
         available: true,
         source: 'test-double',
         indexed_files: 5,
         filtered_paths: 3,
+        index_lagging: true,
+        lagging_path_count: 2,
       });
+      expect(manifest.codegraph.lagging_paths).toEqual(['missing.ts', 'src/index.ts']);
       expect(manifest.counts.indexed).toBe(2);
+      expect(manifest.counts.index_lagging).toBe(1);
       expect(byPath.get('src/index.ts')).toMatchObject({
         indexed: true,
         codegraph_language: 'typescript',
         codegraph_node_count: 2,
+        codegraph_index_lagging: true,
       });
       expect(byPath.get('.env')).toMatchObject({ indexed: true, codegraph_language: 'dotenv' });
       expect(byPath.get('docs/design.md')).toMatchObject({ indexed: false });
@@ -261,6 +274,7 @@ describe('MCP reader tools', () => {
 
       const stat = await jsonTool(cgCtx, 'stat_file', { repo_id: repoId, path: 'src/index.ts', snapshot_id: manifest.snapshot_id });
       expect(stat.snapshot_id).toBe(manifest.snapshot_id);
+      expect(stat.snapshot_cache.hit).toBe(true);
       expect(stat).toMatchObject({ indexed: true, codegraph_language: 'typescript' });
 
       const read = await jsonTool(cgCtx, 'read_file', { repo_id: repoId, path: 'src/index.ts', snapshot_id: manifest.snapshot_id });


### PR DESCRIPTION
## Summary
- Add shared snapshot state fields, TTL/expiry metadata, and bounded snapshot cache metadata to general repo reader responses.
- Detect CodeGraph index lag when indexed paths disappear or indexed file size metadata no longer matches filesystem state.
- Update schema, docs, tests, sprint notes, and checklist evidence for S2-SNP-006/007 while leaving true S2-PERF work open.

## Validation
- `bun test` -> 968 pass, 1 skip, 0 fail
- `bun test tests/cli/mcp-reader-tools.test.ts tests/cli/mcp-codegraph-contract.test.ts`
- `bun run check:type`
- `git diff --check` and `git diff --cached --check`
- `bash scripts/check-deploy-sql-order.sh`
- `bash scripts/check-architecture-sync.sh`
- `bash scripts/check-task-sync.sh`
- `bun scripts/inspect-project-state.ts --repo . --format text`
- `bash scripts/migrate-project-template.sh --repo . --dry-run`
- `bash scripts/prepare-codex-handoff.sh --reason codegraph-sprint2-cache-index-lag-final && bash scripts/check-task-workflow.sh --strict`
- `bash scripts/ensure-codegraph.sh --sync`
- `bun src/cli/index.ts setup check --target codex --check-updates --json`

## Notes
- No new dependency.
- No new file.
- New in-process cache metadata is intentionally repo-wide and revalidated by current manifest digest; per-path cache keys, streaming manifest, and 10k/100k/500k baselines remain in S2-PERF.
