### PR TITLE
Add capability-gated write_file tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,14 +351,18 @@ planner/reviewer that reads state and moves an idea through PRD, checklist
 Sprint, and Codex goal handoff artifacts — with no source-code write access,
 arbitrary shell execution, or default Codex runner. Codex remains the executor.
 
-The same `planner` Connector also exposes read-only general repo tools for
+The same `planner` Connector also exposes general repo tools for
 registered adopted repos. Use `discover_harness_repos` first, then call
 `list_allowed_roots` to get the stable `repo_id`. General repo reads use
 `repo_manifest`, `list_tree`, `stat_file`, `read_file`, `read_files`, and
-`search_text`. The repo whitelist is the authorization boundary, `.ignore` is
-the only content exclusion source, paths are repo-relative, and authorized file
-content is not implicitly redacted. External non-repo local roots require
-explicit `--allow-root` authorization.
+`search_text`. The initial write surface is `write_file`, which is rejected
+unless that registered repo is explicitly configured as `read_write`.
+`write_file` creates only with `must_not_exist: true`, replaces only with
+`expected_sha256`, and reports `before`, `after`, `diff`, `mutation_id`, and
+`index_state` after an atomic same-directory rename. The repo whitelist is the
+authorization boundary, `.ignore` is the only content exclusion source, paths
+are repo-relative, and authorized file content is not implicitly redacted.
+External non-repo local roots require explicit `--allow-root` authorization.
 
 When CodeGraph is initialized for a registered repo, the general reader merges
 CodeGraph indexed-file metadata into manifest/stat/read/search responses while

--- a/assets/mcp/general-repo-reader-tools.v1.schema.json
+++ b/assets/mcp/general-repo-reader-tools.v1.schema.json
@@ -45,7 +45,7 @@
     },
     "tools": {
       "type": "array",
-      "minItems": 7,
+      "minItems": 8,
       "items": {
         "$ref": "#/$defs/tool"
       }
@@ -117,7 +117,8 @@
             "search_text",
             "read_file",
             "read_files",
-            "stat_file"
+            "stat_file",
+            "write_file"
           ]
         },
         "description": {
@@ -135,13 +136,13 @@
           "additionalProperties": false,
           "properties": {
             "readOnlyHint": {
-              "const": true
+              "type": "boolean"
             },
             "destructiveHint": {
-              "const": false
+              "type": "boolean"
             },
             "idempotentHint": {
-              "const": true
+              "type": "boolean"
             },
             "openWorldHint": {
               "const": false
@@ -500,6 +501,64 @@
           "type",
           "indexed",
           "readable"
+        ],
+        "properties": {},
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "write_file",
+      "description": "Create or replace one repo-relative file in a read_write repo using revision preconditions and atomic same-directory rename.",
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "input_schema": {
+        "type": "object",
+        "required": [
+          "repo_id",
+          "path",
+          "content"
+        ],
+        "properties": {
+          "repo_id": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "encoding": {
+            "enum": [
+              "utf-8",
+              "base64"
+            ]
+          },
+          "expected_sha256": {
+            "type": "string"
+          },
+          "must_not_exist": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "required": [
+          "repo_id",
+          "snapshot_id",
+          "ignore_digest",
+          "path",
+          "mutation_id",
+          "before",
+          "after",
+          "diff",
+          "index_state"
         ],
         "properties": {},
         "additionalProperties": false

--- a/docs/architecture/decisions/20260622-general-repo-codegraph-access.md
+++ b/docs/architecture/decisions/20260622-general-repo-codegraph-access.md
@@ -41,8 +41,9 @@ For a registered repo:
 - Authorized file content is not implicitly redacted in tool responses for this
   API. Logs, traces, metrics, errors, and audit records must not include file
   content.
-- Write tools are not registered for read-only repos. Write access requires an
-  explicit repo-level `read_write` capability.
+- Write tools are rejected for read-only repos. Write access requires an
+  explicit repo-level `read_write` capability; tool availability is advertised
+  through `get_repo_capabilities.write_tools`.
 - Every overwriting write, patch, move, or delete operation requires a revision
   precondition such as `expected_sha256`; new file creation requires an explicit
   must-not-exist precondition.
@@ -59,8 +60,9 @@ Sprint 0 freezes the read contract for:
 - `read_files`
 - `search_text`
 
-The write contract remains design-frozen but implementation-gated until the
-read plane and snapshot behavior are proven.
+The initial write implementation covers `write_file` create/replace. Patch,
+move, delete, and explicit index-refresh tools remain implementation-gated until
+their Sprint 3 slices land.
 
 ## Snapshot Contract
 

--- a/docs/repo-harness-chatgpt-mcp-setup.md
+++ b/docs/repo-harness-chatgpt-mcp-setup.md
@@ -123,14 +123,15 @@ If `repo-harness mcp doctor --repo . --json` reports `chatgpt.serverNameConfigur
 
 Use ChatGPT for planning and review. Use Codex for local execution.
 
-1. Use the single configured Connector for workflow planning and read-only repo tools.
+1. Use the single configured Connector for workflow planning and repo tools.
 2. Call `discover_harness_repos` to list registered adopted repos, then pass `repo_path` when targeting a specific project.
 3. For registered repo document/code reading, call `list_allowed_roots` to get the stable `repo_id`, then use `get_repo_capabilities`, `repo_manifest`, `list_tree`, `stat_file`, `read_file`, `read_files`, and `search_text`.
-4. Ask ChatGPT to turn the idea into a PRD with `write_prd_from_idea`.
-5. Ask ChatGPT to turn the PRD into a checklist Sprint with `write_checklist_sprint`.
-6. Ask ChatGPT to prepare a Codex Goal with `prepare_codex_goal_from_sprint`.
-7. Open Codex locally and run the generated `/goal` prompt.
-8. Let Codex execute one Sprint task card at a time, run checks, update the checklist, and stage each completed phase before continuing.
+4. For registered repo writes, first check `get_repo_capabilities.write_tools`; only repos explicitly configured as `read_write` expose `write_file`.
+5. Ask ChatGPT to turn the idea into a PRD with `write_prd_from_idea`.
+6. Ask ChatGPT to turn the PRD into a checklist Sprint with `write_checklist_sprint`.
+7. Ask ChatGPT to prepare a Codex Goal with `prepare_codex_goal_from_sprint`.
+8. Open Codex locally and run the generated `/goal` prompt.
+9. Let Codex execute one Sprint task card at a time, run checks, update the checklist, and stage each completed phase before continuing.
 
 The sidecar is not a remote coding agent. It prepares workflow artifacts for the local agent host.
 
@@ -149,6 +150,14 @@ normal manifest entry.
 Authorized file content is not implicitly redacted in `read_file`,
 `read_files`, or `search_text` responses. The MCP audit path records tool name,
 target path, input hash, status, and errors, but not file bodies.
+
+`write_file` is the first general repo mutation tool. It is runtime-gated by the
+registered repo access mode and returns `WRITE_DISABLED` for `read_only` repos.
+New files require `must_not_exist: true`; replacements require
+`expected_sha256`; mismatches return `REVISION_CONFLICT` without writing. A
+successful write uses a same-directory temporary file plus atomic rename,
+returns `before`, `after`, `diff`, `mutation_id`, and `index_state`, and leaves
+CodeGraph refresh explicitly pending until the index-sync slice handles it.
 
 When a repo has a CodeGraph index, `repo_manifest`, `list_tree`, `stat_file`,
 `read_file`, `read_files`, and `search_text` share a deterministic

--- a/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
+++ b/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
@@ -520,10 +520,10 @@ Sprint 2 adapter/snapshot evidence:
 
 ## 10.1 写 capability 与 API
 
-- [ ] **S3-CAP-001** repo 默认保持 `read_only`。
-- [ ] **S3-CAP-002** 只有现有授权系统显式配置 `read_write` 时才注册/允许写工具。
-- [ ] **S3-CAP-003** 写请求复用同一 Path Guard 和 IgnorePolicy。
-- [ ] **S3-API-001** 实现 `write_file` create/replace。
+- [x] **S3-CAP-001** repo 默认保持 `read_only`。
+- [x] **S3-CAP-002** 只有现有授权系统显式配置 `read_write` 时才注册/允许写工具。
+- [x] **S3-CAP-003** 写请求复用同一 Path Guard 和 IgnorePolicy。
+- [x] **S3-API-001** 实现 `write_file` create/replace。
 - [ ] **S3-API-002** 实现 `apply_patch`，优先结构化 edits，必要时支持 unified diff。
 - [ ] **S3-API-003** 实现 `move_path`。
 - [ ] **S3-API-004** 实现 `delete_path`。
@@ -532,11 +532,11 @@ Sprint 2 adapter/snapshot evidence:
 
 ## 10.2 乐观并发与原子写
 
-- [ ] **S3-MUT-001** 覆盖已有文件必须提交 `expected_sha256`。
-- [ ] **S3-MUT-002** 新建必须提交 `must_not_exist: true`。
-- [ ] **S3-MUT-003** hash 不匹配返回 `REVISION_CONFLICT`，禁止自动覆盖。
-- [ ] **S3-MUT-004** 临时文件必须位于目标同一文件系统/目录边界。
-- [ ] **S3-MUT-005** 写临时文件 → fsync → atomic rename。
+- [x] **S3-MUT-001** 覆盖已有文件必须提交 `expected_sha256`。
+- [x] **S3-MUT-002** 新建必须提交 `must_not_exist: true`。
+- [x] **S3-MUT-003** hash 不匹配返回 `REVISION_CONFLICT`，禁止自动覆盖。
+- [x] **S3-MUT-004** 临时文件必须位于目标同一文件系统/目录边界。
+- [x] **S3-MUT-005** 写临时文件 → fsync → atomic rename。
 - [ ] **S3-MUT-006** 保留原文件权限和必要 metadata，策略写入 ADR。
 - [ ] **S3-MUT-007** patch 应验证每个 hunk 或精确文本 precondition。
 - [ ] **S3-MUT-008** move/delete 同样进行版本和目标存在性检查。
@@ -572,6 +572,23 @@ Sprint 2 adapter/snapshot evidence:
 - [ ] 写后 search 在定义的 index lag SLO 内可见，或明确返回 pending。
 - [ ] move/delete 后 manifest 与索引最终一致。
 - [ ] 所有写操作可通过 mutation id 审计。
+
+Sprint 3 write_file evidence:
+
+- Runtime: `src/cli/mcp/general-repo-access.ts`
+- Tests: `tests/cli/mcp-reader-tools.test.ts`
+- Schema/docs: `assets/mcp/general-repo-reader-tools.v1.schema.json`, `README.md`, `docs/repo-harness-chatgpt-mcp-setup.md`
+- Completed slice: `write_file` create/replace is gated by registered repo
+  `read_write`, reuses the general repo Path Guard and `.ignore` policy,
+  requires `must_not_exist` for create and `expected_sha256` for replace,
+  writes through a same-directory temporary file plus fsync/atomic rename, and
+  returns `mutation_id`, `before`, `after`, `diff`, and `index_state`.
+- Verified in this slice: success and precondition-conflict paths leave no
+  `.repo-harness-*` temporary files in the target directory. Full write-failure
+  injection remains open under `S3-MUT-009/010`.
+- Explicitly still open: `apply_patch`, `move_path`, `delete_path`,
+  `refresh_repo_index`, recursive directory policy, full index retry/dead-letter,
+  and complete write audit/runbook coverage.
 
 ---
 

--- a/src/cli/mcp/general-repo-access.ts
+++ b/src/cli/mcp/general-repo-access.ts
@@ -1,6 +1,6 @@
-import { createHash } from 'crypto';
-import { existsSync, lstatSync, readFileSync, readdirSync, realpathSync, statSync, type Dirent } from 'fs';
-import { basename, isAbsolute, relative, resolve, sep } from 'path';
+import { createHash, randomBytes } from 'crypto';
+import { closeSync, existsSync, fsyncSync, lstatSync, openSync, readFileSync, readdirSync, realpathSync, renameSync, rmSync, statSync, writeSync, type Dirent } from 'fs';
+import { basename, dirname, isAbsolute, relative, resolve, sep } from 'path';
 import { readRegisteredRepoHarnessRepos, repoHarnessRepoIdFor, type RepoHarnessAccessMode } from '../../effects/repo-registry';
 import { hashMcpInput, tryWriteMcpAuditEntry } from './audit';
 import { createCodeGraphCliAdapter, type CodeGraphRepoSnapshot, type GeneralRepoCodeGraphAdapter } from './codegraph-adapter';
@@ -64,6 +64,16 @@ interface ResolvedRepoPath {
   contentFile: boolean;
   symlinkTargetKind: SymlinkTargetKind;
   readable: boolean;
+}
+
+interface ResolvedRepoWritePath {
+  repo: RepoRecord;
+  relativePath: string;
+  absolutePath: string;
+  canonicalPath: string;
+  parentRelativePath: string;
+  parentCanonicalPath: string;
+  existing?: ResolvedRepoPath;
 }
 
 interface ManifestEntry {
@@ -154,6 +164,7 @@ const GENERAL_REPO_TOOLS = [
   'read_file',
   'read_files',
   'stat_file',
+  'write_file',
 ] as const;
 
 const DEFAULT_PAGE_SIZE = 300;
@@ -221,6 +232,16 @@ function numberArg(value: unknown, fallback: number, min: number, max: number): 
   const parsed = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN;
   if (!Number.isFinite(parsed)) return fallback;
   return Math.min(Math.max(Math.trunc(parsed), min), max);
+}
+
+function booleanArg(value: unknown, fallback = false): boolean {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
+    if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
+  }
+  return fallback;
 }
 
 function cachePaths(paths: string[] | undefined): string[] {
@@ -482,6 +503,75 @@ function resolveRepoPath(repo: RepoRecord, inputPath: unknown, ignore: IgnorePol
     contentFile: fileStat.isFile(),
     symlinkTargetKind,
     readable,
+  };
+}
+
+function parentRelativePath(relativePath: string): string {
+  const index = relativePath.lastIndexOf('/');
+  return index < 0 ? '.' : relativePath.slice(0, index) || '.';
+}
+
+function leafName(relativePath: string): string {
+  const index = relativePath.lastIndexOf('/');
+  return index < 0 ? relativePath : relativePath.slice(index + 1);
+}
+
+function assertRepoWriteEnabled(repo: RepoRecord): void {
+  if (repo.accessMode !== 'read_write') {
+    throw new GeneralRepoAccessError('WRITE_DISABLED', 'repo is read_only; write_file requires read_write capability', {
+      repo_id: repo.repoId,
+      access_mode: repo.accessMode,
+    });
+  }
+}
+
+function resolveRepoWritePath(repo: RepoRecord, inputPath: unknown, ignore: IgnorePolicy): ResolvedRepoWritePath {
+  const relativePath = normalizeRepoRelativePath(inputPath);
+  if (isIgnored(ignore, relativePath)) {
+    throw new GeneralRepoAccessError('PATH_IGNORED', 'path is excluded by .ignore', { path: relativePath });
+  }
+  const absolutePath = resolve(repo.canonicalRoot, relativePath);
+  if (!isPathInside(repo.canonicalRoot, absolutePath)) {
+    throw new GeneralRepoAccessError('PATH_OUTSIDE_REPO', 'path escapes repo root', { path: relativePath });
+  }
+
+  if (existsSync(absolutePath)) {
+    const existing = resolveRepoPath(repo, relativePath, ignore, { requireFile: true });
+    if (existing.type === 'symlink') {
+      throw new GeneralRepoAccessError('SYMLINK_ESCAPE', 'write_file does not write through symlinks', { path: relativePath });
+    }
+    return {
+      repo,
+      relativePath,
+      absolutePath,
+      canonicalPath: existing.canonicalPath,
+      parentRelativePath: parentRelativePath(relativePath),
+      parentCanonicalPath: realpathSync(dirname(existing.canonicalPath)),
+      existing,
+    };
+  }
+
+  const parentRelative = parentRelativePath(relativePath);
+  const parent = resolveRepoPath(repo, parentRelative, ignore, { allowRoot: true, requireDirectory: true });
+  if (!parent.readable || parent.symlinkTargetKind === 'external') {
+    throw new GeneralRepoAccessError('PATH_OUTSIDE_REPO', 'write parent escapes repo root', { path: relativePath });
+  }
+  const canonicalPath = resolve(parent.canonicalPath, leafName(relativePath));
+  if (!isPathInside(repo.canonicalRoot, canonicalPath)) {
+    throw new GeneralRepoAccessError('PATH_OUTSIDE_REPO', 'path escapes repo root', { path: relativePath });
+  }
+  const physicalRelative = toPosixPath(relative(repo.canonicalRoot, canonicalPath)) || '.';
+  if (physicalRelative !== '.' && isIgnored(ignore, physicalRelative)) {
+    throw new GeneralRepoAccessError('PATH_IGNORED', 'write target is excluded by .ignore', { path: relativePath });
+  }
+
+  return {
+    repo,
+    relativePath,
+    absolutePath,
+    canonicalPath,
+    parentRelativePath: parent.relativePath,
+    parentCanonicalPath: parent.canonicalPath,
   };
 }
 
@@ -1062,6 +1152,62 @@ function assertSnapshotEntryCurrent(snapshot: VisibleEntrySnapshot, path: string
   }
 }
 
+function writeContentBuffer(args: Record<string, unknown>): { raw: Buffer; encoding: 'utf-8' | 'base64' } {
+  if (typeof args.content !== 'string') {
+    throw new GeneralRepoAccessError('INVALID_RANGE', 'content must be a string');
+  }
+  const encoding = args.encoding === 'base64' ? 'base64' : args.encoding === undefined || args.encoding === 'utf-8' ? 'utf-8' : null;
+  if (!encoding) throw new GeneralRepoAccessError('INVALID_RANGE', 'encoding must be utf-8 or base64');
+  return { raw: Buffer.from(args.content, encoding), encoding };
+}
+
+function fsyncDirectoryBestEffort(path: string): void {
+  let fd: number | null = null;
+  try {
+    fd = openSync(path, 'r');
+    fsyncSync(fd);
+  } catch (_error) {
+    // Some filesystems/platforms do not allow directory fsync; the same-directory rename remains atomic.
+  } finally {
+    if (fd !== null) {
+      try {
+        closeSync(fd);
+      } catch (_error) {
+        // Ignore close failures on best-effort directory fsync.
+      }
+    }
+  }
+}
+
+function atomicWriteFile(target: ResolvedRepoWritePath, raw: Buffer, mode: number): void {
+  const tempPath = resolve(target.parentCanonicalPath, `.${leafName(target.relativePath)}.repo-harness-${process.pid}-${Date.now()}-${randomBytes(4).toString('hex')}.tmp`);
+  if (!isPathInside(target.parentCanonicalPath, tempPath)) {
+    throw new GeneralRepoAccessError('PATH_OUTSIDE_REPO', 'temporary write path escapes parent directory', { path: target.relativePath });
+  }
+  const fd = openSync(tempPath, 'wx', mode);
+  let renamed = false;
+  try {
+    try {
+      writeSync(fd, raw, 0, raw.length, 0);
+      fsyncSync(fd);
+    } finally {
+      closeSync(fd);
+    }
+    renameSync(tempPath, target.canonicalPath);
+    renamed = true;
+    fsyncDirectoryBestEffort(target.parentCanonicalPath);
+  } finally {
+    if (!renamed) rmSync(tempPath, { force: true });
+  }
+}
+
+function invalidateRepoCaches(repo: RepoRecord): void {
+  for (const [key, snapshot] of SNAPSHOT_CACHE) {
+    if (snapshot.repoId === repo.repoId && snapshot.repoRoot === repo.canonicalRoot) SNAPSHOT_CACHE.delete(key);
+  }
+  ENTRY_METADATA_CACHE.clear();
+}
+
 function readFilePayload(repo: RepoRecord, ignore: IgnorePolicy, snapshot: VisibleEntrySnapshot, args: Record<string, unknown>, maxBytes = HARD_READ_BYTES, tool = 'read_file', verifySnapshotEntry = false): Record<string, unknown> {
   if (args.line_range !== undefined && args.byte_range !== undefined) {
     throw new GeneralRepoAccessError('INVALID_RANGE', 'line_range and byte_range are mutually exclusive');
@@ -1156,8 +1302,8 @@ function getRepoCapabilities(ctx: GeneralRepoToolContext, args: Record<string, u
     display_name: repo.displayName,
     registry_revision: repo.registryRevision,
     source: repo.source,
-    read_tools: GENERAL_REPO_TOOLS.filter((tool) => tool !== 'get_repo_capabilities'),
-    write_tools: repo.accessMode === 'read_write' ? [] : [],
+    read_tools: GENERAL_REPO_TOOLS.filter((tool) => tool !== 'get_repo_capabilities' && tool !== 'write_file'),
+    write_tools: repo.accessMode === 'read_write' ? ['write_file'] : [],
     codegraph: {
       primary_backend: true,
       ...codeGraphSummary(snapshot),
@@ -1170,6 +1316,96 @@ function getRepoCapabilities(ctx: GeneralRepoToolContext, args: Record<string, u
       max_read_bytes: HARD_READ_BYTES,
       max_read_lines: MAX_READ_LINES,
     },
+  });
+}
+
+function writeFileTool(ctx: GeneralRepoToolContext, args: Record<string, unknown>): GeneralRepoToolResult {
+  const repo = resolveRepo(ctx, args.repo_id);
+  assertRepoWriteEnabled(repo);
+  const ignore = readIgnorePolicy(repo.canonicalRoot);
+  const target = resolveRepoWritePath(repo, args.path, ignore);
+  const { raw, encoding } = writeContentBuffer(args);
+  const expectedHash = typeof args.expected_sha256 === 'string' ? args.expected_sha256.trim() : '';
+  const mustNotExist = booleanArg(args.must_not_exist, false);
+  const existed = target.existing !== undefined;
+
+  let beforeHash: string | null = null;
+  let beforeSize = 0;
+  let mode = 0o666;
+  if (target.existing) {
+    if (mustNotExist) {
+      throw new GeneralRepoAccessError('TARGET_EXISTS', 'target already exists', { path: target.relativePath });
+    }
+    const beforeRaw = readFileSync(target.existing.canonicalPath);
+    beforeHash = sha256(beforeRaw);
+    beforeSize = beforeRaw.length;
+    mode = statSync(target.existing.canonicalPath).mode & 0o777;
+    if (!expectedHash) {
+      throw new GeneralRepoAccessError('REVISION_CONFLICT', 'expected_sha256 is required when replacing an existing file', {
+        path: target.relativePath,
+        actual_sha256: beforeHash,
+      });
+    }
+    if (expectedHash !== beforeHash) {
+      throw new GeneralRepoAccessError('REVISION_CONFLICT', 'file changed after it was read', {
+        path: target.relativePath,
+        expected_sha256: expectedHash,
+        actual_sha256: beforeHash,
+      });
+    }
+  } else if (!mustNotExist) {
+    throw new GeneralRepoAccessError('REVISION_CONFLICT', 'must_not_exist: true is required when creating a new file', {
+      path: target.relativePath,
+    });
+  }
+
+  atomicWriteFile(target, raw, mode);
+  invalidateRepoCaches(repo);
+
+  const after = resolveRepoPath(repo, target.relativePath, ignore, { requireFile: true });
+  const afterRaw = readFileSync(after.canonicalPath);
+  const afterHash = sha256(afterRaw);
+  const afterEntry = metadataForResolved(after, ignore);
+  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore, { contentHash: false });
+  const indexedEntry = snapshot.entriesByPath.get(target.relativePath);
+  const indexState = snapshot.codeGraph.available ? 'pending' : 'failed';
+  const mutationId = `mut_${sha256(`${repo.repoId}\0${target.relativePath}\0${beforeHash ?? 'new'}\0${afterHash}\0${Date.now()}`).slice(0, 16)}`;
+
+  return textResult({
+    ...commonFields(repo, ignore, snapshot, { tool: 'write_file', paths: [target.relativePath] }),
+    path: target.relativePath,
+    operation: existed ? 'replace' : 'create',
+    mutation_id: mutationId,
+    encoding,
+    before: {
+      existed,
+      sha256: beforeHash,
+      size: beforeSize,
+    },
+    after: {
+      ...afterEntry,
+      indexed: indexedEntry?.indexed ?? false,
+      codegraph_language: indexedEntry?.codegraph_language,
+      codegraph_node_count: indexedEntry?.codegraph_node_count,
+      codegraph_size: indexedEntry?.codegraph_size,
+      codegraph_index_lagging: indexedEntry?.codegraph_index_lagging,
+    },
+    diff: {
+      format: 'summary',
+      bytes_before: beforeSize,
+      bytes_after: afterRaw.length,
+      bytes_delta: afterRaw.length - beforeSize,
+      before_sha256: beforeHash,
+      after_sha256: afterHash,
+    },
+    index_state: indexState,
+    index: {
+      state: indexState,
+      action: snapshot.codeGraph.available ? 'refresh_repo_index_required' : 'codegraph_unavailable',
+      changed_paths: [target.relativePath],
+      mutation_id: mutationId,
+    },
+    codegraph: codeGraphSummary(snapshot),
   });
 }
 
@@ -1432,6 +1668,7 @@ export function hasGeneralRepoArgs(args: Record<string, unknown>): boolean {
 
 export function buildGeneralRepoToolDefinitions(): GeneralRepoToolDefinition[] {
   const readOnly = { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false };
+  const writeTool = { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false };
   const repoSchema = {
     type: 'object',
     properties: { repo_id: { type: 'string' } },
@@ -1506,6 +1743,24 @@ export function buildGeneralRepoToolDefinitions(): GeneralRepoToolDefinition[] {
       },
       annotations: readOnly,
     },
+    {
+      name: 'write_file',
+      description: 'Create or replace one repo-relative file in a read_write repo using revision preconditions and atomic same-directory rename.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          repo_id: { type: 'string' },
+          path: { type: 'string' },
+          content: { type: 'string' },
+          encoding: { enum: ['utf-8', 'base64'] },
+          expected_sha256: { type: 'string' },
+          must_not_exist: { type: 'boolean' },
+        },
+        required: ['repo_id', 'path', 'content'],
+        additionalProperties: false,
+      },
+      annotations: writeTool,
+    },
   ];
 }
 
@@ -1533,6 +1788,9 @@ export async function callGeneralRepoTool(ctx: GeneralRepoToolContext, name: str
         break;
       case 'stat_file':
         result = statFile(ctx, args);
+        break;
+      case 'write_file':
+        result = writeFileTool(ctx, args);
         break;
       default:
         return errorResult('INTERNAL_ADAPTER_ERROR', `tool is not a general repo reader tool: ${name}`);

--- a/tasks/notes/20260622-repo-harness-codegraph.notes.md
+++ b/tasks/notes/20260622-repo-harness-codegraph.notes.md
@@ -129,3 +129,25 @@ Sprint 0 contract freeze for `plans/sprints/20260622-repo-harness-codegraph-spri
   `counts.content_deferred=499010`. This records the Sprint 2 baseline and
   leaves 500k latency as a future optimization target rather than an open S2
   checklist item.
+
+## 2026-06-23 write_file slice
+
+- The first Sprint 3 mutation slice adds only `write_file` create/replace. It
+  reuses the general repo registry, Path Guard, `.ignore` policy, audit writer,
+  snapshot fields, and filesystem fallback path instead of adding a parallel
+  write service.
+- `read_only` repos return `WRITE_DISABLED`. `read_write` is sourced only from
+  the registered repo entry and surfaced through `get_repo_capabilities`.
+- New files require `must_not_exist: true`; replacing existing files requires
+  `expected_sha256`. Missing or stale preconditions return
+  `REVISION_CONFLICT`, and `must_not_exist` on an existing file returns
+  `TARGET_EXISTS`.
+- Writes use a temporary file in the same canonical parent directory, fsync the
+  file, then atomically rename into place. The first slice requires the parent
+  directory to already exist; directory creation, recursive delete, patch,
+  move, and delete stay out of scope.
+- CodeGraph refresh is explicit pending state in this slice:
+  `index_state: "pending"` with `refresh_repo_index_required` when CodeGraph is
+  available, or `failed` when no index is available. The process-local snapshot
+  and metadata caches are invalidated after successful writes so immediate
+  read/stat calls see filesystem truth.

--- a/tests/cli/mcp-codegraph-contract.test.ts
+++ b/tests/cli/mcp-codegraph-contract.test.ts
@@ -17,6 +17,7 @@ const TOOL_NAMES = [
   'read_file',
   'read_files',
   'stat_file',
+  'write_file',
 ];
 
 const COMMON_RESPONSE_FIELDS = [
@@ -165,7 +166,7 @@ function manifestFromSecureWalker(root: string, indexedPaths: Set<string>): { ig
 }
 
 describe('general repo CodeGraph contract', () => {
-  test('versioned schema freezes the Sprint 0 reader tool surface', () => {
+  test('versioned schema freezes the general repo reader plus initial write_file surface', () => {
     const schema = readJson(SCHEMA_PATH);
     expect(schema.properties.version.const).toBe('1');
     expect(schema.properties.policy.properties.content_exclusion.const).toBe('.ignore');
@@ -174,12 +175,24 @@ describe('general repo CodeGraph contract', () => {
     expect(schema.properties.common_response_fields.items.enum).toEqual(COMMON_RESPONSE_FIELDS);
 
     for (const tool of schema['x-repo-harness-tools']) {
-      expect(tool.annotations).toEqual({
-        readOnlyHint: true,
-        destructiveHint: false,
-        idempotentHint: true,
-        openWorldHint: false,
-      });
+      if (tool.name === 'write_file') {
+        expect(tool.annotations).toEqual({
+          readOnlyHint: false,
+          destructiveHint: true,
+          idempotentHint: false,
+          openWorldHint: false,
+        });
+        expect(tool.input_schema.required).toEqual(['repo_id', 'path', 'content']);
+        expect(tool.input_schema.properties.expected_sha256).toEqual({ type: 'string' });
+        expect(tool.input_schema.properties.must_not_exist).toEqual({ type: 'boolean' });
+      } else {
+        expect(tool.annotations).toEqual({
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: false,
+        });
+      }
       expect(tool.input_schema.additionalProperties).toBe(false);
       expect(tool.output_schema.additionalProperties).toBe(false);
       expect(tool.input_schema.properties.repo_id).toEqual({ type: 'string' });

--- a/tests/cli/mcp-reader-tools.test.ts
+++ b/tests/cli/mcp-reader-tools.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from 'bun:test';
-import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { repoHarnessRepoIdFor, type RepoHarnessAccessMode } from '../../src/effects/repo-registry';
 import { getMcpPolicy } from '../../src/cli/mcp/policy';
 import { buildReaderToolDefinitions, callReaderTool, createReaderToolContext, type ReaderToolContext } from '../../src/cli/mcp/reader-tools';
 import { WorkspaceManager } from '../../src/cli/mcp/workspaces';
@@ -12,9 +13,12 @@ async function jsonTool(ctx: ReaderToolContext, name: string, args: Record<strin
   return JSON.parse(result.content[0].text);
 }
 
-async function withReaderRepo<T>(fn: (repoRoot: string, ctx: ReaderToolContext) => Promise<T>): Promise<T> {
+async function withReaderRepo<T>(fn: (repoRoot: string, ctx: ReaderToolContext) => Promise<T>, opts: { accessMode?: RepoHarnessAccessMode } = {}): Promise<T> {
   const repoRoot = mkdtempSync(join(tmpdir(), 'repo-harness-mcp-reader-tools-'));
+  const repoHarnessHome = mkdtempSync(join(tmpdir(), 'repo-harness-mcp-home-'));
+  const previousRepoHarnessHome = process.env.REPO_HARNESS_HOME;
   try {
+    process.env.REPO_HARNESS_HOME = repoHarnessHome;
     mkdirSync(join(repoRoot, 'docs'), { recursive: true });
     mkdirSync(join(repoRoot, 'src'), { recursive: true });
     mkdirSync(join(repoRoot, 'secrets'), { recursive: true });
@@ -32,6 +36,23 @@ async function withReaderRepo<T>(fn: (repoRoot: string, ctx: ReaderToolContext) 
     writeFileSync(join(repoRoot, '.ssh', 'id_rsa'), 'private\n');
     writeFileSync(join(repoRoot, 'ignored.md'), '# Ignored\n');
     writeFileSync(join(repoRoot, 'ignored-dir', 'note.md'), '# Ignored child\n');
+    if (opts.accessMode) {
+      const canonicalRoot = realpathSync(repoRoot);
+      mkdirSync(join(repoRoot, '.ai', 'harness'), { recursive: true });
+      writeFileSync(join(repoRoot, '.ai', 'harness', 'policy.json'), '{}\n');
+      mkdirSync(repoHarnessHome, { recursive: true });
+      writeFileSync(join(repoHarnessHome, 'registered-repos.json'), `${JSON.stringify({
+        version: 1,
+        repos: [{
+          id: repoHarnessRepoIdFor(canonicalRoot),
+          path: canonicalRoot,
+          accessMode: opts.accessMode,
+          source: 'manual',
+          registeredAt: '2026-06-23T00:00:00.000Z',
+          lastSeenAt: '2026-06-23T00:00:00.000Z',
+        }],
+      }, null, 2)}\n`);
+    }
     try {
       symlinkSync(repoRoot, join(repoRoot, 'docs', 'loop'));
     } catch (_error) {
@@ -41,12 +62,18 @@ async function withReaderRepo<T>(fn: (repoRoot: string, ctx: ReaderToolContext) 
     const ctx = createReaderToolContext(repoRoot, policy, new WorkspaceManager({ allowedRoots: [repoRoot], policy }));
     return await fn(repoRoot, ctx);
   } finally {
+    if (previousRepoHarnessHome === undefined) {
+      delete process.env.REPO_HARNESS_HOME;
+    } else {
+      process.env.REPO_HARNESS_HOME = previousRepoHarnessHome;
+    }
     rmSync(repoRoot, { recursive: true, force: true });
+    rmSync(repoHarnessHome, { recursive: true, force: true });
   }
 }
 
 describe('MCP reader tools', () => {
-  test('exposes exactly the read-only reader tool registry and session-local workspaces', async () => {
+  test('exposes reader and gated general repo tool registry with session-local workspaces', async () => {
     await withReaderRepo(async (repoRoot, ctx) => {
       const definitions = buildReaderToolDefinitions();
       expect(definitions.map((tool) => tool.name)).toEqual([
@@ -62,14 +89,24 @@ describe('MCP reader tools', () => {
         'read_file',
         'read_files',
         'stat_file',
+        'write_file',
       ]);
       for (const definition of definitions) {
-        expect(definition.annotations).toMatchObject({
-          readOnlyHint: true,
-          destructiveHint: false,
-          idempotentHint: true,
-          openWorldHint: false,
-        });
+        if (definition.name === 'write_file') {
+          expect(definition.annotations).toMatchObject({
+            readOnlyHint: false,
+            destructiveHint: true,
+            idempotentHint: false,
+            openWorldHint: false,
+          });
+        } else {
+          expect(definition.annotations).toMatchObject({
+            readOnlyHint: true,
+            destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
+          });
+        }
         expect(definition.inputSchema.additionalProperties).toBe(false);
       }
 
@@ -132,8 +169,18 @@ describe('MCP reader tools', () => {
 
         const capabilities = await jsonTool(ctx, 'get_repo_capabilities', { repo_id: repoId });
         expect(capabilities.access_mode).toBe('read_only');
+        expect(capabilities.write_tools).toEqual([]);
         expect(capabilities.repo_id).toBe(repoId);
         expect(capabilities.registry_revision).toMatch(/^registry_/);
+
+        const readOnlyWrite = await jsonTool(ctx, 'write_file', {
+          repo_id: repoId,
+          path: 'docs/created-by-write.txt',
+          content: 'blocked\n',
+          must_not_exist: true,
+        });
+        expect(readOnlyWrite.error.code).toBe('WRITE_DISABLED');
+        expect(existsSync(join(repoRoot, 'docs', 'created-by-write.txt'))).toBe(false);
 
         const manifest = await jsonTool(ctx, 'repo_manifest', { repo_id: repoId, page_size: 1000 });
         const visiblePaths = manifest.entries.map((entry: { path: string }) => entry.path);
@@ -229,6 +276,128 @@ describe('MCP reader tools', () => {
         rmSync(outside, { recursive: true, force: true });
       }
     });
+  });
+
+  test('write_file is capability-gated, atomic, and guarded by revision preconditions', async () => {
+    await withReaderRepo(async (repoRoot, ctx) => {
+      writeFileSync(join(repoRoot, '.ignore'), 'ignored.md\n');
+      const fakeCodeGraph: GeneralRepoCodeGraphAdapter = {
+        discoverRepo() {
+          return {
+            available: true,
+            integrated: true,
+            source: 'test-double',
+            indexRevision: 'index_before_write',
+            latencyMs: 1,
+            files: [],
+          };
+        },
+      };
+      const writeCtx = createReaderToolContext(
+        repoRoot,
+        ctx.policy,
+        new WorkspaceManager({ allowedRoots: [repoRoot], policy: ctx.policy }),
+        fakeCodeGraph,
+      );
+      const repoId = (await jsonTool(writeCtx, 'list_allowed_roots')).roots[0].repo_id;
+      const capabilities = await jsonTool(writeCtx, 'get_repo_capabilities', { repo_id: repoId });
+      expect(capabilities.access_mode).toBe('read_write');
+      expect(capabilities.write_tools).toEqual(['write_file']);
+
+      const missingCreatePrecondition = await jsonTool(writeCtx, 'write_file', {
+        repo_id: repoId,
+        path: 'docs/generated.txt',
+        content: 'first\n',
+      });
+      expect(missingCreatePrecondition.error.code).toBe('REVISION_CONFLICT');
+      expect(existsSync(join(repoRoot, 'docs', 'generated.txt'))).toBe(false);
+
+      const created = await jsonTool(writeCtx, 'write_file', {
+        repo_id: repoId,
+        path: 'docs/generated.txt',
+        content: 'first\n',
+        must_not_exist: true,
+      });
+      expect(created.error).toBeUndefined();
+      expect(created).toMatchObject({
+        path: 'docs/generated.txt',
+        operation: 'create',
+        index_state: 'pending',
+        before: { existed: false, sha256: null, size: 0 },
+        index: { action: 'refresh_repo_index_required', changed_paths: ['docs/generated.txt'] },
+      });
+      expect(created.mutation_id).toMatch(/^mut_[a-f0-9]{16}$/);
+      expect(created.after.sha256).toMatch(/^[a-f0-9]{64}$/);
+      expect(created.diff.after_sha256).toBe(created.after.sha256);
+      expect(readFileSync(join(repoRoot, 'docs', 'generated.txt'), 'utf-8')).toBe('first\n');
+      expect(readdirSync(join(repoRoot, 'docs')).some((name) => name.includes('.repo-harness-'))).toBe(false);
+
+      const readCreated = await jsonTool(writeCtx, 'read_file', { repo_id: repoId, path: 'docs/generated.txt' });
+      expect(readCreated.content).toBe('first\n');
+      expect(readCreated.sha256).toBe(created.after.sha256);
+
+      const targetExists = await jsonTool(writeCtx, 'write_file', {
+        repo_id: repoId,
+        path: 'docs/generated.txt',
+        content: 'duplicate\n',
+        must_not_exist: true,
+      });
+      expect(targetExists.error.code).toBe('TARGET_EXISTS');
+      expect(readFileSync(join(repoRoot, 'docs', 'generated.txt'), 'utf-8')).toBe('first\n');
+      expect(readdirSync(join(repoRoot, 'docs')).some((name) => name.includes('.repo-harness-'))).toBe(false);
+
+      const conflict = await jsonTool(writeCtx, 'write_file', {
+        repo_id: repoId,
+        path: 'docs/generated.txt',
+        content: 'stale\n',
+        expected_sha256: 'bad',
+      });
+      expect(conflict.error.code).toBe('REVISION_CONFLICT');
+      expect(conflict.error.details.actual_sha256).toBe(created.after.sha256);
+      expect(readFileSync(join(repoRoot, 'docs', 'generated.txt'), 'utf-8')).toBe('first\n');
+
+      const replaced = await jsonTool(writeCtx, 'write_file', {
+        repo_id: repoId,
+        path: 'docs/generated.txt',
+        content: 'second\n',
+        expected_sha256: created.after.sha256,
+      });
+      expect(replaced.error).toBeUndefined();
+      expect(replaced.operation).toBe('replace');
+      expect(replaced.before.sha256).toBe(created.after.sha256);
+      expect(replaced.after.sha256).not.toBe(created.after.sha256);
+      expect(replaced.diff.bytes_delta).toBe('second\n'.length - 'first\n'.length);
+
+      const readReplaced = await jsonTool(writeCtx, 'read_file', { repo_id: repoId, path: 'docs/generated.txt' });
+      expect(readReplaced.content).toBe('second\n');
+      expect(readReplaced.sha256).toBe(replaced.after.sha256);
+      expect(readdirSync(join(repoRoot, 'docs')).some((name) => name.includes('.repo-harness-'))).toBe(false);
+      const statReplaced = await jsonTool(writeCtx, 'stat_file', { repo_id: repoId, path: 'docs/generated.txt' });
+      expect(statReplaced.sha256).toBe(replaced.after.sha256);
+
+      const ignored = await jsonTool(writeCtx, 'write_file', {
+        repo_id: repoId,
+        path: 'ignored.md',
+        content: 'blocked\n',
+        must_not_exist: true,
+      });
+      expect(ignored.error.code).toBe('PATH_IGNORED');
+      const missingParent = await jsonTool(writeCtx, 'write_file', {
+        repo_id: repoId,
+        path: 'missing-dir/file.txt',
+        content: 'blocked\n',
+        must_not_exist: true,
+      });
+      expect(missingParent.error.code).toBe('NOT_FOUND');
+
+      const auditText = readFileSync(join(repoRoot, '.ai', 'harness', 'mcp', 'audit.log'), 'utf-8');
+      expect(auditText).toContain('"tool":"write_file"');
+      expect(auditText).toContain('"status":"ok"');
+      expect(auditText).toContain('"status":"blocked"');
+      expect(auditText).not.toContain('first\n');
+      expect(auditText).not.toContain('second\n');
+      expect(auditText).not.toContain('stale\n');
+    }, { accessMode: 'read_write' });
   });
 
   test('general repo tools merge CodeGraph metadata under the same guarded snapshot', async () => {


### PR DESCRIPTION
## Summary

- add the first general repo mutation tool, `write_file`, gated by registered repo `read_write` access mode
- enforce create/replace preconditions: `must_not_exist: true` for new files and `expected_sha256` for replacements
- write through a same-directory temp file, fsync, atomic rename, then invalidate local reader caches so immediate stat/read sees filesystem truth
- return `mutation_id`, `before`, `after`, `diff`, and explicit `index_state`; CodeGraph refresh remains pending for the later index-sync slice
- update runtime/static MCP schema, docs, ADR, sprint ledger, and contract tests

## Validation

- `bun test tests/cli/mcp-reader-tools.test.ts`
- `bun run check:type`
- `node -e "JSON.parse(require('fs').readFileSync('assets/mcp/general-repo-reader-tools.v1.schema.json','utf8')); console.log('schema json ok')"`
- `bun test tests/cli/mcp-reader-tools.test.ts tests/cli/mcp-codegraph-contract.test.ts tests/cli/mcp-policy.test.ts tests/cli/mcp-tools.test.ts tests/cli/codegraph.test.ts tests/cli/codegraph-resolver.test.ts tests/tooling/codegraph-integration.test.ts && bun run check:type`
- `git diff --check`
- `bash scripts/check-deploy-sql-order.sh`
- `bash scripts/check-architecture-sync.sh`
- `bash scripts/check-task-sync.sh`
- `bun scripts/inspect-project-state.ts --repo . --format text`
- `bun test`
- `bash scripts/ensure-codegraph.sh --sync`
- `bun src/cli/index.ts setup check --target codex --check-updates --json` (exit 0; optional `runtime.skills_cli` timeout warning only)
- `bash scripts/migrate-project-template.sh --repo . --dry-run`
- `bash scripts/prepare-codex-handoff.sh --reason codegraph-s3-write-file && bash scripts/check-task-workflow.sh --strict`

## Scope Notes

This PR intentionally does not implement `apply_patch`, `move_path`, `delete_path`, or `refresh_repo_index`. Successful writes report index refresh as pending when CodeGraph is available; the explicit index-sync management slice stays open.
