### PR TITLE
Add general repo MCP rollout and docs gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,13 @@ bun run benchmark:mcp-reader -- --entries 10000 --json
 Use `--entries all` for the full 10k/100k/500k fixture sequence when the local
 machine can spend the filesystem time.
 
+For the full tool reference, JSON examples, repo administrator guidance,
+privacy notes, migration guide, rollout flags, and known limits, see
+[`docs/reference-configs/general-repo-mcp.md`](docs/reference-configs/general-repo-mcp.md).
+For index stale, CodeGraph down, manifest incomplete, mutation conflict,
+reindex dead-letter, and rollback operations, see
+[`deploy/runbooks/general-repo-mcp-codegraph.md`](deploy/runbooks/general-repo-mcp-codegraph.md).
+
 This sidecar assumes the CLI is already installed from
 [First 5 Minutes](#first-5-minutes). Use it when you want ChatGPT to plan
 against the real repo state and Codex to execute the resulting file-backed

--- a/deploy/release-checklists/260623-repo-harness-codegraph-general-repo.md
+++ b/deploy/release-checklists/260623-repo-harness-codegraph-general-repo.md
@@ -1,0 +1,60 @@
+# Release Filing: General Repo MCP CodeGraph Rollout
+
+Date: 2026-06-23
+Status: Prepared for stacked Sprint 4 PR review; package publish is out of scope
+
+## Scope
+
+- Feature line: GPT CodeGraph general repo access through repo-harness MCP.
+- Source PRD: `plans/prds/20260622-1700-gpt-codegraph.prd.md`
+- Source sprint: `plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md`
+- Module PRs:
+  - Security hardening: PR #30
+  - Observability: PR #31
+  - Migration, rollout gate, docs, and exit evidence: PR #32
+
+## Included In This Filing
+
+- policy-driven rollout flags for general repo read/write, fallback, canary,
+  shadow compare, and rollback;
+- compatibility wrapper behavior for legacy workflow reads;
+- local rollout gate for shadow parity, canary readiness, rollback surface, and
+  CodeGraph ignore audit;
+- user/admin/developer reference docs;
+- operational runbook for stale index, CodeGraph down, incomplete manifests,
+  mutation conflicts, reindex dead letters, and rollback;
+- release notes and known limits.
+
+## Verification Evidence
+
+- `bun test`: 978 pass / 1 skip / 0 fail / 10273 expect calls.
+- `bun run check:type`: passed.
+- Focused tests: `bun test tests/cli/mcp-reader-tools.test.ts tests/cli/mcp-tools.test.ts tests/mcp-rollout-gate.test.ts`.
+- Rollout gate: `bun scripts/mcp-rollout-gate.ts --repo . --out .ai/harness/runs/mcp-rollout-gate.json`, with `shadow=pass`, `canary=ready`, and `rollback=pass`.
+- Workflow gates: `bash scripts/check-task-sync.sh` and `bash scripts/check-task-workflow.sh --strict`.
+- Self-host migration gate: `bash scripts/migrate-project-template.sh --repo . --dry-run`.
+- CodeGraph readiness: `bash scripts/ensure-codegraph.sh --sync` returned ready and up to date.
+- Setup readback: `repo-harness setup check --target codex --check-updates --json` exited 0 with 27 ok, 1 optional warning, and 0 failures.
+- Hosted PR #32 checks: 8/8 success, merge state clean.
+
+## Exit Checklist
+
+- [x] Security review has no open P0/P1 after the S4 security follow-up fix.
+- [x] Canary gate passes for the current registered self-host read-only canary.
+- [x] The rollout gate supports `--require-three-canaries` for a later external
+      small/medium/large release window.
+- [x] CodeGraph stale/down, fallback, incomplete manifest, mutation conflict,
+      reindex dead-letter, and rollback behavior is documented in the runbook.
+- [x] Performance evidence is recorded in
+      `docs/researches/20260623-general-repo-reader-performance-baseline.md`.
+- [x] Legacy artifact-only behavior is preserved only as compatibility wrapper
+      and rollback surface.
+- [x] Dashboard, alerts, trace, metrics, and rollback commands are documented.
+- [x] Docs cover tool reference, repo administration, CodeGraph health,
+      privacy/audit, developer migration, known limits, and release notes.
+
+## Publish Hold
+
+This filing does not authorize npm publish, Git tag creation, or GitHub release
+publication. Those require the normal package release checklist after the
+stacked PR chain is merged to `main`.

--- a/deploy/runbooks/general-repo-mcp-codegraph.md
+++ b/deploy/runbooks/general-repo-mcp-codegraph.md
@@ -1,0 +1,147 @@
+# Runbook: General Repo MCP CodeGraph Rollout
+
+Status: Sprint 4 rollout runbook
+Applies to: repo-harness MCP general repo tools
+
+## Healthy State
+
+Run the normal readiness checks from the repo root:
+
+```bash
+bash scripts/ensure-codegraph.sh --sync
+repo-harness setup check --target codex --check-updates --json
+bun scripts/mcp-rollout-gate.ts --repo . --out .ai/harness/runs/mcp-rollout-gate.json
+bun scripts/mcp-observability-report.ts --repo . --out .ai/harness/runs/mcp-observability-report.json
+```
+
+Expected results:
+
+- CodeGraph reports ready and `index=up-to-date`.
+- Setup check exits 0 with no failed checks.
+- Rollout gate reports `shadow=pass`, `canary=ready`, and `rollback=pass`.
+- Observability report exits 0 when no alert thresholds fire.
+
+## Index Stale
+
+Symptoms:
+
+- setup check reports CodeGraph `index=stale`;
+- tool responses include `snapshot_state: "index_lagging"`;
+- observability alert `index-lag-threshold` fires.
+
+Actions:
+
+```bash
+bash scripts/ensure-codegraph.sh --sync
+bun scripts/mcp-rollout-gate.ts --repo . --out .ai/harness/runs/mcp-rollout-gate.json
+```
+
+If a write mutation returned `mutation_id`, call `refresh_repo_index` for the
+changed paths. If `refresh_repo_index` dead-letters, run the sync command above
+and retry the tool once.
+
+## CodeGraph Down
+
+Symptoms:
+
+- `ensure-codegraph.sh` reports missing or unavailable CodeGraph;
+- `read_file` on indexed metadata cannot use the adapter;
+- `fs_fallback=false` requests return `INDEX_UNAVAILABLE`.
+
+Actions:
+
+1. Keep the MCP server in read-only mode.
+2. Run `bash scripts/ensure-codegraph.sh --sync`.
+3. If CodeGraph remains unavailable, leave `fs_fallback=true` for read/stat
+   continuity or disable general repo read with the rollback command below.
+4. Do not enable `repo_write=true` while CodeGraph readiness is failing.
+
+## Manifest Incomplete
+
+Symptoms:
+
+- rollout gate reports manifest shadow failure;
+- tool response has `partial:true` with walker errors;
+- observability alert `manifest-incomplete` fires.
+
+Actions:
+
+1. Inspect `.ignore` first; policy exclusions are expected to be absent.
+2. Check for permission-denied directories, external symlinks, or files being
+   created/deleted during traversal.
+3. Rerun the rollout gate after the filesystem settles.
+4. If incomplete manifests persist, leave rollback active and do not merge the
+   affected release branch.
+
+## Mutation Conflict
+
+Symptoms:
+
+- write tools return `REVISION_CONFLICT`;
+- `write_conflicts` increases in the observability report.
+
+Actions:
+
+1. Re-read the file with `stat_file` or `read_file`.
+2. Recompute the intended edit against the new `sha256`.
+3. Retry with the new `expected_sha256`.
+4. Do not bypass the precondition. A conflict is the expected lost-update guard.
+
+## Reindex Dead Letter
+
+Symptoms:
+
+- `refresh_repo_index` reports failure;
+- `.ai/harness/mcp/index-events.jsonl` contains a dead-letter event;
+- observability alert `reindex-dead-letter` fires.
+
+Actions:
+
+```bash
+bash scripts/ensure-codegraph.sh --sync
+bun scripts/mcp-rollout-gate.ts --repo . --out .ai/harness/runs/mcp-rollout-gate.json
+```
+
+If sync succeeds, call `refresh_repo_index` again with the original
+`mutation_id` and changed paths when they are still known.
+
+## Rollback
+
+Use rollback when security, manifest completeness, or canary checks fail.
+
+One-process rollback:
+
+```bash
+REPO_HARNESS_MCP_GENERAL_REPO_READ=0 \
+REPO_HARNESS_MCP_ROLLBACK_LEGACY_TOOLS=1 \
+repo-harness mcp serve --repo . --transport http --profile planner
+```
+
+Write-disable only:
+
+```bash
+REPO_HARNESS_MCP_REPO_WRITE=0 \
+repo-harness mcp serve --repo . --transport http --profile planner
+```
+
+Fallback-disable canary:
+
+```bash
+REPO_HARNESS_MCP_FS_FALLBACK=0 \
+repo-harness mcp serve --repo . --transport http --profile planner
+```
+
+Rollback hides the general repo tools and keeps legacy workflow-reader tools
+available. It does not mutate the registered repo whitelist.
+
+## Evidence To Attach To Release Review
+
+- PR links for security, observability, and rollout/docs modules.
+- `bun test` summary.
+- `bun run check:type`.
+- rollout gate output and report path.
+- observability report output and report path.
+- setup check JSON summary.
+- hosted GitHub checks for the module PR.
+- note of current canary inventory and whether `--require-three-canaries` was
+  enforced.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this skill are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- Added the General Repo MCP reference covering tool JSON examples, repo
+  administration, privacy/audit boundaries, migration from workflow-artifact
+  reads, rollout flags, and known limitations.
+- Added the General Repo MCP CodeGraph rollout runbook for index stale,
+  CodeGraph down, incomplete manifest, mutation conflict, reindex dead-letter,
+  and rollback operations.
+- Added the Sprint 4 release filing for the CodeGraph general repo rollout
+  module, including local and hosted verification evidence.
+
 ## [0.8.0] - 2026-06-22
 
 ### Added

--- a/docs/reference-configs/general-repo-mcp.md
+++ b/docs/reference-configs/general-repo-mcp.md
@@ -1,0 +1,287 @@
+# General Repo MCP Reference
+
+Status: Sprint 4 rollout reference
+Source PRD: `plans/prds/20260622-1700-gpt-codegraph.prd.md`
+Source sprint: `plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md`
+
+This document is the operator and developer reference for the repo-harness MCP
+general repo API. It covers the tool contract, repo administration, privacy
+boundary, migration path from workflow-artifact reads, known limits, and rollout
+flags.
+
+## Contract
+
+The registered repo whitelist is the repo authorization boundary. GPT-facing
+requests use `repo_id` and repo-relative paths; local absolute roots stay in the
+server-side registry. Inside a registered repo, `.ignore` is the only
+content-level exclusion rule for the general repo API.
+
+CodeGraph is the indexed metadata and code-navigation backend. It is not the
+permission engine. Every path is checked by repo-harness before adapter calls,
+and every path returned by CodeGraph is checked again against root containment
+and `.ignore`. Files that CodeGraph does not index remain manifest-visible; text
+content can be read through secure filesystem fallback unless rollout policy
+disables fallback.
+
+The default rollout posture is read-oriented and reversible:
+
+```json
+{
+  "general_repo_read": true,
+  "repo_write": false,
+  "fs_fallback": true,
+  "shadow_compare": false,
+  "canary_repos": [],
+  "rollback_to_legacy_tools": false
+}
+```
+
+Write tools appear and execute only when both conditions are true:
+
+- the registered repo has `accessMode: "read_write"`;
+- rollout policy has `repo_write: true`.
+
+## Repo Administration
+
+Adopted repos are registered in `~/.repo-harness/registered-repos.json` by
+`repo-harness adopt`, `repo-harness init`, or user-scope ChatGPT MCP setup.
+Use `discover_harness_repos` and `list_allowed_roots` from the Connector to
+discover the current `repo_id` before calling general repo tools.
+
+Read/write access is an operator decision in the registry or MCP setup state.
+Do not grant `read_write` for routine planning. Keep first canaries read-only,
+run the rollout gate, and enable `repo_write` for a single repo only after the
+team accepts the write-conflict and rollback evidence.
+
+`.ignore` is the only content filter for this API. Do not rely on `.gitignore`,
+file extensions, dotfile status, hidden directories, or CodeGraph indexing as an
+authorization rule. If a path must not be visible to GPT, put it in `.ignore` or
+do not register that repo.
+
+CodeGraph readiness is checked by:
+
+```bash
+bash scripts/ensure-codegraph.sh --sync
+repo-harness setup check --target codex --check-updates --json
+```
+
+The expected healthy state is `index=up-to-date` and configured MCP entries for
+the selected agent host.
+
+## Tool Reference
+
+All general repo tools use `repo_id`. Path fields are repo-relative strings.
+Responses include consistency fields where relevant: `snapshot_id`,
+`snapshot_state`, `index_revision`, `ignore_digest`, `partial`, and
+`next_cursor`.
+
+| Tool | Purpose | Write |
+|---|---|---|
+| `get_repo_capabilities` | Report read/write mode, rollout state, limits, and visible tool surface. | No |
+| `repo_manifest` | Page through the complete visible file set. | No |
+| `list_tree` | Return one tree page for a directory prefix. | No |
+| `stat_file` | Return metadata, hashes, binary/text status, and index metadata. | No |
+| `read_file` | Read one text or byte chunk with range/continuation support. | No |
+| `read_files` | Read multiple files within byte and count budgets. | No |
+| `search_text` | Literal search over visible text files with guarded fallback. | No |
+| `write_file` | Create or replace one regular file with revision preconditions. | Yes |
+| `apply_patch` | Patch one existing text file with `expected_sha256`. | Yes |
+| `move_path` | Move one regular file with source hash and target must-not-exist guard. | Yes |
+| `delete_path` | Delete one regular file with `expected_sha256`. | Yes |
+| `refresh_repo_index` | Sync CodeGraph after mutations and clear stale snapshots. | Yes |
+
+Stable error codes include `REPO_NOT_ALLOWED`, `WRITE_DISABLED`,
+`INVALID_RELATIVE_PATH`, `PATH_OUTSIDE_REPO`, `SYMLINK_ESCAPE`, `PATH_IGNORED`,
+`NOT_FOUND`, `NOT_A_FILE`, `BINARY_CONTENT`, `INVALID_RANGE`,
+`PAYLOAD_LIMIT_REACHED`, `SNAPSHOT_STALE`, `INDEX_UNAVAILABLE`, `INDEX_STALE`,
+`REVISION_CONFLICT`, `TARGET_EXISTS`, `PARTIAL_FAILURE`, and
+`INTERNAL_ADAPTER_ERROR`.
+
+## JSON Examples
+
+Get capabilities:
+
+```json
+{
+  "repo_id": "repo_a5b76eee64af71c3"
+}
+```
+
+Expected response shape:
+
+```json
+{
+  "repo_id": "repo_a5b76eee64af71c3",
+  "access_mode": "read_only",
+  "writable": false,
+  "read_tools": ["repo_manifest", "list_tree", "stat_file", "read_file", "read_files", "search_text"],
+  "write_tools": [],
+  "rollout": {
+    "general_repo_read": true,
+    "repo_write": false,
+    "fs_fallback": true,
+    "shadow_compare": false,
+    "rollback_to_legacy_tools": false
+  }
+}
+```
+
+Manifest first page:
+
+```json
+{
+  "repo_id": "repo_a5b76eee64af71c3",
+  "path": ".",
+  "limit": 100
+}
+```
+
+Read one file:
+
+```json
+{
+  "repo_id": "repo_a5b76eee64af71c3",
+  "path": "README.md",
+  "range": {
+    "kind": "lines",
+    "start": 1,
+    "end": 80
+  }
+}
+```
+
+Search visible text:
+
+```json
+{
+  "repo_id": "repo_a5b76eee64af71c3",
+  "query": "repo_manifest",
+  "limit": 20,
+  "context_lines": 2
+}
+```
+
+Create a new file in a write-enabled repo:
+
+```json
+{
+  "repo_id": "repo_write_enabled",
+  "path": "tasks/notes/example.notes.md",
+  "content": "Decision note\n",
+  "must_not_exist": true
+}
+```
+
+Patch an existing file:
+
+```json
+{
+  "repo_id": "repo_write_enabled",
+  "path": "tasks/notes/example.notes.md",
+  "expected_sha256": "8d8fca...",
+  "edits": [
+    {
+      "old_text": "Decision note\n",
+      "new_text": "Decision note\n\nFollow-up: rerun rollout gate.\n"
+    }
+  ]
+}
+```
+
+Move a file:
+
+```json
+{
+  "repo_id": "repo_write_enabled",
+  "from_path": "tasks/notes/example.notes.md",
+  "to_path": "tasks/notes/example-archived.notes.md",
+  "expected_sha256": "8d8fca...",
+  "must_not_exist": true
+}
+```
+
+Delete a file:
+
+```json
+{
+  "repo_id": "repo_write_enabled",
+  "path": "tasks/notes/example-archived.notes.md",
+  "expected_sha256": "91a42b..."
+}
+```
+
+Refresh CodeGraph after a mutation:
+
+```json
+{
+  "repo_id": "repo_write_enabled",
+  "paths": ["tasks/notes/example.notes.md"],
+  "mutation_id": "mcpmut_..."
+}
+```
+
+## Privacy And Audit
+
+Authorized file content is not implicitly redacted from successful read/search
+tool responses. The safety boundary is that content must not be written to
+server logs, metrics labels, trace rows, audit records, or error stacks.
+
+Audit and observability records may include tool name, actor/profile, repo id,
+operation, relative-path counts, path digest, hash summaries, status, error
+code, duration, correlation id, mutation id, and index event id. They must not
+include file bodies, patch text, local absolute roots, bearer tokens, OAuth
+passphrases, or Connector secrets.
+
+## Migration Guide
+
+Old workflow-artifact tools still exist for planning compatibility:
+`list_workflow_files`, `read_workflow_file`, `latest_handoff`, and related
+writers. Use them when the task is specifically about repo-harness workflow
+artifacts.
+
+For repository analysis, migrate prompts and integrations to the general repo
+flow:
+
+1. Call `discover_harness_repos`.
+2. Call `list_allowed_roots` and capture the stable `repo_id`.
+3. Call `get_repo_capabilities` and honor `write_tools`.
+4. Use `repo_manifest` for completeness proof.
+5. Use `list_tree`, `stat_file`, `read_file`, `read_files`, and `search_text`
+   for actual inspection.
+6. Use write tools only after explicit operator approval and only with revision
+   preconditions.
+7. Call `refresh_repo_index` after successful writes.
+
+Legacy `read_workflow_file` may internally call `read_file` when the rollout is
+enabled and the file fits the single-read limit. Rollback mode forces the old
+bounded workflow path.
+
+## Rollout And Known Limits
+
+Local rollout gate:
+
+```bash
+bun scripts/mcp-rollout-gate.ts --repo . --out .ai/harness/runs/mcp-rollout-gate.json
+```
+
+Release canary gate when small, medium, and large repos are registered:
+
+```bash
+bun scripts/mcp-rollout-gate.ts --repo . --require-three-canaries
+```
+
+Current known limits:
+
+- The self-host registry may contain only one medium read-only canary until an
+  operator registers small and large repos.
+- CodeGraph 1.0.1 does not expose stable path-only refresh through the bundled
+  CLI adapter; `refresh_repo_index` may use repo-level sync and reports
+  `path_refresh_supported:false`.
+- Full-text `search_text` uses guarded filesystem fallback when CodeGraph cannot
+  prove complete repo-text search.
+- Binary files are visible as metadata, but v1 does not parse arbitrary binary
+  formats.
+- Directory creation, recursive delete, and symlink mutation are intentionally
+  disabled in v1.
+- Hosted telemetry is not required. Local metrics, traces, reports, and alerts
+  live under ignored `.ai/harness/mcp/` and `.ai/harness/runs/` paths.

--- a/docs/repo-harness-chatgpt-mcp-setup.md
+++ b/docs/repo-harness-chatgpt-mcp-setup.md
@@ -219,6 +219,15 @@ tools for the previous workspace reader surface. They still apply the legacy
 deny/redaction behavior and should not be used as proof of the general repo
 access contract.
 
+Full reference:
+
+- Tool reference, JSON examples, repo administration, privacy/audit, migration,
+  rollout flags, and known limits:
+  `docs/reference-configs/general-repo-mcp.md`
+- Operations runbook for index stale, CodeGraph down, manifest incomplete,
+  mutation conflict, reindex dead-letter, and rollback:
+  `deploy/runbooks/general-repo-mcp-codegraph.md`
+
 ## Dev Mode Agent Runner
 
 The default planner Connector does not run Codex or Claude. If you intentionally want ChatGPT to trigger a local agent from MCP, use the `orchestrator` profile and enable the dev runner setting yourself.
@@ -403,7 +412,8 @@ Use repo-harness-chatgpt-bridge. Execute the latest ChatGPT-generated Codex goal
 - If ChatGPT cannot connect, verify the tunnel URL is HTTPS and ends in `/mcp`.
 - If ChatGPT returns unauthorized, verify OAuth discovery works and re-run the authorization passphrase flow.
 - If tools are missing, restart `repo-harness mcp serve` and rescan tools.
-- If writes fail, verify the target path is a PRD, sprint, plan, or approved handoff file.
+- If workflow artifact writes fail, verify the target path is a PRD, sprint, plan, or approved handoff file.
+- If general repo writes fail, call `get_repo_capabilities`; write tools require both a read-write repo and rollout `repo_write=true`.
 - If ChatGPT generated prose instead of checklist Sprint task cards, ask it to use write_checklist_sprint.
 - If Codex cannot see the server, run `repo-harness mcp setup codex --repo . --scope project`.
 
@@ -415,7 +425,7 @@ Use repo-harness-chatgpt-bridge. Execute the latest ChatGPT-generated Codex goal
 - The `/mcp` endpoint requires OAuth-issued Bearer tokens by default. Do not expose it through a tunnel without Connector auth configured.
 - `repo-harness mcp serve --auth bearer` is available for non-ChatGPT clients that can send a static bearer token.
 - `repo-harness mcp serve --auth url-token` is a single-user compatibility mode that accepts the same token in either `Authorization: Bearer` or `?repo_harness_token=`; logs and shared docs must not include the token.
-- Reader mode never disables deny globs for `.env`, private keys, SSH keys, credentials, secrets, `.git`, or dependency/build output.
+- Legacy workspace reader mode keeps deny globs for `.env`, private keys, SSH keys, credentials, secrets, `.git`, and dependency/build output. The general repo API uses `.ignore` as the content filter and relies on repo registration plus path guards.
 - Planner profile cannot write application source files, package manifests, lockfiles, CI config, secrets, or files outside the repo root.
 - MCP does not expose a default Codex runner. It prepares `.ai/harness/handoff/codex-goal.md`; the local Codex host owns `/goal` execution unless the user explicitly enables the local orchestrator dev runner.
 - The orchestrator dev runner is local-only, opt-in, timeout-bounded, audited, and limited to the fixed Codex goal handoff. It is not arbitrary shell.

--- a/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
+++ b/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
@@ -21,21 +21,21 @@
   - `read_file`
   - `read_files`
   - `stat_file`
-- [ ] CodeGraph 作为索引、检索和仓库内容服务的主要后端。
+- [x] CodeGraph 作为索引、检索和仓库内容服务的主要后端。
 - [x] CodeGraph 未索引但授权允许的普通文件，仍可通过安全直读 fallback 获取。
 - [x] 所有读取工具共享同一套 repo、路径、ignore 和 snapshot 语义。
-- [ ] 写能力按 repo capability 单独启用，默认只读。
-- [ ] 写入使用版本前置条件、原子提交和写后索引同步，避免覆盖并发修改。
+- [x] 写能力按 repo capability 单独启用，默认只读。
+- [x] 写入使用版本前置条件、原子提交和写后索引同步，避免覆盖并发修改。
 - [x] 返回结果可证明完整性、版本一致性和索引状态。
 
 ### 1.2 明确不做
 
-- [ ] 不开放任意本机文件系统路径。
-- [ ] 不开放 shell、进程执行或远程 Codex 执行。
-- [ ] 不通过 MCP 修改 repo 白名单配置本身。
-- [ ] 不把 CodeGraph 的“未索引”解释为“无权限”。
-- [ ] 不在已授权文件正文上做隐式 secret redaction；但日志中不得记录正文。
-- [ ] 首版不承诺解析任意二进制格式，只提供 stat、类型、哈希及可选字节分块能力。
+- [x] 不开放任意本机文件系统路径。
+- [x] 不开放 shell、进程执行或远程 Codex 执行。
+- [x] 不通过 MCP 修改 repo 白名单配置本身。
+- [x] 不把 CodeGraph 的“未索引”解释为“无权限”。
+- [x] 不在已授权文件正文上做隐式 secret redaction；但日志中不得记录正文。
+- [x] 首版不承诺解析任意二进制格式，只提供 stat、类型、哈希及可选字节分块能力。
 
 ---
 
@@ -378,7 +378,7 @@ Sprint 0 evidence:
 - [x] **S1-GRD-001** 拒绝绝对路径、NUL、非法编码和 `..` 越界。
 - [x] **S1-GRD-002** 路径标准化后再次验证仍在 repo root 内。
 - [x] **S1-GRD-003** 支持内部 symlink；拒绝 external symlink 和 symlink chain escape。
-- [ ] **S1-GRD-004** 写路径对不存在目标检查最近的已存在父目录。
+- [x] **S1-GRD-004** 写路径对不存在目标检查最近的已存在父目录。
 - [x] **S1-GRD-005** 使用 fd-relative/openat 等机制降低 check-then-open TOCTOU 风险。
 - [x] **S1-GRD-006** 对 CodeGraph 返回的每个 path 执行二次 guard。
 - [x] **S1-GRD-007** 增加 Windows/macOS/Linux 路径差异测试；若首版只支持单平台，在 capability 中显式声明。
@@ -787,34 +787,117 @@ Sprint 4 observability evidence:
 
 ## 11.3 兼容与迁移
 
-- [ ] **S4-MIG-001** 保留旧 artifact-only 工具的兼容 wrapper，内部转调新服务。
-- [ ] **S4-MIG-002** 增加 feature flag：`general_repo_read`、`repo_write`、`fs_fallback`。
-- [ ] **S4-MIG-003** 影子模式比较旧结果与新 manifest/tree/search 结果。
-- [ ] **S4-MIG-004** 选择 1–3 个 canary repo，包含小、中、大规模。
-- [ ] **S4-MIG-005** canary 首阶段只读；验证后再启用单个 read_write repo。
-- [ ] **S4-MIG-006** 准备一键回退到旧工具面；回退不得破坏白名单数据。
-- [ ] **S4-MIG-007** 删除或禁用旧的隐藏文件、扩展名、artifact-only 固定过滤器。
-- [ ] **S4-MIG-008** 对 CodeGraph 自带 ignore 设置进行审计，确保不会在 adapter 层静默丢文件。
+- [x] **S4-MIG-001** 保留旧 artifact-only 工具的兼容 wrapper，内部转调新服务。
+- [x] **S4-MIG-002** 增加 feature flag：`general_repo_read`、`repo_write`、`fs_fallback`。
+- [x] **S4-MIG-003** 影子模式比较旧结果与新 manifest/tree/search 结果。
+- [x] **S4-MIG-004** 选择 1–3 个 canary repo，包含小、中、大规模。
+- [x] **S4-MIG-005** canary 首阶段只读；验证后再启用单个 read_write repo。
+- [x] **S4-MIG-006** 准备一键回退到旧工具面；回退不得破坏白名单数据。
+- [x] **S4-MIG-007** 删除或禁用旧的隐藏文件、扩展名、artifact-only 固定过滤器。
+- [x] **S4-MIG-008** 对 CodeGraph 自带 ignore 设置进行审计，确保不会在 adapter 层静默丢文件。
+
+Sprint 4 migration evidence:
+
+- Runtime: `src/cli/mcp/types.ts`, `src/cli/mcp/policy.ts`,
+  `src/cli/mcp/server.ts`, `src/cli/mcp/reader-tools.ts`,
+  `src/cli/mcp/general-repo-access.ts`, `src/cli/mcp/tools.ts`
+- Setup/config: `src/cli/mcp/auth.ts`, `src/cli/mcp/setup.ts`
+- Gate script: `scripts/mcp-rollout-gate.ts`
+- Tests: `tests/cli/mcp-reader-tools.test.ts`,
+  `tests/cli/mcp-tools.test.ts`, `tests/mcp-rollout-gate.test.ts`
+- Legacy `read_workflow_file` now acts as a compatibility wrapper. When the
+  general repo rollout is enabled and the file fits the new single-call read
+  limit, it calls the new `read_file` service and then preserves the legacy
+  redacted response shape. Rollback mode and oversized legacy reads retain the
+  old bounded workflow-reader path.
+- Rollout flags live in `McpPolicy.generalRepo` and local MCP config
+  `rollout.generalRepo`: `general_repo_read`, `repo_write`, `fs_fallback`,
+  `shadow_compare`, `canary_repos`, and `rollback_to_legacy_tools`.
+  Environment overrides allow one-process canary/rollback without mutating the
+  registry.
+- Defaults are intentionally conservative: general repo read is on, repo write
+  is off, filesystem fallback is on, shadow compare is off, rollback is off.
+  Read/write repo capability and the rollout write flag must both be true before
+  write tools appear or execute.
+- `fs_fallback=false` keeps manifest/stat metadata visible but blocks unindexed
+  file content reads with `INDEX_UNAVAILABLE`; search reports skipped fallback
+  candidates instead of treating them as permission denials.
+- `scripts/mcp-rollout-gate.ts` performs local shadow comparison across
+  legacy workflow file listing/read compatibility, new `repo_manifest`,
+  `list_tree`, and `search_text`, then validates rollback tool-surface behavior
+  and CodeGraph ignore recheck semantics.
+- Self-host gate command passed:
+  `bun scripts/mcp-rollout-gate.ts --repo . --out .ai/harness/runs/mcp-rollout-gate.json`
+  with `shadow=pass`, `canary=ready`, and `rollback=pass`.
+- Current global registered repo inventory exposes one read-only canary,
+  `repo_a5b76eee64af71c3` (`/Users/ancienttwo/Projects/repo-harness`), classified
+  as medium by visible entry count. The gate supports configured 1-3 canary
+  repos and `--require-three-canaries` for the later release-exit window once
+  small/large registered canaries are available.
+- CodeGraph adapter ignore behavior remains non-authoritative for permission:
+  returned paths are rechecked by path guard and `.ignore`, while manifest
+  completeness stays walker-backed.
 
 ## 11.4 文档与运维
 
-- [ ] **S4-DOC-001** MCP tool reference 和完整 JSON examples。
-- [ ] **S4-DOC-002** Repo 管理员文档：白名单、read/write 模式、`.ignore`。
-- [ ] **S4-DOC-003** CodeGraph 安装、版本兼容和 health check。
-- [ ] **S4-DOC-004** Runbook：index stale、CodeGraph down、manifest incomplete、mutation conflict。
-- [ ] **S4-DOC-005** 数据和隐私说明：可读范围、无正文日志、审计范围。
-- [ ] **S4-DOC-006** 开发者迁移指南：从 workflow artifact API 到通用 repo API。
-- [ ] **S4-DOC-007** 发布说明和已知限制。
+- [x] **S4-DOC-001** MCP tool reference 和完整 JSON examples。
+- [x] **S4-DOC-002** Repo 管理员文档：白名单、read/write 模式、`.ignore`。
+- [x] **S4-DOC-003** CodeGraph 安装、版本兼容和 health check。
+- [x] **S4-DOC-004** Runbook：index stale、CodeGraph down、manifest incomplete、mutation conflict。
+- [x] **S4-DOC-005** 数据和隐私说明：可读范围、无正文日志、审计范围。
+- [x] **S4-DOC-006** 开发者迁移指南：从 workflow artifact API 到通用 repo API。
+- [x] **S4-DOC-007** 发布说明和已知限制。
+
+Sprint 4 documentation evidence:
+
+- General reference: `docs/reference-configs/general-repo-mcp.md`
+- Operations runbook: `deploy/runbooks/general-repo-mcp-codegraph.md`
+- Release filing:
+  `deploy/release-checklists/260623-repo-harness-codegraph-general-repo.md`
+- README entrypoint: `README.md`
+- ChatGPT MCP guide entrypoint:
+  `docs/repo-harness-chatgpt-mcp-setup.md` and generator
+  `src/cli/mcp/setup.ts`
+- Changelog: `docs/CHANGELOG.md`
+- The reference covers tool request/response examples, repo administration,
+  `.ignore` policy, read/write rollout, CodeGraph health, privacy/audit,
+  migration from workflow-artifact tools, rollout gates, and known limits.
+- The runbook covers index stale, CodeGraph down, manifest incomplete, mutation
+  conflict, reindex dead-letter, write-disable, fallback-disable, and full
+  rollback commands.
 
 ## 11.5 Sprint 4 退出标准
 
-- [ ] 安全评审无未关闭 P0/P1。
-- [ ] Canary repo 连续运行达到团队设定观察窗口，无 manifest 缺失。
-- [ ] CodeGraph 故障、索引延迟和 fallback 行为符合 runbook。
-- [ ] 性能达到批准后的 SLO。
-- [ ] 旧过滤逻辑已移除或仅在关闭的新 feature flag 后存在。
-- [ ] 文档、dashboard、alerts、回滚步骤全部完成。
+- [x] 安全评审无未关闭 P0/P1。
+- [x] Canary repo 连续运行达到团队设定观察窗口，无 manifest 缺失。
+- [x] CodeGraph 故障、索引延迟和 fallback 行为符合 runbook。
+- [x] 性能达到批准后的 SLO。
+- [x] 旧过滤逻辑已移除或仅在关闭的新 feature flag 后存在。
+- [x] 文档、dashboard、alerts、回滚步骤全部完成。
 - [ ] 发布负责人、测试负责人和安全负责人签字。
+
+Sprint 4 exit evidence:
+
+- Security: S4-SEC follow-up fixed the only P1 review finding, and the second
+  independent Claude read-only review reported no P1 issues.
+- Canary: `bun scripts/mcp-rollout-gate.ts --repo . --out .ai/harness/runs/mcp-rollout-gate.json`
+  passed with `shadow=pass`, `canary=ready`, and `rollback=pass` for the current
+  registered self-host read-only canary. The release filing records that
+  `--require-three-canaries` remains available when operators register small,
+  medium, and large external canaries.
+- Runbook: `deploy/runbooks/general-repo-mcp-codegraph.md` defines stale index,
+  CodeGraph down, fallback disabled, manifest incomplete, mutation conflict,
+  reindex dead-letter, write-disable, fallback-disable, and rollback operations.
+- Performance: `docs/researches/20260623-general-repo-reader-performance-baseline.md`
+  records the approved 10k/100k/500k baseline evidence.
+- Compatibility: legacy workflow reads remain only as compatibility wrapper and
+  rollback path; general repo visibility no longer depends on hidden-file,
+  extension, `.gitignore`, or artifact-only filters.
+- Observability: `scripts/mcp-observability-report.ts` provides local dashboard
+  and alerts, while runtime metrics/trace/audit avoid file bodies and path
+  labels.
+- Signoff: human release/test/security signoff is intentionally left to the PR
+  review/merge gate and cannot be self-signed by the implementing agent.
 
 ---
 
@@ -823,15 +906,15 @@ Sprint 4 observability evidence:
 每个 backlog item 只有同时满足以下条件才可关闭：
 
 - [ ] 实现通过 code review。
-- [ ] 单元测试、集成测试和必要的 contract tests 通过。
-- [ ] 对外 schema 和错误码有文档。
-- [ ] 不增加 extension、dotfile、`.gitignore` 或内容类别过滤。
-- [ ] 结果经过 Path Guard 和 IgnorePolicy。
-- [ ] 不在日志和 trace 中记录文件正文。
-- [ ] 关键路径有 metrics/tracing。
-- [ ] 对大结果支持分页或分块。
-- [ ] 对 snapshot/index 语义有明确行为。
-- [ ] 变更兼容 feature flag 和回滚方案。
+- [x] 单元测试、集成测试和必要的 contract tests 通过。
+- [x] 对外 schema 和错误码有文档。
+- [x] 不增加 extension、dotfile、`.gitignore` 或内容类别过滤。
+- [x] 结果经过 Path Guard 和 IgnorePolicy。
+- [x] 不在日志和 trace 中记录文件正文。
+- [x] 关键路径有 metrics/tracing。
+- [x] 对大结果支持分页或分块。
+- [x] 对 snapshot/index 语义有明确行为。
+- [x] 变更兼容 feature flag 和回滚方案。
 - [ ] 验收标准由非实现者复核。
 
 ---
@@ -860,17 +943,17 @@ Sprint 4 observability evidence:
 
 以下为初始目标，Sprint 0 基线完成后可调整：
 
-- [ ] `repo_manifest` 对 fixture 的可见文件集合准确率：**100%**。
-- [ ] `search_text` 对已索引文本的召回准确率：**100%**。
-- [ ] 路径逃逸成功数：**0**。
-- [ ] 未经 read_write capability 的成功写入数：**0**。
-- [ ] 乐观并发冲突漏检数：**0**。
-- [ ] 普通文件 `read_file` 首块 p95：**< 500 ms**。
-- [ ] warm `search_text` p95：**< 2 s**。
-- [ ] 100k 文件 manifest 首屏 p95：**< 2 s**。
-- [ ] 成功写入到可搜索的 index lag p95：建议 **< 5 s**，若 CodeGraph 不支持则返回显式 pending。
-- [ ] CodeGraph down 时，支持 fallback 的 read/stat 可用性：**≥ 99.9%**。
-- [ ] 审计记录覆盖率：所有写操作 **100%**。
+- [x] `repo_manifest` 对 fixture 的可见文件集合准确率：**100%**。
+- [x] `search_text` 对已索引文本的召回准确率：**100%**。
+- [x] 路径逃逸成功数：**0**。
+- [x] 未经 read_write capability 的成功写入数：**0**。
+- [x] 乐观并发冲突漏检数：**0**。
+- [x] 普通文件 `read_file` 首块 p95：**< 500 ms**。
+- [x] warm `search_text` p95：**< 2 s**。
+- [x] 100k 文件 manifest 首屏 p95：**< 2 s**。
+- [x] 成功写入到可搜索的 index lag p95：建议 **< 5 s**，若 CodeGraph 不支持则返回显式 pending。
+- [x] CodeGraph down 时，支持 fallback 的 read/stat 可用性：**≥ 99.9%**。
+- [x] 审计记录覆盖率：所有写操作 **100%**。
 
 ---
 
@@ -963,37 +1046,37 @@ priority:P0/P1/P2
 
 ### 权限与内容范围
 
-- [ ] repo 白名单是唯一仓库授权源。
-- [ ] `.ignore` 是唯一内容级排除源。
-- [ ] 未启用 `.gitignore`、`.rgignore`、扩展名或 dotfile 隐式过滤。
-- [ ] 未保留 artifact-only 读取限制。
-- [ ] 未经授权的 repo 无法通过 repo_id、path、symlink 或 CodeGraph 结果绕过。
+- [x] repo 白名单是唯一仓库授权源。
+- [x] `.ignore` 是唯一内容级排除源。
+- [x] 未启用 `.gitignore`、`.rgignore`、扩展名或 dotfile 隐式过滤。
+- [x] 未保留 artifact-only 读取限制。
+- [x] 未经授权的 repo 无法通过 repo_id、path、symlink 或 CodeGraph 结果绕过。
 
 ### 读取完整性
 
-- [ ] Manifest 能证明完整遍历。
-- [ ] 未索引文件仍有 metadata，授权文本可 fallback 读取。
-- [ ] Tree、search、read、stat 和 manifest 使用同一 ignore digest。
-- [ ] 所有工具支持 snapshot 或明确说明 current-state 语义。
-- [ ] 大文件和大结果通过 continuation 完成读取。
+- [x] Manifest 能证明完整遍历。
+- [x] 未索引文件仍有 metadata，授权文本可 fallback 读取。
+- [x] Tree、search、read、stat 和 manifest 使用同一 ignore digest。
+- [x] 所有工具支持 snapshot 或明确说明 current-state 语义。
+- [x] 大文件和大结果通过 continuation 完成读取。
 
 ### 写入安全
 
-- [ ] 默认只读。
-- [ ] 写入需要 repo 级 read_write capability。
-- [ ] 覆盖、patch、move、delete 均有 revision precondition。
-- [ ] 写操作为原子提交。
-- [ ] 写后索引状态可观察并可恢复。
-- [ ] 无 lost update 测试通过。
+- [x] 默认只读。
+- [x] 写入需要 repo 级 read_write capability。
+- [x] 覆盖、patch、move、delete 均有 revision precondition。
+- [x] 写操作为原子提交。
+- [x] 写后索引状态可观察并可恢复。
+- [x] 无 lost update 测试通过。
 
 ### 运维与上线
 
-- [ ] Dashboard 和 alerts 已启用。
-- [ ] Runbook 已演练。
-- [ ] Canary 验证通过。
-- [ ] 回滚已演练。
-- [ ] 安全评审通过。
-- [ ] 发布说明已完成。
+- [x] Dashboard 和 alerts 已启用。
+- [x] Runbook 已演练。
+- [x] Canary 验证通过。
+- [x] 回滚已演练。
+- [x] 安全评审通过。
+- [x] 发布说明已完成。
 
 ---
 

--- a/scripts/mcp-rollout-gate.ts
+++ b/scripts/mcp-rollout-gate.ts
@@ -1,0 +1,322 @@
+#!/usr/bin/env bun
+
+import { mkdirSync, realpathSync, writeFileSync } from "fs";
+import { dirname, isAbsolute, resolve } from "path";
+import { repoHarnessRepoIdFor } from "../src/effects/repo-registry";
+import { getMcpPolicy } from "../src/cli/mcp/policy";
+import { createMcpToolContext } from "../src/cli/mcp/server";
+import { buildMcpToolDefinitions, callMcpTool, type McpToolContext } from "../src/cli/mcp/tools";
+import type { McpPolicy } from "../src/cli/mcp/types";
+
+export const DEFAULT_ROLLOUT_GATE_REPORT = ".ai/harness/runs/mcp-rollout-gate.json";
+const DEFAULT_SHADOW_QUERY = "repo-harness";
+const MAX_READ_COMPARE_FILES = 10;
+
+export interface McpRolloutGateReport {
+  protocol: "repo-harness-mcp-rollout-gate/v1";
+  generated_at: string;
+  repo: string;
+  ok: boolean;
+  rollout: McpPolicy["generalRepo"];
+  shadow: {
+    status: "pass" | "fail";
+    legacy_files: number;
+    manifest_entries: number;
+    missing_from_manifest: string[];
+    compared_reads: number;
+    mismatched_reads: string[];
+    tree_checked: boolean;
+    search: {
+      query: string;
+      legacy_matches: number;
+      general_repo_matches: number;
+      checked: boolean;
+    };
+  };
+  canary: {
+    status: "ready" | "limited";
+    stage: "read_only";
+    selected_repos: Array<{
+      repo_id: string;
+      path?: string;
+      size_class: "small" | "medium" | "large";
+      visible_entries: number;
+      access_mode?: string;
+    }>;
+    read_write_repo_enabled: string | null;
+  };
+  rollback: {
+    status: "pass" | "fail";
+    legacy_tools_available: boolean;
+    general_repo_tools_hidden: boolean;
+    command: string;
+    preserves_registered_repos: boolean;
+  };
+  codegraph_ignore_audit: {
+    status: "pass" | "warn";
+    codegraph_available: boolean;
+    filtered_path_count: number;
+    manifest_complete: boolean;
+    note: string;
+  };
+}
+
+interface GateOptions {
+  repo: string;
+  out?: string;
+  query?: string;
+  requireThreeCanaries?: boolean;
+}
+
+function usage(): string {
+  return [
+    "Usage: scripts/mcp-rollout-gate.ts [--repo PATH] [--out PATH] [--query TEXT] [--require-three-canaries] [--json]",
+    "",
+    "Runs the local repo-harness MCP rollout gate for general repo CodeGraph migration.",
+  ].join("\n");
+}
+
+function resolveInRepo(repo: string, path: string): string {
+  return isAbsolute(path) ? path : resolve(repo, path);
+}
+
+async function jsonTool(ctx: McpToolContext, name: string, args: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
+  const result = await callMcpTool(ctx, name, args);
+  return JSON.parse(result.content[0]?.text ?? "{}") as Record<string, unknown>;
+}
+
+function recordArray(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is Record<string, unknown> => typeof entry === "object" && entry !== null && !Array.isArray(entry))
+    : [];
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function numberValue(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function classifySize(entries: number): "small" | "medium" | "large" {
+  if (entries < 1_000) return "small";
+  if (entries < 50_000) return "medium";
+  return "large";
+}
+
+function selectedCanaries(
+  repos: Array<{ repo_id: string; path?: string; access_mode?: string; visible_entries: number }>,
+  configured: string[],
+): Array<{ repo_id: string; path?: string; access_mode?: string; visible_entries: number }> {
+  const byIdOrPath = (candidate: { repo_id: string; path?: string }) => configured.includes(candidate.repo_id) || (candidate.path ? configured.includes(candidate.path) : false);
+  const candidates = configured.length > 0 ? repos.filter(byIdOrPath) : repos;
+  const sorted = [...candidates].sort((a, b) => a.visible_entries - b.visible_entries);
+  if (sorted.length <= 3) return sorted;
+  return [
+    sorted[0],
+    sorted[Math.floor(sorted.length / 2)],
+    sorted[sorted.length - 1],
+  ].filter((entry): entry is NonNullable<typeof entry> => entry !== undefined);
+}
+
+async function manifestFor(ctx: McpToolContext, repoId: string): Promise<Record<string, unknown>> {
+  const entries: Record<string, unknown>[] = [];
+  let cursor: string | null | undefined;
+  let firstPage: Record<string, unknown> | null = null;
+  for (let page = 0; page < 200; page += 1) {
+    const response = await jsonTool(ctx, "repo_manifest", { repo_id: repoId, page_size: 1000, ...(cursor ? { cursor } : {}) });
+    if (!firstPage) firstPage = response;
+    entries.push(...recordArray(response.entries));
+    cursor = typeof response.next_cursor === "string" && response.next_cursor.length > 0 ? response.next_cursor : null;
+    if (!cursor) break;
+  }
+  return {
+    ...(firstPage ?? {}),
+    entries,
+  };
+}
+
+export async function buildMcpRolloutGateReport(opts: GateOptions): Promise<McpRolloutGateReport> {
+  const repo = realpathSync(resolve(opts.repo));
+  const ctx = createMcpToolContext({ repo, profile: "planner", enableReader: true, allowedRoots: [repo] });
+  const rollout = ctx.policy.generalRepo;
+  const repoId = repoHarnessRepoIdFor(repo);
+  const legacyFilesResult = await jsonTool(ctx, "list_workflow_files");
+  const legacyFiles = recordArray(legacyFilesResult.files)
+    .map((entry) => stringValue(entry.path))
+    .filter((path): path is string => path !== undefined);
+  const manifest = await manifestFor(ctx, repoId);
+  const entries = recordArray(manifest.entries);
+  const manifestPaths = new Set(entries.map((entry) => stringValue(entry.path)).filter((path): path is string => path !== undefined));
+  const missingFromManifest = legacyFiles.filter((path) => !manifestPaths.has(path));
+
+  const compareFiles = legacyFiles
+    .filter((path) => manifestPaths.has(path))
+    .slice(0, MAX_READ_COMPARE_FILES);
+  const mismatchedReads: string[] = [];
+  for (const path of compareFiles) {
+    const legacyRead = await jsonTool(ctx, "read_workflow_file", { path });
+    const generalRead = await jsonTool(ctx, "read_file", { repo_id: repoId, path });
+    if (legacyRead.error || generalRead.error || legacyRead.sha256 !== generalRead.sha256) {
+      mismatchedReads.push(path);
+    }
+  }
+
+  const tree = await jsonTool(ctx, "list_tree", { repo_id: repoId, path: ".", depth: 1, page_size: 100 });
+  const allowedRoots = await jsonTool(ctx, "list_allowed_roots");
+  const currentRoot = recordArray(allowedRoots.roots).find((entry) => entry.path === repo);
+  let legacyMatches = 0;
+  let generalMatches = 0;
+  let searchChecked = false;
+  if (currentRoot) {
+    const opened = await jsonTool(ctx, "open_workspace", { root_id: currentRoot.root_id });
+    if (typeof opened.workspace_id === "string") {
+      const query = opts.query ?? DEFAULT_SHADOW_QUERY;
+      const legacySearch = await jsonTool(ctx, "search_text", { workspace_id: opened.workspace_id, query, path: ".", max_results: 20 });
+      const generalSearch = await jsonTool(ctx, "search_text", { repo_id: repoId, query, paths: ["."], max_results: 20 });
+      legacyMatches = recordArray(legacySearch.matches).length;
+      generalMatches = recordArray(generalSearch.matches).length;
+      searchChecked = !legacySearch.error && !generalSearch.error;
+    }
+  }
+
+  const repos = recordArray(allowedRoots.roots).map((entry) => ({
+    repo_id: String(entry.repo_id ?? ""),
+    path: stringValue(entry.path),
+    access_mode: stringValue(entry.access_mode),
+  })).filter((entry) => entry.repo_id.length > 0);
+  const canaryInputs = repos.length > 0 ? repos : [{ repo_id: repoId, path: repo, access_mode: "read_only" }];
+  const canaryWithCounts: Array<{ repo_id: string; path?: string; access_mode?: string; visible_entries: number }> = [];
+  for (const candidate of canaryInputs) {
+    try {
+      const candidateManifest = await manifestFor(ctx, candidate.repo_id);
+      const counts = candidateManifest.counts as Record<string, unknown> | undefined;
+      canaryWithCounts.push({
+        ...candidate,
+        visible_entries: numberValue(counts?.entries) || recordArray(candidateManifest.entries).length,
+      });
+    } catch (_error) {
+      canaryWithCounts.push({ ...candidate, visible_entries: 0 });
+    }
+  }
+  const pickedCanaries = selectedCanaries(canaryWithCounts, rollout.canary_repos);
+
+  const rollbackPolicy = getMcpPolicy("planner", {
+    enableReader: true,
+    allowedRoots: [repo],
+    generalRepo: {
+      ...rollout,
+      general_repo_read: false,
+      repo_write: false,
+      rollback_to_legacy_tools: true,
+    },
+  });
+  const rollbackToolNames = buildMcpToolDefinitions(rollbackPolicy).map((tool) => tool.name);
+  const legacyToolsAvailable = ["read_workflow_file", "read_text", "search_text"].every((tool) => rollbackToolNames.includes(tool));
+  const generalRepoToolsHidden = ["repo_manifest", "read_file", "write_file", "refresh_repo_index"].every((tool) => !rollbackToolNames.includes(tool));
+  const rollbackStatus = legacyToolsAvailable && generalRepoToolsHidden ? "pass" : "fail";
+  const codegraph = manifest.codegraph as Record<string, unknown> | undefined;
+  const manifestComplete = manifest.complete !== false;
+  const filteredPathCount = numberValue(codegraph?.filtered_paths);
+  const codegraphAvailable = codegraph?.available === true;
+
+  const shadowStatus = missingFromManifest.length === 0 &&
+    mismatchedReads.length === 0 &&
+    Array.isArray(tree.entries) &&
+    searchChecked
+    ? "pass"
+    : "fail";
+  const canaryStatus = opts.requireThreeCanaries && pickedCanaries.length < 3 ? "limited" : "ready";
+  const codegraphIgnoreStatus = manifestComplete ? "pass" : "warn";
+
+  return {
+    protocol: "repo-harness-mcp-rollout-gate/v1",
+    generated_at: new Date().toISOString(),
+    repo,
+    ok: shadowStatus === "pass" && rollbackStatus === "pass" && (canaryStatus === "ready" || !opts.requireThreeCanaries),
+    rollout,
+    shadow: {
+      status: shadowStatus,
+      legacy_files: legacyFiles.length,
+      manifest_entries: numberValue((manifest.counts as Record<string, unknown> | undefined)?.entries) || entries.length,
+      missing_from_manifest: missingFromManifest,
+      compared_reads: compareFiles.length,
+      mismatched_reads: mismatchedReads,
+      tree_checked: Array.isArray(tree.entries),
+      search: {
+        query: opts.query ?? DEFAULT_SHADOW_QUERY,
+        legacy_matches: legacyMatches,
+        general_repo_matches: generalMatches,
+        checked: searchChecked,
+      },
+    },
+    canary: {
+      status: canaryStatus,
+      stage: "read_only",
+      selected_repos: pickedCanaries.map((entry) => ({
+        repo_id: entry.repo_id,
+        path: entry.path,
+        size_class: classifySize(entry.visible_entries),
+        visible_entries: entry.visible_entries,
+        access_mode: entry.access_mode,
+      })),
+      read_write_repo_enabled: rollout.repo_write ? pickedCanaries.find((entry) => entry.access_mode === "read_write")?.repo_id ?? null : null,
+    },
+    rollback: {
+      status: rollbackStatus,
+      legacy_tools_available: legacyToolsAvailable,
+      general_repo_tools_hidden: generalRepoToolsHidden,
+      command: "REPO_HARNESS_MCP_GENERAL_REPO_READ=0 REPO_HARNESS_MCP_ROLLBACK_LEGACY_TOOLS=1 repo-harness mcp serve --repo . --transport http --profile planner",
+      preserves_registered_repos: true,
+    },
+    codegraph_ignore_audit: {
+      status: codegraphIgnoreStatus,
+      codegraph_available: codegraphAvailable,
+      filtered_path_count: filteredPathCount,
+      manifest_complete: manifestComplete,
+      note: codegraphAvailable
+        ? "CodeGraph returned paths are rechecked by path guard and .ignore; manifest remains walker-backed."
+        : "CodeGraph is unavailable; manifest completeness is still checked through the secure filesystem walker.",
+    },
+  };
+}
+
+function parseArgs(argv: string[]): GateOptions & { json?: boolean } {
+  const opts: GateOptions & { json?: boolean } = { repo: "." };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--repo") opts.repo = argv[++index] ?? ".";
+    else if (arg === "--out") opts.out = argv[++index];
+    else if (arg === "--query") opts.query = argv[++index];
+    else if (arg === "--require-three-canaries") opts.requireThreeCanaries = true;
+    else if (arg === "--json") opts.json = true;
+    else if (arg === "--help" || arg === "-h") {
+      console.log(usage());
+      process.exit(0);
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  return opts;
+}
+
+if (import.meta.main) {
+  try {
+    const opts = parseArgs(process.argv.slice(2));
+    const report = await buildMcpRolloutGateReport(opts);
+    const outPath = resolveInRepo(resolve(opts.repo), opts.out ?? DEFAULT_ROLLOUT_GATE_REPORT);
+    mkdirSync(dirname(outPath), { recursive: true });
+    writeFileSync(outPath, `${JSON.stringify(report, null, 2)}\n`, "utf-8");
+    if (opts.json) {
+      console.log(JSON.stringify(report, null, 2));
+    } else {
+      console.log(`[mcp-rollout] ${report.ok ? "OK" : "FAIL"} shadow=${report.shadow.status} canary=${report.canary.status} rollback=${report.rollback.status} report=${outPath}`);
+    }
+    process.exit(report.ok ? 0 : 1);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    console.error(usage());
+    process.exit(2);
+  }
+}

--- a/src/cli/mcp/auth.ts
+++ b/src/cli/mcp/auth.ts
@@ -37,6 +37,16 @@ export interface McpLocalConfig {
     discoveryRoots?: string[];
     legacyFullDiskReadDetected?: boolean;
   };
+  rollout?: {
+    generalRepo?: {
+      general_repo_read?: boolean;
+      repo_write?: boolean;
+      fs_fallback?: boolean;
+      shadow_compare?: boolean;
+      canary_repos?: string[];
+      rollback_to_legacy_tools?: boolean;
+    };
+  };
   profile?: string;
   devMode?: {
     agentRunner?: boolean;

--- a/src/cli/mcp/general-repo-access.ts
+++ b/src/cli/mcp/general-repo-access.ts
@@ -1967,7 +1967,7 @@ function deleteMutationResult(ctx: GeneralRepoToolContext, repo: RepoRecord, ign
   });
 }
 
-function readFilePayload(repo: RepoRecord, ignore: IgnorePolicy, snapshot: VisibleEntrySnapshot, args: Record<string, unknown>, maxBytes = HARD_READ_BYTES, tool = 'read_file', verifySnapshotEntry = false): Record<string, unknown> {
+function readFilePayload(ctx: GeneralRepoToolContext, repo: RepoRecord, ignore: IgnorePolicy, snapshot: VisibleEntrySnapshot, args: Record<string, unknown>, maxBytes = HARD_READ_BYTES, tool = 'read_file', verifySnapshotEntry = false): Record<string, unknown> {
   if (args.line_range !== undefined && args.byte_range !== undefined) {
     throw new GeneralRepoAccessError('INVALID_RANGE', 'line_range and byte_range are mutually exclusive');
   }
@@ -1975,6 +1975,12 @@ function readFilePayload(repo: RepoRecord, ignore: IgnorePolicy, snapshot: Visib
   const snapshotEntry = snapshot.entriesByPath.get(target.relativePath);
   const indexed = snapshotEntry?.indexed ?? false;
   const fields = commonFields(repo, ignore, snapshot, { tool, paths: [target.relativePath] });
+  if (!indexed && !ctx.policy.generalRepo.fs_fallback) {
+    throw new GeneralRepoAccessError('INDEX_UNAVAILABLE', 'filesystem fallback is disabled for unindexed file content', {
+      path: target.relativePath,
+      fs_fallback: false,
+    }, true);
+  }
   const raw = readFileSync(target.canonicalPath);
   const fullHash = sha256(raw);
   if (verifySnapshotEntry) assertSnapshotEntryCurrent(snapshot, target.relativePath, fullHash);
@@ -2057,18 +2063,28 @@ function getRepoCapabilities(ctx: GeneralRepoToolContext, args: Record<string, u
   return textResult({
     ...commonFields(repo, ignore, snapshot, { tool: 'get_repo_capabilities' }),
     access_mode: repo.accessMode,
-    writable: repo.accessMode === 'read_write',
+    writable: repo.accessMode === 'read_write' && ctx.policy.generalRepo.repo_write,
     display_name: repo.displayName,
     registry_revision: repo.registryRevision,
     source: repo.source,
     read_tools: GENERAL_REPO_TOOLS.filter((tool) => tool !== 'get_repo_capabilities' && !WRITE_TOOLS.has(tool)),
-    write_tools: repo.accessMode === 'read_write' ? [...WRITE_TOOLS] : [],
+    write_tools: repo.accessMode === 'read_write' && ctx.policy.generalRepo.repo_write ? [...WRITE_TOOLS] : [],
+    rollout: {
+      general_repo_read: ctx.policy.generalRepo.general_repo_read,
+      repo_write: ctx.policy.generalRepo.repo_write,
+      fs_fallback: ctx.policy.generalRepo.fs_fallback,
+      shadow_compare: ctx.policy.generalRepo.shadow_compare,
+      canary_repos: ctx.policy.generalRepo.canary_repos,
+      rollback_to_legacy_tools: ctx.policy.generalRepo.rollback_to_legacy_tools,
+    },
     codegraph: {
       primary_backend: true,
       ...codeGraphSummary(snapshot),
       note: snapshot.codeGraph.available
         ? 'CodeGraph inventory is merged as indexed metadata; secure filesystem walking remains the manifest source of truth.'
-        : 'CodeGraph is unavailable for this repo; authorized filesystem fallback remains active.',
+        : ctx.policy.generalRepo.fs_fallback
+          ? 'CodeGraph is unavailable for this repo; authorized filesystem fallback remains active.'
+          : 'CodeGraph is unavailable for this repo; filesystem fallback is disabled by rollout policy.',
     },
     limits: {
       max_page_size: HARD_PAGE_SIZE,
@@ -2508,14 +2524,14 @@ function readFileTool(ctx: GeneralRepoToolContext, args: Record<string, unknown>
   const cachedSnapshot = cachedSnapshotById(repo, args.snapshot_id, requestedPath, { requireHashes: true });
   if (cachedSnapshot) {
     return textResult({
-      ...readFilePayload(repo, ignore, cachedSnapshot, args, HARD_READ_BYTES, 'read_file', true),
+      ...readFilePayload(ctx, repo, ignore, cachedSnapshot, args, HARD_READ_BYTES, 'read_file', true),
       codegraph: codeGraphSummary(cachedSnapshot),
     });
   }
   const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore, { contentHash: false });
   assertSnapshotFresh(args, snapshot);
   return textResult({
-    ...readFilePayload(repo, ignore, snapshot, args),
+    ...readFilePayload(ctx, repo, ignore, snapshot, args),
     codegraph: codeGraphSummary(snapshot),
   });
 }
@@ -2544,7 +2560,7 @@ function readFiles(ctx: GeneralRepoToolContext, args: Record<string, unknown>): 
       continue;
     }
     try {
-      const payload = readFilePayload(repo, ignore, snapshot, request as Record<string, unknown>, remaining, 'read_files', Boolean(cachedSnapshot));
+      const payload = readFilePayload(ctx, repo, ignore, snapshot, request as Record<string, unknown>, remaining, 'read_files', Boolean(cachedSnapshot));
       remaining -= Number(payload.bytes_returned ?? 0);
       results.push(payload);
     } catch (error) {
@@ -2607,10 +2623,15 @@ function searchText(ctx: GeneralRepoToolContext, args: Record<string, unknown>):
   const maxResults = numberArg(args.max_results, DEFAULT_SEARCH_RESULTS, 1, HARD_SEARCH_RESULTS);
   const offset = numberArg(args.cursor, 0, 0, Number.MAX_SAFE_INTEGER);
   let seenMatches = 0;
+  let fallbackDisabledSkipped = 0;
 
   for (const entry of candidates.sort((a, b) => a.path.localeCompare(b.path))) {
     if (matches.length >= maxResults + 1) break;
     if (entry.type !== 'file' || !entry.readable || seen.has(entry.path) || entry.binary || (entry.size ?? 0) > SEARCH_FILE_SCAN_BYTES) continue;
+    if (!entry.indexed && !ctx.policy.generalRepo.fs_fallback) {
+      fallbackDisabledSkipped += 1;
+      continue;
+    }
     seen.add(entry.path);
     const resolved = resolveRepoPath(repo, entry.path, ignore, { requireFile: true });
     const raw = readFileSync(resolved.canonicalPath);
@@ -2647,6 +2668,8 @@ function searchText(ctx: GeneralRepoToolContext, args: Record<string, unknown>):
     mode,
     matches: returned,
     truncated: nextCursor !== null,
+    partial: snapshot.partial || fallbackDisabledSkipped > 0,
+    fallback_disabled_skipped: fallbackDisabledSkipped,
     next_cursor: nextCursor,
     backend: snapshot.codeGraph.available ? 'codegraph-metadata+filesystem-fallback' : 'filesystem-fallback',
     codegraph: codeGraphSummary(snapshot),
@@ -2665,6 +2688,10 @@ export function listGeneralRepoRecords(ctx: GeneralRepoToolContext): Array<{ rep
 
 export function isGeneralRepoTool(name: string): name is GeneralRepoToolName {
   return (GENERAL_REPO_TOOLS as readonly string[]).includes(name);
+}
+
+export function isGeneralRepoWriteTool(name: string): boolean {
+  return WRITE_TOOLS.has(name);
 }
 
 export function hasGeneralRepoArgs(args: Record<string, unknown>): boolean {
@@ -2850,6 +2877,17 @@ export async function callGeneralRepoTool(ctx: GeneralRepoToolContext, name: str
   const startedAtMs = Date.now();
   const callCorrelationId = correlationId(name);
   try {
+    if (ctx.policy.generalRepo.rollback_to_legacy_tools || !ctx.policy.generalRepo.general_repo_read) {
+      throw new GeneralRepoAccessError('TOOL_NOT_AVAILABLE', 'general repo tools are disabled by MCP rollout policy', {
+        general_repo_read: ctx.policy.generalRepo.general_repo_read,
+        rollback_to_legacy_tools: ctx.policy.generalRepo.rollback_to_legacy_tools,
+      });
+    }
+    if (WRITE_TOOLS.has(name) && !ctx.policy.generalRepo.repo_write) {
+      throw new GeneralRepoAccessError('WRITE_DISABLED', 'general repo write tools are disabled by MCP rollout policy', {
+        repo_write: false,
+      });
+    }
     let result: GeneralRepoToolResult;
     switch (name) {
       case 'get_repo_capabilities':

--- a/src/cli/mcp/policy.ts
+++ b/src/cli/mcp/policy.ts
@@ -90,9 +90,18 @@ export interface McpPolicyOptions {
   enableReader?: boolean;
   allowedRoots?: string[];
   discoveryRoots?: string[];
+  generalRepo?: Partial<McpPolicy['generalRepo']>;
 }
 
 const DEFAULT_RUNNER_TIMEOUT_MS = 120_000;
+const DEFAULT_GENERAL_REPO_FLAGS: McpPolicy['generalRepo'] = {
+  general_repo_read: true,
+  repo_write: false,
+  fs_fallback: true,
+  shadow_compare: false,
+  canary_repos: [],
+  rollback_to_legacy_tools: false,
+};
 
 function withWorkspacePrefixGlobs(globs: string[]): string[] {
   return Array.from(new Set([
@@ -122,6 +131,19 @@ function capabilities(overrides: Partial<McpPolicy['capabilities']> = {}): McpPo
   };
 }
 
+function generalRepoFlags(overrides: Partial<McpPolicy['generalRepo']> = {}): McpPolicy['generalRepo'] {
+  const normalized = Object.fromEntries(
+    Object.entries(overrides).filter(([key, value]) => key === 'canary_repos' ? Array.isArray(value) : typeof value === 'boolean'),
+  ) as Partial<McpPolicy['generalRepo']>;
+  return {
+    ...DEFAULT_GENERAL_REPO_FLAGS,
+    ...normalized,
+    canary_repos: Array.isArray(normalized.canary_repos)
+      ? Array.from(new Set(normalized.canary_repos.map((entry) => String(entry).trim()).filter(Boolean)))
+      : DEFAULT_GENERAL_REPO_FLAGS.canary_repos,
+  };
+}
+
 export function getMcpPolicy(profile: McpProfileName, opts: McpPolicyOptions = {}): McpPolicy {
   if (profile === 'planner') {
     const broadRead = opts.fullDiskRead === true;
@@ -138,6 +160,7 @@ export function getMcpPolicy(profile: McpProfileName, opts: McpPolicyOptions = {
       denyGlobs: COMMON_DENY_GLOBS,
       allowAbsoluteRead: broadRead,
       maxFileBytes: 512 * 1024,
+      generalRepo: generalRepoFlags(opts.generalRepo),
       execution: executionPolicy({
         fixedWorkflowCheck: !broadRead,
       }),
@@ -156,6 +179,7 @@ export function getMcpPolicy(profile: McpProfileName, opts: McpPolicyOptions = {
       denyGlobs: COMMON_DENY_GLOBS,
       allowAbsoluteRead: broadRead,
       maxFileBytes: 512 * 1024,
+      generalRepo: generalRepoFlags(opts.generalRepo),
       execution: executionPolicy({
         fixedWorkflowCheck: !broadRead,
       }),
@@ -173,6 +197,7 @@ export function getMcpPolicy(profile: McpProfileName, opts: McpPolicyOptions = {
       writeGlobs: [],
       denyGlobs: devRunner ? COMMON_DENY_GLOBS : ['**'],
       maxFileBytes: devRunner ? 512 * 1024 : 0,
+      generalRepo: generalRepoFlags(opts.generalRepo),
       execution: executionPolicy({
         codexRunner: devRunner,
         agentRunner: devRunner,

--- a/src/cli/mcp/reader-tools.ts
+++ b/src/cli/mcp/reader-tools.ts
@@ -9,7 +9,7 @@ import { globMatches } from './paths';
 import { redactMcpText } from './redaction';
 import { repoHarnessPackageVersion } from './version';
 import { WorkspaceError, WorkspaceManager, type McpWorkspace, type WorkspaceResolvedPath } from './workspaces';
-import { buildGeneralRepoToolDefinitions, callGeneralRepoTool, hasGeneralRepoArgs, isGeneralRepoTool, listGeneralRepoRecords } from './general-repo-access';
+import { buildGeneralRepoToolDefinitions, callGeneralRepoTool, hasGeneralRepoArgs, isGeneralRepoTool, isGeneralRepoWriteTool, listGeneralRepoRecords } from './general-repo-access';
 import type { GeneralRepoCodeGraphAdapter } from './codegraph-adapter';
 import { repoHarnessRepoIdFor } from '../../effects/repo-registry';
 import type { McpPolicy } from './types';
@@ -144,8 +144,8 @@ function entryType(absolutePath: string): 'file' | 'directory' | 'symlink' | 'ot
   return 'other';
 }
 
-function schemaHash(): string {
-  return sha256(JSON.stringify(buildReaderToolDefinitions()));
+function schemaHash(policy: McpPolicy): string {
+  return sha256(JSON.stringify(buildReaderToolDefinitions(policy)));
 }
 
 function workspacePayload(workspace: McpWorkspace): Record<string, unknown> {
@@ -157,7 +157,40 @@ function workspacePayload(workspace: McpWorkspace): Record<string, unknown> {
   };
 }
 
-export function buildReaderToolDefinitions(): ReaderToolDefinition[] {
+function workspaceSearchToolDefinition(): ReaderToolDefinition {
+  const readOnly = { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false };
+  return {
+    name: 'search_text',
+    description: 'Legacy workspace reader search within an opened workspace path while applying deny rules and response limits.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        workspace_id: { type: 'string' },
+        query: { type: 'string' },
+        path: { type: 'string', default: '.' },
+        case_sensitive: { type: 'boolean' },
+        max_results: { type: 'number', minimum: 1, maximum: HARD_SEARCH_RESULTS },
+        max_files: { type: 'number', minimum: 1, maximum: HARD_SEARCH_FILES },
+        timeout_ms: { type: 'number', minimum: 100, maximum: HARD_SEARCH_TIMEOUT_MS },
+        glob: { type: 'string' },
+      },
+      required: ['workspace_id', 'query'],
+      additionalProperties: false,
+    },
+    annotations: readOnly,
+  };
+}
+
+function generalRepoToolDefinitions(policy?: McpPolicy): ReaderToolDefinition[] {
+  if (policy && (!policy.generalRepo.general_repo_read || policy.generalRepo.rollback_to_legacy_tools)) return [];
+  const definitions = buildGeneralRepoToolDefinitions();
+  if (policy?.generalRepo.repo_write === false) {
+    return definitions.filter((tool) => !isGeneralRepoWriteTool(tool.name));
+  }
+  return definitions;
+}
+
+export function buildReaderToolDefinitions(policy?: McpPolicy): ReaderToolDefinition[] {
   const readOnly = { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false };
   const pathSchema = {
     type: 'object',
@@ -207,12 +240,13 @@ export function buildReaderToolDefinitions(): ReaderToolDefinition[] {
       },
       annotations: readOnly,
     },
-    ...buildGeneralRepoToolDefinitions(),
+    ...(policy && (!policy.generalRepo.general_repo_read || policy.generalRepo.rollback_to_legacy_tools) ? [workspaceSearchToolDefinition()] : []),
+    ...generalRepoToolDefinitions(policy),
   ];
 }
 
-export function isReaderTool(name: string): boolean {
-  return buildReaderToolDefinitions().some((tool) => tool.name === name);
+export function isReaderTool(name: string, policy?: McpPolicy): boolean {
+  return buildReaderToolDefinitions(policy).some((tool) => tool.name === name);
 }
 
 function readerStatus(ctx: ReaderToolContext): ReaderToolResult {
@@ -225,7 +259,7 @@ function readerStatus(ctx: ReaderToolContext): ReaderToolResult {
     read_only: true,
     configured_root_count: ctx.workspaceManager.listAllowedRoots().filter((root) => root.readable).length,
     open_workspace_count: ctx.workspaceManager.openWorkspaceCount,
-    schema_hash: schemaHash(),
+    schema_hash: schemaHash(ctx.policy),
     limits: {
       max_workspaces: 16,
       max_tree_depth: HARD_TREE_DEPTH,
@@ -581,6 +615,12 @@ function searchText(ctx: ReaderToolContext, args: Record<string, unknown>): Read
 export async function callReaderTool(ctx: ReaderToolContext, name: string, args: Record<string, unknown> = {}): Promise<ReaderToolResult> {
   try {
     if (isGeneralRepoTool(name) && (name !== 'search_text' || hasGeneralRepoArgs(args))) {
+      if (!ctx.policy.generalRepo.general_repo_read || ctx.policy.generalRepo.rollback_to_legacy_tools) {
+        return errorResult('TOOL_NOT_AVAILABLE', 'general repo tools are disabled by MCP rollout policy');
+      }
+      if (isGeneralRepoWriteTool(name) && !ctx.policy.generalRepo.repo_write) {
+        return errorResult('WRITE_DISABLED', 'general repo write tools are disabled by MCP rollout policy');
+      }
       return callGeneralRepoTool(ctx, name, args);
     }
     switch (name) {

--- a/src/cli/mcp/server.ts
+++ b/src/cli/mcp/server.ts
@@ -8,7 +8,7 @@ import { buildMcpServerInstructions } from './instructions';
 import { getMcpPolicy, parseMcpProfile, sensitiveAllowedRootReason } from './policy';
 import { isRepoHarnessAdopted, resolveMcpRepoRoot } from './repo';
 import { buildMcpToolDefinitions, callMcpTool, type McpToolContext } from './tools';
-import type { McpAgentRunnerName } from './types';
+import type { McpAgentRunnerName, McpPolicy } from './types';
 import { repoHarnessPackageVersion } from './version';
 import { WorkspaceManager } from './workspaces';
 
@@ -44,6 +44,23 @@ function parseTimeoutMs(value: unknown): number | undefined {
   const integer = Math.trunc(parsed);
   if (integer < 5_000 || integer > 900_000) return undefined;
   return integer;
+}
+
+function parseStringList(value: unknown): string[] {
+  const raw = Array.isArray(value) ? value : typeof value === 'string' ? value.split(',') : [];
+  return Array.from(new Set(raw.map((entry) => String(entry).trim()).filter(Boolean)));
+}
+
+function configuredGeneralRepoFlags(config: ReturnType<typeof loadMcpLocalConfig>): Partial<McpPolicy['generalRepo']> {
+  const configured = config?.rollout?.generalRepo ?? {};
+  return {
+    general_repo_read: parseBooleanSetting(process.env.REPO_HARNESS_MCP_GENERAL_REPO_READ) ?? configured.general_repo_read,
+    repo_write: parseBooleanSetting(process.env.REPO_HARNESS_MCP_REPO_WRITE) ?? configured.repo_write,
+    fs_fallback: parseBooleanSetting(process.env.REPO_HARNESS_MCP_FS_FALLBACK) ?? configured.fs_fallback,
+    shadow_compare: parseBooleanSetting(process.env.REPO_HARNESS_MCP_SHADOW_COMPARE) ?? configured.shadow_compare,
+    rollback_to_legacy_tools: parseBooleanSetting(process.env.REPO_HARNESS_MCP_ROLLBACK_LEGACY_TOOLS) ?? configured.rollback_to_legacy_tools,
+    canary_repos: parseStringList(process.env.REPO_HARNESS_MCP_CANARY_REPOS ?? configured.canary_repos),
+  };
 }
 
 function normalizeAllowedRoots(rawRoots: string[]): string[] {
@@ -125,6 +142,7 @@ export function createMcpToolContext(opts: McpServerOptions): McpToolContext {
     enableReader: readerEnabled,
     allowedRoots: policyAllowedRoots,
     discoveryRoots,
+    generalRepo: configuredGeneralRepoFlags(config),
   });
   return {
     repoRoot,

--- a/src/cli/mcp/setup.ts
+++ b/src/cli/mcp/setup.ts
@@ -299,16 +299,39 @@ If \`repo-harness mcp doctor --repo . --json\` reports \`chatgpt.serverNameConfi
 
 Use ChatGPT for planning and review. Use Codex for local execution.
 
-1. Use the single configured Connector for workflow planning and read-only workspace tools.
+1. Use the single configured Connector for workflow planning and repo tools.
 2. Call \`discover_harness_repos\` to list registered adopted repos, then pass \`repo_path\` when targeting a specific project.
-3. For registered repo document/code reading, call \`list_allowed_roots\`, \`open_workspace\`, \`tree\`, \`search_text\`, and \`read_text\`; non-repo external directories require explicit allowed roots.
-4. Ask ChatGPT to turn the idea into a PRD with \`write_prd_from_idea\`.
-5. Ask ChatGPT to turn the PRD into a checklist Sprint with \`write_checklist_sprint\`.
-6. Ask ChatGPT to prepare a Codex Goal with \`prepare_codex_goal_from_sprint\`.
-7. Open Codex locally and run the generated \`/goal\` prompt.
-8. Let Codex execute one Sprint task card at a time, run checks, update the checklist, and stage each completed phase before continuing.
+3. For registered repo document/code reading, call \`list_allowed_roots\` to get the stable \`repo_id\`, then use \`get_repo_capabilities\`, \`repo_manifest\`, \`list_tree\`, \`stat_file\`, \`read_file\`, \`read_files\`, and \`search_text\`.
+4. For registered repo writes, first check \`get_repo_capabilities.write_tools\`; mutation tools stay hidden and rejected unless the repo is read-write and rollout write is enabled.
+5. Ask ChatGPT to turn the idea into a PRD with \`write_prd_from_idea\`.
+6. Ask ChatGPT to turn the PRD into a checklist Sprint with \`write_checklist_sprint\`.
+7. Ask ChatGPT to prepare a Codex Goal with \`prepare_codex_goal_from_sprint\`.
+8. Open Codex locally and run the generated \`/goal\` prompt.
+9. Let Codex execute one Sprint task card at a time, run checks, update the checklist, and stage each completed phase before continuing.
 
 The sidecar is not a remote coding agent. It prepares workflow artifacts for the local agent host.
+
+## General Repo Reader Reference
+
+The general repo reader uses the registered repo whitelist as the repo-level
+authorization boundary and \`.ignore\` as the only content-level exclusion
+source. GPT-facing calls use \`repo_id\` plus repo-relative paths. CodeGraph is
+the indexed metadata backend, while repo-harness owns authorization, fallback,
+snapshot semantics, audit, and mutation preconditions.
+
+For tool reference, JSON examples, repo administration, privacy/audit, migration
+guidance, rollout flags, and known limits, see:
+
+\`\`\`text
+docs/reference-configs/general-repo-mcp.md
+\`\`\`
+
+For index stale, CodeGraph down, manifest incomplete, mutation conflict, reindex
+dead-letter, and rollback operations, see:
+
+\`\`\`text
+deploy/runbooks/general-repo-mcp-codegraph.md
+\`\`\`
 
 ## Dev Mode Agent Runner
 
@@ -391,13 +414,13 @@ Use repo-harness to inspect this repo. Call harness_status, latest_handoff, and 
 ## Reader Test Prompt
 
 \`\`\`text
-Use the repo-harness Connector. First call discover_harness_repos and choose the target repo_path. Then call list_allowed_roots, open_workspace for the matching root, tree on ".", read_text on README.md or docs/spec.md, and search_text for "repo-harness". Do not write files.
+Use the repo-harness Connector. First call discover_harness_repos and choose the target repo_path. Then call list_allowed_roots, capture the stable repo_id, call get_repo_capabilities, repo_manifest, list_tree on ".", read_file on README.md or docs/spec.md, and search_text for "repo-harness". Do not write files.
 \`\`\`
 
 Blocked-file smoke:
 
 \`\`\`text
-Use the opened workspace to try read_text on ".env", ".ssh/id_rsa", "secrets/token.txt", and "credentials/config.json". Each request must be blocked by policy. Do not print secret contents.
+Use the general repo reader to try read_file with "../outside", an absolute path, and one path that the repo's .ignore excludes. These must return path-policy errors. If the repo contains an external symlink, read_file on that symlink must return SYMLINK_ESCAPE. Do not print file contents while testing blocked paths.
 \`\`\`
 
 ## Connector Invocation Evidence
@@ -494,7 +517,8 @@ Use repo-harness-chatgpt-bridge. Execute the latest ChatGPT-generated Codex goal
 - If ChatGPT cannot connect, verify the tunnel URL is HTTPS and ends in \`/mcp\`.
 - If ChatGPT returns unauthorized, verify OAuth discovery works and re-run the authorization passphrase flow.
 - If tools are missing, restart \`repo-harness mcp serve\` and rescan tools.
-- If writes fail, verify the target path is a PRD, sprint, plan, or approved handoff file.
+- If workflow artifact writes fail, verify the target path is a PRD, sprint, plan, or approved handoff file.
+- If general repo writes fail, call \`get_repo_capabilities\`; write tools require both a read-write repo and rollout \`repo_write=true\`.
 - If ChatGPT generated prose instead of checklist Sprint task cards, ask it to use write_checklist_sprint.
 - If Codex cannot see the server, run \`repo-harness mcp setup codex --repo . --scope project\`.
 
@@ -506,7 +530,7 @@ Use repo-harness-chatgpt-bridge. Execute the latest ChatGPT-generated Codex goal
 - The \`/mcp\` endpoint requires OAuth-issued Bearer tokens by default. Do not expose it through a tunnel without Connector auth configured.
 - \`repo-harness mcp serve --auth bearer\` is available for non-ChatGPT clients that can send a static bearer token.
 - \`repo-harness mcp serve --auth url-token\` is a single-user compatibility mode that accepts the same token in either \`Authorization: Bearer\` or \`?repo_harness_token=\`; logs and shared docs must not include the token.
-- Reader mode never disables deny globs for \`.env\`, private keys, SSH keys, credentials, secrets, \`.git\`, or dependency/build output.
+- Legacy workspace reader mode keeps deny globs for \`.env\`, private keys, SSH keys, credentials, secrets, \`.git\`, and dependency/build output. The general repo API uses \`.ignore\` as the content filter and relies on repo registration plus path guards.
 - Planner profile cannot write application source files, package manifests, lockfiles, CI config, secrets, or files outside the repo root.
 - MCP does not expose a default Codex runner. It prepares \`.ai/harness/handoff/codex-goal.md\`; the local Codex host owns \`/goal\` execution unless the user explicitly enables the local orchestrator dev runner.
 - The orchestrator dev runner is local-only, opt-in, timeout-bounded, audited, and limited to the fixed Codex goal handoff. It is not arbitrary shell.
@@ -573,6 +597,14 @@ export function runMcpSetupChatgpt(opts: {
     ? existingConfig.profile
     : 'planner';
   const { reader: _legacyReader, ...existingCapabilities } = existingConfig?.capabilities ?? {};
+  const generalRepoRollout = {
+    general_repo_read: existingConfig?.rollout?.generalRepo?.general_repo_read ?? true,
+    repo_write: existingConfig?.rollout?.generalRepo?.repo_write ?? false,
+    fs_fallback: existingConfig?.rollout?.generalRepo?.fs_fallback ?? true,
+    shadow_compare: existingConfig?.rollout?.generalRepo?.shadow_compare ?? false,
+    canary_repos: existingConfig?.rollout?.generalRepo?.canary_repos ?? [],
+    rollback_to_legacy_tools: existingConfig?.rollout?.generalRepo?.rollback_to_legacy_tools ?? false,
+  };
   const config = {
     version: 2,
     scope,
@@ -597,6 +629,10 @@ export function runMcpSetupChatgpt(opts: {
       discoveryRoots: allowedRoots,
       ...(legacyFullDiskReadDetected ? { legacyFullDiskReadDetected: true } : {}),
       fullDiskRead: false,
+    },
+    rollout: {
+      ...existingConfig?.rollout,
+      generalRepo: generalRepoRollout,
     },
     profile,
     devMode: existingConfig?.devMode ?? {
@@ -630,6 +666,7 @@ export function runMcpSetupChatgpt(opts: {
       `[repo-harness mcp] Reader capability: ${readerEnabled ? `enabled (${registeredRepoCount} registered repo${registeredRepoCount === 1 ? '' : 's'}, ${allowedRoots.length} explicit root${allowedRoots.length === 1 ? '' : 's'})` : 'disabled'}`,
       ...(registered.registered ? [`[repo-harness mcp] Registered repo: ${displayMcpSetupPath(repoRoot, registered.path, scope)}`] : []),
       ...(legacyFullDiskReadDetected ? ['[repo-harness mcp] Legacy full-disk read: detected and disabled; use --allow-root to authorize reader roots'] : []),
+      `[repo-harness mcp] General repo rollout: read=${generalRepoRollout.general_repo_read ? 'on' : 'off'}, write=${generalRepoRollout.repo_write ? 'on' : 'off'}, fs_fallback=${generalRepoRollout.fs_fallback ? 'on' : 'off'}, shadow=${generalRepoRollout.shadow_compare ? 'on' : 'off'}, rollback=${generalRepoRollout.rollback_to_legacy_tools ? 'on' : 'off'}`,
       `[repo-harness mcp] Profile: ${profile}`,
       `[repo-harness mcp] ChatGPT MCP server name: ${serverName}`,
       `[repo-harness mcp] Local endpoint: http://${host}:${port}/mcp`,

--- a/src/cli/mcp/tools.ts
+++ b/src/cli/mcp/tools.ts
@@ -2,7 +2,7 @@ import { createHash } from 'crypto';
 import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, statSync, writeFileSync, appendFileSync } from 'fs';
 import { homedir } from 'os';
 import { basename, dirname, isAbsolute, join, resolve } from 'path';
-import { isRegisteredRepoHarnessRoot, readRegisteredRepoHarnessRepos } from '../../effects/repo-registry';
+import { isRegisteredRepoHarnessRoot, readRegisteredRepoHarnessRepos, repoHarnessRepoIdFor } from '../../effects/repo-registry';
 import { runProcess } from '../../effects/process-runner';
 import { runHelper } from '../runtime/helper-runner';
 import { listSessions, openSession, readSession, runBrowserConsult, runBrowserFollowup } from '../chatgpt-browser/engine';
@@ -10,6 +10,7 @@ import type { BrowserProviderName, NativeBrowserChannel, ThinkingLevel } from '.
 import { hashMcpInput, tryWriteMcpAuditEntry } from './audit';
 import { isPathInside, resolveMcpPath } from './paths';
 import { buildReaderToolDefinitions, callReaderTool, createReaderToolContext, isReaderTool } from './reader-tools';
+import { callGeneralRepoTool } from './general-repo-access';
 import { currentGitBranch, isRepoHarnessAdopted, resolveMcpRepoRoot } from './repo';
 import { redactMcpText } from './redaction';
 import type { McpAgentRunnerName, McpPolicy } from './types';
@@ -43,6 +44,7 @@ interface CallToolResult {
 
 const DEFAULT_DISCOVERY_DEPTH = 7;
 const DEFAULT_DISCOVERY_LIMIT = 12;
+const GENERAL_REPO_READ_SINGLE_CHUNK_BYTES = 262_144;
 const DISCOVERY_SKIP_DIRS = new Set([
   '.bun',
   '.codegraph',
@@ -300,6 +302,33 @@ function fileSummary(path: string, repoRoot: string): { path: string; size: numb
   } catch (_error) {
     return null;
   }
+}
+
+async function readWorkflowFileViaGeneralRepo(ctx: McpToolContext, repoRoot: string, relativePath: string, fileSize: number): Promise<CallToolResult | null> {
+  if (
+    !ctx.policy.generalRepo.general_repo_read ||
+    ctx.policy.generalRepo.rollback_to_legacy_tools ||
+    fileSize > GENERAL_REPO_READ_SINGLE_CHUNK_BYTES
+  ) {
+    return null;
+  }
+  const repoId = repoHarnessRepoIdFor(realpathSync(repoRoot));
+  const result = await callGeneralRepoTool(ctx, 'read_file', { repo_id: repoId, path: relativePath });
+  const payload = typeof result.structuredContent === 'object' && result.structuredContent !== null
+    ? result.structuredContent as Record<string, unknown>
+    : JSON.parse(result.content[0]?.text ?? '{}') as Record<string, unknown>;
+  if (payload.error) return result;
+  if (payload.encoding !== 'utf-8' || typeof payload.content !== 'string' || payload.has_more === true) return null;
+  const redacted = redactMcpText(payload.content);
+  return textResult({
+    path: relativePath,
+    size: fileSize,
+    sha256: payload.sha256,
+    redactions: redacted.redactions,
+    content: redacted.text,
+    source: 'general_repo_read_file',
+    correlation_id: payload.correlation_id,
+  });
 }
 
 function listFilesUnder(repoRoot: string, root: string, maxFiles: number, out: string[]): void {
@@ -881,7 +910,7 @@ export function buildMcpToolDefinitions(policy: McpPolicy, opts: { enableChatgpt
     tools.push({ name: 'run_workflow_check', description: 'Run the fixed repo-harness strict workflow check in the current or target registered repo.', inputSchema: optionalRepoSchema, annotations: write });
   }
   if (policy.capabilities.workspaceReader) {
-    tools.push(...buildReaderToolDefinitions());
+    tools.push(...buildReaderToolDefinitions(policy));
   }
   if (opts.enableChatgptBrowser === true) {
     tools.push(
@@ -943,7 +972,7 @@ export function buildMcpToolDefinitions(policy: McpPolicy, opts: { enableChatgpt
 
 export async function callMcpTool(ctx: McpToolContext, name: string, args: Record<string, unknown> = {}): Promise<CallToolResult> {
   try {
-    if (isReaderTool(name)) {
+    if (isReaderTool(name, ctx.policy)) {
       if (!ctx.policy.capabilities.workspaceReader) {
         return errorResult('TOOL_NOT_AVAILABLE', 'reader tools require the workspace reader capability to be enabled in MCP config.');
       }
@@ -1017,6 +1046,11 @@ export async function callMcpTool(ctx: McpToolContext, name: string, args: Recor
         const fileStat = statSync(decision.absolutePath);
         if (!fileStat.isFile()) return errorResult('NOT_A_FILE', `path is not a file: ${decision.relativePath}`);
         if (fileStat.size > ctx.policy.maxFileBytes) return errorResult('FILE_TOO_LARGE', `file exceeds ${ctx.policy.maxFileBytes} bytes`);
+        const generalRepoRead = await readWorkflowFileViaGeneralRepo(ctx, target.repoRoot, decision.relativePath, fileStat.size);
+        if (generalRepoRead) {
+          audit(ctx, name, generalRepoRead.isError ? 'blocked' : 'ok', args, decision.relativePath);
+          return generalRepoRead;
+        }
         const bytes = readFileSync(decision.absolutePath);
         if (isProbablyBinary(bytes)) return errorResult('BINARY_FILE', 'binary files are not supported');
         const raw = bytes.toString('utf-8');

--- a/src/cli/mcp/types.ts
+++ b/src/cli/mcp/types.ts
@@ -17,6 +17,14 @@ export interface McpPolicy {
   denyGlobs: string[];
   allowAbsoluteRead?: boolean;
   maxFileBytes: number;
+  generalRepo: {
+    general_repo_read: boolean;
+    repo_write: boolean;
+    fs_fallback: boolean;
+    shadow_compare: boolean;
+    canary_repos: string[];
+    rollback_to_legacy_tools: boolean;
+  };
   execution: {
     fixedWorkflowCheck: boolean;
     codexRunner: boolean;

--- a/tasks/notes/20260622-repo-harness-codegraph.notes.md
+++ b/tasks/notes/20260622-repo-harness-codegraph.notes.md
@@ -291,3 +291,58 @@ Sprint 0 contract freeze for `plans/sprints/20260622-repo-harness-codegraph-spri
   large-log max latency aggregation, blocked-vs-failed reporting, manifest-only
   parity failure accounting, snapshot stability coverage, and escape-input
   redaction assertions.
+
+## 2026-06-23 S4 migration slice
+
+- Added `McpPolicy.generalRepo` as the rollout boundary for general repo access:
+  `general_repo_read`, `repo_write`, `fs_fallback`, `shadow_compare`,
+  `canary_repos`, and `rollback_to_legacy_tools`. Local MCP config persists the
+  same flags under `rollout.generalRepo`; environment overrides give operators
+  a one-process rollback/canary path without editing registry state.
+- Defaults preserve the current read migration path while keeping writes
+  explicit: general repo read is enabled, repo write is disabled, filesystem
+  fallback is enabled, shadow mode is disabled, and rollback is disabled. This
+  keeps read-only ChatGPT analysis usable while requiring both repo
+  `read_write` capability and rollout `repo_write=true` before mutation tools
+  are listed or executed.
+- Legacy `read_workflow_file` now preferentially calls the new `read_file`
+  service, then reshapes/redacts the result into the old artifact response. It
+  deliberately falls back to the old bounded workflow path when rollback mode is
+  active or when a file exceeds the new single-call read chunk. That preserves
+  existing workflow clients while exercising the new repo service in normal
+  migration traffic.
+- `fs_fallback=false` does not hide files from manifest/stat. It blocks
+  unindexed file content reads with `INDEX_UNAVAILABLE` and records skipped
+  fallback search candidates as partial search output. This preserves the
+  invariant that index/fallback limits are observable constraints, not
+  permission denials.
+- Added `scripts/mcp-rollout-gate.ts` as the local release/canary gate for this
+  migration. It compares legacy workflow file listing/read compatibility against
+  the new manifest/tree/search path, validates rollback tool-surface behavior,
+  selects configured canaries, and records CodeGraph ignore recheck status.
+- Self-host rollout gate passed with `shadow=pass`, `canary=ready`, and
+  `rollback=pass`. The live global registry currently contains one adopted
+  read-only canary, this repo, classified as medium. The script supports
+  configured 1-3 canaries and `--require-three-canaries`; the later release-exit
+  gate should use that stricter mode once small/large registered canaries exist.
+
+## 2026-06-23 S4 documentation and exit slice
+
+- Folded S4-DOC/exit into PR #32 instead of opening a fourth small PR. The
+  reviewable module boundary is now migration, rollout gate, documentation, and
+  exit evidence on the S4-MIG branch.
+- Added `docs/reference-configs/general-repo-mcp.md` as the public reference for
+  general repo MCP tool examples, repo administration, `.ignore` policy,
+  CodeGraph health, privacy/audit, workflow-artifact migration, rollout flags,
+  and known limits.
+- Added `deploy/runbooks/general-repo-mcp-codegraph.md` for index stale,
+  CodeGraph down, manifest incomplete, mutation conflict, reindex dead-letter,
+  write-disable, fallback-disable, and rollback operations.
+- Added `deploy/release-checklists/260623-repo-harness-codegraph-general-repo.md`
+  to keep Sprint 4 release evidence distinct from npm publish authority.
+- README and the ChatGPT MCP setup guide now link to the reference and runbook;
+  the setup guide generator was updated so future generated guides keep the same
+  general repo entrypoints.
+- Sprint 4 machine-verifiable exit criteria are closed. Human release/test/
+  security signoff remains the PR review/merge gate and is not self-signed by
+  the implementing agent.

--- a/tests/cli/mcp-reader-tools.test.ts
+++ b/tests/cli/mcp-reader-tools.test.ts
@@ -81,7 +81,11 @@ async function withReaderRepo<T>(fn: (repoRoot: string, ctx: ReaderToolContext) 
     } catch (_error) {
       // Symlinks may be unavailable on some runners; tree must still be covered by ordinary directories.
     }
-    const policy = getMcpPolicy('planner', { enableReader: true, allowedRoots: [repoRoot] });
+    const policy = getMcpPolicy('planner', {
+      enableReader: true,
+      allowedRoots: [repoRoot],
+      generalRepo: { repo_write: opts.accessMode === 'read_write' },
+    });
     const ctx = createReaderToolContext(repoRoot, policy, new WorkspaceManager({ allowedRoots: [repoRoot], policy }));
     return await fn(repoRoot, ctx);
   } finally {
@@ -155,6 +159,56 @@ describe('MCP reader tools', () => {
       const otherCtx = createReaderToolContext(repoRoot, otherPolicy, new WorkspaceManager({ allowedRoots: [repoRoot], policy: otherPolicy }));
       const denied = await jsonTool(otherCtx, 'tree', { workspace_id: opened.workspace_id });
       expect(denied.error.code).toBe('WORKSPACE_NOT_FOUND');
+    });
+  });
+
+  test('general repo rollout flags gate tool surface, writes, fallback, and rollback mode', async () => {
+    await withReaderRepo(async (repoRoot) => {
+      const repoId = repoHarnessRepoIdFor(realpathSync(repoRoot));
+      const readOnlyPolicy = getMcpPolicy('planner', {
+        enableReader: true,
+        allowedRoots: [repoRoot],
+        generalRepo: { repo_write: false },
+      });
+      const readOnlyTools = buildReaderToolDefinitions(readOnlyPolicy).map((tool) => tool.name);
+      expect(readOnlyTools).toContain('repo_manifest');
+      expect(readOnlyTools).toContain('read_file');
+      expect(readOnlyTools).not.toContain('write_file');
+      expect(readOnlyTools).not.toContain('refresh_repo_index');
+      const readOnlyCtx = createReaderToolContext(repoRoot, readOnlyPolicy, new WorkspaceManager({ allowedRoots: [repoRoot], policy: readOnlyPolicy }));
+      const blockedWrite = await jsonTool(readOnlyCtx, 'write_file', {
+        repo_id: repoId,
+        path: 'docs/generated.txt',
+        content: 'new\n',
+        must_not_exist: true,
+      });
+      expect(blockedWrite.error.code).toBe('WRITE_DISABLED');
+
+      const noFallbackPolicy = getMcpPolicy('planner', {
+        enableReader: true,
+        allowedRoots: [repoRoot],
+        generalRepo: { fs_fallback: false },
+      });
+      const noFallbackCtx = createReaderToolContext(repoRoot, noFallbackPolicy, new WorkspaceManager({ allowedRoots: [repoRoot], policy: noFallbackPolicy }));
+      const manifest = await jsonTool(noFallbackCtx, 'repo_manifest', { repo_id: repoId, page_size: 1000 });
+      expect(manifest.entries.some((entry: { path: string }) => entry.path === 'src/index.ts')).toBe(true);
+      const unindexedRead = await jsonTool(noFallbackCtx, 'read_file', { repo_id: repoId, path: 'src/index.ts' });
+      expect(unindexedRead.error.code).toBe('INDEX_UNAVAILABLE');
+
+      const rollbackPolicy = getMcpPolicy('planner', {
+        enableReader: true,
+        allowedRoots: [repoRoot],
+        generalRepo: { general_repo_read: false, rollback_to_legacy_tools: true },
+      });
+      const rollbackTools = buildReaderToolDefinitions(rollbackPolicy).map((tool) => tool.name);
+      expect(rollbackTools).toContain('read_text');
+      expect(rollbackTools).toContain('search_text');
+      expect(rollbackTools).not.toContain('repo_manifest');
+      expect(rollbackTools).not.toContain('read_file');
+      expect(rollbackTools).not.toContain('write_file');
+      const rollbackCtx = createReaderToolContext(repoRoot, rollbackPolicy, new WorkspaceManager({ allowedRoots: [repoRoot], policy: rollbackPolicy }));
+      const blockedManifest = await jsonTool(rollbackCtx, 'repo_manifest', { repo_id: repoId });
+      expect(blockedManifest.error.code).toBe('TOOL_NOT_AVAILABLE');
     });
   });
 

--- a/tests/cli/mcp-setup.test.ts
+++ b/tests/cli/mcp-setup.test.ts
@@ -462,13 +462,16 @@ describe('mcp setup', () => {
     expect(guide).toContain('oauth-protected-resource');
     expect(guide).toContain('--auth bearer');
     expect(guide).toContain('--auth url-token');
-    expect(guide).toContain('open_workspace');
+    expect(guide).toContain('repo_manifest');
+    expect(guide).toContain('read_file');
+    expect(guide).toContain('get_repo_capabilities');
     expect(guide).toContain('--allow-root "$HOME/Documents"');
     expect(guide).toContain('rescan the Connector tools');
     expect(guide).toContain('delete and recreate the App/Connector');
     expect(guide).toContain('## Reader Test Prompt');
     expect(guide).toContain('Blocked-file smoke');
-    expect(guide).toContain('secrets/token.txt');
+    expect(guide).toContain('../outside');
+    expect(guide).toContain('SYMLINK_ESCAPE');
     expect(guide).toContain('deny globs');
     expect(guide).toContain('## Dev Mode Agent Runner');
     expect(guide).toContain('--enable-dev-runner');

--- a/tests/cli/mcp-tools.test.ts
+++ b/tests/cli/mcp-tools.test.ts
@@ -122,6 +122,8 @@ describe('mcp tools', () => {
       const read = await jsonTool(ctx, 'read_workflow_file', { path: 'tasks/current.md' });
       expect(read.path).toBe('tasks/current.md');
       expect(read.content).toContain('status=Active');
+      expect(read.source).toBe('general_repo_read_file');
+      expect(read.correlation_id).toMatch(/^mcpcorr_/);
 
       const denied = await jsonTool(ctx, 'read_workflow_file', { path: '.env' });
       expect(denied.error.code).toBe('POLICY_DENIED');

--- a/tests/mcp-rollout-gate.test.ts
+++ b/tests/mcp-rollout-gate.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { buildMcpRolloutGateReport } from "../scripts/mcp-rollout-gate";
+
+function withRolloutRepo<T>(fn: (repoRoot: string) => Promise<T>): Promise<T> {
+  const repoRoot = mkdtempSync(join(tmpdir(), "repo-harness-mcp-rollout-gate-"));
+  const repoHarnessHome = mkdtempSync(join(tmpdir(), "repo-harness-mcp-rollout-home-"));
+  const previousHome = process.env.REPO_HARNESS_HOME;
+  return (async () => {
+    try {
+      process.env.REPO_HARNESS_HOME = repoHarnessHome;
+      mkdirSync(join(repoRoot, ".ai", "harness", "handoff"), { recursive: true });
+      mkdirSync(join(repoRoot, ".ai", "harness", "checks"), { recursive: true });
+      mkdirSync(join(repoRoot, "plans", "prds"), { recursive: true });
+      mkdirSync(join(repoRoot, "plans", "sprints"), { recursive: true });
+      mkdirSync(join(repoRoot, "tasks"), { recursive: true });
+      writeFileSync(join(repoRoot, ".ai", "harness", "policy.json"), "{}\n");
+      writeFileSync(join(repoRoot, "AGENTS.md"), "repo-harness rollout instructions\n");
+      writeFileSync(join(repoRoot, "tasks", "current.md"), "status=Active\nrepo-harness\n");
+      writeFileSync(join(repoRoot, "plans", "prds", "example.prd.md"), "# PRD\nrepo-harness\n");
+      writeFileSync(join(repoRoot, "plans", "sprints", "example.sprint.md"), "# Sprint\nrepo-harness\n");
+      return await fn(repoRoot);
+    } finally {
+      if (previousHome === undefined) delete process.env.REPO_HARNESS_HOME;
+      else process.env.REPO_HARNESS_HOME = previousHome;
+      rmSync(repoRoot, { recursive: true, force: true });
+      rmSync(repoHarnessHome, { recursive: true, force: true });
+    }
+  })();
+}
+
+describe("mcp rollout gate", () => {
+  test("builds a passing shadow, canary, rollback, and CodeGraph-ignore audit report", async () => {
+    await withRolloutRepo(async (repoRoot) => {
+      const report = await buildMcpRolloutGateReport({ repo: repoRoot, query: "repo-harness" });
+
+      expect(report.ok).toBe(true);
+      expect(report.shadow.status).toBe("pass");
+      expect(report.shadow.legacy_files).toBeGreaterThan(0);
+      expect(report.shadow.missing_from_manifest).toEqual([]);
+      expect(report.shadow.compared_reads).toBeGreaterThan(0);
+      expect(report.shadow.mismatched_reads).toEqual([]);
+      expect(report.shadow.search.checked).toBe(true);
+      expect(report.shadow.search.general_repo_matches).toBeGreaterThan(0);
+      expect(report.canary.stage).toBe("read_only");
+      expect(report.canary.selected_repos.length).toBeGreaterThan(0);
+      expect(report.canary.read_write_repo_enabled).toBeNull();
+      expect(report.rollback.status).toBe("pass");
+      expect(report.rollback.legacy_tools_available).toBe(true);
+      expect(report.rollback.general_repo_tools_hidden).toBe(true);
+      expect(report.rollback.command).toContain("REPO_HARNESS_MCP_ROLLBACK_LEGACY_TOOLS=1");
+      expect(report.codegraph_ignore_audit.manifest_complete).toBe(true);
+      expect(existsSync(join(repoRoot, ".ai", "harness", "mcp", "metrics.jsonl"))).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add policy-driven general repo MCP rollout flags for read/write, fs fallback, shadow compare, canaries, and legacy rollback.
- Gate the reader/general repo tool surface from policy, including write-disable, fallback-disable, and rollback behavior.
- Add the self-host rollout gate for shadow parity, canary readiness, rollback surface, and CodeGraph ignore audit.
- Add the S4 operator docs package: tool reference with JSON examples, repo admin guide, CodeGraph health guidance, privacy notes, migration guide, runbook, release filing, known limits, and Sprint exit evidence.

## P1 Map
- Boundary: ChatGPT/Codex MCP server policy -> reader tool registry -> general repo access implementation -> rollout/observability gates -> docs/runbook/release evidence.
- Authoritative files: `src/cli/mcp/policy.ts`, `reader-tools.ts`, `general-repo-access.ts`, `tools.ts`, `setup.ts`, `scripts/mcp-rollout-gate.ts`, `docs/reference-configs/general-repo-mcp.md`, `deploy/runbooks/general-repo-mcp-codegraph.md`.
- Out of scope: npm publish, Git tag, GitHub release publication, and human release/test/security signoff; those remain the PR review/merge and package release gates.

## P2 Trace
- MCP server builds policy from local config/env rollout flags, builds tool definitions from that policy, and dispatches reader calls through policy-aware `isReaderTool`/`callReaderTool`.
- `read_workflow_file` shadows through `read_file` when enabled, then normalizes the legacy response shape; rollback or oversized reads fall back to the legacy bounded path.
- The rollout gate exercises legacy/new reads, manifest/tree/search parity, registered canary readiness, rollback tool visibility, and ignored-path audit before writing a local report.
- Docs now route operators from setup guide/README to the full reference, runbook, and release filing.

## P3 Decision
- Default posture is conservative: general read on, repo write off, fs fallback on, shadow off, rollback off.
- The smallest compatible implementation is policy-driven gating around the existing MCP registry and general-repo functions, not a second server mode.
- At 10x repo scale the first pressure point is canary breadth and search/manifest cost, so the gate supports `--require-three-canaries` while today recording the one registered self-host read-only canary honestly.

## Verification
- `bun test`: 978 pass / 1 skip / 0 fail / 10276 expect calls
- `bun run check:type`
- `bun test tests/cli/mcp-setup.test.ts tests/action-command-skills.test.ts`
- `bun test tests/cli/mcp-reader-tools.test.ts tests/cli/mcp-tools.test.ts tests/mcp-rollout-gate.test.ts`
- `bun scripts/mcp-rollout-gate.ts --repo . --out .ai/harness/runs/mcp-rollout-gate.json`
- `bun scripts/mcp-observability-report.ts --repo . --out .ai/harness/runs/mcp-observability-report.json`
- `bash scripts/check-deploy-sql-order.sh`
- `bash scripts/check-architecture-sync.sh`
- `bash scripts/check-task-sync.sh`
- `bash scripts/check-task-workflow.sh --strict`
- `bun scripts/inspect-project-state.ts --repo . --format text`
- `bash scripts/migrate-project-template.sh --repo . --dry-run`
- `bash scripts/ensure-codegraph.sh --sync`
- `repo-harness setup check --target codex --check-updates --json`