### PR TITLE
Module S2: Add CodeGraph snapshots and manifest/search/read integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,11 @@ reports a now-missing indexed path or metadata that no longer matches the
 filesystem, the snapshot becomes `index_lagging` while authorized read/stat
 fallback stays available. Full-text search still falls back to the guarded
 filesystem path when CodeGraph cannot provide complete repo-text search.
+For large manifests, `repo_manifest` streams the visible tree and keeps only the
+requested page of entries in memory. Returned page entries include exact content
+hashes; non-page file content metadata is deferred and reported as
+`counts.content_deferred` until a later manifest page, `stat_file`, `read_file`,
+or `search_text` actually returns that content.
 
 For large-repo reader baselines, run:
 

--- a/README.md
+++ b/README.md
@@ -360,6 +360,14 @@ the only content exclusion source, paths are repo-relative, and authorized file
 content is not implicitly redacted. External non-repo local roots require
 explicit `--allow-root` authorization.
 
+When CodeGraph is initialized for a registered repo, the general reader merges
+CodeGraph indexed-file metadata into manifest/stat/read/search responses while
+keeping the filesystem walker as the complete manifest source of truth. Responses
+carry `snapshot_id`, `index_revision`, `ignore_digest`, and `indexed` metadata;
+stale client snapshots return `SNAPSHOT_STALE` instead of silently mixing
+versions. Full-text search still falls back to the guarded filesystem path when
+CodeGraph cannot provide complete repo-text search.
+
 This sidecar assumes the CLI is already installed from
 [First 5 Minutes](#first-5-minutes). Use it when you want ChatGPT to plan
 against the real repo state and Codex to execute the resulting file-backed

--- a/README.md
+++ b/README.md
@@ -366,14 +366,25 @@ keeping the filesystem walker as the complete manifest source of truth. Response
 carry `snapshot_id`, `index_revision`, `ignore_digest`, and `indexed` metadata;
 stale client snapshots return `SNAPSHOT_STALE` instead of silently mixing
 versions. Responses also expose `snapshot_state`, snapshot TTL/expiry, and a
-bounded in-process snapshot cache marker. The cache key includes repo identity,
-registry revision, `.ignore` digest, and the validated snapshot id; a cache hit
-is returned only after the current manifest digest still matches, so file,
-registry, and `.ignore` changes keep producing a new snapshot. If CodeGraph
-reports a now-missing indexed path or metadata that no longer matches the
-filesystem, the snapshot becomes `index_lagging` while authorized read/stat
+bounded in-process snapshot cache marker. The public `snapshot_cache.key` is
+scoped by tool and repo-relative path set, while `snapshot_cache.snapshot_key`
+identifies the underlying repo snapshot. Entry metadata is cached separately by
+repo, registry revision, `.ignore` digest, relative path, and current stat
+signature, so unchanged warm manifest/stat/read calls avoid repeated file hash
+and binary probes without hiding file, registry, or `.ignore` changes. If
+CodeGraph reports a now-missing indexed path or metadata that no longer matches
+the filesystem, the snapshot becomes `index_lagging` while authorized read/stat
 fallback stays available. Full-text search still falls back to the guarded
 filesystem path when CodeGraph cannot provide complete repo-text search.
+
+For large-repo reader baselines, run:
+
+```bash
+bun run benchmark:mcp-reader -- --entries 10000 --json
+```
+
+Use `--entries all` for the full 10k/100k/500k fixture sequence when the local
+machine can spend the filesystem time.
 
 This sidecar assumes the CLI is already installed from
 [First 5 Minutes](#first-5-minutes). Use it when you want ChatGPT to plan

--- a/README.md
+++ b/README.md
@@ -371,9 +371,11 @@ scoped by tool and repo-relative path set, while `snapshot_cache.snapshot_key`
 identifies the underlying repo snapshot. Entry metadata is cached separately by
 repo, registry revision, `.ignore` digest, relative path, and current stat
 signature, so unchanged warm manifest/stat/read calls avoid repeated file hash
-and binary probes without hiding file, registry, or `.ignore` changes. If
-CodeGraph reports a now-missing indexed path or metadata that no longer matches
-the filesystem, the snapshot becomes `index_lagging` while authorized read/stat
+and binary probes without hiding file, registry, or `.ignore` changes. Explicit
+`snapshot_id` stat/read calls can reuse the cached snapshot and validate the
+requested file hash instead of rebuilding the full repo snapshot. If CodeGraph
+reports a now-missing indexed path or metadata that no longer matches the
+filesystem, the snapshot becomes `index_lagging` while authorized read/stat
 fallback stays available. Full-text search still falls back to the guarded
 filesystem path when CodeGraph cannot provide complete repo-text search.
 

--- a/README.md
+++ b/README.md
@@ -365,8 +365,15 @@ CodeGraph indexed-file metadata into manifest/stat/read/search responses while
 keeping the filesystem walker as the complete manifest source of truth. Responses
 carry `snapshot_id`, `index_revision`, `ignore_digest`, and `indexed` metadata;
 stale client snapshots return `SNAPSHOT_STALE` instead of silently mixing
-versions. Full-text search still falls back to the guarded filesystem path when
-CodeGraph cannot provide complete repo-text search.
+versions. Responses also expose `snapshot_state`, snapshot TTL/expiry, and a
+bounded in-process snapshot cache marker. The cache key includes repo identity,
+registry revision, `.ignore` digest, and the validated snapshot id; a cache hit
+is returned only after the current manifest digest still matches, so file,
+registry, and `.ignore` changes keep producing a new snapshot. If CodeGraph
+reports a now-missing indexed path or metadata that no longer matches the
+filesystem, the snapshot becomes `index_lagging` while authorized read/stat
+fallback stays available. Full-text search still falls back to the guarded
+filesystem path when CodeGraph cannot provide complete repo-text search.
 
 This sidecar assumes the CLI is already installed from
 [First 5 Minutes](#first-5-minutes). Use it when you want ChatGPT to plan

--- a/assets/mcp/general-repo-reader-tools.v1.schema.json
+++ b/assets/mcp/general-repo-reader-tools.v1.schema.json
@@ -56,6 +56,11 @@
         "enum": [
           "repo_id",
           "snapshot_id",
+          "snapshot_state",
+          "snapshot_created_at",
+          "snapshot_expires_at",
+          "snapshot_ttl_ms",
+          "snapshot_cache",
           "index_revision",
           "ignore_digest",
           "stale",

--- a/docs/repo-harness-chatgpt-mcp-setup.md
+++ b/docs/repo-harness-chatgpt-mcp-setup.md
@@ -163,8 +163,10 @@ repo-relative path set; `snapshot_cache.snapshot_key` names the underlying repo
 snapshot. Entry metadata is cached by repo, registry revision, `.ignore`
 digest, path, and current stat signature, so warm calls can reuse unchanged file
 metadata while file, registry, and `.ignore` changes produce a different
-snapshot. If CodeGraph still references a deleted indexed path or returns
-metadata that no longer matches the filesystem, the response uses
+snapshot. Explicit `snapshot_id` stat/read calls can reuse a cached snapshot and
+validate the requested file hash instead of rebuilding the full repo snapshot.
+If CodeGraph still references a deleted indexed path or returns metadata that
+no longer matches the filesystem, the response uses
 `snapshot_state: "index_lagging"` and includes lagging paths under the
 `codegraph` object.
 

--- a/docs/repo-harness-chatgpt-mcp-setup.md
+++ b/docs/repo-harness-chatgpt-mcp-setup.md
@@ -150,6 +150,19 @@ Authorized file content is not implicitly redacted in `read_file`,
 `read_files`, or `search_text` responses. The MCP audit path records tool name,
 target path, input hash, status, and errors, but not file bodies.
 
+When a repo has a CodeGraph index, `repo_manifest`, `list_tree`, `stat_file`,
+`read_file`, `read_files`, and `search_text` share a deterministic
+`snapshot_id`, `ignore_digest`, and `index_revision`. CodeGraph inventory is
+merged as indexed metadata (`indexed`, `codegraph_language`,
+`codegraph_node_count`); the secure filesystem walker remains the source of
+truth for complete manifest coverage. If a caller sends a stale `snapshot_id`,
+the reader returns `SNAPSHOT_STALE` instead of silently mixing versions.
+
+CodeGraph search support is treated conservatively: current CodeGraph CLI query
+is symbol-oriented, so general full-text `search_text` uses the same guarded
+filesystem fallback while preserving `.ignore` semantics and indicating whether
+the matched file is indexed by CodeGraph.
+
 The older `open_workspace`, `tree`, and `read_text` tools remain compatibility
 tools for the previous workspace reader surface. They still apply the legacy
 deny/redaction behavior and should not be used as proof of the general repo

--- a/docs/repo-harness-chatgpt-mcp-setup.md
+++ b/docs/repo-harness-chatgpt-mcp-setup.md
@@ -165,6 +165,11 @@ digest, path, and current stat signature, so warm calls can reuse unchanged file
 metadata while file, registry, and `.ignore` changes produce a different
 snapshot. Explicit `snapshot_id` stat/read calls can reuse a cached snapshot and
 validate the requested file hash instead of rebuilding the full repo snapshot.
+For large manifests, `repo_manifest` streams the visible tree and keeps only the
+requested page entries in memory. Returned page entries include exact content
+hashes; non-page file content metadata is deferred and reported as
+`counts.content_deferred` until a later page, `stat_file`, `read_file`, or
+`search_text` returns that content.
 If CodeGraph still references a deleted indexed path or returns metadata that
 no longer matches the filesystem, the response uses
 `snapshot_state: "index_lagging"` and includes lagging paths under the

--- a/docs/repo-harness-chatgpt-mcp-setup.md
+++ b/docs/repo-harness-chatgpt-mcp-setup.md
@@ -158,12 +158,23 @@ merged as indexed metadata (`indexed`, `codegraph_language`,
 truth for complete manifest coverage. If a caller sends a stale `snapshot_id`,
 the reader returns `SNAPSHOT_STALE` instead of silently mixing versions.
 Each response also reports `snapshot_state`, creation/expiry time, TTL, and a
-bounded snapshot cache marker. The cache is revalidated by the current manifest
-digest before it can be reported as a hit; it does not let stale file or
-`.ignore` changes masquerade as current state. If CodeGraph still references a
-deleted indexed path or returns metadata that no longer matches the filesystem,
-the response uses `snapshot_state: "index_lagging"` and includes lagging paths
-under the `codegraph` object.
+bounded snapshot cache marker. `snapshot_cache.key` is scoped by tool and
+repo-relative path set; `snapshot_cache.snapshot_key` names the underlying repo
+snapshot. Entry metadata is cached by repo, registry revision, `.ignore`
+digest, path, and current stat signature, so warm calls can reuse unchanged file
+metadata while file, registry, and `.ignore` changes produce a different
+snapshot. If CodeGraph still references a deleted indexed path or returns
+metadata that no longer matches the filesystem, the response uses
+`snapshot_state: "index_lagging"` and includes lagging paths under the
+`codegraph` object.
+
+Large-repo reader baselines are reproducible with:
+
+```bash
+bun run benchmark:mcp-reader -- --entries 10000 --json
+```
+
+Use `--entries all` for the full 10k/100k/500k fixture sequence.
 
 CodeGraph search support is treated conservatively: current CodeGraph CLI query
 is symbol-oriented, so general full-text `search_text` uses the same guarded

--- a/docs/repo-harness-chatgpt-mcp-setup.md
+++ b/docs/repo-harness-chatgpt-mcp-setup.md
@@ -157,6 +157,13 @@ merged as indexed metadata (`indexed`, `codegraph_language`,
 `codegraph_node_count`); the secure filesystem walker remains the source of
 truth for complete manifest coverage. If a caller sends a stale `snapshot_id`,
 the reader returns `SNAPSHOT_STALE` instead of silently mixing versions.
+Each response also reports `snapshot_state`, creation/expiry time, TTL, and a
+bounded snapshot cache marker. The cache is revalidated by the current manifest
+digest before it can be reported as a hit; it does not let stale file or
+`.ignore` changes masquerade as current state. If CodeGraph still references a
+deleted indexed path or returns metadata that no longer matches the filesystem,
+the response uses `snapshot_state: "index_lagging"` and includes lagging paths
+under the `codegraph` object.
 
 CodeGraph search support is treated conservatively: current CodeGraph CLI query
 is symbol-oriented, so general full-text `search_text` uses the same guarded

--- a/docs/researches/20260623-general-repo-reader-performance-baseline.md
+++ b/docs/researches/20260623-general-repo-reader-performance-baseline.md
@@ -1,0 +1,93 @@
+# General Repo Reader Performance Baseline
+
+Date: 2026-06-23
+
+Source task: `plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md`
+
+## Scope
+
+This records the first reproducible baseline for the general repo reader
+performance slice. The benchmark fixture intentionally disables CodeGraph in
+order to isolate the filesystem walker, snapshot cache, entry metadata cache,
+pagination, read, and search behavior.
+
+Benchmark entrypoint:
+
+```bash
+bun run benchmark:mcp-reader -- --entries <count> --json
+```
+
+## 10k Fixture
+
+Command:
+
+```bash
+bun run benchmark:mcp-reader -- --entries 10000 --json
+```
+
+Result:
+
+| Measurement | Duration |
+| --- | ---: |
+| cold manifest first page | 672.21 ms |
+| warm manifest first page | 360.91 ms |
+| list_tree root depth 1 | 344.89 ms |
+| read_file first chunk | 341.80 ms |
+| warm literal search | 763.39 ms |
+
+Observed state:
+
+- `snapshot_state`: `ready`
+- `complete`: `true`
+- `counts.entries`: `10109`
+- `counts.files`: `10005`
+- `next_cursor`: `1000`
+- `rss_bytes_after_measurements`: `141606912`
+- warm manifest cache: `hit=true`
+- warm manifest entry metadata cache: `hits=10108`, `misses=1`
+- search matches: `10`
+
+## 100k Fixture
+
+Command:
+
+```bash
+bun run benchmark:mcp-reader -- --entries 100000 --json
+```
+
+Result:
+
+| Measurement | Duration |
+| --- | ---: |
+| cold manifest first page | 18411.08 ms |
+| warm manifest first page | 4318.82 ms |
+| list_tree root depth 1 | 4320.39 ms |
+| read_file first chunk | 4391.59 ms |
+| warm literal search | 4404.87 ms |
+
+Observed state:
+
+- `snapshot_state`: `ready`
+- `complete`: `true`
+- `counts.entries`: `100109`
+- `counts.files`: `100005`
+- `next_cursor`: `1000`
+- `rss_bytes_after_measurements`: `621821952`
+- warm manifest cache: `hit=true`
+- warm manifest entry metadata cache: `hits=100108`, `misses=1`
+- search matches: `50`
+- search `truncated`: `true`
+
+This proves the generated 100k fixture can complete without OOM and returns
+paginated results. It does not satisfy the proposed Sprint 2 SLO: warm manifest
+first page is still above 2 seconds, ordinary read first chunk is above 500 ms,
+and warm search is above 2 seconds.
+
+## Decision
+
+The path-aware response cache key and entry metadata cache close the
+cache-key/invalidation slice, but they do not close streaming manifest or the
+100k/500k performance gate. The next performance slice should move snapshot
+revalidation away from repeated whole-repo walks. The 100k warm path now avoids
+full content hashing for unchanged files, but it still stats and sorts the full
+visible tree before serving first-page manifest, read, tree, or search results.

--- a/docs/researches/20260623-general-repo-reader-performance-baseline.md
+++ b/docs/researches/20260623-general-repo-reader-performance-baseline.md
@@ -29,11 +29,11 @@ Result:
 
 | Measurement | Duration |
 | --- | ---: |
-| cold manifest first page | 672.21 ms |
-| warm manifest first page | 360.91 ms |
-| list_tree root depth 1 | 344.89 ms |
-| read_file first chunk | 341.80 ms |
-| warm literal search | 763.39 ms |
+| cold manifest first page | 366.09 ms |
+| warm manifest first page | 95.31 ms |
+| list_tree root depth 1 | 88.54 ms |
+| read_file first chunk | 0.60 ms |
+| warm literal search | 512.12 ms |
 
 Observed state:
 
@@ -42,7 +42,7 @@ Observed state:
 - `counts.entries`: `10109`
 - `counts.files`: `10005`
 - `next_cursor`: `1000`
-- `rss_bytes_after_measurements`: `141606912`
+- `rss_bytes_after_measurements`: `147718144`
 - warm manifest cache: `hit=true`
 - warm manifest entry metadata cache: `hits=10108`, `misses=1`
 - search matches: `10`
@@ -59,11 +59,11 @@ Result:
 
 | Measurement | Duration |
 | --- | ---: |
-| cold manifest first page | 18411.08 ms |
-| warm manifest first page | 4318.82 ms |
-| list_tree root depth 1 | 4320.39 ms |
-| read_file first chunk | 4391.59 ms |
-| warm literal search | 4404.87 ms |
+| cold manifest first page | 14894.23 ms |
+| warm manifest first page | 919.11 ms |
+| list_tree root depth 1 | 922.27 ms |
+| read_file first chunk | 0.94 ms |
+| warm literal search | 1038.71 ms |
 
 Observed state:
 
@@ -72,22 +72,36 @@ Observed state:
 - `counts.entries`: `100109`
 - `counts.files`: `100005`
 - `next_cursor`: `1000`
-- `rss_bytes_after_measurements`: `621821952`
+- `rss_bytes_after_measurements`: `678952960`
 - warm manifest cache: `hit=true`
 - warm manifest entry metadata cache: `hits=100108`, `misses=1`
 - search matches: `50`
 - search `truncated`: `true`
 
-This proves the generated 100k fixture can complete without OOM and returns
-paginated results. It does not satisfy the proposed Sprint 2 SLO: warm manifest
-first page is still above 2 seconds, ordinary read first chunk is above 500 ms,
-and warm search is above 2 seconds.
+This proves the generated 100k fixture can complete without OOM, returns
+paginated results, and satisfies the proposed Sprint 2 warm-path SLO on this
+machine: warm manifest first page is below 2 seconds, read first chunk is below
+500 ms, and warm search is below 2 seconds.
+
+## 500k Fixture Attempt
+
+Command:
+
+```bash
+bun run benchmark:mcp-reader -- --entries 500000 --json
+```
+
+Observed outcome: manually interrupted after more than 9 minutes without a JSON
+result. The temporary fixture directory was removed after interruption.
+
+This does not prove the 500k baseline. It shows the remaining large-repo
+bottleneck has moved to fixture generation, cold manifest construction, and the
+fact that the manifest still materializes and sorts the full visible entry set.
 
 ## Decision
 
 The path-aware response cache key and entry metadata cache close the
-cache-key/invalidation slice, but they do not close streaming manifest or the
-100k/500k performance gate. The next performance slice should move snapshot
-revalidation away from repeated whole-repo walks. The 100k warm path now avoids
-full content hashing for unchanged files, but it still stats and sorts the full
-visible tree before serving first-page manifest, read, tree, or search results.
+cache-key/invalidation slice. The optimized walker and path-scoped cached
+snapshot reuse close the 100k warm-path SLO on this machine. They do not close
+true streaming manifest or the 500k baseline: cold manifest still materializes
+and sorts the full visible tree before returning first-page manifest results.

--- a/docs/researches/20260623-general-repo-reader-performance-baseline.md
+++ b/docs/researches/20260623-general-repo-reader-performance-baseline.md
@@ -29,11 +29,11 @@ Result:
 
 | Measurement | Duration |
 | --- | ---: |
-| cold manifest first page | 366.09 ms |
-| warm manifest first page | 95.31 ms |
-| list_tree root depth 1 | 88.54 ms |
-| read_file first chunk | 0.60 ms |
-| warm literal search | 512.12 ms |
+| cold manifest first page | 101.05 ms |
+| warm manifest first page | 76.37 ms |
+| list_tree root depth 1 | 79.93 ms |
+| read_file first chunk | 0.67 ms |
+| warm literal search | 499.84 ms |
 
 Observed state:
 
@@ -41,10 +41,11 @@ Observed state:
 - `complete`: `true`
 - `counts.entries`: `10109`
 - `counts.files`: `10005`
+- `counts.content_deferred`: `9019`
 - `next_cursor`: `1000`
-- `rss_bytes_after_measurements`: `147718144`
+- `rss_bytes_after_measurements`: `133677056`
 - warm manifest cache: `hit=true`
-- warm manifest entry metadata cache: `hits=10108`, `misses=1`
+- warm manifest entry metadata cache: `hits=999`, `misses=9110`
 - search matches: `10`
 
 ## 100k Fixture
@@ -59,11 +60,11 @@ Result:
 
 | Measurement | Duration |
 | --- | ---: |
-| cold manifest first page | 14894.23 ms |
-| warm manifest first page | 919.11 ms |
-| list_tree root depth 1 | 922.27 ms |
-| read_file first chunk | 0.94 ms |
-| warm literal search | 1038.71 ms |
+| cold manifest first page | 821.85 ms |
+| warm manifest first page | 733.76 ms |
+| list_tree root depth 1 | 782.31 ms |
+| read_file first chunk | 0.74 ms |
+| warm literal search | 779.04 ms |
 
 Observed state:
 
@@ -71,10 +72,11 @@ Observed state:
 - `complete`: `true`
 - `counts.entries`: `100109`
 - `counts.files`: `100005`
+- `counts.content_deferred`: `99010`
 - `next_cursor`: `1000`
-- `rss_bytes_after_measurements`: `678952960`
+- `rss_bytes_after_measurements`: `416284672`
 - warm manifest cache: `hit=true`
-- warm manifest entry metadata cache: `hits=100108`, `misses=1`
+- warm manifest entry metadata cache: `hits=999`, `misses=99110`
 - search matches: `50`
 - search `truncated`: `true`
 
@@ -83,7 +85,7 @@ paginated results, and satisfies the proposed Sprint 2 warm-path SLO on this
 machine: warm manifest first page is below 2 seconds, read first chunk is below
 500 ms, and warm search is below 2 seconds.
 
-## 500k Fixture Attempt
+## 500k Fixture
 
 Command:
 
@@ -91,17 +93,43 @@ Command:
 bun run benchmark:mcp-reader -- --entries 500000 --json
 ```
 
-Observed outcome: manually interrupted after more than 9 minutes without a JSON
-result. The temporary fixture directory was removed after interruption.
+Result:
 
-This does not prove the 500k baseline. It shows the remaining large-repo
-bottleneck has moved to fixture generation, cold manifest construction, and the
-fact that the manifest still materializes and sorts the full visible entry set.
+| Measurement | Duration |
+| --- | ---: |
+| cold manifest first page | 11393.94 ms |
+| warm manifest first page | 12201.90 ms |
+| list_tree root depth 1 | 12641.15 ms |
+| read_file first chunk | 3.67 ms |
+| warm literal search | 12668.28 ms |
+
+Observed state:
+
+- `snapshot_state`: `ready`
+- `complete`: `true`
+- `counts.entries`: `500109`
+- `counts.files`: `500005`
+- `counts.content_deferred`: `499010`
+- `next_cursor`: `1000`
+- `rss_bytes_after_measurements`: `1677410304`
+- warm manifest cache: `hit=true`
+- warm manifest entry metadata cache: `hits=999`, `misses=499110`
+- search matches: `50`
+- search `truncated`: `true`
+
+This proves the generated 500k fixture can complete without OOM and returns
+paginated results. The 500k warm path is a recorded baseline, not an SLO pass.
 
 ## Decision
 
 The path-aware response cache key and entry metadata cache close the
-cache-key/invalidation slice. The optimized walker and path-scoped cached
-snapshot reuse close the 100k warm-path SLO on this machine. They do not close
-true streaming manifest or the 500k baseline: cold manifest still materializes
-and sorts the full visible tree before returning first-page manifest results.
+cache-key/invalidation slice. The streaming manifest page path closes the
+`S2-PERF-001` memory-shape requirement for `repo_manifest`: it traverses the
+visible tree to prove counts and digest but stores only the requested page of
+entries. Non-page file content metadata is deferred and surfaced through
+`counts.content_deferred`; returned page entries, `stat_file`, `read_file`, and
+`search_text` still compute content hashes when content is actually returned.
+
+The 10k, 100k, and 500k baselines close `S2-PERF-004`. The 100k warm-path SLO
+is satisfied on this machine. The 500k baseline remains a future optimization
+target rather than a Sprint 2 exit blocker.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "bun": ">=1.0.0"
   },
   "scripts": {
+    "benchmark:mcp-reader": "bun scripts/benchmark-general-repo-reader.ts",
     "benchmark:skills": "bun scripts/run-skill-evals.ts",
     "test": "bun test",
     "test:coverage": "bun test --coverage",

--- a/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
+++ b/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
@@ -380,7 +380,7 @@ Sprint 0 evidence:
 - [x] **S1-GRD-003** 支持内部 symlink；拒绝 external symlink 和 symlink chain escape。
 - [ ] **S1-GRD-004** 写路径对不存在目标检查最近的已存在父目录。
 - [x] **S1-GRD-005** 使用 fd-relative/openat 等机制降低 check-then-open TOCTOU 风险。
-- [ ] **S1-GRD-006** 对 CodeGraph 返回的每个 path 执行二次 guard。
+- [x] **S1-GRD-006** 对 CodeGraph 返回的每个 path 执行二次 guard。
 - [x] **S1-GRD-007** 增加 Windows/macOS/Linux 路径差异测试；若首版只支持单平台，在 capability 中显式声明。
 
 ## 8.3 Ignore Policy
@@ -439,49 +439,49 @@ Sprint 1 evidence:
 
 ## 9.1 CodeGraph Adapter
 
-- [ ] **S2-CG-001** 定义稳定 adapter interface，隔离 CodeGraph 具体版本和调用方式。
-- [ ] **S2-CG-002** 启动时执行 capability discovery，并缓存结果。
-- [ ] **S2-CG-003** 统一 CodeGraph timeout、取消、重试和错误映射。
-- [ ] **S2-CG-004** 所有返回路径执行 canonical guard 和 `.ignore` 二次过滤。
-- [ ] **S2-CG-005** 记录 adapter latency、failure 和 index revision 指标。
-- [ ] **S2-CG-006** 对 CodeGraph 不支持的能力提供明确 fallback，而非静默缺失。
-- [ ] **S2-CG-007** 建立 adapter contract tests，可替换 fake/real CodeGraph。
+- [x] **S2-CG-001** 定义稳定 adapter interface，隔离 CodeGraph 具体版本和调用方式。
+- [x] **S2-CG-002** 启动时执行 capability discovery，并缓存结果。
+- [x] **S2-CG-003** 统一 CodeGraph timeout、取消、重试和错误映射。
+- [x] **S2-CG-004** 所有返回路径执行 canonical guard 和 `.ignore` 二次过滤。
+- [x] **S2-CG-005** 记录 adapter latency、failure 和 index revision 指标。
+- [x] **S2-CG-006** 对 CodeGraph 不支持的能力提供明确 fallback，而非静默缺失。
+- [x] **S2-CG-007** 建立 adapter contract tests，可替换 fake/real CodeGraph。
 
 ## 9.2 Snapshot Coordinator
 
-- [ ] **S2-SNP-001** 定义 `snapshot_id` 生命周期。
-- [ ] **S2-SNP-002** snapshot 绑定 `fs_revision + codegraph_revision + ignore_digest`。
-- [ ] **S2-SNP-003** manifest、tree、search、read、batch read 可复用同一 snapshot。
-- [ ] **S2-SNP-004** 文件或 ignore 变化时标记 snapshot stale。
-- [ ] **S2-SNP-005** stale 时返回显式状态；禁止静默混合版本。
+- [x] **S2-SNP-001** 定义 `snapshot_id` 生命周期。
+- [x] **S2-SNP-002** snapshot 绑定 `fs_revision + codegraph_revision + ignore_digest`。
+- [x] **S2-SNP-003** manifest、tree、search、read、batch read 可复用同一 snapshot。
+- [x] **S2-SNP-004** 文件或 ignore 变化时标记 snapshot stale。
+- [x] **S2-SNP-005** stale 时返回显式状态；禁止静默混合版本。
 - [ ] **S2-SNP-006** 定义 snapshot TTL、最大并发数和清理策略。
 - [ ] **S2-SNP-007** 为“索引落后于文件系统”提供 `index_lagging` 状态。
 
 ## 9.3 Repo Manifest
 
-- [ ] **S2-MAN-001** 实现 `repo_manifest`，覆盖所有非忽略 entries。
-- [ ] **S2-MAN-002** 每项包含 `indexed/readable/binary/size/mtime/hash/type`。
-- [ ] **S2-MAN-003** CodeGraph inventory 不完整时，由 secure walker 补齐。
-- [ ] **S2-MAN-004** 合并 CodeGraph metadata 和文件系统 metadata，定义冲突优先级。
-- [ ] **S2-MAN-005** 支持稳定排序、分页、cursor 和 manifest digest。
-- [ ] **S2-MAN-006** 返回总文件数、目录数、文本/二进制数、未索引数。
-- [ ] **S2-MAN-007** 仅在完整遍历成功时返回 `complete: true`。
-- [ ] **S2-MAN-008** 对遍历中发生的变化返回 stale/partial，而不是伪造完整性。
-- [ ] **S2-MAN-009** 建立 manifest parity test：期望集合与实际集合逐项对比。
+- [x] **S2-MAN-001** 实现 `repo_manifest`，覆盖所有非忽略 entries。
+- [x] **S2-MAN-002** 每项包含 `indexed/readable/binary/size/mtime/hash/type`。
+- [x] **S2-MAN-003** CodeGraph inventory 不完整时，由 secure walker 补齐。
+- [x] **S2-MAN-004** 合并 CodeGraph metadata 和文件系统 metadata，定义冲突优先级。
+- [x] **S2-MAN-005** 支持稳定排序、分页、cursor 和 manifest digest。
+- [x] **S2-MAN-006** 返回总文件数、目录数、文本/二进制数、未索引数。
+- [x] **S2-MAN-007** 仅在完整遍历成功时返回 `complete: true`。
+- [x] **S2-MAN-008** 对遍历中发生的变化返回 stale/partial，而不是伪造完整性。
+- [x] **S2-MAN-009** 建立 manifest parity test：期望集合与实际集合逐项对比。
 
 ## 9.4 搜索与批量读取
 
-- [ ] **S2-SRC-001** 实现 `search_text` literal 模式。
-- [ ] **S2-SRC-002** 实现 regex 模式；限制复杂度但不按路径或扩展名过滤。
-- [ ] **S2-SRC-003** 支持 path include filter；filter 只能缩小用户主动请求，不得成为隐式 policy。
-- [ ] **S2-SRC-004** 返回行号、上下文、文件 hash、snapshot。
-- [ ] **S2-SRC-005** 支持稳定分页和 continuation。
-- [ ] **S2-SRC-006** CodeGraph 搜索不可用时提供受限 filesystem search fallback，并保持同一 ignore 语义。
-- [ ] **S2-RD-001** 实现 `read_files`。
-- [ ] **S2-RD-002** 支持 per-file range、全局 byte budget 和 partial success。
-- [ ] **S2-RD-003** CodeGraph 未索引但授权允许的文本使用 secure read fallback。
-- [ ] **S2-RD-004** 二进制文件默认返回 metadata；可选开放 byte chunk。
-- [ ] **S2-RD-005** 为读取结果返回 sha256，供后续写前置条件使用。
+- [x] **S2-SRC-001** 实现 `search_text` literal 模式。
+- [x] **S2-SRC-002** 实现 regex 模式；限制复杂度但不按路径或扩展名过滤。
+- [x] **S2-SRC-003** 支持 path include filter；filter 只能缩小用户主动请求，不得成为隐式 policy。
+- [x] **S2-SRC-004** 返回行号、上下文、文件 hash、snapshot。
+- [x] **S2-SRC-005** 支持稳定分页和 continuation。
+- [x] **S2-SRC-006** CodeGraph 搜索不可用时提供受限 filesystem search fallback，并保持同一 ignore 语义。
+- [x] **S2-RD-001** 实现 `read_files`。
+- [x] **S2-RD-002** 支持 per-file range、全局 byte budget 和 partial success。
+- [x] **S2-RD-003** CodeGraph 未索引但授权允许的文本使用 secure read fallback。
+- [x] **S2-RD-004** 二进制文件默认返回 metadata；可选开放 byte chunk。
+- [x] **S2-RD-005** 为读取结果返回 sha256，供后续写前置条件使用。
 
 ## 9.5 性能与缓存
 
@@ -493,13 +493,20 @@ Sprint 1 evidence:
 
 ## 9.6 Sprint 2 退出标准
 
-- [ ] Manifest 与真实非忽略文件集合在 fixture 中达到 100% parity。
-- [ ] 未索引文件仍会出现在 manifest，并可在授权条件下读取。
-- [ ] 同一 snapshot 中 manifest/search/read 的 hash 一致。
-- [ ] CodeGraph 返回越界或已忽略路径时被二次过滤。
-- [ ] search 不因 dotfile、扩展名或 `.gitignore` 漏结果。
+- [x] Manifest 与真实非忽略文件集合在 fixture 中达到 100% parity。
+- [x] 未索引文件仍会出现在 manifest，并可在授权条件下读取。
+- [x] 同一 snapshot 中 manifest/search/read 的 hash 一致。
+- [x] CodeGraph 返回越界或已忽略路径时被二次过滤。
+- [x] search 不因 dotfile、扩展名或 `.gitignore` 漏结果。
 - [ ] 100k 文件规模下无 OOM，所有大结果均可分页恢复。
-- [ ] CodeGraph 故障时错误清晰；允许 fallback 的路径可降级运行。
+- [x] CodeGraph 故障时错误清晰；允许 fallback 的路径可降级运行。
+
+Sprint 2 adapter/snapshot evidence:
+
+- Runtime: `src/cli/mcp/codegraph-adapter.ts`, `src/cli/mcp/general-repo-access.ts`, `src/cli/mcp/reader-tools.ts`
+- Tests: `tests/cli/mcp-reader-tools.test.ts`
+- Verification: `bun test tests/cli/mcp-reader-tools.test.ts`, `bun run check:type`
+- Deferred by design: `S2-SNP-006`, `S2-SNP-007`, and all `S2-PERF-*` remain open for cache/TTL/index-lag/performance baselines. CodeGraph CLI `query` remains symbol-oriented, so full-text `search_text` continues to use the policy-consistent filesystem fallback while exposing CodeGraph indexed metadata.
 
 ---
 

--- a/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
+++ b/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
@@ -454,8 +454,8 @@ Sprint 1 evidence:
 - [x] **S2-SNP-003** manifest、tree、search、read、batch read 可复用同一 snapshot。
 - [x] **S2-SNP-004** 文件或 ignore 变化时标记 snapshot stale。
 - [x] **S2-SNP-005** stale 时返回显式状态；禁止静默混合版本。
-- [ ] **S2-SNP-006** 定义 snapshot TTL、最大并发数和清理策略。
-- [ ] **S2-SNP-007** 为“索引落后于文件系统”提供 `index_lagging` 状态。
+- [x] **S2-SNP-006** 定义 snapshot TTL、最大并发数和清理策略。
+- [x] **S2-SNP-007** 为“索引落后于文件系统”提供 `index_lagging` 状态。
 
 ## 9.3 Repo Manifest
 
@@ -506,7 +506,8 @@ Sprint 2 adapter/snapshot evidence:
 - Runtime: `src/cli/mcp/codegraph-adapter.ts`, `src/cli/mcp/general-repo-access.ts`, `src/cli/mcp/reader-tools.ts`
 - Tests: `tests/cli/mcp-reader-tools.test.ts`
 - Verification: `bun test tests/cli/mcp-reader-tools.test.ts`, `bun run check:type`
-- Deferred by design: `S2-SNP-006`, `S2-SNP-007`, and all `S2-PERF-*` remain open for cache/TTL/index-lag/performance baselines. CodeGraph CLI `query` remains symbol-oriented, so full-text `search_text` continues to use the policy-consistent filesystem fallback while exposing CodeGraph indexed metadata.
+- Snapshot cache/index-lag update: responses now expose `snapshot_state`, creation/expiry, TTL, bounded snapshot metadata, and CodeGraph lagging path summaries. Snapshot memoization is repo-wide and revalidated by the current manifest digest, so it closes `S2-SNP-006/007` but does not claim the per-path cache requirements in `S2-PERF-002/003`.
+- Deferred by design: all `S2-PERF-*` items and the 100k/OOM exit gate remain open for true streaming inventory, per-path cache keys, precise cache invalidation, and measured large-repo baselines. CodeGraph CLI `query` remains symbol-oriented, so full-text `search_text` continues to use the policy-consistent filesystem fallback while exposing CodeGraph indexed metadata.
 
 ---
 

--- a/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
+++ b/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
@@ -486,8 +486,8 @@ Sprint 1 evidence:
 ## 9.5 性能与缓存
 
 - [ ] **S2-PERF-001** manifest 流式生成，不将全仓库一次性载入内存。
-- [ ] **S2-PERF-002** cache key 包含 repo、snapshot、ignore digest 和路径。
-- [ ] **S2-PERF-003** 文件变化、ignore 变化、registry 变化时精确失效。
+- [x] **S2-PERF-002** cache key 包含 repo、snapshot、ignore digest 和路径。
+- [x] **S2-PERF-003** 文件变化、ignore 变化、registry 变化时精确失效。
 - [ ] **S2-PERF-004** 在 10k/100k/500k entries fixture 上记录基线。
 - [ ] **S2-PERF-005** 建议初始目标：100k 文件 warm manifest 首屏 p95 < 2s；普通 read 首块 p95 < 500ms；warm search p95 < 2s。最终以环境基线调整。
 
@@ -507,7 +507,8 @@ Sprint 2 adapter/snapshot evidence:
 - Tests: `tests/cli/mcp-reader-tools.test.ts`
 - Verification: `bun test tests/cli/mcp-reader-tools.test.ts`, `bun run check:type`
 - Snapshot cache/index-lag update: responses now expose `snapshot_state`, creation/expiry, TTL, bounded snapshot metadata, and CodeGraph lagging path summaries. Snapshot memoization is repo-wide and revalidated by the current manifest digest, so it closes `S2-SNP-006/007` but does not claim the per-path cache requirements in `S2-PERF-002/003`.
-- Deferred by design: all `S2-PERF-*` items and the 100k/OOM exit gate remain open for true streaming inventory, per-path cache keys, precise cache invalidation, and measured large-repo baselines. CodeGraph CLI `query` remains symbol-oriented, so full-text `search_text` continues to use the policy-consistent filesystem fallback while exposing CodeGraph indexed metadata.
+- Cache-key/performance update: public `snapshot_cache.key` is scoped by tool and repo-relative path set, with `snapshot_cache.snapshot_key` naming the underlying snapshot. Entry metadata cache keys include repo id, registry revision, `.ignore` digest, path, and current stat signature, so file, `.ignore`, and registry changes do not reuse stale metadata. Verification: `bun test tests/cli/mcp-reader-tools.test.ts tests/cli/mcp-codegraph-contract.test.ts`, `bun run check:type`, and `bun run benchmark:mcp-reader -- --entries 10000 --json`.
+- Deferred by design: `S2-PERF-001`, `S2-PERF-004/005`, and the 100k/OOM exit gate remain open. The 10k and 100k baselines are recorded in `docs/researches/20260623-general-repo-reader-performance-baseline.md`; 100k completes without OOM and returns paginated results, but warm manifest/read/search still take about 4.3-4.4 seconds and miss the proposed S2 SLO. CodeGraph CLI `query` remains symbol-oriented, so full-text `search_text` continues to use the policy-consistent filesystem fallback while exposing CodeGraph indexed metadata.
 
 ---
 

--- a/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
+++ b/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
@@ -485,10 +485,10 @@ Sprint 1 evidence:
 
 ## 9.5 性能与缓存
 
-- [ ] **S2-PERF-001** manifest 流式生成，不将全仓库一次性载入内存。
+- [x] **S2-PERF-001** manifest 流式生成，不将全仓库一次性载入内存。
 - [x] **S2-PERF-002** cache key 包含 repo、snapshot、ignore digest 和路径。
 - [x] **S2-PERF-003** 文件变化、ignore 变化、registry 变化时精确失效。
-- [ ] **S2-PERF-004** 在 10k/100k/500k entries fixture 上记录基线。
+- [x] **S2-PERF-004** 在 10k/100k/500k entries fixture 上记录基线。
 - [x] **S2-PERF-005** 建议初始目标：100k 文件 warm manifest 首屏 p95 < 2s；普通 read 首块 p95 < 500ms；warm search p95 < 2s。最终以环境基线调整。
 
 ## 9.6 Sprint 2 退出标准
@@ -508,8 +508,8 @@ Sprint 2 adapter/snapshot evidence:
 - Verification: `bun test tests/cli/mcp-reader-tools.test.ts`, `bun run check:type`
 - Snapshot cache/index-lag update: responses now expose `snapshot_state`, creation/expiry, TTL, bounded snapshot metadata, and CodeGraph lagging path summaries. Snapshot memoization is repo-wide and revalidated by the current manifest digest, so it closes `S2-SNP-006/007` but does not claim the per-path cache requirements in `S2-PERF-002/003`.
 - Cache-key/performance update: public `snapshot_cache.key` is scoped by tool and repo-relative path set, with `snapshot_cache.snapshot_key` naming the underlying snapshot. Entry metadata cache keys include repo id, registry revision, `.ignore` digest, path, and current stat signature, so file, `.ignore`, and registry changes do not reuse stale metadata. Verification: `bun test tests/cli/mcp-reader-tools.test.ts tests/cli/mcp-codegraph-contract.test.ts`, `bun run check:type`, and `bun run benchmark:mcp-reader -- --entries 10000 --json`.
-- Performance update: the manifest walker now avoids the per-entry `resolveRepoPath` hot path, and explicit `snapshot_id` stat/read calls reuse cached snapshots with requested-file hash validation instead of rebuilding the full repo snapshot. The 100k benchmark completes without OOM, returns paginated results, and meets the warm-path SLO on this machine: manifest 919.11 ms, read first chunk 0.94 ms, search 1038.71 ms. Verification: `bun test tests/cli/mcp-reader-tools.test.ts tests/cli/mcp-codegraph-contract.test.ts`, `bun run check:type`, and `bun run benchmark:mcp-reader -- --entries 100000 --json`.
-- Deferred by design: `S2-PERF-001` and `S2-PERF-004` remain open. The 10k and 100k baselines are recorded in `docs/researches/20260623-general-repo-reader-performance-baseline.md`; a 500k benchmark attempt was interrupted after more than 9 minutes without JSON output and then cleaned up. Cold manifest still materializes and sorts the full visible entry set, so true streaming manifest remains the next S2 performance bottleneck. CodeGraph CLI `query` remains symbol-oriented, so full-text `search_text` continues to use the policy-consistent filesystem fallback while exposing CodeGraph indexed metadata.
+- Performance update: the manifest walker now avoids the per-entry `resolveRepoPath` hot path, and explicit `snapshot_id` stat/read calls reuse cached snapshots with requested-file hash validation instead of rebuilding the full repo snapshot. The 100k benchmark completes without OOM, returns paginated results, and meets the warm-path SLO on this machine: manifest 733.76 ms, read first chunk 0.74 ms, search 779.04 ms. Verification: `bun test tests/cli/mcp-reader-tools.test.ts tests/cli/mcp-codegraph-contract.test.ts`, `bun run check:type`, and `bun run benchmark:mcp-reader -- --entries 100000 --json`.
+- Streaming manifest update: `repo_manifest` now traverses the visible tree to prove counts and digest while retaining only the requested page entries. Non-page file content metadata is deferred and exposed via `counts.content_deferred`; returned manifest entries, `stat_file`, `read_file`, and `search_text` still compute content hashes when content is returned. The 10k/100k/500k baselines are recorded in `docs/researches/20260623-general-repo-reader-performance-baseline.md`; the 500k fixture now completes without OOM with a recorded warm manifest baseline of 12201.90 ms and read first chunk of 3.67 ms. CodeGraph CLI `query` remains symbol-oriented, so full-text `search_text` continues to use the policy-consistent filesystem fallback while exposing CodeGraph indexed metadata.
 
 ---
 

--- a/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
+++ b/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
@@ -489,7 +489,7 @@ Sprint 1 evidence:
 - [x] **S2-PERF-002** cache key 包含 repo、snapshot、ignore digest 和路径。
 - [x] **S2-PERF-003** 文件变化、ignore 变化、registry 变化时精确失效。
 - [ ] **S2-PERF-004** 在 10k/100k/500k entries fixture 上记录基线。
-- [ ] **S2-PERF-005** 建议初始目标：100k 文件 warm manifest 首屏 p95 < 2s；普通 read 首块 p95 < 500ms；warm search p95 < 2s。最终以环境基线调整。
+- [x] **S2-PERF-005** 建议初始目标：100k 文件 warm manifest 首屏 p95 < 2s；普通 read 首块 p95 < 500ms；warm search p95 < 2s。最终以环境基线调整。
 
 ## 9.6 Sprint 2 退出标准
 
@@ -498,7 +498,7 @@ Sprint 1 evidence:
 - [x] 同一 snapshot 中 manifest/search/read 的 hash 一致。
 - [x] CodeGraph 返回越界或已忽略路径时被二次过滤。
 - [x] search 不因 dotfile、扩展名或 `.gitignore` 漏结果。
-- [ ] 100k 文件规模下无 OOM，所有大结果均可分页恢复。
+- [x] 100k 文件规模下无 OOM，所有大结果均可分页恢复。
 - [x] CodeGraph 故障时错误清晰；允许 fallback 的路径可降级运行。
 
 Sprint 2 adapter/snapshot evidence:
@@ -508,7 +508,8 @@ Sprint 2 adapter/snapshot evidence:
 - Verification: `bun test tests/cli/mcp-reader-tools.test.ts`, `bun run check:type`
 - Snapshot cache/index-lag update: responses now expose `snapshot_state`, creation/expiry, TTL, bounded snapshot metadata, and CodeGraph lagging path summaries. Snapshot memoization is repo-wide and revalidated by the current manifest digest, so it closes `S2-SNP-006/007` but does not claim the per-path cache requirements in `S2-PERF-002/003`.
 - Cache-key/performance update: public `snapshot_cache.key` is scoped by tool and repo-relative path set, with `snapshot_cache.snapshot_key` naming the underlying snapshot. Entry metadata cache keys include repo id, registry revision, `.ignore` digest, path, and current stat signature, so file, `.ignore`, and registry changes do not reuse stale metadata. Verification: `bun test tests/cli/mcp-reader-tools.test.ts tests/cli/mcp-codegraph-contract.test.ts`, `bun run check:type`, and `bun run benchmark:mcp-reader -- --entries 10000 --json`.
-- Deferred by design: `S2-PERF-001`, `S2-PERF-004/005`, and the 100k/OOM exit gate remain open. The 10k and 100k baselines are recorded in `docs/researches/20260623-general-repo-reader-performance-baseline.md`; 100k completes without OOM and returns paginated results, but warm manifest/read/search still take about 4.3-4.4 seconds and miss the proposed S2 SLO. CodeGraph CLI `query` remains symbol-oriented, so full-text `search_text` continues to use the policy-consistent filesystem fallback while exposing CodeGraph indexed metadata.
+- Performance update: the manifest walker now avoids the per-entry `resolveRepoPath` hot path, and explicit `snapshot_id` stat/read calls reuse cached snapshots with requested-file hash validation instead of rebuilding the full repo snapshot. The 100k benchmark completes without OOM, returns paginated results, and meets the warm-path SLO on this machine: manifest 919.11 ms, read first chunk 0.94 ms, search 1038.71 ms. Verification: `bun test tests/cli/mcp-reader-tools.test.ts tests/cli/mcp-codegraph-contract.test.ts`, `bun run check:type`, and `bun run benchmark:mcp-reader -- --entries 100000 --json`.
+- Deferred by design: `S2-PERF-001` and `S2-PERF-004` remain open. The 10k and 100k baselines are recorded in `docs/researches/20260623-general-repo-reader-performance-baseline.md`; a 500k benchmark attempt was interrupted after more than 9 minutes without JSON output and then cleaned up. Cold manifest still materializes and sorts the full visible entry set, so true streaming manifest remains the next S2 performance bottleneck. CodeGraph CLI `query` remains symbol-oriented, so full-text `search_text` continues to use the policy-consistent filesystem fallback while exposing CodeGraph indexed metadata.
 
 ---
 

--- a/scripts/benchmark-general-repo-reader.ts
+++ b/scripts/benchmark-general-repo-reader.ts
@@ -1,0 +1,259 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+import { performance } from 'perf_hooks';
+import { getMcpPolicy } from '../src/cli/mcp/policy';
+import {
+  callReaderTool,
+  createReaderToolContext,
+  type ReaderToolContext,
+} from '../src/cli/mcp/reader-tools';
+import { WorkspaceManager } from '../src/cli/mcp/workspaces';
+import type { GeneralRepoCodeGraphAdapter } from '../src/cli/mcp/codegraph-adapter';
+
+interface BenchmarkOptions {
+  entries: number[];
+  pageSize: number;
+  maxResults: number;
+  keep: boolean;
+  json: boolean;
+}
+
+const DEFAULT_ENTRIES = [10_000];
+const PLAN_ENTRIES = [10_000, 100_000, 500_000];
+
+function parseArgs(argv: string[]): BenchmarkOptions {
+  const options: BenchmarkOptions = {
+    entries: DEFAULT_ENTRIES,
+    pageSize: 1000,
+    maxResults: 50,
+    keep: false,
+    json: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+    if (arg === '--entries' && next) {
+      options.entries = next === 'all'
+        ? PLAN_ENTRIES
+        : next.split(',').map((value) => Number(value.trim())).filter((value) => Number.isInteger(value) && value > 0);
+      index += 1;
+    } else if (arg === '--page-size' && next) {
+      options.pageSize = Number(next);
+      index += 1;
+    } else if (arg === '--max-results' && next) {
+      options.maxResults = Number(next);
+      index += 1;
+    } else if (arg === '--keep') {
+      options.keep = true;
+    } else if (arg === '--json') {
+      options.json = true;
+    } else if (arg === '--help' || arg === '-h') {
+      printHelp();
+      process.exit(0);
+    }
+  }
+  if (options.entries.length === 0) {
+    throw new Error('--entries must include at least one positive integer or "all"');
+  }
+  return options;
+}
+
+function printHelp(): void {
+  console.log(`Usage: bun scripts/benchmark-general-repo-reader.ts [options]
+
+Options:
+  --entries <n[,n]|all>  File counts to generate. Default: 10000.
+  --page-size <n>        repo_manifest/list_tree page size. Default: 1000.
+  --max-results <n>      search_text max_results. Default: 50.
+  --keep                 Keep generated fixture repos.
+  --json                 Print JSON only.
+`);
+}
+
+function pad(value: number, width: number): string {
+  return String(value).padStart(width, '0');
+}
+
+function generatedPath(index: number): string {
+  return `src/${pad(index % 100, 3)}/file-${pad(index, 7)}.txt`;
+}
+
+function generateFixture(repoRoot: string, entries: number): void {
+  mkdirSync(join(repoRoot, 'src'), { recursive: true });
+  mkdirSync(join(repoRoot, 'ignored'), { recursive: true });
+  writeFileSync(
+    join(repoRoot, '.ignore'),
+    [
+      'ignored/**',
+      '!ignored/reincluded.txt',
+      '',
+    ].join('\n'),
+  );
+  writeFileSync(join(repoRoot, '.dotfile'), 'dotfile remains visible\n');
+  writeFileSync(join(repoRoot, 'unknown.extless'), 'unknown extension remains visible\n');
+  writeFileSync(join(repoRoot, 'binary.bin'), Buffer.from([0, 1, 2, 3, 4, 5]));
+  writeFileSync(join(repoRoot, 'ignored', 'hidden.txt'), 'ignored\n');
+  writeFileSync(join(repoRoot, 'ignored', 'reincluded.txt'), 'reincluded\n');
+  for (let dir = 0; dir < 100; dir += 1) {
+    mkdirSync(join(repoRoot, 'src', pad(dir, 3)), { recursive: true });
+  }
+  for (let index = 0; index < entries; index += 1) {
+    const needle = index % 1000 === 0 ? ' benchmark-needle' : '';
+    writeFileSync(
+      join(repoRoot, generatedPath(index)),
+      `line ${index}${needle}\nsecond line ${entries - index}\n`,
+    );
+  }
+}
+
+async function jsonTool(ctx: ReaderToolContext, name: string, args: Record<string, unknown> = {}) {
+  const result = await callReaderTool(ctx, name, args);
+  return JSON.parse(result.content[0].text);
+}
+
+async function measure<T>(name: string, fn: () => Promise<T>): Promise<{ name: string; duration_ms: number; result: T }> {
+  const start = performance.now();
+  const result = await fn();
+  return { name, duration_ms: Number((performance.now() - start).toFixed(2)), result };
+}
+
+function disabledCodeGraphAdapter(): GeneralRepoCodeGraphAdapter {
+  return {
+    discoverRepo() {
+      return {
+        available: false,
+        integrated: false,
+        source: 'benchmark-disabled',
+        indexRevision: 'index_unavailable',
+        latencyMs: 0,
+        files: [],
+        error: 'benchmark fixture intentionally isolates filesystem walker/cache behavior',
+      };
+    },
+  };
+}
+
+async function runOne(entries: number, options: BenchmarkOptions) {
+  const repoRoot = mkdtempSync(join(tmpdir(), `repo-harness-reader-bench-${entries}-`));
+  const startedAt = new Date().toISOString();
+  try {
+    generateFixture(repoRoot, entries);
+    const policy = getMcpPolicy('planner', { enableReader: true, allowedRoots: [repoRoot] });
+    const workspaceManager = new WorkspaceManager({ allowedRoots: [repoRoot], policy });
+    const ctx = createReaderToolContext(repoRoot, policy, workspaceManager, disabledCodeGraphAdapter());
+    const roots = await jsonTool(ctx, 'list_allowed_roots');
+    const repoId = roots.roots[0].repo_id;
+    const firstPath = generatedPath(0);
+
+    const coldManifest = await measure('cold_manifest_first_page', () => jsonTool(ctx, 'repo_manifest', {
+      repo_id: repoId,
+      page_size: options.pageSize,
+    }));
+    const warmManifest = await measure('warm_manifest_first_page', () => jsonTool(ctx, 'repo_manifest', {
+      repo_id: repoId,
+      page_size: options.pageSize,
+    }));
+    const listTree = await measure('list_tree_root_depth_1', () => jsonTool(ctx, 'list_tree', {
+      repo_id: repoId,
+      path: '.',
+      depth: 1,
+      page_size: options.pageSize,
+      snapshot_id: warmManifest.result.snapshot_id,
+    }));
+    const readFile = await measure('read_file_first_chunk', () => jsonTool(ctx, 'read_file', {
+      repo_id: repoId,
+      path: firstPath,
+      snapshot_id: warmManifest.result.snapshot_id,
+    }));
+    const warmSearch = await measure('warm_literal_search', () => jsonTool(ctx, 'search_text', {
+      repo_id: repoId,
+      query: 'benchmark-needle',
+      mode: 'literal',
+      max_results: options.maxResults,
+      snapshot_id: warmManifest.result.snapshot_id,
+    }));
+
+    return {
+      entries_requested: entries,
+      repo_root: repoRoot,
+      started_at: startedAt,
+      completed_at: new Date().toISOString(),
+      generated_first_path: firstPath,
+      rss_bytes_after_measurements: process.memoryUsage().rss,
+      measurements: [
+        summarize(coldManifest),
+        summarize(warmManifest),
+        summarize(listTree),
+        summarize(readFile),
+        summarize(warmSearch),
+      ],
+      manifest: {
+        snapshot_state: warmManifest.result.snapshot_state,
+        complete: warmManifest.result.complete,
+        counts: warmManifest.result.counts,
+        next_cursor: warmManifest.result.next_cursor,
+        cache: warmManifest.result.snapshot_cache,
+      },
+      search: {
+        match_count: warmSearch.result.matches?.length ?? 0,
+        truncated: warmSearch.result.truncated,
+        next_cursor: warmSearch.result.next_cursor,
+        cache: warmSearch.result.snapshot_cache,
+      },
+      read: {
+        bytes_returned: readFile.result.bytes_returned,
+        has_more: readFile.result.has_more,
+        cache: readFile.result.snapshot_cache,
+      },
+    };
+  } finally {
+    if (!options.keep) rmSync(repoRoot, { recursive: true, force: true });
+  }
+}
+
+function summarize(measurement: { name: string; duration_ms: number; result: Record<string, unknown> }) {
+  return {
+    name: measurement.name,
+    duration_ms: measurement.duration_ms,
+    snapshot_id: measurement.result.snapshot_id,
+    snapshot_state: measurement.result.snapshot_state,
+    partial: measurement.result.partial,
+    next_cursor: measurement.result.next_cursor,
+    cache_hit: (measurement.result.snapshot_cache as { hit?: boolean } | undefined)?.hit,
+  };
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  const results = [];
+  for (const entries of options.entries) {
+    results.push(await runOne(entries, options));
+  }
+  const output = {
+    version: 1,
+    benchmark: 'general-repo-reader',
+    generated_at: new Date().toISOString(),
+    options: {
+      entries: options.entries,
+      page_size: options.pageSize,
+      max_results: options.maxResults,
+    },
+    results,
+  };
+  if (options.json) {
+    console.log(JSON.stringify(output, null, 2));
+  } else {
+    for (const result of results) {
+      console.log(`entries=${result.entries_requested} rss=${result.rss_bytes_after_measurements}`);
+      for (const measurement of result.measurements) {
+        console.log(`  ${measurement.name}: ${measurement.duration_ms}ms cache_hit=${measurement.cache_hit}`);
+      }
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/src/cli/mcp/codegraph-adapter.ts
+++ b/src/cli/mcp/codegraph-adapter.ts
@@ -1,0 +1,181 @@
+import { spawnSync } from 'child_process';
+import { createHash } from 'crypto';
+import { existsSync } from 'fs';
+import { join } from 'path';
+
+export interface CodeGraphIndexedFile {
+  path: string;
+  language?: string;
+  nodeCount?: number;
+  size?: number;
+}
+
+export interface CodeGraphRepoSnapshot {
+  available: boolean;
+  integrated: boolean;
+  source: 'codegraph-cli' | 'unavailable' | 'test-double';
+  indexRevision: string | 0;
+  files: CodeGraphIndexedFile[];
+  latencyMs: number;
+  error?: {
+    code: 'INDEX_UNAVAILABLE' | 'INTERNAL_ADAPTER_ERROR';
+    message: string;
+    retryable: boolean;
+  };
+}
+export interface CodeGraphTextSearchMatch {
+  path: string;
+  line?: number;
+  column?: number;
+  snippet?: string;
+  score?: number;
+}
+
+export interface CodeGraphTextSearchResult {
+  available: boolean;
+  matches: CodeGraphTextSearchMatch[];
+  latencyMs: number;
+  error?: CodeGraphRepoSnapshot['error'];
+}
+
+export interface GeneralRepoCodeGraphAdapter {
+  discoverRepo(repoRoot: string): CodeGraphRepoSnapshot;
+  searchText?(repoRoot: string, query: string, opts: { mode: 'literal' | 'regex'; paths: string[]; maxResults: number }): CodeGraphTextSearchResult;
+}
+
+const DEFAULT_TIMEOUT_MS = 5_000;
+const MAX_STDOUT_BYTES = 10 * 1024 * 1024;
+
+function sha256(value: string | Buffer): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function unavailable(message: string, latencyMs = 0, retryable = true): CodeGraphRepoSnapshot {
+  return {
+    available: false,
+    integrated: false,
+    source: 'unavailable',
+    indexRevision: 0,
+    files: [],
+    latencyMs,
+    error: { code: 'INDEX_UNAVAILABLE', message, retryable },
+  };
+}
+
+function codegraphBin(repoRoot: string, env: NodeJS.ProcessEnv): string {
+  if (env.REPO_HARNESS_CODEGRAPH_BIN) return env.REPO_HARNESS_CODEGRAPH_BIN;
+  const repoLocal = join(repoRoot, 'node_modules', '.bin', 'codegraph');
+  if (existsSync(repoLocal)) return repoLocal;
+  const cwdLocal = join(process.cwd(), 'node_modules', '.bin', 'codegraph');
+  if (existsSync(cwdLocal)) return cwdLocal;
+  return 'codegraph';
+}
+
+function normalizeIndexedFile(value: unknown): CodeGraphIndexedFile | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null;
+  const raw = value as Record<string, unknown>;
+  const path = typeof raw.path === 'string' ? raw.path : '';
+  if (!path) return null;
+  return {
+    path,
+    language: typeof raw.language === 'string' ? raw.language : undefined,
+    nodeCount: typeof raw.nodeCount === 'number' ? raw.nodeCount : undefined,
+    size: typeof raw.size === 'number' ? raw.size : undefined,
+  };
+}
+
+function revisionFor(files: CodeGraphIndexedFile[]): string {
+  const stable = files
+    .map((file) => ({
+      path: file.path,
+      language: file.language ?? '',
+      nodeCount: file.nodeCount ?? 0,
+      size: file.size ?? 0,
+    }))
+    .sort((a, b) => a.path.localeCompare(b.path));
+  return `index_${sha256(JSON.stringify(stable)).slice(0, 16)}`;
+}
+
+export function createCodeGraphCliAdapter(opts: {
+  env?: NodeJS.ProcessEnv;
+  timeoutMs?: number;
+} = {}): GeneralRepoCodeGraphAdapter {
+  const env = opts.env ?? process.env;
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  return {
+    discoverRepo(repoRoot: string): CodeGraphRepoSnapshot {
+      const start = Date.now();
+      if (!existsSync(join(repoRoot, '.codegraph'))) {
+        return unavailable('CodeGraph index is not initialized for this repo', 0, false);
+      }
+
+      const bin = codegraphBin(repoRoot, env);
+      const result = spawnSync(bin, ['files', '--path', repoRoot, '--format', 'flat', '--json'], {
+        cwd: repoRoot,
+        env,
+        encoding: 'utf-8',
+        timeout: timeoutMs,
+        maxBuffer: MAX_STDOUT_BYTES,
+      });
+      const latencyMs = Date.now() - start;
+
+      if (result.error) {
+        const code = result.error.message.includes('ETIMEDOUT') ? 'INDEX_UNAVAILABLE' : 'INTERNAL_ADAPTER_ERROR';
+        return {
+          available: false,
+          integrated: false,
+          source: 'unavailable',
+          indexRevision: 0,
+          files: [],
+          latencyMs,
+          error: { code, message: result.error.message, retryable: code === 'INDEX_UNAVAILABLE' },
+        };
+      }
+      if (result.status !== 0) {
+        return {
+          available: false,
+          integrated: false,
+          source: 'unavailable',
+          indexRevision: 0,
+          files: [],
+          latencyMs,
+          error: {
+            code: 'INDEX_UNAVAILABLE',
+            message: (result.stderr || result.stdout || `codegraph exited with ${result.status}`).trim(),
+            retryable: true,
+          },
+        };
+      }
+
+      try {
+        const parsed = JSON.parse(result.stdout);
+        const files = Array.isArray(parsed)
+          ? parsed.map(normalizeIndexedFile).filter((file): file is CodeGraphIndexedFile => file !== null)
+          : [];
+        return {
+          available: true,
+          integrated: true,
+          source: 'codegraph-cli',
+          indexRevision: revisionFor(files),
+          files,
+          latencyMs,
+        };
+      } catch (error) {
+        return {
+          available: false,
+          integrated: false,
+          source: 'unavailable',
+          indexRevision: 0,
+          files: [],
+          latencyMs,
+          error: {
+            code: 'INTERNAL_ADAPTER_ERROR',
+            message: error instanceof Error ? error.message : String(error),
+            retryable: false,
+          },
+        };
+      }
+    },
+  };
+}

--- a/src/cli/mcp/general-repo-access.ts
+++ b/src/cli/mcp/general-repo-access.ts
@@ -28,6 +28,7 @@ export interface GeneralRepoToolResult {
 
 type RepoEntryType = 'file' | 'directory' | 'symlink' | 'other';
 type SymlinkTargetKind = 'internal' | 'external' | 'none';
+type SnapshotState = 'ready' | 'index_lagging' | 'failed';
 
 interface RepoRecord {
   repoId: string;
@@ -75,6 +76,7 @@ interface ManifestEntry {
   codegraph_language?: string;
   codegraph_node_count?: number;
   codegraph_size?: number;
+  codegraph_index_lagging?: boolean;
   readable: boolean;
   writable: boolean;
   symlink_target_kind: SymlinkTargetKind;
@@ -82,6 +84,14 @@ interface ManifestEntry {
 
 interface VisibleEntrySnapshot {
   id: string;
+  state: SnapshotState;
+  createdAtMs: number;
+  createdAt: string;
+  expiresAt: string;
+  ttlMs: number;
+  cacheKey: string;
+  cacheHit: boolean;
+  cacheSize: number;
   entries: ManifestEntry[];
   entriesByPath: Map<string, ManifestEntry>;
   manifestDigest: string;
@@ -89,6 +99,7 @@ interface VisibleEntrySnapshot {
   walkerErrors: number;
   codeGraph: CodeGraphRepoSnapshot;
   codeGraphFilteredPaths: number;
+  codeGraphLaggingPaths: string[];
 }
 
 const GENERAL_REPO_TOOLS = [
@@ -109,7 +120,11 @@ const BINARY_PROBE_BYTES = 8 * 1024;
 const SEARCH_FILE_SCAN_BYTES = 1024 * 1024;
 const DEFAULT_SEARCH_RESULTS = 50;
 const HARD_SEARCH_RESULTS = 100;
+const SNAPSHOT_TTL_MS = 30_000;
+const MAX_SNAPSHOT_CACHE_ENTRIES = 16;
+const MAX_LAGGING_PATHS_RETURNED = 50;
 const DEFAULT_CODEGRAPH_ADAPTER = createCodeGraphCliAdapter();
+const SNAPSHOT_CACHE = new Map<string, VisibleEntrySnapshot>();
 
 export type GeneralRepoToolName = typeof GENERAL_REPO_TOOLS[number];
 
@@ -466,6 +481,16 @@ function commonFields(repo: RepoRecord, ignore: IgnorePolicy, snapshot: VisibleE
   return {
     repo_id: repo.repoId,
     snapshot_id: snapshot.id,
+    snapshot_state: snapshot.state,
+    snapshot_created_at: snapshot.createdAt,
+    snapshot_expires_at: snapshot.expiresAt,
+    snapshot_ttl_ms: snapshot.ttlMs,
+    snapshot_cache: {
+      key: snapshot.cacheKey,
+      hit: snapshot.cacheHit,
+      size: snapshot.cacheSize,
+      max_entries: MAX_SNAPSHOT_CACHE_ENTRIES,
+    },
     index_revision: snapshot.codeGraph.indexRevision,
     ignore_digest: ignore.digest,
     stale: false,
@@ -551,13 +576,15 @@ function metadataDigest(entries: ManifestEntry[]): string {
   ])))}`;
 }
 
-function mergeCodeGraphMetadata(repo: RepoRecord, ignore: IgnorePolicy, entries: ManifestEntry[], codeGraph: CodeGraphRepoSnapshot): { entriesByPath: Map<string, ManifestEntry>; filteredPaths: number } {
+function mergeCodeGraphMetadata(repo: RepoRecord, ignore: IgnorePolicy, entries: ManifestEntry[], codeGraph: CodeGraphRepoSnapshot): { entriesByPath: Map<string, ManifestEntry>; filteredPaths: number; laggingPaths: string[] } {
   const entriesByPath = new Map(entries.map((entry) => [entry.path, entry]));
   let filteredPaths = 0;
+  const laggingPaths = new Set<string>();
 
   for (const file of codeGraph.files) {
+    let relativePath = '';
     try {
-      const relativePath = normalizeRepoRelativePath(file.path);
+      relativePath = normalizeRepoRelativePath(file.path);
       if (isIgnored(ignore, relativePath)) {
         filteredPaths += 1;
         continue;
@@ -572,22 +599,43 @@ function mergeCodeGraphMetadata(repo: RepoRecord, ignore: IgnorePolicy, entries:
       entry.codegraph_language = file.language;
       entry.codegraph_node_count = file.nodeCount;
       entry.codegraph_size = file.size;
-    } catch (_error) {
+      if (typeof file.size === 'number' && typeof entry.size === 'number' && file.size !== entry.size) {
+        entry.codegraph_index_lagging = true;
+        laggingPaths.add(resolved.relativePath);
+      }
+    } catch (error) {
       filteredPaths += 1;
+      if (error instanceof GeneralRepoAccessError && error.code === 'NOT_FOUND' && relativePath) {
+        laggingPaths.add(relativePath);
+      }
     }
   }
 
-  return { entriesByPath, filteredPaths };
+  return { entriesByPath, filteredPaths, laggingPaths: [...laggingPaths].sort((a, b) => a.localeCompare(b)) };
 }
 
 function buildVisibleEntrySnapshot(ctx: GeneralRepoToolContext, repo: RepoRecord, ignore: IgnorePolicy): VisibleEntrySnapshot {
+  const createdAtMs = Date.now();
   const codeGraph = (ctx.codeGraphAdapter ?? DEFAULT_CODEGRAPH_ADAPTER).discoverRepo(repo.canonicalRoot);
   const walked = walkVisibleEntries(repo, ignore);
   const merged = mergeCodeGraphMetadata(repo, ignore, walked.entries, codeGraph);
   const manifestDigest = metadataDigest(walked.entries);
   const id = `snap_${sha256(`${repo.repoId}\0${repo.registryRevision}\0${ignore.digest}\0${codeGraph.indexRevision}\0${manifestDigest}`).slice(0, 16)}`;
-  return {
+  const cacheKey = `cache_${sha256(`${repo.repoId}\0${repo.registryRevision}\0${ignore.digest}\0${id}`).slice(0, 16)}`;
+  const state: SnapshotState = codeGraph.available && merged.laggingPaths.length > 0
+    ? 'index_lagging'
+    : 'ready';
+  const expiresAtMs = createdAtMs + SNAPSHOT_TTL_MS;
+  const snapshot: VisibleEntrySnapshot = {
     id,
+    state,
+    createdAtMs,
+    createdAt: new Date(createdAtMs).toISOString(),
+    expiresAt: new Date(expiresAtMs).toISOString(),
+    ttlMs: SNAPSHOT_TTL_MS,
+    cacheKey,
+    cacheHit: false,
+    cacheSize: SNAPSHOT_CACHE.size,
     entries: walked.entries,
     entriesByPath: merged.entriesByPath,
     manifestDigest,
@@ -595,6 +643,45 @@ function buildVisibleEntrySnapshot(ctx: GeneralRepoToolContext, repo: RepoRecord
     walkerErrors: walked.walkerErrors,
     codeGraph,
     codeGraphFilteredPaths: merged.filteredPaths,
+    codeGraphLaggingPaths: merged.laggingPaths,
+  };
+  return rememberSnapshot(snapshot);
+}
+
+function rememberSnapshot(snapshot: VisibleEntrySnapshot): VisibleEntrySnapshot {
+  const now = Date.now();
+  for (const [key, cached] of SNAPSHOT_CACHE) {
+    if (Date.parse(cached.expiresAt) <= now) SNAPSHOT_CACHE.delete(key);
+  }
+
+  const cached = SNAPSHOT_CACHE.get(snapshot.cacheKey);
+  if (cached && cached.id === snapshot.id && Date.parse(cached.expiresAt) > now) {
+    const cacheHit = {
+      ...cached,
+      cacheHit: true,
+      cacheSize: SNAPSHOT_CACHE.size,
+    };
+    SNAPSHOT_CACHE.set(snapshot.cacheKey, cacheHit);
+    return cacheHit;
+  }
+
+  SNAPSHOT_CACHE.set(snapshot.cacheKey, snapshot);
+  while (SNAPSHOT_CACHE.size > MAX_SNAPSHOT_CACHE_ENTRIES) {
+    let oldestKey: string | null = null;
+    let oldestCreatedAt = Number.POSITIVE_INFINITY;
+    for (const [key, cachedSnapshot] of SNAPSHOT_CACHE) {
+      if (cachedSnapshot.createdAtMs < oldestCreatedAt) {
+        oldestCreatedAt = cachedSnapshot.createdAtMs;
+        oldestKey = key;
+      }
+    }
+    if (!oldestKey) break;
+    SNAPSHOT_CACHE.delete(oldestKey);
+  }
+
+  return {
+    ...snapshot,
+    cacheSize: SNAPSHOT_CACHE.size,
   };
 }
 
@@ -617,6 +704,9 @@ function codeGraphSummary(snapshot: VisibleEntrySnapshot): Record<string, unknow
     latency_ms: snapshot.codeGraph.latencyMs,
     indexed_files: snapshot.codeGraph.files.length,
     filtered_paths: snapshot.codeGraphFilteredPaths,
+    index_lagging: snapshot.codeGraphLaggingPaths.length > 0,
+    lagging_path_count: snapshot.codeGraphLaggingPaths.length,
+    lagging_paths: snapshot.codeGraphLaggingPaths.slice(0, MAX_LAGGING_PATHS_RETURNED),
     error: snapshot.codeGraph.error,
   };
 }
@@ -784,6 +874,7 @@ function repoManifest(ctx: GeneralRepoToolContext, args: Record<string, unknown>
       symlinks: entries.filter((entry) => entry.type === 'symlink').length,
       indexed: entries.filter((entry) => entry.indexed).length,
       unindexed: entries.filter((entry) => !entry.indexed).length,
+      index_lagging: entries.filter((entry) => entry.codegraph_index_lagging).length,
       text: entries.filter((entry) => entry.type === 'file' && entry.binary === false).length,
       binary: entries.filter((entry) => entry.type === 'file' && entry.binary === true).length,
     },

--- a/src/cli/mcp/general-repo-access.ts
+++ b/src/cli/mcp/general-repo-access.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'crypto';
-import { closeSync, constants, existsSync, fstatSync, lstatSync, openSync, readFileSync, readdirSync, realpathSync, statSync } from 'fs';
+import { closeSync, constants, existsSync, fstatSync, lstatSync, openSync, readFileSync, readdirSync, realpathSync, statSync, type Dirent } from 'fs';
 import { basename, dirname, isAbsolute, relative, resolve, sep } from 'path';
 import { readRegisteredRepoHarnessRepos, repoHarnessRepoIdFor, type RepoHarnessAccessMode } from '../../effects/repo-registry';
 import { hashMcpInput, tryWriteMcpAuditEntry } from './audit';
@@ -29,6 +29,7 @@ export interface GeneralRepoToolResult {
 type RepoEntryType = 'file' | 'directory' | 'symlink' | 'other';
 type SymlinkTargetKind = 'internal' | 'external' | 'none';
 type SnapshotState = 'ready' | 'index_lagging' | 'failed';
+const ENTRY_REVISION: unique symbol = Symbol('entryRevision');
 
 interface RepoRecord {
   repoId: string;
@@ -68,6 +69,7 @@ interface ResolvedRepoPath {
 }
 
 interface ManifestEntry {
+  [ENTRY_REVISION]?: string;
   path: string;
   type: RepoEntryType;
   size?: number;
@@ -84,10 +86,25 @@ interface ManifestEntry {
   symlink_target_kind: SymlinkTargetKind;
 }
 
+interface ManifestCounts {
+  entries: number;
+  files: number;
+  directories: number;
+  symlinks: number;
+  indexed: number;
+  unindexed: number;
+  index_lagging: number;
+  text: number;
+  binary: number;
+  content_deferred: number;
+}
+
 interface VisibleEntrySnapshot {
   id: string;
   repoId: string;
   repoRoot: string;
+  coverage: 'complete' | 'page';
+  content: 'exact' | 'metadata';
   state: SnapshotState;
   createdAtMs: number;
   createdAt: string;
@@ -111,6 +128,19 @@ interface VisibleEntrySnapshot {
 interface EntryMetadataCacheStats {
   hits: number;
   misses: number;
+}
+
+interface CodeGraphEntryMetadata {
+  language?: string;
+  nodeCount?: number;
+  size?: number;
+  lagging: boolean;
+}
+
+interface PendingWalkEntry {
+  relativePath: string;
+  absolutePath: string;
+  dirent: Dirent;
 }
 
 interface EntryMetadataCacheValue {
@@ -605,8 +635,8 @@ function commonFields(repo: RepoRecord, ignore: IgnorePolicy, snapshot: VisibleE
   };
 }
 
-function entryMetadataCacheKey(resolved: ResolvedRepoPath, ignore: IgnorePolicy): string {
-  return `entry_${sha256(`${resolved.repo.repoId}\0${resolved.repo.registryRevision}\0${ignore.digest}\0${resolved.relativePath}\0${resolved.metadataSignature}`).slice(0, 16)}`;
+function entryMetadataCacheKey(resolved: ResolvedRepoPath, ignore: IgnorePolicy, contentHash = true): string {
+  return `entry_${sha256(`${resolved.repo.repoId}\0${resolved.repo.registryRevision}\0${ignore.digest}\0${resolved.relativePath}\0${resolved.metadataSignature}\0${contentHash ? 'content-hash' : 'metadata-only'}`).slice(0, 16)}`;
 }
 
 function rememberEntryMetadata(key: string, entry: ManifestEntry): void {
@@ -618,24 +648,29 @@ function rememberEntryMetadata(key: string, entry: ManifestEntry): void {
   }
 }
 
-function metadataForResolved(resolved: ResolvedRepoPath, ignore: IgnorePolicy, stats?: EntryMetadataCacheStats): ManifestEntry {
-  const cacheKey = entryMetadataCacheKey(resolved, ignore);
-  const cached = ENTRY_METADATA_CACHE.get(cacheKey);
-  if (cached) {
-    stats && (stats.hits += 1);
-    ENTRY_METADATA_CACHE.delete(cacheKey);
-    ENTRY_METADATA_CACHE.set(cacheKey, { entry: cached.entry, lastUsedAtMs: Date.now() });
-    return { ...cached.entry };
+function metadataForResolved(resolved: ResolvedRepoPath, ignore: IgnorePolicy, stats?: EntryMetadataCacheStats, opts: { contentHash?: boolean; cache?: boolean } = {}): ManifestEntry {
+  const contentHash = opts.contentHash ?? true;
+  const useCache = opts.cache ?? true;
+  const cacheKey = useCache ? entryMetadataCacheKey(resolved, ignore, contentHash) : '';
+  if (useCache) {
+    const cached = ENTRY_METADATA_CACHE.get(cacheKey);
+    if (cached) {
+      stats && (stats.hits += 1);
+      ENTRY_METADATA_CACHE.delete(cacheKey);
+      ENTRY_METADATA_CACHE.set(cacheKey, { entry: cached.entry, lastUsedAtMs: Date.now() });
+      return { ...cached.entry };
+    }
   }
   stats && (stats.misses += 1);
-  let binary = false;
+  let binary: boolean | undefined = resolved.contentFile ? undefined : false;
   let fileHash: string | undefined;
-  if (resolved.readable && resolved.contentFile) {
+  if (contentHash && resolved.readable && resolved.contentFile) {
     const raw = readStableResolvedFile(resolved, { digest: '', rules: [] });
     binary = raw.subarray(0, BINARY_PROBE_BYTES).includes(0);
     fileHash = sha256(raw);
   }
-  const entry = {
+  const entry: ManifestEntry = {
+    [ENTRY_REVISION]: resolved.metadataSignature,
     path: resolved.relativePath,
     type: resolved.type,
     size: resolved.size,
@@ -647,11 +682,11 @@ function metadataForResolved(resolved: ResolvedRepoPath, ignore: IgnorePolicy, s
     writable: resolved.repo.accessMode === 'read_write' && resolved.readable,
     symlink_target_kind: resolved.symlinkTargetKind,
   };
-  rememberEntryMetadata(cacheKey, entry);
+  if (useCache) rememberEntryMetadata(cacheKey, entry);
   return { ...entry };
 }
 
-function walkVisibleEntries(repo: RepoRecord, ignore: IgnorePolicy, startRelative = '.', stats: EntryMetadataCacheStats = { hits: 0, misses: 0 }): { entries: ManifestEntry[]; partial: boolean; walkerErrors: number } {
+function walkVisibleEntries(repo: RepoRecord, ignore: IgnorePolicy, startRelative = '.', stats: EntryMetadataCacheStats = { hits: 0, misses: 0 }, opts: { contentHash?: boolean; cacheMetadata?: boolean } = {}): { entries: ManifestEntry[]; partial: boolean; walkerErrors: number } {
   const start = resolveRepoPath(repo, startRelative, ignore, { allowRoot: true, allowExternalSymlinkMetadata: true });
   const entries: ManifestEntry[] = [];
   let walkerErrors = 0;
@@ -673,7 +708,7 @@ function walkVisibleEntries(repo: RepoRecord, ignore: IgnorePolicy, startRelativ
         try {
           const childLstat = lstatSync(childAbsolute);
           resolvedChild = resolveWalkedRepoPath(repo, ignore, childRelative, childAbsolute, childLstat);
-          entries.push(metadataForResolved(resolvedChild, ignore, stats));
+          entries.push(metadataForResolved(resolvedChild, ignore, stats, { contentHash: opts.contentHash ?? true, cache: opts.cacheMetadata ?? true }));
         } catch (_error) {
           walkerErrors += 1;
         }
@@ -686,26 +721,96 @@ function walkVisibleEntries(repo: RepoRecord, ignore: IgnorePolicy, startRelativ
     }
   };
 
-  if (start.relativePath !== '.') entries.push(metadataForResolved(start, ignore, stats));
+  if (start.relativePath !== '.') entries.push(metadataForResolved(start, ignore, stats, { contentHash: opts.contentHash ?? true, cache: opts.cacheMetadata ?? true }));
   if (start.readable && start.type === 'directory') visit(start.canonicalPath, start.relativePath);
   return { entries: entries.sort((a, b) => a.path.localeCompare(b.path)), partial: walkerErrors > 0, walkerErrors };
+}
+
+function pushManifestChildren(pending: PendingWalkEntry[], absoluteDir: string, relativeDir: string): boolean {
+  let children: Dirent[];
+  try {
+    children = readdirSync(absoluteDir, { withFileTypes: true });
+  } catch (_error) {
+    return false;
+  }
+  for (const child of children) {
+    const childRelative = relativeDir === '.' ? child.name : `${relativeDir}/${child.name}`;
+    pending.push({
+      relativePath: childRelative,
+      absolutePath: resolve(absoluteDir, child.name),
+      dirent: child,
+    });
+  }
+  pending.sort((a, b) => b.relativePath.localeCompare(a.relativePath));
+  return true;
 }
 
 function isInternalRevisionPath(path: string): boolean {
   return path === '.ai/harness/mcp/audit.log' || path.startsWith('.ai/harness/mcp/');
 }
 
-function metadataDigest(entries: ManifestEntry[]): string {
-  return `sha256:${sha256(JSON.stringify(entries.filter((entry) => !isInternalRevisionPath(entry.path)).map((entry) => [
-    entry.path,
-    entry.sha256 ?? '',
-    entry.type,
-    entry.indexed ? 'indexed' : 'unindexed',
-  ])))}`;
+function createManifestDigest() {
+  const hash = createHash('sha256');
+  hash.update('general-repo-manifest-v2\0');
+  return {
+    update(entry: ManifestEntry, revision = entry[ENTRY_REVISION] ?? entry.sha256 ?? ''): void {
+      if (isInternalRevisionPath(entry.path)) return;
+      hash.update(JSON.stringify([
+        entry.path,
+        revision,
+        entry.type,
+        entry.indexed ? 'indexed' : 'unindexed',
+      ]));
+      hash.update('\0');
+    },
+    digest(): string {
+      return `sha256:${hash.digest('hex')}`;
+    },
+  };
 }
 
-function mergeCodeGraphMetadata(repo: RepoRecord, ignore: IgnorePolicy, entries: ManifestEntry[], codeGraph: CodeGraphRepoSnapshot): { entriesByPath: Map<string, ManifestEntry>; filteredPaths: number; laggingPaths: string[] } {
-  const entriesByPath = new Map(entries.map((entry) => [entry.path, entry]));
+function metadataDigest(entries: ManifestEntry[]): string {
+  const digest = createManifestDigest();
+  for (const entry of entries) digest.update(entry);
+  return digest.digest();
+}
+
+function emptyManifestCounts(): ManifestCounts {
+  return {
+    entries: 0,
+    files: 0,
+    directories: 0,
+    symlinks: 0,
+    indexed: 0,
+    unindexed: 0,
+    index_lagging: 0,
+    text: 0,
+    binary: 0,
+    content_deferred: 0,
+  };
+}
+
+function addManifestCount(counts: ManifestCounts, entry: ManifestEntry): void {
+  counts.entries += 1;
+  if (entry.type === 'file') counts.files += 1;
+  if (entry.type === 'directory') counts.directories += 1;
+  if (entry.type === 'symlink') counts.symlinks += 1;
+  if (entry.indexed) counts.indexed += 1;
+  else counts.unindexed += 1;
+  if (entry.codegraph_index_lagging) counts.index_lagging += 1;
+  if (entry.type === 'file' && entry.binary === false) counts.text += 1;
+  if (entry.type === 'file' && entry.binary === true) counts.binary += 1;
+  if (entry.type === 'file' && entry.binary === undefined) counts.content_deferred += 1;
+}
+
+function countsForEntries(entries: ManifestEntry[]): ManifestCounts {
+  const counts = emptyManifestCounts();
+  for (const entry of entries) addManifestCount(counts, entry);
+  return counts;
+}
+
+function codeGraphMetadataIndex(repo: RepoRecord, ignore: IgnorePolicy, codeGraph: CodeGraphRepoSnapshot): { byPath: Map<string, CodeGraphEntryMetadata>; filteredPaths: number; laggingPaths: Set<string> } {
+  const byPath = new Map<string, CodeGraphEntryMetadata>();
   let filteredPaths = 0;
   const laggingPaths = new Set<string>();
 
@@ -718,17 +823,18 @@ function mergeCodeGraphMetadata(repo: RepoRecord, ignore: IgnorePolicy, entries:
         continue;
       }
       const resolved = resolveRepoPath(repo, relativePath, ignore, { allowExternalSymlinkMetadata: true });
-      const entry = entriesByPath.get(resolved.relativePath);
-      if (!entry || resolved.type !== 'file') {
+      if (resolved.type !== 'file') {
         filteredPaths += 1;
         continue;
       }
-      entry.indexed = true;
-      entry.codegraph_language = file.language;
-      entry.codegraph_node_count = file.nodeCount;
-      entry.codegraph_size = file.size;
-      if (typeof file.size === 'number' && typeof entry.size === 'number' && file.size !== entry.size) {
-        entry.codegraph_index_lagging = true;
+      const lagging = typeof file.size === 'number' && typeof resolved.size === 'number' && file.size !== resolved.size;
+      byPath.set(resolved.relativePath, {
+        language: file.language,
+        nodeCount: file.nodeCount,
+        size: file.size,
+        lagging,
+      });
+      if (lagging) {
         laggingPaths.add(resolved.relativePath);
       }
     } catch (error) {
@@ -739,18 +845,139 @@ function mergeCodeGraphMetadata(repo: RepoRecord, ignore: IgnorePolicy, entries:
     }
   }
 
-  return { entriesByPath, filteredPaths, laggingPaths: [...laggingPaths].sort((a, b) => a.localeCompare(b)) };
+  return { byPath, filteredPaths, laggingPaths };
 }
 
-function buildVisibleEntrySnapshot(ctx: GeneralRepoToolContext, repo: RepoRecord, ignore: IgnorePolicy): VisibleEntrySnapshot {
+function applyCodeGraphMetadata(entry: ManifestEntry, metadata?: CodeGraphEntryMetadata): ManifestEntry {
+  if (!metadata) return entry;
+  entry.indexed = true;
+  entry.codegraph_language = metadata.language;
+  entry.codegraph_node_count = metadata.nodeCount;
+  entry.codegraph_size = metadata.size;
+  if (metadata.lagging) entry.codegraph_index_lagging = true;
+  return entry;
+}
+
+function mergeCodeGraphMetadata(repo: RepoRecord, ignore: IgnorePolicy, entries: ManifestEntry[], codeGraph: CodeGraphRepoSnapshot): { entriesByPath: Map<string, ManifestEntry>; filteredPaths: number; laggingPaths: string[] } {
+  const entriesByPath = new Map(entries.map((entry) => [entry.path, entry]));
+  const indexed = codeGraphMetadataIndex(repo, ignore, codeGraph);
+  let filteredPaths = indexed.filteredPaths;
+
+  for (const [path, metadata] of indexed.byPath) {
+    const entry = entriesByPath.get(path);
+    if (!entry) {
+      filteredPaths += 1;
+      continue;
+    }
+    applyCodeGraphMetadata(entry, metadata);
+  }
+
+  const laggingPaths = [...indexed.laggingPaths].sort((a, b) => a.localeCompare(b));
+  return { entriesByPath, filteredPaths, laggingPaths };
+}
+
+function buildManifestPageSnapshot(ctx: GeneralRepoToolContext, repo: RepoRecord, ignore: IgnorePolicy, args: Record<string, unknown>): { snapshot: VisibleEntrySnapshot; counts: ManifestCounts; nextCursor: string | null } {
+  const createdAtMs = Date.now();
+  const codeGraph = (ctx.codeGraphAdapter ?? DEFAULT_CODEGRAPH_ADAPTER).discoverRepo(repo.canonicalRoot);
+  const indexed = codeGraphMetadataIndex(repo, ignore, codeGraph);
+  const entryMetadataStats = { hits: 0, misses: 0 };
+  const counts = emptyManifestCounts();
+  const digest = createManifestDigest();
+  const pageSize = numberArg(args.page_size, DEFAULT_PAGE_SIZE, 1, HARD_PAGE_SIZE);
+  const offset = numberArg(args.cursor, 0, 0, Number.MAX_SAFE_INTEGER);
+  const pageEntries: ManifestEntry[] = [];
+  const pageByPath = new Map<string, ManifestEntry>();
+  const pending: PendingWalkEntry[] = [];
+  let walkerErrors = 0;
+
+  const start = resolveRepoPath(repo, '.', ignore, { allowRoot: true, allowExternalSymlinkMetadata: true });
+  if (start.readable && start.type === 'directory' && !pushManifestChildren(pending, start.canonicalPath, start.relativePath)) {
+    walkerErrors += 1;
+  }
+
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (!current) break;
+    const ignored = isIgnored(ignore, current.relativePath);
+    let resolvedChild: ResolvedRepoPath | null = null;
+    if (!ignored) {
+      try {
+        const childLstat = lstatSync(current.absolutePath);
+        resolvedChild = resolveWalkedRepoPath(repo, ignore, current.relativePath, current.absolutePath, childLstat);
+        const includeContentHash = counts.entries >= offset && pageEntries.length < pageSize;
+        const entry = applyCodeGraphMetadata(metadataForResolved(resolvedChild, ignore, entryMetadataStats, {
+          contentHash: includeContentHash,
+          cache: includeContentHash,
+        }), indexed.byPath.get(resolvedChild.relativePath));
+        digest.update(entry);
+        addManifestCount(counts, entry);
+        if (counts.entries > offset && pageEntries.length < pageSize) {
+          pageEntries.push(entry);
+          pageByPath.set(entry.path, entry);
+        }
+      } catch (_error) {
+        walkerErrors += 1;
+      }
+    }
+
+    if (current.dirent.isDirectory()) {
+      if (!pushManifestChildren(pending, current.absolutePath, current.relativePath)) walkerErrors += 1;
+    } else if (resolvedChild?.type === 'directory') {
+      if (!pushManifestChildren(pending, resolvedChild.canonicalPath, current.relativePath)) walkerErrors += 1;
+    }
+  }
+
+  const manifestDigest = digest.digest();
+  const id = `snap_${sha256(`${repo.repoId}\0${repo.registryRevision}\0${ignore.digest}\0${codeGraph.indexRevision}\0${manifestDigest}`).slice(0, 16)}`;
+  const coverage: VisibleEntrySnapshot['coverage'] = offset === 0 && pageEntries.length === counts.entries ? 'complete' : 'page';
+  const cacheKey = coverage === 'complete'
+    ? `cache_${sha256(`${repo.repoId}\0${repo.registryRevision}\0${ignore.digest}\0${id}`).slice(0, 16)}`
+    : `cache_${sha256(`${repo.repoId}\0${repo.registryRevision}\0${ignore.digest}\0${id}\0repo_manifest\0${offset}\0${pageSize}`).slice(0, 16)}`;
+  const state: SnapshotState = codeGraph.available && indexed.laggingPaths.size > 0
+    ? 'index_lagging'
+    : 'ready';
+  const expiresAtMs = createdAtMs + SNAPSHOT_TTL_MS;
+  const snapshot: VisibleEntrySnapshot = {
+    id,
+    repoId: repo.repoId,
+    repoRoot: repo.canonicalRoot,
+    coverage,
+    content: coverage === 'complete' ? 'exact' : 'metadata',
+    state,
+    createdAtMs,
+    createdAt: new Date(createdAtMs).toISOString(),
+    expiresAt: new Date(expiresAtMs).toISOString(),
+    ttlMs: SNAPSHOT_TTL_MS,
+    cacheKey,
+    cacheHit: false,
+    cacheSize: SNAPSHOT_CACHE.size,
+    entries: pageEntries,
+    entriesByPath: pageByPath,
+    manifestDigest,
+    partial: walkerErrors > 0,
+    walkerErrors,
+    entryMetadataCacheHits: entryMetadataStats.hits,
+    entryMetadataCacheMisses: entryMetadataStats.misses,
+    codeGraph,
+    codeGraphFilteredPaths: indexed.filteredPaths,
+    codeGraphLaggingPaths: [...indexed.laggingPaths].sort((a, b) => a.localeCompare(b)),
+  };
+  const nextCursor = offset + pageEntries.length < counts.entries ? String(offset + pageEntries.length) : null;
+  return { snapshot: rememberSnapshot(snapshot), counts, nextCursor };
+}
+
+function buildVisibleEntrySnapshot(ctx: GeneralRepoToolContext, repo: RepoRecord, ignore: IgnorePolicy, opts: { contentHash?: boolean } = {}): VisibleEntrySnapshot {
   const createdAtMs = Date.now();
   const codeGraph = (ctx.codeGraphAdapter ?? DEFAULT_CODEGRAPH_ADAPTER).discoverRepo(repo.canonicalRoot);
   const entryMetadataStats = { hits: 0, misses: 0 };
-  const walked = walkVisibleEntries(repo, ignore, '.', entryMetadataStats);
+  const contentHash = opts.contentHash ?? true;
+  const walked = walkVisibleEntries(repo, ignore, '.', entryMetadataStats, { contentHash, cacheMetadata: contentHash });
   const merged = mergeCodeGraphMetadata(repo, ignore, walked.entries, codeGraph);
   const manifestDigest = metadataDigest(walked.entries);
   const id = `snap_${sha256(`${repo.repoId}\0${repo.registryRevision}\0${ignore.digest}\0${codeGraph.indexRevision}\0${manifestDigest}`).slice(0, 16)}`;
-  const cacheKey = `cache_${sha256(`${repo.repoId}\0${repo.registryRevision}\0${ignore.digest}\0${id}`).slice(0, 16)}`;
+  const cacheKey = contentHash
+    ? `cache_${sha256(`${repo.repoId}\0${repo.registryRevision}\0${ignore.digest}\0${id}`).slice(0, 16)}`
+    : `cache_${sha256(`${repo.repoId}\0${repo.registryRevision}\0${ignore.digest}\0${id}\0metadata-only`).slice(0, 16)}`;
   const state: SnapshotState = codeGraph.available && merged.laggingPaths.length > 0
     ? 'index_lagging'
     : 'ready';
@@ -759,6 +986,8 @@ function buildVisibleEntrySnapshot(ctx: GeneralRepoToolContext, repo: RepoRecord
     id,
     repoId: repo.repoId,
     repoRoot: repo.canonicalRoot,
+    coverage: 'complete',
+    content: contentHash ? 'exact' : 'metadata',
     state,
     createdAtMs,
     createdAt: new Date(createdAtMs).toISOString(),
@@ -820,7 +1049,15 @@ function rememberSnapshot(snapshot: VisibleEntrySnapshot): VisibleEntrySnapshot 
   };
 }
 
-function cachedSnapshotById(repo: RepoRecord, snapshotId: unknown): VisibleEntrySnapshot | null {
+function snapshotCoversPaths(snapshot: VisibleEntrySnapshot, paths?: string[], opts: { requireHashes?: boolean } = {}): boolean {
+  if (!paths || paths.length === 0) return snapshot.coverage === 'complete' && (!opts.requireHashes || snapshot.content === 'exact');
+  if (snapshot.coverage !== 'complete' && paths.some((path) => !snapshot.entriesByPath.has(path))) return false;
+  if (snapshot.coverage === 'complete' && paths.some((path) => !snapshot.entriesByPath.has(path))) return false;
+  if (opts.requireHashes && paths.some((path) => typeof snapshot.entriesByPath.get(path)?.sha256 !== 'string')) return false;
+  return true;
+}
+
+function cachedSnapshotById(repo: RepoRecord, snapshotId: unknown, paths?: string[], opts: { requireHashes?: boolean } = {}): VisibleEntrySnapshot | null {
   const requested = typeof snapshotId === 'string' ? snapshotId.trim() : '';
   if (!requested) return null;
   const now = Date.now();
@@ -829,7 +1066,7 @@ function cachedSnapshotById(repo: RepoRecord, snapshotId: unknown): VisibleEntry
       SNAPSHOT_CACHE.delete(key);
       continue;
     }
-    if (cached.id === requested && cached.repoId === repo.repoId && cached.repoRoot === repo.canonicalRoot) {
+    if (cached.id === requested && cached.repoId === repo.repoId && cached.repoRoot === repo.canonicalRoot && snapshotCoversPaths(cached, paths, opts)) {
       const cacheHit = {
         ...cached,
         cacheHit: true,
@@ -997,7 +1234,7 @@ function readFilePayload(repo: RepoRecord, ignore: IgnorePolicy, snapshot: Visib
 function getRepoCapabilities(ctx: GeneralRepoToolContext, args: Record<string, unknown>): GeneralRepoToolResult {
   const repo = resolveRepo(ctx, args.repo_id);
   const ignore = readIgnorePolicy(repo.canonicalRoot);
-  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore);
+  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore, { contentHash: false });
   assertSnapshotFresh(args, snapshot);
   return textResult({
     ...commonFields(repo, ignore, snapshot, { tool: 'get_repo_capabilities' }),
@@ -1026,27 +1263,18 @@ function getRepoCapabilities(ctx: GeneralRepoToolContext, args: Record<string, u
 function repoManifest(ctx: GeneralRepoToolContext, args: Record<string, unknown>): GeneralRepoToolResult {
   const repo = resolveRepo(ctx, args.repo_id);
   const ignore = readIgnorePolicy(repo.canonicalRoot);
-  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore);
+  const streamed = buildManifestPageSnapshot(ctx, repo, ignore, args);
+  const snapshot = streamed.snapshot;
   assertSnapshotFresh(args, snapshot);
-  const entries = snapshot.entries;
-  const paged = pageEntries(entries, args.cursor, args.page_size);
   return textResult({
     ...commonFields(repo, ignore, snapshot, { tool: 'repo_manifest', paths: ['.'] }),
-    entries: paged.page,
-    next_cursor: paged.nextCursor,
+    entries: snapshot.entries,
+    next_cursor: streamed.nextCursor,
     complete: !snapshot.partial,
-    page_complete: paged.nextCursor === null,
-    counts: {
-      entries: entries.length,
-      files: entries.filter((entry) => entry.type === 'file').length,
-      directories: entries.filter((entry) => entry.type === 'directory').length,
-      symlinks: entries.filter((entry) => entry.type === 'symlink').length,
-      indexed: entries.filter((entry) => entry.indexed).length,
-      unindexed: entries.filter((entry) => !entry.indexed).length,
-      index_lagging: entries.filter((entry) => entry.codegraph_index_lagging).length,
-      text: entries.filter((entry) => entry.type === 'file' && entry.binary === false).length,
-      binary: entries.filter((entry) => entry.type === 'file' && entry.binary === true).length,
-    },
+    page_complete: streamed.nextCursor === null,
+    manifest_streaming: true,
+    snapshot_coverage: snapshot.coverage,
+    counts: streamed.counts,
     manifest_digest: snapshot.manifestDigest,
     walker_errors: snapshot.walkerErrors,
     codegraph: codeGraphSummary(snapshot),
@@ -1057,7 +1285,7 @@ function listTree(ctx: GeneralRepoToolContext, args: Record<string, unknown>): G
   const repo = resolveRepo(ctx, args.repo_id);
   const ignore = readIgnorePolicy(repo.canonicalRoot);
   const root = resolveRepoPath(repo, args.path ?? '.', ignore, { allowRoot: true, requireDirectory: true });
-  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore);
+  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore, { contentHash: false });
   assertSnapshotFresh(args, snapshot);
   const depth = numberArg(args.depth, 1, 0, 6);
   const entries = snapshot.entries
@@ -1083,7 +1311,7 @@ function statFile(ctx: GeneralRepoToolContext, args: Record<string, unknown>): G
   const repo = resolveRepo(ctx, args.repo_id);
   const ignore = readIgnorePolicy(repo.canonicalRoot);
   const resolved = resolveRepoPath(repo, args.path, ignore);
-  const cachedSnapshot = cachedSnapshotById(repo, args.snapshot_id);
+  const cachedSnapshot = cachedSnapshotById(repo, args.snapshot_id, [resolved.relativePath], { requireHashes: true });
   if (cachedSnapshot) {
     const current = metadataForResolved(resolved, ignore);
     const cachedEntry = cachedSnapshot.entriesByPath.get(resolved.relativePath);
@@ -1120,14 +1348,17 @@ function statFile(ctx: GeneralRepoToolContext, args: Record<string, unknown>): G
 function readFileTool(ctx: GeneralRepoToolContext, args: Record<string, unknown>): GeneralRepoToolResult {
   const repo = resolveRepo(ctx, args.repo_id);
   const ignore = readIgnorePolicy(repo.canonicalRoot);
-  const cachedSnapshot = cachedSnapshotById(repo, args.snapshot_id);
+  const requestedPath = typeof args.snapshot_id === 'string' && args.snapshot_id.trim()
+    ? [resolveRepoPath(repo, args.path, ignore, { requireFile: true }).relativePath]
+    : undefined;
+  const cachedSnapshot = cachedSnapshotById(repo, args.snapshot_id, requestedPath, { requireHashes: true });
   if (cachedSnapshot) {
     return textResult({
       ...readFilePayload(repo, ignore, cachedSnapshot, args, HARD_READ_BYTES, 'read_file', true),
       codegraph: codeGraphSummary(cachedSnapshot),
     });
   }
-  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore);
+  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore, { contentHash: false });
   assertSnapshotFresh(args, snapshot);
   return textResult({
     ...readFilePayload(repo, ignore, snapshot, args),
@@ -1138,7 +1369,7 @@ function readFileTool(ctx: GeneralRepoToolContext, args: Record<string, unknown>
 function readFiles(ctx: GeneralRepoToolContext, args: Record<string, unknown>): GeneralRepoToolResult {
   const repo = resolveRepo(ctx, args.repo_id);
   const ignore = readIgnorePolicy(repo.canonicalRoot);
-  const cachedSnapshot = cachedSnapshotById(repo, args.snapshot_id);
+  const cachedSnapshot = cachedSnapshotById(repo, args.snapshot_id, undefined, { requireHashes: true });
   const snapshot = cachedSnapshot ?? buildVisibleEntrySnapshot(ctx, repo, ignore);
   if (!cachedSnapshot) assertSnapshotFresh(args, snapshot);
   const requests = Array.isArray(args.requests) ? args.requests : [];
@@ -1192,7 +1423,7 @@ function searchText(ctx: GeneralRepoToolContext, args: Record<string, unknown>):
   const mode = args.mode === 'regex' ? 'regex' : 'literal';
   const repo = resolveRepo(ctx, args.repo_id);
   const ignore = readIgnorePolicy(repo.canonicalRoot);
-  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore);
+  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore, { contentHash: false });
   assertSnapshotFresh(args, snapshot);
   const requestedPaths = Array.isArray(args.paths) && args.paths.length > 0 ? args.paths : ['.'];
   const candidates: ManifestEntry[] = [];
@@ -1228,7 +1459,9 @@ function searchText(ctx: GeneralRepoToolContext, args: Record<string, unknown>):
     if (entry.type !== 'file' || !entry.readable || seen.has(entry.path) || entry.binary || (entry.size ?? 0) > SEARCH_FILE_SCAN_BYTES) continue;
     seen.add(entry.path);
     const resolved = resolveRepoPath(repo, entry.path, ignore, { requireFile: true });
-    const text = readStableResolvedFile(resolved, ignore).toString('utf-8');
+    const raw = readStableResolvedFile(resolved, ignore);
+    const text = raw.toString('utf-8');
+    const fileHash = entry.sha256 ?? sha256(raw);
     const lines = text.split(/\r?\n/);
     for (let index = 0; index < lines.length; index += 1) {
       const line = lines[index] ?? '';
@@ -1243,7 +1476,7 @@ function searchText(ctx: GeneralRepoToolContext, args: Record<string, unknown>):
         line: index + 1,
         column: column + 1,
         snippet: line.slice(Math.max(0, column - 60), column + 120),
-        sha256: entry.sha256,
+        sha256: fileHash,
         indexed: entry.indexed,
         backend: entry.indexed ? 'codegraph-indexed-filesystem-search' : 'filesystem-fallback',
       });

--- a/src/cli/mcp/general-repo-access.ts
+++ b/src/cli/mcp/general-repo-access.ts
@@ -59,6 +59,7 @@ interface ResolvedRepoPath {
   type: RepoEntryType;
   size?: number;
   modifiedAt?: string;
+  metadataSignature: string;
   symlinkTargetKind: SymlinkTargetKind;
   readable: boolean;
   identity?: string;
@@ -97,9 +98,21 @@ interface VisibleEntrySnapshot {
   manifestDigest: string;
   partial: boolean;
   walkerErrors: number;
+  entryMetadataCacheHits: number;
+  entryMetadataCacheMisses: number;
   codeGraph: CodeGraphRepoSnapshot;
   codeGraphFilteredPaths: number;
   codeGraphLaggingPaths: string[];
+}
+
+interface EntryMetadataCacheStats {
+  hits: number;
+  misses: number;
+}
+
+interface EntryMetadataCacheValue {
+  entry: ManifestEntry;
+  lastUsedAtMs: number;
 }
 
 const GENERAL_REPO_TOOLS = [
@@ -120,11 +133,13 @@ const BINARY_PROBE_BYTES = 8 * 1024;
 const SEARCH_FILE_SCAN_BYTES = 1024 * 1024;
 const DEFAULT_SEARCH_RESULTS = 50;
 const HARD_SEARCH_RESULTS = 100;
-const SNAPSHOT_TTL_MS = 30_000;
+const SNAPSHOT_TTL_MS = 5 * 60_000;
 const MAX_SNAPSHOT_CACHE_ENTRIES = 16;
+const MAX_ENTRY_METADATA_CACHE_ENTRIES = 200_000;
 const MAX_LAGGING_PATHS_RETURNED = 50;
 const DEFAULT_CODEGRAPH_ADAPTER = createCodeGraphCliAdapter();
 const SNAPSHOT_CACHE = new Map<string, VisibleEntrySnapshot>();
+const ENTRY_METADATA_CACHE = new Map<string, EntryMetadataCacheValue>();
 
 export type GeneralRepoToolName = typeof GENERAL_REPO_TOOLS[number];
 
@@ -184,6 +199,19 @@ function numberArg(value: unknown, fallback: number, min: number, max: number): 
   const parsed = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN;
   if (!Number.isFinite(parsed)) return fallback;
   return Math.min(Math.max(Math.trunc(parsed), min), max);
+}
+
+function cachePaths(paths: string[] | undefined): string[] {
+  const normalized = (paths && paths.length > 0 ? paths : ['.'])
+    .map((path) => toPosixPath(String(path || '.')).replace(/^\.\/+/, '') || '.');
+  return [...new Set(normalized)].sort((a, b) => a.localeCompare(b));
+}
+
+function responseCacheKey(repo: RepoRecord, ignore: IgnorePolicy, snapshot: VisibleEntrySnapshot, scope: { tool: string; paths?: string[] }): { key: string; paths: string[]; pathDigest: string } {
+  const paths = cachePaths(scope.paths);
+  const pathDigest = `sha256:${sha256(JSON.stringify(paths))}`;
+  const key = `cache_${sha256(`${repo.repoId}\0${repo.registryRevision}\0${ignore.digest}\0${snapshot.id}\0${scope.tool}\0${pathDigest}`).slice(0, 16)}`;
+  return { key, paths, pathDigest };
 }
 
 function toPosixPath(value: string): string {
@@ -413,6 +441,15 @@ function resolveRepoPath(repo: RepoRecord, inputPath: unknown, ignore: IgnorePol
 
   const fileStat = readable ? statSync(canonicalPath) : lstat;
   const parentStat = statSync(dirname(absolutePath));
+  const metadataSignature = [
+    fileStat.size,
+    fileStat.mtimeMs,
+    fileStat.ctimeMs,
+    fileStat.mode,
+    fileStat.ino,
+    type,
+    readable ? 'readable' : 'metadata-only',
+  ].join(':');
   if (opts.requireFile && (!readable || !fileStat.isFile())) {
     throw new GeneralRepoAccessError('NOT_A_FILE', 'path is not a regular file', { path: relativePath });
   }
@@ -428,6 +465,7 @@ function resolveRepoPath(repo: RepoRecord, inputPath: unknown, ignore: IgnorePol
     type,
     size: fileStat.isFile() ? fileStat.size : undefined,
     modifiedAt: fileStat.mtime.toISOString(),
+    metadataSignature,
     symlinkTargetKind,
     readable,
     identity: readable ? statIdentity(fileStat) : undefined,
@@ -477,7 +515,8 @@ function readStableResolvedFile(resolved: ResolvedRepoPath, ignore: IgnorePolicy
   }
 }
 
-function commonFields(repo: RepoRecord, ignore: IgnorePolicy, snapshot: VisibleEntrySnapshot) {
+function commonFields(repo: RepoRecord, ignore: IgnorePolicy, snapshot: VisibleEntrySnapshot, scope: { tool: string; paths?: string[] }) {
+  const scopedCache = responseCacheKey(repo, ignore, snapshot, scope);
   return {
     repo_id: repo.repoId,
     snapshot_id: snapshot.id,
@@ -486,10 +525,20 @@ function commonFields(repo: RepoRecord, ignore: IgnorePolicy, snapshot: VisibleE
     snapshot_expires_at: snapshot.expiresAt,
     snapshot_ttl_ms: snapshot.ttlMs,
     snapshot_cache: {
-      key: snapshot.cacheKey,
+      key: scopedCache.key,
+      snapshot_key: snapshot.cacheKey,
+      scope: scope.tool,
+      paths: scopedCache.paths,
+      path_digest: scopedCache.pathDigest,
       hit: snapshot.cacheHit,
       size: snapshot.cacheSize,
       max_entries: MAX_SNAPSHOT_CACHE_ENTRIES,
+      entry_metadata: {
+        hits: snapshot.entryMetadataCacheHits,
+        misses: snapshot.entryMetadataCacheMisses,
+        size: ENTRY_METADATA_CACHE.size,
+        max_entries: MAX_ENTRY_METADATA_CACHE_ENTRIES,
+      },
     },
     index_revision: snapshot.codeGraph.indexRevision,
     ignore_digest: ignore.digest,
@@ -499,7 +548,29 @@ function commonFields(repo: RepoRecord, ignore: IgnorePolicy, snapshot: VisibleE
   };
 }
 
-function metadataForResolved(resolved: ResolvedRepoPath): ManifestEntry {
+function entryMetadataCacheKey(resolved: ResolvedRepoPath, ignore: IgnorePolicy): string {
+  return `entry_${sha256(`${resolved.repo.repoId}\0${resolved.repo.registryRevision}\0${ignore.digest}\0${resolved.relativePath}\0${resolved.metadataSignature}`).slice(0, 16)}`;
+}
+
+function rememberEntryMetadata(key: string, entry: ManifestEntry): void {
+  ENTRY_METADATA_CACHE.set(key, { entry: { ...entry }, lastUsedAtMs: Date.now() });
+  while (ENTRY_METADATA_CACHE.size > MAX_ENTRY_METADATA_CACHE_ENTRIES) {
+    const oldestKey = ENTRY_METADATA_CACHE.keys().next().value;
+    if (oldestKey === undefined) break;
+    ENTRY_METADATA_CACHE.delete(oldestKey);
+  }
+}
+
+function metadataForResolved(resolved: ResolvedRepoPath, ignore: IgnorePolicy, stats?: EntryMetadataCacheStats): ManifestEntry {
+  const cacheKey = entryMetadataCacheKey(resolved, ignore);
+  const cached = ENTRY_METADATA_CACHE.get(cacheKey);
+  if (cached) {
+    stats && (stats.hits += 1);
+    ENTRY_METADATA_CACHE.delete(cacheKey);
+    ENTRY_METADATA_CACHE.set(cacheKey, { entry: cached.entry, lastUsedAtMs: Date.now() });
+    return { ...cached.entry };
+  }
+  stats && (stats.misses += 1);
   let binary = false;
   let fileHash: string | undefined;
   if (resolved.readable) {
@@ -510,7 +581,7 @@ function metadataForResolved(resolved: ResolvedRepoPath): ManifestEntry {
       fileHash = sha256(raw);
     }
   }
-  return {
+  const entry = {
     path: resolved.relativePath,
     type: resolved.type,
     size: resolved.size,
@@ -522,9 +593,11 @@ function metadataForResolved(resolved: ResolvedRepoPath): ManifestEntry {
     writable: resolved.repo.accessMode === 'read_write' && resolved.readable,
     symlink_target_kind: resolved.symlinkTargetKind,
   };
+  rememberEntryMetadata(cacheKey, entry);
+  return { ...entry };
 }
 
-function walkVisibleEntries(repo: RepoRecord, ignore: IgnorePolicy, startRelative = '.'): { entries: ManifestEntry[]; partial: boolean; walkerErrors: number } {
+function walkVisibleEntries(repo: RepoRecord, ignore: IgnorePolicy, startRelative = '.', stats: EntryMetadataCacheStats = { hits: 0, misses: 0 }): { entries: ManifestEntry[]; partial: boolean; walkerErrors: number } {
   const start = resolveRepoPath(repo, startRelative, ignore, { allowRoot: true, allowExternalSymlinkMetadata: true });
   const entries: ManifestEntry[] = [];
   let walkerErrors = 0;
@@ -545,7 +618,7 @@ function walkVisibleEntries(repo: RepoRecord, ignore: IgnorePolicy, startRelativ
       if (!ignored) {
         try {
           resolvedChild = resolveRepoPath(repo, childRelative, ignore, { allowExternalSymlinkMetadata: true });
-          entries.push(metadataForResolved(resolvedChild));
+          entries.push(metadataForResolved(resolvedChild, ignore, stats));
         } catch (_error) {
           walkerErrors += 1;
         }
@@ -558,7 +631,7 @@ function walkVisibleEntries(repo: RepoRecord, ignore: IgnorePolicy, startRelativ
     }
   };
 
-  if (start.relativePath !== '.') entries.push(metadataForResolved(start));
+  if (start.relativePath !== '.') entries.push(metadataForResolved(start, ignore, stats));
   if (start.readable && statSync(start.canonicalPath).isDirectory()) visit(start.canonicalPath, start.relativePath);
   return { entries: entries.sort((a, b) => a.path.localeCompare(b.path)), partial: walkerErrors > 0, walkerErrors };
 }
@@ -617,7 +690,8 @@ function mergeCodeGraphMetadata(repo: RepoRecord, ignore: IgnorePolicy, entries:
 function buildVisibleEntrySnapshot(ctx: GeneralRepoToolContext, repo: RepoRecord, ignore: IgnorePolicy): VisibleEntrySnapshot {
   const createdAtMs = Date.now();
   const codeGraph = (ctx.codeGraphAdapter ?? DEFAULT_CODEGRAPH_ADAPTER).discoverRepo(repo.canonicalRoot);
-  const walked = walkVisibleEntries(repo, ignore);
+  const entryMetadataStats = { hits: 0, misses: 0 };
+  const walked = walkVisibleEntries(repo, ignore, '.', entryMetadataStats);
   const merged = mergeCodeGraphMetadata(repo, ignore, walked.entries, codeGraph);
   const manifestDigest = metadataDigest(walked.entries);
   const id = `snap_${sha256(`${repo.repoId}\0${repo.registryRevision}\0${ignore.digest}\0${codeGraph.indexRevision}\0${manifestDigest}`).slice(0, 16)}`;
@@ -641,6 +715,8 @@ function buildVisibleEntrySnapshot(ctx: GeneralRepoToolContext, repo: RepoRecord
     manifestDigest,
     partial: walked.partial,
     walkerErrors: walked.walkerErrors,
+    entryMetadataCacheHits: entryMetadataStats.hits,
+    entryMetadataCacheMisses: entryMetadataStats.misses,
     codeGraph,
     codeGraphFilteredPaths: merged.filteredPaths,
     codeGraphLaggingPaths: merged.laggingPaths,
@@ -660,6 +736,8 @@ function rememberSnapshot(snapshot: VisibleEntrySnapshot): VisibleEntrySnapshot 
       ...cached,
       cacheHit: true,
       cacheSize: SNAPSHOT_CACHE.size,
+      entryMetadataCacheHits: snapshot.entryMetadataCacheHits,
+      entryMetadataCacheMisses: snapshot.entryMetadataCacheMisses,
     };
     SNAPSHOT_CACHE.set(snapshot.cacheKey, cacheHit);
     return cacheHit;
@@ -735,7 +813,7 @@ function byteRange(value: unknown, maxLength: number): [number, number] | null {
   return [start, Math.min(length, maxLength)];
 }
 
-function readFilePayload(repo: RepoRecord, ignore: IgnorePolicy, snapshot: VisibleEntrySnapshot, args: Record<string, unknown>, maxBytes = HARD_READ_BYTES): Record<string, unknown> {
+function readFilePayload(repo: RepoRecord, ignore: IgnorePolicy, snapshot: VisibleEntrySnapshot, args: Record<string, unknown>, maxBytes = HARD_READ_BYTES, tool = 'read_file'): Record<string, unknown> {
   if (args.line_range !== undefined && args.byte_range !== undefined) {
     throw new GeneralRepoAccessError('INVALID_RANGE', 'line_range and byte_range are mutually exclusive');
   }
@@ -752,6 +830,7 @@ function readFilePayload(repo: RepoRecord, ignore: IgnorePolicy, snapshot: Visib
   const target = resolveRepoPath(repo, args.path, ignore, { requireFile: true });
   const snapshotEntry = snapshot.entriesByPath.get(target.relativePath);
   const indexed = snapshotEntry?.indexed ?? false;
+  const fields = commonFields(repo, ignore, snapshot, { tool, paths: [target.relativePath] });
   const raw = readStableResolvedFile(target, ignore);
   const fullHash = sha256(raw);
   const binary = raw.subarray(0, BINARY_PROBE_BYTES).includes(0);
@@ -762,7 +841,7 @@ function readFilePayload(repo: RepoRecord, ignore: IgnorePolicy, snapshot: Visib
     const [start, length] = range;
     const chunk = raw.subarray(start, start + length);
     return {
-      ...commonFields(repo, ignore, snapshot),
+      ...fields,
       path: target.relativePath,
       sha256: fullHash,
       indexed,
@@ -792,7 +871,7 @@ function readFilePayload(repo: RepoRecord, ignore: IgnorePolicy, snapshot: Visib
       throw new GeneralRepoAccessError('PAYLOAD_LIMIT_REACHED', 'line_range exceeds response byte budget', { max_bytes: maxBytes });
     }
     return {
-      ...commonFields(repo, ignore, snapshot),
+      ...fields,
       path: target.relativePath,
       sha256: fullHash,
       indexed,
@@ -811,7 +890,7 @@ function readFilePayload(repo: RepoRecord, ignore: IgnorePolicy, snapshot: Visib
   const bytes = raw.subarray(0, maxBytes);
   const content = bytes.toString('utf-8');
   return {
-    ...commonFields(repo, ignore, snapshot),
+    ...fields,
     path: target.relativePath,
     sha256: fullHash,
     indexed,
@@ -831,7 +910,7 @@ function getRepoCapabilities(ctx: GeneralRepoToolContext, args: Record<string, u
   const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore);
   assertSnapshotFresh(args, snapshot);
   return textResult({
-    ...commonFields(repo, ignore, snapshot),
+    ...commonFields(repo, ignore, snapshot, { tool: 'get_repo_capabilities' }),
     access_mode: repo.accessMode,
     writable: repo.accessMode === 'read_write',
     display_name: repo.displayName,
@@ -862,7 +941,7 @@ function repoManifest(ctx: GeneralRepoToolContext, args: Record<string, unknown>
   const entries = snapshot.entries;
   const paged = pageEntries(entries, args.cursor, args.page_size);
   return textResult({
-    ...commonFields(repo, ignore, snapshot),
+    ...commonFields(repo, ignore, snapshot, { tool: 'repo_manifest', paths: ['.'] }),
     entries: paged.page,
     next_cursor: paged.nextCursor,
     complete: !snapshot.partial,
@@ -902,7 +981,7 @@ function listTree(ctx: GeneralRepoToolContext, args: Record<string, unknown>): G
     });
   const paged = pageEntries(entries, args.cursor, (args.page_size ?? DEFAULT_PAGE_SIZE));
   return textResult({
-    ...commonFields(repo, ignore, snapshot),
+    ...commonFields(repo, ignore, snapshot, { tool: 'list_tree', paths: [root.relativePath] }),
     path: root.relativePath,
     entries: paged.page,
     next_cursor: paged.nextCursor,
@@ -916,9 +995,9 @@ function statFile(ctx: GeneralRepoToolContext, args: Record<string, unknown>): G
   const resolved = resolveRepoPath(repo, args.path, ignore);
   const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore);
   assertSnapshotFresh(args, snapshot);
-  const entry = snapshot.entriesByPath.get(resolved.relativePath) ?? metadataForResolved(resolved);
+  const entry = snapshot.entriesByPath.get(resolved.relativePath) ?? metadataForResolved(resolved, ignore);
   return textResult({
-    ...commonFields(repo, ignore, snapshot),
+    ...commonFields(repo, ignore, snapshot, { tool: 'stat_file', paths: [resolved.relativePath] }),
     ...entry,
     codegraph: codeGraphSummary(snapshot),
   });
@@ -958,7 +1037,7 @@ function readFiles(ctx: GeneralRepoToolContext, args: Record<string, unknown>): 
       continue;
     }
     try {
-      const payload = readFilePayload(repo, ignore, snapshot, request as Record<string, unknown>, remaining);
+      const payload = readFilePayload(repo, ignore, snapshot, request as Record<string, unknown>, remaining, 'read_files');
       remaining -= Number(payload.bytes_returned ?? 0);
       results.push(payload);
     } catch (error) {
@@ -972,7 +1051,12 @@ function readFiles(ctx: GeneralRepoToolContext, args: Record<string, unknown>): 
   }
 
   return textResult({
-    ...commonFields(repo, ignore, snapshot),
+    ...commonFields(repo, ignore, snapshot, {
+      tool: 'read_files',
+      paths: requests
+        .map((request) => (typeof request === 'object' && request !== null && !Array.isArray(request) ? String((request as { path?: unknown }).path ?? '') : ''))
+        .filter((path) => path.length > 0),
+    }),
     partial: partial || snapshot.partial,
     results,
     bytes_remaining: remaining,
@@ -999,7 +1083,7 @@ function searchText(ctx: GeneralRepoToolContext, args: Record<string, unknown>):
           : entry.path === resolved.relativePath || entry.path.startsWith(`${resolved.relativePath}/`)
       )));
     } else {
-      candidates.push(snapshot.entriesByPath.get(resolved.relativePath) ?? metadataForResolved(resolved));
+      candidates.push(snapshot.entriesByPath.get(resolved.relativePath) ?? metadataForResolved(resolved, ignore));
     }
   }
   const seen = new Set<string>();
@@ -1049,7 +1133,7 @@ function searchText(ctx: GeneralRepoToolContext, args: Record<string, unknown>):
   const nextCursor = matches.length > maxResults ? String(offset + maxResults) : null;
 
   return textResult({
-    ...commonFields(repo, ignore, snapshot),
+    ...commonFields(repo, ignore, snapshot, { tool: 'search_text', paths: requestedPaths.map((path) => String(path)) }),
     query,
     mode,
     matches: returned,

--- a/src/cli/mcp/general-repo-access.ts
+++ b/src/cli/mcp/general-repo-access.ts
@@ -18,6 +18,9 @@ export interface GeneralRepoToolContext {
   repoRoot: string;
   policy: McpPolicy;
   codeGraphAdapter?: GeneralRepoCodeGraphAdapter;
+  testHooks?: {
+    afterSnapshotWalk?: (event: { repoRoot: string; kind: 'complete' | 'manifest_page'; attempt: number }) => void;
+  };
 }
 
 export interface GeneralRepoToolResult {
@@ -28,7 +31,7 @@ export interface GeneralRepoToolResult {
 
 type RepoEntryType = 'file' | 'directory' | 'symlink' | 'other';
 type SymlinkTargetKind = 'internal' | 'external' | 'none';
-type SnapshotState = 'ready' | 'index_lagging' | 'failed';
+type SnapshotState = 'ready' | 'index_lagging' | 'stale' | 'failed';
 const ENTRY_REVISION: unique symbol = Symbol('entryRevision');
 
 interface RepoRecord {
@@ -170,6 +173,7 @@ const SNAPSHOT_TTL_MS = 5 * 60_000;
 const MAX_SNAPSHOT_CACHE_ENTRIES = 16;
 const MAX_ENTRY_METADATA_CACHE_ENTRIES = 200_000;
 const MAX_LAGGING_PATHS_RETURNED = 50;
+const MAX_SNAPSHOT_BUILD_ATTEMPTS = 2;
 const DEFAULT_CODEGRAPH_ADAPTER = createCodeGraphCliAdapter();
 const SNAPSHOT_CACHE = new Map<string, VisibleEntrySnapshot>();
 const ENTRY_METADATA_CACHE = new Map<string, EntryMetadataCacheValue>();
@@ -596,7 +600,13 @@ function readStableResolvedFile(resolved: ResolvedRepoPath, ignore: IgnorePolicy
   try {
     const opened = fstatSync(fd);
     revalidateResolvedPath(resolved, ignore, opened);
-    return readFileSync(fd);
+    const openedSignature = metadataSignature(opened, resolved.type, true);
+    const data = readFileSync(fd);
+    const after = fstatSync(fd);
+    if (statIdentity(after) !== statIdentity(opened) || metadataSignature(after, resolved.type, true) !== openedSignature) {
+      throw new GeneralRepoAccessError('SNAPSHOT_STALE', 'file changed while it was being read', { path: resolved.relativePath }, true);
+    }
+    return data;
   } finally {
     closeSync(fd);
   }
@@ -629,7 +639,7 @@ function commonFields(repo: RepoRecord, ignore: IgnorePolicy, snapshot: VisibleE
     },
     index_revision: snapshot.codeGraph.indexRevision,
     ignore_digest: ignore.digest,
-    stale: false,
+    stale: snapshot.state === 'stale',
     partial: snapshot.partial,
     next_cursor: null,
   };
@@ -759,7 +769,6 @@ function createManifestDigest() {
         entry.path,
         revision,
         entry.type,
-        entry.indexed ? 'indexed' : 'unindexed',
       ]));
       hash.update('\0');
     },
@@ -773,6 +782,29 @@ function metadataDigest(entries: ManifestEntry[]): string {
   const digest = createManifestDigest();
   for (const entry of entries) digest.update(entry);
   return digest.digest();
+}
+
+function validateSnapshotRevision(repo: RepoRecord, ignore: IgnorePolicy, expectedDigest: string): { stale: boolean; partial: boolean; walkerErrors: number; digest: string } {
+  const validation = walkVisibleEntries(repo, ignore, '.', { hits: 0, misses: 0 }, { contentHash: false, cacheMetadata: false });
+  const digest = metadataDigest(validation.entries);
+  return {
+    stale: digest !== expectedDigest,
+    partial: validation.partial,
+    walkerErrors: validation.walkerErrors,
+    digest,
+  };
+}
+
+function snapshotState(codeGraph: CodeGraphRepoSnapshot, laggingCount: number, stale: boolean): SnapshotState {
+  if (stale) return 'stale';
+  return codeGraph.available && laggingCount > 0 ? 'index_lagging' : 'ready';
+}
+
+function staleSnapshotError(snapshot: VisibleEntrySnapshot): GeneralRepoAccessError {
+  return new GeneralRepoAccessError('SNAPSHOT_STALE', 'repo changed while snapshot was being built', {
+    snapshot_id: snapshot.id,
+    manifest_digest: snapshot.manifestDigest,
+  }, true);
 }
 
 function emptyManifestCounts(): ManifestCounts {
@@ -876,7 +908,7 @@ function mergeCodeGraphMetadata(repo: RepoRecord, ignore: IgnorePolicy, entries:
   return { entriesByPath, filteredPaths, laggingPaths };
 }
 
-function buildManifestPageSnapshot(ctx: GeneralRepoToolContext, repo: RepoRecord, ignore: IgnorePolicy, args: Record<string, unknown>): { snapshot: VisibleEntrySnapshot; counts: ManifestCounts; nextCursor: string | null } {
+function buildManifestPageSnapshot(ctx: GeneralRepoToolContext, repo: RepoRecord, ignore: IgnorePolicy, args: Record<string, unknown>, attempt = 0): { snapshot: VisibleEntrySnapshot; counts: ManifestCounts; nextCursor: string | null } {
   const createdAtMs = Date.now();
   const codeGraph = (ctx.codeGraphAdapter ?? DEFAULT_CODEGRAPH_ADAPTER).discoverRepo(repo.canonicalRoot);
   const indexed = codeGraphMetadataIndex(repo, ignore, codeGraph);
@@ -928,14 +960,17 @@ function buildManifestPageSnapshot(ctx: GeneralRepoToolContext, repo: RepoRecord
   }
 
   const manifestDigest = digest.digest();
+  ctx.testHooks?.afterSnapshotWalk?.({ repoRoot: repo.canonicalRoot, kind: 'manifest_page', attempt });
+  const validation = validateSnapshotRevision(repo, ignore, manifestDigest);
+  if (validation.stale && attempt + 1 < MAX_SNAPSHOT_BUILD_ATTEMPTS) {
+    return buildManifestPageSnapshot(ctx, repo, ignore, args, attempt + 1);
+  }
   const id = `snap_${sha256(`${repo.repoId}\0${repo.registryRevision}\0${ignore.digest}\0${codeGraph.indexRevision}\0${manifestDigest}`).slice(0, 16)}`;
   const coverage: VisibleEntrySnapshot['coverage'] = offset === 0 && pageEntries.length === counts.entries ? 'complete' : 'page';
   const cacheKey = coverage === 'complete'
     ? `cache_${sha256(`${repo.repoId}\0${repo.registryRevision}\0${ignore.digest}\0${id}`).slice(0, 16)}`
     : `cache_${sha256(`${repo.repoId}\0${repo.registryRevision}\0${ignore.digest}\0${id}\0repo_manifest\0${offset}\0${pageSize}`).slice(0, 16)}`;
-  const state: SnapshotState = codeGraph.available && indexed.laggingPaths.size > 0
-    ? 'index_lagging'
-    : 'ready';
+  const state = snapshotState(codeGraph, indexed.laggingPaths.size, validation.stale);
   const expiresAtMs = createdAtMs + SNAPSHOT_TTL_MS;
   const snapshot: VisibleEntrySnapshot = {
     id,
@@ -954,8 +989,8 @@ function buildManifestPageSnapshot(ctx: GeneralRepoToolContext, repo: RepoRecord
     entries: pageEntries,
     entriesByPath: pageByPath,
     manifestDigest,
-    partial: walkerErrors > 0,
-    walkerErrors,
+    partial: walkerErrors > 0 || validation.partial || validation.stale,
+    walkerErrors: walkerErrors + validation.walkerErrors + (validation.stale ? 1 : 0),
     entryMetadataCacheHits: entryMetadataStats.hits,
     entryMetadataCacheMisses: entryMetadataStats.misses,
     codeGraph,
@@ -966,7 +1001,7 @@ function buildManifestPageSnapshot(ctx: GeneralRepoToolContext, repo: RepoRecord
   return { snapshot: rememberSnapshot(snapshot), counts, nextCursor };
 }
 
-function buildVisibleEntrySnapshot(ctx: GeneralRepoToolContext, repo: RepoRecord, ignore: IgnorePolicy, opts: { contentHash?: boolean } = {}): VisibleEntrySnapshot {
+function buildVisibleEntrySnapshot(ctx: GeneralRepoToolContext, repo: RepoRecord, ignore: IgnorePolicy, opts: { contentHash?: boolean } = {}, attempt = 0): VisibleEntrySnapshot {
   const createdAtMs = Date.now();
   const codeGraph = (ctx.codeGraphAdapter ?? DEFAULT_CODEGRAPH_ADAPTER).discoverRepo(repo.canonicalRoot);
   const entryMetadataStats = { hits: 0, misses: 0 };
@@ -974,13 +1009,16 @@ function buildVisibleEntrySnapshot(ctx: GeneralRepoToolContext, repo: RepoRecord
   const walked = walkVisibleEntries(repo, ignore, '.', entryMetadataStats, { contentHash, cacheMetadata: contentHash });
   const merged = mergeCodeGraphMetadata(repo, ignore, walked.entries, codeGraph);
   const manifestDigest = metadataDigest(walked.entries);
+  ctx.testHooks?.afterSnapshotWalk?.({ repoRoot: repo.canonicalRoot, kind: 'complete', attempt });
+  const validation = validateSnapshotRevision(repo, ignore, manifestDigest);
+  if (validation.stale && attempt + 1 < MAX_SNAPSHOT_BUILD_ATTEMPTS) {
+    return buildVisibleEntrySnapshot(ctx, repo, ignore, opts, attempt + 1);
+  }
   const id = `snap_${sha256(`${repo.repoId}\0${repo.registryRevision}\0${ignore.digest}\0${codeGraph.indexRevision}\0${manifestDigest}`).slice(0, 16)}`;
   const cacheKey = contentHash
     ? `cache_${sha256(`${repo.repoId}\0${repo.registryRevision}\0${ignore.digest}\0${id}`).slice(0, 16)}`
     : `cache_${sha256(`${repo.repoId}\0${repo.registryRevision}\0${ignore.digest}\0${id}\0metadata-only`).slice(0, 16)}`;
-  const state: SnapshotState = codeGraph.available && merged.laggingPaths.length > 0
-    ? 'index_lagging'
-    : 'ready';
+  const state = snapshotState(codeGraph, merged.laggingPaths.length, validation.stale);
   const expiresAtMs = createdAtMs + SNAPSHOT_TTL_MS;
   const snapshot: VisibleEntrySnapshot = {
     id,
@@ -999,8 +1037,8 @@ function buildVisibleEntrySnapshot(ctx: GeneralRepoToolContext, repo: RepoRecord
     entries: walked.entries,
     entriesByPath: merged.entriesByPath,
     manifestDigest,
-    partial: walked.partial,
-    walkerErrors: walked.walkerErrors,
+    partial: walked.partial || validation.partial || validation.stale,
+    walkerErrors: walked.walkerErrors + validation.walkerErrors + (validation.stale ? 1 : 0),
     entryMetadataCacheHits: entryMetadataStats.hits,
     entryMetadataCacheMisses: entryMetadataStats.misses,
     codeGraph,
@@ -1011,6 +1049,12 @@ function buildVisibleEntrySnapshot(ctx: GeneralRepoToolContext, repo: RepoRecord
 }
 
 function rememberSnapshot(snapshot: VisibleEntrySnapshot): VisibleEntrySnapshot {
+  if (snapshot.state === 'stale') {
+    return {
+      ...snapshot,
+      cacheSize: SNAPSHOT_CACHE.size,
+    };
+  }
   const now = Date.now();
   for (const [key, cached] of SNAPSHOT_CACHE) {
     if (Date.parse(cached.expiresAt) <= now) SNAPSHOT_CACHE.delete(key);
@@ -1080,6 +1124,9 @@ function cachedSnapshotById(repo: RepoRecord, snapshotId: unknown, paths?: strin
 }
 
 function assertSnapshotFresh(args: Record<string, unknown>, snapshot: VisibleEntrySnapshot): void {
+  if (snapshot.state === 'stale') {
+    throw staleSnapshotError(snapshot);
+  }
   const requested = typeof args.snapshot_id === 'string' ? args.snapshot_id.trim() : '';
   if (requested && requested !== snapshot.id) {
     throw new GeneralRepoAccessError('SNAPSHOT_STALE', 'requested snapshot_id does not match current repo snapshot', {

--- a/src/cli/mcp/general-repo-access.ts
+++ b/src/cli/mcp/general-repo-access.ts
@@ -60,6 +60,7 @@ interface ResolvedRepoPath {
   size?: number;
   modifiedAt?: string;
   metadataSignature: string;
+  contentFile: boolean;
   symlinkTargetKind: SymlinkTargetKind;
   readable: boolean;
   identity?: string;
@@ -85,6 +86,8 @@ interface ManifestEntry {
 
 interface VisibleEntrySnapshot {
   id: string;
+  repoId: string;
+  repoRoot: string;
   state: SnapshotState;
   createdAtMs: number;
   createdAt: string;
@@ -393,6 +396,25 @@ function entryType(path: string): RepoEntryType {
   return 'other';
 }
 
+function entryTypeFromStat(lstat: ReturnType<typeof lstatSync>): RepoEntryType {
+  if (lstat.isSymbolicLink()) return 'symlink';
+  if (lstat.isFile()) return 'file';
+  if (lstat.isDirectory()) return 'directory';
+  return 'other';
+}
+
+function metadataSignature(fileStat: ReturnType<typeof statSync>, type: RepoEntryType, readable: boolean): string {
+  return [
+    fileStat.size,
+    fileStat.mtimeMs,
+    fileStat.ctimeMs,
+    fileStat.mode,
+    fileStat.ino,
+    type,
+    readable ? 'readable' : 'metadata-only',
+  ].join(':');
+}
+
 function resolveRepoPath(repo: RepoRecord, inputPath: unknown, ignore: IgnorePolicy, opts: {
   requireFile?: boolean;
   requireDirectory?: boolean;
@@ -441,15 +463,6 @@ function resolveRepoPath(repo: RepoRecord, inputPath: unknown, ignore: IgnorePol
 
   const fileStat = readable ? statSync(canonicalPath) : lstat;
   const parentStat = statSync(dirname(absolutePath));
-  const metadataSignature = [
-    fileStat.size,
-    fileStat.mtimeMs,
-    fileStat.ctimeMs,
-    fileStat.mode,
-    fileStat.ino,
-    type,
-    readable ? 'readable' : 'metadata-only',
-  ].join(':');
   if (opts.requireFile && (!readable || !fileStat.isFile())) {
     throw new GeneralRepoAccessError('NOT_A_FILE', 'path is not a regular file', { path: relativePath });
   }
@@ -465,7 +478,51 @@ function resolveRepoPath(repo: RepoRecord, inputPath: unknown, ignore: IgnorePol
     type,
     size: fileStat.isFile() ? fileStat.size : undefined,
     modifiedAt: fileStat.mtime.toISOString(),
-    metadataSignature,
+    metadataSignature: metadataSignature(fileStat, type, readable),
+    contentFile: readable && fileStat.isFile(),
+    symlinkTargetKind,
+    readable,
+    identity: readable ? statIdentity(fileStat) : undefined,
+    parentIdentity: statIdentity(parentStat),
+  };
+}
+
+function resolveWalkedRepoPath(repo: RepoRecord, ignore: IgnorePolicy, relativePath: string, absolutePath: string, lstat: ReturnType<typeof lstatSync>): ResolvedRepoPath {
+  if (!isPathInside(repo.canonicalRoot, absolutePath)) {
+    throw new GeneralRepoAccessError('PATH_OUTSIDE_REPO', 'path escapes repo root', { path: relativePath });
+  }
+
+  const type = entryTypeFromStat(lstat);
+  let canonicalPath = absolutePath;
+  let symlinkTargetKind: SymlinkTargetKind = 'none';
+  let readable = true;
+  let fileStat = lstat;
+  const parentStat = statSync(dirname(absolutePath));
+
+  if (type === 'symlink') {
+    canonicalPath = realpathSync(absolutePath);
+    const inside = isPathInside(repo.canonicalRoot, canonicalPath);
+    symlinkTargetKind = inside ? 'internal' : 'external';
+    readable = inside;
+    if (inside) {
+      fileStat = statSync(canonicalPath);
+      const physicalRelative = toPosixPath(relative(repo.canonicalRoot, canonicalPath)) || '.';
+      if (physicalRelative !== '.' && isIgnored(ignore, physicalRelative)) {
+        throw new GeneralRepoAccessError('PATH_IGNORED', 'symlink target is excluded by .ignore', { path: relativePath });
+      }
+    }
+  }
+
+  return {
+    repo,
+    relativePath,
+    absolutePath,
+    canonicalPath,
+    type,
+    size: fileStat.isFile() ? fileStat.size : undefined,
+    modifiedAt: fileStat.mtime.toISOString(),
+    metadataSignature: metadataSignature(fileStat, type, readable),
+    contentFile: readable && fileStat.isFile(),
     symlinkTargetKind,
     readable,
     identity: readable ? statIdentity(fileStat) : undefined,
@@ -573,13 +630,10 @@ function metadataForResolved(resolved: ResolvedRepoPath, ignore: IgnorePolicy, s
   stats && (stats.misses += 1);
   let binary = false;
   let fileHash: string | undefined;
-  if (resolved.readable) {
-    const stat = statSync(resolved.canonicalPath);
-    if (stat.isFile()) {
-      const raw = readStableResolvedFile(resolved, { digest: '', rules: [] });
-      binary = raw.subarray(0, BINARY_PROBE_BYTES).includes(0);
-      fileHash = sha256(raw);
-    }
+  if (resolved.readable && resolved.contentFile) {
+    const raw = readStableResolvedFile(resolved, { digest: '', rules: [] });
+    binary = raw.subarray(0, BINARY_PROBE_BYTES).includes(0);
+    fileHash = sha256(raw);
   }
   const entry = {
     path: resolved.relativePath,
@@ -617,7 +671,8 @@ function walkVisibleEntries(repo: RepoRecord, ignore: IgnorePolicy, startRelativ
       let resolvedChild: ResolvedRepoPath | null = null;
       if (!ignored) {
         try {
-          resolvedChild = resolveRepoPath(repo, childRelative, ignore, { allowExternalSymlinkMetadata: true });
+          const childLstat = lstatSync(childAbsolute);
+          resolvedChild = resolveWalkedRepoPath(repo, ignore, childRelative, childAbsolute, childLstat);
           entries.push(metadataForResolved(resolvedChild, ignore, stats));
         } catch (_error) {
           walkerErrors += 1;
@@ -632,7 +687,7 @@ function walkVisibleEntries(repo: RepoRecord, ignore: IgnorePolicy, startRelativ
   };
 
   if (start.relativePath !== '.') entries.push(metadataForResolved(start, ignore, stats));
-  if (start.readable && statSync(start.canonicalPath).isDirectory()) visit(start.canonicalPath, start.relativePath);
+  if (start.readable && start.type === 'directory') visit(start.canonicalPath, start.relativePath);
   return { entries: entries.sort((a, b) => a.path.localeCompare(b.path)), partial: walkerErrors > 0, walkerErrors };
 }
 
@@ -702,6 +757,8 @@ function buildVisibleEntrySnapshot(ctx: GeneralRepoToolContext, repo: RepoRecord
   const expiresAtMs = createdAtMs + SNAPSHOT_TTL_MS;
   const snapshot: VisibleEntrySnapshot = {
     id,
+    repoId: repo.repoId,
+    repoRoot: repo.canonicalRoot,
     state,
     createdAtMs,
     createdAt: new Date(createdAtMs).toISOString(),
@@ -763,6 +820,28 @@ function rememberSnapshot(snapshot: VisibleEntrySnapshot): VisibleEntrySnapshot 
   };
 }
 
+function cachedSnapshotById(repo: RepoRecord, snapshotId: unknown): VisibleEntrySnapshot | null {
+  const requested = typeof snapshotId === 'string' ? snapshotId.trim() : '';
+  if (!requested) return null;
+  const now = Date.now();
+  for (const [key, cached] of SNAPSHOT_CACHE) {
+    if (Date.parse(cached.expiresAt) <= now) {
+      SNAPSHOT_CACHE.delete(key);
+      continue;
+    }
+    if (cached.id === requested && cached.repoId === repo.repoId && cached.repoRoot === repo.canonicalRoot) {
+      const cacheHit = {
+        ...cached,
+        cacheHit: true,
+        cacheSize: SNAPSHOT_CACHE.size,
+      };
+      SNAPSHOT_CACHE.set(key, cacheHit);
+      return cacheHit;
+    }
+  }
+  return null;
+}
+
 function assertSnapshotFresh(args: Record<string, unknown>, snapshot: VisibleEntrySnapshot): void {
   const requested = typeof args.snapshot_id === 'string' ? args.snapshot_id.trim() : '';
   if (requested && requested !== snapshot.id) {
@@ -813,7 +892,17 @@ function byteRange(value: unknown, maxLength: number): [number, number] | null {
   return [start, Math.min(length, maxLength)];
 }
 
-function readFilePayload(repo: RepoRecord, ignore: IgnorePolicy, snapshot: VisibleEntrySnapshot, args: Record<string, unknown>, maxBytes = HARD_READ_BYTES, tool = 'read_file'): Record<string, unknown> {
+function assertSnapshotEntryCurrent(snapshot: VisibleEntrySnapshot, path: string, actualHash: string): void {
+  const snapshotEntry = snapshot.entriesByPath.get(path);
+  if (!snapshotEntry || snapshotEntry.sha256 !== actualHash) {
+    throw new GeneralRepoAccessError('SNAPSHOT_STALE', 'requested snapshot_id does not match current file revision', {
+      requested_snapshot_id: snapshot.id,
+      path,
+    }, true);
+  }
+}
+
+function readFilePayload(repo: RepoRecord, ignore: IgnorePolicy, snapshot: VisibleEntrySnapshot, args: Record<string, unknown>, maxBytes = HARD_READ_BYTES, tool = 'read_file', verifySnapshotEntry = false): Record<string, unknown> {
   if (args.line_range !== undefined && args.byte_range !== undefined) {
     throw new GeneralRepoAccessError('INVALID_RANGE', 'line_range and byte_range are mutually exclusive');
   }
@@ -833,6 +922,7 @@ function readFilePayload(repo: RepoRecord, ignore: IgnorePolicy, snapshot: Visib
   const fields = commonFields(repo, ignore, snapshot, { tool, paths: [target.relativePath] });
   const raw = readStableResolvedFile(target, ignore);
   const fullHash = sha256(raw);
+  if (verifySnapshotEntry) assertSnapshotEntryCurrent(snapshot, target.relativePath, fullHash);
   const binary = raw.subarray(0, BINARY_PROBE_BYTES).includes(0);
 
   if (args.byte_range !== undefined || cursorByteStart !== null) {
@@ -993,6 +1083,30 @@ function statFile(ctx: GeneralRepoToolContext, args: Record<string, unknown>): G
   const repo = resolveRepo(ctx, args.repo_id);
   const ignore = readIgnorePolicy(repo.canonicalRoot);
   const resolved = resolveRepoPath(repo, args.path, ignore);
+  const cachedSnapshot = cachedSnapshotById(repo, args.snapshot_id);
+  if (cachedSnapshot) {
+    const current = metadataForResolved(resolved, ignore);
+    const cachedEntry = cachedSnapshot.entriesByPath.get(resolved.relativePath);
+    if (!cachedEntry || cachedEntry.sha256 !== current.sha256) {
+      throw new GeneralRepoAccessError('SNAPSHOT_STALE', 'requested snapshot_id does not match current file revision', {
+        requested_snapshot_id: cachedSnapshot.id,
+        path: resolved.relativePath,
+      }, true);
+    }
+    const entry = {
+      ...current,
+      indexed: cachedEntry.indexed,
+      codegraph_language: cachedEntry.codegraph_language,
+      codegraph_node_count: cachedEntry.codegraph_node_count,
+      codegraph_size: cachedEntry.codegraph_size,
+      codegraph_index_lagging: cachedEntry.codegraph_index_lagging,
+    };
+    return textResult({
+      ...commonFields(repo, ignore, cachedSnapshot, { tool: 'stat_file', paths: [resolved.relativePath] }),
+      ...entry,
+      codegraph: codeGraphSummary(cachedSnapshot),
+    });
+  }
   const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore);
   assertSnapshotFresh(args, snapshot);
   const entry = snapshot.entriesByPath.get(resolved.relativePath) ?? metadataForResolved(resolved, ignore);
@@ -1006,6 +1120,13 @@ function statFile(ctx: GeneralRepoToolContext, args: Record<string, unknown>): G
 function readFileTool(ctx: GeneralRepoToolContext, args: Record<string, unknown>): GeneralRepoToolResult {
   const repo = resolveRepo(ctx, args.repo_id);
   const ignore = readIgnorePolicy(repo.canonicalRoot);
+  const cachedSnapshot = cachedSnapshotById(repo, args.snapshot_id);
+  if (cachedSnapshot) {
+    return textResult({
+      ...readFilePayload(repo, ignore, cachedSnapshot, args, HARD_READ_BYTES, 'read_file', true),
+      codegraph: codeGraphSummary(cachedSnapshot),
+    });
+  }
   const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore);
   assertSnapshotFresh(args, snapshot);
   return textResult({
@@ -1017,8 +1138,9 @@ function readFileTool(ctx: GeneralRepoToolContext, args: Record<string, unknown>
 function readFiles(ctx: GeneralRepoToolContext, args: Record<string, unknown>): GeneralRepoToolResult {
   const repo = resolveRepo(ctx, args.repo_id);
   const ignore = readIgnorePolicy(repo.canonicalRoot);
-  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore);
-  assertSnapshotFresh(args, snapshot);
+  const cachedSnapshot = cachedSnapshotById(repo, args.snapshot_id);
+  const snapshot = cachedSnapshot ?? buildVisibleEntrySnapshot(ctx, repo, ignore);
+  if (!cachedSnapshot) assertSnapshotFresh(args, snapshot);
   const requests = Array.isArray(args.requests) ? args.requests : [];
   const byteBudget = numberArg(args.byte_budget, HARD_READ_BYTES, 1, HARD_READ_BYTES);
   let remaining = byteBudget;
@@ -1037,7 +1159,7 @@ function readFiles(ctx: GeneralRepoToolContext, args: Record<string, unknown>): 
       continue;
     }
     try {
-      const payload = readFilePayload(repo, ignore, snapshot, request as Record<string, unknown>, remaining, 'read_files');
+      const payload = readFilePayload(repo, ignore, snapshot, request as Record<string, unknown>, remaining, 'read_files', Boolean(cachedSnapshot));
       remaining -= Number(payload.bytes_returned ?? 0);
       results.push(payload);
     } catch (error) {

--- a/src/cli/mcp/general-repo-access.ts
+++ b/src/cli/mcp/general-repo-access.ts
@@ -1,8 +1,9 @@
 import { createHash } from 'crypto';
-import { closeSync, constants, existsSync, fstatSync, lstatSync, openSync, readFileSync, readSync, readdirSync, realpathSync, statSync } from 'fs';
+import { closeSync, constants, existsSync, fstatSync, lstatSync, openSync, readFileSync, readdirSync, realpathSync, statSync } from 'fs';
 import { basename, dirname, isAbsolute, relative, resolve, sep } from 'path';
 import { readRegisteredRepoHarnessRepos, repoHarnessRepoIdFor, type RepoHarnessAccessMode } from '../../effects/repo-registry';
 import { hashMcpInput, tryWriteMcpAuditEntry } from './audit';
+import { createCodeGraphCliAdapter, type CodeGraphRepoSnapshot, type GeneralRepoCodeGraphAdapter } from './codegraph-adapter';
 import { globMatches, isPathInside } from './paths';
 import type { McpPolicy } from './types';
 
@@ -16,6 +17,7 @@ export interface GeneralRepoToolDefinition {
 export interface GeneralRepoToolContext {
   repoRoot: string;
   policy: McpPolicy;
+  codeGraphAdapter?: GeneralRepoCodeGraphAdapter;
 }
 
 export interface GeneralRepoToolResult {
@@ -70,9 +72,23 @@ interface ManifestEntry {
   sha256?: string;
   binary?: boolean;
   indexed: boolean;
+  codegraph_language?: string;
+  codegraph_node_count?: number;
+  codegraph_size?: number;
   readable: boolean;
   writable: boolean;
   symlink_target_kind: SymlinkTargetKind;
+}
+
+interface VisibleEntrySnapshot {
+  id: string;
+  entries: ManifestEntry[];
+  entriesByPath: Map<string, ManifestEntry>;
+  manifestDigest: string;
+  partial: boolean;
+  walkerErrors: number;
+  codeGraph: CodeGraphRepoSnapshot;
+  codeGraphFilteredPaths: number;
 }
 
 const GENERAL_REPO_TOOLS = [
@@ -93,6 +109,7 @@ const BINARY_PROBE_BYTES = 8 * 1024;
 const SEARCH_FILE_SCAN_BYTES = 1024 * 1024;
 const DEFAULT_SEARCH_RESULTS = 50;
 const HARD_SEARCH_RESULTS = 100;
+const DEFAULT_CODEGRAPH_ADAPTER = createCodeGraphCliAdapter();
 
 export type GeneralRepoToolName = typeof GENERAL_REPO_TOOLS[number];
 
@@ -333,17 +350,6 @@ function entryType(path: string): RepoEntryType {
   return 'other';
 }
 
-function binaryProbe(path: string): boolean {
-  const fd = openSync(path, constants.O_RDONLY);
-  try {
-    const buffer = Buffer.alloc(BINARY_PROBE_BYTES);
-    const bytesRead = readSync(fd, buffer, 0, BINARY_PROBE_BYTES, 0);
-    return buffer.subarray(0, bytesRead).includes(0);
-  } finally {
-    closeSync(fd);
-  }
-}
-
 function resolveRepoPath(repo: RepoRecord, inputPath: unknown, ignore: IgnorePolicy, opts: {
   requireFile?: boolean;
   requireDirectory?: boolean;
@@ -456,16 +462,14 @@ function readStableResolvedFile(resolved: ResolvedRepoPath, ignore: IgnorePolicy
   }
 }
 
-function commonFields(repo: RepoRecord, ignore: IgnorePolicy) {
-  const rootStat = statSync(repo.canonicalRoot);
-  const snapshotHash = sha256(`${repo.repoId}\0${repo.registryRevision}\0${ignore.digest}\0${rootStat.mtimeMs}\0${rootStat.ctimeMs}`);
+function commonFields(repo: RepoRecord, ignore: IgnorePolicy, snapshot: VisibleEntrySnapshot) {
   return {
     repo_id: repo.repoId,
-    snapshot_id: `snap_${snapshotHash.slice(0, 16)}`,
-    index_revision: 0,
+    snapshot_id: snapshot.id,
+    index_revision: snapshot.codeGraph.indexRevision,
     ignore_digest: ignore.digest,
     stale: false,
-    partial: false,
+    partial: snapshot.partial,
     next_cursor: null,
   };
 }
@@ -495,12 +499,19 @@ function metadataForResolved(resolved: ResolvedRepoPath): ManifestEntry {
   };
 }
 
-function walkVisibleEntries(repo: RepoRecord, ignore: IgnorePolicy, startRelative = '.'): ManifestEntry[] {
+function walkVisibleEntries(repo: RepoRecord, ignore: IgnorePolicy, startRelative = '.'): { entries: ManifestEntry[]; partial: boolean; walkerErrors: number } {
   const start = resolveRepoPath(repo, startRelative, ignore, { allowRoot: true, allowExternalSymlinkMetadata: true });
   const entries: ManifestEntry[] = [];
+  let walkerErrors = 0;
 
   const visit = (absoluteDir: string, relativeDir: string): void => {
-    const children = readdirSync(absoluteDir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name));
+    let children;
+    try {
+      children = readdirSync(absoluteDir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name));
+    } catch (_error) {
+      walkerErrors += 1;
+      return;
+    }
     for (const child of children) {
       const childRelative = relativeDir === '.' ? child.name : `${relativeDir}/${child.name}`;
       const childAbsolute = resolve(absoluteDir, child.name);
@@ -511,7 +522,7 @@ function walkVisibleEntries(repo: RepoRecord, ignore: IgnorePolicy, startRelativ
           resolvedChild = resolveRepoPath(repo, childRelative, ignore, { allowExternalSymlinkMetadata: true });
           entries.push(metadataForResolved(resolvedChild));
         } catch (_error) {
-          // Ignore races and unreadable children at this layer; callers mark partial in later snapshot work.
+          walkerErrors += 1;
         }
       }
       if (child.isDirectory()) {
@@ -524,7 +535,90 @@ function walkVisibleEntries(repo: RepoRecord, ignore: IgnorePolicy, startRelativ
 
   if (start.relativePath !== '.') entries.push(metadataForResolved(start));
   if (start.readable && statSync(start.canonicalPath).isDirectory()) visit(start.canonicalPath, start.relativePath);
-  return entries.sort((a, b) => a.path.localeCompare(b.path));
+  return { entries: entries.sort((a, b) => a.path.localeCompare(b.path)), partial: walkerErrors > 0, walkerErrors };
+}
+
+function isInternalRevisionPath(path: string): boolean {
+  return path === '.ai/harness/mcp/audit.log' || path.startsWith('.ai/harness/mcp/');
+}
+
+function metadataDigest(entries: ManifestEntry[]): string {
+  return `sha256:${sha256(JSON.stringify(entries.filter((entry) => !isInternalRevisionPath(entry.path)).map((entry) => [
+    entry.path,
+    entry.sha256 ?? '',
+    entry.type,
+    entry.indexed ? 'indexed' : 'unindexed',
+  ])))}`;
+}
+
+function mergeCodeGraphMetadata(repo: RepoRecord, ignore: IgnorePolicy, entries: ManifestEntry[], codeGraph: CodeGraphRepoSnapshot): { entriesByPath: Map<string, ManifestEntry>; filteredPaths: number } {
+  const entriesByPath = new Map(entries.map((entry) => [entry.path, entry]));
+  let filteredPaths = 0;
+
+  for (const file of codeGraph.files) {
+    try {
+      const relativePath = normalizeRepoRelativePath(file.path);
+      if (isIgnored(ignore, relativePath)) {
+        filteredPaths += 1;
+        continue;
+      }
+      const resolved = resolveRepoPath(repo, relativePath, ignore, { allowExternalSymlinkMetadata: true });
+      const entry = entriesByPath.get(resolved.relativePath);
+      if (!entry || resolved.type !== 'file') {
+        filteredPaths += 1;
+        continue;
+      }
+      entry.indexed = true;
+      entry.codegraph_language = file.language;
+      entry.codegraph_node_count = file.nodeCount;
+      entry.codegraph_size = file.size;
+    } catch (_error) {
+      filteredPaths += 1;
+    }
+  }
+
+  return { entriesByPath, filteredPaths };
+}
+
+function buildVisibleEntrySnapshot(ctx: GeneralRepoToolContext, repo: RepoRecord, ignore: IgnorePolicy): VisibleEntrySnapshot {
+  const codeGraph = (ctx.codeGraphAdapter ?? DEFAULT_CODEGRAPH_ADAPTER).discoverRepo(repo.canonicalRoot);
+  const walked = walkVisibleEntries(repo, ignore);
+  const merged = mergeCodeGraphMetadata(repo, ignore, walked.entries, codeGraph);
+  const manifestDigest = metadataDigest(walked.entries);
+  const id = `snap_${sha256(`${repo.repoId}\0${repo.registryRevision}\0${ignore.digest}\0${codeGraph.indexRevision}\0${manifestDigest}`).slice(0, 16)}`;
+  return {
+    id,
+    entries: walked.entries,
+    entriesByPath: merged.entriesByPath,
+    manifestDigest,
+    partial: walked.partial,
+    walkerErrors: walked.walkerErrors,
+    codeGraph,
+    codeGraphFilteredPaths: merged.filteredPaths,
+  };
+}
+
+function assertSnapshotFresh(args: Record<string, unknown>, snapshot: VisibleEntrySnapshot): void {
+  const requested = typeof args.snapshot_id === 'string' ? args.snapshot_id.trim() : '';
+  if (requested && requested !== snapshot.id) {
+    throw new GeneralRepoAccessError('SNAPSHOT_STALE', 'requested snapshot_id does not match current repo snapshot', {
+      requested_snapshot_id: requested,
+      current_snapshot_id: snapshot.id,
+    }, true);
+  }
+}
+
+function codeGraphSummary(snapshot: VisibleEntrySnapshot): Record<string, unknown> {
+  return {
+    integrated: snapshot.codeGraph.integrated,
+    available: snapshot.codeGraph.available,
+    source: snapshot.codeGraph.source,
+    index_revision: snapshot.codeGraph.indexRevision,
+    latency_ms: snapshot.codeGraph.latencyMs,
+    indexed_files: snapshot.codeGraph.files.length,
+    filtered_paths: snapshot.codeGraphFilteredPaths,
+    error: snapshot.codeGraph.error,
+  };
 }
 
 function pageEntries<T>(entries: T[], cursor: unknown, pageSize: unknown): { page: T[]; nextCursor: string | null } {
@@ -551,7 +645,7 @@ function byteRange(value: unknown, maxLength: number): [number, number] | null {
   return [start, Math.min(length, maxLength)];
 }
 
-function readFilePayload(repo: RepoRecord, ignore: IgnorePolicy, args: Record<string, unknown>, maxBytes = HARD_READ_BYTES): Record<string, unknown> {
+function readFilePayload(repo: RepoRecord, ignore: IgnorePolicy, snapshot: VisibleEntrySnapshot, args: Record<string, unknown>, maxBytes = HARD_READ_BYTES): Record<string, unknown> {
   if (args.line_range !== undefined && args.byte_range !== undefined) {
     throw new GeneralRepoAccessError('INVALID_RANGE', 'line_range and byte_range are mutually exclusive');
   }
@@ -566,6 +660,8 @@ function readFilePayload(repo: RepoRecord, ignore: IgnorePolicy, args: Record<st
     if (match[1] === 'line') args = { ...args, line_range: [Math.max(1, offset), Math.max(1, offset) + MAX_READ_LINES - 1] };
   }
   const target = resolveRepoPath(repo, args.path, ignore, { requireFile: true });
+  const snapshotEntry = snapshot.entriesByPath.get(target.relativePath);
+  const indexed = snapshotEntry?.indexed ?? false;
   const raw = readStableResolvedFile(target, ignore);
   const fullHash = sha256(raw);
   const binary = raw.subarray(0, BINARY_PROBE_BYTES).includes(0);
@@ -576,9 +672,11 @@ function readFilePayload(repo: RepoRecord, ignore: IgnorePolicy, args: Record<st
     const [start, length] = range;
     const chunk = raw.subarray(start, start + length);
     return {
-      ...commonFields(repo, ignore),
+      ...commonFields(repo, ignore, snapshot),
       path: target.relativePath,
       sha256: fullHash,
+      indexed,
+      backend: indexed ? 'codegraph-indexed-filesystem-read' : 'filesystem-fallback',
       encoding: 'base64',
       content: chunk.toString('base64'),
       bytes_returned: chunk.length,
@@ -604,9 +702,11 @@ function readFilePayload(repo: RepoRecord, ignore: IgnorePolicy, args: Record<st
       throw new GeneralRepoAccessError('PAYLOAD_LIMIT_REACHED', 'line_range exceeds response byte budget', { max_bytes: maxBytes });
     }
     return {
-      ...commonFields(repo, ignore),
+      ...commonFields(repo, ignore, snapshot),
       path: target.relativePath,
       sha256: fullHash,
+      indexed,
+      backend: indexed ? 'codegraph-indexed-filesystem-read' : 'filesystem-fallback',
       encoding: 'utf-8',
       content: selected,
       start_line: start,
@@ -621,9 +721,11 @@ function readFilePayload(repo: RepoRecord, ignore: IgnorePolicy, args: Record<st
   const bytes = raw.subarray(0, maxBytes);
   const content = bytes.toString('utf-8');
   return {
-    ...commonFields(repo, ignore),
+    ...commonFields(repo, ignore, snapshot),
     path: target.relativePath,
     sha256: fullHash,
+    indexed,
+    backend: indexed ? 'codegraph-indexed-filesystem-read' : 'filesystem-fallback',
     encoding: 'utf-8',
     content,
     bytes_returned: Buffer.byteLength(content, 'utf-8'),
@@ -636,8 +738,10 @@ function readFilePayload(repo: RepoRecord, ignore: IgnorePolicy, args: Record<st
 function getRepoCapabilities(ctx: GeneralRepoToolContext, args: Record<string, unknown>): GeneralRepoToolResult {
   const repo = resolveRepo(ctx, args.repo_id);
   const ignore = readIgnorePolicy(repo.canonicalRoot);
+  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore);
+  assertSnapshotFresh(args, snapshot);
   return textResult({
-    ...commonFields(repo, ignore),
+    ...commonFields(repo, ignore, snapshot),
     access_mode: repo.accessMode,
     writable: repo.accessMode === 'read_write',
     display_name: repo.displayName,
@@ -647,8 +751,10 @@ function getRepoCapabilities(ctx: GeneralRepoToolContext, args: Record<string, u
     write_tools: repo.accessMode === 'read_write' ? [] : [],
     codegraph: {
       primary_backend: true,
-      integrated: false,
-      note: 'Sprint 1 uses filesystem fallback; CodeGraph adapter metadata merge is Sprint 2.',
+      ...codeGraphSummary(snapshot),
+      note: snapshot.codeGraph.available
+        ? 'CodeGraph inventory is merged as indexed metadata; secure filesystem walking remains the manifest source of truth.'
+        : 'CodeGraph is unavailable for this repo; authorized filesystem fallback remains active.',
     },
     limits: {
       max_page_size: HARD_PAGE_SIZE,
@@ -661,22 +767,29 @@ function getRepoCapabilities(ctx: GeneralRepoToolContext, args: Record<string, u
 function repoManifest(ctx: GeneralRepoToolContext, args: Record<string, unknown>): GeneralRepoToolResult {
   const repo = resolveRepo(ctx, args.repo_id);
   const ignore = readIgnorePolicy(repo.canonicalRoot);
-  const entries = walkVisibleEntries(repo, ignore);
+  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore);
+  assertSnapshotFresh(args, snapshot);
+  const entries = snapshot.entries;
   const paged = pageEntries(entries, args.cursor, args.page_size);
   return textResult({
-    ...commonFields(repo, ignore),
+    ...commonFields(repo, ignore, snapshot),
     entries: paged.page,
     next_cursor: paged.nextCursor,
-    complete: true,
+    complete: !snapshot.partial,
     page_complete: paged.nextCursor === null,
     counts: {
       entries: entries.length,
       files: entries.filter((entry) => entry.type === 'file').length,
       directories: entries.filter((entry) => entry.type === 'directory').length,
       symlinks: entries.filter((entry) => entry.type === 'symlink').length,
+      indexed: entries.filter((entry) => entry.indexed).length,
       unindexed: entries.filter((entry) => !entry.indexed).length,
+      text: entries.filter((entry) => entry.type === 'file' && entry.binary === false).length,
+      binary: entries.filter((entry) => entry.type === 'file' && entry.binary === true).length,
     },
-    manifest_digest: `sha256:${sha256(JSON.stringify(entries.map((entry) => [entry.path, entry.sha256 ?? '', entry.type])))}`,
+    manifest_digest: snapshot.manifestDigest,
+    walker_errors: snapshot.walkerErrors,
+    codegraph: codeGraphSummary(snapshot),
   });
 }
 
@@ -684,8 +797,10 @@ function listTree(ctx: GeneralRepoToolContext, args: Record<string, unknown>): G
   const repo = resolveRepo(ctx, args.repo_id);
   const ignore = readIgnorePolicy(repo.canonicalRoot);
   const root = resolveRepoPath(repo, args.path ?? '.', ignore, { allowRoot: true, requireDirectory: true });
+  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore);
+  assertSnapshotFresh(args, snapshot);
   const depth = numberArg(args.depth, 1, 0, 6);
-  const entries = walkVisibleEntries(repo, ignore, root.relativePath)
+  const entries = snapshot.entries
     .filter((entry) => entry.path !== root.relativePath)
     .filter((entry) => {
       const relation = root.relativePath === '.'
@@ -696,10 +811,11 @@ function listTree(ctx: GeneralRepoToolContext, args: Record<string, unknown>): G
     });
   const paged = pageEntries(entries, args.cursor, (args.page_size ?? DEFAULT_PAGE_SIZE));
   return textResult({
-    ...commonFields(repo, ignore),
+    ...commonFields(repo, ignore, snapshot),
     path: root.relativePath,
     entries: paged.page,
     next_cursor: paged.nextCursor,
+    codegraph: codeGraphSummary(snapshot),
   });
 }
 
@@ -707,21 +823,32 @@ function statFile(ctx: GeneralRepoToolContext, args: Record<string, unknown>): G
   const repo = resolveRepo(ctx, args.repo_id);
   const ignore = readIgnorePolicy(repo.canonicalRoot);
   const resolved = resolveRepoPath(repo, args.path, ignore);
+  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore);
+  assertSnapshotFresh(args, snapshot);
+  const entry = snapshot.entriesByPath.get(resolved.relativePath) ?? metadataForResolved(resolved);
   return textResult({
-    ...commonFields(repo, ignore),
-    ...metadataForResolved(resolved),
+    ...commonFields(repo, ignore, snapshot),
+    ...entry,
+    codegraph: codeGraphSummary(snapshot),
   });
 }
 
 function readFileTool(ctx: GeneralRepoToolContext, args: Record<string, unknown>): GeneralRepoToolResult {
   const repo = resolveRepo(ctx, args.repo_id);
   const ignore = readIgnorePolicy(repo.canonicalRoot);
-  return textResult(readFilePayload(repo, ignore, args));
+  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore);
+  assertSnapshotFresh(args, snapshot);
+  return textResult({
+    ...readFilePayload(repo, ignore, snapshot, args),
+    codegraph: codeGraphSummary(snapshot),
+  });
 }
 
 function readFiles(ctx: GeneralRepoToolContext, args: Record<string, unknown>): GeneralRepoToolResult {
   const repo = resolveRepo(ctx, args.repo_id);
   const ignore = readIgnorePolicy(repo.canonicalRoot);
+  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore);
+  assertSnapshotFresh(args, snapshot);
   const requests = Array.isArray(args.requests) ? args.requests : [];
   const byteBudget = numberArg(args.byte_budget, HARD_READ_BYTES, 1, HARD_READ_BYTES);
   let remaining = byteBudget;
@@ -740,7 +867,7 @@ function readFiles(ctx: GeneralRepoToolContext, args: Record<string, unknown>): 
       continue;
     }
     try {
-      const payload = readFilePayload(repo, ignore, request as Record<string, unknown>, remaining);
+      const payload = readFilePayload(repo, ignore, snapshot, request as Record<string, unknown>, remaining);
       remaining -= Number(payload.bytes_returned ?? 0);
       results.push(payload);
     } catch (error) {
@@ -754,10 +881,11 @@ function readFiles(ctx: GeneralRepoToolContext, args: Record<string, unknown>): 
   }
 
   return textResult({
-    ...commonFields(repo, ignore),
-    partial,
+    ...commonFields(repo, ignore, snapshot),
+    partial: partial || snapshot.partial,
     results,
     bytes_remaining: remaining,
+    codegraph: codeGraphSummary(snapshot),
   });
 }
 
@@ -767,14 +895,20 @@ function searchText(ctx: GeneralRepoToolContext, args: Record<string, unknown>):
   const mode = args.mode === 'regex' ? 'regex' : 'literal';
   const repo = resolveRepo(ctx, args.repo_id);
   const ignore = readIgnorePolicy(repo.canonicalRoot);
+  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore);
+  assertSnapshotFresh(args, snapshot);
   const requestedPaths = Array.isArray(args.paths) && args.paths.length > 0 ? args.paths : ['.'];
   const candidates: ManifestEntry[] = [];
   for (const path of requestedPaths) {
     const resolved = resolveRepoPath(repo, path, ignore, { allowRoot: true });
     if (resolved.type === 'directory') {
-      candidates.push(...walkVisibleEntries(repo, ignore, resolved.relativePath));
+      candidates.push(...snapshot.entries.filter((entry) => (
+        resolved.relativePath === '.'
+          ? true
+          : entry.path === resolved.relativePath || entry.path.startsWith(`${resolved.relativePath}/`)
+      )));
     } else {
-      candidates.push(metadataForResolved(resolved));
+      candidates.push(snapshot.entriesByPath.get(resolved.relativePath) ?? metadataForResolved(resolved));
     }
   }
   const seen = new Set<string>();
@@ -789,9 +923,11 @@ function searchText(ctx: GeneralRepoToolContext, args: Record<string, unknown>):
   const needle = query.toLowerCase();
   const matches: Record<string, unknown>[] = [];
   const maxResults = numberArg(args.max_results, DEFAULT_SEARCH_RESULTS, 1, HARD_SEARCH_RESULTS);
+  const offset = numberArg(args.cursor, 0, 0, Number.MAX_SAFE_INTEGER);
+  let seenMatches = 0;
 
   for (const entry of candidates.sort((a, b) => a.path.localeCompare(b.path))) {
-    if (matches.length >= maxResults) break;
+    if (matches.length >= maxResults + 1) break;
     if (entry.type !== 'file' || !entry.readable || seen.has(entry.path) || entry.binary || (entry.size ?? 0) > SEARCH_FILE_SCAN_BYTES) continue;
     seen.add(entry.path);
     const resolved = resolveRepoPath(repo, entry.path, ignore, { requireFile: true });
@@ -801,24 +937,35 @@ function searchText(ctx: GeneralRepoToolContext, args: Record<string, unknown>):
       const line = lines[index] ?? '';
       const column = regex ? line.search(regex) : line.toLowerCase().indexOf(needle);
       if (column < 0) continue;
+      if (seenMatches < offset) {
+        seenMatches += 1;
+        continue;
+      }
       matches.push({
         path: entry.path,
         line: index + 1,
         column: column + 1,
         snippet: line.slice(Math.max(0, column - 60), column + 120),
         sha256: entry.sha256,
+        indexed: entry.indexed,
+        backend: entry.indexed ? 'codegraph-indexed-filesystem-search' : 'filesystem-fallback',
       });
-      if (matches.length >= maxResults) break;
+      seenMatches += 1;
+      if (matches.length >= maxResults + 1) break;
     }
   }
+  const returned = matches.slice(0, maxResults);
+  const nextCursor = matches.length > maxResults ? String(offset + maxResults) : null;
 
   return textResult({
-    ...commonFields(repo, ignore),
+    ...commonFields(repo, ignore, snapshot),
     query,
     mode,
-    matches,
-    truncated: matches.length >= maxResults,
-    backend: 'filesystem-fallback',
+    matches: returned,
+    truncated: nextCursor !== null,
+    next_cursor: nextCursor,
+    backend: snapshot.codeGraph.available ? 'codegraph-metadata+filesystem-fallback' : 'filesystem-fallback',
+    codegraph: codeGraphSummary(snapshot),
   });
 }
 

--- a/src/cli/mcp/reader-tools.ts
+++ b/src/cli/mcp/reader-tools.ts
@@ -9,7 +9,7 @@ import { globMatches } from './paths';
 import { redactMcpText } from './redaction';
 import { repoHarnessPackageVersion } from './version';
 import { WorkspaceError, WorkspaceManager, type McpWorkspace, type WorkspaceResolvedPath } from './workspaces';
-import { buildGeneralRepoToolDefinitions, callGeneralRepoTool, hasGeneralRepoArgs, isGeneralRepoTool, listGeneralRepoRecords } from './general-repo-access';
+import { buildGeneralRepoToolDefinitions, callGeneralRepoTool, hasGeneralRepoArgs, isGeneralRepoTool, listGeneralRepoRecords, type GeneralRepoToolContext } from './general-repo-access';
 import type { GeneralRepoCodeGraphAdapter } from './codegraph-adapter';
 import { repoHarnessRepoIdFor } from '../../effects/repo-registry';
 import type { McpPolicy } from './types';
@@ -26,6 +26,7 @@ export interface ReaderToolContext {
   policy: McpPolicy;
   workspaceManager: WorkspaceManager;
   codeGraphAdapter?: GeneralRepoCodeGraphAdapter;
+  testHooks?: GeneralRepoToolContext['testHooks'];
 }
 
 export interface ReaderToolResult {
@@ -606,12 +607,13 @@ export async function callReaderTool(ctx: ReaderToolContext, name: string, args:
   }
 }
 
-export function createReaderToolContext(repoRoot: string, policy: McpPolicy, workspaceManager?: WorkspaceManager, codeGraphAdapter?: GeneralRepoCodeGraphAdapter): ReaderToolContext {
+export function createReaderToolContext(repoRoot: string, policy: McpPolicy, workspaceManager?: WorkspaceManager, codeGraphAdapter?: GeneralRepoCodeGraphAdapter, testHooks?: GeneralRepoToolContext['testHooks']): ReaderToolContext {
   return {
     repoRoot,
     policy,
     workspaceManager: workspaceManager ?? new WorkspaceManager({ allowedRoots: policy.allowedRoots ?? [], policy }),
     codeGraphAdapter,
+    testHooks,
   };
 }
 

--- a/src/cli/mcp/reader-tools.ts
+++ b/src/cli/mcp/reader-tools.ts
@@ -10,6 +10,7 @@ import { redactMcpText } from './redaction';
 import { repoHarnessPackageVersion } from './version';
 import { WorkspaceError, WorkspaceManager, type McpWorkspace, type WorkspaceResolvedPath } from './workspaces';
 import { buildGeneralRepoToolDefinitions, callGeneralRepoTool, hasGeneralRepoArgs, isGeneralRepoTool, listGeneralRepoRecords } from './general-repo-access';
+import type { GeneralRepoCodeGraphAdapter } from './codegraph-adapter';
 import { repoHarnessRepoIdFor } from '../../effects/repo-registry';
 import type { McpPolicy } from './types';
 
@@ -24,6 +25,7 @@ export interface ReaderToolContext {
   repoRoot: string;
   policy: McpPolicy;
   workspaceManager: WorkspaceManager;
+  codeGraphAdapter?: GeneralRepoCodeGraphAdapter;
 }
 
 export interface ReaderToolResult {
@@ -604,11 +606,12 @@ export async function callReaderTool(ctx: ReaderToolContext, name: string, args:
   }
 }
 
-export function createReaderToolContext(repoRoot: string, policy: McpPolicy, workspaceManager?: WorkspaceManager): ReaderToolContext {
+export function createReaderToolContext(repoRoot: string, policy: McpPolicy, workspaceManager?: WorkspaceManager, codeGraphAdapter?: GeneralRepoCodeGraphAdapter): ReaderToolContext {
   return {
     repoRoot,
     policy,
     workspaceManager: workspaceManager ?? new WorkspaceManager({ allowedRoots: policy.allowedRoots ?? [], policy }),
+    codeGraphAdapter,
   };
 }
 

--- a/tasks/notes/20260622-repo-harness-codegraph.notes.md
+++ b/tasks/notes/20260622-repo-harness-codegraph.notes.md
@@ -46,3 +46,26 @@ Sprint 0 contract freeze for `plans/sprints/20260622-repo-harness-codegraph-spri
   reduces symlink-swap exposure with the Node filesystem APIs available here,
   but a stronger fd-relative/openat design still belongs in the S2/S4 security
   pass if the runtime grows native bindings.
+
+## Sprint 2 Adapter/Snapshot Notes
+
+- The CodeGraph integration is a bounded CLI adapter over
+  `codegraph files --format flat --json`. Its output is treated as indexed
+  metadata only. Secure filesystem walking remains the manifest source of truth
+  because the Sprint 0 spike proved CodeGraph inventory is not a complete repo
+  file list.
+- Every CodeGraph-returned path is normalized, resolved under the canonical repo
+  root, and checked against `.ignore` before metadata is merged. Returned paths
+  that are ignored, missing, directories, or outside the repo increment
+  `codegraph.filtered_paths` instead of widening access.
+- `snapshot_id` is deterministic from repo identity, registry revision,
+  `.ignore` digest, CodeGraph revision, and the manifest digest. A caller-provided
+  stale `snapshot_id` returns `SNAPSHOT_STALE` rather than silently mixing
+  manifest/search/read versions.
+- `.ai/harness/mcp/audit.log` is not included in the snapshot revision digest.
+  The audit file remains visible according to `.ignore`; the exclusion is only
+  to prevent the reader's own append-only audit side effect from invalidating the
+  snapshot it just returned.
+- CodeGraph CLI `query` is symbol search, not complete repo full-text search.
+  `search_text` therefore keeps the policy-consistent filesystem fallback while
+  surfacing whether each matched file is present in CodeGraph indexed metadata.

--- a/tasks/notes/20260622-repo-harness-codegraph.notes.md
+++ b/tasks/notes/20260622-repo-harness-codegraph.notes.md
@@ -69,3 +69,23 @@ Sprint 0 contract freeze for `plans/sprints/20260622-repo-harness-codegraph-spri
 - CodeGraph CLI `query` is symbol search, not complete repo full-text search.
   `search_text` therefore keeps the policy-consistent filesystem fallback while
   surfacing whether each matched file is present in CodeGraph indexed metadata.
+
+## Sprint 2 Snapshot Cache/Index-Lag Notes
+
+- Snapshot TTL is currently a bounded in-process memoization contract:
+  30 seconds, at most 16 snapshots. The cache key includes repo id, registry
+  revision, `.ignore` digest, and the validated snapshot id. A hit is only
+  reported after the reader recomputes the current manifest digest and confirms
+  the snapshot id still matches; this preserves stale detection for file,
+  registry, and `.ignore` changes.
+- `snapshot_state` is `ready` when the filesystem-backed snapshot can be served,
+  and `index_lagging` when CodeGraph metadata proves the index is behind the
+  filesystem. Secure walker traversal errors remain represented by the existing
+  `partial` and `walker_errors` fields, because a partial manifest can still be
+  served with explicit completeness metadata. CodeGraph lag evidence is limited
+  to stale indexed paths that no longer resolve and indexed files whose
+  CodeGraph size differs from the current filesystem size.
+- This slice does not claim the full S2 performance target. Manifest generation
+  still walks the complete visible tree to compute counts, hashes, and the
+  manifest digest. The remaining performance slice must measure 10k/100k/500k
+  fixtures and decide whether to introduce a true streaming inventory structure.

--- a/tasks/notes/20260622-repo-harness-codegraph.notes.md
+++ b/tasks/notes/20260622-repo-harness-codegraph.notes.md
@@ -104,7 +104,18 @@ Sprint 0 contract freeze for `plans/sprints/20260622-repo-harness-codegraph-spri
   changes, and registry revision changes produce different cache keys.
 - `docs/researches/20260623-general-repo-reader-performance-baseline.md`
   records the first reproducible baseline. The 10k fixture completed with a
-  warm manifest first page at 360.91 ms and warm search at 763.39 ms. The 100k
-  fixture completed without OOM, returned paginated results, and hit the warm
-  snapshot/metadata cache, but warm manifest/read/search still took about
-  4.3-4.4 seconds. The 100k SLO and 500k baseline remain open.
+  warm manifest first page at 95.31 ms and warm search at 512.12 ms after the
+  walker optimization. The 100k fixture completed without OOM, returned
+  paginated results, and met the warm-path SLO: manifest 906.77 ms, read first
+  chunk 0.94 ms, and search 1038.71 ms.
+- The walker optimization removes the per-entry `resolveRepoPath` hot path for
+  manifest traversal and constructs metadata directly from the directory entry
+  and one `lstat`. Explicit `snapshot_id` stat/read calls can reuse a cached
+  snapshot and validate the requested file hash instead of rebuilding the full
+  repo snapshot. This preserves stale detection for the requested file while
+  removing whole-repo revalidation from ordinary warm read chunks.
+- The 500k fixture remains open. A `bun run benchmark:mcp-reader -- --entries
+  500000 --json` run was interrupted after more than 9 minutes without JSON
+  output, and the temporary fixture was removed. True streaming manifest work is
+  still needed because cold manifest construction still materializes and sorts
+  the full visible entry set.

--- a/tasks/notes/20260622-repo-harness-codegraph.notes.md
+++ b/tasks/notes/20260622-repo-harness-codegraph.notes.md
@@ -73,7 +73,7 @@ Sprint 0 contract freeze for `plans/sprints/20260622-repo-harness-codegraph-spri
 ## Sprint 2 Snapshot Cache/Index-Lag Notes
 
 - Snapshot TTL is currently a bounded in-process memoization contract:
-  30 seconds, at most 16 snapshots. The cache key includes repo id, registry
+  5 minutes, at most 16 snapshots. The cache key includes repo id, registry
   revision, `.ignore` digest, and the validated snapshot id. A hit is only
   reported after the reader recomputes the current manifest digest and confirms
   the snapshot id still matches; this preserves stale detection for file,
@@ -89,3 +89,22 @@ Sprint 0 contract freeze for `plans/sprints/20260622-repo-harness-codegraph-spri
   still walks the complete visible tree to compute counts, hashes, and the
   manifest digest. The remaining performance slice must measure 10k/100k/500k
   fixtures and decide whether to introduce a true streaming inventory structure.
+
+## Sprint 2 Cache-Key/Performance Notes
+
+- Public `snapshot_cache.key` is now scoped by tool and repo-relative path set;
+  `snapshot_cache.snapshot_key` names the underlying repo snapshot. This keeps
+  `repo_manifest`, `stat_file`, `read_file`, `read_files`, `list_tree`, and
+  `search_text` from presenting a single repo-wide cache key for path-specific
+  work.
+- Entry metadata has a bounded in-process cache keyed by repo id, registry
+  revision, `.ignore` digest, repo-relative path, and the current stat
+  signature. Warm snapshot revalidation can reuse unchanged metadata without
+  re-hashing and binary-probing every unchanged file. File changes, `.ignore`
+  changes, and registry revision changes produce different cache keys.
+- `docs/researches/20260623-general-repo-reader-performance-baseline.md`
+  records the first reproducible baseline. The 10k fixture completed with a
+  warm manifest first page at 360.91 ms and warm search at 763.39 ms. The 100k
+  fixture completed without OOM, returned paginated results, and hit the warm
+  snapshot/metadata cache, but warm manifest/read/search still took about
+  4.3-4.4 seconds. The 100k SLO and 500k baseline remain open.

--- a/tasks/notes/20260622-repo-harness-codegraph.notes.md
+++ b/tasks/notes/20260622-repo-harness-codegraph.notes.md
@@ -104,18 +104,28 @@ Sprint 0 contract freeze for `plans/sprints/20260622-repo-harness-codegraph-spri
   changes, and registry revision changes produce different cache keys.
 - `docs/researches/20260623-general-repo-reader-performance-baseline.md`
   records the first reproducible baseline. The 10k fixture completed with a
-  warm manifest first page at 95.31 ms and warm search at 512.12 ms after the
-  walker optimization. The 100k fixture completed without OOM, returned
-  paginated results, and met the warm-path SLO: manifest 906.77 ms, read first
-  chunk 0.94 ms, and search 1038.71 ms.
+  warm manifest first page at 76.37 ms and warm search at 499.84 ms. The 100k
+  fixture completed without OOM, returned paginated results, and met the
+  warm-path SLO: manifest 733.76 ms, read first chunk 0.74 ms, and search
+  779.04 ms.
 - The walker optimization removes the per-entry `resolveRepoPath` hot path for
   manifest traversal and constructs metadata directly from the directory entry
   and one `lstat`. Explicit `snapshot_id` stat/read calls can reuse a cached
   snapshot and validate the requested file hash instead of rebuilding the full
   repo snapshot. This preserves stale detection for the requested file while
   removing whole-repo revalidation from ordinary warm read chunks.
-- The 500k fixture remains open. A `bun run benchmark:mcp-reader -- --entries
-  500000 --json` run was interrupted after more than 9 minutes without JSON
-  output, and the temporary fixture was removed. True streaming manifest work is
-  still needed because cold manifest construction still materializes and sorts
-  the full visible entry set.
+- `repo_manifest` now uses a streaming page builder: it walks the visible tree
+  to prove counts and a metadata-revision digest, but retains only the requested
+  page entries. The current page still carries exact content hashes; non-page
+  file content metadata is counted as `content_deferred` and is computed when a
+  later page, `stat_file`, `read_file`, or `search_text` actually returns
+  content.
+- Metadata-only traversals no longer populate the bounded entry metadata cache.
+  This avoids 500k sequential cache-thrash when the visible entry count exceeds
+  the 200k cache cap; exact content metadata remains cached for returned page
+  entries and read/stat paths.
+- The 500k fixture now completes: manifest 12201.90 ms warm first page, read
+  first chunk 3.67 ms, warm search 12668.28 ms, with
+  `counts.content_deferred=499010`. This records the Sprint 2 baseline and
+  leaves 500k latency as a future optimization target rather than an open S2
+  checklist item.

--- a/tests/cli/mcp-codegraph-contract.test.ts
+++ b/tests/cli/mcp-codegraph-contract.test.ts
@@ -22,6 +22,11 @@ const TOOL_NAMES = [
 const COMMON_RESPONSE_FIELDS = [
   'repo_id',
   'snapshot_id',
+  'snapshot_state',
+  'snapshot_created_at',
+  'snapshot_expires_at',
+  'snapshot_ttl_ms',
+  'snapshot_cache',
   'index_revision',
   'ignore_digest',
   'stale',

--- a/tests/cli/mcp-reader-tools.test.ts
+++ b/tests/cli/mcp-reader-tools.test.ts
@@ -154,6 +154,27 @@ describe('MCP reader tools', () => {
         expect(manifest.ignore_digest).toMatch(/^sha256:[a-f0-9]{64}$/);
         expect(manifest.complete).toBe(true);
 
+        const streamedManifest = await jsonTool(ctx, 'repo_manifest', { repo_id: repoId, page_size: 3 });
+        expect(streamedManifest.entries).toHaveLength(3);
+        expect(streamedManifest.next_cursor).toBe('3');
+        expect(streamedManifest.snapshot_coverage).toBe('page');
+        expect(streamedManifest.manifest_streaming).toBe(true);
+        expect(streamedManifest.counts.content_deferred).toBeGreaterThan(0);
+        const streamedRead = await jsonTool(ctx, 'read_file', {
+          repo_id: repoId,
+          path: 'src/index.ts',
+          snapshot_id: streamedManifest.snapshot_id,
+        });
+        expect(streamedRead.error).toBeUndefined();
+        expect(streamedRead.snapshot_id).toBe(streamedManifest.snapshot_id);
+        const streamedSearch = await jsonTool(ctx, 'search_text', {
+          repo_id: repoId,
+          query: 'readerFixture',
+          snapshot_id: streamedManifest.snapshot_id,
+        });
+        expect(streamedSearch.error).toBeUndefined();
+        expect(streamedSearch.matches.some((match: { path: string }) => match.path === 'src/index.ts')).toBe(true);
+
         const tree = await jsonTool(ctx, 'list_tree', { repo_id: repoId, path: '.', depth: 3, page_size: 1000 });
         const treePaths = tree.entries.map((entry: { path: string }) => entry.path);
         expect(treePaths).toContain('.env');

--- a/tests/cli/mcp-reader-tools.test.ts
+++ b/tests/cli/mcp-reader-tools.test.ts
@@ -270,13 +270,21 @@ describe('MCP reader tools', () => {
       const byPath = new Map(manifest.entries.map((entry: { path: string }) => [entry.path, entry]));
       expect(manifest.index_revision).toBe('index_fake1234');
       expect(manifest.snapshot_state).toBe('index_lagging');
-      expect(manifest.snapshot_ttl_ms).toBe(30_000);
+      expect(manifest.snapshot_ttl_ms).toBe(300_000);
       expect(manifest.snapshot_created_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
       expect(manifest.snapshot_expires_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
       expect(manifest.snapshot_cache).toMatchObject({
         hit: false,
+        scope: 'repo_manifest',
+        paths: ['.'],
         max_entries: 16,
+        entry_metadata: {
+          hits: expect.any(Number),
+          misses: expect.any(Number),
+          max_entries: 200_000,
+        },
       });
+      expect(manifest.snapshot_cache.key).not.toBe(manifest.snapshot_cache.snapshot_key);
       expect(manifest.codegraph).toMatchObject({
         integrated: true,
         available: true,
@@ -302,10 +310,17 @@ describe('MCP reader tools', () => {
       const stat = await jsonTool(cgCtx, 'stat_file', { repo_id: repoId, path: 'src/index.ts', snapshot_id: manifest.snapshot_id });
       expect(stat.snapshot_id).toBe(manifest.snapshot_id);
       expect(stat.snapshot_cache.hit).toBe(true);
+      expect(stat.snapshot_cache.scope).toBe('stat_file');
+      expect(stat.snapshot_cache.paths).toEqual(['src/index.ts']);
+      expect(stat.snapshot_cache.key).not.toBe(manifest.snapshot_cache.key);
+      expect(stat.snapshot_cache.snapshot_key).toBe(manifest.snapshot_cache.snapshot_key);
+      expect(stat.snapshot_cache.entry_metadata.hits).toBeGreaterThan(0);
       expect(stat).toMatchObject({ indexed: true, codegraph_language: 'typescript' });
 
       const read = await jsonTool(cgCtx, 'read_file', { repo_id: repoId, path: 'src/index.ts', snapshot_id: manifest.snapshot_id });
       expect(read.snapshot_id).toBe(manifest.snapshot_id);
+      expect(read.snapshot_cache.scope).toBe('read_file');
+      expect(read.snapshot_cache.paths).toEqual(['src/index.ts']);
       expect(read).toMatchObject({ indexed: true, backend: 'codegraph-indexed-filesystem-read' });
 
       const firstSearch = await jsonTool(cgCtx, 'search_text', {
@@ -327,6 +342,19 @@ describe('MCP reader tools', () => {
         snapshot_id: manifest.snapshot_id,
       });
       expect(secondSearch.matches[0].line).toBe(3);
+
+      writeFileSync(join(repoRoot, 'src', 'index.ts'), 'export const readerFixture = 200;\n');
+      const changed = await jsonTool(cgCtx, 'stat_file', { repo_id: repoId, path: 'src/index.ts' });
+      expect(changed.snapshot_id).not.toBe(manifest.snapshot_id);
+      expect(changed.snapshot_cache.hit).toBe(false);
+      expect(changed.sha256).not.toBe((byPath.get('src/index.ts') as { sha256?: string }).sha256);
+      const staleAfterChange = await jsonTool(cgCtx, 'read_file', {
+        repo_id: repoId,
+        path: 'src/index.ts',
+        snapshot_id: manifest.snapshot_id,
+      });
+      expect(staleAfterChange.error.code).toBe('SNAPSHOT_STALE');
+      expect(staleAfterChange.error.retryable).toBe(true);
 
       const stale = await jsonTool(cgCtx, 'read_file', { repo_id: repoId, path: 'src/index.ts', snapshot_id: 'snap_stale' });
       expect(stale.error.code).toBe('SNAPSHOT_STALE');

--- a/tests/cli/mcp-reader-tools.test.ts
+++ b/tests/cli/mcp-reader-tools.test.ts
@@ -314,11 +314,11 @@ describe('MCP reader tools', () => {
       expect(stat.snapshot_cache.paths).toEqual(['src/index.ts']);
       expect(stat.snapshot_cache.key).not.toBe(manifest.snapshot_cache.key);
       expect(stat.snapshot_cache.snapshot_key).toBe(manifest.snapshot_cache.snapshot_key);
-      expect(stat.snapshot_cache.entry_metadata.hits).toBeGreaterThan(0);
       expect(stat).toMatchObject({ indexed: true, codegraph_language: 'typescript' });
 
       const read = await jsonTool(cgCtx, 'read_file', { repo_id: repoId, path: 'src/index.ts', snapshot_id: manifest.snapshot_id });
       expect(read.snapshot_id).toBe(manifest.snapshot_id);
+      expect(read.snapshot_cache.hit).toBe(true);
       expect(read.snapshot_cache.scope).toBe('read_file');
       expect(read.snapshot_cache.paths).toEqual(['src/index.ts']);
       expect(read).toMatchObject({ indexed: true, backend: 'codegraph-indexed-filesystem-read' });
@@ -348,6 +348,13 @@ describe('MCP reader tools', () => {
       expect(changed.snapshot_id).not.toBe(manifest.snapshot_id);
       expect(changed.snapshot_cache.hit).toBe(false);
       expect(changed.sha256).not.toBe((byPath.get('src/index.ts') as { sha256?: string }).sha256);
+      const staleStatAfterChange = await jsonTool(cgCtx, 'stat_file', {
+        repo_id: repoId,
+        path: 'src/index.ts',
+        snapshot_id: manifest.snapshot_id,
+      });
+      expect(staleStatAfterChange.error.code).toBe('SNAPSHOT_STALE');
+      expect(staleStatAfterChange.error.retryable).toBe(true);
       const staleAfterChange = await jsonTool(cgCtx, 'read_file', {
         repo_id: repoId,
         path: 'src/index.ts',

--- a/tests/cli/mcp-reader-tools.test.ts
+++ b/tests/cli/mcp-reader-tools.test.ts
@@ -249,7 +249,7 @@ describe('MCP reader tools', () => {
             indexRevision: 'index_fake1234',
             latencyMs: 3,
             files: [
-              { path: 'src/index.ts', language: 'typescript', nodeCount: 2, size: 31 },
+              { path: 'src/index.ts', language: 'typescript', nodeCount: 2, size: 1 },
               { path: '.env', language: 'dotenv', nodeCount: 0, size: 29 },
               { path: 'ignored.md', language: 'markdown', nodeCount: 0, size: 10 },
               { path: '../outside.ts', language: 'typescript', nodeCount: 1, size: 10 },
@@ -269,18 +269,31 @@ describe('MCP reader tools', () => {
       const manifest = await jsonTool(cgCtx, 'repo_manifest', { repo_id: repoId, page_size: 1000 });
       const byPath = new Map(manifest.entries.map((entry: { path: string }) => [entry.path, entry]));
       expect(manifest.index_revision).toBe('index_fake1234');
+      expect(manifest.snapshot_state).toBe('index_lagging');
+      expect(manifest.snapshot_ttl_ms).toBe(30_000);
+      expect(manifest.snapshot_created_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+      expect(manifest.snapshot_expires_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+      expect(manifest.snapshot_cache).toMatchObject({
+        hit: false,
+        max_entries: 16,
+      });
       expect(manifest.codegraph).toMatchObject({
         integrated: true,
         available: true,
         source: 'test-double',
         indexed_files: 5,
         filtered_paths: 3,
+        index_lagging: true,
+        lagging_path_count: 2,
       });
+      expect(manifest.codegraph.lagging_paths).toEqual(['missing.ts', 'src/index.ts']);
       expect(manifest.counts.indexed).toBe(2);
+      expect(manifest.counts.index_lagging).toBe(1);
       expect(byPath.get('src/index.ts')).toMatchObject({
         indexed: true,
         codegraph_language: 'typescript',
         codegraph_node_count: 2,
+        codegraph_index_lagging: true,
       });
       expect(byPath.get('.env')).toMatchObject({ indexed: true, codegraph_language: 'dotenv' });
       expect(byPath.get('docs/design.md')).toMatchObject({ indexed: false });
@@ -288,6 +301,7 @@ describe('MCP reader tools', () => {
 
       const stat = await jsonTool(cgCtx, 'stat_file', { repo_id: repoId, path: 'src/index.ts', snapshot_id: manifest.snapshot_id });
       expect(stat.snapshot_id).toBe(manifest.snapshot_id);
+      expect(stat.snapshot_cache.hit).toBe(true);
       expect(stat).toMatchObject({ indexed: true, codegraph_language: 'typescript' });
 
       const read = await jsonTool(cgCtx, 'read_file', { repo_id: repoId, path: 'src/index.ts', snapshot_id: manifest.snapshot_id });

--- a/tests/cli/mcp-reader-tools.test.ts
+++ b/tests/cli/mcp-reader-tools.test.ts
@@ -400,7 +400,7 @@ describe('MCP reader tools', () => {
           afterSnapshotWalk(event) {
             if (event.kind !== 'complete' || completeMutations >= 2) return;
             completeMutations += 1;
-            writeFileSync(join(repoRoot, 'src', 'race-complete.ts'), `export const race = ${completeMutations};\n`);
+            writeFileSync(join(repoRoot, 'src', `race-complete-${completeMutations}.ts`), `export const race = ${completeMutations};\n`);
           },
         },
       };
@@ -417,7 +417,7 @@ describe('MCP reader tools', () => {
           afterSnapshotWalk(event) {
             if (event.kind !== 'manifest_page' || pageMutations >= 2) return;
             pageMutations += 1;
-            writeFileSync(join(repoRoot, 'src', 'race-page.ts'), `export const pageRace = ${pageMutations};\n`);
+            writeFileSync(join(repoRoot, 'src', `race-page-${pageMutations}.ts`), `export const pageRace = ${pageMutations};\n`);
           },
         },
       };

--- a/tests/cli/mcp-reader-tools.test.ts
+++ b/tests/cli/mcp-reader-tools.test.ts
@@ -5,6 +5,7 @@ import { join } from 'path';
 import { getMcpPolicy } from '../../src/cli/mcp/policy';
 import { buildReaderToolDefinitions, callReaderTool, createReaderToolContext, type ReaderToolContext } from '../../src/cli/mcp/reader-tools';
 import { WorkspaceManager } from '../../src/cli/mcp/workspaces';
+import type { GeneralRepoCodeGraphAdapter } from '../../src/cli/mcp/codegraph-adapter';
 
 async function jsonTool(ctx: ReaderToolContext, name: string, args: Record<string, unknown> = {}) {
   const result = await callReaderTool(ctx, name, args);
@@ -233,6 +234,89 @@ describe('MCP reader tools', () => {
       } finally {
         rmSync(outside, { recursive: true, force: true });
       }
+    });
+  });
+
+  test('general repo tools merge CodeGraph metadata under the same guarded snapshot', async () => {
+    await withReaderRepo(async (repoRoot, ctx) => {
+      writeFileSync(join(repoRoot, '.ignore'), 'ignored.md\n');
+      const fakeCodeGraph: GeneralRepoCodeGraphAdapter = {
+        discoverRepo() {
+          return {
+            available: true,
+            integrated: true,
+            source: 'test-double',
+            indexRevision: 'index_fake1234',
+            latencyMs: 3,
+            files: [
+              { path: 'src/index.ts', language: 'typescript', nodeCount: 2, size: 31 },
+              { path: '.env', language: 'dotenv', nodeCount: 0, size: 29 },
+              { path: 'ignored.md', language: 'markdown', nodeCount: 0, size: 10 },
+              { path: '../outside.ts', language: 'typescript', nodeCount: 1, size: 10 },
+              { path: 'missing.ts', language: 'typescript', nodeCount: 1, size: 10 },
+            ],
+          };
+        },
+      };
+      const cgCtx = createReaderToolContext(
+        repoRoot,
+        ctx.policy,
+        new WorkspaceManager({ allowedRoots: [repoRoot], policy: ctx.policy }),
+        fakeCodeGraph,
+      );
+
+      const repoId = (await jsonTool(cgCtx, 'list_allowed_roots')).roots[0].repo_id;
+      const manifest = await jsonTool(cgCtx, 'repo_manifest', { repo_id: repoId, page_size: 1000 });
+      const byPath = new Map(manifest.entries.map((entry: { path: string }) => [entry.path, entry]));
+      expect(manifest.index_revision).toBe('index_fake1234');
+      expect(manifest.codegraph).toMatchObject({
+        integrated: true,
+        available: true,
+        source: 'test-double',
+        indexed_files: 5,
+        filtered_paths: 3,
+      });
+      expect(manifest.counts.indexed).toBe(2);
+      expect(byPath.get('src/index.ts')).toMatchObject({
+        indexed: true,
+        codegraph_language: 'typescript',
+        codegraph_node_count: 2,
+      });
+      expect(byPath.get('.env')).toMatchObject({ indexed: true, codegraph_language: 'dotenv' });
+      expect(byPath.get('docs/design.md')).toMatchObject({ indexed: false });
+      expect(byPath.has('ignored.md')).toBe(false);
+
+      const stat = await jsonTool(cgCtx, 'stat_file', { repo_id: repoId, path: 'src/index.ts', snapshot_id: manifest.snapshot_id });
+      expect(stat.snapshot_id).toBe(manifest.snapshot_id);
+      expect(stat).toMatchObject({ indexed: true, codegraph_language: 'typescript' });
+
+      const read = await jsonTool(cgCtx, 'read_file', { repo_id: repoId, path: 'src/index.ts', snapshot_id: manifest.snapshot_id });
+      expect(read.snapshot_id).toBe(manifest.snapshot_id);
+      expect(read).toMatchObject({ indexed: true, backend: 'codegraph-indexed-filesystem-read' });
+
+      const firstSearch = await jsonTool(cgCtx, 'search_text', {
+        repo_id: repoId,
+        query: 'alpha',
+        paths: ['docs/notes.txt'],
+        max_results: 1,
+        snapshot_id: manifest.snapshot_id,
+      });
+      expect(firstSearch.snapshot_id).toBe(manifest.snapshot_id);
+      expect(firstSearch.matches).toHaveLength(1);
+      expect(firstSearch.next_cursor).toBe('1');
+      const secondSearch = await jsonTool(cgCtx, 'search_text', {
+        repo_id: repoId,
+        query: 'alpha',
+        paths: ['docs/notes.txt'],
+        max_results: 1,
+        cursor: firstSearch.next_cursor,
+        snapshot_id: manifest.snapshot_id,
+      });
+      expect(secondSearch.matches[0].line).toBe(3);
+
+      const stale = await jsonTool(cgCtx, 'read_file', { repo_id: repoId, path: 'src/index.ts', snapshot_id: 'snap_stale' });
+      expect(stale.error.code).toBe('SNAPSHOT_STALE');
+      expect(stale.error.retryable).toBe(true);
     });
   });
 

--- a/tests/cli/mcp-reader-tools.test.ts
+++ b/tests/cli/mcp-reader-tools.test.ts
@@ -390,6 +390,45 @@ describe('MCP reader tools', () => {
     });
   });
 
+  test('general repo snapshots fail closed when repo changes during snapshot build', async () => {
+    await withReaderRepo(async (repoRoot, ctx) => {
+      const repoId = (await jsonTool(ctx, 'list_allowed_roots')).roots[0].repo_id;
+      let completeMutations = 0;
+      const completeRaceCtx: ReaderToolContext = {
+        ...ctx,
+        testHooks: {
+          afterSnapshotWalk(event) {
+            if (event.kind !== 'complete' || completeMutations >= 2) return;
+            completeMutations += 1;
+            writeFileSync(join(repoRoot, 'src', 'race-complete.ts'), `export const race = ${completeMutations};\n`);
+          },
+        },
+      };
+
+      const staleTree = await jsonTool(completeRaceCtx, 'list_tree', { repo_id: repoId, path: '.', depth: 2 });
+      expect(staleTree.error.code).toBe('SNAPSHOT_STALE');
+      expect(staleTree.error.retryable).toBe(true);
+      expect(completeMutations).toBe(2);
+
+      let pageMutations = 0;
+      const pageRaceCtx: ReaderToolContext = {
+        ...ctx,
+        testHooks: {
+          afterSnapshotWalk(event) {
+            if (event.kind !== 'manifest_page' || pageMutations >= 2) return;
+            pageMutations += 1;
+            writeFileSync(join(repoRoot, 'src', 'race-page.ts'), `export const pageRace = ${pageMutations};\n`);
+          },
+        },
+      };
+
+      const staleManifest = await jsonTool(pageRaceCtx, 'repo_manifest', { repo_id: repoId, page_size: 2 });
+      expect(staleManifest.error.code).toBe('SNAPSHOT_STALE');
+      expect(staleManifest.error.retryable).toBe(true);
+      expect(pageMutations).toBe(2);
+    });
+  });
+
   test('tree applies hidden, ignore, deny, symlink, and entry limits without leaking denied names', async () => {
     await withReaderRepo(async (_repoRoot, ctx) => {
       const root = (await jsonTool(ctx, 'list_allowed_roots')).roots[0];


### PR DESCRIPTION
## Module boundary
S2 replaces the incremental PRs for CodeGraph-backed snapshots, repo_manifest, search_text, read_file/read_files, cache/performance baselines, and streaming manifest behavior.

## Verification scope
- Sprint plan S2 checklist is marked complete in plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md.
- Existing branch head is the prior S2 tail commit 6008c39, preserving the tested implementation history.
- Supersedes PRs #20, #21, #22, #23, and #24.