### PR TITLE
Add guarded apply_patch tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,15 +355,18 @@ The same `planner` Connector also exposes general repo tools for
 registered adopted repos. Use `discover_harness_repos` first, then call
 `list_allowed_roots` to get the stable `repo_id`. General repo reads use
 `repo_manifest`, `list_tree`, `stat_file`, `read_file`, `read_files`, and
-`search_text`. The write surface currently exposes `write_file` and
-`refresh_repo_index`, both rejected unless that registered repo is explicitly
+`search_text`. The write surface currently exposes `write_file`, `apply_patch`,
+and `refresh_repo_index`, all rejected unless that registered repo is explicitly
 configured as `read_write`.
 `write_file` creates only with `must_not_exist: true`, replaces only with
 `expected_sha256`, and reports `before`, `after`, `diff`, `mutation_id`, and
-`index_state` after an atomic same-directory rename. Successful writes leave the
-index pending; `refresh_repo_index` runs CodeGraph sync for the repo, invalidates
-reader snapshots, and returns the new `snapshot_id`, `index_revision`,
-`index_state`, and refresh strategy. The CLI adapter reports
+`index_state` after an atomic same-directory rename. `apply_patch` operates only
+on existing text files, requires `expected_sha256`, and accepts either structured
+`old_text`/`new_text` edits or guarded unified diff hunks. Patch precondition
+misses and stale hashes return `REVISION_CONFLICT` without writing. Successful
+writes leave the index pending; `refresh_repo_index` runs CodeGraph sync for the
+repo, invalidates reader snapshots, and returns the new `snapshot_id`,
+`index_revision`, `index_state`, and refresh strategy. The CLI adapter reports
 `path_refresh_supported:false` when it must use repo-level sync for requested
 paths. The repo whitelist is the authorization boundary, `.ignore` is the only
 content exclusion source, paths are repo-relative, and authorized file content is

--- a/assets/mcp/general-repo-reader-tools.v1.schema.json
+++ b/assets/mcp/general-repo-reader-tools.v1.schema.json
@@ -45,7 +45,7 @@
     },
     "tools": {
       "type": "array",
-      "minItems": 9,
+      "minItems": 10,
       "items": {
         "$ref": "#/$defs/tool"
       }
@@ -119,6 +119,7 @@
             "read_files",
             "stat_file",
             "write_file",
+            "apply_patch",
             "refresh_repo_index"
           ]
         },
@@ -559,6 +560,78 @@
           "before",
           "after",
           "diff",
+          "index_state"
+        ],
+        "properties": {},
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "apply_patch",
+      "description": "Apply structured text edits or a guarded unified diff to one existing repo-relative file using an expected_sha256 precondition.",
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "input_schema": {
+        "type": "object",
+        "required": [
+          "repo_id",
+          "path",
+          "expected_sha256"
+        ],
+        "properties": {
+          "repo_id": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "expected_sha256": {
+            "type": "string"
+          },
+          "edits": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "old_text",
+                "new_text"
+              ],
+              "properties": {
+                "old_text": {
+                  "type": "string"
+                },
+                "new_text": {
+                  "type": "string"
+                },
+                "occurrence": {
+                  "type": "number"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "unified_diff": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "required": [
+          "repo_id",
+          "snapshot_id",
+          "ignore_digest",
+          "path",
+          "mutation_id",
+          "before",
+          "after",
+          "diff",
+          "patch",
           "index_state"
         ],
         "properties": {},

--- a/docs/architecture/decisions/20260622-general-repo-codegraph-access.md
+++ b/docs/architecture/decisions/20260622-general-repo-codegraph-access.md
@@ -60,20 +60,27 @@ Sprint 0 freezes the read contract for:
 - `read_files`
 - `search_text`
 
-The current write implementation covers `write_file` create/replace and
-`refresh_repo_index`. Patch, move, and delete remain implementation-gated until
-their Sprint 3 slices land.
+The current write implementation covers `write_file` create/replace,
+`apply_patch`, and `refresh_repo_index`. Move and delete remain
+implementation-gated until their Sprint 3 slices land.
 
-`write_file` commits filesystem truth first and returns an index invalidation
-record with `index_state: pending` when CodeGraph is available. The explicit
-`refresh_repo_index` tool requires the same `read_write` repo capability,
-reuses the same path guard and `.ignore` policy for requested paths, runs the
-adapter refresh, invalidates in-process repo snapshots, then returns the new
-snapshot and CodeGraph revision. The bundled CLI adapter uses repo-level
+`write_file` and `apply_patch` commit filesystem truth first and return an index
+invalidation record with `index_state: pending` when CodeGraph is available.
+`apply_patch` is text-only and supports structured `old_text`/`new_text` edits
+plus guarded unified diff hunks. Both patch modes require an exact
+`expected_sha256` file precondition; each edit/hunk also acts as a local text
+precondition and returns `REVISION_CONFLICT` if it no longer matches. Existing
+file replacements preserve the file mode bits used by the target. Filesystem
+mtime changes as part of the commit, and ownership, xattrs, and platform-specific
+metadata are not preserved in this portable v1 mutation layer.
+
+The explicit `refresh_repo_index` tool requires the same `read_write` repo
+capability, reuses the same path guard and `.ignore` policy for requested paths,
+runs the adapter refresh, invalidates in-process repo snapshots, then returns the
+new snapshot and CodeGraph revision. The bundled CLI adapter uses repo-level
 `codegraph sync` because the local CodeGraph CLI surface does not expose a
-stable path-only refresh command; responses report
-`path_refresh_supported:false` so callers do not assume true incremental
-reindexing.
+stable path-only refresh command; responses report `path_refresh_supported:false`
+so callers do not assume true incremental reindexing.
 
 ## Snapshot Contract
 

--- a/docs/repo-harness-chatgpt-mcp-setup.md
+++ b/docs/repo-harness-chatgpt-mcp-setup.md
@@ -126,7 +126,7 @@ Use ChatGPT for planning and review. Use Codex for local execution.
 1. Use the single configured Connector for workflow planning and repo tools.
 2. Call `discover_harness_repos` to list registered adopted repos, then pass `repo_path` when targeting a specific project.
 3. For registered repo document/code reading, call `list_allowed_roots` to get the stable `repo_id`, then use `get_repo_capabilities`, `repo_manifest`, `list_tree`, `stat_file`, `read_file`, `read_files`, and `search_text`.
-4. For registered repo writes, first check `get_repo_capabilities.write_tools`; only repos explicitly configured as `read_write` expose `write_file` and `refresh_repo_index`.
+4. For registered repo writes, first check `get_repo_capabilities.write_tools`; only repos explicitly configured as `read_write` expose `write_file`, `apply_patch`, and `refresh_repo_index`.
 5. Ask ChatGPT to turn the idea into a PRD with `write_prd_from_idea`.
 6. Ask ChatGPT to turn the PRD into a checklist Sprint with `write_checklist_sprint`.
 7. Ask ChatGPT to prepare a Codex Goal with `prepare_codex_goal_from_sprint`.
@@ -151,14 +151,16 @@ Authorized file content is not implicitly redacted in `read_file`,
 `read_files`, or `search_text` responses. The MCP audit path records tool name,
 target path, input hash, status, and errors, but not file bodies.
 
-`write_file` is the first general repo mutation tool. It is runtime-gated by the
-registered repo access mode and returns `WRITE_DISABLED` for `read_only` repos.
-New files require `must_not_exist: true`; replacements require
-`expected_sha256`; mismatches return `REVISION_CONFLICT` without writing. A
-successful write uses a same-directory temporary file plus atomic rename,
+`write_file` and `apply_patch` are the first general repo mutation tools. They
+are runtime-gated by the registered repo access mode and return `WRITE_DISABLED`
+for `read_only` repos. New files require `must_not_exist: true`; replacements
+and patches require `expected_sha256`; mismatches return `REVISION_CONFLICT`
+without writing. `apply_patch` operates on existing text files and accepts either
+structured `old_text`/`new_text` edits or guarded unified diff hunks. A
+successful mutation uses a same-directory temporary file plus atomic rename,
 returns `before`, `after`, `diff`, `mutation_id`, and `index_state`, and leaves
 CodeGraph refresh explicitly pending. Call `refresh_repo_index` with the changed
-paths after a successful write to run CodeGraph sync, invalidate repo snapshot
+paths after a successful mutation to run CodeGraph sync, invalidate repo snapshot
 caches, and receive the new `index_revision`, `snapshot_id`, `index_state`, and
 refresh strategy. The bundled CLI adapter uses repo-level `codegraph sync` when
 path-only refresh is unavailable and reports that tradeoff with

--- a/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
+++ b/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
@@ -524,7 +524,7 @@ Sprint 2 adapter/snapshot evidence:
 - [x] **S3-CAP-002** 只有现有授权系统显式配置 `read_write` 时才注册/允许写工具。
 - [x] **S3-CAP-003** 写请求复用同一 Path Guard 和 IgnorePolicy。
 - [x] **S3-API-001** 实现 `write_file` create/replace。
-- [ ] **S3-API-002** 实现 `apply_patch`，优先结构化 edits，必要时支持 unified diff。
+- [x] **S3-API-002** 实现 `apply_patch`，优先结构化 edits，必要时支持 unified diff。
 - [ ] **S3-API-003** 实现 `move_path`。
 - [ ] **S3-API-004** 实现 `delete_path`。
 - [ ] **S3-API-005** 定义目录创建、空目录和递归删除策略；递归删除建议首版默认关闭或要求显式参数。
@@ -537,8 +537,8 @@ Sprint 2 adapter/snapshot evidence:
 - [x] **S3-MUT-003** hash 不匹配返回 `REVISION_CONFLICT`，禁止自动覆盖。
 - [x] **S3-MUT-004** 临时文件必须位于目标同一文件系统/目录边界。
 - [x] **S3-MUT-005** 写临时文件 → fsync → atomic rename。
-- [ ] **S3-MUT-006** 保留原文件权限和必要 metadata，策略写入 ADR。
-- [ ] **S3-MUT-007** patch 应验证每个 hunk 或精确文本 precondition。
+- [x] **S3-MUT-006** 保留原文件权限和必要 metadata，策略写入 ADR。
+- [x] **S3-MUT-007** patch 应验证每个 hunk 或精确文本 precondition。
 - [ ] **S3-MUT-008** move/delete 同样进行版本和目标存在性检查。
 - [ ] **S3-MUT-009** 写失败不得留下半文件或跨 repo 临时文件。
 - [ ] **S3-MUT-010** 对写入过程进行故障注入测试：磁盘满、权限变化、进程中断、rename 失败。
@@ -586,9 +586,9 @@ Sprint 3 write_file evidence:
 - Verified in this slice: success and precondition-conflict paths leave no
   `.repo-harness-*` temporary files in the target directory. Full write-failure
   injection remains open under `S3-MUT-009/010`.
-- Explicitly still open: `apply_patch`, `move_path`, `delete_path`,
-  recursive directory policy, full index retry/dead-letter, index-lag monitoring,
-  and complete write audit/runbook coverage.
+- Explicitly still open: `move_path`, `delete_path`, recursive directory policy,
+  full index retry/dead-letter, index-lag monitoring, and complete write
+  audit/runbook coverage.
 
 Sprint 3 index-sync evidence:
 
@@ -609,6 +609,27 @@ Sprint 3 index-sync evidence:
 - Pending-state reads/stat use filesystem truth and return the latest hash;
   `search_text` keeps the explicit CodeGraph-metadata plus guarded filesystem
   fallback backend instead of claiming the changed path is already indexed.
+
+Sprint 3 apply_patch evidence:
+
+- Runtime: `src/cli/mcp/general-repo-access.ts`
+- Tests: `tests/cli/mcp-reader-tools.test.ts`,
+  `tests/cli/mcp-codegraph-contract.test.ts`
+- Schema/docs: `assets/mcp/general-repo-reader-tools.v1.schema.json`,
+  `README.md`, `docs/repo-harness-chatgpt-mcp-setup.md`,
+  `docs/architecture/decisions/20260622-general-repo-codegraph-access.md`,
+  `tasks/notes/20260622-repo-harness-codegraph.notes.md`
+- Completed slice: `apply_patch` is exposed only for `read_write` repos,
+  targets existing text files, requires `expected_sha256`, supports structured
+  `old_text`/`new_text` edits plus guarded unified diff hunks, and returns the
+  shared mutation readback with `before`, `after`, `diff`, `mutation_id`, and
+  `index_state`.
+- Patch preconditions are fail-closed: stale file hash, ambiguous structured
+  match without `occurrence`, missing text, and hunk mismatch return
+  `REVISION_CONFLICT` before writing.
+- Metadata policy: existing file mode bits are preserved. Filesystem mtime
+  changes as part of the commit; ownership, xattrs, and platform-specific
+  metadata are out of scope for the portable v1 mutation layer.
 
 ---
 

--- a/src/cli/mcp/general-repo-access.ts
+++ b/src/cli/mcp/general-repo-access.ts
@@ -165,6 +165,7 @@ const GENERAL_REPO_TOOLS = [
   'read_files',
   'stat_file',
   'write_file',
+  'apply_patch',
   'refresh_repo_index',
 ] as const;
 
@@ -183,7 +184,7 @@ const MAX_LAGGING_PATHS_RETURNED = 50;
 const DEFAULT_CODEGRAPH_ADAPTER = createCodeGraphCliAdapter();
 const SNAPSHOT_CACHE = new Map<string, VisibleEntrySnapshot>();
 const ENTRY_METADATA_CACHE = new Map<string, EntryMetadataCacheValue>();
-const WRITE_TOOLS = new Set<string>(['write_file', 'refresh_repo_index']);
+const WRITE_TOOLS = new Set<string>(['write_file', 'apply_patch', 'refresh_repo_index']);
 
 export type GeneralRepoToolName = typeof GENERAL_REPO_TOOLS[number];
 
@@ -1179,6 +1180,187 @@ function writeContentBuffer(args: Record<string, unknown>): { raw: Buffer; encod
   return { raw: Buffer.from(args.content, encoding), encoding };
 }
 
+function assertTextPatchable(raw: Buffer, path: string): string {
+  if (raw.subarray(0, BINARY_PROBE_BYTES).includes(0)) {
+    throw new GeneralRepoAccessError('BINARY_CONTENT', 'apply_patch requires text content', { path });
+  }
+  return raw.toString('utf-8');
+}
+
+function findOccurrences(text: string, needle: string): number[] {
+  const matches: number[] = [];
+  let index = text.indexOf(needle);
+  while (index >= 0) {
+    matches.push(index);
+    index = text.indexOf(needle, index + Math.max(needle.length, 1));
+  }
+  return matches;
+}
+
+function replaceTextAt(text: string, start: number, oldText: string, newText: string): string {
+  return `${text.slice(0, start)}${newText}${text.slice(start + oldText.length)}`;
+}
+
+function patchOccurrenceArg(value: unknown, matchCount: number, editIndex: number): number {
+  if (value === undefined) {
+    if (matchCount !== 1) {
+      throw new GeneralRepoAccessError('REVISION_CONFLICT', 'patch edit precondition is ambiguous or missing', {
+        edit_index: editIndex,
+        match_count: matchCount,
+      });
+    }
+    return 1;
+  }
+  const parsed = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN;
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new GeneralRepoAccessError('INVALID_RANGE', 'edit occurrence must be a positive integer', { edit_index: editIndex });
+  }
+  if (parsed > matchCount) {
+    throw new GeneralRepoAccessError('REVISION_CONFLICT', 'patch edit occurrence does not exist', {
+      edit_index: editIndex,
+      occurrence: parsed,
+      match_count: matchCount,
+    });
+  }
+  return parsed;
+}
+
+function applyStructuredPatchEdits(beforeText: string, edits: unknown): { text: string; applied: Array<Record<string, unknown>>; format: 'structured_edits' } {
+  if (!Array.isArray(edits) || edits.length === 0) {
+    throw new GeneralRepoAccessError('INVALID_RANGE', 'edits must be a non-empty array');
+  }
+  let text = beforeText;
+  const applied: Array<Record<string, unknown>> = [];
+  for (let index = 0; index < edits.length; index += 1) {
+    const editIndex = index + 1;
+    const edit = edits[index];
+    if (typeof edit !== 'object' || edit === null || Array.isArray(edit)) {
+      throw new GeneralRepoAccessError('INVALID_RANGE', 'each edit must be an object', { edit_index: editIndex });
+    }
+    const raw = edit as Record<string, unknown>;
+    if (typeof raw.old_text !== 'string' || raw.old_text.length === 0 || typeof raw.new_text !== 'string') {
+      throw new GeneralRepoAccessError('INVALID_RANGE', 'each edit requires non-empty old_text and string new_text', { edit_index: editIndex });
+    }
+    const matches = findOccurrences(text, raw.old_text);
+    const occurrence = patchOccurrenceArg(raw.occurrence, matches.length, editIndex);
+    const start = matches[occurrence - 1];
+    if (start === undefined) {
+      throw new GeneralRepoAccessError('REVISION_CONFLICT', 'patch edit precondition does not match', { edit_index: editIndex });
+    }
+    text = replaceTextAt(text, start, raw.old_text, raw.new_text);
+    applied.push({
+      edit_index: editIndex,
+      mode: 'old_text',
+      occurrence,
+      old_sha256: sha256(raw.old_text),
+      new_sha256: sha256(raw.new_text),
+      bytes_before: Buffer.byteLength(raw.old_text, 'utf-8'),
+      bytes_after: Buffer.byteLength(raw.new_text, 'utf-8'),
+    });
+  }
+  return { text, applied, format: 'structured_edits' };
+}
+
+function lineStartOffset(text: string, lineNumber: number): number {
+  if (lineNumber <= 1) return 0;
+  let offset = 0;
+  let currentLine = 1;
+  while (currentLine < lineNumber) {
+    const next = text.indexOf('\n', offset);
+    if (next < 0) return text.length;
+    offset = next + 1;
+    currentLine += 1;
+  }
+  return offset;
+}
+
+function applyUnifiedDiffPatch(beforeText: string, diff: unknown): { text: string; applied: Array<Record<string, unknown>>; format: 'unified_diff' } {
+  if (typeof diff !== 'string' || diff.trim().length === 0) {
+    throw new GeneralRepoAccessError('INVALID_RANGE', 'unified_diff must be a non-empty string');
+  }
+  const lines = diff.replace(/\r\n/g, '\n').split('\n');
+  let text = beforeText;
+  let lineDelta = 0;
+  const applied: Array<Record<string, unknown>> = [];
+  let cursor = 0;
+  while (cursor < lines.length) {
+    const header = lines[cursor] ?? '';
+    if (!header || header.startsWith('--- ') || header.startsWith('+++ ')) {
+      cursor += 1;
+      continue;
+    }
+    const match = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/.exec(header);
+    if (!match) {
+      throw new GeneralRepoAccessError('INVALID_RANGE', 'unified_diff contains an unsupported line', { line: cursor + 1 });
+    }
+    const oldStart = Number(match[1]);
+    const oldLines: string[] = [];
+    const newLines: string[] = [];
+    cursor += 1;
+    while (cursor < lines.length && !(lines[cursor] ?? '').startsWith('@@ ')) {
+      const line = lines[cursor] ?? '';
+      if (line.startsWith('--- ') || line.startsWith('+++ ')) break;
+      if (line.startsWith('\\ No newline at end of file')) {
+        cursor += 1;
+        continue;
+      }
+      if (line.startsWith(' ')) {
+        oldLines.push(line.slice(1));
+        newLines.push(line.slice(1));
+      } else if (line.startsWith('-')) {
+        oldLines.push(line.slice(1));
+      } else if (line.startsWith('+')) {
+        newLines.push(line.slice(1));
+      } else if (line === '' && cursor === lines.length - 1) {
+        cursor += 1;
+        break;
+      } else {
+        throw new GeneralRepoAccessError('INVALID_RANGE', 'unified_diff hunk contains an unsupported line', { line: cursor + 1 });
+      }
+      cursor += 1;
+    }
+    if (oldLines.length === 0) {
+      throw new GeneralRepoAccessError('INVALID_RANGE', 'unified_diff pure insertion hunks require surrounding context');
+    }
+    const oldBlock = oldLines.join('\n');
+    const newBlock = newLines.join('\n');
+    const expectedOffset = lineStartOffset(text, oldStart + lineDelta);
+    if (!text.startsWith(oldBlock, expectedOffset)) {
+      throw new GeneralRepoAccessError('REVISION_CONFLICT', 'unified_diff hunk precondition does not match', {
+        hunk_index: applied.length + 1,
+        old_start: oldStart,
+      });
+    }
+    text = replaceTextAt(text, expectedOffset, oldBlock, newBlock);
+    lineDelta += newLines.length - oldLines.length;
+    applied.push({
+      hunk_index: applied.length + 1,
+      old_start: oldStart,
+      old_lines: oldLines.length,
+      new_lines: newLines.length,
+      old_sha256: sha256(oldBlock),
+      new_sha256: sha256(newBlock),
+    });
+  }
+  if (applied.length === 0) {
+    throw new GeneralRepoAccessError('INVALID_RANGE', 'unified_diff contains no hunks');
+  }
+  return { text, applied, format: 'unified_diff' };
+}
+
+function applyPatchContent(beforeText: string, args: Record<string, unknown>): { raw: Buffer; format: 'structured_edits' | 'unified_diff'; applied: Array<Record<string, unknown>> } {
+  const hasEdits = args.edits !== undefined;
+  const hasUnifiedDiff = args.unified_diff !== undefined;
+  if (hasEdits === hasUnifiedDiff) {
+    throw new GeneralRepoAccessError('INVALID_RANGE', 'provide exactly one of edits or unified_diff');
+  }
+  const patched = hasEdits ? applyStructuredPatchEdits(beforeText, args.edits) : applyUnifiedDiffPatch(beforeText, args.unified_diff);
+  if (patched.text === beforeText) {
+    throw new GeneralRepoAccessError('REVISION_CONFLICT', 'patch produced no content change');
+  }
+  return { raw: Buffer.from(patched.text, 'utf-8'), format: patched.format, applied: patched.applied };
+}
+
 function fsyncDirectoryBestEffort(path: string): void {
   let fd: number | null = null;
   try {
@@ -1243,6 +1425,63 @@ function indexRefreshError(refresh: CodeGraphRefreshResult): GeneralRepoAccessEr
     path_refresh_supported: refresh.pathRefreshSupported,
     index_revision: refresh.indexRevision,
   }, error?.retryable ?? true);
+}
+
+function mutationResult(ctx: GeneralRepoToolContext, repo: RepoRecord, ignore: IgnorePolicy, target: ResolvedRepoWritePath, opts: {
+  operation: 'create' | 'replace' | 'patch';
+  beforeHash: string | null;
+  beforeSize: number;
+  extra?: Record<string, unknown>;
+}): GeneralRepoToolResult {
+  const after = resolveRepoPath(repo, target.relativePath, ignore, { requireFile: true });
+  const afterRaw = readFileSync(after.canonicalPath);
+  const afterHash = sha256(afterRaw);
+  const afterEntry = metadataForResolved(after, ignore);
+  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore, { contentHash: false });
+  const indexedEntry = snapshot.entriesByPath.get(target.relativePath);
+  const indexState = mutationIndexState(snapshot);
+  const mutationId = `mut_${sha256(`${repo.repoId}\0${target.relativePath}\0${opts.beforeHash ?? 'new'}\0${afterHash}\0${Date.now()}`).slice(0, 16)}`;
+  const invalidationId = `idxinv_${sha256(`${mutationId}\0${snapshot.codeGraph.indexRevision}\0${target.relativePath}`).slice(0, 16)}`;
+
+  return textResult({
+    ...commonFields(repo, ignore, snapshot, { tool: opts.operation === 'patch' ? 'apply_patch' : 'write_file', paths: [target.relativePath] }),
+    path: target.relativePath,
+    operation: opts.operation,
+    mutation_id: mutationId,
+    before: {
+      existed: opts.beforeHash !== null,
+      sha256: opts.beforeHash,
+      size: opts.beforeSize,
+    },
+    after: {
+      ...afterEntry,
+      indexed: indexedEntry?.indexed ?? false,
+      codegraph_language: indexedEntry?.codegraph_language,
+      codegraph_node_count: indexedEntry?.codegraph_node_count,
+      codegraph_size: indexedEntry?.codegraph_size,
+      codegraph_index_lagging: indexedEntry?.codegraph_index_lagging,
+    },
+    diff: {
+      format: 'summary',
+      bytes_before: opts.beforeSize,
+      bytes_after: afterRaw.length,
+      bytes_delta: afterRaw.length - opts.beforeSize,
+      before_sha256: opts.beforeHash,
+      after_sha256: afterHash,
+    },
+    ...opts.extra,
+    index_state: indexState,
+    index: {
+      state: indexState,
+      action: snapshot.codeGraph.available ? 'refresh_repo_index_required' : 'codegraph_unavailable',
+      changed_paths: [target.relativePath],
+      mutation_id: mutationId,
+      invalidation_id: invalidationId,
+      refresh_tool: 'refresh_repo_index',
+      before_index_revision: snapshot.codeGraph.indexRevision,
+    },
+    codegraph: codeGraphSummary(snapshot),
+  });
 }
 
 function readFilePayload(repo: RepoRecord, ignore: IgnorePolicy, snapshot: VisibleEntrySnapshot, args: Record<string, unknown>, maxBytes = HARD_READ_BYTES, tool = 'read_file', verifySnapshotEntry = false): Record<string, unknown> {
@@ -1399,54 +1638,53 @@ function writeFileTool(ctx: GeneralRepoToolContext, args: Record<string, unknown
   atomicWriteFile(target, raw, mode);
   invalidateRepoCaches(repo);
 
-  const after = resolveRepoPath(repo, target.relativePath, ignore, { requireFile: true });
-  const afterRaw = readFileSync(after.canonicalPath);
-  const afterHash = sha256(afterRaw);
-  const afterEntry = metadataForResolved(after, ignore);
-  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore, { contentHash: false });
-  const indexedEntry = snapshot.entriesByPath.get(target.relativePath);
-  const indexState = mutationIndexState(snapshot);
-  const mutationId = `mut_${sha256(`${repo.repoId}\0${target.relativePath}\0${beforeHash ?? 'new'}\0${afterHash}\0${Date.now()}`).slice(0, 16)}`;
-  const invalidationId = `idxinv_${sha256(`${mutationId}\0${snapshot.codeGraph.indexRevision}\0${target.relativePath}`).slice(0, 16)}`;
-
-  return textResult({
-    ...commonFields(repo, ignore, snapshot, { tool: 'write_file', paths: [target.relativePath] }),
-    path: target.relativePath,
+  return mutationResult(ctx, repo, ignore, target, {
     operation: existed ? 'replace' : 'create',
-    mutation_id: mutationId,
-    encoding,
-    before: {
-      existed,
-      sha256: beforeHash,
-      size: beforeSize,
+    beforeHash,
+    beforeSize,
+    extra: { encoding },
+  });
+}
+
+function applyPatchTool(ctx: GeneralRepoToolContext, args: Record<string, unknown>): GeneralRepoToolResult {
+  const repo = resolveRepo(ctx, args.repo_id);
+  assertRepoWriteEnabled(repo);
+  const ignore = readIgnorePolicy(repo.canonicalRoot);
+  const target = resolveRepoWritePath(repo, args.path, ignore);
+  if (!target.existing) {
+    throw new GeneralRepoAccessError('NOT_FOUND', 'apply_patch requires an existing file', { path: target.relativePath });
+  }
+  const expectedHash = typeof args.expected_sha256 === 'string' ? args.expected_sha256.trim() : '';
+  if (!expectedHash) {
+    throw new GeneralRepoAccessError('REVISION_CONFLICT', 'expected_sha256 is required when applying a patch', { path: target.relativePath });
+  }
+  const beforeRaw = readFileSync(target.existing.canonicalPath);
+  const beforeHash = sha256(beforeRaw);
+  if (expectedHash !== beforeHash) {
+    throw new GeneralRepoAccessError('REVISION_CONFLICT', 'file changed after it was read', {
+      path: target.relativePath,
+      expected_sha256: expectedHash,
+      actual_sha256: beforeHash,
+    });
+  }
+  const beforeText = assertTextPatchable(beforeRaw, target.relativePath);
+  const patched = applyPatchContent(beforeText, args);
+  const mode = statSync(target.existing.canonicalPath).mode & 0o777;
+
+  atomicWriteFile(target, patched.raw, mode);
+  invalidateRepoCaches(repo);
+
+  return mutationResult(ctx, repo, ignore, target, {
+    operation: 'patch',
+    beforeHash,
+    beforeSize: beforeRaw.length,
+    extra: {
+      patch: {
+        format: patched.format,
+        applied_count: patched.applied.length,
+        applied: patched.applied,
+      },
     },
-    after: {
-      ...afterEntry,
-      indexed: indexedEntry?.indexed ?? false,
-      codegraph_language: indexedEntry?.codegraph_language,
-      codegraph_node_count: indexedEntry?.codegraph_node_count,
-      codegraph_size: indexedEntry?.codegraph_size,
-      codegraph_index_lagging: indexedEntry?.codegraph_index_lagging,
-    },
-    diff: {
-      format: 'summary',
-      bytes_before: beforeSize,
-      bytes_after: afterRaw.length,
-      bytes_delta: afterRaw.length - beforeSize,
-      before_sha256: beforeHash,
-      after_sha256: afterHash,
-    },
-    index_state: indexState,
-    index: {
-      state: indexState,
-      action: snapshot.codeGraph.available ? 'refresh_repo_index_required' : 'codegraph_unavailable',
-      changed_paths: [target.relativePath],
-      mutation_id: mutationId,
-      invalidation_id: invalidationId,
-      refresh_tool: 'refresh_repo_index',
-      before_index_revision: snapshot.codeGraph.indexRevision,
-    },
-    codegraph: codeGraphSummary(snapshot),
   });
 }
 
@@ -1851,6 +2089,35 @@ export function buildGeneralRepoToolDefinitions(): GeneralRepoToolDefinition[] {
       annotations: writeTool,
     },
     {
+      name: 'apply_patch',
+      description: 'Apply structured text edits or a guarded unified diff to one existing repo-relative file using an expected_sha256 precondition.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          repo_id: { type: 'string' },
+          path: { type: 'string' },
+          expected_sha256: { type: 'string' },
+          edits: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                old_text: { type: 'string' },
+                new_text: { type: 'string' },
+                occurrence: { type: 'number' },
+              },
+              required: ['old_text', 'new_text'],
+              additionalProperties: false,
+            },
+          },
+          unified_diff: { type: 'string' },
+        },
+        required: ['repo_id', 'path', 'expected_sha256'],
+        additionalProperties: false,
+      },
+      annotations: writeTool,
+    },
+    {
       name: 'refresh_repo_index',
       description: 'Synchronize CodeGraph for a read_write repo after mutations and return the new index/snapshot state.',
       inputSchema: {
@@ -1894,6 +2161,9 @@ export async function callGeneralRepoTool(ctx: GeneralRepoToolContext, name: str
         break;
       case 'write_file':
         result = writeFileTool(ctx, args);
+        break;
+      case 'apply_patch':
+        result = applyPatchTool(ctx, args);
         break;
       case 'refresh_repo_index':
         result = refreshRepoIndex(ctx, args);

--- a/tasks/notes/20260622-repo-harness-codegraph.notes.md
+++ b/tasks/notes/20260622-repo-harness-codegraph.notes.md
@@ -171,3 +171,22 @@ Sprint 0 contract freeze for `plans/sprints/20260622-repo-harness-codegraph-spri
 - Search still uses the existing CodeGraph-metadata plus guarded filesystem
   fallback path. This slice makes the index state observable; it does not claim
   a CodeGraph-only full-text backend.
+
+## 2026-06-23 apply_patch slice
+
+- `apply_patch` is implemented as an existing-file text mutation, not as a
+  create/update hybrid. Missing files return `NOT_FOUND`; binary targets return
+  `BINARY_CONTENT`.
+- The tool requires `expected_sha256` for the whole file before any patch
+  preconditions are evaluated. Stale file hashes, missing `old_text`, ambiguous
+  structured edits, and mismatched unified diff hunks all fail before writing.
+- Structured edits are the primary API shape: each edit replaces one exact
+  `old_text` with `new_text`. Repeated text requires a 1-based `occurrence` so
+  the caller cannot accidentally patch an ambiguous match.
+- Unified diff support is intentionally constrained to guarded hunks with
+  surrounding old/context lines. Pure insertion hunks without context are
+  rejected until there is a stronger insertion precondition shape.
+- The write path reuses the `write_file` atomic same-directory temp + fsync +
+  rename commit and shared mutation response. Existing file mode bits are
+  preserved; mtime changes and platform-specific metadata are not preserved in
+  the portable v1 mutation layer.

--- a/tests/cli/mcp-codegraph-contract.test.ts
+++ b/tests/cli/mcp-codegraph-contract.test.ts
@@ -18,6 +18,7 @@ const TOOL_NAMES = [
   'read_files',
   'stat_file',
   'write_file',
+  'apply_patch',
   'refresh_repo_index',
 ];
 
@@ -176,7 +177,7 @@ describe('general repo CodeGraph contract', () => {
     expect(schema.properties.common_response_fields.items.enum).toEqual(COMMON_RESPONSE_FIELDS);
 
     for (const tool of schema['x-repo-harness-tools']) {
-      if (tool.name === 'write_file' || tool.name === 'refresh_repo_index') {
+      if (tool.name === 'write_file' || tool.name === 'apply_patch' || tool.name === 'refresh_repo_index') {
         expect(tool.annotations).toEqual({
           readOnlyHint: false,
           destructiveHint: true,
@@ -187,6 +188,10 @@ describe('general repo CodeGraph contract', () => {
           expect(tool.input_schema.required).toEqual(['repo_id', 'path', 'content']);
           expect(tool.input_schema.properties.expected_sha256).toEqual({ type: 'string' });
           expect(tool.input_schema.properties.must_not_exist).toEqual({ type: 'boolean' });
+        } else if (tool.name === 'apply_patch') {
+          expect(tool.input_schema.required).toEqual(['repo_id', 'path', 'expected_sha256']);
+          expect(tool.input_schema.properties.edits.items.required).toEqual(['old_text', 'new_text']);
+          expect(tool.input_schema.properties.unified_diff).toEqual({ type: 'string' });
         } else {
           expect(tool.input_schema.required).toEqual(['repo_id']);
           expect(tool.input_schema.properties.paths.items).toEqual({ type: 'string' });

--- a/tests/cli/mcp-reader-tools.test.ts
+++ b/tests/cli/mcp-reader-tools.test.ts
@@ -90,10 +90,11 @@ describe('MCP reader tools', () => {
         'read_files',
         'stat_file',
         'write_file',
+        'apply_patch',
         'refresh_repo_index',
       ]);
       for (const definition of definitions) {
-        if (definition.name === 'write_file' || definition.name === 'refresh_repo_index') {
+        if (definition.name === 'write_file' || definition.name === 'apply_patch' || definition.name === 'refresh_repo_index') {
           expect(definition.annotations).toMatchObject({
             readOnlyHint: false,
             destructiveHint: true,
@@ -182,6 +183,13 @@ describe('MCP reader tools', () => {
         });
         expect(readOnlyWrite.error.code).toBe('WRITE_DISABLED');
         expect(existsSync(join(repoRoot, 'docs', 'created-by-write.txt'))).toBe(false);
+        const readOnlyPatch = await jsonTool(ctx, 'apply_patch', {
+          repo_id: repoId,
+          path: 'docs/design.md',
+          expected_sha256: 'unused',
+          edits: [{ old_text: 'authentication', new_text: 'authorization' }],
+        });
+        expect(readOnlyPatch.error.code).toBe('WRITE_DISABLED');
         const readOnlyRefresh = await jsonTool(ctx, 'refresh_repo_index', { repo_id: repoId, paths: ['docs/design.md'] });
         expect(readOnlyRefresh.error.code).toBe('WRITE_DISABLED');
 
@@ -326,7 +334,7 @@ describe('MCP reader tools', () => {
       const repoId = (await jsonTool(writeCtx, 'list_allowed_roots')).roots[0].repo_id;
       const capabilities = await jsonTool(writeCtx, 'get_repo_capabilities', { repo_id: repoId });
       expect(capabilities.access_mode).toBe('read_write');
-      expect(capabilities.write_tools).toEqual(['write_file', 'refresh_repo_index']);
+      expect(capabilities.write_tools).toEqual(['write_file', 'apply_patch', 'refresh_repo_index']);
 
       const missingCreatePrecondition = await jsonTool(writeCtx, 'write_file', {
         repo_id: repoId,
@@ -441,6 +449,76 @@ describe('MCP reader tools', () => {
         codegraph_size: 'second\n'.length,
       });
 
+      const patched = await jsonTool(writeCtx, 'apply_patch', {
+        repo_id: repoId,
+        path: 'docs/generated.txt',
+        expected_sha256: statAfterRefresh.sha256,
+        edits: [{ old_text: 'second\n', new_text: 'second patched\n' }],
+      });
+      expect(patched.error).toBeUndefined();
+      expect(patched).toMatchObject({
+        path: 'docs/generated.txt',
+        operation: 'patch',
+        before: { sha256: statAfterRefresh.sha256, size: 'second\n'.length },
+        patch: { format: 'structured_edits', applied_count: 1 },
+        index: { action: 'refresh_repo_index_required', changed_paths: ['docs/generated.txt'] },
+      });
+      expect(patched.mutation_id).toMatch(/^mut_[a-f0-9]{16}$/);
+      expect(patched.index.invalidation_id).toMatch(/^idxinv_[a-f0-9]{16}$/);
+      expect(patched.after.sha256).not.toBe(statAfterRefresh.sha256);
+      expect(readFileSync(join(repoRoot, 'docs', 'generated.txt'), 'utf-8')).toBe('second patched\n');
+      expect(readdirSync(join(repoRoot, 'docs')).some((name) => name.includes('.repo-harness-'))).toBe(false);
+
+      const stalePatch = await jsonTool(writeCtx, 'apply_patch', {
+        repo_id: repoId,
+        path: 'docs/generated.txt',
+        expected_sha256: statAfterRefresh.sha256,
+        edits: [{ old_text: 'second patched', new_text: 'stale write' }],
+      });
+      expect(stalePatch.error.code).toBe('REVISION_CONFLICT');
+      expect(stalePatch.error.details.actual_sha256).toBe(patched.after.sha256);
+      expect(readFileSync(join(repoRoot, 'docs', 'generated.txt'), 'utf-8')).toBe('second patched\n');
+
+      writeFileSync(join(repoRoot, 'docs', 'ambiguous.txt'), 'same\nsame\n');
+      const ambiguousStat = await jsonTool(writeCtx, 'stat_file', { repo_id: repoId, path: 'docs/ambiguous.txt' });
+      const ambiguousPatch = await jsonTool(writeCtx, 'apply_patch', {
+        repo_id: repoId,
+        path: 'docs/ambiguous.txt',
+        expected_sha256: ambiguousStat.sha256,
+        edits: [{ old_text: 'same', new_text: 'changed' }],
+      });
+      expect(ambiguousPatch.error.code).toBe('REVISION_CONFLICT');
+      expect(readFileSync(join(repoRoot, 'docs', 'ambiguous.txt'), 'utf-8')).toBe('same\nsame\n');
+
+      const occurrencePatch = await jsonTool(writeCtx, 'apply_patch', {
+        repo_id: repoId,
+        path: 'docs/ambiguous.txt',
+        expected_sha256: ambiguousStat.sha256,
+        edits: [{ old_text: 'same', new_text: 'changed', occurrence: 2 }],
+      });
+      expect(occurrencePatch.error).toBeUndefined();
+      expect(readFileSync(join(repoRoot, 'docs', 'ambiguous.txt'), 'utf-8')).toBe('same\nchanged\n');
+
+      writeFileSync(join(repoRoot, 'docs', 'unified.txt'), 'alpha\nbeta\ngamma\n');
+      const unifiedStat = await jsonTool(writeCtx, 'stat_file', { repo_id: repoId, path: 'docs/unified.txt' });
+      const unifiedPatch = await jsonTool(writeCtx, 'apply_patch', {
+        repo_id: repoId,
+        path: 'docs/unified.txt',
+        expected_sha256: unifiedStat.sha256,
+        unified_diff: [
+          '--- a/docs/unified.txt',
+          '+++ b/docs/unified.txt',
+          '@@ -1,3 +1,3 @@',
+          ' alpha',
+          '-beta',
+          '+bravo',
+          ' gamma',
+        ].join('\n'),
+      });
+      expect(unifiedPatch.error).toBeUndefined();
+      expect(unifiedPatch.patch).toMatchObject({ format: 'unified_diff', applied_count: 1 });
+      expect(readFileSync(join(repoRoot, 'docs', 'unified.txt'), 'utf-8')).toBe('alpha\nbravo\ngamma\n');
+
       const ignored = await jsonTool(writeCtx, 'write_file', {
         repo_id: repoId,
         path: 'ignored.md',
@@ -458,10 +536,13 @@ describe('MCP reader tools', () => {
 
       const auditText = readFileSync(join(repoRoot, '.ai', 'harness', 'mcp', 'audit.log'), 'utf-8');
       expect(auditText).toContain('"tool":"write_file"');
+      expect(auditText).toContain('"tool":"apply_patch"');
       expect(auditText).toContain('"status":"ok"');
       expect(auditText).toContain('"status":"blocked"');
       expect(auditText).not.toContain('first\n');
       expect(auditText).not.toContain('second\n');
+      expect(auditText).not.toContain('second patched\n');
+      expect(auditText).not.toContain('bravo');
       expect(auditText).not.toContain('stale\n');
     }, { accessMode: 'read_write' });
   });


### PR DESCRIPTION
## Summary
- Add a capability-gated general repo `apply_patch` tool behind read_write access.
- Support existing-file text patches with required `expected_sha256`, structured `old_text` edits, guarded unified-diff hunks, atomic same-directory writes, and index invalidation responses.
- Update schema, docs, ADR notes, sprint checklist evidence, and MCP reader/contract tests.

## Verification
- `jq empty assets/mcp/general-repo-reader-tools.v1.schema.json`
- `git diff --check`
- `bun test tests/readme-dx.test.ts tests/cli/mcp-reader-tools.test.ts tests/cli/mcp-codegraph-contract.test.ts`
- `bun run check:type`
- `bash scripts/check-deploy-sql-order.sh`
- `bash scripts/check-architecture-sync.sh`
- `bash scripts/check-task-sync.sh`
- `bun scripts/inspect-project-state.ts --repo . --format text`
- `bash scripts/migrate-project-template.sh --repo . --dry-run`
- `bun test`
- `bash scripts/ensure-codegraph.sh --sync`
- `repo-harness setup check --target codex --check-updates --json` (0 fail; optional `skills_cli` timeout warning)
- `bash scripts/prepare-codex-handoff.sh --reason codegraph-s3-apply-patch`
- `bash scripts/check-task-workflow.sh --strict`

## Stack
- Based on #26 / `codex/repo-harness-codegraph-s3-index-sync`.
