### PR TITLE
Add mutation recovery audit events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ tasks/.current.md.tmp.*
 .ai/harness/worktrees/
 .ai/harness/runs/
 .ai/harness/mcp/audit.log
+.ai/harness/mcp/index-events.jsonl
 .ai/harness/chatgpt/browser-lock.json
 .ai/harness/chatgpt/bridge-extension/
 .ai/harness/chatgpt/oracle-home/

--- a/README.md
+++ b/README.md
@@ -367,14 +367,19 @@ misses and stale hashes return `REVISION_CONFLICT` without writing. Successful
 file moves require a source `expected_sha256` plus `must_not_exist: true` for the
 target. Deletes require `expected_sha256`; v1 deletes regular files only and
 rejects directory or recursive deletes. Successful writes leave the index
-pending; `refresh_repo_index` runs CodeGraph sync for the repo, invalidates
-reader snapshots, and returns the new `snapshot_id`, `index_revision`,
-`index_state`, and refresh strategy. The CLI adapter reports
-`path_refresh_supported:false` when it must use repo-level sync for requested
-paths. The repo whitelist is the authorization boundary, `.ignore` is the only
-content exclusion source, paths are repo-relative, and authorized file content is
-not implicitly redacted. External non-repo local roots require explicit
-`--allow-root` authorization.
+pending and append an index invalidation event under
+`.ai/harness/mcp/index-events.jsonl`; `refresh_repo_index` runs CodeGraph sync
+for the repo, invalidates reader snapshots, records refresh success or
+dead-letter failure in that same event log, and returns the new `snapshot_id`,
+`index_revision`, `index_state`, refresh strategy, and optional mutation lag when
+called with `mutation_id`. The CLI adapter reports `path_refresh_supported:false`
+when it must use repo-level sync for requested paths. The MCP audit log records
+actor/profile, repo id, operation, relative paths, hash summary, result, error
+code, duration, and mutation/index event ids without storing file bodies or
+patch text. The repo whitelist is the authorization boundary, `.ignore` is the
+only content exclusion source, paths are repo-relative, and authorized file
+content is not implicitly redacted. External non-repo local roots require
+explicit `--allow-root` authorization.
 
 When CodeGraph is initialized for a registered repo, the general reader merges
 CodeGraph indexed-file metadata into manifest/stat/read/search responses while

--- a/assets/mcp/general-repo-reader-tools.v1.schema.json
+++ b/assets/mcp/general-repo-reader-tools.v1.schema.json
@@ -770,6 +770,9 @@
             "items": {
               "type": "string"
             }
+          },
+          "mutation_id": {
+            "type": "string"
           }
         },
         "additionalProperties": false

--- a/docs/architecture/decisions/20260622-general-repo-codegraph-access.md
+++ b/docs/architecture/decisions/20260622-general-repo-codegraph-access.md
@@ -63,8 +63,12 @@ Sprint 0 freezes the read contract for:
 The current write implementation covers `write_file` create/replace,
 `apply_patch`, `move_path`, `delete_path`, and `refresh_repo_index`.
 
-`write_file` and `apply_patch` commit filesystem truth first and return an index
-invalidation record with `index_state: pending` when CodeGraph is available.
+`write_file` and `apply_patch` commit filesystem truth first, return an index
+invalidation record with `index_state: pending` when CodeGraph is available, and
+append an index invalidation event under `.ai/harness/mcp/index-events.jsonl`.
+The same mutation result shape is used by `move_path` and `delete_path`; the
+event log stores mutation ids, invalidation ids, relative paths, hash summaries,
+index revisions, and retry instructions, but never file bodies or patch text.
 `apply_patch` is text-only and supports structured `old_text`/`new_text` edits
 plus guarded unified diff hunks. Both patch modes require an exact
 `expected_sha256` file precondition; each edit/hunk also acts as a local text
@@ -84,11 +88,18 @@ lost-update contract for file moves and deletes.
 
 The explicit `refresh_repo_index` tool requires the same `read_write` repo
 capability, reuses the same path guard and `.ignore` policy for requested paths,
-runs the adapter refresh, invalidates in-process repo snapshots, then returns the
-new snapshot and CodeGraph revision. The bundled CLI adapter uses repo-level
-`codegraph sync` because the local CodeGraph CLI surface does not expose a
-stable path-only refresh command; responses report `path_refresh_supported:false`
-so callers do not assume true incremental reindexing.
+runs the adapter refresh, invalidates in-process repo snapshots, records refresh
+success or failure in the index event log, then returns the new snapshot and
+CodeGraph revision. Requested refresh paths may be recently deleted paths so
+delete and move invalidations can still be synchronized. Callers may pass the
+mutation id returned by the write tool; when the matching invalidation event is
+still in the recent event window, refresh responses include mutation-to-refresh
+lag and the source event id. Refresh failures are written as dead-letter events
+with retry metadata and the manual recovery command
+`bash scripts/ensure-codegraph.sh --sync`. The bundled CLI adapter uses repo-level
+`codegraph sync` because the local CodeGraph CLI surface does not expose a stable
+path-only refresh command; responses report `path_refresh_supported:false` so
+callers do not assume true incremental reindexing.
 
 ## Snapshot Contract
 

--- a/docs/repo-harness-chatgpt-mcp-setup.md
+++ b/docs/repo-harness-chatgpt-mcp-setup.md
@@ -149,7 +149,9 @@ normal manifest entry.
 
 Authorized file content is not implicitly redacted in `read_file`,
 `read_files`, or `search_text` responses. The MCP audit path records tool name,
-target path, input hash, status, and errors, but not file bodies.
+target path, input hash, actor/profile, repo id, operation, relative paths,
+hash summary, status, result, error code, duration, and mutation/index event ids,
+but not file bodies or patch text.
 
 `write_file`, `apply_patch`, `move_path`, and `delete_path` are the general repo
 mutation tools. They are runtime-gated by the registered repo access mode and
@@ -162,12 +164,17 @@ regular file only when the target also carries `must_not_exist: true`.
 `delete_path` deletes regular files only; directory creation, empty-directory
 mutation, and recursive delete are disabled in v1. A successful mutation returns
 `before`, `after`, `diff`, `mutation_id`, and `index_state`, and leaves CodeGraph
-refresh explicitly pending. Call `refresh_repo_index` with the changed paths
-after a successful mutation to run CodeGraph sync, invalidate repo snapshot
-caches, and receive the new `index_revision`, `snapshot_id`, `index_state`, and
-refresh strategy. The bundled CLI adapter uses repo-level `codegraph sync` when
-path-only refresh is unavailable and reports that tradeoff with
-`path_refresh_supported:false`.
+refresh explicitly pending. It also appends an index invalidation event to
+`.ai/harness/mcp/index-events.jsonl`. Call `refresh_repo_index` with the changed
+paths and, when available, the returned `mutation_id` after a successful mutation
+to run CodeGraph sync, invalidate repo snapshot caches, append refresh success or
+dead-letter failure to the same event log, and receive the new `index_revision`,
+`snapshot_id`, `index_state`, refresh strategy, and mutation-to-refresh lag. The
+bundled CLI adapter uses repo-level `codegraph sync` when path-only refresh is
+unavailable and reports that tradeoff with `path_refresh_supported:false`. Manual
+recovery for a dead-letter refresh is to rerun `refresh_repo_index`; if the
+adapter stays unavailable, run `bash scripts/ensure-codegraph.sh --sync` and then
+retry the tool.
 
 When a repo has a CodeGraph index, `repo_manifest`, `list_tree`, `stat_file`,
 `read_file`, `read_files`, and `search_text` share a deterministic

--- a/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
+++ b/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
@@ -540,38 +540,38 @@ Sprint 2 adapter/snapshot evidence:
 - [x] **S3-MUT-006** 保留原文件权限和必要 metadata，策略写入 ADR。
 - [x] **S3-MUT-007** patch 应验证每个 hunk 或精确文本 precondition。
 - [x] **S3-MUT-008** move/delete 同样进行版本和目标存在性检查。
-- [ ] **S3-MUT-009** 写失败不得留下半文件或跨 repo 临时文件。
-- [ ] **S3-MUT-010** 对写入过程进行故障注入测试：磁盘满、权限变化、进程中断、rename 失败。
+- [x] **S3-MUT-009** 写失败不得留下半文件或跨 repo 临时文件。
+- [x] **S3-MUT-010** 对写入过程进行故障注入测试：磁盘满、权限变化、进程中断、rename 失败。
 
 ## 10.3 Index Sync
 
-- [ ] **S3-IDX-001** 每次成功 mutation 产生 index invalidation event。
+- [x] **S3-IDX-001** 每次成功 mutation 产生 index invalidation event。
 - [x] **S3-IDX-002** 能按 path 增量 reindex 时优先使用；否则明确使用 repo refresh。
 - [x] **S3-IDX-003** 写后返回 `index_state: pending|ready|failed`。
 - [x] **S3-IDX-004** 索引完成后生成新 `codegraph_revision` 和 snapshot。
 - [x] **S3-IDX-005** 在索引 pending 时，changed path 的 read/stat 走安全直读并返回最新 hash。
 - [x] **S3-IDX-006** search 必须明确使用旧索引还是等待新索引；禁止假装已可搜。
 - [x] **S3-IDX-007** 实现 `refresh_repo_index` 或内部等价管理接口。
-- [ ] **S3-IDX-008** 定义 reindex retry、dead-letter 和人工恢复流程。
-- [ ] **S3-IDX-009** 监控 mutation commit 到 CodeGraph 可搜索的 index lag。
+- [x] **S3-IDX-008** 定义 reindex retry、dead-letter 和人工恢复流程。
+- [x] **S3-IDX-009** 监控 mutation commit 到 CodeGraph 可搜索的 index lag。
 
 ## 10.4 审计
 
-- [ ] **S3-AUD-001** 审计 actor、repo_id、operation、relative paths、hash、结果和耗时。
-- [ ] **S3-AUD-002** 不记录文件正文、patch 全文或 secret。
-- [ ] **S3-AUD-003** 审计日志与应用日志分离并设置保留策略。
-- [ ] **S3-AUD-004** mutation id 可追踪到索引刷新状态。
-- [ ] **S3-AUD-005** 对拒绝的写请求记录错误码，不记录内容。
+- [x] **S3-AUD-001** 审计 actor、repo_id、operation、relative paths、hash、结果和耗时。
+- [x] **S3-AUD-002** 不记录文件正文、patch 全文或 secret。
+- [x] **S3-AUD-003** 审计日志与应用日志分离并设置保留策略。
+- [x] **S3-AUD-004** mutation id 可追踪到索引刷新状态。
+- [x] **S3-AUD-005** 对拒绝的写请求记录错误码，不记录内容。
 
 ## 10.5 Sprint 3 退出标准
 
-- [ ] 所有写工具在 read-only repo 中可靠拒绝。
-- [ ] 100% 检测并发覆盖冲突，无 lost update。
-- [ ] 原子写故障注入不产生半写文件。
-- [ ] 写后 stat/read 立即可见最新内容。
-- [ ] 写后 search 在定义的 index lag SLO 内可见，或明确返回 pending。
-- [ ] move/delete 后 manifest 与索引最终一致。
-- [ ] 所有写操作可通过 mutation id 审计。
+- [x] 所有写工具在 read-only repo 中可靠拒绝。
+- [x] 100% 检测并发覆盖冲突，无 lost update。
+- [x] 原子写故障注入不产生半写文件。
+- [x] 写后 stat/read 立即可见最新内容。
+- [x] 写后 search 在定义的 index lag SLO 内可见，或明确返回 pending。
+- [x] move/delete 后 manifest 与索引最终一致。
+- [x] 所有写操作可通过 mutation id 审计。
 
 Sprint 3 write_file evidence:
 
@@ -583,12 +583,13 @@ Sprint 3 write_file evidence:
   requires `must_not_exist` for create and `expected_sha256` for replace,
   writes through a same-directory temporary file plus fsync/atomic rename, and
   returns `mutation_id`, `before`, `after`, `diff`, and `index_state`.
-- Verified in this slice: success and precondition-conflict paths leave no
-  `.repo-harness-*` temporary files in the target directory. Full write-failure
-  injection remains open under `S3-MUT-009/010`.
-- Explicitly still open: full write-failure injection, full index
-  retry/dead-letter, index-lag monitoring, and complete write audit/runbook
-  coverage.
+- Verified in this slice: success, precondition-conflict, and injected
+  pre-commit fault paths leave no `.repo-harness-*` temporary files in the
+  target directory and preserve the old file or absent target state.
+- Fault coverage: deterministic fault points cover temp-write-after-fsync before
+  rename, move before rename, and delete before unlink. These model disk-full,
+  permission-change, interrupted-process, and rename-failure boundaries before a
+  filesystem commit.
 
 Sprint 3 index-sync evidence:
 
@@ -609,6 +610,15 @@ Sprint 3 index-sync evidence:
 - Pending-state reads/stat use filesystem truth and return the latest hash;
   `search_text` keeps the explicit CodeGraph-metadata plus guarded filesystem
   fallback backend instead of claiming the changed path is already indexed.
+- Successful mutations now append `.ai/harness/mcp/index-events.jsonl`
+  invalidation events with mutation id, invalidation id, relative paths, hash
+  summaries, retry metadata, and the refresh tool. `refresh_repo_index` accepts
+  the returned `mutation_id`, accepts recently deleted paths for move/delete
+  refresh, records refresh success or dead-letter failure, and reports
+  mutation-to-refresh lag when the source event is in the recent event window.
+- Manual recovery for dead-letter refresh is documented as retrying
+  `refresh_repo_index`, then running `bash scripts/ensure-codegraph.sh --sync`
+  before retrying the tool if the adapter remains unavailable.
 
 Sprint 3 apply_patch evidence:
 
@@ -653,6 +663,27 @@ Sprint 3 move/delete path mutation evidence:
 - Directory policy for v1 is now explicit: write tools do not create parent
   directories; empty-directory mutation is unsupported; recursive delete is
   disabled and returns a stable policy error before any filesystem mutation.
+
+Sprint 3 failure-injection and audit evidence:
+
+- Runtime: `src/cli/mcp/general-repo-access.ts`, `src/cli/mcp/types.ts`,
+  `src/cli/mcp/setup.ts`
+- Tests: `tests/cli/mcp-reader-tools.test.ts`,
+  `tests/cli/mcp-codegraph-contract.test.ts`, `tests/cli/mcp-setup.test.ts`
+- Docs/schema: `assets/mcp/general-repo-reader-tools.v1.schema.json`,
+  `.gitignore`, `README.md`, `docs/repo-harness-chatgpt-mcp-setup.md`,
+  `docs/architecture/decisions/20260622-general-repo-codegraph-access.md`
+- Completed slice: deterministic test-only mutation fault points verify
+  create/replace/patch abort after temp fsync but before rename, move aborts
+  before rename, and delete aborts before unlink. All fault cases leave no
+  committed partial file and no same-directory repo-harness temp residue.
+- The MCP audit log remains separate at `.ai/harness/mcp/audit.log`; the index
+  event/recovery log is separate ignored runtime state at
+  `.ai/harness/mcp/index-events.jsonl`. Both are managed by MCP setup ignore
+  entries. Audit records actor/profile, repo id, operation, relative paths, hash
+  summaries, result, duration, mutation id, index invalidation id, index event id,
+  and rejection error code without storing file bodies, patch text, or secret
+  error strings.
 
 ---
 

--- a/src/cli/mcp/general-repo-access.ts
+++ b/src/cli/mcp/general-repo-access.ts
@@ -1,11 +1,12 @@
 import { createHash, randomBytes } from 'crypto';
-import { closeSync, existsSync, fsyncSync, lstatSync, openSync, readFileSync, readdirSync, realpathSync, renameSync, rmSync, statSync, writeSync, type Dirent } from 'fs';
-import { basename, dirname, isAbsolute, relative, resolve, sep } from 'path';
+import { appendFileSync, closeSync, existsSync, fsyncSync, lstatSync, mkdirSync, openSync, readFileSync, readdirSync, realpathSync, renameSync, rmSync, statSync, writeSync, type Dirent } from 'fs';
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'path';
 import { readRegisteredRepoHarnessRepos, repoHarnessRepoIdFor, type RepoHarnessAccessMode } from '../../effects/repo-registry';
 import { hashMcpInput, tryWriteMcpAuditEntry } from './audit';
 import { createCodeGraphCliAdapter, type CodeGraphRefreshResult, type CodeGraphRepoSnapshot, type GeneralRepoCodeGraphAdapter } from './codegraph-adapter';
 import { globMatches, isPathInside } from './paths';
-import type { McpPolicy } from './types';
+import { redactMcpText } from './redaction';
+import type { McpAuditEntry, McpPolicy } from './types';
 
 export interface GeneralRepoToolDefinition {
   name: string;
@@ -187,6 +188,8 @@ const DEFAULT_CODEGRAPH_ADAPTER = createCodeGraphCliAdapter();
 const SNAPSHOT_CACHE = new Map<string, VisibleEntrySnapshot>();
 const ENTRY_METADATA_CACHE = new Map<string, EntryMetadataCacheValue>();
 const WRITE_TOOLS = new Set<string>(['write_file', 'apply_patch', 'move_path', 'delete_path', 'refresh_repo_index']);
+const MCP_INDEX_EVENTS_RELATIVE_PATH = '.ai/harness/mcp/index-events.jsonl';
+const MUTATION_FAULT_ENV = 'REPO_HARNESS_MCP_MUTATION_FAULT_POINT';
 
 export type GeneralRepoToolName = typeof GENERAL_REPO_TOOLS[number];
 
@@ -218,13 +221,16 @@ function errorResult(code: string, message: string, details?: unknown, retryable
   };
 }
 
-function audit(ctx: GeneralRepoToolContext, tool: string, status: 'ok' | 'blocked' | 'failed', input: unknown, targetPath?: string, error?: string): void {
+function audit(ctx: GeneralRepoToolContext, tool: string, status: 'ok' | 'blocked' | 'failed', input: unknown, targetPath?: string, error?: string, details: Partial<McpAuditEntry> = {}): void {
   tryWriteMcpAuditEntry(ctx.repoRoot, {
     timestamp: new Date().toISOString(),
     tool,
     status,
+    actor: `mcp:${ctx.policy.profile}`,
+    result: status,
     targetPath,
     inputHash: hashMcpInput(input),
+    ...details,
     error,
   });
 }
@@ -233,6 +239,76 @@ function auditTargetPath(input: Record<string, unknown>): string | undefined {
   if (typeof input.path === 'string') return input.path;
   if (typeof input.from_path === 'string' && typeof input.to_path === 'string') return `${input.from_path} -> ${input.to_path}`;
   return undefined;
+}
+
+function auditPaths(input: Record<string, unknown>): string[] {
+  const paths = new Set<string>();
+  if (typeof input.path === 'string') paths.add(input.path);
+  if (typeof input.from_path === 'string') paths.add(input.from_path);
+  if (typeof input.to_path === 'string') paths.add(input.to_path);
+  if (Array.isArray(input.paths)) {
+    for (const path of input.paths) {
+      if (typeof path === 'string') paths.add(path);
+    }
+  }
+  return [...paths];
+}
+
+function recordObject(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function stringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const values = value.filter((entry): entry is string => typeof entry === 'string');
+  return values.length > 0 ? values : undefined;
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === 'string' && value ? value : undefined;
+}
+
+function auditDetailsFromResult(result: GeneralRepoToolResult, input: Record<string, unknown>, durationMs: number, tool: string): Partial<McpAuditEntry> {
+  const payload = recordObject(result.structuredContent);
+  if (!payload) {
+    return {
+      repoId: stringField(input.repo_id),
+      operation: tool,
+      relativePaths: auditPaths(input),
+      durationMs,
+    };
+  }
+  const index = recordObject(payload.index);
+  const diff = recordObject(payload.diff);
+  const relativePaths = stringArray(index?.changed_paths)
+    ?? stringArray(index?.refreshed_paths)
+    ?? stringArray(payload.paths)
+    ?? auditPaths(input);
+  return {
+    repoId: stringField(payload.repo_id) ?? stringField(input.repo_id),
+    operation: stringField(payload.operation) ?? stringField(input.operation) ?? tool,
+    relativePaths,
+    mutationId: stringField(payload.mutation_id) ?? stringField(index?.mutation_id),
+    indexInvalidationId: stringField(index?.invalidation_id),
+    indexEventId: stringField(index?.event_id),
+    indexState: stringField(payload.index_state) ?? stringField(index?.state),
+    fileHashes: diff ? {
+      before_sha256: typeof diff.before_sha256 === 'string' ? diff.before_sha256 : diff.before_sha256 === null ? null : undefined,
+      after_sha256: typeof diff.after_sha256 === 'string' ? diff.after_sha256 : diff.after_sha256 === null ? null : undefined,
+    } : undefined,
+    durationMs,
+  };
+}
+
+function auditDetailsFromError(error: GeneralRepoAccessError, input: Record<string, unknown>, durationMs: number, tool: string): Partial<McpAuditEntry> {
+  return {
+    repoId: stringField(input.repo_id),
+    operation: tool,
+    relativePaths: auditPaths(input),
+    durationMs,
+    errorCode: error.code,
+  };
 }
 
 function sha256(value: string | Buffer): string {
@@ -259,6 +335,99 @@ function cachePaths(paths: string[] | undefined): string[] {
   const normalized = (paths && paths.length > 0 ? paths : ['.'])
     .map((path) => toPosixPath(String(path || '.')).replace(/^\.\/+/, '') || '.');
   return [...new Set(normalized)].sort((a, b) => a.localeCompare(b));
+}
+
+function mcpIndexEventsPath(repoRoot: string): string {
+  return join(repoRoot, MCP_INDEX_EVENTS_RELATIVE_PATH);
+}
+
+function indexEventId(repo: RepoRecord, eventType: string, seed: string): string {
+  return `idxevt_${sha256(`${repo.repoId}\0${eventType}\0${seed}\0${Date.now()}\0${randomBytes(4).toString('hex')}`).slice(0, 16)}`;
+}
+
+function safeEventError(error: CodeGraphRefreshResult['error'] | undefined): Record<string, unknown> | undefined {
+  if (!error) return undefined;
+  return {
+    code: error.code,
+    message: redactMcpText(error.message).text,
+    retryable: error.retryable,
+  };
+}
+
+function tryWriteIndexEvent(ctx: GeneralRepoToolContext, repo: RepoRecord, event: Record<string, unknown>): string | null {
+  const eventId = typeof event.event_id === 'string'
+    ? event.event_id
+    : indexEventId(repo, String(event.event_type ?? 'index_event'), JSON.stringify(event));
+  try {
+    const logPath = mcpIndexEventsPath(ctx.repoRoot);
+    mkdirSync(dirname(logPath), { recursive: true });
+    appendFileSync(logPath, `${JSON.stringify({
+      schema_version: 1,
+      timestamp: new Date().toISOString(),
+      event_id: eventId,
+      repo_id: repo.repoId,
+      ...event,
+    })}\n`, 'utf-8');
+    return eventId;
+  } catch (_error) {
+    return null;
+  }
+}
+
+function readRecentIndexEvents(repoRoot: string): Record<string, unknown>[] {
+  const logPath = mcpIndexEventsPath(repoRoot);
+  if (!existsSync(logPath)) return [];
+  try {
+    return readFileSync(logPath, 'utf-8')
+      .trimEnd()
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .slice(-1000)
+      .map((line) => JSON.parse(line))
+      .filter((entry): entry is Record<string, unknown> => typeof entry === 'object' && entry !== null && !Array.isArray(entry));
+  } catch (_error) {
+    return [];
+  }
+}
+
+function eventPathsOverlap(eventPaths: unknown, paths: string[]): boolean {
+  const values = stringArray(eventPaths);
+  if (!values) return false;
+  const refreshPaths = new Set(cachePaths(paths));
+  return values.some((path) => refreshPaths.has(path) || refreshPaths.has('.') || path === '.');
+}
+
+function latestIndexInvalidationEvent(ctx: GeneralRepoToolContext, repo: RepoRecord, mutationId: string, paths: string[]): Record<string, unknown> | null {
+  const events = readRecentIndexEvents(ctx.repoRoot);
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index];
+    if (event?.event_type !== 'index_invalidation' || event.repo_id !== repo.repoId) continue;
+    if (mutationId && event.mutation_id === mutationId) return event;
+    if (!mutationId && eventPathsOverlap(event.relative_paths, paths)) return event;
+  }
+  return null;
+}
+
+function indexLagMsFrom(event: Record<string, unknown> | null, nowMs = Date.now()): number | undefined {
+  if (!event || typeof event.timestamp !== 'string') return undefined;
+  const startedAt = Date.parse(event.timestamp);
+  if (!Number.isFinite(startedAt)) return undefined;
+  return Math.max(0, nowMs - startedAt);
+}
+
+function indexRecovery(paths: string[], retryable = true): Record<string, unknown> {
+  return {
+    retryable,
+    retry_tool: 'refresh_repo_index',
+    retry_paths: paths,
+    dead_letter_log: MCP_INDEX_EVENTS_RELATIVE_PATH,
+    manual_recovery: 'bash scripts/ensure-codegraph.sh --sync',
+  };
+}
+
+function injectMutationFault(point: string): void {
+  if ((process.env[MUTATION_FAULT_ENV] ?? '').trim() !== point) return;
+  throw new GeneralRepoAccessError('INJECTED_MUTATION_FAULT', `injected mutation fault at ${point}`, { fault_point: point }, true);
 }
 
 function responseCacheKey(repo: RepoRecord, ignore: IgnorePolicy, snapshot: VisibleEntrySnapshot, scope: { tool: string; paths?: string[] }): { key: string; paths: string[]; pathDigest: string } {
@@ -546,8 +715,20 @@ function refreshPathsArg(repo: RepoRecord, ignore: IgnorePolicy, value: unknown)
     if (typeof item !== 'string') {
       throw new GeneralRepoAccessError('INVALID_RELATIVE_PATH', 'paths must contain only strings');
     }
-    const resolved = resolveRepoPath(repo, item, ignore, { allowRoot: true, allowExternalSymlinkMetadata: true });
-    paths.add(resolved.relativePath);
+    const relativePath = normalizeRepoRelativePath(item, { allowRoot: true });
+    if (relativePath !== '.' && isIgnored(ignore, relativePath)) {
+      throw new GeneralRepoAccessError('PATH_IGNORED', 'path is excluded by .ignore', { path: relativePath });
+    }
+    const absolutePath = relativePath === '.' ? repo.canonicalRoot : resolve(repo.canonicalRoot, relativePath);
+    if (!isPathInside(repo.canonicalRoot, absolutePath)) {
+      throw new GeneralRepoAccessError('PATH_OUTSIDE_REPO', 'path escapes repo root', { path: relativePath });
+    }
+    if (existsSync(absolutePath)) {
+      const resolved = resolveRepoPath(repo, relativePath, ignore, { allowRoot: true, allowExternalSymlinkMetadata: true });
+      paths.add(resolved.relativePath);
+    } else {
+      paths.add(relativePath);
+    }
   }
   return [...paths].sort((a, b) => a.localeCompare(b));
 }
@@ -1401,6 +1582,7 @@ function atomicWriteFile(target: ResolvedRepoWritePath, raw: Buffer, mode: numbe
     } finally {
       closeSync(fd);
     }
+    injectMutationFault('atomic_write_before_rename');
     renameSync(tempPath, target.canonicalPath);
     renamed = true;
     fsyncDirectoryBestEffort(target.parentCanonicalPath);
@@ -1456,6 +1638,21 @@ function mutationResult(ctx: GeneralRepoToolContext, repo: RepoRecord, ignore: I
   const mutationTool = opts.tool ?? (opts.operation === 'patch' ? 'apply_patch' : 'write_file');
   const mutationId = `mut_${sha256(`${repo.repoId}\0${changedPaths.join('\0')}\0${opts.beforeHash ?? 'new'}\0${afterHash}\0${Date.now()}`).slice(0, 16)}`;
   const invalidationId = `idxinv_${sha256(`${mutationId}\0${snapshot.codeGraph.indexRevision}\0${target.relativePath}`).slice(0, 16)}`;
+  const indexEventId = tryWriteIndexEvent(ctx, repo, {
+    event_type: 'index_invalidation',
+    status: 'pending',
+    operation: opts.operation,
+    mutation_id: mutationId,
+    invalidation_id: invalidationId,
+    relative_paths: changedPaths,
+    index_state: indexState,
+    before_index_revision: snapshot.codeGraph.indexRevision,
+    file_hashes: {
+      before_sha256: opts.beforeHash,
+      after_sha256: afterHash,
+    },
+    retry: indexRecovery(changedPaths, snapshot.codeGraph.available),
+  });
 
   return textResult({
     ...commonFields(repo, ignore, snapshot, { tool: mutationTool, paths: changedPaths }),
@@ -1491,6 +1688,8 @@ function mutationResult(ctx: GeneralRepoToolContext, repo: RepoRecord, ignore: I
       changed_paths: changedPaths,
       mutation_id: mutationId,
       invalidation_id: invalidationId,
+      event_id: indexEventId,
+      event_log: MCP_INDEX_EVENTS_RELATIVE_PATH,
       refresh_tool: 'refresh_repo_index',
       before_index_revision: snapshot.codeGraph.indexRevision,
     },
@@ -1503,6 +1702,21 @@ function deleteMutationResult(ctx: GeneralRepoToolContext, repo: RepoRecord, ign
   const indexState = mutationIndexState(snapshot);
   const mutationId = `mut_${sha256(`${repo.repoId}\0${deleted.path}\0${beforeHash}\0deleted\0${Date.now()}`).slice(0, 16)}`;
   const invalidationId = `idxinv_${sha256(`${mutationId}\0${snapshot.codeGraph.indexRevision}\0${deleted.path}`).slice(0, 16)}`;
+  const indexEventId = tryWriteIndexEvent(ctx, repo, {
+    event_type: 'index_invalidation',
+    status: 'pending',
+    operation: 'delete',
+    mutation_id: mutationId,
+    invalidation_id: invalidationId,
+    relative_paths: [deleted.path],
+    index_state: indexState,
+    before_index_revision: snapshot.codeGraph.indexRevision,
+    file_hashes: {
+      before_sha256: beforeHash,
+      after_sha256: null,
+    },
+    retry: indexRecovery([deleted.path], snapshot.codeGraph.available),
+  });
 
   return textResult({
     ...commonFields(repo, ignore, snapshot, { tool: 'delete_path', paths: [deleted.path] }),
@@ -1535,6 +1749,8 @@ function deleteMutationResult(ctx: GeneralRepoToolContext, repo: RepoRecord, ign
       changed_paths: [deleted.path],
       mutation_id: mutationId,
       invalidation_id: invalidationId,
+      event_id: indexEventId,
+      event_log: MCP_INDEX_EVENTS_RELATIVE_PATH,
       refresh_tool: 'refresh_repo_index',
       before_index_revision: snapshot.codeGraph.indexRevision,
     },
@@ -1781,6 +1997,7 @@ function movePathTool(ctx: GeneralRepoToolContext, args: Record<string, unknown>
     });
   }
 
+  injectMutationFault('move_before_rename');
   renameSync(source.canonicalPath, target.canonicalPath);
   fsyncDirectoryBestEffort(dirname(source.canonicalPath));
   if (dirname(source.canonicalPath) !== target.parentCanonicalPath) fsyncDirectoryBestEffort(target.parentCanonicalPath);
@@ -1843,6 +2060,7 @@ function deletePathTool(ctx: GeneralRepoToolContext, args: Record<string, unknow
   }
   const deleted = metadataForResolved(target, ignore, undefined, { contentHash: true, cache: false });
 
+  injectMutationFault('delete_before_unlink');
   rmSync(target.canonicalPath);
   fsyncDirectoryBestEffort(dirname(target.canonicalPath));
   invalidateRepoCaches(repo);
@@ -1856,21 +2074,101 @@ function refreshRepoIndex(ctx: GeneralRepoToolContext, args: Record<string, unkn
   const ignore = readIgnorePolicy(repo.canonicalRoot);
   const paths = refreshPathsArg(repo, ignore, args.paths);
   const refreshScope = paths.length > 0 ? paths : ['.'];
+  const mutationId = typeof args.mutation_id === 'string' ? args.mutation_id.trim() : '';
+  const sourceEvent = latestIndexInvalidationEvent(ctx, repo, mutationId, refreshScope);
+  const sourceEventId = typeof sourceEvent?.event_id === 'string' ? sourceEvent.event_id : undefined;
+  const sourceMutationId = typeof sourceEvent?.mutation_id === 'string' ? sourceEvent.mutation_id : mutationId || undefined;
+  const sourceInvalidationId = typeof sourceEvent?.invalidation_id === 'string' ? sourceEvent.invalidation_id : undefined;
   const before = buildVisibleEntrySnapshot(ctx, repo, ignore, { contentHash: false });
   const adapter = ctx.codeGraphAdapter ?? DEFAULT_CODEGRAPH_ADAPTER;
   if (!adapter.refreshRepo) {
+    tryWriteIndexEvent(ctx, repo, {
+      event_type: 'index_refresh',
+      status: 'failed',
+      operation: 'refresh_repo_index',
+      mutation_id: sourceMutationId,
+      source_event_id: sourceEventId,
+      invalidation_id: sourceInvalidationId,
+      relative_paths: refreshScope,
+      before_index_revision: before.codeGraph.indexRevision,
+      strategy: 'unsupported',
+      index_lag_ms: indexLagMsFrom(sourceEvent),
+      error: { code: 'INDEX_UNAVAILABLE', message: 'CodeGraph adapter does not support explicit refresh', retryable: true },
+      dead_letter: indexRecovery(refreshScope, true),
+    });
     throw new GeneralRepoAccessError('INDEX_UNAVAILABLE', 'CodeGraph adapter does not support explicit refresh', {
       paths: refreshScope,
     }, true);
   }
 
-  const refresh = adapter.refreshRepo(repo.canonicalRoot, { paths });
+  let refresh: CodeGraphRefreshResult;
+  try {
+    refresh = adapter.refreshRepo(repo.canonicalRoot, { paths });
+  } catch (error) {
+    tryWriteIndexEvent(ctx, repo, {
+      event_type: 'index_refresh',
+      status: 'failed',
+      operation: 'refresh_repo_index',
+      mutation_id: sourceMutationId,
+      source_event_id: sourceEventId,
+      invalidation_id: sourceInvalidationId,
+      relative_paths: refreshScope,
+      before_index_revision: before.codeGraph.indexRevision,
+      strategy: 'repo-sync',
+      index_lag_ms: indexLagMsFrom(sourceEvent),
+      error: {
+        code: 'INTERNAL_ADAPTER_ERROR',
+        message: redactMcpText(error instanceof Error ? error.message : String(error)).text,
+        retryable: false,
+      },
+      dead_letter: indexRecovery(refreshScope, false),
+    });
+    throw error;
+  }
   invalidateRepoCaches(repo);
   if (!refresh.available || !refresh.refreshed) {
+    tryWriteIndexEvent(ctx, repo, {
+      event_type: 'index_refresh',
+      status: 'failed',
+      operation: 'refresh_repo_index',
+      mutation_id: sourceMutationId,
+      source_event_id: sourceEventId,
+      invalidation_id: sourceInvalidationId,
+      relative_paths: refreshScope,
+      before_index_revision: before.codeGraph.indexRevision,
+      adapter_index_revision: refresh.indexRevision,
+      strategy: refresh.strategy,
+      path_refresh_supported: refresh.pathRefreshSupported,
+      latency_ms: refresh.latencyMs,
+      index_lag_ms: indexLagMsFrom(sourceEvent),
+      error: safeEventError(refresh.error),
+      dead_letter: indexRecovery(refreshScope, refresh.error?.retryable ?? true),
+    });
     throw indexRefreshError(refresh);
   }
   const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore, { contentHash: false });
   const indexState = refreshedIndexState(snapshot);
+  const indexLagMs = indexLagMsFrom(sourceEvent);
+  const indexEventId = tryWriteIndexEvent(ctx, repo, {
+    event_type: 'index_refresh',
+    status: indexState,
+    operation: 'refresh_repo_index',
+    mutation_id: sourceMutationId,
+    source_event_id: sourceEventId,
+    invalidation_id: sourceInvalidationId,
+    relative_paths: refreshScope,
+    before_index_revision: before.codeGraph.indexRevision,
+    adapter_index_revision: refresh.indexRevision,
+    after_index_revision: snapshot.codeGraph.indexRevision,
+    strategy: refresh.strategy,
+    path_refresh_supported: refresh.pathRefreshSupported,
+    latency_ms: refresh.latencyMs,
+    indexed_files: refresh.files,
+    index_lag_ms: indexLagMs,
+    lagging_path_count: snapshot.codeGraphLaggingPaths.length,
+    lagging_paths: snapshot.codeGraphLaggingPaths.slice(0, MAX_LAGGING_PATHS_RETURNED),
+    recovery: indexState === 'ready' ? undefined : indexRecovery(refreshScope, true),
+  });
 
   return textResult({
     ...commonFields(repo, ignore, snapshot, { tool: 'refresh_repo_index', paths: refreshScope }),
@@ -1886,11 +2184,20 @@ function refreshRepoIndex(ctx: GeneralRepoToolContext, args: Record<string, unkn
       adapter_index_revision: refresh.indexRevision,
       after_index_revision: snapshot.codeGraph.indexRevision,
       indexed_files: refresh.files,
+      source_event_id: sourceEventId,
+      mutation_id: sourceMutationId,
+      index_lag_ms: indexLagMs,
     },
     index: {
       state: indexState,
       action: indexState === 'ready' ? 'refresh_complete' : 'refresh_complete_with_lag',
       refreshed_paths: refreshScope,
+      mutation_id: sourceMutationId,
+      source_event_id: sourceEventId,
+      event_id: indexEventId,
+      event_log: MCP_INDEX_EVENTS_RELATIVE_PATH,
+      index_lag_ms: indexLagMs,
+      lagging_path_count: snapshot.codeGraphLaggingPaths.length,
       before_index_revision: before.codeGraph.indexRevision,
       after_index_revision: snapshot.codeGraph.indexRevision,
     },
@@ -2320,6 +2627,7 @@ export function buildGeneralRepoToolDefinitions(): GeneralRepoToolDefinition[] {
         properties: {
           repo_id: { type: 'string' },
           paths: { type: 'array', items: { type: 'string' } },
+          mutation_id: { type: 'string' },
         },
         required: ['repo_id'],
         additionalProperties: false,
@@ -2330,6 +2638,7 @@ export function buildGeneralRepoToolDefinitions(): GeneralRepoToolDefinition[] {
 }
 
 export async function callGeneralRepoTool(ctx: GeneralRepoToolContext, name: string, args: Record<string, unknown> = {}): Promise<GeneralRepoToolResult> {
+  const startedAtMs = Date.now();
   try {
     let result: GeneralRepoToolResult;
     switch (name) {
@@ -2372,14 +2681,20 @@ export async function callGeneralRepoTool(ctx: GeneralRepoToolContext, name: str
       default:
         return errorResult('INTERNAL_ADAPTER_ERROR', `tool is not a general repo reader tool: ${name}`);
     }
-    audit(ctx, name, 'ok', args, auditTargetPath(args));
+    audit(ctx, name, 'ok', args, auditTargetPath(args), undefined, auditDetailsFromResult(result, args, Date.now() - startedAtMs, name));
     return result;
   } catch (error) {
     if (error instanceof GeneralRepoAccessError) {
-      audit(ctx, name, 'blocked', args, auditTargetPath(args), error.message);
+      audit(ctx, name, 'blocked', args, auditTargetPath(args), error.message, auditDetailsFromError(error, args, Date.now() - startedAtMs, name));
       return errorResult(error.code, error.message, error.details, error.retryable);
     }
-    audit(ctx, name, 'failed', args, auditTargetPath(args), error instanceof Error ? error.message : String(error));
+    audit(ctx, name, 'failed', args, auditTargetPath(args), error instanceof Error ? error.message : String(error), {
+      repoId: stringField(args.repo_id),
+      operation: name,
+      relativePaths: auditPaths(args),
+      durationMs: Date.now() - startedAtMs,
+      errorCode: 'INTERNAL_ADAPTER_ERROR',
+    });
     return errorResult('INTERNAL_ADAPTER_ERROR', error instanceof Error ? error.message : String(error));
   }
 }

--- a/src/cli/mcp/setup.ts
+++ b/src/cli/mcp/setup.ts
@@ -614,6 +614,7 @@ export function runMcpSetupChatgpt(opts: {
       '.repo-harness/mcp.oauth.json',
       '.repo-harness/mcp.oauth-tokens.json',
       '.ai/harness/mcp/audit.log',
+      '.ai/harness/mcp/index-events.jsonl',
     ], changed);
   }
 

--- a/src/cli/mcp/types.ts
+++ b/src/cli/mcp/types.ts
@@ -37,6 +37,21 @@ export interface McpAuditEntry {
   timestamp: string;
   tool: string;
   status: 'ok' | 'blocked' | 'failed';
+  actor?: string;
+  repoId?: string;
+  operation?: string;
+  relativePaths?: string[];
+  mutationId?: string;
+  indexInvalidationId?: string;
+  indexEventId?: string;
+  indexState?: string;
+  fileHashes?: {
+    before_sha256?: string | null;
+    after_sha256?: string | null;
+  };
+  result?: 'ok' | 'blocked' | 'failed';
+  durationMs?: number;
+  errorCode?: string;
   targetPath?: string;
   inputHash?: string;
   error?: string;

--- a/tasks/notes/20260622-repo-harness-codegraph.notes.md
+++ b/tasks/notes/20260622-repo-harness-codegraph.notes.md
@@ -205,3 +205,28 @@ Sprint 0 contract freeze for `plans/sprints/20260622-repo-harness-codegraph-spri
   returns an explicit unsupported-policy error.
 - Successful move/delete mutations invalidate snapshots and return the same
   pending CodeGraph refresh contract as `write_file` and `apply_patch`.
+
+## 2026-06-23 failure injection, index recovery, and audit slice
+
+- Mutation fault injection is intentionally test-only and env-gated through
+  `REPO_HARNESS_MCP_MUTATION_FAULT_POINT`. The supported fault points sit after
+  temp-file fsync and before atomic rename, before move rename, and before
+  delete unlink. They model the pre-commit boundaries for disk/permission,
+  interrupted-process, and rename/delete failures without adding a public MCP
+  option.
+- Successful mutations now append `.ai/harness/mcp/index-events.jsonl`
+  invalidation events. The event log is ignored runtime state, separate from
+  `.ai/harness/mcp/audit.log`, and carries mutation id, invalidation id, relative
+  paths, hash summaries, index revision, and retry metadata without file bodies
+  or patch text.
+- `refresh_repo_index` accepts an optional `mutation_id` so callers can trace
+  the refresh back to the invalidation event and measure mutation-to-refresh lag.
+  It also accepts recently deleted repo-relative paths so move/delete old paths
+  can be synchronized instead of failing `NOT_FOUND` before refresh.
+- Refresh failures write dead-letter index events with retry metadata and the
+  manual recovery command `bash scripts/ensure-codegraph.sh --sync`; the tool
+  still returns the adapter error to the caller.
+- General repo MCP audit entries now include actor/profile, repo id, operation,
+  relative paths, mutation id, index invalidation/event ids, hash summaries,
+  result, duration, and rejection error code. The logged input remains hashed,
+  not embedded, so file contents and patch bodies do not enter the audit log.

--- a/tests/cli/mcp-codegraph-contract.test.ts
+++ b/tests/cli/mcp-codegraph-contract.test.ts
@@ -201,10 +201,11 @@ describe('general repo CodeGraph contract', () => {
         } else if (tool.name === 'delete_path') {
           expect(tool.input_schema.required).toEqual(['repo_id', 'path', 'expected_sha256']);
           expect(tool.input_schema.properties.recursive).toEqual({ type: 'boolean' });
-        } else {
-          expect(tool.input_schema.required).toEqual(['repo_id']);
-          expect(tool.input_schema.properties.paths.items).toEqual({ type: 'string' });
-        }
+	        } else {
+	          expect(tool.input_schema.required).toEqual(['repo_id']);
+	          expect(tool.input_schema.properties.paths.items).toEqual({ type: 'string' });
+	          expect(tool.input_schema.properties.mutation_id).toEqual({ type: 'string' });
+	        }
       } else {
         expect(tool.annotations).toEqual({
           readOnlyHint: true,

--- a/tests/cli/mcp-reader-tools.test.ts
+++ b/tests/cli/mcp-reader-tools.test.ts
@@ -13,6 +13,29 @@ async function jsonTool(ctx: ReaderToolContext, name: string, args: Record<strin
   return JSON.parse(result.content[0].text);
 }
 
+function readJsonLines(path: string): Record<string, unknown>[] {
+  if (!existsSync(path)) return [];
+  return readFileSync(path, 'utf-8')
+    .trimEnd()
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+async function withMutationFault<T>(point: string, fn: () => Promise<T>): Promise<T> {
+  const previous = process.env.REPO_HARNESS_MCP_MUTATION_FAULT_POINT;
+  try {
+    process.env.REPO_HARNESS_MCP_MUTATION_FAULT_POINT = point;
+    return await fn();
+  } finally {
+    if (previous === undefined) {
+      delete process.env.REPO_HARNESS_MCP_MUTATION_FAULT_POINT;
+    } else {
+      process.env.REPO_HARNESS_MCP_MUTATION_FAULT_POINT = previous;
+    }
+  }
+}
+
 async function withReaderRepo<T>(fn: (repoRoot: string, ctx: ReaderToolContext) => Promise<T>, opts: { accessMode?: RepoHarnessAccessMode } = {}): Promise<T> {
   const repoRoot = mkdtempSync(join(tmpdir(), 'repo-harness-mcp-reader-tools-'));
   const repoHarnessHome = mkdtempSync(join(tmpdir(), 'repo-harness-mcp-home-'));
@@ -305,8 +328,8 @@ describe('MCP reader tools', () => {
     });
   });
 
-  test('write_file is capability-gated, atomic, and guarded by revision preconditions', async () => {
-    await withReaderRepo(async (repoRoot, ctx) => {
+	  test('write_file is capability-gated, atomic, and guarded by revision preconditions', async () => {
+	    await withReaderRepo(async (repoRoot, ctx) => {
       writeFileSync(join(repoRoot, '.ignore'), 'ignored.md\n');
       let indexedAfterRefresh = false;
       const refreshCalls: string[][] = [];
@@ -378,12 +401,32 @@ describe('MCP reader tools', () => {
       expect(created.index.invalidation_id).toMatch(/^idxinv_[a-f0-9]{16}$/);
       expect(created.index.refresh_tool).toBe('refresh_repo_index');
       expect(created.after.sha256).toMatch(/^[a-f0-9]{64}$/);
-      expect(created.diff.after_sha256).toBe(created.after.sha256);
-      expect(readFileSync(join(repoRoot, 'docs', 'generated.txt'), 'utf-8')).toBe('first\n');
-      expect(readdirSync(join(repoRoot, 'docs')).some((name) => name.includes('.repo-harness-'))).toBe(false);
+	      expect(created.diff.after_sha256).toBe(created.after.sha256);
+	      expect(readFileSync(join(repoRoot, 'docs', 'generated.txt'), 'utf-8')).toBe('first\n');
+	      expect(readdirSync(join(repoRoot, 'docs')).some((name) => name.includes('.repo-harness-'))).toBe(false);
+	      const indexEventsAfterCreate = readJsonLines(join(repoRoot, '.ai', 'harness', 'mcp', 'index-events.jsonl'));
+	      const createdIndexEvent = indexEventsAfterCreate.find((entry) => entry.mutation_id === created.mutation_id);
+	      expect(created.index.event_id).toBe(createdIndexEvent?.event_id);
+	      expect(createdIndexEvent).toMatchObject({
+	        event_type: 'index_invalidation',
+	        status: 'pending',
+	        repo_id: repoId,
+	        operation: 'create',
+	        mutation_id: created.mutation_id,
+	        invalidation_id: created.index.invalidation_id,
+	        relative_paths: ['docs/generated.txt'],
+	        before_index_revision: 'index_before_write',
+	        retry: {
+	          retryable: true,
+	          retry_tool: 'refresh_repo_index',
+	          retry_paths: ['docs/generated.txt'],
+	          manual_recovery: 'bash scripts/ensure-codegraph.sh --sync',
+	        },
+	      });
+	      expect(JSON.stringify(createdIndexEvent)).not.toContain('first\n');
 
-      const readCreated = await jsonTool(writeCtx, 'read_file', { repo_id: repoId, path: 'docs/generated.txt' });
-      expect(readCreated.content).toBe('first\n');
+	      const readCreated = await jsonTool(writeCtx, 'read_file', { repo_id: repoId, path: 'docs/generated.txt' });
+	      expect(readCreated.content).toBe('first\n');
       expect(readCreated.sha256).toBe(created.after.sha256);
 
       const targetExists = await jsonTool(writeCtx, 'write_file', {
@@ -433,31 +476,56 @@ describe('MCP reader tools', () => {
       expect(searchBeforeRefresh.backend).toBe('codegraph-metadata+filesystem-fallback');
       expect(searchBeforeRefresh.matches).toMatchObject([{ path: 'docs/generated.txt', indexed: false }]);
 
-      const refreshed = await jsonTool(writeCtx, 'refresh_repo_index', {
-        repo_id: repoId,
-        paths: ['docs/generated.txt'],
-      });
-      expect(refreshed).toMatchObject({
-        paths: ['docs/generated.txt'],
-        refreshed: true,
+	      const refreshed = await jsonTool(writeCtx, 'refresh_repo_index', {
+	        repo_id: repoId,
+	        paths: ['docs/generated.txt'],
+	        mutation_id: replaced.mutation_id,
+	      });
+	      const refreshedEventId = refreshed.index.event_id;
+	      const refreshedSourceEventId = refreshed.refresh.source_event_id;
+	      expect(typeof refreshedEventId).toBe('string');
+	      expect(typeof refreshedSourceEventId).toBe('string');
+	      expect(refreshed).toMatchObject({
+	        paths: ['docs/generated.txt'],
+	        refreshed: true,
         index_state: 'ready',
         refresh: {
           strategy: 'repo-sync',
           requested_paths: ['docs/generated.txt'],
           path_refresh_supported: false,
-          before_index_revision: 'index_before_write',
-          adapter_index_revision: 'index_after_write',
-          after_index_revision: 'index_after_write',
-          indexed_files: 1,
-        },
-        index: {
-          state: 'ready',
-          action: 'refresh_complete',
-          refreshed_paths: ['docs/generated.txt'],
-        },
-      });
-      expect(refreshCalls).toEqual([['docs/generated.txt']]);
-      const statAfterRefresh = await jsonTool(writeCtx, 'stat_file', { repo_id: repoId, path: 'docs/generated.txt' });
+	          before_index_revision: 'index_before_write',
+	          adapter_index_revision: 'index_after_write',
+	          after_index_revision: 'index_after_write',
+	          indexed_files: 1,
+	          source_event_id: refreshedSourceEventId,
+	          mutation_id: replaced.mutation_id,
+	          index_lag_ms: expect.any(Number),
+	        },
+	        index: {
+	          state: 'ready',
+	          action: 'refresh_complete',
+	          refreshed_paths: ['docs/generated.txt'],
+	          mutation_id: replaced.mutation_id,
+	          event_id: refreshedEventId,
+	          event_log: '.ai/harness/mcp/index-events.jsonl',
+	          index_lag_ms: expect.any(Number),
+	        },
+	      });
+	      expect(refreshCalls).toEqual([['docs/generated.txt']]);
+	      const indexEventsAfterRefresh = readJsonLines(join(repoRoot, '.ai', 'harness', 'mcp', 'index-events.jsonl'));
+	      const refreshEvent = indexEventsAfterRefresh.find((entry) => entry.event_type === 'index_refresh' && entry.mutation_id === replaced.mutation_id);
+	      expect(refreshEvent?.event_id).toBe(refreshedEventId);
+	      expect(refreshEvent).toMatchObject({
+	        event_type: 'index_refresh',
+	        status: 'ready',
+	        repo_id: repoId,
+	        operation: 'refresh_repo_index',
+	        mutation_id: replaced.mutation_id,
+	        source_event_id: refreshedSourceEventId,
+	        relative_paths: ['docs/generated.txt'],
+	        index_lag_ms: expect.any(Number),
+	      });
+	      const statAfterRefresh = await jsonTool(writeCtx, 'stat_file', { repo_id: repoId, path: 'docs/generated.txt' });
       expect(statAfterRefresh).toMatchObject({
         indexed: true,
         codegraph_language: 'text',
@@ -610,19 +678,36 @@ describe('MCP reader tools', () => {
         expected_sha256: deleteStat.sha256,
       });
       expect(deleted.error).toBeUndefined();
-      expect(deleted).toMatchObject({
-        path: 'docs/moved.txt',
-        operation: 'delete',
-        before: { existed: true, sha256: deleteStat.sha256, size: 'move me\n'.length },
+	      expect(deleted).toMatchObject({
+	        path: 'docs/moved.txt',
+	        operation: 'delete',
+	        before: { existed: true, sha256: deleteStat.sha256, size: 'move me\n'.length },
         after: { existed: false, sha256: null, size: 0 },
         deleted: { path: 'docs/moved.txt', type: 'file' },
         index: { action: 'refresh_repo_index_required', changed_paths: ['docs/moved.txt'] },
-      });
-      expect(existsSync(join(repoRoot, 'docs', 'moved.txt'))).toBe(false);
-      const readDeleted = await jsonTool(writeCtx, 'read_file', { repo_id: repoId, path: 'docs/moved.txt' });
-      expect(readDeleted.error.code).toBe('NOT_FOUND');
+	      });
+	      expect(existsSync(join(repoRoot, 'docs', 'moved.txt'))).toBe(false);
+	      const readDeleted = await jsonTool(writeCtx, 'read_file', { repo_id: repoId, path: 'docs/moved.txt' });
+	      expect(readDeleted.error.code).toBe('NOT_FOUND');
+	      const refreshedAfterDelete = await jsonTool(writeCtx, 'refresh_repo_index', {
+	        repo_id: repoId,
+	        paths: ['docs/moved.txt'],
+	        mutation_id: deleted.mutation_id,
+	      });
+	      expect(refreshedAfterDelete.error).toBeUndefined();
+	      expect(refreshedAfterDelete).toMatchObject({
+	        paths: ['docs/moved.txt'],
+	        refreshed: true,
+	        index: {
+	          action: 'refresh_complete',
+	          refreshed_paths: ['docs/moved.txt'],
+	          mutation_id: deleted.mutation_id,
+	          source_event_id: deleted.index.event_id,
+	        },
+	      });
+	      expect(refreshCalls.at(-1)).toEqual(['docs/moved.txt']);
 
-      const directoryDelete = await jsonTool(writeCtx, 'delete_path', {
+	      const directoryDelete = await jsonTool(writeCtx, 'delete_path', {
         repo_id: repoId,
         path: 'docs',
         expected_sha256: 'unused',
@@ -643,16 +728,74 @@ describe('MCP reader tools', () => {
         must_not_exist: true,
       });
       expect(ignored.error.code).toBe('PATH_IGNORED');
-      const missingParent = await jsonTool(writeCtx, 'write_file', {
-        repo_id: repoId,
-        path: 'missing-dir/file.txt',
-        content: 'blocked\n',
-        must_not_exist: true,
-      });
-      expect(missingParent.error.code).toBe('NOT_FOUND');
+	      const missingParent = await jsonTool(writeCtx, 'write_file', {
+	        repo_id: repoId,
+	        path: 'missing-dir/file.txt',
+	        content: 'blocked\n',
+	        must_not_exist: true,
+	      });
+	      expect(missingParent.error.code).toBe('NOT_FOUND');
 
-      const auditText = readFileSync(join(repoRoot, '.ai', 'harness', 'mcp', 'audit.log'), 'utf-8');
-      expect(auditText).toContain('"tool":"write_file"');
+	      const failingCodeGraph: GeneralRepoCodeGraphAdapter = {
+	        discoverRepo() {
+	          return {
+	            available: true,
+	            integrated: true,
+	            source: 'test-double',
+	            indexRevision: 'index_before_failed_refresh',
+	            latencyMs: 1,
+	            files: [],
+	          };
+	        },
+	        refreshRepo(_repoRoot, opts = {}) {
+	          return {
+	            available: false,
+	            refreshed: false,
+	            integrated: true,
+	            source: 'test-double',
+	            indexRevision: 'index_before_failed_refresh',
+	            latencyMs: 4,
+	            strategy: 'repo-sync',
+	            requestedPaths: opts.paths ?? [],
+	            pathRefreshSupported: false,
+	            files: 0,
+	            error: {
+	              code: 'INDEX_UNAVAILABLE',
+	              message: 'OPENAI_API_KEY=sk-testsecret refresh failed',
+	              retryable: true,
+	            },
+	          };
+	        },
+	      };
+	      const failingCtx = createReaderToolContext(
+	        repoRoot,
+	        ctx.policy,
+	        new WorkspaceManager({ allowedRoots: [repoRoot], policy: ctx.policy }),
+	        failingCodeGraph,
+	      );
+	      const failedRefresh = await jsonTool(failingCtx, 'refresh_repo_index', {
+	        repo_id: repoId,
+	        paths: ['docs/generated.txt'],
+	        mutation_id: patched.mutation_id,
+	      });
+	      expect(failedRefresh.error.code).toBe('INDEX_UNAVAILABLE');
+	      expect(failedRefresh.error.retryable).toBe(true);
+	      const failedRefreshEvent = readJsonLines(join(repoRoot, '.ai', 'harness', 'mcp', 'index-events.jsonl'))
+	        .find((entry) => entry.event_type === 'index_refresh' && entry.status === 'failed' && entry.mutation_id === patched.mutation_id);
+	      expect(failedRefreshEvent).toMatchObject({
+	        operation: 'refresh_repo_index',
+	        relative_paths: ['docs/generated.txt'],
+	        error: { code: 'INDEX_UNAVAILABLE', retryable: true },
+	        dead_letter: {
+	          retry_tool: 'refresh_repo_index',
+	          retry_paths: ['docs/generated.txt'],
+	          manual_recovery: 'bash scripts/ensure-codegraph.sh --sync',
+	        },
+	      });
+	      expect(JSON.stringify(failedRefreshEvent)).not.toContain('sk-testsecret');
+
+	      const auditText = readFileSync(join(repoRoot, '.ai', 'harness', 'mcp', 'audit.log'), 'utf-8');
+	      expect(auditText).toContain('"tool":"write_file"');
       expect(auditText).toContain('"tool":"apply_patch"');
       expect(auditText).toContain('"tool":"move_path"');
       expect(auditText).toContain('"tool":"delete_path"');
@@ -662,13 +805,111 @@ describe('MCP reader tools', () => {
       expect(auditText).not.toContain('second\n');
       expect(auditText).not.toContain('second patched\n');
       expect(auditText).not.toContain('bravo');
-      expect(auditText).not.toContain('move me\n');
-      expect(auditText).not.toContain('changed\n');
-      expect(auditText).not.toContain('stale\n');
-    }, { accessMode: 'read_write' });
-  });
+	      expect(auditText).not.toContain('move me\n');
+	      expect(auditText).not.toContain('changed\n');
+	      expect(auditText).not.toContain('stale\n');
+	      const auditEntries = readJsonLines(join(repoRoot, '.ai', 'harness', 'mcp', 'audit.log'));
+	      const createdAudit = auditEntries.find((entry) => entry.tool === 'write_file' && entry.mutationId === created.mutation_id);
+	      expect(createdAudit).toMatchObject({
+	        status: 'ok',
+	        actor: 'mcp:planner',
+	        repoId,
+	        operation: 'create',
+	        relativePaths: ['docs/generated.txt'],
+	        mutationId: created.mutation_id,
+	        indexInvalidationId: created.index.invalidation_id,
+	        indexEventId: created.index.event_id,
+	        result: 'ok',
+	        fileHashes: {
+	          before_sha256: null,
+	          after_sha256: created.after.sha256,
+	        },
+	      });
+	      expect(typeof createdAudit?.durationMs).toBe('number');
+	      const blockedDeleteAudit = auditEntries.find((entry) => entry.tool === 'delete_path' && entry.errorCode === 'REVISION_CONFLICT');
+	      expect(blockedDeleteAudit).toMatchObject({
+	        status: 'blocked',
+	        repoId,
+	        relativePaths: ['docs/moved.txt'],
+	        result: 'blocked',
+	        errorCode: 'REVISION_CONFLICT',
+	      });
+	      expect(JSON.stringify(auditEntries)).not.toContain('OPENAI_API_KEY=sk-testsecret refresh failed');
+	    }, { accessMode: 'read_write' });
+	  });
 
-  test('general repo tools merge CodeGraph metadata under the same guarded snapshot', async () => {
+	  test('write mutations cleanly abort injected pre-commit filesystem faults', async () => {
+	    await withReaderRepo(async (repoRoot, ctx) => {
+	      const writeCtx = createReaderToolContext(
+	        repoRoot,
+	        ctx.policy,
+	        new WorkspaceManager({ allowedRoots: [repoRoot], policy: ctx.policy }),
+	      );
+	      const repoId = (await jsonTool(writeCtx, 'list_allowed_roots')).roots[0].repo_id;
+
+	      const createFault = await withMutationFault('atomic_write_before_rename', () => jsonTool(writeCtx, 'write_file', {
+	        repo_id: repoId,
+	        path: 'docs/fault-create.txt',
+	        content: 'new\n',
+	        must_not_exist: true,
+	      }));
+	      expect(createFault.error.code).toBe('INJECTED_MUTATION_FAULT');
+	      expect(existsSync(join(repoRoot, 'docs', 'fault-create.txt'))).toBe(false);
+	      expect(readdirSync(join(repoRoot, 'docs')).some((name) => name.includes('.repo-harness-'))).toBe(false);
+
+	      writeFileSync(join(repoRoot, 'docs', 'fault-replace.txt'), 'old\n');
+	      const replaceStat = await jsonTool(writeCtx, 'stat_file', { repo_id: repoId, path: 'docs/fault-replace.txt' });
+	      const replaceFault = await withMutationFault('atomic_write_before_rename', () => jsonTool(writeCtx, 'write_file', {
+	        repo_id: repoId,
+	        path: 'docs/fault-replace.txt',
+	        content: 'new\n',
+	        expected_sha256: replaceStat.sha256,
+	      }));
+	      expect(replaceFault.error.code).toBe('INJECTED_MUTATION_FAULT');
+	      expect(readFileSync(join(repoRoot, 'docs', 'fault-replace.txt'), 'utf-8')).toBe('old\n');
+	      expect(readdirSync(join(repoRoot, 'docs')).some((name) => name.includes('.repo-harness-'))).toBe(false);
+
+	      const patchFault = await withMutationFault('atomic_write_before_rename', () => jsonTool(writeCtx, 'apply_patch', {
+	        repo_id: repoId,
+	        path: 'docs/fault-replace.txt',
+	        expected_sha256: replaceStat.sha256,
+	        edits: [{ old_text: 'old\n', new_text: 'patched\n' }],
+	      }));
+	      expect(patchFault.error.code).toBe('INJECTED_MUTATION_FAULT');
+	      expect(readFileSync(join(repoRoot, 'docs', 'fault-replace.txt'), 'utf-8')).toBe('old\n');
+	      expect(readdirSync(join(repoRoot, 'docs')).some((name) => name.includes('.repo-harness-'))).toBe(false);
+
+	      writeFileSync(join(repoRoot, 'docs', 'fault-move.txt'), 'move\n');
+	      const moveStat = await jsonTool(writeCtx, 'stat_file', { repo_id: repoId, path: 'docs/fault-move.txt' });
+	      const moveFault = await withMutationFault('move_before_rename', () => jsonTool(writeCtx, 'move_path', {
+	        repo_id: repoId,
+	        from_path: 'docs/fault-move.txt',
+	        to_path: 'docs/fault-moved.txt',
+	        expected_sha256: moveStat.sha256,
+	        must_not_exist: true,
+	      }));
+	      expect(moveFault.error.code).toBe('INJECTED_MUTATION_FAULT');
+	      expect(readFileSync(join(repoRoot, 'docs', 'fault-move.txt'), 'utf-8')).toBe('move\n');
+	      expect(existsSync(join(repoRoot, 'docs', 'fault-moved.txt'))).toBe(false);
+
+	      const deleteFault = await withMutationFault('delete_before_unlink', () => jsonTool(writeCtx, 'delete_path', {
+	        repo_id: repoId,
+	        path: 'docs/fault-move.txt',
+	        expected_sha256: moveStat.sha256,
+	      }));
+	      expect(deleteFault.error.code).toBe('INJECTED_MUTATION_FAULT');
+	      expect(readFileSync(join(repoRoot, 'docs', 'fault-move.txt'), 'utf-8')).toBe('move\n');
+	      expect(readJsonLines(join(repoRoot, '.ai', 'harness', 'mcp', 'index-events.jsonl'))).toEqual([]);
+
+	      const auditText = readFileSync(join(repoRoot, '.ai', 'harness', 'mcp', 'audit.log'), 'utf-8');
+	      expect(auditText).toContain('"errorCode":"INJECTED_MUTATION_FAULT"');
+	      expect(auditText).not.toContain('new\n');
+	      expect(auditText).not.toContain('patched\n');
+	      expect(auditText).not.toContain('move\n');
+	    }, { accessMode: 'read_write' });
+	  });
+
+	  test('general repo tools merge CodeGraph metadata under the same guarded snapshot', async () => {
     await withReaderRepo(async (repoRoot, ctx) => {
       writeFileSync(join(repoRoot, '.ignore'), 'ignored.md\n');
       const fakeCodeGraph: GeneralRepoCodeGraphAdapter = {

--- a/tests/cli/mcp-setup.test.ts
+++ b/tests/cli/mcp-setup.test.ts
@@ -62,6 +62,7 @@ describe('mcp setup', () => {
       expect(ignore).toContain('.repo-harness/mcp.oauth.json');
       expect(ignore).toContain('.repo-harness/mcp.oauth-tokens.json');
       expect(ignore).toContain('.ai/harness/mcp/audit.log');
+      expect(ignore).toContain('.ai/harness/mcp/index-events.jsonl');
 
       const doctor = JSON.parse(runMcpDoctor({ repo: repoRoot, json: true }).lines[0]);
       expect(doctor.mcp.packageVersion).toBe(repoHarnessPackageVersion());


### PR DESCRIPTION
## Summary
- add persistent MCP index invalidation/refresh events with retry, dead-letter, and mutation lag readback
- allow refresh_repo_index to accept deleted changed paths and optional mutation_id for move/delete/index recovery
- add deterministic mutation fault injection coverage and enrich general repo audit fields without logging file bodies or patch text

## Verification
- bun test
- bun run check:type
- bun test tests/cli/mcp-reader-tools.test.ts tests/cli/mcp-codegraph-contract.test.ts tests/cli/mcp-setup.test.ts
- git diff --check
- jq empty assets/mcp/general-repo-reader-tools.v1.schema.json
- bun test tests/readme-dx.test.ts
- bash scripts/check-deploy-sql-order.sh
- bash scripts/check-architecture-sync.sh
- bash scripts/check-task-sync.sh
- bash scripts/check-task-workflow.sh --strict
- bun scripts/inspect-project-state.ts --repo . --format text
- bash scripts/migrate-project-template.sh --repo . --dry-run
- bash scripts/ensure-codegraph.sh --sync
- repo-harness setup check --target codex --check-updates --json