### PR TITLE
Stream manifest pages for large repo baselines

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,11 @@ reports a now-missing indexed path or metadata that no longer matches the
 filesystem, the snapshot becomes `index_lagging` while authorized read/stat
 fallback stays available. Full-text search still falls back to the guarded
 filesystem path when CodeGraph cannot provide complete repo-text search.
+For large manifests, `repo_manifest` streams the visible tree and keeps only the
+requested page of entries in memory. Returned page entries include exact content
+hashes; non-page file content metadata is deferred and reported as
+`counts.content_deferred` until a later manifest page, `stat_file`, `read_file`,
+or `search_text` actually returns that content.
 
 For large-repo reader baselines, run:
 

--- a/docs/repo-harness-chatgpt-mcp-setup.md
+++ b/docs/repo-harness-chatgpt-mcp-setup.md
@@ -165,6 +165,11 @@ digest, path, and current stat signature, so warm calls can reuse unchanged file
 metadata while file, registry, and `.ignore` changes produce a different
 snapshot. Explicit `snapshot_id` stat/read calls can reuse a cached snapshot and
 validate the requested file hash instead of rebuilding the full repo snapshot.
+For large manifests, `repo_manifest` streams the visible tree and keeps only the
+requested page entries in memory. Returned page entries include exact content
+hashes; non-page file content metadata is deferred and reported as
+`counts.content_deferred` until a later page, `stat_file`, `read_file`, or
+`search_text` returns that content.
 If CodeGraph still references a deleted indexed path or returns metadata that
 no longer matches the filesystem, the response uses
 `snapshot_state: "index_lagging"` and includes lagging paths under the

--- a/docs/researches/20260623-general-repo-reader-performance-baseline.md
+++ b/docs/researches/20260623-general-repo-reader-performance-baseline.md
@@ -29,11 +29,11 @@ Result:
 
 | Measurement | Duration |
 | --- | ---: |
-| cold manifest first page | 366.09 ms |
-| warm manifest first page | 95.31 ms |
-| list_tree root depth 1 | 88.54 ms |
-| read_file first chunk | 0.60 ms |
-| warm literal search | 512.12 ms |
+| cold manifest first page | 101.05 ms |
+| warm manifest first page | 76.37 ms |
+| list_tree root depth 1 | 79.93 ms |
+| read_file first chunk | 0.67 ms |
+| warm literal search | 499.84 ms |
 
 Observed state:
 
@@ -41,10 +41,11 @@ Observed state:
 - `complete`: `true`
 - `counts.entries`: `10109`
 - `counts.files`: `10005`
+- `counts.content_deferred`: `9019`
 - `next_cursor`: `1000`
-- `rss_bytes_after_measurements`: `147718144`
+- `rss_bytes_after_measurements`: `133677056`
 - warm manifest cache: `hit=true`
-- warm manifest entry metadata cache: `hits=10108`, `misses=1`
+- warm manifest entry metadata cache: `hits=999`, `misses=9110`
 - search matches: `10`
 
 ## 100k Fixture
@@ -59,11 +60,11 @@ Result:
 
 | Measurement | Duration |
 | --- | ---: |
-| cold manifest first page | 14894.23 ms |
-| warm manifest first page | 919.11 ms |
-| list_tree root depth 1 | 922.27 ms |
-| read_file first chunk | 0.94 ms |
-| warm literal search | 1038.71 ms |
+| cold manifest first page | 821.85 ms |
+| warm manifest first page | 733.76 ms |
+| list_tree root depth 1 | 782.31 ms |
+| read_file first chunk | 0.74 ms |
+| warm literal search | 779.04 ms |
 
 Observed state:
 
@@ -71,10 +72,11 @@ Observed state:
 - `complete`: `true`
 - `counts.entries`: `100109`
 - `counts.files`: `100005`
+- `counts.content_deferred`: `99010`
 - `next_cursor`: `1000`
-- `rss_bytes_after_measurements`: `678952960`
+- `rss_bytes_after_measurements`: `416284672`
 - warm manifest cache: `hit=true`
-- warm manifest entry metadata cache: `hits=100108`, `misses=1`
+- warm manifest entry metadata cache: `hits=999`, `misses=99110`
 - search matches: `50`
 - search `truncated`: `true`
 
@@ -83,7 +85,7 @@ paginated results, and satisfies the proposed Sprint 2 warm-path SLO on this
 machine: warm manifest first page is below 2 seconds, read first chunk is below
 500 ms, and warm search is below 2 seconds.
 
-## 500k Fixture Attempt
+## 500k Fixture
 
 Command:
 
@@ -91,17 +93,43 @@ Command:
 bun run benchmark:mcp-reader -- --entries 500000 --json
 ```
 
-Observed outcome: manually interrupted after more than 9 minutes without a JSON
-result. The temporary fixture directory was removed after interruption.
+Result:
 
-This does not prove the 500k baseline. It shows the remaining large-repo
-bottleneck has moved to fixture generation, cold manifest construction, and the
-fact that the manifest still materializes and sorts the full visible entry set.
+| Measurement | Duration |
+| --- | ---: |
+| cold manifest first page | 11393.94 ms |
+| warm manifest first page | 12201.90 ms |
+| list_tree root depth 1 | 12641.15 ms |
+| read_file first chunk | 3.67 ms |
+| warm literal search | 12668.28 ms |
+
+Observed state:
+
+- `snapshot_state`: `ready`
+- `complete`: `true`
+- `counts.entries`: `500109`
+- `counts.files`: `500005`
+- `counts.content_deferred`: `499010`
+- `next_cursor`: `1000`
+- `rss_bytes_after_measurements`: `1677410304`
+- warm manifest cache: `hit=true`
+- warm manifest entry metadata cache: `hits=999`, `misses=499110`
+- search matches: `50`
+- search `truncated`: `true`
+
+This proves the generated 500k fixture can complete without OOM and returns
+paginated results. The 500k warm path is a recorded baseline, not an SLO pass.
 
 ## Decision
 
 The path-aware response cache key and entry metadata cache close the
-cache-key/invalidation slice. The optimized walker and path-scoped cached
-snapshot reuse close the 100k warm-path SLO on this machine. They do not close
-true streaming manifest or the 500k baseline: cold manifest still materializes
-and sorts the full visible tree before returning first-page manifest results.
+cache-key/invalidation slice. The streaming manifest page path closes the
+`S2-PERF-001` memory-shape requirement for `repo_manifest`: it traverses the
+visible tree to prove counts and digest but stores only the requested page of
+entries. Non-page file content metadata is deferred and surfaced through
+`counts.content_deferred`; returned page entries, `stat_file`, `read_file`, and
+`search_text` still compute content hashes when content is actually returned.
+
+The 10k, 100k, and 500k baselines close `S2-PERF-004`. The 100k warm-path SLO
+is satisfied on this machine. The 500k baseline remains a future optimization
+target rather than a Sprint 2 exit blocker.

--- a/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
+++ b/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
@@ -485,10 +485,10 @@ Sprint 1 evidence:
 
 ## 9.5 性能与缓存
 
-- [ ] **S2-PERF-001** manifest 流式生成，不将全仓库一次性载入内存。
+- [x] **S2-PERF-001** manifest 流式生成，不将全仓库一次性载入内存。
 - [x] **S2-PERF-002** cache key 包含 repo、snapshot、ignore digest 和路径。
 - [x] **S2-PERF-003** 文件变化、ignore 变化、registry 变化时精确失效。
-- [ ] **S2-PERF-004** 在 10k/100k/500k entries fixture 上记录基线。
+- [x] **S2-PERF-004** 在 10k/100k/500k entries fixture 上记录基线。
 - [x] **S2-PERF-005** 建议初始目标：100k 文件 warm manifest 首屏 p95 < 2s；普通 read 首块 p95 < 500ms；warm search p95 < 2s。最终以环境基线调整。
 
 ## 9.6 Sprint 2 退出标准
@@ -508,8 +508,8 @@ Sprint 2 adapter/snapshot evidence:
 - Verification: `bun test tests/cli/mcp-reader-tools.test.ts`, `bun run check:type`
 - Snapshot cache/index-lag update: responses now expose `snapshot_state`, creation/expiry, TTL, bounded snapshot metadata, and CodeGraph lagging path summaries. Snapshot memoization is repo-wide and revalidated by the current manifest digest, so it closes `S2-SNP-006/007` but does not claim the per-path cache requirements in `S2-PERF-002/003`.
 - Cache-key/performance update: public `snapshot_cache.key` is scoped by tool and repo-relative path set, with `snapshot_cache.snapshot_key` naming the underlying snapshot. Entry metadata cache keys include repo id, registry revision, `.ignore` digest, path, and current stat signature, so file, `.ignore`, and registry changes do not reuse stale metadata. Verification: `bun test tests/cli/mcp-reader-tools.test.ts tests/cli/mcp-codegraph-contract.test.ts`, `bun run check:type`, and `bun run benchmark:mcp-reader -- --entries 10000 --json`.
-- Performance update: the manifest walker now avoids the per-entry `resolveRepoPath` hot path, and explicit `snapshot_id` stat/read calls reuse cached snapshots with requested-file hash validation instead of rebuilding the full repo snapshot. The 100k benchmark completes without OOM, returns paginated results, and meets the warm-path SLO on this machine: manifest 919.11 ms, read first chunk 0.94 ms, search 1038.71 ms. Verification: `bun test tests/cli/mcp-reader-tools.test.ts tests/cli/mcp-codegraph-contract.test.ts`, `bun run check:type`, and `bun run benchmark:mcp-reader -- --entries 100000 --json`.
-- Deferred by design: `S2-PERF-001` and `S2-PERF-004` remain open. The 10k and 100k baselines are recorded in `docs/researches/20260623-general-repo-reader-performance-baseline.md`; a 500k benchmark attempt was interrupted after more than 9 minutes without JSON output and then cleaned up. Cold manifest still materializes and sorts the full visible entry set, so true streaming manifest remains the next S2 performance bottleneck. CodeGraph CLI `query` remains symbol-oriented, so full-text `search_text` continues to use the policy-consistent filesystem fallback while exposing CodeGraph indexed metadata.
+- Performance update: the manifest walker now avoids the per-entry `resolveRepoPath` hot path, and explicit `snapshot_id` stat/read calls reuse cached snapshots with requested-file hash validation instead of rebuilding the full repo snapshot. The 100k benchmark completes without OOM, returns paginated results, and meets the warm-path SLO on this machine: manifest 733.76 ms, read first chunk 0.74 ms, search 779.04 ms. Verification: `bun test tests/cli/mcp-reader-tools.test.ts tests/cli/mcp-codegraph-contract.test.ts`, `bun run check:type`, and `bun run benchmark:mcp-reader -- --entries 100000 --json`.
+- Streaming manifest update: `repo_manifest` now traverses the visible tree to prove counts and digest while retaining only the requested page entries. Non-page file content metadata is deferred and exposed via `counts.content_deferred`; returned manifest entries, `stat_file`, `read_file`, and `search_text` still compute content hashes when content is returned. The 10k/100k/500k baselines are recorded in `docs/researches/20260623-general-repo-reader-performance-baseline.md`; the 500k fixture now completes without OOM with a recorded warm manifest baseline of 12201.90 ms and read first chunk of 3.67 ms. CodeGraph CLI `query` remains symbol-oriented, so full-text `search_text` continues to use the policy-consistent filesystem fallback while exposing CodeGraph indexed metadata.
 
 ---
 

--- a/src/cli/mcp/general-repo-access.ts
+++ b/src/cli/mcp/general-repo-access.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'crypto';
-import { closeSync, constants, existsSync, lstatSync, openSync, readFileSync, readSync, readdirSync, realpathSync, statSync } from 'fs';
+import { existsSync, lstatSync, readFileSync, readdirSync, realpathSync, statSync, type Dirent } from 'fs';
 import { basename, isAbsolute, relative, resolve, sep } from 'path';
 import { readRegisteredRepoHarnessRepos, repoHarnessRepoIdFor, type RepoHarnessAccessMode } from '../../effects/repo-registry';
 import { hashMcpInput, tryWriteMcpAuditEntry } from './audit';
@@ -29,6 +29,7 @@ export interface GeneralRepoToolResult {
 type RepoEntryType = 'file' | 'directory' | 'symlink' | 'other';
 type SymlinkTargetKind = 'internal' | 'external' | 'none';
 type SnapshotState = 'ready' | 'index_lagging' | 'failed';
+const ENTRY_REVISION: unique symbol = Symbol('entryRevision');
 
 interface RepoRecord {
   repoId: string;
@@ -66,6 +67,7 @@ interface ResolvedRepoPath {
 }
 
 interface ManifestEntry {
+  [ENTRY_REVISION]?: string;
   path: string;
   type: RepoEntryType;
   size?: number;
@@ -82,10 +84,25 @@ interface ManifestEntry {
   symlink_target_kind: SymlinkTargetKind;
 }
 
+interface ManifestCounts {
+  entries: number;
+  files: number;
+  directories: number;
+  symlinks: number;
+  indexed: number;
+  unindexed: number;
+  index_lagging: number;
+  text: number;
+  binary: number;
+  content_deferred: number;
+}
+
 interface VisibleEntrySnapshot {
   id: string;
   repoId: string;
   repoRoot: string;
+  coverage: 'complete' | 'page';
+  content: 'exact' | 'metadata';
   state: SnapshotState;
   createdAtMs: number;
   createdAt: string;
@@ -109,6 +126,19 @@ interface VisibleEntrySnapshot {
 interface EntryMetadataCacheStats {
   hits: number;
   misses: number;
+}
+
+interface CodeGraphEntryMetadata {
+  language?: string;
+  nodeCount?: number;
+  size?: number;
+  lagging: boolean;
+}
+
+interface PendingWalkEntry {
+  relativePath: string;
+  absolutePath: string;
+  dirent: Dirent;
 }
 
 interface EntryMetadataCacheValue {
@@ -386,17 +416,6 @@ function metadataSignature(fileStat: ReturnType<typeof statSync>, type: RepoEntr
   ].join(':');
 }
 
-function binaryProbe(path: string): boolean {
-  const fd = openSync(path, constants.O_RDONLY);
-  try {
-    const buffer = Buffer.alloc(BINARY_PROBE_BYTES);
-    const bytesRead = readSync(fd, buffer, 0, BINARY_PROBE_BYTES, 0);
-    return buffer.subarray(0, bytesRead).includes(0);
-  } finally {
-    closeSync(fd);
-  }
-}
-
 function resolveRepoPath(repo: RepoRecord, inputPath: unknown, ignore: IgnorePolicy, opts: {
   requireFile?: boolean;
   requireDirectory?: boolean;
@@ -539,8 +558,8 @@ function commonFields(repo: RepoRecord, ignore: IgnorePolicy, snapshot: VisibleE
   };
 }
 
-function entryMetadataCacheKey(resolved: ResolvedRepoPath, ignore: IgnorePolicy): string {
-  return `entry_${sha256(`${resolved.repo.repoId}\0${resolved.repo.registryRevision}\0${ignore.digest}\0${resolved.relativePath}\0${resolved.metadataSignature}`).slice(0, 16)}`;
+function entryMetadataCacheKey(resolved: ResolvedRepoPath, ignore: IgnorePolicy, contentHash = true): string {
+  return `entry_${sha256(`${resolved.repo.repoId}\0${resolved.repo.registryRevision}\0${ignore.digest}\0${resolved.relativePath}\0${resolved.metadataSignature}\0${contentHash ? 'content-hash' : 'metadata-only'}`).slice(0, 16)}`;
 }
 
 function rememberEntryMetadata(key: string, entry: ManifestEntry): void {
@@ -552,23 +571,29 @@ function rememberEntryMetadata(key: string, entry: ManifestEntry): void {
   }
 }
 
-function metadataForResolved(resolved: ResolvedRepoPath, ignore: IgnorePolicy, stats?: EntryMetadataCacheStats): ManifestEntry {
-  const cacheKey = entryMetadataCacheKey(resolved, ignore);
-  const cached = ENTRY_METADATA_CACHE.get(cacheKey);
-  if (cached) {
-    stats && (stats.hits += 1);
-    ENTRY_METADATA_CACHE.delete(cacheKey);
-    ENTRY_METADATA_CACHE.set(cacheKey, { entry: cached.entry, lastUsedAtMs: Date.now() });
-    return { ...cached.entry };
+function metadataForResolved(resolved: ResolvedRepoPath, ignore: IgnorePolicy, stats?: EntryMetadataCacheStats, opts: { contentHash?: boolean; cache?: boolean } = {}): ManifestEntry {
+  const contentHash = opts.contentHash ?? true;
+  const useCache = opts.cache ?? true;
+  const cacheKey = useCache ? entryMetadataCacheKey(resolved, ignore, contentHash) : '';
+  if (useCache) {
+    const cached = ENTRY_METADATA_CACHE.get(cacheKey);
+    if (cached) {
+      stats && (stats.hits += 1);
+      ENTRY_METADATA_CACHE.delete(cacheKey);
+      ENTRY_METADATA_CACHE.set(cacheKey, { entry: cached.entry, lastUsedAtMs: Date.now() });
+      return { ...cached.entry };
+    }
   }
   stats && (stats.misses += 1);
-  let binary = false;
+  let binary: boolean | undefined = resolved.contentFile ? undefined : false;
   let fileHash: string | undefined;
-  if (resolved.readable && resolved.contentFile) {
-    binary = binaryProbe(resolved.canonicalPath);
-    fileHash = sha256(readFileSync(resolved.canonicalPath));
+  if (contentHash && resolved.readable && resolved.contentFile) {
+    const raw = readFileSync(resolved.canonicalPath);
+    binary = raw.subarray(0, BINARY_PROBE_BYTES).includes(0);
+    fileHash = sha256(raw);
   }
-  const entry = {
+  const entry: ManifestEntry = {
+    [ENTRY_REVISION]: resolved.metadataSignature,
     path: resolved.relativePath,
     type: resolved.type,
     size: resolved.size,
@@ -580,11 +605,11 @@ function metadataForResolved(resolved: ResolvedRepoPath, ignore: IgnorePolicy, s
     writable: resolved.repo.accessMode === 'read_write' && resolved.readable,
     symlink_target_kind: resolved.symlinkTargetKind,
   };
-  rememberEntryMetadata(cacheKey, entry);
+  if (useCache) rememberEntryMetadata(cacheKey, entry);
   return { ...entry };
 }
 
-function walkVisibleEntries(repo: RepoRecord, ignore: IgnorePolicy, startRelative = '.', stats: EntryMetadataCacheStats = { hits: 0, misses: 0 }): { entries: ManifestEntry[]; partial: boolean; walkerErrors: number } {
+function walkVisibleEntries(repo: RepoRecord, ignore: IgnorePolicy, startRelative = '.', stats: EntryMetadataCacheStats = { hits: 0, misses: 0 }, opts: { contentHash?: boolean; cacheMetadata?: boolean } = {}): { entries: ManifestEntry[]; partial: boolean; walkerErrors: number } {
   const start = resolveRepoPath(repo, startRelative, ignore, { allowRoot: true, allowExternalSymlinkMetadata: true });
   const entries: ManifestEntry[] = [];
   let walkerErrors = 0;
@@ -606,7 +631,7 @@ function walkVisibleEntries(repo: RepoRecord, ignore: IgnorePolicy, startRelativ
         try {
           const childLstat = lstatSync(childAbsolute);
           resolvedChild = resolveWalkedRepoPath(repo, ignore, childRelative, childAbsolute, childLstat);
-          entries.push(metadataForResolved(resolvedChild, ignore, stats));
+          entries.push(metadataForResolved(resolvedChild, ignore, stats, { contentHash: opts.contentHash ?? true, cache: opts.cacheMetadata ?? true }));
         } catch (_error) {
           walkerErrors += 1;
         }
@@ -619,26 +644,96 @@ function walkVisibleEntries(repo: RepoRecord, ignore: IgnorePolicy, startRelativ
     }
   };
 
-  if (start.relativePath !== '.') entries.push(metadataForResolved(start, ignore, stats));
+  if (start.relativePath !== '.') entries.push(metadataForResolved(start, ignore, stats, { contentHash: opts.contentHash ?? true, cache: opts.cacheMetadata ?? true }));
   if (start.readable && start.type === 'directory') visit(start.canonicalPath, start.relativePath);
   return { entries: entries.sort((a, b) => a.path.localeCompare(b.path)), partial: walkerErrors > 0, walkerErrors };
+}
+
+function pushManifestChildren(pending: PendingWalkEntry[], absoluteDir: string, relativeDir: string): boolean {
+  let children: Dirent[];
+  try {
+    children = readdirSync(absoluteDir, { withFileTypes: true });
+  } catch (_error) {
+    return false;
+  }
+  for (const child of children) {
+    const childRelative = relativeDir === '.' ? child.name : `${relativeDir}/${child.name}`;
+    pending.push({
+      relativePath: childRelative,
+      absolutePath: resolve(absoluteDir, child.name),
+      dirent: child,
+    });
+  }
+  pending.sort((a, b) => b.relativePath.localeCompare(a.relativePath));
+  return true;
 }
 
 function isInternalRevisionPath(path: string): boolean {
   return path === '.ai/harness/mcp/audit.log' || path.startsWith('.ai/harness/mcp/');
 }
 
-function metadataDigest(entries: ManifestEntry[]): string {
-  return `sha256:${sha256(JSON.stringify(entries.filter((entry) => !isInternalRevisionPath(entry.path)).map((entry) => [
-    entry.path,
-    entry.sha256 ?? '',
-    entry.type,
-    entry.indexed ? 'indexed' : 'unindexed',
-  ])))}`;
+function createManifestDigest() {
+  const hash = createHash('sha256');
+  hash.update('general-repo-manifest-v2\0');
+  return {
+    update(entry: ManifestEntry, revision = entry[ENTRY_REVISION] ?? entry.sha256 ?? ''): void {
+      if (isInternalRevisionPath(entry.path)) return;
+      hash.update(JSON.stringify([
+        entry.path,
+        revision,
+        entry.type,
+        entry.indexed ? 'indexed' : 'unindexed',
+      ]));
+      hash.update('\0');
+    },
+    digest(): string {
+      return `sha256:${hash.digest('hex')}`;
+    },
+  };
 }
 
-function mergeCodeGraphMetadata(repo: RepoRecord, ignore: IgnorePolicy, entries: ManifestEntry[], codeGraph: CodeGraphRepoSnapshot): { entriesByPath: Map<string, ManifestEntry>; filteredPaths: number; laggingPaths: string[] } {
-  const entriesByPath = new Map(entries.map((entry) => [entry.path, entry]));
+function metadataDigest(entries: ManifestEntry[]): string {
+  const digest = createManifestDigest();
+  for (const entry of entries) digest.update(entry);
+  return digest.digest();
+}
+
+function emptyManifestCounts(): ManifestCounts {
+  return {
+    entries: 0,
+    files: 0,
+    directories: 0,
+    symlinks: 0,
+    indexed: 0,
+    unindexed: 0,
+    index_lagging: 0,
+    text: 0,
+    binary: 0,
+    content_deferred: 0,
+  };
+}
+
+function addManifestCount(counts: ManifestCounts, entry: ManifestEntry): void {
+  counts.entries += 1;
+  if (entry.type === 'file') counts.files += 1;
+  if (entry.type === 'directory') counts.directories += 1;
+  if (entry.type === 'symlink') counts.symlinks += 1;
+  if (entry.indexed) counts.indexed += 1;
+  else counts.unindexed += 1;
+  if (entry.codegraph_index_lagging) counts.index_lagging += 1;
+  if (entry.type === 'file' && entry.binary === false) counts.text += 1;
+  if (entry.type === 'file' && entry.binary === true) counts.binary += 1;
+  if (entry.type === 'file' && entry.binary === undefined) counts.content_deferred += 1;
+}
+
+function countsForEntries(entries: ManifestEntry[]): ManifestCounts {
+  const counts = emptyManifestCounts();
+  for (const entry of entries) addManifestCount(counts, entry);
+  return counts;
+}
+
+function codeGraphMetadataIndex(repo: RepoRecord, ignore: IgnorePolicy, codeGraph: CodeGraphRepoSnapshot): { byPath: Map<string, CodeGraphEntryMetadata>; filteredPaths: number; laggingPaths: Set<string> } {
+  const byPath = new Map<string, CodeGraphEntryMetadata>();
   let filteredPaths = 0;
   const laggingPaths = new Set<string>();
 
@@ -651,17 +746,18 @@ function mergeCodeGraphMetadata(repo: RepoRecord, ignore: IgnorePolicy, entries:
         continue;
       }
       const resolved = resolveRepoPath(repo, relativePath, ignore, { allowExternalSymlinkMetadata: true });
-      const entry = entriesByPath.get(resolved.relativePath);
-      if (!entry || resolved.type !== 'file') {
+      if (resolved.type !== 'file') {
         filteredPaths += 1;
         continue;
       }
-      entry.indexed = true;
-      entry.codegraph_language = file.language;
-      entry.codegraph_node_count = file.nodeCount;
-      entry.codegraph_size = file.size;
-      if (typeof file.size === 'number' && typeof entry.size === 'number' && file.size !== entry.size) {
-        entry.codegraph_index_lagging = true;
+      const lagging = typeof file.size === 'number' && typeof resolved.size === 'number' && file.size !== resolved.size;
+      byPath.set(resolved.relativePath, {
+        language: file.language,
+        nodeCount: file.nodeCount,
+        size: file.size,
+        lagging,
+      });
+      if (lagging) {
         laggingPaths.add(resolved.relativePath);
       }
     } catch (error) {
@@ -672,18 +768,139 @@ function mergeCodeGraphMetadata(repo: RepoRecord, ignore: IgnorePolicy, entries:
     }
   }
 
-  return { entriesByPath, filteredPaths, laggingPaths: [...laggingPaths].sort((a, b) => a.localeCompare(b)) };
+  return { byPath, filteredPaths, laggingPaths };
 }
 
-function buildVisibleEntrySnapshot(ctx: GeneralRepoToolContext, repo: RepoRecord, ignore: IgnorePolicy): VisibleEntrySnapshot {
+function applyCodeGraphMetadata(entry: ManifestEntry, metadata?: CodeGraphEntryMetadata): ManifestEntry {
+  if (!metadata) return entry;
+  entry.indexed = true;
+  entry.codegraph_language = metadata.language;
+  entry.codegraph_node_count = metadata.nodeCount;
+  entry.codegraph_size = metadata.size;
+  if (metadata.lagging) entry.codegraph_index_lagging = true;
+  return entry;
+}
+
+function mergeCodeGraphMetadata(repo: RepoRecord, ignore: IgnorePolicy, entries: ManifestEntry[], codeGraph: CodeGraphRepoSnapshot): { entriesByPath: Map<string, ManifestEntry>; filteredPaths: number; laggingPaths: string[] } {
+  const entriesByPath = new Map(entries.map((entry) => [entry.path, entry]));
+  const indexed = codeGraphMetadataIndex(repo, ignore, codeGraph);
+  let filteredPaths = indexed.filteredPaths;
+
+  for (const [path, metadata] of indexed.byPath) {
+    const entry = entriesByPath.get(path);
+    if (!entry) {
+      filteredPaths += 1;
+      continue;
+    }
+    applyCodeGraphMetadata(entry, metadata);
+  }
+
+  const laggingPaths = [...indexed.laggingPaths].sort((a, b) => a.localeCompare(b));
+  return { entriesByPath, filteredPaths, laggingPaths };
+}
+
+function buildManifestPageSnapshot(ctx: GeneralRepoToolContext, repo: RepoRecord, ignore: IgnorePolicy, args: Record<string, unknown>): { snapshot: VisibleEntrySnapshot; counts: ManifestCounts; nextCursor: string | null } {
+  const createdAtMs = Date.now();
+  const codeGraph = (ctx.codeGraphAdapter ?? DEFAULT_CODEGRAPH_ADAPTER).discoverRepo(repo.canonicalRoot);
+  const indexed = codeGraphMetadataIndex(repo, ignore, codeGraph);
+  const entryMetadataStats = { hits: 0, misses: 0 };
+  const counts = emptyManifestCounts();
+  const digest = createManifestDigest();
+  const pageSize = numberArg(args.page_size, DEFAULT_PAGE_SIZE, 1, HARD_PAGE_SIZE);
+  const offset = numberArg(args.cursor, 0, 0, Number.MAX_SAFE_INTEGER);
+  const pageEntries: ManifestEntry[] = [];
+  const pageByPath = new Map<string, ManifestEntry>();
+  const pending: PendingWalkEntry[] = [];
+  let walkerErrors = 0;
+
+  const start = resolveRepoPath(repo, '.', ignore, { allowRoot: true, allowExternalSymlinkMetadata: true });
+  if (start.readable && start.type === 'directory' && !pushManifestChildren(pending, start.canonicalPath, start.relativePath)) {
+    walkerErrors += 1;
+  }
+
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (!current) break;
+    const ignored = isIgnored(ignore, current.relativePath);
+    let resolvedChild: ResolvedRepoPath | null = null;
+    if (!ignored) {
+      try {
+        const childLstat = lstatSync(current.absolutePath);
+        resolvedChild = resolveWalkedRepoPath(repo, ignore, current.relativePath, current.absolutePath, childLstat);
+        const includeContentHash = counts.entries >= offset && pageEntries.length < pageSize;
+        const entry = applyCodeGraphMetadata(metadataForResolved(resolvedChild, ignore, entryMetadataStats, {
+          contentHash: includeContentHash,
+          cache: includeContentHash,
+        }), indexed.byPath.get(resolvedChild.relativePath));
+        digest.update(entry);
+        addManifestCount(counts, entry);
+        if (counts.entries > offset && pageEntries.length < pageSize) {
+          pageEntries.push(entry);
+          pageByPath.set(entry.path, entry);
+        }
+      } catch (_error) {
+        walkerErrors += 1;
+      }
+    }
+
+    if (current.dirent.isDirectory()) {
+      if (!pushManifestChildren(pending, current.absolutePath, current.relativePath)) walkerErrors += 1;
+    } else if (resolvedChild?.type === 'directory') {
+      if (!pushManifestChildren(pending, resolvedChild.canonicalPath, current.relativePath)) walkerErrors += 1;
+    }
+  }
+
+  const manifestDigest = digest.digest();
+  const id = `snap_${sha256(`${repo.repoId}\0${repo.registryRevision}\0${ignore.digest}\0${codeGraph.indexRevision}\0${manifestDigest}`).slice(0, 16)}`;
+  const coverage: VisibleEntrySnapshot['coverage'] = offset === 0 && pageEntries.length === counts.entries ? 'complete' : 'page';
+  const cacheKey = coverage === 'complete'
+    ? `cache_${sha256(`${repo.repoId}\0${repo.registryRevision}\0${ignore.digest}\0${id}`).slice(0, 16)}`
+    : `cache_${sha256(`${repo.repoId}\0${repo.registryRevision}\0${ignore.digest}\0${id}\0repo_manifest\0${offset}\0${pageSize}`).slice(0, 16)}`;
+  const state: SnapshotState = codeGraph.available && indexed.laggingPaths.size > 0
+    ? 'index_lagging'
+    : 'ready';
+  const expiresAtMs = createdAtMs + SNAPSHOT_TTL_MS;
+  const snapshot: VisibleEntrySnapshot = {
+    id,
+    repoId: repo.repoId,
+    repoRoot: repo.canonicalRoot,
+    coverage,
+    content: coverage === 'complete' ? 'exact' : 'metadata',
+    state,
+    createdAtMs,
+    createdAt: new Date(createdAtMs).toISOString(),
+    expiresAt: new Date(expiresAtMs).toISOString(),
+    ttlMs: SNAPSHOT_TTL_MS,
+    cacheKey,
+    cacheHit: false,
+    cacheSize: SNAPSHOT_CACHE.size,
+    entries: pageEntries,
+    entriesByPath: pageByPath,
+    manifestDigest,
+    partial: walkerErrors > 0,
+    walkerErrors,
+    entryMetadataCacheHits: entryMetadataStats.hits,
+    entryMetadataCacheMisses: entryMetadataStats.misses,
+    codeGraph,
+    codeGraphFilteredPaths: indexed.filteredPaths,
+    codeGraphLaggingPaths: [...indexed.laggingPaths].sort((a, b) => a.localeCompare(b)),
+  };
+  const nextCursor = offset + pageEntries.length < counts.entries ? String(offset + pageEntries.length) : null;
+  return { snapshot: rememberSnapshot(snapshot), counts, nextCursor };
+}
+
+function buildVisibleEntrySnapshot(ctx: GeneralRepoToolContext, repo: RepoRecord, ignore: IgnorePolicy, opts: { contentHash?: boolean } = {}): VisibleEntrySnapshot {
   const createdAtMs = Date.now();
   const codeGraph = (ctx.codeGraphAdapter ?? DEFAULT_CODEGRAPH_ADAPTER).discoverRepo(repo.canonicalRoot);
   const entryMetadataStats = { hits: 0, misses: 0 };
-  const walked = walkVisibleEntries(repo, ignore, '.', entryMetadataStats);
+  const contentHash = opts.contentHash ?? true;
+  const walked = walkVisibleEntries(repo, ignore, '.', entryMetadataStats, { contentHash, cacheMetadata: contentHash });
   const merged = mergeCodeGraphMetadata(repo, ignore, walked.entries, codeGraph);
   const manifestDigest = metadataDigest(walked.entries);
   const id = `snap_${sha256(`${repo.repoId}\0${repo.registryRevision}\0${ignore.digest}\0${codeGraph.indexRevision}\0${manifestDigest}`).slice(0, 16)}`;
-  const cacheKey = `cache_${sha256(`${repo.repoId}\0${repo.registryRevision}\0${ignore.digest}\0${id}`).slice(0, 16)}`;
+  const cacheKey = contentHash
+    ? `cache_${sha256(`${repo.repoId}\0${repo.registryRevision}\0${ignore.digest}\0${id}`).slice(0, 16)}`
+    : `cache_${sha256(`${repo.repoId}\0${repo.registryRevision}\0${ignore.digest}\0${id}\0metadata-only`).slice(0, 16)}`;
   const state: SnapshotState = codeGraph.available && merged.laggingPaths.length > 0
     ? 'index_lagging'
     : 'ready';
@@ -692,6 +909,8 @@ function buildVisibleEntrySnapshot(ctx: GeneralRepoToolContext, repo: RepoRecord
     id,
     repoId: repo.repoId,
     repoRoot: repo.canonicalRoot,
+    coverage: 'complete',
+    content: contentHash ? 'exact' : 'metadata',
     state,
     createdAtMs,
     createdAt: new Date(createdAtMs).toISOString(),
@@ -753,7 +972,15 @@ function rememberSnapshot(snapshot: VisibleEntrySnapshot): VisibleEntrySnapshot 
   };
 }
 
-function cachedSnapshotById(repo: RepoRecord, snapshotId: unknown): VisibleEntrySnapshot | null {
+function snapshotCoversPaths(snapshot: VisibleEntrySnapshot, paths?: string[], opts: { requireHashes?: boolean } = {}): boolean {
+  if (!paths || paths.length === 0) return snapshot.coverage === 'complete' && (!opts.requireHashes || snapshot.content === 'exact');
+  if (snapshot.coverage !== 'complete' && paths.some((path) => !snapshot.entriesByPath.has(path))) return false;
+  if (snapshot.coverage === 'complete' && paths.some((path) => !snapshot.entriesByPath.has(path))) return false;
+  if (opts.requireHashes && paths.some((path) => typeof snapshot.entriesByPath.get(path)?.sha256 !== 'string')) return false;
+  return true;
+}
+
+function cachedSnapshotById(repo: RepoRecord, snapshotId: unknown, paths?: string[], opts: { requireHashes?: boolean } = {}): VisibleEntrySnapshot | null {
   const requested = typeof snapshotId === 'string' ? snapshotId.trim() : '';
   if (!requested) return null;
   const now = Date.now();
@@ -762,7 +989,7 @@ function cachedSnapshotById(repo: RepoRecord, snapshotId: unknown): VisibleEntry
       SNAPSHOT_CACHE.delete(key);
       continue;
     }
-    if (cached.id === requested && cached.repoId === repo.repoId && cached.repoRoot === repo.canonicalRoot) {
+    if (cached.id === requested && cached.repoId === repo.repoId && cached.repoRoot === repo.canonicalRoot && snapshotCoversPaths(cached, paths, opts)) {
       const cacheHit = {
         ...cached,
         cacheHit: true,
@@ -920,7 +1147,7 @@ function readFilePayload(repo: RepoRecord, ignore: IgnorePolicy, snapshot: Visib
 function getRepoCapabilities(ctx: GeneralRepoToolContext, args: Record<string, unknown>): GeneralRepoToolResult {
   const repo = resolveRepo(ctx, args.repo_id);
   const ignore = readIgnorePolicy(repo.canonicalRoot);
-  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore);
+  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore, { contentHash: false });
   assertSnapshotFresh(args, snapshot);
   return textResult({
     ...commonFields(repo, ignore, snapshot, { tool: 'get_repo_capabilities' }),
@@ -949,27 +1176,18 @@ function getRepoCapabilities(ctx: GeneralRepoToolContext, args: Record<string, u
 function repoManifest(ctx: GeneralRepoToolContext, args: Record<string, unknown>): GeneralRepoToolResult {
   const repo = resolveRepo(ctx, args.repo_id);
   const ignore = readIgnorePolicy(repo.canonicalRoot);
-  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore);
+  const streamed = buildManifestPageSnapshot(ctx, repo, ignore, args);
+  const snapshot = streamed.snapshot;
   assertSnapshotFresh(args, snapshot);
-  const entries = snapshot.entries;
-  const paged = pageEntries(entries, args.cursor, args.page_size);
   return textResult({
     ...commonFields(repo, ignore, snapshot, { tool: 'repo_manifest', paths: ['.'] }),
-    entries: paged.page,
-    next_cursor: paged.nextCursor,
+    entries: snapshot.entries,
+    next_cursor: streamed.nextCursor,
     complete: !snapshot.partial,
-    page_complete: paged.nextCursor === null,
-    counts: {
-      entries: entries.length,
-      files: entries.filter((entry) => entry.type === 'file').length,
-      directories: entries.filter((entry) => entry.type === 'directory').length,
-      symlinks: entries.filter((entry) => entry.type === 'symlink').length,
-      indexed: entries.filter((entry) => entry.indexed).length,
-      unindexed: entries.filter((entry) => !entry.indexed).length,
-      index_lagging: entries.filter((entry) => entry.codegraph_index_lagging).length,
-      text: entries.filter((entry) => entry.type === 'file' && entry.binary === false).length,
-      binary: entries.filter((entry) => entry.type === 'file' && entry.binary === true).length,
-    },
+    page_complete: streamed.nextCursor === null,
+    manifest_streaming: true,
+    snapshot_coverage: snapshot.coverage,
+    counts: streamed.counts,
     manifest_digest: snapshot.manifestDigest,
     walker_errors: snapshot.walkerErrors,
     codegraph: codeGraphSummary(snapshot),
@@ -980,7 +1198,7 @@ function listTree(ctx: GeneralRepoToolContext, args: Record<string, unknown>): G
   const repo = resolveRepo(ctx, args.repo_id);
   const ignore = readIgnorePolicy(repo.canonicalRoot);
   const root = resolveRepoPath(repo, args.path ?? '.', ignore, { allowRoot: true, requireDirectory: true });
-  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore);
+  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore, { contentHash: false });
   assertSnapshotFresh(args, snapshot);
   const depth = numberArg(args.depth, 1, 0, 6);
   const entries = snapshot.entries
@@ -1006,7 +1224,7 @@ function statFile(ctx: GeneralRepoToolContext, args: Record<string, unknown>): G
   const repo = resolveRepo(ctx, args.repo_id);
   const ignore = readIgnorePolicy(repo.canonicalRoot);
   const resolved = resolveRepoPath(repo, args.path, ignore);
-  const cachedSnapshot = cachedSnapshotById(repo, args.snapshot_id);
+  const cachedSnapshot = cachedSnapshotById(repo, args.snapshot_id, [resolved.relativePath], { requireHashes: true });
   if (cachedSnapshot) {
     const current = metadataForResolved(resolved, ignore);
     const cachedEntry = cachedSnapshot.entriesByPath.get(resolved.relativePath);
@@ -1043,14 +1261,17 @@ function statFile(ctx: GeneralRepoToolContext, args: Record<string, unknown>): G
 function readFileTool(ctx: GeneralRepoToolContext, args: Record<string, unknown>): GeneralRepoToolResult {
   const repo = resolveRepo(ctx, args.repo_id);
   const ignore = readIgnorePolicy(repo.canonicalRoot);
-  const cachedSnapshot = cachedSnapshotById(repo, args.snapshot_id);
+  const requestedPath = typeof args.snapshot_id === 'string' && args.snapshot_id.trim()
+    ? [resolveRepoPath(repo, args.path, ignore, { requireFile: true }).relativePath]
+    : undefined;
+  const cachedSnapshot = cachedSnapshotById(repo, args.snapshot_id, requestedPath, { requireHashes: true });
   if (cachedSnapshot) {
     return textResult({
       ...readFilePayload(repo, ignore, cachedSnapshot, args, HARD_READ_BYTES, 'read_file', true),
       codegraph: codeGraphSummary(cachedSnapshot),
     });
   }
-  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore);
+  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore, { contentHash: false });
   assertSnapshotFresh(args, snapshot);
   return textResult({
     ...readFilePayload(repo, ignore, snapshot, args),
@@ -1061,7 +1282,7 @@ function readFileTool(ctx: GeneralRepoToolContext, args: Record<string, unknown>
 function readFiles(ctx: GeneralRepoToolContext, args: Record<string, unknown>): GeneralRepoToolResult {
   const repo = resolveRepo(ctx, args.repo_id);
   const ignore = readIgnorePolicy(repo.canonicalRoot);
-  const cachedSnapshot = cachedSnapshotById(repo, args.snapshot_id);
+  const cachedSnapshot = cachedSnapshotById(repo, args.snapshot_id, undefined, { requireHashes: true });
   const snapshot = cachedSnapshot ?? buildVisibleEntrySnapshot(ctx, repo, ignore);
   if (!cachedSnapshot) assertSnapshotFresh(args, snapshot);
   const requests = Array.isArray(args.requests) ? args.requests : [];
@@ -1115,7 +1336,7 @@ function searchText(ctx: GeneralRepoToolContext, args: Record<string, unknown>):
   const mode = args.mode === 'regex' ? 'regex' : 'literal';
   const repo = resolveRepo(ctx, args.repo_id);
   const ignore = readIgnorePolicy(repo.canonicalRoot);
-  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore);
+  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore, { contentHash: false });
   assertSnapshotFresh(args, snapshot);
   const requestedPaths = Array.isArray(args.paths) && args.paths.length > 0 ? args.paths : ['.'];
   const candidates: ManifestEntry[] = [];
@@ -1151,7 +1372,9 @@ function searchText(ctx: GeneralRepoToolContext, args: Record<string, unknown>):
     if (entry.type !== 'file' || !entry.readable || seen.has(entry.path) || entry.binary || (entry.size ?? 0) > SEARCH_FILE_SCAN_BYTES) continue;
     seen.add(entry.path);
     const resolved = resolveRepoPath(repo, entry.path, ignore, { requireFile: true });
-    const text = readFileSync(resolved.canonicalPath, 'utf-8');
+    const raw = readFileSync(resolved.canonicalPath);
+    const text = raw.toString('utf-8');
+    const fileHash = entry.sha256 ?? sha256(raw);
     const lines = text.split(/\r?\n/);
     for (let index = 0; index < lines.length; index += 1) {
       const line = lines[index] ?? '';
@@ -1166,7 +1389,7 @@ function searchText(ctx: GeneralRepoToolContext, args: Record<string, unknown>):
         line: index + 1,
         column: column + 1,
         snippet: line.slice(Math.max(0, column - 60), column + 120),
-        sha256: entry.sha256,
+        sha256: fileHash,
         indexed: entry.indexed,
         backend: entry.indexed ? 'codegraph-indexed-filesystem-search' : 'filesystem-fallback',
       });

--- a/tasks/notes/20260622-repo-harness-codegraph.notes.md
+++ b/tasks/notes/20260622-repo-harness-codegraph.notes.md
@@ -104,18 +104,28 @@ Sprint 0 contract freeze for `plans/sprints/20260622-repo-harness-codegraph-spri
   changes, and registry revision changes produce different cache keys.
 - `docs/researches/20260623-general-repo-reader-performance-baseline.md`
   records the first reproducible baseline. The 10k fixture completed with a
-  warm manifest first page at 95.31 ms and warm search at 512.12 ms after the
-  walker optimization. The 100k fixture completed without OOM, returned
-  paginated results, and met the warm-path SLO: manifest 906.77 ms, read first
-  chunk 0.94 ms, and search 1038.71 ms.
+  warm manifest first page at 76.37 ms and warm search at 499.84 ms. The 100k
+  fixture completed without OOM, returned paginated results, and met the
+  warm-path SLO: manifest 733.76 ms, read first chunk 0.74 ms, and search
+  779.04 ms.
 - The walker optimization removes the per-entry `resolveRepoPath` hot path for
   manifest traversal and constructs metadata directly from the directory entry
   and one `lstat`. Explicit `snapshot_id` stat/read calls can reuse a cached
   snapshot and validate the requested file hash instead of rebuilding the full
   repo snapshot. This preserves stale detection for the requested file while
   removing whole-repo revalidation from ordinary warm read chunks.
-- The 500k fixture remains open. A `bun run benchmark:mcp-reader -- --entries
-  500000 --json` run was interrupted after more than 9 minutes without JSON
-  output, and the temporary fixture was removed. True streaming manifest work is
-  still needed because cold manifest construction still materializes and sorts
-  the full visible entry set.
+- `repo_manifest` now uses a streaming page builder: it walks the visible tree
+  to prove counts and a metadata-revision digest, but retains only the requested
+  page entries. The current page still carries exact content hashes; non-page
+  file content metadata is counted as `content_deferred` and is computed when a
+  later page, `stat_file`, `read_file`, or `search_text` actually returns
+  content.
+- Metadata-only traversals no longer populate the bounded entry metadata cache.
+  This avoids 500k sequential cache-thrash when the visible entry count exceeds
+  the 200k cache cap; exact content metadata remains cached for returned page
+  entries and read/stat paths.
+- The 500k fixture now completes: manifest 12201.90 ms warm first page, read
+  first chunk 3.67 ms, warm search 12668.28 ms, with
+  `counts.content_deferred=499010`. This records the Sprint 2 baseline and
+  leaves 500k latency as a future optimization target rather than an open S2
+  checklist item.

--- a/tests/cli/mcp-reader-tools.test.ts
+++ b/tests/cli/mcp-reader-tools.test.ts
@@ -153,6 +153,27 @@ describe('MCP reader tools', () => {
         expect(manifest.ignore_digest).toMatch(/^sha256:[a-f0-9]{64}$/);
         expect(manifest.complete).toBe(true);
 
+        const streamedManifest = await jsonTool(ctx, 'repo_manifest', { repo_id: repoId, page_size: 3 });
+        expect(streamedManifest.entries).toHaveLength(3);
+        expect(streamedManifest.next_cursor).toBe('3');
+        expect(streamedManifest.snapshot_coverage).toBe('page');
+        expect(streamedManifest.manifest_streaming).toBe(true);
+        expect(streamedManifest.counts.content_deferred).toBeGreaterThan(0);
+        const streamedRead = await jsonTool(ctx, 'read_file', {
+          repo_id: repoId,
+          path: 'src/index.ts',
+          snapshot_id: streamedManifest.snapshot_id,
+        });
+        expect(streamedRead.error).toBeUndefined();
+        expect(streamedRead.snapshot_id).toBe(streamedManifest.snapshot_id);
+        const streamedSearch = await jsonTool(ctx, 'search_text', {
+          repo_id: repoId,
+          query: 'readerFixture',
+          snapshot_id: streamedManifest.snapshot_id,
+        });
+        expect(streamedSearch.error).toBeUndefined();
+        expect(streamedSearch.matches.some((match: { path: string }) => match.path === 'src/index.ts')).toBe(true);
+
         const tree = await jsonTool(ctx, 'list_tree', { repo_id: repoId, path: '.', depth: 3, page_size: 1000 });
         const treePaths = tree.entries.map((entry: { path: string }) => entry.path);
         expect(treePaths).toContain('.env');


### PR DESCRIPTION
## Summary

- stream `repo_manifest` page snapshots so large manifests retain only the requested page while still walking the full tree for deterministic counts and snapshot digest
- add `manifest_streaming`, `snapshot_coverage`, and `counts.content_deferred` to make deferred non-page content hashing explicit
- keep exact hashes for returned page entries plus `read_file`/`read_files`/`search_text` result content, with coverage guards for page-scoped snapshot reuse
- record 10k/100k/500k reader baselines and mark S2-PERF-001/S2-PERF-004 complete in the sprint ledger

## Validation

- `bun run check:type`
- `bun test tests/cli/mcp-reader-tools.test.ts tests/cli/mcp-codegraph-contract.test.ts`
- `bun test tests/cli/mcp-reader-tools.test.ts tests/cli/mcp-codegraph-contract.test.ts tests/cli/mcp-policy.test.ts tests/cli/mcp-tools.test.ts tests/cli/codegraph.test.ts tests/cli/codegraph-resolver.test.ts tests/tooling/codegraph-integration.test.ts && bun run check:type`
- `bun test`
- `bash scripts/check-deploy-sql-order.sh`
- `bash scripts/check-architecture-sync.sh`
- `bash scripts/check-task-sync.sh`
- `bun scripts/inspect-project-state.ts --repo . --format text`
- `bash scripts/ensure-codegraph.sh --sync`
- `bash scripts/prepare-codex-handoff.sh --reason codegraph-s2-streaming-manifest && bash scripts/check-task-workflow.sh --strict`
- `bash scripts/migrate-project-template.sh --repo . --dry-run`
- `bun src/cli/index.ts setup check --target codex --check-updates --json` (exit 0; optional `runtime.skills_cli` timeout warning only)

## Baselines

- 10k fixture: warm first page 76.37 ms, RSS 133,677,056, `content_deferred=9019`
- 100k fixture: warm first page 733.76 ms, RSS 416,284,672, `content_deferred=99010`
- 500k fixture: warm first page 12,201.90 ms, RSS 1,677,410,304, `content_deferred=499010`
