### PR TITLE
Add guarded path mutation tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,17 +356,20 @@ registered adopted repos. Use `discover_harness_repos` first, then call
 `list_allowed_roots` to get the stable `repo_id`. General repo reads use
 `repo_manifest`, `list_tree`, `stat_file`, `read_file`, `read_files`, and
 `search_text`. The write surface currently exposes `write_file`, `apply_patch`,
-and `refresh_repo_index`, all rejected unless that registered repo is explicitly
-configured as `read_write`.
+`move_path`, `delete_path`, and `refresh_repo_index`, all rejected unless that
+registered repo is explicitly configured as `read_write`.
 `write_file` creates only with `must_not_exist: true`, replaces only with
 `expected_sha256`, and reports `before`, `after`, `diff`, `mutation_id`, and
 `index_state` after an atomic same-directory rename. `apply_patch` operates only
 on existing text files, requires `expected_sha256`, and accepts either structured
 `old_text`/`new_text` edits or guarded unified diff hunks. Patch precondition
 misses and stale hashes return `REVISION_CONFLICT` without writing. Successful
-writes leave the index pending; `refresh_repo_index` runs CodeGraph sync for the
-repo, invalidates reader snapshots, and returns the new `snapshot_id`,
-`index_revision`, `index_state`, and refresh strategy. The CLI adapter reports
+file moves require a source `expected_sha256` plus `must_not_exist: true` for the
+target. Deletes require `expected_sha256`; v1 deletes regular files only and
+rejects directory or recursive deletes. Successful writes leave the index
+pending; `refresh_repo_index` runs CodeGraph sync for the repo, invalidates
+reader snapshots, and returns the new `snapshot_id`, `index_revision`,
+`index_state`, and refresh strategy. The CLI adapter reports
 `path_refresh_supported:false` when it must use repo-level sync for requested
 paths. The repo whitelist is the authorization boundary, `.ignore` is the only
 content exclusion source, paths are repo-relative, and authorized file content is

--- a/assets/mcp/general-repo-reader-tools.v1.schema.json
+++ b/assets/mcp/general-repo-reader-tools.v1.schema.json
@@ -45,7 +45,7 @@
     },
     "tools": {
       "type": "array",
-      "minItems": 10,
+      "minItems": 12,
       "items": {
         "$ref": "#/$defs/tool"
       }
@@ -120,6 +120,8 @@
             "stat_file",
             "write_file",
             "apply_patch",
+            "move_path",
+            "delete_path",
             "refresh_repo_index"
           ]
         },
@@ -632,6 +634,113 @@
           "after",
           "diff",
           "patch",
+          "index_state"
+        ],
+        "properties": {},
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "move_path",
+      "description": "Move one existing repo-relative file to a new repo-relative path using source hash and target-existence preconditions.",
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "input_schema": {
+        "type": "object",
+        "required": [
+          "repo_id",
+          "from_path",
+          "to_path",
+          "expected_sha256",
+          "must_not_exist"
+        ],
+        "properties": {
+          "repo_id": {
+            "type": "string"
+          },
+          "from_path": {
+            "type": "string"
+          },
+          "to_path": {
+            "type": "string"
+          },
+          "expected_sha256": {
+            "type": "string"
+          },
+          "must_not_exist": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "required": [
+          "repo_id",
+          "snapshot_id",
+          "ignore_digest",
+          "path",
+          "from_path",
+          "to_path",
+          "mutation_id",
+          "before",
+          "after",
+          "diff",
+          "move",
+          "index_state"
+        ],
+        "properties": {},
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "delete_path",
+      "description": "Delete one existing repo-relative regular file using an expected_sha256 precondition; directory and recursive deletes are disabled in v1.",
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "input_schema": {
+        "type": "object",
+        "required": [
+          "repo_id",
+          "path",
+          "expected_sha256"
+        ],
+        "properties": {
+          "repo_id": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "expected_sha256": {
+            "type": "string"
+          },
+          "recursive": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "required": [
+          "repo_id",
+          "snapshot_id",
+          "ignore_digest",
+          "path",
+          "mutation_id",
+          "before",
+          "after",
+          "diff",
+          "deleted",
           "index_state"
         ],
         "properties": {},

--- a/docs/architecture/decisions/20260622-general-repo-codegraph-access.md
+++ b/docs/architecture/decisions/20260622-general-repo-codegraph-access.md
@@ -61,8 +61,7 @@ Sprint 0 freezes the read contract for:
 - `search_text`
 
 The current write implementation covers `write_file` create/replace,
-`apply_patch`, and `refresh_repo_index`. Move and delete remain
-implementation-gated until their Sprint 3 slices land.
+`apply_patch`, `move_path`, `delete_path`, and `refresh_repo_index`.
 
 `write_file` and `apply_patch` commit filesystem truth first and return an index
 invalidation record with `index_state: pending` when CodeGraph is available.
@@ -73,6 +72,15 @@ precondition and returns `REVISION_CONFLICT` if it no longer matches. Existing
 file replacements preserve the file mode bits used by the target. Filesystem
 mtime changes as part of the commit, and ownership, xattrs, and platform-specific
 metadata are not preserved in this portable v1 mutation layer.
+
+`move_path` is a regular-file-only mutation. It requires the source
+`expected_sha256`, refuses symlink moves, requires the target parent directory to
+already exist, and requires `must_not_exist: true` for the target path.
+`delete_path` also deletes only regular files and requires `expected_sha256`.
+Directory creation, empty-directory mutation, and recursive delete are explicitly
+disabled in v1; directory targets fail before any filesystem mutation. This
+keeps tree-shape changes out of the first mutation layer while still closing the
+lost-update contract for file moves and deletes.
 
 The explicit `refresh_repo_index` tool requires the same `read_write` repo
 capability, reuses the same path guard and `.ignore` policy for requested paths,

--- a/docs/repo-harness-chatgpt-mcp-setup.md
+++ b/docs/repo-harness-chatgpt-mcp-setup.md
@@ -126,7 +126,7 @@ Use ChatGPT for planning and review. Use Codex for local execution.
 1. Use the single configured Connector for workflow planning and repo tools.
 2. Call `discover_harness_repos` to list registered adopted repos, then pass `repo_path` when targeting a specific project.
 3. For registered repo document/code reading, call `list_allowed_roots` to get the stable `repo_id`, then use `get_repo_capabilities`, `repo_manifest`, `list_tree`, `stat_file`, `read_file`, `read_files`, and `search_text`.
-4. For registered repo writes, first check `get_repo_capabilities.write_tools`; only repos explicitly configured as `read_write` expose `write_file`, `apply_patch`, and `refresh_repo_index`.
+4. For registered repo writes, first check `get_repo_capabilities.write_tools`; only repos explicitly configured as `read_write` expose `write_file`, `apply_patch`, `move_path`, `delete_path`, and `refresh_repo_index`.
 5. Ask ChatGPT to turn the idea into a PRD with `write_prd_from_idea`.
 6. Ask ChatGPT to turn the PRD into a checklist Sprint with `write_checklist_sprint`.
 7. Ask ChatGPT to prepare a Codex Goal with `prepare_codex_goal_from_sprint`.
@@ -151,16 +151,19 @@ Authorized file content is not implicitly redacted in `read_file`,
 `read_files`, or `search_text` responses. The MCP audit path records tool name,
 target path, input hash, status, and errors, but not file bodies.
 
-`write_file` and `apply_patch` are the first general repo mutation tools. They
-are runtime-gated by the registered repo access mode and return `WRITE_DISABLED`
-for `read_only` repos. New files require `must_not_exist: true`; replacements
-and patches require `expected_sha256`; mismatches return `REVISION_CONFLICT`
-without writing. `apply_patch` operates on existing text files and accepts either
-structured `old_text`/`new_text` edits or guarded unified diff hunks. A
-successful mutation uses a same-directory temporary file plus atomic rename,
-returns `before`, `after`, `diff`, `mutation_id`, and `index_state`, and leaves
-CodeGraph refresh explicitly pending. Call `refresh_repo_index` with the changed
-paths after a successful mutation to run CodeGraph sync, invalidate repo snapshot
+`write_file`, `apply_patch`, `move_path`, and `delete_path` are the general repo
+mutation tools. They are runtime-gated by the registered repo access mode and
+return `WRITE_DISABLED` for `read_only` repos. New files require
+`must_not_exist: true`; replacements, patches, moves, and deletes require
+`expected_sha256`; mismatches return `REVISION_CONFLICT` without writing.
+`apply_patch` operates on existing text files and accepts either structured
+`old_text`/`new_text` edits or guarded unified diff hunks. `move_path` moves one
+regular file only when the target also carries `must_not_exist: true`.
+`delete_path` deletes regular files only; directory creation, empty-directory
+mutation, and recursive delete are disabled in v1. A successful mutation returns
+`before`, `after`, `diff`, `mutation_id`, and `index_state`, and leaves CodeGraph
+refresh explicitly pending. Call `refresh_repo_index` with the changed paths
+after a successful mutation to run CodeGraph sync, invalidate repo snapshot
 caches, and receive the new `index_revision`, `snapshot_id`, `index_state`, and
 refresh strategy. The bundled CLI adapter uses repo-level `codegraph sync` when
 path-only refresh is unavailable and reports that tradeoff with

--- a/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
+++ b/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
@@ -525,9 +525,9 @@ Sprint 2 adapter/snapshot evidence:
 - [x] **S3-CAP-003** 写请求复用同一 Path Guard 和 IgnorePolicy。
 - [x] **S3-API-001** 实现 `write_file` create/replace。
 - [x] **S3-API-002** 实现 `apply_patch`，优先结构化 edits，必要时支持 unified diff。
-- [ ] **S3-API-003** 实现 `move_path`。
-- [ ] **S3-API-004** 实现 `delete_path`。
-- [ ] **S3-API-005** 定义目录创建、空目录和递归删除策略；递归删除建议首版默认关闭或要求显式参数。
+- [x] **S3-API-003** 实现 `move_path`。
+- [x] **S3-API-004** 实现 `delete_path`。
+- [x] **S3-API-005** 定义目录创建、空目录和递归删除策略；递归删除建议首版默认关闭或要求显式参数。
 - [x] **S3-API-006** 写响应返回 before/after hash、diff、mutation id 和 index state。
 
 ## 10.2 乐观并发与原子写
@@ -539,7 +539,7 @@ Sprint 2 adapter/snapshot evidence:
 - [x] **S3-MUT-005** 写临时文件 → fsync → atomic rename。
 - [x] **S3-MUT-006** 保留原文件权限和必要 metadata，策略写入 ADR。
 - [x] **S3-MUT-007** patch 应验证每个 hunk 或精确文本 precondition。
-- [ ] **S3-MUT-008** move/delete 同样进行版本和目标存在性检查。
+- [x] **S3-MUT-008** move/delete 同样进行版本和目标存在性检查。
 - [ ] **S3-MUT-009** 写失败不得留下半文件或跨 repo 临时文件。
 - [ ] **S3-MUT-010** 对写入过程进行故障注入测试：磁盘满、权限变化、进程中断、rename 失败。
 
@@ -586,9 +586,9 @@ Sprint 3 write_file evidence:
 - Verified in this slice: success and precondition-conflict paths leave no
   `.repo-harness-*` temporary files in the target directory. Full write-failure
   injection remains open under `S3-MUT-009/010`.
-- Explicitly still open: `move_path`, `delete_path`, recursive directory policy,
-  full index retry/dead-letter, index-lag monitoring, and complete write
-  audit/runbook coverage.
+- Explicitly still open: full write-failure injection, full index
+  retry/dead-letter, index-lag monitoring, and complete write audit/runbook
+  coverage.
 
 Sprint 3 index-sync evidence:
 
@@ -630,6 +630,29 @@ Sprint 3 apply_patch evidence:
 - Metadata policy: existing file mode bits are preserved. Filesystem mtime
   changes as part of the commit; ownership, xattrs, and platform-specific
   metadata are out of scope for the portable v1 mutation layer.
+
+Sprint 3 move/delete path mutation evidence:
+
+- Runtime: `src/cli/mcp/general-repo-access.ts`
+- Tests: `tests/cli/mcp-reader-tools.test.ts`,
+  `tests/cli/mcp-codegraph-contract.test.ts`
+- Schema/docs: `assets/mcp/general-repo-reader-tools.v1.schema.json`,
+  `README.md`, `docs/repo-harness-chatgpt-mcp-setup.md`,
+  `docs/architecture/decisions/20260622-general-repo-codegraph-access.md`,
+  `tasks/notes/20260622-repo-harness-codegraph.notes.md`
+- Completed slice: `move_path` and `delete_path` are exposed only for
+  `read_write` repos and reuse the same repo registry, Path Guard, `.ignore`,
+  snapshot invalidation, audit hash, and pending CodeGraph refresh contract as
+  `write_file` and `apply_patch`.
+- `move_path` is regular-file only, requires the source `expected_sha256`,
+  rejects stale hashes, requires an existing target parent directory, and
+  requires `must_not_exist: true` so target collisions return `TARGET_EXISTS`
+  before `rename`.
+- `delete_path` is regular-file only, requires `expected_sha256`, returns the
+  deleted metadata, and rejects stale hashes before removing the file.
+- Directory policy for v1 is now explicit: write tools do not create parent
+  directories; empty-directory mutation is unsupported; recursive delete is
+  disabled and returns a stable policy error before any filesystem mutation.
 
 ---
 

--- a/src/cli/mcp/general-repo-access.ts
+++ b/src/cli/mcp/general-repo-access.ts
@@ -166,6 +166,8 @@ const GENERAL_REPO_TOOLS = [
   'stat_file',
   'write_file',
   'apply_patch',
+  'move_path',
+  'delete_path',
   'refresh_repo_index',
 ] as const;
 
@@ -184,7 +186,7 @@ const MAX_LAGGING_PATHS_RETURNED = 50;
 const DEFAULT_CODEGRAPH_ADAPTER = createCodeGraphCliAdapter();
 const SNAPSHOT_CACHE = new Map<string, VisibleEntrySnapshot>();
 const ENTRY_METADATA_CACHE = new Map<string, EntryMetadataCacheValue>();
-const WRITE_TOOLS = new Set<string>(['write_file', 'apply_patch', 'refresh_repo_index']);
+const WRITE_TOOLS = new Set<string>(['write_file', 'apply_patch', 'move_path', 'delete_path', 'refresh_repo_index']);
 
 export type GeneralRepoToolName = typeof GENERAL_REPO_TOOLS[number];
 
@@ -225,6 +227,12 @@ function audit(ctx: GeneralRepoToolContext, tool: string, status: 'ok' | 'blocke
     inputHash: hashMcpInput(input),
     error,
   });
+}
+
+function auditTargetPath(input: Record<string, unknown>): string | undefined {
+  if (typeof input.path === 'string') return input.path;
+  if (typeof input.from_path === 'string' && typeof input.to_path === 'string') return `${input.from_path} -> ${input.to_path}`;
+  return undefined;
 }
 
 function sha256(value: string | Buffer): string {
@@ -1428,9 +1436,12 @@ function indexRefreshError(refresh: CodeGraphRefreshResult): GeneralRepoAccessEr
 }
 
 function mutationResult(ctx: GeneralRepoToolContext, repo: RepoRecord, ignore: IgnorePolicy, target: ResolvedRepoWritePath, opts: {
-  operation: 'create' | 'replace' | 'patch';
+  operation: 'create' | 'replace' | 'patch' | 'move';
   beforeHash: string | null;
   beforeSize: number;
+  tool?: string;
+  responsePath?: string;
+  changedPaths?: string[];
   extra?: Record<string, unknown>;
 }): GeneralRepoToolResult {
   const after = resolveRepoPath(repo, target.relativePath, ignore, { requireFile: true });
@@ -1440,12 +1451,15 @@ function mutationResult(ctx: GeneralRepoToolContext, repo: RepoRecord, ignore: I
   const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore, { contentHash: false });
   const indexedEntry = snapshot.entriesByPath.get(target.relativePath);
   const indexState = mutationIndexState(snapshot);
-  const mutationId = `mut_${sha256(`${repo.repoId}\0${target.relativePath}\0${opts.beforeHash ?? 'new'}\0${afterHash}\0${Date.now()}`).slice(0, 16)}`;
+  const changedPaths = cachePaths(opts.changedPaths ?? [target.relativePath]);
+  const responsePath = opts.responsePath ?? target.relativePath;
+  const mutationTool = opts.tool ?? (opts.operation === 'patch' ? 'apply_patch' : 'write_file');
+  const mutationId = `mut_${sha256(`${repo.repoId}\0${changedPaths.join('\0')}\0${opts.beforeHash ?? 'new'}\0${afterHash}\0${Date.now()}`).slice(0, 16)}`;
   const invalidationId = `idxinv_${sha256(`${mutationId}\0${snapshot.codeGraph.indexRevision}\0${target.relativePath}`).slice(0, 16)}`;
 
   return textResult({
-    ...commonFields(repo, ignore, snapshot, { tool: opts.operation === 'patch' ? 'apply_patch' : 'write_file', paths: [target.relativePath] }),
-    path: target.relativePath,
+    ...commonFields(repo, ignore, snapshot, { tool: mutationTool, paths: changedPaths }),
+    path: responsePath,
     operation: opts.operation,
     mutation_id: mutationId,
     before: {
@@ -1474,7 +1488,51 @@ function mutationResult(ctx: GeneralRepoToolContext, repo: RepoRecord, ignore: I
     index: {
       state: indexState,
       action: snapshot.codeGraph.available ? 'refresh_repo_index_required' : 'codegraph_unavailable',
-      changed_paths: [target.relativePath],
+      changed_paths: changedPaths,
+      mutation_id: mutationId,
+      invalidation_id: invalidationId,
+      refresh_tool: 'refresh_repo_index',
+      before_index_revision: snapshot.codeGraph.indexRevision,
+    },
+    codegraph: codeGraphSummary(snapshot),
+  });
+}
+
+function deleteMutationResult(ctx: GeneralRepoToolContext, repo: RepoRecord, ignore: IgnorePolicy, deleted: ManifestEntry, beforeHash: string, beforeSize: number): GeneralRepoToolResult {
+  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore, { contentHash: false });
+  const indexState = mutationIndexState(snapshot);
+  const mutationId = `mut_${sha256(`${repo.repoId}\0${deleted.path}\0${beforeHash}\0deleted\0${Date.now()}`).slice(0, 16)}`;
+  const invalidationId = `idxinv_${sha256(`${mutationId}\0${snapshot.codeGraph.indexRevision}\0${deleted.path}`).slice(0, 16)}`;
+
+  return textResult({
+    ...commonFields(repo, ignore, snapshot, { tool: 'delete_path', paths: [deleted.path] }),
+    path: deleted.path,
+    operation: 'delete',
+    mutation_id: mutationId,
+    before: {
+      existed: true,
+      sha256: beforeHash,
+      size: beforeSize,
+    },
+    after: {
+      existed: false,
+      sha256: null,
+      size: 0,
+    },
+    deleted,
+    diff: {
+      format: 'summary',
+      bytes_before: beforeSize,
+      bytes_after: 0,
+      bytes_delta: -beforeSize,
+      before_sha256: beforeHash,
+      after_sha256: null,
+    },
+    index_state: indexState,
+    index: {
+      state: indexState,
+      action: snapshot.codeGraph.available ? 'refresh_repo_index_required' : 'codegraph_unavailable',
+      changed_paths: [deleted.path],
       mutation_id: mutationId,
       invalidation_id: invalidationId,
       refresh_tool: 'refresh_repo_index',
@@ -1686,6 +1744,110 @@ function applyPatchTool(ctx: GeneralRepoToolContext, args: Record<string, unknow
       },
     },
   });
+}
+
+function movePathTool(ctx: GeneralRepoToolContext, args: Record<string, unknown>): GeneralRepoToolResult {
+  const repo = resolveRepo(ctx, args.repo_id);
+  assertRepoWriteEnabled(repo);
+  const ignore = readIgnorePolicy(repo.canonicalRoot);
+  const source = resolveRepoPath(repo, args.from_path, ignore, { requireFile: true });
+  if (source.type === 'symlink') {
+    throw new GeneralRepoAccessError('SYMLINK_ESCAPE', 'move_path does not move symlinks', { path: source.relativePath });
+  }
+  const beforeRaw = readFileSync(source.canonicalPath);
+  const beforeHash = sha256(beforeRaw);
+  const expectedHash = typeof args.expected_sha256 === 'string' ? args.expected_sha256.trim() : '';
+  if (!expectedHash) {
+    throw new GeneralRepoAccessError('REVISION_CONFLICT', 'expected_sha256 is required when moving a file', {
+      path: source.relativePath,
+      actual_sha256: beforeHash,
+    });
+  }
+  if (expectedHash !== beforeHash) {
+    throw new GeneralRepoAccessError('REVISION_CONFLICT', 'file changed after it was read', {
+      path: source.relativePath,
+      expected_sha256: expectedHash,
+      actual_sha256: beforeHash,
+    });
+  }
+  const mustNotExist = booleanArg(args.must_not_exist, false);
+  const target = resolveRepoWritePath(repo, args.to_path, ignore);
+  if (target.existing) {
+    throw new GeneralRepoAccessError('TARGET_EXISTS', 'move target already exists', { path: target.relativePath });
+  }
+  if (!mustNotExist) {
+    throw new GeneralRepoAccessError('REVISION_CONFLICT', 'must_not_exist: true is required when moving to a new target', {
+      path: target.relativePath,
+    });
+  }
+
+  renameSync(source.canonicalPath, target.canonicalPath);
+  fsyncDirectoryBestEffort(dirname(source.canonicalPath));
+  if (dirname(source.canonicalPath) !== target.parentCanonicalPath) fsyncDirectoryBestEffort(target.parentCanonicalPath);
+  invalidateRepoCaches(repo);
+
+  return mutationResult(ctx, repo, ignore, target, {
+    operation: 'move',
+    tool: 'move_path',
+    responsePath: target.relativePath,
+    changedPaths: [source.relativePath, target.relativePath],
+    beforeHash,
+    beforeSize: beforeRaw.length,
+    extra: {
+      from_path: source.relativePath,
+      to_path: target.relativePath,
+      move: {
+        source_sha256: beforeHash,
+        target_must_not_exist: true,
+      },
+    },
+  });
+}
+
+function deletePathTool(ctx: GeneralRepoToolContext, args: Record<string, unknown>): GeneralRepoToolResult {
+  const repo = resolveRepo(ctx, args.repo_id);
+  assertRepoWriteEnabled(repo);
+  const ignore = readIgnorePolicy(repo.canonicalRoot);
+  const target = resolveRepoPath(repo, args.path, ignore);
+  const recursive = booleanArg(args.recursive, false);
+  if (target.type === 'directory') {
+    if (recursive) {
+      throw new GeneralRepoAccessError('INVALID_RANGE', 'recursive delete is disabled in v1', { path: target.relativePath, recursive });
+    }
+    throw new GeneralRepoAccessError('NOT_A_FILE', 'delete_path only deletes regular files; directory deletion is disabled', {
+      path: target.relativePath,
+      recursive: false,
+    });
+  }
+  if (target.type === 'symlink') {
+    throw new GeneralRepoAccessError('SYMLINK_ESCAPE', 'delete_path does not delete symlinks', { path: target.relativePath });
+  }
+  if (!target.contentFile) {
+    throw new GeneralRepoAccessError('NOT_A_FILE', 'delete_path only deletes regular files', { path: target.relativePath });
+  }
+  const beforeRaw = readFileSync(target.canonicalPath);
+  const beforeHash = sha256(beforeRaw);
+  const expectedHash = typeof args.expected_sha256 === 'string' ? args.expected_sha256.trim() : '';
+  if (!expectedHash) {
+    throw new GeneralRepoAccessError('REVISION_CONFLICT', 'expected_sha256 is required when deleting a file', {
+      path: target.relativePath,
+      actual_sha256: beforeHash,
+    });
+  }
+  if (expectedHash !== beforeHash) {
+    throw new GeneralRepoAccessError('REVISION_CONFLICT', 'file changed after it was read', {
+      path: target.relativePath,
+      expected_sha256: expectedHash,
+      actual_sha256: beforeHash,
+    });
+  }
+  const deleted = metadataForResolved(target, ignore, undefined, { contentHash: true, cache: false });
+
+  rmSync(target.canonicalPath);
+  fsyncDirectoryBestEffort(dirname(target.canonicalPath));
+  invalidateRepoCaches(repo);
+
+  return deleteMutationResult(ctx, repo, ignore, deleted, beforeHash, beforeRaw.length);
 }
 
 function refreshRepoIndex(ctx: GeneralRepoToolContext, args: Record<string, unknown>): GeneralRepoToolResult {
@@ -2118,6 +2280,39 @@ export function buildGeneralRepoToolDefinitions(): GeneralRepoToolDefinition[] {
       annotations: writeTool,
     },
     {
+      name: 'move_path',
+      description: 'Move one existing repo-relative file to a new repo-relative path using source hash and target-existence preconditions.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          repo_id: { type: 'string' },
+          from_path: { type: 'string' },
+          to_path: { type: 'string' },
+          expected_sha256: { type: 'string' },
+          must_not_exist: { type: 'boolean' },
+        },
+        required: ['repo_id', 'from_path', 'to_path', 'expected_sha256', 'must_not_exist'],
+        additionalProperties: false,
+      },
+      annotations: writeTool,
+    },
+    {
+      name: 'delete_path',
+      description: 'Delete one existing repo-relative regular file using an expected_sha256 precondition; directory and recursive deletes are disabled in v1.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          repo_id: { type: 'string' },
+          path: { type: 'string' },
+          expected_sha256: { type: 'string' },
+          recursive: { type: 'boolean' },
+        },
+        required: ['repo_id', 'path', 'expected_sha256'],
+        additionalProperties: false,
+      },
+      annotations: writeTool,
+    },
+    {
       name: 'refresh_repo_index',
       description: 'Synchronize CodeGraph for a read_write repo after mutations and return the new index/snapshot state.',
       inputSchema: {
@@ -2165,20 +2360,26 @@ export async function callGeneralRepoTool(ctx: GeneralRepoToolContext, name: str
       case 'apply_patch':
         result = applyPatchTool(ctx, args);
         break;
+      case 'move_path':
+        result = movePathTool(ctx, args);
+        break;
+      case 'delete_path':
+        result = deletePathTool(ctx, args);
+        break;
       case 'refresh_repo_index':
         result = refreshRepoIndex(ctx, args);
         break;
       default:
         return errorResult('INTERNAL_ADAPTER_ERROR', `tool is not a general repo reader tool: ${name}`);
     }
-    audit(ctx, name, 'ok', args, typeof args.path === 'string' ? args.path : undefined);
+    audit(ctx, name, 'ok', args, auditTargetPath(args));
     return result;
   } catch (error) {
     if (error instanceof GeneralRepoAccessError) {
-      audit(ctx, name, 'blocked', args, typeof args.path === 'string' ? args.path : undefined, error.message);
+      audit(ctx, name, 'blocked', args, auditTargetPath(args), error.message);
       return errorResult(error.code, error.message, error.details, error.retryable);
     }
-    audit(ctx, name, 'failed', args, typeof args.path === 'string' ? args.path : undefined, error instanceof Error ? error.message : String(error));
+    audit(ctx, name, 'failed', args, auditTargetPath(args), error instanceof Error ? error.message : String(error));
     return errorResult('INTERNAL_ADAPTER_ERROR', error instanceof Error ? error.message : String(error));
   }
 }

--- a/tasks/notes/20260622-repo-harness-codegraph.notes.md
+++ b/tasks/notes/20260622-repo-harness-codegraph.notes.md
@@ -190,3 +190,18 @@ Sprint 0 contract freeze for `plans/sprints/20260622-repo-harness-codegraph-spri
   rename commit and shared mutation response. Existing file mode bits are
   preserved; mtime changes and platform-specific metadata are not preserved in
   the portable v1 mutation layer.
+
+## 2026-06-23 move/delete path mutation slice
+
+- `move_path` and `delete_path` deliberately target regular files only. Moving
+  or deleting symlinks, directories, empty directories, or recursive trees stays
+  disabled in v1 so the first path-mutation surface does not create unbounded
+  tree semantics.
+- `move_path` requires the source `expected_sha256`, requires the target parent
+  directory to already exist, and requires `must_not_exist: true` for the target.
+  Stale source hashes and existing targets fail before `rename`.
+- `delete_path` requires `expected_sha256` and returns the deleted file metadata.
+  Directory targets fail before any filesystem mutation; `recursive: true`
+  returns an explicit unsupported-policy error.
+- Successful move/delete mutations invalidate snapshots and return the same
+  pending CodeGraph refresh contract as `write_file` and `apply_patch`.

--- a/tests/cli/mcp-codegraph-contract.test.ts
+++ b/tests/cli/mcp-codegraph-contract.test.ts
@@ -19,6 +19,8 @@ const TOOL_NAMES = [
   'stat_file',
   'write_file',
   'apply_patch',
+  'move_path',
+  'delete_path',
   'refresh_repo_index',
 ];
 
@@ -177,7 +179,7 @@ describe('general repo CodeGraph contract', () => {
     expect(schema.properties.common_response_fields.items.enum).toEqual(COMMON_RESPONSE_FIELDS);
 
     for (const tool of schema['x-repo-harness-tools']) {
-      if (tool.name === 'write_file' || tool.name === 'apply_patch' || tool.name === 'refresh_repo_index') {
+      if (tool.name === 'write_file' || tool.name === 'apply_patch' || tool.name === 'move_path' || tool.name === 'delete_path' || tool.name === 'refresh_repo_index') {
         expect(tool.annotations).toEqual({
           readOnlyHint: false,
           destructiveHint: true,
@@ -192,6 +194,13 @@ describe('general repo CodeGraph contract', () => {
           expect(tool.input_schema.required).toEqual(['repo_id', 'path', 'expected_sha256']);
           expect(tool.input_schema.properties.edits.items.required).toEqual(['old_text', 'new_text']);
           expect(tool.input_schema.properties.unified_diff).toEqual({ type: 'string' });
+        } else if (tool.name === 'move_path') {
+          expect(tool.input_schema.required).toEqual(['repo_id', 'from_path', 'to_path', 'expected_sha256', 'must_not_exist']);
+          expect(tool.input_schema.properties.from_path).toEqual({ type: 'string' });
+          expect(tool.input_schema.properties.to_path).toEqual({ type: 'string' });
+        } else if (tool.name === 'delete_path') {
+          expect(tool.input_schema.required).toEqual(['repo_id', 'path', 'expected_sha256']);
+          expect(tool.input_schema.properties.recursive).toEqual({ type: 'boolean' });
         } else {
           expect(tool.input_schema.required).toEqual(['repo_id']);
           expect(tool.input_schema.properties.paths.items).toEqual({ type: 'string' });

--- a/tests/cli/mcp-reader-tools.test.ts
+++ b/tests/cli/mcp-reader-tools.test.ts
@@ -91,10 +91,12 @@ describe('MCP reader tools', () => {
         'stat_file',
         'write_file',
         'apply_patch',
+        'move_path',
+        'delete_path',
         'refresh_repo_index',
       ]);
       for (const definition of definitions) {
-        if (definition.name === 'write_file' || definition.name === 'apply_patch' || definition.name === 'refresh_repo_index') {
+        if (definition.name === 'write_file' || definition.name === 'apply_patch' || definition.name === 'move_path' || definition.name === 'delete_path' || definition.name === 'refresh_repo_index') {
           expect(definition.annotations).toMatchObject({
             readOnlyHint: false,
             destructiveHint: true,
@@ -190,6 +192,20 @@ describe('MCP reader tools', () => {
           edits: [{ old_text: 'authentication', new_text: 'authorization' }],
         });
         expect(readOnlyPatch.error.code).toBe('WRITE_DISABLED');
+        const readOnlyMove = await jsonTool(ctx, 'move_path', {
+          repo_id: repoId,
+          from_path: 'docs/design.md',
+          to_path: 'docs/moved.md',
+          expected_sha256: 'unused',
+          must_not_exist: true,
+        });
+        expect(readOnlyMove.error.code).toBe('WRITE_DISABLED');
+        const readOnlyDelete = await jsonTool(ctx, 'delete_path', {
+          repo_id: repoId,
+          path: 'docs/design.md',
+          expected_sha256: 'unused',
+        });
+        expect(readOnlyDelete.error.code).toBe('WRITE_DISABLED');
         const readOnlyRefresh = await jsonTool(ctx, 'refresh_repo_index', { repo_id: repoId, paths: ['docs/design.md'] });
         expect(readOnlyRefresh.error.code).toBe('WRITE_DISABLED');
 
@@ -334,7 +350,7 @@ describe('MCP reader tools', () => {
       const repoId = (await jsonTool(writeCtx, 'list_allowed_roots')).roots[0].repo_id;
       const capabilities = await jsonTool(writeCtx, 'get_repo_capabilities', { repo_id: repoId });
       expect(capabilities.access_mode).toBe('read_write');
-      expect(capabilities.write_tools).toEqual(['write_file', 'apply_patch', 'refresh_repo_index']);
+      expect(capabilities.write_tools).toEqual(['write_file', 'apply_patch', 'move_path', 'delete_path', 'refresh_repo_index']);
 
       const missingCreatePrecondition = await jsonTool(writeCtx, 'write_file', {
         repo_id: repoId,
@@ -519,6 +535,107 @@ describe('MCP reader tools', () => {
       expect(unifiedPatch.patch).toMatchObject({ format: 'unified_diff', applied_count: 1 });
       expect(readFileSync(join(repoRoot, 'docs', 'unified.txt'), 'utf-8')).toBe('alpha\nbravo\ngamma\n');
 
+      writeFileSync(join(repoRoot, 'docs', 'move-source.txt'), 'move me\n');
+      const moveStat = await jsonTool(writeCtx, 'stat_file', { repo_id: repoId, path: 'docs/move-source.txt' });
+      const moveWithoutTargetPrecondition = await jsonTool(writeCtx, 'move_path', {
+        repo_id: repoId,
+        from_path: 'docs/move-source.txt',
+        to_path: 'docs/moved.txt',
+        expected_sha256: moveStat.sha256,
+      });
+      expect(moveWithoutTargetPrecondition.error.code).toBe('REVISION_CONFLICT');
+      expect(existsSync(join(repoRoot, 'docs', 'move-source.txt'))).toBe(true);
+      expect(existsSync(join(repoRoot, 'docs', 'moved.txt'))).toBe(false);
+
+      const moved = await jsonTool(writeCtx, 'move_path', {
+        repo_id: repoId,
+        from_path: 'docs/move-source.txt',
+        to_path: 'docs/moved.txt',
+        expected_sha256: moveStat.sha256,
+        must_not_exist: true,
+      });
+      expect(moved.error).toBeUndefined();
+      expect(moved).toMatchObject({
+        path: 'docs/moved.txt',
+        operation: 'move',
+        from_path: 'docs/move-source.txt',
+        to_path: 'docs/moved.txt',
+        before: { sha256: moveStat.sha256, size: 'move me\n'.length },
+        index: { action: 'refresh_repo_index_required', changed_paths: ['docs/move-source.txt', 'docs/moved.txt'] },
+      });
+      expect(moved.after.sha256).toBe(moveStat.sha256);
+      expect(existsSync(join(repoRoot, 'docs', 'move-source.txt'))).toBe(false);
+      expect(readFileSync(join(repoRoot, 'docs', 'moved.txt'), 'utf-8')).toBe('move me\n');
+      expect(readdirSync(join(repoRoot, 'docs')).some((name) => name.includes('.repo-harness-'))).toBe(false);
+
+      writeFileSync(join(repoRoot, 'docs', 'stale-move.txt'), 'original\n');
+      const staleMoveStat = await jsonTool(writeCtx, 'stat_file', { repo_id: repoId, path: 'docs/stale-move.txt' });
+      writeFileSync(join(repoRoot, 'docs', 'stale-move.txt'), 'changed\n');
+      const staleMove = await jsonTool(writeCtx, 'move_path', {
+        repo_id: repoId,
+        from_path: 'docs/stale-move.txt',
+        to_path: 'docs/stale-moved.txt',
+        expected_sha256: staleMoveStat.sha256,
+        must_not_exist: true,
+      });
+      expect(staleMove.error.code).toBe('REVISION_CONFLICT');
+      expect(readFileSync(join(repoRoot, 'docs', 'stale-move.txt'), 'utf-8')).toBe('changed\n');
+      expect(existsSync(join(repoRoot, 'docs', 'stale-moved.txt'))).toBe(false);
+
+      writeFileSync(join(repoRoot, 'docs', 'existing-target.txt'), 'target\n');
+      const targetExistsMove = await jsonTool(writeCtx, 'move_path', {
+        repo_id: repoId,
+        from_path: 'docs/stale-move.txt',
+        to_path: 'docs/existing-target.txt',
+        expected_sha256: staleMove.error.details.actual_sha256,
+        must_not_exist: true,
+      });
+      expect(targetExistsMove.error.code).toBe('TARGET_EXISTS');
+      expect(readFileSync(join(repoRoot, 'docs', 'stale-move.txt'), 'utf-8')).toBe('changed\n');
+      expect(readFileSync(join(repoRoot, 'docs', 'existing-target.txt'), 'utf-8')).toBe('target\n');
+
+      const deleteStat = await jsonTool(writeCtx, 'stat_file', { repo_id: repoId, path: 'docs/moved.txt' });
+      const staleDelete = await jsonTool(writeCtx, 'delete_path', {
+        repo_id: repoId,
+        path: 'docs/moved.txt',
+        expected_sha256: 'bad',
+      });
+      expect(staleDelete.error.code).toBe('REVISION_CONFLICT');
+      expect(staleDelete.error.details.actual_sha256).toBe(deleteStat.sha256);
+      expect(readFileSync(join(repoRoot, 'docs', 'moved.txt'), 'utf-8')).toBe('move me\n');
+
+      const deleted = await jsonTool(writeCtx, 'delete_path', {
+        repo_id: repoId,
+        path: 'docs/moved.txt',
+        expected_sha256: deleteStat.sha256,
+      });
+      expect(deleted.error).toBeUndefined();
+      expect(deleted).toMatchObject({
+        path: 'docs/moved.txt',
+        operation: 'delete',
+        before: { existed: true, sha256: deleteStat.sha256, size: 'move me\n'.length },
+        after: { existed: false, sha256: null, size: 0 },
+        deleted: { path: 'docs/moved.txt', type: 'file' },
+        index: { action: 'refresh_repo_index_required', changed_paths: ['docs/moved.txt'] },
+      });
+      expect(existsSync(join(repoRoot, 'docs', 'moved.txt'))).toBe(false);
+      const readDeleted = await jsonTool(writeCtx, 'read_file', { repo_id: repoId, path: 'docs/moved.txt' });
+      expect(readDeleted.error.code).toBe('NOT_FOUND');
+
+      const directoryDelete = await jsonTool(writeCtx, 'delete_path', {
+        repo_id: repoId,
+        path: 'docs',
+        expected_sha256: 'unused',
+      });
+      expect(directoryDelete.error.code).toBe('NOT_A_FILE');
+      const recursiveDelete = await jsonTool(writeCtx, 'delete_path', {
+        repo_id: repoId,
+        path: 'docs',
+        expected_sha256: 'unused',
+        recursive: true,
+      });
+      expect(recursiveDelete.error.code).toBe('INVALID_RANGE');
+
       const ignored = await jsonTool(writeCtx, 'write_file', {
         repo_id: repoId,
         path: 'ignored.md',
@@ -537,12 +654,16 @@ describe('MCP reader tools', () => {
       const auditText = readFileSync(join(repoRoot, '.ai', 'harness', 'mcp', 'audit.log'), 'utf-8');
       expect(auditText).toContain('"tool":"write_file"');
       expect(auditText).toContain('"tool":"apply_patch"');
+      expect(auditText).toContain('"tool":"move_path"');
+      expect(auditText).toContain('"tool":"delete_path"');
       expect(auditText).toContain('"status":"ok"');
       expect(auditText).toContain('"status":"blocked"');
       expect(auditText).not.toContain('first\n');
       expect(auditText).not.toContain('second\n');
       expect(auditText).not.toContain('second patched\n');
       expect(auditText).not.toContain('bravo');
+      expect(auditText).not.toContain('move me\n');
+      expect(auditText).not.toContain('changed\n');
       expect(auditText).not.toContain('stale\n');
     }, { accessMode: 'read_write' });
   });


### PR DESCRIPTION
## Summary
- Add read_write-gated `move_path` and `delete_path` general repo tools.
- Enforce source/delete `expected_sha256`, target `must_not_exist`, same policy path guards, snapshot invalidation, and pending CodeGraph refresh responses.
- Define v1 directory policy: write tools do not create parent directories; empty-directory mutation and recursive delete are disabled.
- Update schema, docs, ADR, sprint checklist evidence, and MCP reader/contract tests.

## Verification
- `jq empty assets/mcp/general-repo-reader-tools.v1.schema.json`
- `git diff --check`
- `bun test tests/cli/mcp-reader-tools.test.ts tests/cli/mcp-codegraph-contract.test.ts tests/readme-dx.test.ts`
- `bun run check:type`
- `bash scripts/check-deploy-sql-order.sh`
- `bash scripts/check-architecture-sync.sh`
- `bash scripts/check-task-sync.sh`
- `bun scripts/inspect-project-state.ts --repo . --format text`
- `bash scripts/migrate-project-template.sh --repo . --dry-run`
- `bun test`
- `bash scripts/ensure-codegraph.sh --sync`
- `repo-harness setup check --target codex --check-updates --json` (0 fail; optional `skills_cli` timeout warning)
- `bash scripts/prepare-codex-handoff.sh --reason codegraph-s3-path-mutations`
- `bash scripts/check-task-workflow.sh --strict`

## Stack
- Based on #27 / `codex/repo-harness-codegraph-s3-apply-patch`.
