### PR TITLE
Add explicit CodeGraph index refresh tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,21 +348,27 @@ before applying anything.
 As an optional sidecar, `repo-harness mcp` exposes workflow artifacts to MCP
 clients through the default `planner` profile. ChatGPT acts as a
 planner/reviewer that reads state and moves an idea through PRD, checklist
-Sprint, and Codex goal handoff artifacts — with no source-code write access,
+Sprint, and Codex goal handoff artifacts — with no default source-code write access,
 arbitrary shell execution, or default Codex runner. Codex remains the executor.
 
 The same `planner` Connector also exposes general repo tools for
 registered adopted repos. Use `discover_harness_repos` first, then call
 `list_allowed_roots` to get the stable `repo_id`. General repo reads use
 `repo_manifest`, `list_tree`, `stat_file`, `read_file`, `read_files`, and
-`search_text`. The initial write surface is `write_file`, which is rejected
-unless that registered repo is explicitly configured as `read_write`.
+`search_text`. The write surface currently exposes `write_file` and
+`refresh_repo_index`, both rejected unless that registered repo is explicitly
+configured as `read_write`.
 `write_file` creates only with `must_not_exist: true`, replaces only with
 `expected_sha256`, and reports `before`, `after`, `diff`, `mutation_id`, and
-`index_state` after an atomic same-directory rename. The repo whitelist is the
-authorization boundary, `.ignore` is the only content exclusion source, paths
-are repo-relative, and authorized file content is not implicitly redacted.
-External non-repo local roots require explicit `--allow-root` authorization.
+`index_state` after an atomic same-directory rename. Successful writes leave the
+index pending; `refresh_repo_index` runs CodeGraph sync for the repo, invalidates
+reader snapshots, and returns the new `snapshot_id`, `index_revision`,
+`index_state`, and refresh strategy. The CLI adapter reports
+`path_refresh_supported:false` when it must use repo-level sync for requested
+paths. The repo whitelist is the authorization boundary, `.ignore` is the only
+content exclusion source, paths are repo-relative, and authorized file content is
+not implicitly redacted. External non-repo local roots require explicit
+`--allow-root` authorization.
 
 When CodeGraph is initialized for a registered repo, the general reader merges
 CodeGraph indexed-file metadata into manifest/stat/read/search responses while

--- a/assets/mcp/general-repo-reader-tools.v1.schema.json
+++ b/assets/mcp/general-repo-reader-tools.v1.schema.json
@@ -45,7 +45,7 @@
     },
     "tools": {
       "type": "array",
-      "minItems": 8,
+      "minItems": 9,
       "items": {
         "$ref": "#/$defs/tool"
       }
@@ -118,7 +118,8 @@
             "read_file",
             "read_files",
             "stat_file",
-            "write_file"
+            "write_file",
+            "refresh_repo_index"
           ]
         },
         "description": {
@@ -559,6 +560,49 @@
           "after",
           "diff",
           "index_state"
+        ],
+        "properties": {},
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "refresh_repo_index",
+      "description": "Synchronize CodeGraph for a read_write repo after mutations and return the new index/snapshot state.",
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "input_schema": {
+        "type": "object",
+        "required": [
+          "repo_id"
+        ],
+        "properties": {
+          "repo_id": {
+            "type": "string"
+          },
+          "paths": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "required": [
+          "repo_id",
+          "snapshot_id",
+          "ignore_digest",
+          "paths",
+          "refreshed",
+          "index_state",
+          "refresh",
+          "index"
         ],
         "properties": {},
         "additionalProperties": false

--- a/docs/architecture/decisions/20260622-general-repo-codegraph-access.md
+++ b/docs/architecture/decisions/20260622-general-repo-codegraph-access.md
@@ -60,9 +60,20 @@ Sprint 0 freezes the read contract for:
 - `read_files`
 - `search_text`
 
-The initial write implementation covers `write_file` create/replace. Patch,
-move, delete, and explicit index-refresh tools remain implementation-gated until
+The current write implementation covers `write_file` create/replace and
+`refresh_repo_index`. Patch, move, and delete remain implementation-gated until
 their Sprint 3 slices land.
+
+`write_file` commits filesystem truth first and returns an index invalidation
+record with `index_state: pending` when CodeGraph is available. The explicit
+`refresh_repo_index` tool requires the same `read_write` repo capability,
+reuses the same path guard and `.ignore` policy for requested paths, runs the
+adapter refresh, invalidates in-process repo snapshots, then returns the new
+snapshot and CodeGraph revision. The bundled CLI adapter uses repo-level
+`codegraph sync` because the local CodeGraph CLI surface does not expose a
+stable path-only refresh command; responses report
+`path_refresh_supported:false` so callers do not assume true incremental
+reindexing.
 
 ## Snapshot Contract
 

--- a/docs/repo-harness-chatgpt-mcp-setup.md
+++ b/docs/repo-harness-chatgpt-mcp-setup.md
@@ -126,7 +126,7 @@ Use ChatGPT for planning and review. Use Codex for local execution.
 1. Use the single configured Connector for workflow planning and repo tools.
 2. Call `discover_harness_repos` to list registered adopted repos, then pass `repo_path` when targeting a specific project.
 3. For registered repo document/code reading, call `list_allowed_roots` to get the stable `repo_id`, then use `get_repo_capabilities`, `repo_manifest`, `list_tree`, `stat_file`, `read_file`, `read_files`, and `search_text`.
-4. For registered repo writes, first check `get_repo_capabilities.write_tools`; only repos explicitly configured as `read_write` expose `write_file`.
+4. For registered repo writes, first check `get_repo_capabilities.write_tools`; only repos explicitly configured as `read_write` expose `write_file` and `refresh_repo_index`.
 5. Ask ChatGPT to turn the idea into a PRD with `write_prd_from_idea`.
 6. Ask ChatGPT to turn the PRD into a checklist Sprint with `write_checklist_sprint`.
 7. Ask ChatGPT to prepare a Codex Goal with `prepare_codex_goal_from_sprint`.
@@ -157,7 +157,12 @@ New files require `must_not_exist: true`; replacements require
 `expected_sha256`; mismatches return `REVISION_CONFLICT` without writing. A
 successful write uses a same-directory temporary file plus atomic rename,
 returns `before`, `after`, `diff`, `mutation_id`, and `index_state`, and leaves
-CodeGraph refresh explicitly pending until the index-sync slice handles it.
+CodeGraph refresh explicitly pending. Call `refresh_repo_index` with the changed
+paths after a successful write to run CodeGraph sync, invalidate repo snapshot
+caches, and receive the new `index_revision`, `snapshot_id`, `index_state`, and
+refresh strategy. The bundled CLI adapter uses repo-level `codegraph sync` when
+path-only refresh is unavailable and reports that tradeoff with
+`path_refresh_supported:false`.
 
 When a repo has a CodeGraph index, `repo_manifest`, `list_tree`, `stat_file`,
 `read_file`, `read_files`, and `search_text` share a deterministic

--- a/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
+++ b/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
@@ -528,7 +528,7 @@ Sprint 2 adapter/snapshot evidence:
 - [ ] **S3-API-003** 实现 `move_path`。
 - [ ] **S3-API-004** 实现 `delete_path`。
 - [ ] **S3-API-005** 定义目录创建、空目录和递归删除策略；递归删除建议首版默认关闭或要求显式参数。
-- [ ] **S3-API-006** 写响应返回 before/after hash、diff、mutation id 和 index state。
+- [x] **S3-API-006** 写响应返回 before/after hash、diff、mutation id 和 index state。
 
 ## 10.2 乐观并发与原子写
 
@@ -546,12 +546,12 @@ Sprint 2 adapter/snapshot evidence:
 ## 10.3 Index Sync
 
 - [ ] **S3-IDX-001** 每次成功 mutation 产生 index invalidation event。
-- [ ] **S3-IDX-002** 能按 path 增量 reindex 时优先使用；否则明确使用 repo refresh。
-- [ ] **S3-IDX-003** 写后返回 `index_state: pending|ready|failed`。
-- [ ] **S3-IDX-004** 索引完成后生成新 `codegraph_revision` 和 snapshot。
-- [ ] **S3-IDX-005** 在索引 pending 时，changed path 的 read/stat 走安全直读并返回最新 hash。
-- [ ] **S3-IDX-006** search 必须明确使用旧索引还是等待新索引；禁止假装已可搜。
-- [ ] **S3-IDX-007** 实现 `refresh_repo_index` 或内部等价管理接口。
+- [x] **S3-IDX-002** 能按 path 增量 reindex 时优先使用；否则明确使用 repo refresh。
+- [x] **S3-IDX-003** 写后返回 `index_state: pending|ready|failed`。
+- [x] **S3-IDX-004** 索引完成后生成新 `codegraph_revision` 和 snapshot。
+- [x] **S3-IDX-005** 在索引 pending 时，changed path 的 read/stat 走安全直读并返回最新 hash。
+- [x] **S3-IDX-006** search 必须明确使用旧索引还是等待新索引；禁止假装已可搜。
+- [x] **S3-IDX-007** 实现 `refresh_repo_index` 或内部等价管理接口。
 - [ ] **S3-IDX-008** 定义 reindex retry、dead-letter 和人工恢复流程。
 - [ ] **S3-IDX-009** 监控 mutation commit 到 CodeGraph 可搜索的 index lag。
 
@@ -587,8 +587,28 @@ Sprint 3 write_file evidence:
   `.repo-harness-*` temporary files in the target directory. Full write-failure
   injection remains open under `S3-MUT-009/010`.
 - Explicitly still open: `apply_patch`, `move_path`, `delete_path`,
-  `refresh_repo_index`, recursive directory policy, full index retry/dead-letter,
+  recursive directory policy, full index retry/dead-letter, index-lag monitoring,
   and complete write audit/runbook coverage.
+
+Sprint 3 index-sync evidence:
+
+- Runtime: `src/cli/mcp/general-repo-access.ts`,
+  `src/cli/mcp/codegraph-adapter.ts`
+- Tests: `tests/cli/mcp-reader-tools.test.ts`,
+  `tests/cli/mcp-codegraph-contract.test.ts`
+- Schema/docs: `assets/mcp/general-repo-reader-tools.v1.schema.json`,
+  `README.md`, `docs/repo-harness-chatgpt-mcp-setup.md`,
+  `docs/architecture/decisions/20260622-general-repo-codegraph-access.md`,
+  `tasks/notes/20260622-repo-harness-codegraph.notes.md`
+- Completed slice: `refresh_repo_index` is exposed only for `read_write` repos,
+  validates requested paths through the same guard/`.ignore` policy, calls
+  CodeGraph refresh, invalidates local snapshots, and returns before/after index
+  revisions plus a fresh snapshot.
+- The bundled adapter uses repo-level `codegraph sync` when path incremental
+  refresh is unavailable and reports `path_refresh_supported:false`.
+- Pending-state reads/stat use filesystem truth and return the latest hash;
+  `search_text` keeps the explicit CodeGraph-metadata plus guarded filesystem
+  fallback backend instead of claiming the changed path is already indexed.
 
 ---
 

--- a/src/cli/mcp/codegraph-adapter.ts
+++ b/src/cli/mcp/codegraph-adapter.ts
@@ -23,6 +23,21 @@ export interface CodeGraphRepoSnapshot {
     retryable: boolean;
   };
 }
+
+export interface CodeGraphRefreshResult {
+  available: boolean;
+  refreshed: boolean;
+  integrated: boolean;
+  source: CodeGraphRepoSnapshot['source'];
+  indexRevision: string | 0;
+  latencyMs: number;
+  strategy: 'repo-sync' | 'path-sync' | 'unsupported';
+  requestedPaths: string[];
+  pathRefreshSupported: boolean;
+  files: number;
+  error?: CodeGraphRepoSnapshot['error'];
+}
+
 export interface CodeGraphTextSearchMatch {
   path: string;
   line?: number;
@@ -40,6 +55,7 @@ export interface CodeGraphTextSearchResult {
 
 export interface GeneralRepoCodeGraphAdapter {
   discoverRepo(repoRoot: string): CodeGraphRepoSnapshot;
+  refreshRepo?(repoRoot: string, opts?: { paths?: string[] }): CodeGraphRefreshResult;
   searchText?(repoRoot: string, query: string, opts: { mode: 'literal' | 'regex'; paths: string[]; maxResults: number }): CodeGraphTextSearchResult;
 }
 
@@ -96,6 +112,80 @@ function revisionFor(files: CodeGraphIndexedFile[]): string {
   return `index_${sha256(JSON.stringify(stable)).slice(0, 16)}`;
 }
 
+function discoverCodeGraphRepo(repoRoot: string, env: NodeJS.ProcessEnv, timeoutMs: number): CodeGraphRepoSnapshot {
+  const start = Date.now();
+  if (!existsSync(join(repoRoot, '.codegraph'))) {
+    return unavailable('CodeGraph index is not initialized for this repo', 0, false);
+  }
+
+  const bin = codegraphBin(repoRoot, env);
+  const result = spawnSync(bin, ['files', '--path', repoRoot, '--format', 'flat', '--json'], {
+    cwd: repoRoot,
+    env,
+    encoding: 'utf-8',
+    timeout: timeoutMs,
+    maxBuffer: MAX_STDOUT_BYTES,
+  });
+  const latencyMs = Date.now() - start;
+
+  if (result.error) {
+    const code = result.error.message.includes('ETIMEDOUT') ? 'INDEX_UNAVAILABLE' : 'INTERNAL_ADAPTER_ERROR';
+    return {
+      available: false,
+      integrated: false,
+      source: 'unavailable',
+      indexRevision: 0,
+      files: [],
+      latencyMs,
+      error: { code, message: result.error.message, retryable: code === 'INDEX_UNAVAILABLE' },
+    };
+  }
+  if (result.status !== 0) {
+    return {
+      available: false,
+      integrated: false,
+      source: 'unavailable',
+      indexRevision: 0,
+      files: [],
+      latencyMs,
+      error: {
+        code: 'INDEX_UNAVAILABLE',
+        message: (result.stderr || result.stdout || `codegraph exited with ${result.status}`).trim(),
+        retryable: true,
+      },
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(result.stdout);
+    const files = Array.isArray(parsed)
+      ? parsed.map(normalizeIndexedFile).filter((file): file is CodeGraphIndexedFile => file !== null)
+      : [];
+    return {
+      available: true,
+      integrated: true,
+      source: 'codegraph-cli',
+      indexRevision: revisionFor(files),
+      files,
+      latencyMs,
+    };
+  } catch (error) {
+    return {
+      available: false,
+      integrated: false,
+      source: 'unavailable',
+      indexRevision: 0,
+      files: [],
+      latencyMs,
+      error: {
+        code: 'INTERNAL_ADAPTER_ERROR',
+        message: error instanceof Error ? error.message : String(error),
+        retryable: false,
+      },
+    };
+  }
+}
+
 export function createCodeGraphCliAdapter(opts: {
   env?: NodeJS.ProcessEnv;
   timeoutMs?: number;
@@ -105,41 +195,65 @@ export function createCodeGraphCliAdapter(opts: {
 
   return {
     discoverRepo(repoRoot: string): CodeGraphRepoSnapshot {
+      return discoverCodeGraphRepo(repoRoot, env, timeoutMs);
+    },
+    refreshRepo(repoRoot: string, opts: { paths?: string[] } = {}): CodeGraphRefreshResult {
       const start = Date.now();
       if (!existsSync(join(repoRoot, '.codegraph'))) {
-        return unavailable('CodeGraph index is not initialized for this repo', 0, false);
+        const snapshot = unavailable('CodeGraph index is not initialized for this repo', 0, false);
+        return {
+          available: false,
+          refreshed: false,
+          integrated: false,
+          source: snapshot.source,
+          indexRevision: snapshot.indexRevision,
+          latencyMs: snapshot.latencyMs,
+          strategy: 'unsupported',
+          requestedPaths: opts.paths ?? [],
+          pathRefreshSupported: false,
+          files: 0,
+          error: snapshot.error,
+        };
       }
 
       const bin = codegraphBin(repoRoot, env);
-      const result = spawnSync(bin, ['files', '--path', repoRoot, '--format', 'flat', '--json'], {
+      const result = spawnSync(bin, ['sync', repoRoot], {
         cwd: repoRoot,
         env,
         encoding: 'utf-8',
-        timeout: timeoutMs,
+        timeout: Math.max(timeoutMs, 30_000),
         maxBuffer: MAX_STDOUT_BYTES,
       });
-      const latencyMs = Date.now() - start;
+      const syncLatencyMs = Date.now() - start;
 
       if (result.error) {
         const code = result.error.message.includes('ETIMEDOUT') ? 'INDEX_UNAVAILABLE' : 'INTERNAL_ADAPTER_ERROR';
         return {
           available: false,
+          refreshed: false,
           integrated: false,
           source: 'unavailable',
           indexRevision: 0,
-          files: [],
-          latencyMs,
+          latencyMs: syncLatencyMs,
+          strategy: 'repo-sync',
+          requestedPaths: opts.paths ?? [],
+          pathRefreshSupported: false,
+          files: 0,
           error: { code, message: result.error.message, retryable: code === 'INDEX_UNAVAILABLE' },
         };
       }
       if (result.status !== 0) {
         return {
           available: false,
+          refreshed: false,
           integrated: false,
           source: 'unavailable',
           indexRevision: 0,
-          files: [],
-          latencyMs,
+          latencyMs: syncLatencyMs,
+          strategy: 'repo-sync',
+          requestedPaths: opts.paths ?? [],
+          pathRefreshSupported: false,
+          files: 0,
           error: {
             code: 'INDEX_UNAVAILABLE',
             message: (result.stderr || result.stdout || `codegraph exited with ${result.status}`).trim(),
@@ -148,34 +262,20 @@ export function createCodeGraphCliAdapter(opts: {
         };
       }
 
-      try {
-        const parsed = JSON.parse(result.stdout);
-        const files = Array.isArray(parsed)
-          ? parsed.map(normalizeIndexedFile).filter((file): file is CodeGraphIndexedFile => file !== null)
-          : [];
-        return {
-          available: true,
-          integrated: true,
-          source: 'codegraph-cli',
-          indexRevision: revisionFor(files),
-          files,
-          latencyMs,
-        };
-      } catch (error) {
-        return {
-          available: false,
-          integrated: false,
-          source: 'unavailable',
-          indexRevision: 0,
-          files: [],
-          latencyMs,
-          error: {
-            code: 'INTERNAL_ADAPTER_ERROR',
-            message: error instanceof Error ? error.message : String(error),
-            retryable: false,
-          },
-        };
-      }
+      const snapshot = discoverCodeGraphRepo(repoRoot, env, timeoutMs);
+      return {
+        available: snapshot.available,
+        refreshed: snapshot.available,
+        integrated: snapshot.integrated,
+        source: snapshot.source,
+        indexRevision: snapshot.indexRevision,
+        latencyMs: syncLatencyMs + snapshot.latencyMs,
+        strategy: 'repo-sync',
+        requestedPaths: opts.paths ?? [],
+        pathRefreshSupported: false,
+        files: snapshot.files.length,
+        error: snapshot.error,
+      };
     },
   };
 }

--- a/src/cli/mcp/general-repo-access.ts
+++ b/src/cli/mcp/general-repo-access.ts
@@ -3,7 +3,7 @@ import { closeSync, existsSync, fsyncSync, lstatSync, openSync, readFileSync, re
 import { basename, dirname, isAbsolute, relative, resolve, sep } from 'path';
 import { readRegisteredRepoHarnessRepos, repoHarnessRepoIdFor, type RepoHarnessAccessMode } from '../../effects/repo-registry';
 import { hashMcpInput, tryWriteMcpAuditEntry } from './audit';
-import { createCodeGraphCliAdapter, type CodeGraphRepoSnapshot, type GeneralRepoCodeGraphAdapter } from './codegraph-adapter';
+import { createCodeGraphCliAdapter, type CodeGraphRefreshResult, type CodeGraphRepoSnapshot, type GeneralRepoCodeGraphAdapter } from './codegraph-adapter';
 import { globMatches, isPathInside } from './paths';
 import type { McpPolicy } from './types';
 
@@ -165,6 +165,7 @@ const GENERAL_REPO_TOOLS = [
   'read_files',
   'stat_file',
   'write_file',
+  'refresh_repo_index',
 ] as const;
 
 const DEFAULT_PAGE_SIZE = 300;
@@ -182,6 +183,7 @@ const MAX_LAGGING_PATHS_RETURNED = 50;
 const DEFAULT_CODEGRAPH_ADAPTER = createCodeGraphCliAdapter();
 const SNAPSHOT_CACHE = new Map<string, VisibleEntrySnapshot>();
 const ENTRY_METADATA_CACHE = new Map<string, EntryMetadataCacheValue>();
+const WRITE_TOOLS = new Set<string>(['write_file', 'refresh_repo_index']);
 
 export type GeneralRepoToolName = typeof GENERAL_REPO_TOOLS[number];
 
@@ -518,11 +520,27 @@ function leafName(relativePath: string): string {
 
 function assertRepoWriteEnabled(repo: RepoRecord): void {
   if (repo.accessMode !== 'read_write') {
-    throw new GeneralRepoAccessError('WRITE_DISABLED', 'repo is read_only; write_file requires read_write capability', {
+    throw new GeneralRepoAccessError('WRITE_DISABLED', 'repo is read_only; mutation tools require read_write capability', {
       repo_id: repo.repoId,
       access_mode: repo.accessMode,
     });
   }
+}
+
+function refreshPathsArg(repo: RepoRecord, ignore: IgnorePolicy, value: unknown): string[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) {
+    throw new GeneralRepoAccessError('INVALID_RANGE', 'paths must be an array of repo-relative paths');
+  }
+  const paths = new Set<string>();
+  for (const item of value) {
+    if (typeof item !== 'string') {
+      throw new GeneralRepoAccessError('INVALID_RELATIVE_PATH', 'paths must contain only strings');
+    }
+    const resolved = resolveRepoPath(repo, item, ignore, { allowRoot: true, allowExternalSymlinkMetadata: true });
+    paths.add(resolved.relativePath);
+  }
+  return [...paths].sort((a, b) => a.localeCompare(b));
 }
 
 function resolveRepoWritePath(repo: RepoRecord, inputPath: unknown, ignore: IgnorePolicy): ResolvedRepoWritePath {
@@ -1208,6 +1226,25 @@ function invalidateRepoCaches(repo: RepoRecord): void {
   ENTRY_METADATA_CACHE.clear();
 }
 
+function mutationIndexState(snapshot: VisibleEntrySnapshot): 'pending' | 'failed' {
+  return snapshot.codeGraph.available ? 'pending' : 'failed';
+}
+
+function refreshedIndexState(snapshot: VisibleEntrySnapshot): 'ready' | 'index_lagging' | 'failed' {
+  if (!snapshot.codeGraph.available) return 'failed';
+  return snapshot.codeGraphLaggingPaths.length > 0 ? 'index_lagging' : 'ready';
+}
+
+function indexRefreshError(refresh: CodeGraphRefreshResult): GeneralRepoAccessError {
+  const error = refresh.error;
+  return new GeneralRepoAccessError(error?.code ?? 'INDEX_UNAVAILABLE', error?.message ?? 'CodeGraph refresh failed', {
+    strategy: refresh.strategy,
+    requested_paths: refresh.requestedPaths,
+    path_refresh_supported: refresh.pathRefreshSupported,
+    index_revision: refresh.indexRevision,
+  }, error?.retryable ?? true);
+}
+
 function readFilePayload(repo: RepoRecord, ignore: IgnorePolicy, snapshot: VisibleEntrySnapshot, args: Record<string, unknown>, maxBytes = HARD_READ_BYTES, tool = 'read_file', verifySnapshotEntry = false): Record<string, unknown> {
   if (args.line_range !== undefined && args.byte_range !== undefined) {
     throw new GeneralRepoAccessError('INVALID_RANGE', 'line_range and byte_range are mutually exclusive');
@@ -1302,8 +1339,8 @@ function getRepoCapabilities(ctx: GeneralRepoToolContext, args: Record<string, u
     display_name: repo.displayName,
     registry_revision: repo.registryRevision,
     source: repo.source,
-    read_tools: GENERAL_REPO_TOOLS.filter((tool) => tool !== 'get_repo_capabilities' && tool !== 'write_file'),
-    write_tools: repo.accessMode === 'read_write' ? ['write_file'] : [],
+    read_tools: GENERAL_REPO_TOOLS.filter((tool) => tool !== 'get_repo_capabilities' && !WRITE_TOOLS.has(tool)),
+    write_tools: repo.accessMode === 'read_write' ? [...WRITE_TOOLS] : [],
     codegraph: {
       primary_backend: true,
       ...codeGraphSummary(snapshot),
@@ -1368,8 +1405,9 @@ function writeFileTool(ctx: GeneralRepoToolContext, args: Record<string, unknown
   const afterEntry = metadataForResolved(after, ignore);
   const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore, { contentHash: false });
   const indexedEntry = snapshot.entriesByPath.get(target.relativePath);
-  const indexState = snapshot.codeGraph.available ? 'pending' : 'failed';
+  const indexState = mutationIndexState(snapshot);
   const mutationId = `mut_${sha256(`${repo.repoId}\0${target.relativePath}\0${beforeHash ?? 'new'}\0${afterHash}\0${Date.now()}`).slice(0, 16)}`;
+  const invalidationId = `idxinv_${sha256(`${mutationId}\0${snapshot.codeGraph.indexRevision}\0${target.relativePath}`).slice(0, 16)}`;
 
   return textResult({
     ...commonFields(repo, ignore, snapshot, { tool: 'write_file', paths: [target.relativePath] }),
@@ -1404,6 +1442,57 @@ function writeFileTool(ctx: GeneralRepoToolContext, args: Record<string, unknown
       action: snapshot.codeGraph.available ? 'refresh_repo_index_required' : 'codegraph_unavailable',
       changed_paths: [target.relativePath],
       mutation_id: mutationId,
+      invalidation_id: invalidationId,
+      refresh_tool: 'refresh_repo_index',
+      before_index_revision: snapshot.codeGraph.indexRevision,
+    },
+    codegraph: codeGraphSummary(snapshot),
+  });
+}
+
+function refreshRepoIndex(ctx: GeneralRepoToolContext, args: Record<string, unknown>): GeneralRepoToolResult {
+  const repo = resolveRepo(ctx, args.repo_id);
+  assertRepoWriteEnabled(repo);
+  const ignore = readIgnorePolicy(repo.canonicalRoot);
+  const paths = refreshPathsArg(repo, ignore, args.paths);
+  const refreshScope = paths.length > 0 ? paths : ['.'];
+  const before = buildVisibleEntrySnapshot(ctx, repo, ignore, { contentHash: false });
+  const adapter = ctx.codeGraphAdapter ?? DEFAULT_CODEGRAPH_ADAPTER;
+  if (!adapter.refreshRepo) {
+    throw new GeneralRepoAccessError('INDEX_UNAVAILABLE', 'CodeGraph adapter does not support explicit refresh', {
+      paths: refreshScope,
+    }, true);
+  }
+
+  const refresh = adapter.refreshRepo(repo.canonicalRoot, { paths });
+  invalidateRepoCaches(repo);
+  if (!refresh.available || !refresh.refreshed) {
+    throw indexRefreshError(refresh);
+  }
+  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore, { contentHash: false });
+  const indexState = refreshedIndexState(snapshot);
+
+  return textResult({
+    ...commonFields(repo, ignore, snapshot, { tool: 'refresh_repo_index', paths: refreshScope }),
+    paths: refreshScope,
+    refreshed: true,
+    index_state: indexState,
+    refresh: {
+      strategy: refresh.strategy,
+      requested_paths: refresh.requestedPaths,
+      path_refresh_supported: refresh.pathRefreshSupported,
+      latency_ms: refresh.latencyMs,
+      before_index_revision: before.codeGraph.indexRevision,
+      adapter_index_revision: refresh.indexRevision,
+      after_index_revision: snapshot.codeGraph.indexRevision,
+      indexed_files: refresh.files,
+    },
+    index: {
+      state: indexState,
+      action: indexState === 'ready' ? 'refresh_complete' : 'refresh_complete_with_lag',
+      refreshed_paths: refreshScope,
+      before_index_revision: before.codeGraph.indexRevision,
+      after_index_revision: snapshot.codeGraph.indexRevision,
     },
     codegraph: codeGraphSummary(snapshot),
   });
@@ -1761,6 +1850,20 @@ export function buildGeneralRepoToolDefinitions(): GeneralRepoToolDefinition[] {
       },
       annotations: writeTool,
     },
+    {
+      name: 'refresh_repo_index',
+      description: 'Synchronize CodeGraph for a read_write repo after mutations and return the new index/snapshot state.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          repo_id: { type: 'string' },
+          paths: { type: 'array', items: { type: 'string' } },
+        },
+        required: ['repo_id'],
+        additionalProperties: false,
+      },
+      annotations: writeTool,
+    },
   ];
 }
 
@@ -1791,6 +1894,9 @@ export async function callGeneralRepoTool(ctx: GeneralRepoToolContext, name: str
         break;
       case 'write_file':
         result = writeFileTool(ctx, args);
+        break;
+      case 'refresh_repo_index':
+        result = refreshRepoIndex(ctx, args);
         break;
       default:
         return errorResult('INTERNAL_ADAPTER_ERROR', `tool is not a general repo reader tool: ${name}`);

--- a/tasks/notes/20260622-repo-harness-codegraph.notes.md
+++ b/tasks/notes/20260622-repo-harness-codegraph.notes.md
@@ -151,3 +151,23 @@ Sprint 0 contract freeze for `plans/sprints/20260622-repo-harness-codegraph-spri
   available, or `failed` when no index is available. The process-local snapshot
   and metadata caches are invalidated after successful writes so immediate
   read/stat calls see filesystem truth.
+
+## 2026-06-23 refresh_repo_index slice
+
+- The index-sync slice adds `refresh_repo_index` as a read_write-gated mutation
+  companion rather than making `write_file` block on CodeGraph. This keeps the
+  filesystem commit boundary small and makes index lag explicit to the caller.
+- Requested refresh paths are repo-relative, deduplicated, and resolved through
+  the same canonical root, symlink, and `.ignore` guard used by read/write
+  tools. Empty `paths` means repo-level refresh.
+- The CLI adapter uses `codegraph sync <repo>` and then reads
+  `codegraph files --format flat --json` for the new revision. Path-only
+  refresh is reported as unsupported with `path_refresh_supported:false` because
+  the local CodeGraph CLI does not expose a stable path incremental contract.
+- `write_file` now returns an `index.invalidation_id` and
+  `index.refresh_tool`. `refresh_repo_index` returns before/after index
+  revisions, the adapter revision, refresh strategy, snapshot id, and
+  `index_state: ready|index_lagging|failed`.
+- Search still uses the existing CodeGraph-metadata plus guarded filesystem
+  fallback path. This slice makes the index state observable; it does not claim
+  a CodeGraph-only full-text backend.

--- a/tests/cli/mcp-codegraph-contract.test.ts
+++ b/tests/cli/mcp-codegraph-contract.test.ts
@@ -18,6 +18,7 @@ const TOOL_NAMES = [
   'read_files',
   'stat_file',
   'write_file',
+  'refresh_repo_index',
 ];
 
 const COMMON_RESPONSE_FIELDS = [
@@ -166,7 +167,7 @@ function manifestFromSecureWalker(root: string, indexedPaths: Set<string>): { ig
 }
 
 describe('general repo CodeGraph contract', () => {
-  test('versioned schema freezes the general repo reader plus initial write_file surface', () => {
+  test('versioned schema freezes the general repo reader plus write/index-sync surface', () => {
     const schema = readJson(SCHEMA_PATH);
     expect(schema.properties.version.const).toBe('1');
     expect(schema.properties.policy.properties.content_exclusion.const).toBe('.ignore');
@@ -175,16 +176,21 @@ describe('general repo CodeGraph contract', () => {
     expect(schema.properties.common_response_fields.items.enum).toEqual(COMMON_RESPONSE_FIELDS);
 
     for (const tool of schema['x-repo-harness-tools']) {
-      if (tool.name === 'write_file') {
+      if (tool.name === 'write_file' || tool.name === 'refresh_repo_index') {
         expect(tool.annotations).toEqual({
           readOnlyHint: false,
           destructiveHint: true,
           idempotentHint: false,
           openWorldHint: false,
         });
-        expect(tool.input_schema.required).toEqual(['repo_id', 'path', 'content']);
-        expect(tool.input_schema.properties.expected_sha256).toEqual({ type: 'string' });
-        expect(tool.input_schema.properties.must_not_exist).toEqual({ type: 'boolean' });
+        if (tool.name === 'write_file') {
+          expect(tool.input_schema.required).toEqual(['repo_id', 'path', 'content']);
+          expect(tool.input_schema.properties.expected_sha256).toEqual({ type: 'string' });
+          expect(tool.input_schema.properties.must_not_exist).toEqual({ type: 'boolean' });
+        } else {
+          expect(tool.input_schema.required).toEqual(['repo_id']);
+          expect(tool.input_schema.properties.paths.items).toEqual({ type: 'string' });
+        }
       } else {
         expect(tool.annotations).toEqual({
           readOnlyHint: true,

--- a/tests/cli/mcp-reader-tools.test.ts
+++ b/tests/cli/mcp-reader-tools.test.ts
@@ -90,9 +90,10 @@ describe('MCP reader tools', () => {
         'read_files',
         'stat_file',
         'write_file',
+        'refresh_repo_index',
       ]);
       for (const definition of definitions) {
-        if (definition.name === 'write_file') {
+        if (definition.name === 'write_file' || definition.name === 'refresh_repo_index') {
           expect(definition.annotations).toMatchObject({
             readOnlyHint: false,
             destructiveHint: true,
@@ -181,6 +182,8 @@ describe('MCP reader tools', () => {
         });
         expect(readOnlyWrite.error.code).toBe('WRITE_DISABLED');
         expect(existsSync(join(repoRoot, 'docs', 'created-by-write.txt'))).toBe(false);
+        const readOnlyRefresh = await jsonTool(ctx, 'refresh_repo_index', { repo_id: repoId, paths: ['docs/design.md'] });
+        expect(readOnlyRefresh.error.code).toBe('WRITE_DISABLED');
 
         const manifest = await jsonTool(ctx, 'repo_manifest', { repo_id: repoId, page_size: 1000 });
         const visiblePaths = manifest.entries.map((entry: { path: string }) => entry.path);
@@ -281,15 +284,36 @@ describe('MCP reader tools', () => {
   test('write_file is capability-gated, atomic, and guarded by revision preconditions', async () => {
     await withReaderRepo(async (repoRoot, ctx) => {
       writeFileSync(join(repoRoot, '.ignore'), 'ignored.md\n');
+      let indexedAfterRefresh = false;
+      const refreshCalls: string[][] = [];
       const fakeCodeGraph: GeneralRepoCodeGraphAdapter = {
         discoverRepo() {
+          const generatedPath = join(repoRoot, 'docs', 'generated.txt');
           return {
             available: true,
             integrated: true,
             source: 'test-double',
-            indexRevision: 'index_before_write',
+            indexRevision: indexedAfterRefresh ? 'index_after_write' : 'index_before_write',
             latencyMs: 1,
-            files: [],
+            files: indexedAfterRefresh && existsSync(generatedPath)
+              ? [{ path: 'docs/generated.txt', language: 'text', nodeCount: 1, size: readFileSync(generatedPath).length }]
+              : [],
+          };
+        },
+        refreshRepo(_repoRoot, opts = {}) {
+          refreshCalls.push(opts.paths ?? []);
+          indexedAfterRefresh = true;
+          return {
+            available: true,
+            refreshed: true,
+            integrated: true,
+            source: 'test-double',
+            indexRevision: 'index_after_write',
+            latencyMs: 2,
+            strategy: 'repo-sync',
+            requestedPaths: opts.paths ?? [],
+            pathRefreshSupported: false,
+            files: 1,
           };
         },
       };
@@ -302,7 +326,7 @@ describe('MCP reader tools', () => {
       const repoId = (await jsonTool(writeCtx, 'list_allowed_roots')).roots[0].repo_id;
       const capabilities = await jsonTool(writeCtx, 'get_repo_capabilities', { repo_id: repoId });
       expect(capabilities.access_mode).toBe('read_write');
-      expect(capabilities.write_tools).toEqual(['write_file']);
+      expect(capabilities.write_tools).toEqual(['write_file', 'refresh_repo_index']);
 
       const missingCreatePrecondition = await jsonTool(writeCtx, 'write_file', {
         repo_id: repoId,
@@ -327,6 +351,8 @@ describe('MCP reader tools', () => {
         index: { action: 'refresh_repo_index_required', changed_paths: ['docs/generated.txt'] },
       });
       expect(created.mutation_id).toMatch(/^mut_[a-f0-9]{16}$/);
+      expect(created.index.invalidation_id).toMatch(/^idxinv_[a-f0-9]{16}$/);
+      expect(created.index.refresh_tool).toBe('refresh_repo_index');
       expect(created.after.sha256).toMatch(/^[a-f0-9]{64}$/);
       expect(created.diff.after_sha256).toBe(created.after.sha256);
       expect(readFileSync(join(repoRoot, 'docs', 'generated.txt'), 'utf-8')).toBe('first\n');
@@ -374,6 +400,46 @@ describe('MCP reader tools', () => {
       expect(readdirSync(join(repoRoot, 'docs')).some((name) => name.includes('.repo-harness-'))).toBe(false);
       const statReplaced = await jsonTool(writeCtx, 'stat_file', { repo_id: repoId, path: 'docs/generated.txt' });
       expect(statReplaced.sha256).toBe(replaced.after.sha256);
+      expect(statReplaced.indexed).toBe(false);
+      const searchBeforeRefresh = await jsonTool(writeCtx, 'search_text', {
+        repo_id: repoId,
+        query: 'second',
+        paths: ['docs/generated.txt'],
+      });
+      expect(searchBeforeRefresh.backend).toBe('codegraph-metadata+filesystem-fallback');
+      expect(searchBeforeRefresh.matches).toMatchObject([{ path: 'docs/generated.txt', indexed: false }]);
+
+      const refreshed = await jsonTool(writeCtx, 'refresh_repo_index', {
+        repo_id: repoId,
+        paths: ['docs/generated.txt'],
+      });
+      expect(refreshed).toMatchObject({
+        paths: ['docs/generated.txt'],
+        refreshed: true,
+        index_state: 'ready',
+        refresh: {
+          strategy: 'repo-sync',
+          requested_paths: ['docs/generated.txt'],
+          path_refresh_supported: false,
+          before_index_revision: 'index_before_write',
+          adapter_index_revision: 'index_after_write',
+          after_index_revision: 'index_after_write',
+          indexed_files: 1,
+        },
+        index: {
+          state: 'ready',
+          action: 'refresh_complete',
+          refreshed_paths: ['docs/generated.txt'],
+        },
+      });
+      expect(refreshCalls).toEqual([['docs/generated.txt']]);
+      const statAfterRefresh = await jsonTool(writeCtx, 'stat_file', { repo_id: repoId, path: 'docs/generated.txt' });
+      expect(statAfterRefresh).toMatchObject({
+        indexed: true,
+        codegraph_language: 'text',
+        codegraph_node_count: 1,
+        codegraph_size: 'second\n'.length,
+      });
 
       const ignored = await jsonTool(writeCtx, 'write_file', {
         repo_id: repoId,


### PR DESCRIPTION
## Summary
- add read_write-gated refresh_repo_index to sync CodeGraph after mutations
- return invalidation/readback state from write_file and refresh responses
- update schema, docs, ADR, notes, and Sprint 3 checklist evidence

## Verification
- bun test tests/cli/mcp-reader-tools.test.ts tests/cli/mcp-codegraph-contract.test.ts && bun run check:type
- git diff --check
- node JSON parse for assets/mcp/general-repo-reader-tools.v1.schema.json
- bash scripts/check-deploy-sql-order.sh
- bash scripts/check-architecture-sync.sh
- bash scripts/check-task-sync.sh
- bun scripts/inspect-project-state.ts --repo . --format text
- bash scripts/migrate-project-template.sh --repo . --dry-run
- bun test
- bash scripts/ensure-codegraph.sh --sync
- repo-harness setup check --target codex --check-updates --json
- bash scripts/prepare-codex-handoff.sh --reason codegraph-s3-index-sync
- bash scripts/check-task-workflow.sh --strict