### PR TITLE
Add general repo MCP observability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,8 @@ tasks/.current.md.tmp.*
 .ai/harness/runs/
 .ai/harness/mcp/audit.log
 .ai/harness/mcp/index-events.jsonl
+.ai/harness/mcp/metrics.jsonl
+.ai/harness/mcp/trace.jsonl
 .ai/harness/chatgpt/browser-lock.json
 .ai/harness/chatgpt/bridge-extension/
 .ai/harness/chatgpt/oracle-home/

--- a/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
+++ b/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
@@ -737,12 +737,53 @@ Sprint 4 security hardening evidence:
 
 ## 11.2 可观测性
 
-- [ ] **S4-OBS-001** 指标：tool calls、latency、bytes、errors、partial、fallback rate。
-- [ ] **S4-OBS-002** 指标：manifest parity failures、snapshot stale rate、index lag。
-- [ ] **S4-OBS-003** 指标：write conflicts、atomic write failures、reindex failures。
-- [ ] **S4-OBS-004** Dashboard：按 repo、tool、CodeGraph revision 聚合。
-- [ ] **S4-OBS-005** 告警：路径逃逸尝试突增、index lag 超阈值、manifest incomplete、reindex dead-letter。
-- [ ] **S4-OBS-006** tracing：MCP → policy → CodeGraph/FS → response，全链路 correlation id。
+- [x] **S4-OBS-001** 指标：tool calls、latency、bytes、errors、partial、fallback rate。
+- [x] **S4-OBS-002** 指标：manifest parity failures、snapshot stale rate、index lag。
+- [x] **S4-OBS-003** 指标：write conflicts、atomic write failures、reindex failures。
+- [x] **S4-OBS-004** Dashboard：按 repo、tool、CodeGraph revision 聚合。
+- [x] **S4-OBS-005** 告警：路径逃逸尝试突增、index lag 超阈值、manifest incomplete、reindex dead-letter。
+- [x] **S4-OBS-006** tracing：MCP → policy → CodeGraph/FS → response，全链路 correlation id。
+
+Sprint 4 observability evidence:
+
+- Runtime: `src/cli/mcp/general-repo-access.ts`
+- Report script: `scripts/mcp-observability-report.ts`
+- Tests: `tests/cli/mcp-reader-tools.test.ts`,
+  `tests/mcp-observability-report.test.ts`, `tests/cli/mcp-setup.test.ts`
+- Every general repo MCP tool call now receives a `correlation_id` in the MCP
+  response and audit entry. The same id is written to
+  `.ai/harness/mcp/metrics.jsonl` and `.ai/harness/mcp/trace.jsonl`, so an
+  operator can join MCP response, audit, metrics, and trace rows without using
+  local absolute paths.
+- Metrics cover tool, repo id, status, duration, CodeGraph revision/latency,
+  bytes returned/written, partial result, fallback usage, manifest parity
+  mismatches, snapshot stale errors, index lag, write conflicts, atomic write
+  failures, reindex failures, and path-escape attempts. Metrics store path count
+  and path digest, not raw path labels or file content.
+- Trace rows record the route
+  `mcp_tool_gateway -> repo_policy -> path_guard_ignore_policy -> CodeGraph/FS -> response`
+  with backend, status, error code, index state, and index event ids where
+  applicable. Tests verify trace/metrics do not contain authorized file content
+  or secret-bearing fixture text.
+- `scripts/mcp-observability-report.ts` aggregates metrics into a local
+  dashboard grouped by repo, tool, and CodeGraph revision, including p95/max
+  latency, failed-call error rate, blocked-call count, partial/fallback rates,
+  bytes, parity failures, stale
+  snapshots, index lag, write conflicts, atomic failures, reindex failures, and
+  path-escape attempts.
+- The report script emits actionable alerts for path escape spikes, index lag
+  over threshold, incomplete manifests, and reindex dead-letter failures. The
+  CLI exits non-zero when alerts fire, making it usable as a release/canary
+  gate without adding a hosted telemetry dependency.
+- MCP runtime observability files are ignored by setup and `.gitignore`. The
+  snapshot digest explicitly treats `.ai/harness/mcp/` as internal runtime state
+  so metrics/trace writes do not make a caller's `snapshot_id` stale.
+- Claude no-tools diff review reported no P1 findings. The actionable P2s were
+  fixed in this slice: report max-latency aggregation no longer uses argument
+  spreading, large metrics logs are capped to the latest 100k events, blocked
+  policy rejections are separated from failed-call error rate, manifest parity
+  failures are manifest-scoped, and tests cover snapshot stability plus
+  escape-input redaction.
 
 ## 11.3 兼容与迁移
 

--- a/scripts/mcp-observability-report.ts
+++ b/scripts/mcp-observability-report.ts
@@ -1,0 +1,460 @@
+#!/usr/bin/env bun
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { dirname, isAbsolute, resolve } from "path";
+
+export const DEFAULT_METRICS_PATH = ".ai/harness/mcp/metrics.jsonl";
+export const DEFAULT_TRACE_PATH = ".ai/harness/mcp/trace.jsonl";
+export const DEFAULT_REPORT_PATH = ".ai/harness/runs/mcp-observability-report.json";
+export const DEFAULT_PATH_ESCAPE_THRESHOLD = 5;
+export const DEFAULT_INDEX_LAG_THRESHOLD_MS = 5_000;
+export const MAX_OBSERVABILITY_EVENTS = 100_000;
+
+export interface McpObservabilityMetric {
+  schema_version?: number;
+  event_type?: string;
+  timestamp?: string;
+  correlation_id?: string;
+  repo_id?: string;
+  tool?: string;
+  operation?: string;
+  status?: "ok" | "blocked" | "failed";
+  error_code?: string;
+  duration_ms?: number;
+  codegraph_revision?: string;
+  codegraph_available?: boolean;
+  codegraph_latency_ms?: number;
+  path_count?: number;
+  path_digest?: string;
+  bytes_returned?: number;
+  bytes_written?: number;
+  partial?: boolean;
+  fallback_used?: boolean;
+  filtered_path_count?: number;
+  manifest_parity_failure_count?: number;
+  manifest_incomplete?: boolean;
+  snapshot_stale?: boolean;
+  index_lagging?: boolean;
+  index_lag_ms?: number;
+  lagging_path_count?: number;
+  write_conflict?: boolean;
+  atomic_write_failure?: boolean;
+  reindex_failure?: boolean;
+  path_escape_attempt?: boolean;
+}
+
+export interface McpObservabilityTrace {
+  schema_version?: number;
+  event_type?: string;
+  timestamp?: string;
+  correlation_id?: string;
+  trace_id?: string;
+  repo_id?: string;
+  tool?: string;
+  status?: "ok" | "blocked" | "failed";
+  duration_ms?: number;
+  route?: string[];
+  backend?: string;
+  codegraph_revision?: string;
+  index_state?: string;
+}
+
+export interface McpObservabilityReport {
+  protocol: "repo-harness-mcp-observability-report/v1";
+  generated_at: string;
+  source: {
+    metrics_path: string;
+    trace_path: string;
+    metric_events: number;
+    trace_events: number;
+  };
+  dashboard: {
+    totals: DashboardStats;
+    by_repo_tool_codegraph: DashboardStats[];
+  };
+  alerts: Array<{
+    id: string;
+    severity: "warning" | "critical";
+    count: number;
+    threshold?: number;
+    message: string;
+  }>;
+  tracing: {
+    correlated_metric_events: number;
+    missing_trace_events: number;
+    correlation_ids: string[];
+  };
+}
+
+export interface DashboardStats {
+  repo_id: string;
+  tool: string;
+  codegraph_revision: string;
+  calls: number;
+  errors: number;
+  blocked: number;
+  error_rate: number;
+  latency_p95_ms: number;
+  latency_max_ms: number;
+  bytes_returned: number;
+  bytes_written: number;
+  partial_count: number;
+  partial_rate: number;
+  fallback_count: number;
+  fallback_rate: number;
+  manifest_parity_failures: number;
+  manifest_incomplete_count: number;
+  snapshot_stale_count: number;
+  index_lagging_count: number;
+  index_lag_max_ms: number;
+  lagging_path_count: number;
+  write_conflicts: number;
+  atomic_write_failures: number;
+  reindex_failures: number;
+  path_escape_attempts: number;
+}
+
+interface BuildOptions {
+  repo: string;
+  metricsPath?: string;
+  tracePath?: string;
+  now?: Date;
+  pathEscapeThreshold?: number;
+  indexLagThresholdMs?: number;
+}
+
+interface MutableGroup {
+  repoId: string;
+  tool: string;
+  codeGraphRevision: string;
+  calls: number;
+  errors: number;
+  blocked: number;
+  durations: number[];
+  bytesReturned: number;
+  bytesWritten: number;
+  partialCount: number;
+  fallbackCount: number;
+  manifestParityFailures: number;
+  manifestIncompleteCount: number;
+  snapshotStaleCount: number;
+  indexLaggingCount: number;
+  indexLagMaxMs: number;
+  laggingPathCount: number;
+  writeConflicts: number;
+  atomicWriteFailures: number;
+  reindexFailures: number;
+  pathEscapeAttempts: number;
+}
+
+function usage(): string {
+  return [
+    "Usage: scripts/mcp-observability-report.ts [--repo PATH] [--metrics PATH] [--trace PATH] [--out PATH] [--json]",
+    "       [--path-escape-threshold N] [--index-lag-threshold-ms N]",
+    "",
+    "Aggregates repo-harness MCP metrics and trace JSONL into a dashboard/alert report.",
+  ].join("\n");
+}
+
+function resolveInRepo(repo: string, candidate: string): string {
+  return isAbsolute(candidate) ? candidate : resolve(repo, candidate);
+}
+
+function readJsonLines(path: string): Record<string, unknown>[] {
+  if (!existsSync(path)) return [];
+  return readFileSync(path, "utf-8")
+    .trimEnd()
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .slice(-MAX_OBSERVABILITY_EVENTS)
+    .map((line) => JSON.parse(line))
+    .filter((entry): entry is Record<string, unknown> => typeof entry === "object" && entry !== null && !Array.isArray(entry));
+}
+
+function numberValue(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function booleanValue(value: unknown): boolean {
+  return value === true;
+}
+
+function stringValue(value: unknown, fallback: string): string {
+  return typeof value === "string" && value.length > 0 ? value : fallback;
+}
+
+function percentile95(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(sorted.length - 1, Math.ceil(sorted.length * 0.95) - 1);
+  return Math.round(sorted[index] * 100) / 100;
+}
+
+function rate(count: number, total: number): number {
+  if (total <= 0) return 0;
+  return Math.round((count / total) * 10000) / 10000;
+}
+
+function emptyGroup(repoId: string, tool: string, codeGraphRevision: string): MutableGroup {
+  return {
+    repoId,
+    tool,
+    codeGraphRevision,
+    calls: 0,
+    errors: 0,
+    blocked: 0,
+    durations: [],
+    bytesReturned: 0,
+    bytesWritten: 0,
+    partialCount: 0,
+    fallbackCount: 0,
+    manifestParityFailures: 0,
+    manifestIncompleteCount: 0,
+    snapshotStaleCount: 0,
+    indexLaggingCount: 0,
+    indexLagMaxMs: 0,
+    laggingPathCount: 0,
+    writeConflicts: 0,
+    atomicWriteFailures: 0,
+    reindexFailures: 0,
+    pathEscapeAttempts: 0,
+  };
+}
+
+function addMetric(group: MutableGroup, metric: McpObservabilityMetric): void {
+  group.calls += 1;
+  if (metric.status === "failed") group.errors += 1;
+  if (metric.status === "blocked") group.blocked += 1;
+  group.durations.push(numberValue(metric.duration_ms));
+  group.bytesReturned += numberValue(metric.bytes_returned);
+  group.bytesWritten += numberValue(metric.bytes_written);
+  if (booleanValue(metric.partial)) group.partialCount += 1;
+  if (booleanValue(metric.fallback_used)) group.fallbackCount += 1;
+  group.manifestParityFailures += numberValue(metric.manifest_parity_failure_count);
+  if (booleanValue(metric.manifest_incomplete)) group.manifestIncompleteCount += 1;
+  if (booleanValue(metric.snapshot_stale)) group.snapshotStaleCount += 1;
+  if (booleanValue(metric.index_lagging)) group.indexLaggingCount += 1;
+  group.indexLagMaxMs = Math.max(group.indexLagMaxMs, numberValue(metric.index_lag_ms));
+  group.laggingPathCount += numberValue(metric.lagging_path_count);
+  if (booleanValue(metric.write_conflict)) group.writeConflicts += 1;
+  if (booleanValue(metric.atomic_write_failure)) group.atomicWriteFailures += 1;
+  if (booleanValue(metric.reindex_failure)) group.reindexFailures += 1;
+  if (booleanValue(metric.path_escape_attempt)) group.pathEscapeAttempts += 1;
+}
+
+function toStats(group: MutableGroup): DashboardStats {
+  return {
+    repo_id: group.repoId,
+    tool: group.tool,
+    codegraph_revision: group.codeGraphRevision,
+    calls: group.calls,
+    errors: group.errors,
+    blocked: group.blocked,
+    error_rate: rate(group.errors, group.calls),
+    latency_p95_ms: percentile95(group.durations),
+    latency_max_ms: group.durations.reduce((max, duration) => Math.max(max, duration), 0),
+    bytes_returned: group.bytesReturned,
+    bytes_written: group.bytesWritten,
+    partial_count: group.partialCount,
+    partial_rate: rate(group.partialCount, group.calls),
+    fallback_count: group.fallbackCount,
+    fallback_rate: rate(group.fallbackCount, group.calls),
+    manifest_parity_failures: group.manifestParityFailures,
+    manifest_incomplete_count: group.manifestIncompleteCount,
+    snapshot_stale_count: group.snapshotStaleCount,
+    index_lagging_count: group.indexLaggingCount,
+    index_lag_max_ms: group.indexLagMaxMs,
+    lagging_path_count: group.laggingPathCount,
+    write_conflicts: group.writeConflicts,
+    atomic_write_failures: group.atomicWriteFailures,
+    reindex_failures: group.reindexFailures,
+    path_escape_attempts: group.pathEscapeAttempts,
+  };
+}
+
+function buildAlerts(totals: DashboardStats, opts: Required<Pick<BuildOptions, "pathEscapeThreshold" | "indexLagThresholdMs">>): McpObservabilityReport["alerts"] {
+  const alerts: McpObservabilityReport["alerts"] = [];
+  if (totals.path_escape_attempts >= opts.pathEscapeThreshold) {
+    alerts.push({
+      id: "path_escape_spike",
+      severity: "critical",
+      count: totals.path_escape_attempts,
+      threshold: opts.pathEscapeThreshold,
+      message: "Path escape attempts exceeded the configured threshold.",
+    });
+  }
+  if (totals.index_lag_max_ms > opts.indexLagThresholdMs) {
+    alerts.push({
+      id: "index_lag_threshold",
+      severity: "warning",
+      count: totals.index_lag_max_ms,
+      threshold: opts.indexLagThresholdMs,
+      message: "Observed index lag exceeded the configured threshold.",
+    });
+  }
+  if (totals.manifest_incomplete_count > 0) {
+    alerts.push({
+      id: "manifest_incomplete",
+      severity: "critical",
+      count: totals.manifest_incomplete_count,
+      message: "At least one manifest call reported incomplete walking.",
+    });
+  }
+  if (totals.reindex_failures > 0) {
+    alerts.push({
+      id: "reindex_dead_letter",
+      severity: "critical",
+      count: totals.reindex_failures,
+      message: "At least one reindex operation failed and needs dead-letter recovery.",
+    });
+  }
+  return alerts;
+}
+
+export function buildMcpObservabilityReport(options: BuildOptions): McpObservabilityReport {
+  const repo = resolve(options.repo);
+  const metricsPath = resolveInRepo(repo, options.metricsPath ?? DEFAULT_METRICS_PATH);
+  const tracePath = resolveInRepo(repo, options.tracePath ?? DEFAULT_TRACE_PATH);
+  const metrics = readJsonLines(metricsPath) as McpObservabilityMetric[];
+  const traces = readJsonLines(tracePath) as McpObservabilityTrace[];
+  const groups = new Map<string, MutableGroup>();
+  const totals = emptyGroup("all", "all", "all");
+
+  for (const metric of metrics) {
+    const repoId = stringValue(metric.repo_id, "unknown");
+    const tool = stringValue(metric.tool, "unknown");
+    const revision = stringValue(metric.codegraph_revision, "unknown");
+    const key = `${repoId}\0${tool}\0${revision}`;
+    const group = groups.get(key) ?? emptyGroup(repoId, tool, revision);
+    groups.set(key, group);
+    addMetric(group, metric);
+    addMetric(totals, metric);
+  }
+
+  const traceIds = new Set(traces.map((trace) => trace.correlation_id).filter((id): id is string => typeof id === "string" && id.length > 0));
+  const metricIds = metrics.map((metric) => metric.correlation_id).filter((id): id is string => typeof id === "string" && id.length > 0);
+  const correlatedMetricEvents = metricIds.filter((id) => traceIds.has(id)).length;
+
+  return {
+    protocol: "repo-harness-mcp-observability-report/v1",
+    generated_at: (options.now ?? new Date()).toISOString(),
+    source: {
+      metrics_path: metricsPath,
+      trace_path: tracePath,
+      metric_events: metrics.length,
+      trace_events: traces.length,
+    },
+    dashboard: {
+      totals: toStats(totals),
+      by_repo_tool_codegraph: [...groups.values()].map(toStats).sort((a, b) => (
+        `${a.repo_id}\0${a.tool}\0${a.codegraph_revision}`.localeCompare(`${b.repo_id}\0${b.tool}\0${b.codegraph_revision}`)
+      )),
+    },
+    alerts: buildAlerts(toStats(totals), {
+      pathEscapeThreshold: options.pathEscapeThreshold ?? DEFAULT_PATH_ESCAPE_THRESHOLD,
+      indexLagThresholdMs: options.indexLagThresholdMs ?? DEFAULT_INDEX_LAG_THRESHOLD_MS,
+    }),
+    tracing: {
+      correlated_metric_events: correlatedMetricEvents,
+      missing_trace_events: metricIds.length - correlatedMetricEvents,
+      correlation_ids: metricIds.slice(-50),
+    },
+  };
+}
+
+export function writeMcpObservabilityReport(path: string, report: McpObservabilityReport): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(report, null, 2)}\n`, "utf-8");
+}
+
+interface CliOptions {
+  repo: string;
+  metricsPath: string;
+  tracePath: string;
+  out: string;
+  pathEscapeThreshold: number;
+  indexLagThresholdMs: number;
+  json: boolean;
+}
+
+function parsePositiveInteger(value: string | undefined, label: string): number | string {
+  const parsed = Number.parseInt(value ?? "", 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return `invalid ${label}`;
+  return parsed;
+}
+
+function parseArgs(argv: string[]): CliOptions | { error: string; help?: boolean } {
+  const opts: CliOptions = {
+    repo: process.cwd(),
+    metricsPath: DEFAULT_METRICS_PATH,
+    tracePath: DEFAULT_TRACE_PATH,
+    out: DEFAULT_REPORT_PATH,
+    pathEscapeThreshold: DEFAULT_PATH_ESCAPE_THRESHOLD,
+    indexLagThresholdMs: DEFAULT_INDEX_LAG_THRESHOLD_MS,
+    json: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--help" || arg === "-h") return { error: "", help: true };
+    if (arg === "--repo") {
+      opts.repo = argv[++i] ?? "";
+    } else if (arg === "--metrics") {
+      opts.metricsPath = argv[++i] ?? "";
+    } else if (arg === "--trace") {
+      opts.tracePath = argv[++i] ?? "";
+    } else if (arg === "--out") {
+      opts.out = argv[++i] ?? "";
+    } else if (arg === "--path-escape-threshold") {
+      const parsed = parsePositiveInteger(argv[++i], "--path-escape-threshold");
+      if (typeof parsed === "string") return { error: parsed };
+      opts.pathEscapeThreshold = parsed;
+    } else if (arg === "--index-lag-threshold-ms") {
+      const parsed = parsePositiveInteger(argv[++i], "--index-lag-threshold-ms");
+      if (typeof parsed === "string") return { error: parsed };
+      opts.indexLagThresholdMs = parsed;
+    } else if (arg === "--json") {
+      opts.json = true;
+    } else {
+      return { error: `unknown argument: ${arg}` };
+    }
+  }
+
+  if (!opts.repo || !opts.metricsPath || !opts.tracePath || !opts.out) return { error: "missing required option value" };
+  return opts;
+}
+
+function main(argv: string[]): number {
+  const parsed = parseArgs(argv);
+  if ("error" in parsed) {
+    if (parsed.help) {
+      console.log(usage());
+      return 0;
+    }
+    console.error(`mcp-observability-report: ${parsed.error}`);
+    console.error(usage());
+    return 2;
+  }
+
+  const repo = resolve(parsed.repo);
+  const report = buildMcpObservabilityReport({
+    repo,
+    metricsPath: parsed.metricsPath,
+    tracePath: parsed.tracePath,
+    pathEscapeThreshold: parsed.pathEscapeThreshold,
+    indexLagThresholdMs: parsed.indexLagThresholdMs,
+  });
+  const outPath = resolveInRepo(repo, parsed.out);
+  writeMcpObservabilityReport(outPath, report);
+
+  if (parsed.json) {
+    console.log(JSON.stringify(report));
+  } else {
+    console.log(`mcp-observability events=${report.source.metric_events} alerts=${report.alerts.length} out=${parsed.out}`);
+  }
+  return report.alerts.length > 0 ? 1 : 0;
+}
+
+if (import.meta.main) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/src/cli/mcp/general-repo-access.ts
+++ b/src/cli/mcp/general-repo-access.ts
@@ -191,7 +191,10 @@ const SNAPSHOT_CACHE = new Map<string, VisibleEntrySnapshot>();
 const ENTRY_METADATA_CACHE = new Map<string, EntryMetadataCacheValue>();
 const WRITE_TOOLS = new Set<string>(['write_file', 'apply_patch', 'move_path', 'delete_path', 'refresh_repo_index']);
 const MCP_INDEX_EVENTS_RELATIVE_PATH = '.ai/harness/mcp/index-events.jsonl';
+const MCP_METRICS_RELATIVE_PATH = '.ai/harness/mcp/metrics.jsonl';
+const MCP_TRACE_RELATIVE_PATH = '.ai/harness/mcp/trace.jsonl';
 const MUTATION_FAULT_ENV = 'REPO_HARNESS_MCP_MUTATION_FAULT_POINT';
+const PATH_ESCAPE_ERROR_CODES = new Set(['INVALID_RELATIVE_PATH', 'PATH_OUTSIDE_REPO', 'SYMLINK_ESCAPE']);
 
 export type GeneralRepoToolName = typeof GENERAL_REPO_TOOLS[number];
 
@@ -261,6 +264,13 @@ function recordObject(value: unknown): Record<string, unknown> | null {
   return value as Record<string, unknown>;
 }
 
+function recordArray(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((entry) => recordObject(entry))
+    .filter((entry): entry is Record<string, unknown> => entry !== null);
+}
+
 function stringArray(value: unknown): string[] | undefined {
   if (!Array.isArray(value)) return undefined;
   const values = value.filter((entry): entry is string => typeof entry === 'string');
@@ -269,6 +279,10 @@ function stringArray(value: unknown): string[] | undefined {
 
 function stringField(value: unknown): string | undefined {
   return typeof value === 'string' && value ? value : undefined;
+}
+
+function numberField(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
 }
 
 function auditDetailsFromResult(result: GeneralRepoToolResult, input: Record<string, unknown>, durationMs: number, tool: string): Partial<McpAuditEntry> {
@@ -341,6 +355,18 @@ function cachePaths(paths: string[] | undefined): string[] {
 
 function mcpIndexEventsPath(repoRoot: string): string {
   return join(repoRoot, MCP_INDEX_EVENTS_RELATIVE_PATH);
+}
+
+function mcpMetricsPath(repoRoot: string): string {
+  return join(repoRoot, MCP_METRICS_RELATIVE_PATH);
+}
+
+function mcpTracePath(repoRoot: string): string {
+  return join(repoRoot, MCP_TRACE_RELATIVE_PATH);
+}
+
+function correlationId(tool: string): string {
+  return `mcpcorr_${sha256(`${tool}\0${Date.now()}\0${randomBytes(8).toString('hex')}`).slice(0, 16)}`;
 }
 
 function indexEventId(repo: RepoRecord, eventType: string, seed: string): string {
@@ -425,6 +451,164 @@ function indexRecovery(paths: string[], retryable = true): Record<string, unknow
     dead_letter_log: MCP_INDEX_EVENTS_RELATIVE_PATH,
     manual_recovery: 'bash scripts/ensure-codegraph.sh --sync',
   };
+}
+
+function tryAppendJsonLine(path: string, entry: Record<string, unknown>): void {
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    appendFileSync(path, `${JSON.stringify(entry)}\n`, 'utf-8');
+  } catch (_error) {
+    // Observability must never change MCP tool behavior.
+  }
+}
+
+function withCorrelationId(result: GeneralRepoToolResult, id: string): GeneralRepoToolResult {
+  const payload = recordObject(result.structuredContent);
+  if (!payload) return result;
+  const nextPayload = { ...payload, correlation_id: id };
+  return {
+    ...result,
+    structuredContent: nextPayload,
+    content: [{ type: 'text', text: JSON.stringify(nextPayload, null, 2) }],
+  };
+}
+
+function payloadCodeGraph(payload: Record<string, unknown> | null): Record<string, unknown> | null {
+  return recordObject(payload?.codegraph);
+}
+
+function payloadIndex(payload: Record<string, unknown> | null): Record<string, unknown> | null {
+  return recordObject(payload?.index);
+}
+
+function payloadRefresh(payload: Record<string, unknown> | null): Record<string, unknown> | null {
+  return recordObject(payload?.refresh);
+}
+
+function payloadDiff(payload: Record<string, unknown> | null): Record<string, unknown> | null {
+  return recordObject(payload?.diff);
+}
+
+function payloadPathDigest(payload: Record<string, unknown> | null, input: Record<string, unknown>): string {
+  const snapshotCache = recordObject(payload?.snapshot_cache);
+  const digest = stringField(snapshotCache?.path_digest);
+  if (digest) return digest;
+  return `sha256:${sha256(JSON.stringify(cachePaths(auditPaths(input))))}`;
+}
+
+function payloadPathCount(payload: Record<string, unknown> | null, input: Record<string, unknown>): number {
+  const snapshotCache = recordObject(payload?.snapshot_cache);
+  const paths = stringArray(snapshotCache?.paths);
+  return paths?.length ?? cachePaths(auditPaths(input)).length;
+}
+
+function payloadBytesReturned(payload: Record<string, unknown> | null): number {
+  let total = numberField(payload?.bytes_returned) ?? 0;
+  for (const result of recordArray(payload?.results)) {
+    total += numberField(result.bytes_returned) ?? 0;
+  }
+  return total;
+}
+
+function payloadBytesWritten(payload: Record<string, unknown> | null): number {
+  const diff = payloadDiff(payload);
+  return numberField(diff?.bytes_after) ?? 0;
+}
+
+function payloadFallbackUsed(payload: Record<string, unknown> | null): boolean {
+  const values = [
+    stringField(payload?.backend),
+    ...recordArray(payload?.results).map((result) => stringField(result.backend)),
+  ].filter((value): value is string => value !== undefined);
+  return values.some((value) => value.includes('filesystem-fallback'));
+}
+
+function payloadIndexLagMs(payload: Record<string, unknown> | null): number | undefined {
+  const index = payloadIndex(payload);
+  const refresh = payloadRefresh(payload);
+  return numberField(index?.index_lag_ms) ?? numberField(refresh?.index_lag_ms);
+}
+
+function resultErrorCode(payload: Record<string, unknown> | null): string | undefined {
+  return stringField(recordObject(payload?.error)?.code);
+}
+
+function traceBackend(payload: Record<string, unknown> | null): string {
+  const backend = stringField(payload?.backend);
+  if (backend) return backend;
+  const codeGraph = payloadCodeGraph(payload);
+  if (codeGraph?.available === false) return 'filesystem-fallback';
+  return 'codegraph-or-filesystem';
+}
+
+function writeToolObservability(ctx: GeneralRepoToolContext, tool: string, status: 'ok' | 'blocked' | 'failed', input: Record<string, unknown>, result: GeneralRepoToolResult | null, durationMs: number, id: string, errorCode?: string): void {
+  const payload = recordObject(result?.structuredContent);
+  const codeGraph = payloadCodeGraph(payload);
+  const index = payloadIndex(payload);
+  const refresh = payloadRefresh(payload);
+  const effectiveErrorCode = errorCode ?? resultErrorCode(payload);
+  const indexState = stringField(payload?.index_state) ?? stringField(index?.state);
+  const indexLagMs = payloadIndexLagMs(payload);
+  const manifestIncomplete = tool === 'repo_manifest' && payload?.complete === false;
+  const reindexFailure = tool === 'refresh_repo_index' && (status !== 'ok' || indexState === 'failed');
+  const writeConflict = effectiveErrorCode === 'REVISION_CONFLICT';
+  const atomicWriteFailure = WRITE_TOOLS.has(tool) && (effectiveErrorCode === 'INJECTED_MUTATION_FAULT' || status === 'failed');
+  const pathEscapeAttempt = effectiveErrorCode ? PATH_ESCAPE_ERROR_CODES.has(effectiveErrorCode) : false;
+
+  const metric = {
+    schema_version: 1,
+    event_type: 'mcp_tool_metric',
+    timestamp: new Date().toISOString(),
+    correlation_id: id,
+    repo_id: stringField(payload?.repo_id) ?? stringField(input.repo_id),
+    tool,
+    operation: stringField(payload?.operation) ?? tool,
+    status,
+    error_code: effectiveErrorCode,
+    duration_ms: durationMs,
+    codegraph_revision: stringField(payload?.index_revision) ?? stringField(codeGraph?.index_revision),
+    codegraph_available: typeof codeGraph?.available === 'boolean' ? codeGraph.available : undefined,
+    codegraph_latency_ms: numberField(codeGraph?.latency_ms),
+    path_count: payloadPathCount(payload, input),
+    path_digest: payloadPathDigest(payload, input),
+    bytes_returned: payloadBytesReturned(payload),
+    bytes_written: payloadBytesWritten(payload),
+    partial: payload?.partial === true,
+    fallback_used: payloadFallbackUsed(payload),
+    filtered_path_count: numberField(codeGraph?.filtered_paths) ?? 0,
+    manifest_parity_failure_count: tool === 'repo_manifest' ? numberField(codeGraph?.filtered_paths) ?? 0 : 0,
+    manifest_incomplete: manifestIncomplete,
+    snapshot_stale: effectiveErrorCode === 'SNAPSHOT_STALE',
+    index_lagging: codeGraph?.index_lagging === true || indexState === 'index_lagging',
+    index_lag_ms: indexLagMs,
+    lagging_path_count: numberField(codeGraph?.lagging_path_count) ?? numberField(index?.lagging_path_count) ?? 0,
+    write_conflict: writeConflict,
+    atomic_write_failure: atomicWriteFailure,
+    reindex_failure: reindexFailure,
+    path_escape_attempt: pathEscapeAttempt,
+  };
+
+  const trace = {
+    schema_version: 1,
+    event_type: 'mcp_tool_trace',
+    timestamp: metric.timestamp,
+    correlation_id: id,
+    trace_id: id,
+    repo_id: metric.repo_id,
+    tool,
+    status,
+    duration_ms: durationMs,
+    error_code: effectiveErrorCode,
+    route: ['mcp_tool_gateway', 'repo_policy', 'path_guard_ignore_policy', traceBackend(payload), 'response'],
+    backend: traceBackend(payload),
+    codegraph_revision: metric.codegraph_revision,
+    index_state: indexState,
+    source_index_event_id: stringField(index?.source_event_id) ?? stringField(refresh?.source_event_id),
+    index_event_id: stringField(index?.event_id),
+  };
+
+  tryAppendJsonLine(mcpMetricsPath(ctx.repoRoot), metric);
+  tryAppendJsonLine(mcpTracePath(ctx.repoRoot), trace);
 }
 
 function injectMutationFault(point: string): void {
@@ -992,7 +1176,7 @@ function pushManifestChildren(pending: PendingWalkEntry[], absoluteDir: string, 
 }
 
 function isInternalRevisionPath(path: string): boolean {
-  return path === '.ai/harness/mcp/audit.log' || path.startsWith('.ai/harness/mcp/');
+  return path === '.ai' || path === '.ai/harness' || path === '.ai/harness/mcp' || path.startsWith('.ai/harness/mcp/');
 }
 
 function createManifestDigest() {
@@ -2664,6 +2848,7 @@ export function buildGeneralRepoToolDefinitions(): GeneralRepoToolDefinition[] {
 
 export async function callGeneralRepoTool(ctx: GeneralRepoToolContext, name: string, args: Record<string, unknown> = {}): Promise<GeneralRepoToolResult> {
   const startedAtMs = Date.now();
+  const callCorrelationId = correlationId(name);
   try {
     let result: GeneralRepoToolResult;
     switch (name) {
@@ -2706,22 +2891,37 @@ export async function callGeneralRepoTool(ctx: GeneralRepoToolContext, name: str
       default:
         return errorResult('INTERNAL_ADAPTER_ERROR', `tool is not a general repo reader tool: ${name}`);
     }
-    audit(ctx, name, 'ok', args, auditTargetPath(args), undefined, auditDetailsFromResult(result, args, Date.now() - startedAtMs, name));
-    return result;
+    const durationMs = Date.now() - startedAtMs;
+    const correlated = withCorrelationId(result, callCorrelationId);
+    audit(ctx, name, 'ok', args, auditTargetPath(args), undefined, {
+      ...auditDetailsFromResult(correlated, args, durationMs, name),
+      correlationId: callCorrelationId,
+    });
+    writeToolObservability(ctx, name, 'ok', args, correlated, durationMs, callCorrelationId);
+    return correlated;
   } catch (error) {
+    const durationMs = Date.now() - startedAtMs;
     if (error instanceof GeneralRepoAccessError) {
       const message = redactMcpText(error.message).text;
-      audit(ctx, name, 'blocked', args, auditTargetPath(args), message, auditDetailsFromError(error, args, Date.now() - startedAtMs, name));
-      return errorResult(error.code, message, error.details, error.retryable);
+      const result = withCorrelationId(errorResult(error.code, message, error.details, error.retryable), callCorrelationId);
+      audit(ctx, name, 'blocked', args, auditTargetPath(args), message, {
+        ...auditDetailsFromError(error, args, durationMs, name),
+        correlationId: callCorrelationId,
+      });
+      writeToolObservability(ctx, name, 'blocked', args, result, durationMs, callCorrelationId, error.code);
+      return result;
     }
     const message = redactMcpText(error instanceof Error ? error.message : String(error)).text;
+    const result = withCorrelationId(errorResult('INTERNAL_ADAPTER_ERROR', message), callCorrelationId);
     audit(ctx, name, 'failed', args, auditTargetPath(args), message, {
       repoId: stringField(args.repo_id),
       operation: name,
       relativePaths: auditPaths(args),
-      durationMs: Date.now() - startedAtMs,
+      durationMs,
+      correlationId: callCorrelationId,
       errorCode: 'INTERNAL_ADAPTER_ERROR',
     });
-    return errorResult('INTERNAL_ADAPTER_ERROR', message);
+    writeToolObservability(ctx, name, 'failed', args, result, durationMs, callCorrelationId, 'INTERNAL_ADAPTER_ERROR');
+    return result;
   }
 }

--- a/src/cli/mcp/setup.ts
+++ b/src/cli/mcp/setup.ts
@@ -615,6 +615,8 @@ export function runMcpSetupChatgpt(opts: {
       '.repo-harness/mcp.oauth-tokens.json',
       '.ai/harness/mcp/audit.log',
       '.ai/harness/mcp/index-events.jsonl',
+      '.ai/harness/mcp/metrics.jsonl',
+      '.ai/harness/mcp/trace.jsonl',
     ], changed);
   }
 

--- a/src/cli/mcp/types.ts
+++ b/src/cli/mcp/types.ts
@@ -51,6 +51,7 @@ export interface McpAuditEntry {
   };
   result?: 'ok' | 'blocked' | 'failed';
   durationMs?: number;
+  correlationId?: string;
   errorCode?: string;
   targetPath?: string;
   inputHash?: string;

--- a/tasks/notes/20260622-repo-harness-codegraph.notes.md
+++ b/tasks/notes/20260622-repo-harness-codegraph.notes.md
@@ -259,3 +259,35 @@ Sprint 0 contract freeze for `plans/sprints/20260622-repo-harness-codegraph-spri
   theoretically miss a same-path replacement. This is still stricter than the
   previous realpath-only guard and remains fail-closed for normal remove,
   replace, or symlink target changes observed in the test fixture.
+
+## 2026-06-23 S4 observability slice
+
+- General repo MCP tool calls now generate a response/audit/metrics/trace
+  correlation id. The id is returned as `correlation_id`, recorded on audit
+  entries as `correlationId`, and written to both
+  `.ai/harness/mcp/metrics.jsonl` and `.ai/harness/mcp/trace.jsonl`.
+- Metrics stay content-free: they include repo id, tool, operation, status,
+  error code, duration, CodeGraph revision/latency, path count, path digest,
+  bytes returned/written, partial/fallback flags, manifest parity failures,
+  stale snapshots, index lag, write conflicts, atomic write failures, reindex
+  failures, and path escape attempts. Raw paths and file bodies are intentionally
+  excluded from metric labels.
+- Trace rows are deliberately coarse-grained rather than fake subspan timings:
+  they record the observed route from MCP gateway through policy, path/ignore
+  guard, CodeGraph or filesystem backend, and response. This preserves a useful
+  chain for canary/debugging without inventing precision the runtime does not
+  measure.
+- `scripts/mcp-observability-report.ts` is a local JSONL aggregator, not a
+  hosted telemetry dependency. It produces dashboard rows grouped by repo, tool,
+  and CodeGraph revision, separates failed-call error rate from blocked policy
+  rejections, caps input to the latest 100k metrics/trace events, and emits
+  alerts for path escape spikes, high index lag, incomplete manifests, and
+  reindex dead-letter failures.
+- `.ai/harness/mcp/metrics.jsonl` and `.ai/harness/mcp/trace.jsonl` are added
+  to setup-managed ignore entries. The MCP runtime directory is treated as an
+  internal revision path for snapshot digests so observability writes do not
+  invalidate a user's `snapshot_id` between related tool calls.
+- Claude diff-only review found no P1 issues. Its P2s drove follow-up fixes for
+  large-log max latency aggregation, blocked-vs-failed reporting, manifest-only
+  parity failure accounting, snapshot stability coverage, and escape-input
+  redaction assertions.

--- a/tests/cli/mcp-reader-tools.test.ts
+++ b/tests/cli/mcp-reader-tools.test.ts
@@ -1169,6 +1169,113 @@ describe('MCP reader tools', () => {
     }, { accessMode: 'read_write' });
   });
 
+  test('general repo observability emits metrics and traces without content labels', async () => {
+    await withReaderRepo(async (repoRoot, ctx) => {
+      const fakeCodeGraph: GeneralRepoCodeGraphAdapter = {
+        discoverRepo() {
+          return {
+            available: true,
+            integrated: true,
+            source: 'test-double',
+            indexRevision: 'index_observable',
+            latencyMs: 7,
+            files: [
+              { path: 'docs/design.md', language: 'markdown', nodeCount: 2, size: 999 },
+              { path: '../outside.ts', language: 'typescript', nodeCount: 1, size: 10 },
+            ],
+          };
+        },
+      };
+      const obsCtx = createReaderToolContext(
+        repoRoot,
+        ctx.policy,
+        new WorkspaceManager({ allowedRoots: [repoRoot], policy: ctx.policy }),
+        fakeCodeGraph,
+      );
+      const repoId = (await jsonTool(obsCtx, 'list_allowed_roots')).roots[0].repo_id;
+
+      const manifest = await jsonTool(obsCtx, 'repo_manifest', { repo_id: repoId, page_size: 20 });
+      expect(manifest.correlation_id).toMatch(/^mcpcorr_[a-f0-9]{16}$/);
+      expect(manifest.codegraph).toMatchObject({
+        index_revision: 'index_observable',
+        filtered_paths: 1,
+        index_lagging: true,
+        lagging_path_count: 1,
+      });
+
+      const fallbackRead = await jsonTool(obsCtx, 'read_file', { repo_id: repoId, path: '.env' });
+      expect(fallbackRead.content).toContain('sk-testsecret');
+      expect(fallbackRead.backend).toBe('filesystem-fallback');
+      expect(fallbackRead.correlation_id).toMatch(/^mcpcorr_[a-f0-9]{16}$/);
+
+      const blocked = await jsonTool(obsCtx, 'stat_file', { repo_id: repoId, path: '../outside.md' });
+      expect(blocked.error.code).toBe('INVALID_RELATIVE_PATH');
+      expect(blocked.correlation_id).toMatch(/^mcpcorr_[a-f0-9]{16}$/);
+
+      const repeatedManifest = await jsonTool(obsCtx, 'repo_manifest', {
+        repo_id: repoId,
+        page_size: 20,
+        snapshot_id: manifest.snapshot_id,
+      });
+      expect(repeatedManifest.snapshot_id).toBe(manifest.snapshot_id);
+      expect(repeatedManifest.error).toBeUndefined();
+
+      const metrics = readJsonLines(join(repoRoot, '.ai', 'harness', 'mcp', 'metrics.jsonl'));
+      const traces = readJsonLines(join(repoRoot, '.ai', 'harness', 'mcp', 'trace.jsonl'));
+      const metricText = JSON.stringify(metrics);
+      const traceText = JSON.stringify(traces);
+      expect(metricText).not.toContain('authentication route');
+      expect(metricText).not.toContain('sk-testsecret');
+      expect(metricText).not.toContain('docs/design.md');
+      expect(metricText).not.toContain('outside');
+      expect(traceText).not.toContain('authentication route');
+      expect(traceText).not.toContain('sk-testsecret');
+      expect(traceText).not.toContain('docs/design.md');
+      expect(traceText).not.toContain('outside');
+
+      const manifestMetric = metrics.find((entry) => entry.correlation_id === manifest.correlation_id);
+      expect(manifestMetric).toMatchObject({
+        event_type: 'mcp_tool_metric',
+        repo_id: repoId,
+        tool: 'repo_manifest',
+        status: 'ok',
+        codegraph_revision: 'index_observable',
+        manifest_parity_failure_count: 1,
+        index_lagging: true,
+        lagging_path_count: 1,
+      });
+      expect(manifestMetric?.path_digest).toMatch(/^sha256:/);
+
+      const readMetric = metrics.find((entry) => entry.correlation_id === fallbackRead.correlation_id);
+      expect(readMetric).toMatchObject({
+        tool: 'read_file',
+        status: 'ok',
+        fallback_used: true,
+        bytes_returned: fallbackRead.bytes_returned,
+        filtered_path_count: 1,
+        manifest_parity_failure_count: 0,
+      });
+
+      const blockedMetric = metrics.find((entry) => entry.correlation_id === blocked.correlation_id);
+      expect(blockedMetric).toMatchObject({
+        tool: 'stat_file',
+        status: 'blocked',
+        error_code: 'INVALID_RELATIVE_PATH',
+        path_escape_attempt: true,
+      });
+
+      const readTrace = traces.find((entry) => entry.correlation_id === fallbackRead.correlation_id);
+      expect(readTrace).toMatchObject({
+        event_type: 'mcp_tool_trace',
+        trace_id: fallbackRead.correlation_id,
+        tool: 'read_file',
+        status: 'ok',
+        backend: 'filesystem-fallback',
+      });
+      expect(readTrace?.route).toEqual(['mcp_tool_gateway', 'repo_policy', 'path_guard_ignore_policy', 'filesystem-fallback', 'response']);
+    });
+  });
+
   test('general repo tools fail closed when the repo root disappears or is replaced during runtime', async () => {
     await withReaderRepo(async (repoRoot, ctx) => {
       const repoId = (await jsonTool(ctx, 'list_allowed_roots')).roots[0].repo_id;

--- a/tests/cli/mcp-setup.test.ts
+++ b/tests/cli/mcp-setup.test.ts
@@ -63,6 +63,8 @@ describe('mcp setup', () => {
       expect(ignore).toContain('.repo-harness/mcp.oauth-tokens.json');
       expect(ignore).toContain('.ai/harness/mcp/audit.log');
       expect(ignore).toContain('.ai/harness/mcp/index-events.jsonl');
+      expect(ignore).toContain('.ai/harness/mcp/metrics.jsonl');
+      expect(ignore).toContain('.ai/harness/mcp/trace.jsonl');
 
       const doctor = JSON.parse(runMcpDoctor({ repo: repoRoot, json: true }).lines[0]);
       expect(doctor.mcp.packageVersion).toBe(repoHarnessPackageVersion());

--- a/tests/mcp-observability-report.test.ts
+++ b/tests/mcp-observability-report.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { dirname, join } from "path";
+import { buildMcpObservabilityReport, type McpObservabilityReport } from "../scripts/mcp-observability-report";
+
+const ROOT = join(import.meta.dir, "..");
+const SCRIPT = join(ROOT, "scripts/mcp-observability-report.ts");
+
+function writeJsonl(path: string, entries: Record<string, unknown>[]): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`, "utf-8");
+}
+
+describe("MCP observability report", () => {
+  test("aggregates metrics into dashboard rows and actionable alerts", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "mcp-observability-report-"));
+    try {
+      const metricsPath = join(cwd, ".ai/harness/mcp/metrics.jsonl");
+      const tracePath = join(cwd, ".ai/harness/mcp/trace.jsonl");
+      writeJsonl(metricsPath, [
+        {
+          event_type: "mcp_tool_metric",
+          correlation_id: "corr_1",
+          repo_id: "repo_a",
+          tool: "read_file",
+          status: "ok",
+          duration_ms: 12,
+          codegraph_revision: "index_a",
+          bytes_returned: 20,
+          fallback_used: true,
+        },
+        {
+          event_type: "mcp_tool_metric",
+          correlation_id: "corr_2",
+          repo_id: "repo_a",
+          tool: "repo_manifest",
+          status: "ok",
+          duration_ms: 30,
+          codegraph_revision: "index_a",
+          partial: true,
+          manifest_parity_failure_count: 2,
+          manifest_incomplete: true,
+          index_lagging: true,
+          index_lag_ms: 7000,
+          lagging_path_count: 1,
+        },
+        {
+          event_type: "mcp_tool_metric",
+          correlation_id: "corr_3",
+          repo_id: "repo_a",
+          tool: "read_file",
+          status: "blocked",
+          error_code: "INVALID_RELATIVE_PATH",
+          duration_ms: 5,
+          codegraph_revision: "index_a",
+          path_escape_attempt: true,
+        },
+        {
+          event_type: "mcp_tool_metric",
+          correlation_id: "corr_4",
+          repo_id: "repo_a",
+          tool: "refresh_repo_index",
+          status: "failed",
+          error_code: "INDEX_UNAVAILABLE",
+          duration_ms: 8,
+          codegraph_revision: "index_a",
+          reindex_failure: true,
+        },
+      ]);
+      writeJsonl(tracePath, [
+        { event_type: "mcp_tool_trace", correlation_id: "corr_1", route: ["mcp_tool_gateway", "response"] },
+        { event_type: "mcp_tool_trace", correlation_id: "corr_2", route: ["mcp_tool_gateway", "response"] },
+        { event_type: "mcp_tool_trace", correlation_id: "corr_3", route: ["mcp_tool_gateway", "response"] },
+      ]);
+
+      const report = buildMcpObservabilityReport({
+        repo: cwd,
+        now: new Date("2026-06-23T00:00:00Z"),
+        pathEscapeThreshold: 1,
+        indexLagThresholdMs: 5000,
+      });
+
+      expect(report.protocol).toBe("repo-harness-mcp-observability-report/v1");
+      expect(report.dashboard.totals).toMatchObject({
+        calls: 4,
+        errors: 1,
+        blocked: 1,
+        fallback_count: 1,
+        manifest_parity_failures: 2,
+        manifest_incomplete_count: 1,
+        index_lag_max_ms: 7000,
+        reindex_failures: 1,
+        path_escape_attempts: 1,
+      });
+      expect(report.dashboard.by_repo_tool_codegraph.find((row) => row.tool === "read_file")).toMatchObject({
+        repo_id: "repo_a",
+        codegraph_revision: "index_a",
+        calls: 2,
+        errors: 0,
+        blocked: 1,
+        bytes_returned: 20,
+        fallback_rate: 0.5,
+      });
+      expect(report.alerts.map((alert) => alert.id).sort()).toEqual([
+        "index_lag_threshold",
+        "manifest_incomplete",
+        "path_escape_spike",
+        "reindex_dead_letter",
+      ]);
+      expect(report.tracing).toMatchObject({
+        correlated_metric_events: 3,
+        missing_trace_events: 1,
+      });
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test("handles long metric logs without argument-spread failures", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "mcp-observability-large-"));
+    try {
+      const metricsPath = join(cwd, ".ai/harness/mcp/metrics.jsonl");
+      const tracePath = join(cwd, ".ai/harness/mcp/trace.jsonl");
+      const metrics = Array.from({ length: 100_005 }, (_entry, index) => ({
+        event_type: "mcp_tool_metric",
+        correlation_id: `corr_${index}`,
+        repo_id: "repo_a",
+        tool: "read_file",
+        status: "ok",
+        duration_ms: index,
+        codegraph_revision: "index_a",
+      }));
+      writeJsonl(metricsPath, metrics);
+      writeJsonl(tracePath, []);
+
+      const report = buildMcpObservabilityReport({ repo: cwd });
+
+      expect(report.source.metric_events).toBe(100_000);
+      expect(report.dashboard.totals.calls).toBe(100_000);
+      expect(report.dashboard.totals.latency_max_ms).toBe(100_004);
+      expect(report.tracing.missing_trace_events).toBe(100_000);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test("CLI writes a report and exits cleanly when no alerts fire", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "mcp-observability-cli-"));
+    try {
+      const metricsPath = join(cwd, ".ai/harness/mcp/metrics.jsonl");
+      const tracePath = join(cwd, ".ai/harness/mcp/trace.jsonl");
+      const out = join(cwd, "report.json");
+      writeJsonl(metricsPath, [{
+        event_type: "mcp_tool_metric",
+        correlation_id: "corr_ok",
+        repo_id: "repo_a",
+        tool: "stat_file",
+        status: "ok",
+        duration_ms: 3,
+        codegraph_revision: "index_a",
+      }]);
+      writeJsonl(tracePath, [{ event_type: "mcp_tool_trace", correlation_id: "corr_ok" }]);
+
+      const run = spawnSync(process.execPath, [
+        SCRIPT,
+        "--repo",
+        cwd,
+        "--out",
+        out,
+        "--json",
+      ], { encoding: "utf-8" });
+      const report = JSON.parse(run.stdout) as McpObservabilityReport;
+
+      expect(run.status).toBe(0);
+      expect(existsSync(out)).toBe(true);
+      expect(JSON.parse(readFileSync(out, "utf-8")).source.metric_events).toBe(1);
+      expect(report.alerts).toEqual([]);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Complete Sprint 4 observability checklist S4-OBS-001 through S4-OBS-006.
- Emit per-call general repo MCP metrics and traces with response/audit correlation ids.
- Add a local observability report script that aggregates dashboard rows by repo, tool, and CodeGraph revision and emits release/canary alerts.
- Keep observability runtime files ignored and excluded from snapshot revision churn.

## P1 Map
- Runtime boundary: `src/cli/mcp/general-repo-access.ts` owns general repo MCP tool dispatch, common response fields, audit, index events, metrics, and trace JSONL emission.
- Setup boundary: `src/cli/mcp/setup.ts` and `.gitignore` own ignored MCP runtime files.
- Operations boundary: `scripts/mcp-observability-report.ts` owns dashboard/alert aggregation from local JSONL, without a hosted telemetry dependency.
- Verification boundary: `tests/cli/mcp-reader-tools.test.ts`, `tests/mcp-observability-report.test.ts`, and `tests/cli/mcp-setup.test.ts` cover runtime emission, privacy, report aggregation, large-log behavior, and setup ignore entries.
- Out of scope: Sprint 4 migration, user docs/runbooks, canary execution, and release signoff remain unchecked.

## P2 Trace
- `callGeneralRepoTool()` now assigns a `correlation_id`, executes the existing tool path, adds the id to structured MCP responses, records it in audit, then appends content-free metric and trace rows.
- Metric rows capture status, duration, CodeGraph revision/latency, bytes, partial/fallback flags, manifest-scoped parity failures, stale snapshots, index lag, write conflicts, atomic failures, reindex failures, and path escape attempts.
- Trace rows record the route from MCP gateway through policy, path/ignore guard, observed CodeGraph/FS backend, and response. Metrics/traces use path count and path digest, not raw path labels or file content.
- `scripts/mcp-observability-report.ts` reads the latest 100k metric/trace events, aggregates dashboard rows, separates failed-call error rate from blocked policy rejections, and emits alerts for path escape spikes, high index lag, incomplete manifests, and reindex dead-letter failures.

## P3 Decision
- The smallest coherent implementation is local JSONL plus a report script. It reuses the existing `.ai/harness/mcp` runtime surface and avoids adding Prometheus/OpenTelemetry or changing MCP tool schemas beyond a top-level `correlation_id`.
- `.ai/harness/mcp/` is treated as internal revision state for snapshot digests so observability writes do not stale an otherwise valid `snapshot_id`.
- New files are justified by boundary: the report script is operations aggregation, and its test is the executable contract. No new dependency was added.

## Cross Review
- Claude no-tools diff review reported no P1 findings.
- P2 findings were fixed before this PR: large-log max latency no longer uses argument spread, reports cap to the latest 100k events, blocked policy rejections are separated from failed-call error rate, manifest parity failures are manifest-scoped, and tests cover snapshot stability plus escape-input redaction.

## Verification
- `bun test tests/cli/mcp-reader-tools.test.ts tests/mcp-observability-report.test.ts tests/cli/mcp-setup.test.ts`
- `bun run check:type`
- `git diff --check`
- `bun test` (976 pass, 1 skip, 0 fail)
- `bash scripts/check-deploy-sql-order.sh`
- `bash scripts/check-architecture-sync.sh` (advisory, blocking=0)
- `bash scripts/check-task-sync.sh`
- `bun scripts/inspect-project-state.ts --repo . --format text`
- `bash scripts/migrate-project-template.sh --repo . --dry-run`
- `bash scripts/ensure-codegraph.sh --sync`
- `bash scripts/prepare-codex-handoff.sh --reason codegraph-s4-observability-final && bash scripts/check-task-workflow.sh --strict`
- `repo-harness setup check --target codex --check-updates --json` returned attention only for optional `runtime.skills_cli` timeout; fail=0.