### PR TITLE
Harden general repo MCP security

### DIFF
--- a/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
+++ b/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
@@ -694,13 +694,46 @@ Sprint 3 failure-injection and audit evidence:
 
 ## 11.1 安全与一致性加固
 
-- [ ] **S4-SEC-001** 独立安全评审：path traversal、symlink、TOCTOU、权限提升、日志泄露。
-- [ ] **S4-SEC-002** Fuzz path parser、ignore parser 和 patch parser。
-- [ ] **S4-SEC-003** 测试 repo root 在运行期间被替换、卸载或权限变化。
-- [ ] **S4-SEC-004** 测试 CodeGraph 返回恶意/异常 path。
-- [ ] **S4-SEC-005** 测试 manifest 生成期间文件大量变更。
-- [ ] **S4-SEC-006** 确认所有内容大小限制均返回 continuation 或明确错误，不造成隐式文件消失。
-- [ ] **S4-SEC-007** 确认内容不进入 trace、metrics label 或 error stack。
+- [x] **S4-SEC-001** 独立安全评审：path traversal、symlink、TOCTOU、权限提升、日志泄露。
+- [x] **S4-SEC-002** Fuzz path parser、ignore parser 和 patch parser。
+- [x] **S4-SEC-003** 测试 repo root 在运行期间被替换、卸载或权限变化。
+- [x] **S4-SEC-004** 测试 CodeGraph 返回恶意/异常 path。
+- [x] **S4-SEC-005** 测试 manifest 生成期间文件大量变更。
+- [x] **S4-SEC-006** 确认所有内容大小限制均返回 continuation 或明确错误，不造成隐式文件消失。
+- [x] **S4-SEC-007** 确认内容不进入 trace、metrics label 或 error stack。
+
+Sprint 4 security hardening evidence:
+
+- Runtime: `src/cli/mcp/general-repo-access.ts`
+- Tests: `tests/cli/mcp-reader-tools.test.ts`
+- Completed slice: repo records now capture first-observed root identity and
+  reject the same repo id if the root disappears or is replaced at the same
+  canonical path during a long-lived MCP process. This supplements canonical
+  realpath checks without changing the external `repo_id + relative_path`
+  contract.
+- Parser hardening tests cover traversal, absolute paths, Windows-like paths,
+  NUL bytes, ignored refresh paths, guarded unified diff rejection, and existing
+  `.ignore` golden behavior.
+- CodeGraph adapter safety tests cover malicious absolute, Windows-like, NUL,
+  ignored, missing, and traversal paths; every such adapter path is filtered
+  before metadata merge and never becomes readable content.
+- Manifest consistency tests cover disappearing entries through dangling
+  symlinks and POSIX permission-denied directories. The manifest remains
+  explicit with `partial:false|true`, `complete:false`, and `walker_errors`
+  rather than silently dropping entries as complete.
+- Payload-limit tests cover `read_file` continuation and `read_files`
+  byte-budget exhaustion with `PAYLOAD_LIMIT_REACHED`, so large content does
+  not disappear from the API as a permission denial.
+- Error/audit hardening now redacts generic thrown adapter errors and
+  blocked `GeneralRepoAccessError` messages before MCP response and audit
+  emission. Existing audit writer redaction remains a second defensive layer;
+  index event errors already use the same redaction path.
+- Independent Claude read-only review was run on the S4 security diff. The
+  first pass found one P1 redaction consistency issue in the blocked audit path;
+  after fixing it, the second pass reported no P1 findings. Remaining review
+  notes are low-risk: root identity relies on filesystem inode/birthtime
+  behavior, and POSIX permission-denied assertions are skipped when tests run
+  as root.
 
 ## 11.2 可观测性
 

--- a/src/cli/mcp/general-repo-access.ts
+++ b/src/cli/mcp/general-repo-access.ts
@@ -35,6 +35,7 @@ const ENTRY_REVISION: unique symbol = Symbol('entryRevision');
 interface RepoRecord {
   repoId: string;
   canonicalRoot: string;
+  rootIdentity: string;
   displayName: string;
   accessMode: RepoHarnessAccessMode;
   registryRevision: string;
@@ -185,6 +186,7 @@ const MAX_SNAPSHOT_CACHE_ENTRIES = 16;
 const MAX_ENTRY_METADATA_CACHE_ENTRIES = 200_000;
 const MAX_LAGGING_PATHS_RETURNED = 50;
 const DEFAULT_CODEGRAPH_ADAPTER = createCodeGraphCliAdapter();
+const REPO_ROOT_IDENTITIES = new Map<string, string>();
 const SNAPSHOT_CACHE = new Map<string, VisibleEntrySnapshot>();
 const ENTRY_METADATA_CACHE = new Map<string, EntryMetadataCacheValue>();
 const WRITE_TOOLS = new Set<string>(['write_file', 'apply_patch', 'move_path', 'delete_path', 'refresh_repo_index']);
@@ -213,7 +215,7 @@ function textResult(value: unknown): GeneralRepoToolResult {
 }
 
 function errorResult(code: string, message: string, details?: unknown, retryable = false): GeneralRepoToolResult {
-  const value = { error: { code, message, retryable, details } };
+  const value = { error: { code, message: redactMcpText(message).text, retryable, details } };
   return {
     content: [{ type: 'text', text: JSON.stringify(value, null, 2) }],
     structuredContent: value,
@@ -455,6 +457,25 @@ function canonicalDirectory(path: string): string | null {
   }
 }
 
+function directoryIdentity(path: string): string | null {
+  try {
+    const stats = statSync(path);
+    if (!stats.isDirectory()) return null;
+    return `${stats.dev}:${stats.ino}:${Math.trunc(stats.birthtimeMs)}`;
+  } catch {
+    return null;
+  }
+}
+
+function expectedRootIdentity(canonicalRoot: string): string | null {
+  const current = directoryIdentity(canonicalRoot);
+  if (!current) return null;
+  const expected = REPO_ROOT_IDENTITIES.get(canonicalRoot);
+  if (expected) return expected;
+  REPO_ROOT_IDENTITIES.set(canonicalRoot, current);
+  return current;
+}
+
 function registryRevision(records: Array<{ id: string; path: string; accessMode: RepoHarnessAccessMode }>): string {
   return `registry_${sha256(JSON.stringify(records.map((entry) => ({
     id: entry.id,
@@ -477,10 +498,13 @@ function uniqueRepoRecords(ctx: GeneralRepoToolContext): RepoRecord[] {
   const add = (rawPath: string, source: RepoRecord['source']): void => {
     const canonicalRoot = canonicalDirectory(rawPath);
     if (!canonicalRoot || byPath.has(canonicalRoot)) return;
+    const rootIdentity = expectedRootIdentity(canonicalRoot);
+    if (!rootIdentity) return;
     const registeredEntry = known.get(canonicalRoot);
     byPath.set(canonicalRoot, {
       repoId: registeredEntry?.id ?? repoHarnessRepoIdFor(canonicalRoot),
       canonicalRoot,
+      rootIdentity,
       displayName: basename(canonicalRoot) || canonicalRoot,
       accessMode: registeredEntry?.accessMode ?? 'read_only',
       registryRevision: revision,
@@ -501,8 +525,9 @@ function resolveRepo(ctx: GeneralRepoToolContext, repoId: unknown): RepoRecord {
   const repo = uniqueRepoRecords(ctx).find((entry) => entry.repoId === id);
   if (!repo) throw new GeneralRepoAccessError('REPO_NOT_ALLOWED', 'repo_id is not in the registered repo whitelist', { repo_id: id });
   const currentRoot = canonicalDirectory(repo.canonicalRoot);
-  if (currentRoot !== repo.canonicalRoot) {
-    throw new GeneralRepoAccessError('REPO_NOT_ALLOWED', 'registered repo root moved or is no longer readable', { repo_id: id });
+  const currentIdentity = currentRoot ? directoryIdentity(currentRoot) : null;
+  if (currentRoot !== repo.canonicalRoot || !currentIdentity || currentIdentity !== repo.rootIdentity) {
+    throw new GeneralRepoAccessError('REPO_NOT_ALLOWED', 'registered repo root moved, was replaced, or is no longer readable', { repo_id: id });
   }
   return repo;
 }
@@ -2685,16 +2710,18 @@ export async function callGeneralRepoTool(ctx: GeneralRepoToolContext, name: str
     return result;
   } catch (error) {
     if (error instanceof GeneralRepoAccessError) {
-      audit(ctx, name, 'blocked', args, auditTargetPath(args), error.message, auditDetailsFromError(error, args, Date.now() - startedAtMs, name));
-      return errorResult(error.code, error.message, error.details, error.retryable);
+      const message = redactMcpText(error.message).text;
+      audit(ctx, name, 'blocked', args, auditTargetPath(args), message, auditDetailsFromError(error, args, Date.now() - startedAtMs, name));
+      return errorResult(error.code, message, error.details, error.retryable);
     }
-    audit(ctx, name, 'failed', args, auditTargetPath(args), error instanceof Error ? error.message : String(error), {
+    const message = redactMcpText(error instanceof Error ? error.message : String(error)).text;
+    audit(ctx, name, 'failed', args, auditTargetPath(args), message, {
       repoId: stringField(args.repo_id),
       operation: name,
       relativePaths: auditPaths(args),
       durationMs: Date.now() - startedAtMs,
       errorCode: 'INTERNAL_ADAPTER_ERROR',
     });
-    return errorResult('INTERNAL_ADAPTER_ERROR', error instanceof Error ? error.message : String(error));
+    return errorResult('INTERNAL_ADAPTER_ERROR', message);
   }
 }

--- a/tasks/notes/20260622-repo-harness-codegraph.notes.md
+++ b/tasks/notes/20260622-repo-harness-codegraph.notes.md
@@ -230,3 +230,32 @@ Sprint 0 contract freeze for `plans/sprints/20260622-repo-harness-codegraph-spri
   relative paths, mutation id, index invalidation/event ids, hash summaries,
   result, duration, and rejection error code. The logged input remains hashed,
   not embedded, so file contents and patch bodies do not enter the audit log.
+
+## 2026-06-23 S4 security hardening slice
+
+- Root validation now stores a first-observed directory identity for each
+  canonical repo root inside the long-lived MCP process. `resolveRepo` compares
+  the live identity to that first observation, so a repo id fails closed if the
+  root disappears or is replaced at the same canonical path. This is deliberately
+  process-local: a fresh MCP process can adopt the replacement after normal
+  registry/policy checks, while a running process does not silently switch trust
+  to a different directory.
+- Generic thrown adapter errors and blocked `GeneralRepoAccessError` messages
+  are redacted before MCP response/audit emission. The audit writer still
+  performs its own final error-field redaction, and index refresh events use the
+  same redaction path for adapter-provided messages.
+- Security regression tests now cover path parser fuzz samples, ignored refresh
+  paths, guarded patch parser rejection, malicious CodeGraph absolute/
+  Windows-like/NUL paths, same-path root replacement, missing root, manifest
+  partial reporting for disappearing entries and POSIX permission-denied
+  directories, byte-budget continuation/errors, and audit/index-event absence of
+  file content or secret-bearing adapter errors.
+- Independent Claude read-only review was run on the S4 diff. The first pass
+  found a redaction consistency gap in the blocked audit branch; the follow-up
+  fix was applied, local tests passed, and the second pass reported no P1
+  findings.
+- Residual risk: root identity relies on filesystem `dev:ino:birthtimeMs`.
+  Filesystems with unavailable birthtime and immediate inode reuse could
+  theoretically miss a same-path replacement. This is still stricter than the
+  previous realpath-only guard and remains fail-closed for normal remove,
+  replace, or symlink target changes observed in the test fixture.

--- a/tests/cli/mcp-reader-tools.test.ts
+++ b/tests/cli/mcp-reader-tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { repoHarnessRepoIdFor, type RepoHarnessAccessMode } from '../../src/effects/repo-registry';
@@ -925,6 +925,9 @@ describe('MCP reader tools', () => {
               { path: '.env', language: 'dotenv', nodeCount: 0, size: 29 },
               { path: 'ignored.md', language: 'markdown', nodeCount: 0, size: 10 },
               { path: '../outside.ts', language: 'typescript', nodeCount: 1, size: 10 },
+              { path: '/tmp/outside.ts', language: 'typescript', nodeCount: 1, size: 10 },
+              { path: 'C:/Users/example/outside.ts', language: 'typescript', nodeCount: 1, size: 10 },
+              { path: 'docs/bad\0name.ts', language: 'typescript', nodeCount: 1, size: 10 },
               { path: 'missing.ts', language: 'typescript', nodeCount: 1, size: 10 },
             ],
           };
@@ -961,8 +964,8 @@ describe('MCP reader tools', () => {
         integrated: true,
         available: true,
         source: 'test-double',
-        indexed_files: 5,
-        filtered_paths: 3,
+        indexed_files: 8,
+        filtered_paths: 6,
         index_lagging: true,
         lagging_path_count: 2,
       });
@@ -1038,6 +1041,148 @@ describe('MCP reader tools', () => {
       const stale = await jsonTool(cgCtx, 'read_file', { repo_id: repoId, path: 'src/index.ts', snapshot_id: 'snap_stale' });
       expect(stale.error.code).toBe('SNAPSHOT_STALE');
       expect(stale.error.retryable).toBe(true);
+    });
+  });
+
+  test('general repo security hardening fails closed on fuzzed inputs, partial walks, and raw adapter errors', async () => {
+    await withReaderRepo(async (repoRoot, ctx) => {
+      writeFileSync(join(repoRoot, '.ignore'), 'ignored.md\n');
+      const throwingCodeGraph: GeneralRepoCodeGraphAdapter = {
+        discoverRepo() {
+          return {
+            available: true,
+            integrated: true,
+            source: 'test-double',
+            indexRevision: 'index_throw_before',
+            latencyMs: 1,
+            files: [],
+          };
+        },
+        refreshRepo() {
+          throw new Error('OPENAI_API_KEY=sk-testsecret thrown from adapter');
+        },
+      };
+      const secureCtx = createReaderToolContext(
+        repoRoot,
+        ctx.policy,
+        new WorkspaceManager({ allowedRoots: [repoRoot], policy: ctx.policy }),
+        throwingCodeGraph,
+      );
+      const repoId = (await jsonTool(secureCtx, 'list_allowed_roots')).roots[0].repo_id;
+
+      const invalidReadPaths = [
+        { path: '../package.json', code: 'INVALID_RELATIVE_PATH' },
+        { path: '/tmp/package.json', code: 'INVALID_RELATIVE_PATH' },
+        { path: 'C:\\temp\\package.json', code: 'INVALID_RELATIVE_PATH' },
+        { path: 'docs/bad\0name.txt', code: 'INVALID_RELATIVE_PATH' },
+      ];
+      for (const sample of invalidReadPaths) {
+        const result = await jsonTool(secureCtx, 'read_file', { repo_id: repoId, path: sample.path });
+        expect(result.error.code).toBe(sample.code);
+      }
+
+      const ignoredRefresh = await jsonTool(secureCtx, 'refresh_repo_index', {
+        repo_id: repoId,
+        paths: ['ignored.md'],
+      });
+      expect(ignoredRefresh.error.code).toBe('PATH_IGNORED');
+      const traversalRefresh = await jsonTool(secureCtx, 'refresh_repo_index', {
+        repo_id: repoId,
+        paths: ['docs/../package.json'],
+      });
+      expect(traversalRefresh.error.code).toBe('INVALID_RELATIVE_PATH');
+
+      const design = await jsonTool(secureCtx, 'stat_file', { repo_id: repoId, path: 'docs/design.md' });
+      const badPatch = await jsonTool(secureCtx, 'apply_patch', {
+        repo_id: repoId,
+        path: 'docs/design.md',
+        expected_sha256: design.sha256,
+        unified_diff: [
+          '@@ -1,0 +1,1 @@',
+          '+OPENAI_API_KEY=sk-testsecret',
+        ].join('\n'),
+      });
+      expect(badPatch.error.code).toBe('INVALID_RANGE');
+      expect(readFileSync(join(repoRoot, 'docs', 'design.md'), 'utf-8')).toContain('authentication route');
+
+      let danglingEntries = 0;
+      for (let index = 0; index < 24; index += 1) {
+        try {
+          symlinkSync(join(repoRoot, 'docs', `deleted-during-walk-${index}.md`), join(repoRoot, 'docs', `dangling-during-walk-${index}.md`));
+          danglingEntries += 1;
+        } catch (_error) {
+          // Symlinks may be unavailable on some runners; the parser/error redaction checks still cover this test.
+          break;
+        }
+      }
+      if (danglingEntries > 0) {
+        const partialManifest = await jsonTool(secureCtx, 'repo_manifest', { repo_id: repoId, page_size: 1000 });
+        expect(partialManifest.partial).toBe(true);
+        expect(partialManifest.complete).toBe(false);
+        expect(partialManifest.walker_errors).toBeGreaterThanOrEqual(danglingEntries);
+      }
+      if (process.platform !== 'win32' && process.getuid?.() !== 0) {
+        const lockedDir = join(repoRoot, 'docs', 'permission-changed');
+        mkdirSync(lockedDir, { recursive: true });
+        writeFileSync(join(lockedDir, 'locked.txt'), 'locked\n');
+        chmodSync(lockedDir, 0);
+        try {
+          const permissionManifest = await jsonTool(secureCtx, 'repo_manifest', { repo_id: repoId, page_size: 1000 });
+          expect(permissionManifest.partial).toBe(true);
+          expect(permissionManifest.complete).toBe(false);
+          expect(permissionManifest.walker_errors).toBeGreaterThan(0);
+        } finally {
+          chmodSync(lockedDir, 0o700);
+        }
+      }
+
+      writeFileSync(join(repoRoot, 'docs', 'budget-a.txt'), 'abcdef');
+      writeFileSync(join(repoRoot, 'docs', 'budget-b.txt'), 'ghijkl');
+      const budgetedBatch = await jsonTool(secureCtx, 'read_files', {
+        repo_id: repoId,
+        byte_budget: 5,
+        requests: [{ path: 'docs/budget-a.txt' }, { path: 'docs/budget-b.txt' }],
+      });
+      expect(budgetedBatch.partial).toBe(true);
+      expect(budgetedBatch.results[0]).toMatchObject({
+        path: 'docs/budget-a.txt',
+        bytes_returned: 5,
+        has_more: true,
+        next_cursor: 'byte:5',
+      });
+      expect(budgetedBatch.results[1].error.code).toBe('PAYLOAD_LIMIT_REACHED');
+
+      const thrownRefresh = await jsonTool(secureCtx, 'refresh_repo_index', {
+        repo_id: repoId,
+        paths: ['docs/design.md'],
+      });
+      expect(thrownRefresh.error.code).toBe('INTERNAL_ADAPTER_ERROR');
+      expect(JSON.stringify(thrownRefresh)).not.toContain('sk-testsecret');
+      expect(JSON.stringify(thrownRefresh)).toContain('[REDACTED]');
+
+      const auditText = readFileSync(join(repoRoot, '.ai', 'harness', 'mcp', 'audit.log'), 'utf-8');
+      expect(auditText).not.toContain('sk-testsecret');
+      expect(auditText).not.toContain('OPENAI_API_KEY=sk-testsecret');
+      const indexEventsText = readFileSync(join(repoRoot, '.ai', 'harness', 'mcp', 'index-events.jsonl'), 'utf-8');
+      expect(indexEventsText).not.toContain('sk-testsecret');
+      expect(indexEventsText).not.toContain('OPENAI_API_KEY=sk-testsecret');
+    }, { accessMode: 'read_write' });
+  });
+
+  test('general repo tools fail closed when the repo root disappears or is replaced during runtime', async () => {
+    await withReaderRepo(async (repoRoot, ctx) => {
+      const repoId = (await jsonTool(ctx, 'list_allowed_roots')).roots[0].repo_id;
+      rmSync(repoRoot, { recursive: true, force: true });
+      mkdirSync(repoRoot, { recursive: true });
+      writeFileSync(join(repoRoot, 'package.json'), JSON.stringify({ name: 'replacement' }));
+      const replacedRoot = await jsonTool(ctx, 'stat_file', { repo_id: repoId, path: 'package.json' });
+      expect(replacedRoot.error.code).toBe('REPO_NOT_ALLOWED');
+      expect(JSON.stringify(replacedRoot)).not.toContain(repoRoot);
+
+      rmSync(repoRoot, { recursive: true, force: true });
+      const missingRoot = await jsonTool(ctx, 'stat_file', { repo_id: repoId, path: 'package.json' });
+      expect(missingRoot.error.code).toBe('REPO_NOT_ALLOWED');
+      expect(JSON.stringify(missingRoot)).not.toContain(repoRoot);
     });
   });
 


### PR DESCRIPTION
## Summary
- Complete Sprint 4 security checklist S4-SEC-001 through S4-SEC-007.
- Add process-local repo root identity validation so a long-lived MCP process fails closed if an allowed root disappears or is replaced at the same canonical path.
- Add regression coverage for fuzzed paths, ignored refreshes, guarded patch rejection, malicious CodeGraph paths, partial manifest walks, payload limits, and error/audit redaction.
- Record the S4 security evidence in the sprint plan and task notes.

## P1 Map
- Runtime boundary: `src/cli/mcp/general-repo-access.ts` owns general repo MCP tool resolution, path validation, manifest/read/write tool dispatch, audit emission, and CodeGraph adapter integration.
- Test boundary: `tests/cli/mcp-reader-tools.test.ts` owns fixture-level behavior for allowed roots, reader/writer tool contracts, CodeGraph metadata merge, and security regressions.
- Workflow truth: `plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md` and `tasks/notes/20260622-repo-harness-codegraph.notes.md` track checklist completion and slice tradeoffs.
- Out of scope: observability, migration defaults, docs/release tasks remain unchecked Sprint 4 sections.

## P2 Trace
- `callGeneralRepoTool()` receives `repo_id + path` args, resolves the allowlisted repo through `resolveRepo()`, validates relative paths before file/adapter access, then emits structured MCP response plus audit/index events.
- The new pressure point was same-canonical-path replacement in a long-lived process: realpath equality alone could accept a replaced directory. Repo records now capture first-observed `dev:ino:birthtimeMs`; later tool calls reject mismatch as `REPO_NOT_ALLOWED`.
- Adapter and parser error paths now redact messages before MCP response and audit emission; audit writer redaction remains a second defensive layer.

## P3 Decision
- The smallest coherent change is process-local root identity plus focused regression tests. It preserves the external `repo_id + relative_path` contract and avoids introducing a registry or persistence migration.
- Tradeoff: root identity depends on filesystem inode/birthtime behavior. It is stronger than realpath-only guarding and fails closed for normal remove, replace, symlink, and unreadable-root cases.

## Verification
- `bun test tests/cli/mcp-reader-tools.test.ts`
- `bun run check:type`
- `bun test tests/cli/mcp-reader-tools.test.ts tests/cli/mcp-codegraph-contract.test.ts tests/cli/mcp-setup.test.ts`
- `git diff --check`
- `bash scripts/check-task-sync.sh`
- `bun test`
- `bash scripts/check-deploy-sql-order.sh`
- `bash scripts/check-architecture-sync.sh`
- `bun scripts/inspect-project-state.ts --repo . --format text`
- `bash scripts/migrate-project-template.sh --repo . --dry-run`
- `bash scripts/ensure-codegraph.sh --sync`
- `bash scripts/prepare-codex-handoff.sh --reason codegraph-s4-security-hardening-final && bash scripts/check-task-workflow.sh --strict`
- `repo-harness setup check --target codex --check-updates --json` returned attention only for optional `runtime.skills_cli` timeout; fail=0.

## Independent Review
Claude read-only review was run on the S4 diff. First pass found one P1 blocked-audit redaction consistency issue; that was fixed. Re-review reported no P1 findings.