### PR TITLE
Add path-scoped reader cache baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,14 +366,25 @@ keeping the filesystem walker as the complete manifest source of truth. Response
 carry `snapshot_id`, `index_revision`, `ignore_digest`, and `indexed` metadata;
 stale client snapshots return `SNAPSHOT_STALE` instead of silently mixing
 versions. Responses also expose `snapshot_state`, snapshot TTL/expiry, and a
-bounded in-process snapshot cache marker. The cache key includes repo identity,
-registry revision, `.ignore` digest, and the validated snapshot id; a cache hit
-is returned only after the current manifest digest still matches, so file,
-registry, and `.ignore` changes keep producing a new snapshot. If CodeGraph
-reports a now-missing indexed path or metadata that no longer matches the
-filesystem, the snapshot becomes `index_lagging` while authorized read/stat
+bounded in-process snapshot cache marker. The public `snapshot_cache.key` is
+scoped by tool and repo-relative path set, while `snapshot_cache.snapshot_key`
+identifies the underlying repo snapshot. Entry metadata is cached separately by
+repo, registry revision, `.ignore` digest, relative path, and current stat
+signature, so unchanged warm manifest/stat/read calls avoid repeated file hash
+and binary probes without hiding file, registry, or `.ignore` changes. If
+CodeGraph reports a now-missing indexed path or metadata that no longer matches
+the filesystem, the snapshot becomes `index_lagging` while authorized read/stat
 fallback stays available. Full-text search still falls back to the guarded
 filesystem path when CodeGraph cannot provide complete repo-text search.
+
+For large-repo reader baselines, run:
+
+```bash
+bun run benchmark:mcp-reader -- --entries 10000 --json
+```
+
+Use `--entries all` for the full 10k/100k/500k fixture sequence when the local
+machine can spend the filesystem time.
 
 This sidecar assumes the CLI is already installed from
 [First 5 Minutes](#first-5-minutes). Use it when you want ChatGPT to plan

--- a/docs/repo-harness-chatgpt-mcp-setup.md
+++ b/docs/repo-harness-chatgpt-mcp-setup.md
@@ -158,12 +158,23 @@ merged as indexed metadata (`indexed`, `codegraph_language`,
 truth for complete manifest coverage. If a caller sends a stale `snapshot_id`,
 the reader returns `SNAPSHOT_STALE` instead of silently mixing versions.
 Each response also reports `snapshot_state`, creation/expiry time, TTL, and a
-bounded snapshot cache marker. The cache is revalidated by the current manifest
-digest before it can be reported as a hit; it does not let stale file or
-`.ignore` changes masquerade as current state. If CodeGraph still references a
-deleted indexed path or returns metadata that no longer matches the filesystem,
-the response uses `snapshot_state: "index_lagging"` and includes lagging paths
-under the `codegraph` object.
+bounded snapshot cache marker. `snapshot_cache.key` is scoped by tool and
+repo-relative path set; `snapshot_cache.snapshot_key` names the underlying repo
+snapshot. Entry metadata is cached by repo, registry revision, `.ignore`
+digest, path, and current stat signature, so warm calls can reuse unchanged file
+metadata while file, registry, and `.ignore` changes produce a different
+snapshot. If CodeGraph still references a deleted indexed path or returns
+metadata that no longer matches the filesystem, the response uses
+`snapshot_state: "index_lagging"` and includes lagging paths under the
+`codegraph` object.
+
+Large-repo reader baselines are reproducible with:
+
+```bash
+bun run benchmark:mcp-reader -- --entries 10000 --json
+```
+
+Use `--entries all` for the full 10k/100k/500k fixture sequence.
 
 CodeGraph search support is treated conservatively: current CodeGraph CLI query
 is symbol-oriented, so general full-text `search_text` uses the same guarded

--- a/docs/researches/20260623-general-repo-reader-performance-baseline.md
+++ b/docs/researches/20260623-general-repo-reader-performance-baseline.md
@@ -1,0 +1,93 @@
+# General Repo Reader Performance Baseline
+
+Date: 2026-06-23
+
+Source task: `plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md`
+
+## Scope
+
+This records the first reproducible baseline for the general repo reader
+performance slice. The benchmark fixture intentionally disables CodeGraph in
+order to isolate the filesystem walker, snapshot cache, entry metadata cache,
+pagination, read, and search behavior.
+
+Benchmark entrypoint:
+
+```bash
+bun run benchmark:mcp-reader -- --entries <count> --json
+```
+
+## 10k Fixture
+
+Command:
+
+```bash
+bun run benchmark:mcp-reader -- --entries 10000 --json
+```
+
+Result:
+
+| Measurement | Duration |
+| --- | ---: |
+| cold manifest first page | 672.21 ms |
+| warm manifest first page | 360.91 ms |
+| list_tree root depth 1 | 344.89 ms |
+| read_file first chunk | 341.80 ms |
+| warm literal search | 763.39 ms |
+
+Observed state:
+
+- `snapshot_state`: `ready`
+- `complete`: `true`
+- `counts.entries`: `10109`
+- `counts.files`: `10005`
+- `next_cursor`: `1000`
+- `rss_bytes_after_measurements`: `141606912`
+- warm manifest cache: `hit=true`
+- warm manifest entry metadata cache: `hits=10108`, `misses=1`
+- search matches: `10`
+
+## 100k Fixture
+
+Command:
+
+```bash
+bun run benchmark:mcp-reader -- --entries 100000 --json
+```
+
+Result:
+
+| Measurement | Duration |
+| --- | ---: |
+| cold manifest first page | 18411.08 ms |
+| warm manifest first page | 4318.82 ms |
+| list_tree root depth 1 | 4320.39 ms |
+| read_file first chunk | 4391.59 ms |
+| warm literal search | 4404.87 ms |
+
+Observed state:
+
+- `snapshot_state`: `ready`
+- `complete`: `true`
+- `counts.entries`: `100109`
+- `counts.files`: `100005`
+- `next_cursor`: `1000`
+- `rss_bytes_after_measurements`: `621821952`
+- warm manifest cache: `hit=true`
+- warm manifest entry metadata cache: `hits=100108`, `misses=1`
+- search matches: `50`
+- search `truncated`: `true`
+
+This proves the generated 100k fixture can complete without OOM and returns
+paginated results. It does not satisfy the proposed Sprint 2 SLO: warm manifest
+first page is still above 2 seconds, ordinary read first chunk is above 500 ms,
+and warm search is above 2 seconds.
+
+## Decision
+
+The path-aware response cache key and entry metadata cache close the
+cache-key/invalidation slice, but they do not close streaming manifest or the
+100k/500k performance gate. The next performance slice should move snapshot
+revalidation away from repeated whole-repo walks. The 100k warm path now avoids
+full content hashing for unchanged files, but it still stats and sorts the full
+visible tree before serving first-page manifest, read, tree, or search results.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "bun": ">=1.0.0"
   },
   "scripts": {
+    "benchmark:mcp-reader": "bun scripts/benchmark-general-repo-reader.ts",
     "benchmark:skills": "bun scripts/run-skill-evals.ts",
     "test": "bun test",
     "test:coverage": "bun test --coverage",

--- a/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
+++ b/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
@@ -486,8 +486,8 @@ Sprint 1 evidence:
 ## 9.5 性能与缓存
 
 - [ ] **S2-PERF-001** manifest 流式生成，不将全仓库一次性载入内存。
-- [ ] **S2-PERF-002** cache key 包含 repo、snapshot、ignore digest 和路径。
-- [ ] **S2-PERF-003** 文件变化、ignore 变化、registry 变化时精确失效。
+- [x] **S2-PERF-002** cache key 包含 repo、snapshot、ignore digest 和路径。
+- [x] **S2-PERF-003** 文件变化、ignore 变化、registry 变化时精确失效。
 - [ ] **S2-PERF-004** 在 10k/100k/500k entries fixture 上记录基线。
 - [ ] **S2-PERF-005** 建议初始目标：100k 文件 warm manifest 首屏 p95 < 2s；普通 read 首块 p95 < 500ms；warm search p95 < 2s。最终以环境基线调整。
 
@@ -507,7 +507,8 @@ Sprint 2 adapter/snapshot evidence:
 - Tests: `tests/cli/mcp-reader-tools.test.ts`
 - Verification: `bun test tests/cli/mcp-reader-tools.test.ts`, `bun run check:type`
 - Snapshot cache/index-lag update: responses now expose `snapshot_state`, creation/expiry, TTL, bounded snapshot metadata, and CodeGraph lagging path summaries. Snapshot memoization is repo-wide and revalidated by the current manifest digest, so it closes `S2-SNP-006/007` but does not claim the per-path cache requirements in `S2-PERF-002/003`.
-- Deferred by design: all `S2-PERF-*` items and the 100k/OOM exit gate remain open for true streaming inventory, per-path cache keys, precise cache invalidation, and measured large-repo baselines. CodeGraph CLI `query` remains symbol-oriented, so full-text `search_text` continues to use the policy-consistent filesystem fallback while exposing CodeGraph indexed metadata.
+- Cache-key/performance update: public `snapshot_cache.key` is scoped by tool and repo-relative path set, with `snapshot_cache.snapshot_key` naming the underlying snapshot. Entry metadata cache keys include repo id, registry revision, `.ignore` digest, path, and current stat signature, so file, `.ignore`, and registry changes do not reuse stale metadata. Verification: `bun test tests/cli/mcp-reader-tools.test.ts tests/cli/mcp-codegraph-contract.test.ts`, `bun run check:type`, and `bun run benchmark:mcp-reader -- --entries 10000 --json`.
+- Deferred by design: `S2-PERF-001`, `S2-PERF-004/005`, and the 100k/OOM exit gate remain open. The 10k and 100k baselines are recorded in `docs/researches/20260623-general-repo-reader-performance-baseline.md`; 100k completes without OOM and returns paginated results, but warm manifest/read/search still take about 4.3-4.4 seconds and miss the proposed S2 SLO. CodeGraph CLI `query` remains symbol-oriented, so full-text `search_text` continues to use the policy-consistent filesystem fallback while exposing CodeGraph indexed metadata.
 
 ---
 

--- a/scripts/benchmark-general-repo-reader.ts
+++ b/scripts/benchmark-general-repo-reader.ts
@@ -1,0 +1,259 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+import { performance } from 'perf_hooks';
+import { getMcpPolicy } from '../src/cli/mcp/policy';
+import {
+  callReaderTool,
+  createReaderToolContext,
+  type ReaderToolContext,
+} from '../src/cli/mcp/reader-tools';
+import { WorkspaceManager } from '../src/cli/mcp/workspaces';
+import type { GeneralRepoCodeGraphAdapter } from '../src/cli/mcp/codegraph-adapter';
+
+interface BenchmarkOptions {
+  entries: number[];
+  pageSize: number;
+  maxResults: number;
+  keep: boolean;
+  json: boolean;
+}
+
+const DEFAULT_ENTRIES = [10_000];
+const PLAN_ENTRIES = [10_000, 100_000, 500_000];
+
+function parseArgs(argv: string[]): BenchmarkOptions {
+  const options: BenchmarkOptions = {
+    entries: DEFAULT_ENTRIES,
+    pageSize: 1000,
+    maxResults: 50,
+    keep: false,
+    json: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+    if (arg === '--entries' && next) {
+      options.entries = next === 'all'
+        ? PLAN_ENTRIES
+        : next.split(',').map((value) => Number(value.trim())).filter((value) => Number.isInteger(value) && value > 0);
+      index += 1;
+    } else if (arg === '--page-size' && next) {
+      options.pageSize = Number(next);
+      index += 1;
+    } else if (arg === '--max-results' && next) {
+      options.maxResults = Number(next);
+      index += 1;
+    } else if (arg === '--keep') {
+      options.keep = true;
+    } else if (arg === '--json') {
+      options.json = true;
+    } else if (arg === '--help' || arg === '-h') {
+      printHelp();
+      process.exit(0);
+    }
+  }
+  if (options.entries.length === 0) {
+    throw new Error('--entries must include at least one positive integer or "all"');
+  }
+  return options;
+}
+
+function printHelp(): void {
+  console.log(`Usage: bun scripts/benchmark-general-repo-reader.ts [options]
+
+Options:
+  --entries <n[,n]|all>  File counts to generate. Default: 10000.
+  --page-size <n>        repo_manifest/list_tree page size. Default: 1000.
+  --max-results <n>      search_text max_results. Default: 50.
+  --keep                 Keep generated fixture repos.
+  --json                 Print JSON only.
+`);
+}
+
+function pad(value: number, width: number): string {
+  return String(value).padStart(width, '0');
+}
+
+function generatedPath(index: number): string {
+  return `src/${pad(index % 100, 3)}/file-${pad(index, 7)}.txt`;
+}
+
+function generateFixture(repoRoot: string, entries: number): void {
+  mkdirSync(join(repoRoot, 'src'), { recursive: true });
+  mkdirSync(join(repoRoot, 'ignored'), { recursive: true });
+  writeFileSync(
+    join(repoRoot, '.ignore'),
+    [
+      'ignored/**',
+      '!ignored/reincluded.txt',
+      '',
+    ].join('\n'),
+  );
+  writeFileSync(join(repoRoot, '.dotfile'), 'dotfile remains visible\n');
+  writeFileSync(join(repoRoot, 'unknown.extless'), 'unknown extension remains visible\n');
+  writeFileSync(join(repoRoot, 'binary.bin'), Buffer.from([0, 1, 2, 3, 4, 5]));
+  writeFileSync(join(repoRoot, 'ignored', 'hidden.txt'), 'ignored\n');
+  writeFileSync(join(repoRoot, 'ignored', 'reincluded.txt'), 'reincluded\n');
+  for (let dir = 0; dir < 100; dir += 1) {
+    mkdirSync(join(repoRoot, 'src', pad(dir, 3)), { recursive: true });
+  }
+  for (let index = 0; index < entries; index += 1) {
+    const needle = index % 1000 === 0 ? ' benchmark-needle' : '';
+    writeFileSync(
+      join(repoRoot, generatedPath(index)),
+      `line ${index}${needle}\nsecond line ${entries - index}\n`,
+    );
+  }
+}
+
+async function jsonTool(ctx: ReaderToolContext, name: string, args: Record<string, unknown> = {}) {
+  const result = await callReaderTool(ctx, name, args);
+  return JSON.parse(result.content[0].text);
+}
+
+async function measure<T>(name: string, fn: () => Promise<T>): Promise<{ name: string; duration_ms: number; result: T }> {
+  const start = performance.now();
+  const result = await fn();
+  return { name, duration_ms: Number((performance.now() - start).toFixed(2)), result };
+}
+
+function disabledCodeGraphAdapter(): GeneralRepoCodeGraphAdapter {
+  return {
+    discoverRepo() {
+      return {
+        available: false,
+        integrated: false,
+        source: 'benchmark-disabled',
+        indexRevision: 'index_unavailable',
+        latencyMs: 0,
+        files: [],
+        error: 'benchmark fixture intentionally isolates filesystem walker/cache behavior',
+      };
+    },
+  };
+}
+
+async function runOne(entries: number, options: BenchmarkOptions) {
+  const repoRoot = mkdtempSync(join(tmpdir(), `repo-harness-reader-bench-${entries}-`));
+  const startedAt = new Date().toISOString();
+  try {
+    generateFixture(repoRoot, entries);
+    const policy = getMcpPolicy('planner', { enableReader: true, allowedRoots: [repoRoot] });
+    const workspaceManager = new WorkspaceManager({ allowedRoots: [repoRoot], policy });
+    const ctx = createReaderToolContext(repoRoot, policy, workspaceManager, disabledCodeGraphAdapter());
+    const roots = await jsonTool(ctx, 'list_allowed_roots');
+    const repoId = roots.roots[0].repo_id;
+    const firstPath = generatedPath(0);
+
+    const coldManifest = await measure('cold_manifest_first_page', () => jsonTool(ctx, 'repo_manifest', {
+      repo_id: repoId,
+      page_size: options.pageSize,
+    }));
+    const warmManifest = await measure('warm_manifest_first_page', () => jsonTool(ctx, 'repo_manifest', {
+      repo_id: repoId,
+      page_size: options.pageSize,
+    }));
+    const listTree = await measure('list_tree_root_depth_1', () => jsonTool(ctx, 'list_tree', {
+      repo_id: repoId,
+      path: '.',
+      depth: 1,
+      page_size: options.pageSize,
+      snapshot_id: warmManifest.result.snapshot_id,
+    }));
+    const readFile = await measure('read_file_first_chunk', () => jsonTool(ctx, 'read_file', {
+      repo_id: repoId,
+      path: firstPath,
+      snapshot_id: warmManifest.result.snapshot_id,
+    }));
+    const warmSearch = await measure('warm_literal_search', () => jsonTool(ctx, 'search_text', {
+      repo_id: repoId,
+      query: 'benchmark-needle',
+      mode: 'literal',
+      max_results: options.maxResults,
+      snapshot_id: warmManifest.result.snapshot_id,
+    }));
+
+    return {
+      entries_requested: entries,
+      repo_root: repoRoot,
+      started_at: startedAt,
+      completed_at: new Date().toISOString(),
+      generated_first_path: firstPath,
+      rss_bytes_after_measurements: process.memoryUsage().rss,
+      measurements: [
+        summarize(coldManifest),
+        summarize(warmManifest),
+        summarize(listTree),
+        summarize(readFile),
+        summarize(warmSearch),
+      ],
+      manifest: {
+        snapshot_state: warmManifest.result.snapshot_state,
+        complete: warmManifest.result.complete,
+        counts: warmManifest.result.counts,
+        next_cursor: warmManifest.result.next_cursor,
+        cache: warmManifest.result.snapshot_cache,
+      },
+      search: {
+        match_count: warmSearch.result.matches?.length ?? 0,
+        truncated: warmSearch.result.truncated,
+        next_cursor: warmSearch.result.next_cursor,
+        cache: warmSearch.result.snapshot_cache,
+      },
+      read: {
+        bytes_returned: readFile.result.bytes_returned,
+        has_more: readFile.result.has_more,
+        cache: readFile.result.snapshot_cache,
+      },
+    };
+  } finally {
+    if (!options.keep) rmSync(repoRoot, { recursive: true, force: true });
+  }
+}
+
+function summarize(measurement: { name: string; duration_ms: number; result: Record<string, unknown> }) {
+  return {
+    name: measurement.name,
+    duration_ms: measurement.duration_ms,
+    snapshot_id: measurement.result.snapshot_id,
+    snapshot_state: measurement.result.snapshot_state,
+    partial: measurement.result.partial,
+    next_cursor: measurement.result.next_cursor,
+    cache_hit: (measurement.result.snapshot_cache as { hit?: boolean } | undefined)?.hit,
+  };
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  const results = [];
+  for (const entries of options.entries) {
+    results.push(await runOne(entries, options));
+  }
+  const output = {
+    version: 1,
+    benchmark: 'general-repo-reader',
+    generated_at: new Date().toISOString(),
+    options: {
+      entries: options.entries,
+      page_size: options.pageSize,
+      max_results: options.maxResults,
+    },
+    results,
+  };
+  if (options.json) {
+    console.log(JSON.stringify(output, null, 2));
+  } else {
+    for (const result of results) {
+      console.log(`entries=${result.entries_requested} rss=${result.rss_bytes_after_measurements}`);
+      for (const measurement of result.measurements) {
+        console.log(`  ${measurement.name}: ${measurement.duration_ms}ms cache_hit=${measurement.cache_hit}`);
+      }
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/src/cli/mcp/general-repo-access.ts
+++ b/src/cli/mcp/general-repo-access.ts
@@ -59,6 +59,7 @@ interface ResolvedRepoPath {
   type: RepoEntryType;
   size?: number;
   modifiedAt?: string;
+  metadataSignature: string;
   symlinkTargetKind: SymlinkTargetKind;
   readable: boolean;
 }
@@ -95,9 +96,21 @@ interface VisibleEntrySnapshot {
   manifestDigest: string;
   partial: boolean;
   walkerErrors: number;
+  entryMetadataCacheHits: number;
+  entryMetadataCacheMisses: number;
   codeGraph: CodeGraphRepoSnapshot;
   codeGraphFilteredPaths: number;
   codeGraphLaggingPaths: string[];
+}
+
+interface EntryMetadataCacheStats {
+  hits: number;
+  misses: number;
+}
+
+interface EntryMetadataCacheValue {
+  entry: ManifestEntry;
+  lastUsedAtMs: number;
 }
 
 const GENERAL_REPO_TOOLS = [
@@ -118,11 +131,13 @@ const BINARY_PROBE_BYTES = 8 * 1024;
 const SEARCH_FILE_SCAN_BYTES = 1024 * 1024;
 const DEFAULT_SEARCH_RESULTS = 50;
 const HARD_SEARCH_RESULTS = 100;
-const SNAPSHOT_TTL_MS = 30_000;
+const SNAPSHOT_TTL_MS = 5 * 60_000;
 const MAX_SNAPSHOT_CACHE_ENTRIES = 16;
+const MAX_ENTRY_METADATA_CACHE_ENTRIES = 200_000;
 const MAX_LAGGING_PATHS_RETURNED = 50;
 const DEFAULT_CODEGRAPH_ADAPTER = createCodeGraphCliAdapter();
 const SNAPSHOT_CACHE = new Map<string, VisibleEntrySnapshot>();
+const ENTRY_METADATA_CACHE = new Map<string, EntryMetadataCacheValue>();
 
 export type GeneralRepoToolName = typeof GENERAL_REPO_TOOLS[number];
 
@@ -173,6 +188,19 @@ function numberArg(value: unknown, fallback: number, min: number, max: number): 
   const parsed = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN;
   if (!Number.isFinite(parsed)) return fallback;
   return Math.min(Math.max(Math.trunc(parsed), min), max);
+}
+
+function cachePaths(paths: string[] | undefined): string[] {
+  const normalized = (paths && paths.length > 0 ? paths : ['.'])
+    .map((path) => toPosixPath(String(path || '.')).replace(/^\.\/+/, '') || '.');
+  return [...new Set(normalized)].sort((a, b) => a.localeCompare(b));
+}
+
+function responseCacheKey(repo: RepoRecord, ignore: IgnorePolicy, snapshot: VisibleEntrySnapshot, scope: { tool: string; paths?: string[] }): { key: string; paths: string[]; pathDigest: string } {
+  const paths = cachePaths(scope.paths);
+  const pathDigest = `sha256:${sha256(JSON.stringify(paths))}`;
+  const key = `cache_${sha256(`${repo.repoId}\0${repo.registryRevision}\0${ignore.digest}\0${snapshot.id}\0${scope.tool}\0${pathDigest}`).slice(0, 16)}`;
+  return { key, paths, pathDigest };
 }
 
 function toPosixPath(value: string): string {
@@ -394,6 +422,15 @@ function resolveRepoPath(repo: RepoRecord, inputPath: unknown, ignore: IgnorePol
   }
 
   const fileStat = readable ? statSync(canonicalPath) : lstat;
+  const metadataSignature = [
+    fileStat.size,
+    fileStat.mtimeMs,
+    fileStat.ctimeMs,
+    fileStat.mode,
+    fileStat.ino,
+    type,
+    readable ? 'readable' : 'metadata-only',
+  ].join(':');
   if (opts.requireFile && (!readable || !fileStat.isFile())) {
     throw new GeneralRepoAccessError('NOT_A_FILE', 'path is not a regular file', { path: relativePath });
   }
@@ -409,12 +446,14 @@ function resolveRepoPath(repo: RepoRecord, inputPath: unknown, ignore: IgnorePol
     type,
     size: fileStat.isFile() ? fileStat.size : undefined,
     modifiedAt: fileStat.mtime.toISOString(),
+    metadataSignature,
     symlinkTargetKind,
     readable,
   };
 }
 
-function commonFields(repo: RepoRecord, ignore: IgnorePolicy, snapshot: VisibleEntrySnapshot) {
+function commonFields(repo: RepoRecord, ignore: IgnorePolicy, snapshot: VisibleEntrySnapshot, scope: { tool: string; paths?: string[] }) {
+  const scopedCache = responseCacheKey(repo, ignore, snapshot, scope);
   return {
     repo_id: repo.repoId,
     snapshot_id: snapshot.id,
@@ -423,10 +462,20 @@ function commonFields(repo: RepoRecord, ignore: IgnorePolicy, snapshot: VisibleE
     snapshot_expires_at: snapshot.expiresAt,
     snapshot_ttl_ms: snapshot.ttlMs,
     snapshot_cache: {
-      key: snapshot.cacheKey,
+      key: scopedCache.key,
+      snapshot_key: snapshot.cacheKey,
+      scope: scope.tool,
+      paths: scopedCache.paths,
+      path_digest: scopedCache.pathDigest,
       hit: snapshot.cacheHit,
       size: snapshot.cacheSize,
       max_entries: MAX_SNAPSHOT_CACHE_ENTRIES,
+      entry_metadata: {
+        hits: snapshot.entryMetadataCacheHits,
+        misses: snapshot.entryMetadataCacheMisses,
+        size: ENTRY_METADATA_CACHE.size,
+        max_entries: MAX_ENTRY_METADATA_CACHE_ENTRIES,
+      },
     },
     index_revision: snapshot.codeGraph.indexRevision,
     ignore_digest: ignore.digest,
@@ -436,7 +485,29 @@ function commonFields(repo: RepoRecord, ignore: IgnorePolicy, snapshot: VisibleE
   };
 }
 
-function metadataForResolved(resolved: ResolvedRepoPath): ManifestEntry {
+function entryMetadataCacheKey(resolved: ResolvedRepoPath, ignore: IgnorePolicy): string {
+  return `entry_${sha256(`${resolved.repo.repoId}\0${resolved.repo.registryRevision}\0${ignore.digest}\0${resolved.relativePath}\0${resolved.metadataSignature}`).slice(0, 16)}`;
+}
+
+function rememberEntryMetadata(key: string, entry: ManifestEntry): void {
+  ENTRY_METADATA_CACHE.set(key, { entry: { ...entry }, lastUsedAtMs: Date.now() });
+  while (ENTRY_METADATA_CACHE.size > MAX_ENTRY_METADATA_CACHE_ENTRIES) {
+    const oldestKey = ENTRY_METADATA_CACHE.keys().next().value;
+    if (oldestKey === undefined) break;
+    ENTRY_METADATA_CACHE.delete(oldestKey);
+  }
+}
+
+function metadataForResolved(resolved: ResolvedRepoPath, ignore: IgnorePolicy, stats?: EntryMetadataCacheStats): ManifestEntry {
+  const cacheKey = entryMetadataCacheKey(resolved, ignore);
+  const cached = ENTRY_METADATA_CACHE.get(cacheKey);
+  if (cached) {
+    stats && (stats.hits += 1);
+    ENTRY_METADATA_CACHE.delete(cacheKey);
+    ENTRY_METADATA_CACHE.set(cacheKey, { entry: cached.entry, lastUsedAtMs: Date.now() });
+    return { ...cached.entry };
+  }
+  stats && (stats.misses += 1);
   let binary = false;
   let fileHash: string | undefined;
   if (resolved.readable) {
@@ -446,7 +517,7 @@ function metadataForResolved(resolved: ResolvedRepoPath): ManifestEntry {
       fileHash = sha256(readFileSync(resolved.canonicalPath));
     }
   }
-  return {
+  const entry = {
     path: resolved.relativePath,
     type: resolved.type,
     size: resolved.size,
@@ -458,9 +529,11 @@ function metadataForResolved(resolved: ResolvedRepoPath): ManifestEntry {
     writable: resolved.repo.accessMode === 'read_write' && resolved.readable,
     symlink_target_kind: resolved.symlinkTargetKind,
   };
+  rememberEntryMetadata(cacheKey, entry);
+  return { ...entry };
 }
 
-function walkVisibleEntries(repo: RepoRecord, ignore: IgnorePolicy, startRelative = '.'): { entries: ManifestEntry[]; partial: boolean; walkerErrors: number } {
+function walkVisibleEntries(repo: RepoRecord, ignore: IgnorePolicy, startRelative = '.', stats: EntryMetadataCacheStats = { hits: 0, misses: 0 }): { entries: ManifestEntry[]; partial: boolean; walkerErrors: number } {
   const start = resolveRepoPath(repo, startRelative, ignore, { allowRoot: true, allowExternalSymlinkMetadata: true });
   const entries: ManifestEntry[] = [];
   let walkerErrors = 0;
@@ -481,7 +554,7 @@ function walkVisibleEntries(repo: RepoRecord, ignore: IgnorePolicy, startRelativ
       if (!ignored) {
         try {
           resolvedChild = resolveRepoPath(repo, childRelative, ignore, { allowExternalSymlinkMetadata: true });
-          entries.push(metadataForResolved(resolvedChild));
+          entries.push(metadataForResolved(resolvedChild, ignore, stats));
         } catch (_error) {
           walkerErrors += 1;
         }
@@ -494,7 +567,7 @@ function walkVisibleEntries(repo: RepoRecord, ignore: IgnorePolicy, startRelativ
     }
   };
 
-  if (start.relativePath !== '.') entries.push(metadataForResolved(start));
+  if (start.relativePath !== '.') entries.push(metadataForResolved(start, ignore, stats));
   if (start.readable && statSync(start.canonicalPath).isDirectory()) visit(start.canonicalPath, start.relativePath);
   return { entries: entries.sort((a, b) => a.path.localeCompare(b.path)), partial: walkerErrors > 0, walkerErrors };
 }
@@ -553,7 +626,8 @@ function mergeCodeGraphMetadata(repo: RepoRecord, ignore: IgnorePolicy, entries:
 function buildVisibleEntrySnapshot(ctx: GeneralRepoToolContext, repo: RepoRecord, ignore: IgnorePolicy): VisibleEntrySnapshot {
   const createdAtMs = Date.now();
   const codeGraph = (ctx.codeGraphAdapter ?? DEFAULT_CODEGRAPH_ADAPTER).discoverRepo(repo.canonicalRoot);
-  const walked = walkVisibleEntries(repo, ignore);
+  const entryMetadataStats = { hits: 0, misses: 0 };
+  const walked = walkVisibleEntries(repo, ignore, '.', entryMetadataStats);
   const merged = mergeCodeGraphMetadata(repo, ignore, walked.entries, codeGraph);
   const manifestDigest = metadataDigest(walked.entries);
   const id = `snap_${sha256(`${repo.repoId}\0${repo.registryRevision}\0${ignore.digest}\0${codeGraph.indexRevision}\0${manifestDigest}`).slice(0, 16)}`;
@@ -577,6 +651,8 @@ function buildVisibleEntrySnapshot(ctx: GeneralRepoToolContext, repo: RepoRecord
     manifestDigest,
     partial: walked.partial,
     walkerErrors: walked.walkerErrors,
+    entryMetadataCacheHits: entryMetadataStats.hits,
+    entryMetadataCacheMisses: entryMetadataStats.misses,
     codeGraph,
     codeGraphFilteredPaths: merged.filteredPaths,
     codeGraphLaggingPaths: merged.laggingPaths,
@@ -596,6 +672,8 @@ function rememberSnapshot(snapshot: VisibleEntrySnapshot): VisibleEntrySnapshot 
       ...cached,
       cacheHit: true,
       cacheSize: SNAPSHOT_CACHE.size,
+      entryMetadataCacheHits: snapshot.entryMetadataCacheHits,
+      entryMetadataCacheMisses: snapshot.entryMetadataCacheMisses,
     };
     SNAPSHOT_CACHE.set(snapshot.cacheKey, cacheHit);
     return cacheHit;
@@ -671,13 +749,14 @@ function byteRange(value: unknown, maxLength: number): [number, number] | null {
   return [start, Math.min(length, maxLength)];
 }
 
-function readFilePayload(repo: RepoRecord, ignore: IgnorePolicy, snapshot: VisibleEntrySnapshot, args: Record<string, unknown>, maxBytes = HARD_READ_BYTES): Record<string, unknown> {
+function readFilePayload(repo: RepoRecord, ignore: IgnorePolicy, snapshot: VisibleEntrySnapshot, args: Record<string, unknown>, maxBytes = HARD_READ_BYTES, tool = 'read_file'): Record<string, unknown> {
   if (args.line_range !== undefined && args.byte_range !== undefined) {
     throw new GeneralRepoAccessError('INVALID_RANGE', 'line_range and byte_range are mutually exclusive');
   }
   const target = resolveRepoPath(repo, args.path, ignore, { requireFile: true });
   const snapshotEntry = snapshot.entriesByPath.get(target.relativePath);
   const indexed = snapshotEntry?.indexed ?? false;
+  const fields = commonFields(repo, ignore, snapshot, { tool, paths: [target.relativePath] });
   const raw = readFileSync(target.canonicalPath);
   const fullHash = sha256(raw);
   const binary = raw.subarray(0, BINARY_PROBE_BYTES).includes(0);
@@ -688,7 +767,7 @@ function readFilePayload(repo: RepoRecord, ignore: IgnorePolicy, snapshot: Visib
     const [start, length] = range;
     const chunk = raw.subarray(start, start + length);
     return {
-      ...commonFields(repo, ignore, snapshot),
+      ...fields,
       path: target.relativePath,
       sha256: fullHash,
       indexed,
@@ -718,7 +797,7 @@ function readFilePayload(repo: RepoRecord, ignore: IgnorePolicy, snapshot: Visib
       throw new GeneralRepoAccessError('PAYLOAD_LIMIT_REACHED', 'line_range exceeds response byte budget', { max_bytes: maxBytes });
     }
     return {
-      ...commonFields(repo, ignore, snapshot),
+      ...fields,
       path: target.relativePath,
       sha256: fullHash,
       indexed,
@@ -737,7 +816,7 @@ function readFilePayload(repo: RepoRecord, ignore: IgnorePolicy, snapshot: Visib
   const bytes = raw.subarray(0, maxBytes);
   const content = bytes.toString('utf-8');
   return {
-    ...commonFields(repo, ignore, snapshot),
+    ...fields,
     path: target.relativePath,
     sha256: fullHash,
     indexed,
@@ -757,7 +836,7 @@ function getRepoCapabilities(ctx: GeneralRepoToolContext, args: Record<string, u
   const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore);
   assertSnapshotFresh(args, snapshot);
   return textResult({
-    ...commonFields(repo, ignore, snapshot),
+    ...commonFields(repo, ignore, snapshot, { tool: 'get_repo_capabilities' }),
     access_mode: repo.accessMode,
     writable: repo.accessMode === 'read_write',
     display_name: repo.displayName,
@@ -788,7 +867,7 @@ function repoManifest(ctx: GeneralRepoToolContext, args: Record<string, unknown>
   const entries = snapshot.entries;
   const paged = pageEntries(entries, args.cursor, args.page_size);
   return textResult({
-    ...commonFields(repo, ignore, snapshot),
+    ...commonFields(repo, ignore, snapshot, { tool: 'repo_manifest', paths: ['.'] }),
     entries: paged.page,
     next_cursor: paged.nextCursor,
     complete: !snapshot.partial,
@@ -828,7 +907,7 @@ function listTree(ctx: GeneralRepoToolContext, args: Record<string, unknown>): G
     });
   const paged = pageEntries(entries, args.cursor, (args.page_size ?? DEFAULT_PAGE_SIZE));
   return textResult({
-    ...commonFields(repo, ignore, snapshot),
+    ...commonFields(repo, ignore, snapshot, { tool: 'list_tree', paths: [root.relativePath] }),
     path: root.relativePath,
     entries: paged.page,
     next_cursor: paged.nextCursor,
@@ -842,9 +921,9 @@ function statFile(ctx: GeneralRepoToolContext, args: Record<string, unknown>): G
   const resolved = resolveRepoPath(repo, args.path, ignore);
   const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore);
   assertSnapshotFresh(args, snapshot);
-  const entry = snapshot.entriesByPath.get(resolved.relativePath) ?? metadataForResolved(resolved);
+  const entry = snapshot.entriesByPath.get(resolved.relativePath) ?? metadataForResolved(resolved, ignore);
   return textResult({
-    ...commonFields(repo, ignore, snapshot),
+    ...commonFields(repo, ignore, snapshot, { tool: 'stat_file', paths: [resolved.relativePath] }),
     ...entry,
     codegraph: codeGraphSummary(snapshot),
   });
@@ -884,7 +963,7 @@ function readFiles(ctx: GeneralRepoToolContext, args: Record<string, unknown>): 
       continue;
     }
     try {
-      const payload = readFilePayload(repo, ignore, snapshot, request as Record<string, unknown>, remaining);
+      const payload = readFilePayload(repo, ignore, snapshot, request as Record<string, unknown>, remaining, 'read_files');
       remaining -= Number(payload.bytes_returned ?? 0);
       results.push(payload);
     } catch (error) {
@@ -898,7 +977,12 @@ function readFiles(ctx: GeneralRepoToolContext, args: Record<string, unknown>): 
   }
 
   return textResult({
-    ...commonFields(repo, ignore, snapshot),
+    ...commonFields(repo, ignore, snapshot, {
+      tool: 'read_files',
+      paths: requests
+        .map((request) => (typeof request === 'object' && request !== null && !Array.isArray(request) ? String((request as { path?: unknown }).path ?? '') : ''))
+        .filter((path) => path.length > 0),
+    }),
     partial: partial || snapshot.partial,
     results,
     bytes_remaining: remaining,
@@ -925,7 +1009,7 @@ function searchText(ctx: GeneralRepoToolContext, args: Record<string, unknown>):
           : entry.path === resolved.relativePath || entry.path.startsWith(`${resolved.relativePath}/`)
       )));
     } else {
-      candidates.push(snapshot.entriesByPath.get(resolved.relativePath) ?? metadataForResolved(resolved));
+      candidates.push(snapshot.entriesByPath.get(resolved.relativePath) ?? metadataForResolved(resolved, ignore));
     }
   }
   const seen = new Set<string>();
@@ -975,7 +1059,7 @@ function searchText(ctx: GeneralRepoToolContext, args: Record<string, unknown>):
   const nextCursor = matches.length > maxResults ? String(offset + maxResults) : null;
 
   return textResult({
-    ...commonFields(repo, ignore, snapshot),
+    ...commonFields(repo, ignore, snapshot, { tool: 'search_text', paths: requestedPaths.map((path) => String(path)) }),
     query,
     mode,
     matches: returned,

--- a/tasks/notes/20260622-repo-harness-codegraph.notes.md
+++ b/tasks/notes/20260622-repo-harness-codegraph.notes.md
@@ -73,7 +73,7 @@ Sprint 0 contract freeze for `plans/sprints/20260622-repo-harness-codegraph-spri
 ## Sprint 2 Snapshot Cache/Index-Lag Notes
 
 - Snapshot TTL is currently a bounded in-process memoization contract:
-  30 seconds, at most 16 snapshots. The cache key includes repo id, registry
+  5 minutes, at most 16 snapshots. The cache key includes repo id, registry
   revision, `.ignore` digest, and the validated snapshot id. A hit is only
   reported after the reader recomputes the current manifest digest and confirms
   the snapshot id still matches; this preserves stale detection for file,
@@ -89,3 +89,22 @@ Sprint 0 contract freeze for `plans/sprints/20260622-repo-harness-codegraph-spri
   still walks the complete visible tree to compute counts, hashes, and the
   manifest digest. The remaining performance slice must measure 10k/100k/500k
   fixtures and decide whether to introduce a true streaming inventory structure.
+
+## Sprint 2 Cache-Key/Performance Notes
+
+- Public `snapshot_cache.key` is now scoped by tool and repo-relative path set;
+  `snapshot_cache.snapshot_key` names the underlying repo snapshot. This keeps
+  `repo_manifest`, `stat_file`, `read_file`, `read_files`, `list_tree`, and
+  `search_text` from presenting a single repo-wide cache key for path-specific
+  work.
+- Entry metadata has a bounded in-process cache keyed by repo id, registry
+  revision, `.ignore` digest, repo-relative path, and the current stat
+  signature. Warm snapshot revalidation can reuse unchanged metadata without
+  re-hashing and binary-probing every unchanged file. File changes, `.ignore`
+  changes, and registry revision changes produce different cache keys.
+- `docs/researches/20260623-general-repo-reader-performance-baseline.md`
+  records the first reproducible baseline. The 10k fixture completed with a
+  warm manifest first page at 360.91 ms and warm search at 763.39 ms. The 100k
+  fixture completed without OOM, returned paginated results, and hit the warm
+  snapshot/metadata cache, but warm manifest/read/search still took about
+  4.3-4.4 seconds. The 100k SLO and 500k baseline remain open.

--- a/tests/cli/mcp-reader-tools.test.ts
+++ b/tests/cli/mcp-reader-tools.test.ts
@@ -243,13 +243,21 @@ describe('MCP reader tools', () => {
       const byPath = new Map(manifest.entries.map((entry: { path: string }) => [entry.path, entry]));
       expect(manifest.index_revision).toBe('index_fake1234');
       expect(manifest.snapshot_state).toBe('index_lagging');
-      expect(manifest.snapshot_ttl_ms).toBe(30_000);
+      expect(manifest.snapshot_ttl_ms).toBe(300_000);
       expect(manifest.snapshot_created_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
       expect(manifest.snapshot_expires_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
       expect(manifest.snapshot_cache).toMatchObject({
         hit: false,
+        scope: 'repo_manifest',
+        paths: ['.'],
         max_entries: 16,
+        entry_metadata: {
+          hits: expect.any(Number),
+          misses: expect.any(Number),
+          max_entries: 200_000,
+        },
       });
+      expect(manifest.snapshot_cache.key).not.toBe(manifest.snapshot_cache.snapshot_key);
       expect(manifest.codegraph).toMatchObject({
         integrated: true,
         available: true,
@@ -275,10 +283,17 @@ describe('MCP reader tools', () => {
       const stat = await jsonTool(cgCtx, 'stat_file', { repo_id: repoId, path: 'src/index.ts', snapshot_id: manifest.snapshot_id });
       expect(stat.snapshot_id).toBe(manifest.snapshot_id);
       expect(stat.snapshot_cache.hit).toBe(true);
+      expect(stat.snapshot_cache.scope).toBe('stat_file');
+      expect(stat.snapshot_cache.paths).toEqual(['src/index.ts']);
+      expect(stat.snapshot_cache.key).not.toBe(manifest.snapshot_cache.key);
+      expect(stat.snapshot_cache.snapshot_key).toBe(manifest.snapshot_cache.snapshot_key);
+      expect(stat.snapshot_cache.entry_metadata.hits).toBeGreaterThan(0);
       expect(stat).toMatchObject({ indexed: true, codegraph_language: 'typescript' });
 
       const read = await jsonTool(cgCtx, 'read_file', { repo_id: repoId, path: 'src/index.ts', snapshot_id: manifest.snapshot_id });
       expect(read.snapshot_id).toBe(manifest.snapshot_id);
+      expect(read.snapshot_cache.scope).toBe('read_file');
+      expect(read.snapshot_cache.paths).toEqual(['src/index.ts']);
       expect(read).toMatchObject({ indexed: true, backend: 'codegraph-indexed-filesystem-read' });
 
       const firstSearch = await jsonTool(cgCtx, 'search_text', {
@@ -300,6 +315,19 @@ describe('MCP reader tools', () => {
         snapshot_id: manifest.snapshot_id,
       });
       expect(secondSearch.matches[0].line).toBe(3);
+
+      writeFileSync(join(repoRoot, 'src', 'index.ts'), 'export const readerFixture = 200;\n');
+      const changed = await jsonTool(cgCtx, 'stat_file', { repo_id: repoId, path: 'src/index.ts' });
+      expect(changed.snapshot_id).not.toBe(manifest.snapshot_id);
+      expect(changed.snapshot_cache.hit).toBe(false);
+      expect(changed.sha256).not.toBe((byPath.get('src/index.ts') as { sha256?: string }).sha256);
+      const staleAfterChange = await jsonTool(cgCtx, 'read_file', {
+        repo_id: repoId,
+        path: 'src/index.ts',
+        snapshot_id: manifest.snapshot_id,
+      });
+      expect(staleAfterChange.error.code).toBe('SNAPSHOT_STALE');
+      expect(staleAfterChange.error.retryable).toBe(true);
 
       const stale = await jsonTool(cgCtx, 'read_file', { repo_id: repoId, path: 'src/index.ts', snapshot_id: 'snap_stale' });
       expect(stale.error.code).toBe('SNAPSHOT_STALE');


### PR DESCRIPTION
## Summary
- scope general repo reader cache metadata by tool and repo-relative path set while preserving the underlying snapshot key
- add bounded entry metadata caching keyed by repo, registry revision, .ignore digest, path, and stat signature
- add reproducible general repo reader benchmark script and record 10k/100k baseline evidence

## Verification
- git diff --check
- bun test tests/cli/mcp-reader-tools.test.ts tests/cli/mcp-codegraph-contract.test.ts tests/cli/mcp-policy.test.ts tests/cli/mcp-tools.test.ts tests/cli/codegraph.test.ts tests/cli/codegraph-resolver.test.ts tests/tooling/codegraph-integration.test.ts
- bun run check:type
- bun run benchmark:mcp-reader -- --entries 10000 --json
- bun run benchmark:mcp-reader -- --entries 100000 --json
- bun test
- bash scripts/check-deploy-sql-order.sh
- bash scripts/check-architecture-sync.sh
- bash scripts/check-task-sync.sh
- bun scripts/inspect-project-state.ts --repo . --format text
- bash scripts/migrate-project-template.sh --repo . --dry-run
- bash scripts/prepare-codex-handoff.sh --reason codegraph-s2-perf-cache-baseline && bash scripts/check-task-workflow.sh --strict
- bash scripts/ensure-codegraph.sh --sync
- bun src/cli/index.ts setup check --target codex --check-updates --json

## Notes
- This closes S2-PERF-002 and S2-PERF-003 only.
- S2-PERF-001, S2-PERF-004/005, and the 100k/500k performance gate remain open; 100k now completes without OOM but misses the proposed S2 latency SLO.
