### PR TITLE
Module S3: Add guarded repo mutation tools and index recovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ tasks/.current.md.tmp.*
 .ai/harness/worktrees/
 .ai/harness/runs/
 .ai/harness/mcp/audit.log
+.ai/harness/mcp/index-events.jsonl
 .ai/harness/chatgpt/browser-lock.json
 .ai/harness/chatgpt/bridge-extension/
 .ai/harness/chatgpt/oracle-home/

--- a/README.md
+++ b/README.md
@@ -348,21 +348,27 @@ before applying anything.
 As an optional sidecar, `repo-harness mcp` exposes workflow artifacts to MCP
 clients through the default `planner` profile. ChatGPT acts as a
 planner/reviewer that reads state and moves an idea through PRD, checklist
-Sprint, and Codex goal handoff artifacts — with no source-code write access,
+Sprint, and Codex goal handoff artifacts — with no default source-code write access,
 arbitrary shell execution, or default Codex runner. Codex remains the executor.
 
 The same `planner` Connector also exposes general repo tools for
 registered adopted repos. Use `discover_harness_repos` first, then call
 `list_allowed_roots` to get the stable `repo_id`. General repo reads use
 `repo_manifest`, `list_tree`, `stat_file`, `read_file`, `read_files`, and
-`search_text`. The initial write surface is `write_file`, which is rejected
-unless that registered repo is explicitly configured as `read_write`.
+`search_text`. The write surface currently exposes `write_file` and
+`refresh_repo_index`, both rejected unless that registered repo is explicitly
+configured as `read_write`.
 `write_file` creates only with `must_not_exist: true`, replaces only with
 `expected_sha256`, and reports `before`, `after`, `diff`, `mutation_id`, and
-`index_state` after an atomic same-directory rename. The repo whitelist is the
-authorization boundary, `.ignore` is the only content exclusion source, paths
-are repo-relative, and authorized file content is not implicitly redacted.
-External non-repo local roots require explicit `--allow-root` authorization.
+`index_state` after an atomic same-directory rename. Successful writes leave the
+index pending; `refresh_repo_index` runs CodeGraph sync for the repo, invalidates
+reader snapshots, and returns the new `snapshot_id`, `index_revision`,
+`index_state`, and refresh strategy. The CLI adapter reports
+`path_refresh_supported:false` when it must use repo-level sync for requested
+paths. The repo whitelist is the authorization boundary, `.ignore` is the only
+content exclusion source, paths are repo-relative, and authorized file content is
+not implicitly redacted. External non-repo local roots require explicit
+`--allow-root` authorization.
 
 When CodeGraph is initialized for a registered repo, the general reader merges
 CodeGraph indexed-file metadata into manifest/stat/read/search responses while

--- a/README.md
+++ b/README.md
@@ -356,17 +356,20 @@ registered adopted repos. Use `discover_harness_repos` first, then call
 `list_allowed_roots` to get the stable `repo_id`. General repo reads use
 `repo_manifest`, `list_tree`, `stat_file`, `read_file`, `read_files`, and
 `search_text`. The write surface currently exposes `write_file`, `apply_patch`,
-and `refresh_repo_index`, all rejected unless that registered repo is explicitly
-configured as `read_write`.
+`move_path`, `delete_path`, and `refresh_repo_index`, all rejected unless that
+registered repo is explicitly configured as `read_write`.
 `write_file` creates only with `must_not_exist: true`, replaces only with
 `expected_sha256`, and reports `before`, `after`, `diff`, `mutation_id`, and
 `index_state` after an atomic same-directory rename. `apply_patch` operates only
 on existing text files, requires `expected_sha256`, and accepts either structured
 `old_text`/`new_text` edits or guarded unified diff hunks. Patch precondition
 misses and stale hashes return `REVISION_CONFLICT` without writing. Successful
-writes leave the index pending; `refresh_repo_index` runs CodeGraph sync for the
-repo, invalidates reader snapshots, and returns the new `snapshot_id`,
-`index_revision`, `index_state`, and refresh strategy. The CLI adapter reports
+file moves require a source `expected_sha256` plus `must_not_exist: true` for the
+target. Deletes require `expected_sha256`; v1 deletes regular files only and
+rejects directory or recursive deletes. Successful writes leave the index
+pending; `refresh_repo_index` runs CodeGraph sync for the repo, invalidates
+reader snapshots, and returns the new `snapshot_id`, `index_revision`,
+`index_state`, and refresh strategy. The CLI adapter reports
 `path_refresh_supported:false` when it must use repo-level sync for requested
 paths. The repo whitelist is the authorization boundary, `.ignore` is the only
 content exclusion source, paths are repo-relative, and authorized file content is

--- a/README.md
+++ b/README.md
@@ -355,15 +355,18 @@ The same `planner` Connector also exposes general repo tools for
 registered adopted repos. Use `discover_harness_repos` first, then call
 `list_allowed_roots` to get the stable `repo_id`. General repo reads use
 `repo_manifest`, `list_tree`, `stat_file`, `read_file`, `read_files`, and
-`search_text`. The write surface currently exposes `write_file` and
-`refresh_repo_index`, both rejected unless that registered repo is explicitly
+`search_text`. The write surface currently exposes `write_file`, `apply_patch`,
+and `refresh_repo_index`, all rejected unless that registered repo is explicitly
 configured as `read_write`.
 `write_file` creates only with `must_not_exist: true`, replaces only with
 `expected_sha256`, and reports `before`, `after`, `diff`, `mutation_id`, and
-`index_state` after an atomic same-directory rename. Successful writes leave the
-index pending; `refresh_repo_index` runs CodeGraph sync for the repo, invalidates
-reader snapshots, and returns the new `snapshot_id`, `index_revision`,
-`index_state`, and refresh strategy. The CLI adapter reports
+`index_state` after an atomic same-directory rename. `apply_patch` operates only
+on existing text files, requires `expected_sha256`, and accepts either structured
+`old_text`/`new_text` edits or guarded unified diff hunks. Patch precondition
+misses and stale hashes return `REVISION_CONFLICT` without writing. Successful
+writes leave the index pending; `refresh_repo_index` runs CodeGraph sync for the
+repo, invalidates reader snapshots, and returns the new `snapshot_id`,
+`index_revision`, `index_state`, and refresh strategy. The CLI adapter reports
 `path_refresh_supported:false` when it must use repo-level sync for requested
 paths. The repo whitelist is the authorization boundary, `.ignore` is the only
 content exclusion source, paths are repo-relative, and authorized file content is

--- a/README.md
+++ b/README.md
@@ -351,14 +351,18 @@ planner/reviewer that reads state and moves an idea through PRD, checklist
 Sprint, and Codex goal handoff artifacts — with no source-code write access,
 arbitrary shell execution, or default Codex runner. Codex remains the executor.
 
-The same `planner` Connector also exposes read-only general repo tools for
+The same `planner` Connector also exposes general repo tools for
 registered adopted repos. Use `discover_harness_repos` first, then call
 `list_allowed_roots` to get the stable `repo_id`. General repo reads use
 `repo_manifest`, `list_tree`, `stat_file`, `read_file`, `read_files`, and
-`search_text`. The repo whitelist is the authorization boundary, `.ignore` is
-the only content exclusion source, paths are repo-relative, and authorized file
-content is not implicitly redacted. External non-repo local roots require
-explicit `--allow-root` authorization.
+`search_text`. The initial write surface is `write_file`, which is rejected
+unless that registered repo is explicitly configured as `read_write`.
+`write_file` creates only with `must_not_exist: true`, replaces only with
+`expected_sha256`, and reports `before`, `after`, `diff`, `mutation_id`, and
+`index_state` after an atomic same-directory rename. The repo whitelist is the
+authorization boundary, `.ignore` is the only content exclusion source, paths
+are repo-relative, and authorized file content is not implicitly redacted.
+External non-repo local roots require explicit `--allow-root` authorization.
 
 When CodeGraph is initialized for a registered repo, the general reader merges
 CodeGraph indexed-file metadata into manifest/stat/read/search responses while

--- a/README.md
+++ b/README.md
@@ -367,14 +367,19 @@ misses and stale hashes return `REVISION_CONFLICT` without writing. Successful
 file moves require a source `expected_sha256` plus `must_not_exist: true` for the
 target. Deletes require `expected_sha256`; v1 deletes regular files only and
 rejects directory or recursive deletes. Successful writes leave the index
-pending; `refresh_repo_index` runs CodeGraph sync for the repo, invalidates
-reader snapshots, and returns the new `snapshot_id`, `index_revision`,
-`index_state`, and refresh strategy. The CLI adapter reports
-`path_refresh_supported:false` when it must use repo-level sync for requested
-paths. The repo whitelist is the authorization boundary, `.ignore` is the only
-content exclusion source, paths are repo-relative, and authorized file content is
-not implicitly redacted. External non-repo local roots require explicit
-`--allow-root` authorization.
+pending and append an index invalidation event under
+`.ai/harness/mcp/index-events.jsonl`; `refresh_repo_index` runs CodeGraph sync
+for the repo, invalidates reader snapshots, records refresh success or
+dead-letter failure in that same event log, and returns the new `snapshot_id`,
+`index_revision`, `index_state`, refresh strategy, and optional mutation lag when
+called with `mutation_id`. The CLI adapter reports `path_refresh_supported:false`
+when it must use repo-level sync for requested paths. The MCP audit log records
+actor/profile, repo id, operation, relative paths, hash summary, result, error
+code, duration, and mutation/index event ids without storing file bodies or
+patch text. The repo whitelist is the authorization boundary, `.ignore` is the
+only content exclusion source, paths are repo-relative, and authorized file
+content is not implicitly redacted. External non-repo local roots require
+explicit `--allow-root` authorization.
 
 When CodeGraph is initialized for a registered repo, the general reader merges
 CodeGraph indexed-file metadata into manifest/stat/read/search responses while

--- a/assets/mcp/general-repo-reader-tools.v1.schema.json
+++ b/assets/mcp/general-repo-reader-tools.v1.schema.json
@@ -45,7 +45,7 @@
     },
     "tools": {
       "type": "array",
-      "minItems": 8,
+      "minItems": 9,
       "items": {
         "$ref": "#/$defs/tool"
       }
@@ -118,7 +118,8 @@
             "read_file",
             "read_files",
             "stat_file",
-            "write_file"
+            "write_file",
+            "refresh_repo_index"
           ]
         },
         "description": {
@@ -965,6 +966,109 @@
               },
               "index_state": {
                 "type": "string"
+              }
+            },
+            "additionalProperties": true
+          },
+          {
+            "type": "object",
+            "required": [
+              "error"
+            ],
+            "properties": {
+              "error": {
+                "type": "object",
+                "required": [
+                  "code",
+                  "message",
+                  "retryable"
+                ],
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  },
+                  "retryable": {
+                    "type": "boolean"
+                  },
+                  "details": {}
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "refresh_repo_index",
+      "description": "Synchronize CodeGraph for a read_write repo after mutations and return the new index/snapshot state.",
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "input_schema": {
+        "type": "object",
+        "required": [
+          "repo_id"
+        ],
+        "properties": {
+          "repo_id": {
+            "type": "string"
+          },
+          "paths": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "repo_id",
+              "snapshot_id",
+              "ignore_digest",
+              "paths",
+              "refreshed",
+              "index_state",
+              "refresh",
+              "index"
+            ],
+            "properties": {
+              "repo_id": {
+                "type": "string"
+              },
+              "snapshot_id": {
+                "type": "string"
+              },
+              "ignore_digest": {
+                "type": "string"
+              },
+              "paths": {
+                "type": "array"
+              },
+              "refreshed": {
+                "type": "boolean"
+              },
+              "index_state": {
+                "type": "string"
+              },
+              "refresh": {
+                "type": "object"
+              },
+              "index": {
+                "type": "object"
               }
             },
             "additionalProperties": true

--- a/assets/mcp/general-repo-reader-tools.v1.schema.json
+++ b/assets/mcp/general-repo-reader-tools.v1.schema.json
@@ -1412,6 +1412,9 @@
             "items": {
               "type": "string"
             }
+          },
+          "mutation_id": {
+            "type": "string"
           }
         },
         "additionalProperties": false

--- a/assets/mcp/general-repo-reader-tools.v1.schema.json
+++ b/assets/mcp/general-repo-reader-tools.v1.schema.json
@@ -45,7 +45,7 @@
     },
     "tools": {
       "type": "array",
-      "minItems": 7,
+      "minItems": 8,
       "items": {
         "$ref": "#/$defs/tool"
       }
@@ -117,7 +117,8 @@
             "search_text",
             "read_file",
             "read_files",
-            "stat_file"
+            "stat_file",
+            "write_file"
           ]
         },
         "description": {
@@ -135,13 +136,13 @@
           "additionalProperties": false,
           "properties": {
             "readOnlyHint": {
-              "const": true
+              "type": "boolean"
             },
             "destructiveHint": {
-              "const": false
+              "type": "boolean"
             },
             "idempotentHint": {
-              "const": true
+              "type": "boolean"
             },
             "openWorldHint": {
               "const": false
@@ -843,6 +844,127 @@
               },
               "readable": {
                 "type": "boolean"
+              }
+            },
+            "additionalProperties": true
+          },
+          {
+            "type": "object",
+            "required": [
+              "error"
+            ],
+            "properties": {
+              "error": {
+                "type": "object",
+                "required": [
+                  "code",
+                  "message",
+                  "retryable"
+                ],
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  },
+                  "retryable": {
+                    "type": "boolean"
+                  },
+                  "details": {}
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "write_file",
+      "description": "Create or replace one repo-relative file in a read_write repo using revision preconditions and atomic same-directory rename.",
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "input_schema": {
+        "type": "object",
+        "required": [
+          "repo_id",
+          "path",
+          "content"
+        ],
+        "properties": {
+          "repo_id": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "encoding": {
+            "enum": [
+              "utf-8",
+              "base64"
+            ]
+          },
+          "expected_sha256": {
+            "type": "string"
+          },
+          "must_not_exist": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "repo_id",
+              "snapshot_id",
+              "ignore_digest",
+              "path",
+              "mutation_id",
+              "before",
+              "after",
+              "diff",
+              "index_state"
+            ],
+            "properties": {
+              "repo_id": {
+                "type": "string"
+              },
+              "snapshot_id": {
+                "type": "string"
+              },
+              "ignore_digest": {
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              },
+              "mutation_id": {
+                "type": "string"
+              },
+              "before": {
+                "type": "object"
+              },
+              "after": {
+                "type": "object"
+              },
+              "diff": {
+                "type": "object"
+              },
+              "index_state": {
+                "type": "string"
               }
             },
             "additionalProperties": true

--- a/assets/mcp/general-repo-reader-tools.v1.schema.json
+++ b/assets/mcp/general-repo-reader-tools.v1.schema.json
@@ -45,7 +45,7 @@
     },
     "tools": {
       "type": "array",
-      "minItems": 9,
+      "minItems": 10,
       "items": {
         "$ref": "#/$defs/tool"
       }
@@ -119,6 +119,7 @@
             "read_files",
             "stat_file",
             "write_file",
+            "apply_patch",
             "refresh_repo_index"
           ]
         },
@@ -962,6 +963,144 @@
                 "type": "object"
               },
               "diff": {
+                "type": "object"
+              },
+              "index_state": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": true
+          },
+          {
+            "type": "object",
+            "required": [
+              "error"
+            ],
+            "properties": {
+              "error": {
+                "type": "object",
+                "required": [
+                  "code",
+                  "message",
+                  "retryable"
+                ],
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  },
+                  "retryable": {
+                    "type": "boolean"
+                  },
+                  "details": {}
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "apply_patch",
+      "description": "Apply structured text edits or a guarded unified diff to one existing repo-relative file using an expected_sha256 precondition.",
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "input_schema": {
+        "type": "object",
+        "required": [
+          "repo_id",
+          "path",
+          "expected_sha256"
+        ],
+        "properties": {
+          "repo_id": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "expected_sha256": {
+            "type": "string"
+          },
+          "edits": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "old_text",
+                "new_text"
+              ],
+              "properties": {
+                "old_text": {
+                  "type": "string"
+                },
+                "new_text": {
+                  "type": "string"
+                },
+                "occurrence": {
+                  "type": "number"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "unified_diff": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "repo_id",
+              "snapshot_id",
+              "ignore_digest",
+              "path",
+              "mutation_id",
+              "before",
+              "after",
+              "diff",
+              "patch",
+              "index_state"
+            ],
+            "properties": {
+              "repo_id": {
+                "type": "string"
+              },
+              "snapshot_id": {
+                "type": "string"
+              },
+              "ignore_digest": {
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              },
+              "mutation_id": {
+                "type": "string"
+              },
+              "before": {
+                "type": "object"
+              },
+              "after": {
+                "type": "object"
+              },
+              "diff": {
+                "type": "object"
+              },
+              "patch": {
                 "type": "object"
               },
               "index_state": {

--- a/assets/mcp/general-repo-reader-tools.v1.schema.json
+++ b/assets/mcp/general-repo-reader-tools.v1.schema.json
@@ -45,7 +45,7 @@
     },
     "tools": {
       "type": "array",
-      "minItems": 10,
+      "minItems": 12,
       "items": {
         "$ref": "#/$defs/tool"
       }
@@ -120,6 +120,8 @@
             "stat_file",
             "write_file",
             "apply_patch",
+            "move_path",
+            "delete_path",
             "refresh_repo_index"
           ]
         },
@@ -1101,6 +1103,251 @@
                 "type": "object"
               },
               "patch": {
+                "type": "object"
+              },
+              "index_state": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": true
+          },
+          {
+            "type": "object",
+            "required": [
+              "error"
+            ],
+            "properties": {
+              "error": {
+                "type": "object",
+                "required": [
+                  "code",
+                  "message",
+                  "retryable"
+                ],
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  },
+                  "retryable": {
+                    "type": "boolean"
+                  },
+                  "details": {}
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "move_path",
+      "description": "Move one existing repo-relative file to a new repo-relative path using source hash and target-existence preconditions.",
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "input_schema": {
+        "type": "object",
+        "required": [
+          "repo_id",
+          "from_path",
+          "to_path",
+          "expected_sha256",
+          "must_not_exist"
+        ],
+        "properties": {
+          "repo_id": {
+            "type": "string"
+          },
+          "from_path": {
+            "type": "string"
+          },
+          "to_path": {
+            "type": "string"
+          },
+          "expected_sha256": {
+            "type": "string"
+          },
+          "must_not_exist": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "repo_id",
+              "snapshot_id",
+              "ignore_digest",
+              "path",
+              "from_path",
+              "to_path",
+              "mutation_id",
+              "before",
+              "after",
+              "diff",
+              "move",
+              "index_state"
+            ],
+            "properties": {
+              "repo_id": {
+                "type": "string"
+              },
+              "snapshot_id": {
+                "type": "string"
+              },
+              "ignore_digest": {
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              },
+              "from_path": {
+                "type": "string"
+              },
+              "to_path": {
+                "type": "string"
+              },
+              "mutation_id": {
+                "type": "string"
+              },
+              "before": {
+                "type": "object"
+              },
+              "after": {
+                "type": "object"
+              },
+              "diff": {
+                "type": "object"
+              },
+              "move": {
+                "type": "object"
+              },
+              "index_state": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": true
+          },
+          {
+            "type": "object",
+            "required": [
+              "error"
+            ],
+            "properties": {
+              "error": {
+                "type": "object",
+                "required": [
+                  "code",
+                  "message",
+                  "retryable"
+                ],
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  },
+                  "retryable": {
+                    "type": "boolean"
+                  },
+                  "details": {}
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "delete_path",
+      "description": "Delete one existing repo-relative regular file using an expected_sha256 precondition; directory and recursive deletes are disabled in v1.",
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "input_schema": {
+        "type": "object",
+        "required": [
+          "repo_id",
+          "path",
+          "expected_sha256"
+        ],
+        "properties": {
+          "repo_id": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "expected_sha256": {
+            "type": "string"
+          },
+          "recursive": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "repo_id",
+              "snapshot_id",
+              "ignore_digest",
+              "path",
+              "mutation_id",
+              "before",
+              "after",
+              "diff",
+              "deleted",
+              "index_state"
+            ],
+            "properties": {
+              "repo_id": {
+                "type": "string"
+              },
+              "snapshot_id": {
+                "type": "string"
+              },
+              "ignore_digest": {
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              },
+              "mutation_id": {
+                "type": "string"
+              },
+              "before": {
+                "type": "object"
+              },
+              "after": {
+                "type": "object"
+              },
+              "diff": {
+                "type": "object"
+              },
+              "deleted": {
                 "type": "object"
               },
               "index_state": {

--- a/docs/architecture/decisions/20260622-general-repo-codegraph-access.md
+++ b/docs/architecture/decisions/20260622-general-repo-codegraph-access.md
@@ -60,9 +60,20 @@ Sprint 0 freezes the read contract for:
 - `read_files`
 - `search_text`
 
-The initial write implementation covers `write_file` create/replace. Patch,
-move, delete, and explicit index-refresh tools remain implementation-gated until
+The current write implementation covers `write_file` create/replace and
+`refresh_repo_index`. Patch, move, and delete remain implementation-gated until
 their Sprint 3 slices land.
+
+`write_file` commits filesystem truth first and returns an index invalidation
+record with `index_state: pending` when CodeGraph is available. The explicit
+`refresh_repo_index` tool requires the same `read_write` repo capability,
+reuses the same path guard and `.ignore` policy for requested paths, runs the
+adapter refresh, invalidates in-process repo snapshots, then returns the new
+snapshot and CodeGraph revision. The bundled CLI adapter uses repo-level
+`codegraph sync` because the local CodeGraph CLI surface does not expose a
+stable path-only refresh command; responses report
+`path_refresh_supported:false` so callers do not assume true incremental
+reindexing.
 
 ## Snapshot Contract
 

--- a/docs/architecture/decisions/20260622-general-repo-codegraph-access.md
+++ b/docs/architecture/decisions/20260622-general-repo-codegraph-access.md
@@ -61,8 +61,7 @@ Sprint 0 freezes the read contract for:
 - `search_text`
 
 The current write implementation covers `write_file` create/replace,
-`apply_patch`, and `refresh_repo_index`. Move and delete remain
-implementation-gated until their Sprint 3 slices land.
+`apply_patch`, `move_path`, `delete_path`, and `refresh_repo_index`.
 
 `write_file` and `apply_patch` commit filesystem truth first and return an index
 invalidation record with `index_state: pending` when CodeGraph is available.
@@ -73,6 +72,15 @@ precondition and returns `REVISION_CONFLICT` if it no longer matches. Existing
 file replacements preserve the file mode bits used by the target. Filesystem
 mtime changes as part of the commit, and ownership, xattrs, and platform-specific
 metadata are not preserved in this portable v1 mutation layer.
+
+`move_path` is a regular-file-only mutation. It requires the source
+`expected_sha256`, refuses symlink moves, requires the target parent directory to
+already exist, and requires `must_not_exist: true` for the target path.
+`delete_path` also deletes only regular files and requires `expected_sha256`.
+Directory creation, empty-directory mutation, and recursive delete are explicitly
+disabled in v1; directory targets fail before any filesystem mutation. This
+keeps tree-shape changes out of the first mutation layer while still closing the
+lost-update contract for file moves and deletes.
 
 The explicit `refresh_repo_index` tool requires the same `read_write` repo
 capability, reuses the same path guard and `.ignore` policy for requested paths,

--- a/docs/architecture/decisions/20260622-general-repo-codegraph-access.md
+++ b/docs/architecture/decisions/20260622-general-repo-codegraph-access.md
@@ -41,8 +41,9 @@ For a registered repo:
 - Authorized file content is not implicitly redacted in tool responses for this
   API. Logs, traces, metrics, errors, and audit records must not include file
   content.
-- Write tools are not registered for read-only repos. Write access requires an
-  explicit repo-level `read_write` capability.
+- Write tools are rejected for read-only repos. Write access requires an
+  explicit repo-level `read_write` capability; tool availability is advertised
+  through `get_repo_capabilities.write_tools`.
 - Every overwriting write, patch, move, or delete operation requires a revision
   precondition such as `expected_sha256`; new file creation requires an explicit
   must-not-exist precondition.
@@ -59,8 +60,9 @@ Sprint 0 freezes the read contract for:
 - `read_files`
 - `search_text`
 
-The write contract remains design-frozen but implementation-gated until the
-read plane and snapshot behavior are proven.
+The initial write implementation covers `write_file` create/replace. Patch,
+move, delete, and explicit index-refresh tools remain implementation-gated until
+their Sprint 3 slices land.
 
 ## Snapshot Contract
 

--- a/docs/architecture/decisions/20260622-general-repo-codegraph-access.md
+++ b/docs/architecture/decisions/20260622-general-repo-codegraph-access.md
@@ -60,20 +60,27 @@ Sprint 0 freezes the read contract for:
 - `read_files`
 - `search_text`
 
-The current write implementation covers `write_file` create/replace and
-`refresh_repo_index`. Patch, move, and delete remain implementation-gated until
-their Sprint 3 slices land.
+The current write implementation covers `write_file` create/replace,
+`apply_patch`, and `refresh_repo_index`. Move and delete remain
+implementation-gated until their Sprint 3 slices land.
 
-`write_file` commits filesystem truth first and returns an index invalidation
-record with `index_state: pending` when CodeGraph is available. The explicit
-`refresh_repo_index` tool requires the same `read_write` repo capability,
-reuses the same path guard and `.ignore` policy for requested paths, runs the
-adapter refresh, invalidates in-process repo snapshots, then returns the new
-snapshot and CodeGraph revision. The bundled CLI adapter uses repo-level
+`write_file` and `apply_patch` commit filesystem truth first and return an index
+invalidation record with `index_state: pending` when CodeGraph is available.
+`apply_patch` is text-only and supports structured `old_text`/`new_text` edits
+plus guarded unified diff hunks. Both patch modes require an exact
+`expected_sha256` file precondition; each edit/hunk also acts as a local text
+precondition and returns `REVISION_CONFLICT` if it no longer matches. Existing
+file replacements preserve the file mode bits used by the target. Filesystem
+mtime changes as part of the commit, and ownership, xattrs, and platform-specific
+metadata are not preserved in this portable v1 mutation layer.
+
+The explicit `refresh_repo_index` tool requires the same `read_write` repo
+capability, reuses the same path guard and `.ignore` policy for requested paths,
+runs the adapter refresh, invalidates in-process repo snapshots, then returns the
+new snapshot and CodeGraph revision. The bundled CLI adapter uses repo-level
 `codegraph sync` because the local CodeGraph CLI surface does not expose a
-stable path-only refresh command; responses report
-`path_refresh_supported:false` so callers do not assume true incremental
-reindexing.
+stable path-only refresh command; responses report `path_refresh_supported:false`
+so callers do not assume true incremental reindexing.
 
 ## Snapshot Contract
 

--- a/docs/architecture/decisions/20260622-general-repo-codegraph-access.md
+++ b/docs/architecture/decisions/20260622-general-repo-codegraph-access.md
@@ -63,8 +63,12 @@ Sprint 0 freezes the read contract for:
 The current write implementation covers `write_file` create/replace,
 `apply_patch`, `move_path`, `delete_path`, and `refresh_repo_index`.
 
-`write_file` and `apply_patch` commit filesystem truth first and return an index
-invalidation record with `index_state: pending` when CodeGraph is available.
+`write_file` and `apply_patch` commit filesystem truth first, return an index
+invalidation record with `index_state: pending` when CodeGraph is available, and
+append an index invalidation event under `.ai/harness/mcp/index-events.jsonl`.
+The same mutation result shape is used by `move_path` and `delete_path`; the
+event log stores mutation ids, invalidation ids, relative paths, hash summaries,
+index revisions, and retry instructions, but never file bodies or patch text.
 `apply_patch` is text-only and supports structured `old_text`/`new_text` edits
 plus guarded unified diff hunks. Both patch modes require an exact
 `expected_sha256` file precondition; each edit/hunk also acts as a local text
@@ -84,11 +88,18 @@ lost-update contract for file moves and deletes.
 
 The explicit `refresh_repo_index` tool requires the same `read_write` repo
 capability, reuses the same path guard and `.ignore` policy for requested paths,
-runs the adapter refresh, invalidates in-process repo snapshots, then returns the
-new snapshot and CodeGraph revision. The bundled CLI adapter uses repo-level
-`codegraph sync` because the local CodeGraph CLI surface does not expose a
-stable path-only refresh command; responses report `path_refresh_supported:false`
-so callers do not assume true incremental reindexing.
+runs the adapter refresh, invalidates in-process repo snapshots, records refresh
+success or failure in the index event log, then returns the new snapshot and
+CodeGraph revision. Requested refresh paths may be recently deleted paths so
+delete and move invalidations can still be synchronized. Callers may pass the
+mutation id returned by the write tool; when the matching invalidation event is
+still in the recent event window, refresh responses include mutation-to-refresh
+lag and the source event id. Refresh failures are written as dead-letter events
+with retry metadata and the manual recovery command
+`bash scripts/ensure-codegraph.sh --sync`. The bundled CLI adapter uses repo-level
+`codegraph sync` because the local CodeGraph CLI surface does not expose a stable
+path-only refresh command; responses report `path_refresh_supported:false` so
+callers do not assume true incremental reindexing.
 
 ## Snapshot Contract
 

--- a/docs/repo-harness-chatgpt-mcp-setup.md
+++ b/docs/repo-harness-chatgpt-mcp-setup.md
@@ -123,14 +123,15 @@ If `repo-harness mcp doctor --repo . --json` reports `chatgpt.serverNameConfigur
 
 Use ChatGPT for planning and review. Use Codex for local execution.
 
-1. Use the single configured Connector for workflow planning and read-only repo tools.
+1. Use the single configured Connector for workflow planning and repo tools.
 2. Call `discover_harness_repos` to list registered adopted repos, then pass `repo_path` when targeting a specific project.
 3. For registered repo document/code reading, call `list_allowed_roots` to get the stable `repo_id`, then use `get_repo_capabilities`, `repo_manifest`, `list_tree`, `stat_file`, `read_file`, `read_files`, and `search_text`.
-4. Ask ChatGPT to turn the idea into a PRD with `write_prd_from_idea`.
-5. Ask ChatGPT to turn the PRD into a checklist Sprint with `write_checklist_sprint`.
-6. Ask ChatGPT to prepare a Codex Goal with `prepare_codex_goal_from_sprint`.
-7. Open Codex locally and run the generated `/goal` prompt.
-8. Let Codex execute one Sprint task card at a time, run checks, update the checklist, and stage each completed phase before continuing.
+4. For registered repo writes, first check `get_repo_capabilities.write_tools`; only repos explicitly configured as `read_write` expose `write_file`.
+5. Ask ChatGPT to turn the idea into a PRD with `write_prd_from_idea`.
+6. Ask ChatGPT to turn the PRD into a checklist Sprint with `write_checklist_sprint`.
+7. Ask ChatGPT to prepare a Codex Goal with `prepare_codex_goal_from_sprint`.
+8. Open Codex locally and run the generated `/goal` prompt.
+9. Let Codex execute one Sprint task card at a time, run checks, update the checklist, and stage each completed phase before continuing.
 
 The sidecar is not a remote coding agent. It prepares workflow artifacts for the local agent host.
 
@@ -149,6 +150,14 @@ normal manifest entry.
 Authorized file content is not implicitly redacted in `read_file`,
 `read_files`, or `search_text` responses. The MCP audit path records tool name,
 target path, input hash, status, and errors, but not file bodies.
+
+`write_file` is the first general repo mutation tool. It is runtime-gated by the
+registered repo access mode and returns `WRITE_DISABLED` for `read_only` repos.
+New files require `must_not_exist: true`; replacements require
+`expected_sha256`; mismatches return `REVISION_CONFLICT` without writing. A
+successful write uses a same-directory temporary file plus atomic rename,
+returns `before`, `after`, `diff`, `mutation_id`, and `index_state`, and leaves
+CodeGraph refresh explicitly pending until the index-sync slice handles it.
 
 When a repo has a CodeGraph index, `repo_manifest`, `list_tree`, `stat_file`,
 `read_file`, `read_files`, and `search_text` share a deterministic

--- a/docs/repo-harness-chatgpt-mcp-setup.md
+++ b/docs/repo-harness-chatgpt-mcp-setup.md
@@ -126,7 +126,7 @@ Use ChatGPT for planning and review. Use Codex for local execution.
 1. Use the single configured Connector for workflow planning and repo tools.
 2. Call `discover_harness_repos` to list registered adopted repos, then pass `repo_path` when targeting a specific project.
 3. For registered repo document/code reading, call `list_allowed_roots` to get the stable `repo_id`, then use `get_repo_capabilities`, `repo_manifest`, `list_tree`, `stat_file`, `read_file`, `read_files`, and `search_text`.
-4. For registered repo writes, first check `get_repo_capabilities.write_tools`; only repos explicitly configured as `read_write` expose `write_file` and `refresh_repo_index`.
+4. For registered repo writes, first check `get_repo_capabilities.write_tools`; only repos explicitly configured as `read_write` expose `write_file`, `apply_patch`, and `refresh_repo_index`.
 5. Ask ChatGPT to turn the idea into a PRD with `write_prd_from_idea`.
 6. Ask ChatGPT to turn the PRD into a checklist Sprint with `write_checklist_sprint`.
 7. Ask ChatGPT to prepare a Codex Goal with `prepare_codex_goal_from_sprint`.
@@ -151,14 +151,16 @@ Authorized file content is not implicitly redacted in `read_file`,
 `read_files`, or `search_text` responses. The MCP audit path records tool name,
 target path, input hash, status, and errors, but not file bodies.
 
-`write_file` is the first general repo mutation tool. It is runtime-gated by the
-registered repo access mode and returns `WRITE_DISABLED` for `read_only` repos.
-New files require `must_not_exist: true`; replacements require
-`expected_sha256`; mismatches return `REVISION_CONFLICT` without writing. A
-successful write uses a same-directory temporary file plus atomic rename,
+`write_file` and `apply_patch` are the first general repo mutation tools. They
+are runtime-gated by the registered repo access mode and return `WRITE_DISABLED`
+for `read_only` repos. New files require `must_not_exist: true`; replacements
+and patches require `expected_sha256`; mismatches return `REVISION_CONFLICT`
+without writing. `apply_patch` operates on existing text files and accepts either
+structured `old_text`/`new_text` edits or guarded unified diff hunks. A
+successful mutation uses a same-directory temporary file plus atomic rename,
 returns `before`, `after`, `diff`, `mutation_id`, and `index_state`, and leaves
 CodeGraph refresh explicitly pending. Call `refresh_repo_index` with the changed
-paths after a successful write to run CodeGraph sync, invalidate repo snapshot
+paths after a successful mutation to run CodeGraph sync, invalidate repo snapshot
 caches, and receive the new `index_revision`, `snapshot_id`, `index_state`, and
 refresh strategy. The bundled CLI adapter uses repo-level `codegraph sync` when
 path-only refresh is unavailable and reports that tradeoff with

--- a/docs/repo-harness-chatgpt-mcp-setup.md
+++ b/docs/repo-harness-chatgpt-mcp-setup.md
@@ -126,7 +126,7 @@ Use ChatGPT for planning and review. Use Codex for local execution.
 1. Use the single configured Connector for workflow planning and repo tools.
 2. Call `discover_harness_repos` to list registered adopted repos, then pass `repo_path` when targeting a specific project.
 3. For registered repo document/code reading, call `list_allowed_roots` to get the stable `repo_id`, then use `get_repo_capabilities`, `repo_manifest`, `list_tree`, `stat_file`, `read_file`, `read_files`, and `search_text`.
-4. For registered repo writes, first check `get_repo_capabilities.write_tools`; only repos explicitly configured as `read_write` expose `write_file`, `apply_patch`, and `refresh_repo_index`.
+4. For registered repo writes, first check `get_repo_capabilities.write_tools`; only repos explicitly configured as `read_write` expose `write_file`, `apply_patch`, `move_path`, `delete_path`, and `refresh_repo_index`.
 5. Ask ChatGPT to turn the idea into a PRD with `write_prd_from_idea`.
 6. Ask ChatGPT to turn the PRD into a checklist Sprint with `write_checklist_sprint`.
 7. Ask ChatGPT to prepare a Codex Goal with `prepare_codex_goal_from_sprint`.
@@ -151,16 +151,19 @@ Authorized file content is not implicitly redacted in `read_file`,
 `read_files`, or `search_text` responses. The MCP audit path records tool name,
 target path, input hash, status, and errors, but not file bodies.
 
-`write_file` and `apply_patch` are the first general repo mutation tools. They
-are runtime-gated by the registered repo access mode and return `WRITE_DISABLED`
-for `read_only` repos. New files require `must_not_exist: true`; replacements
-and patches require `expected_sha256`; mismatches return `REVISION_CONFLICT`
-without writing. `apply_patch` operates on existing text files and accepts either
-structured `old_text`/`new_text` edits or guarded unified diff hunks. A
-successful mutation uses a same-directory temporary file plus atomic rename,
-returns `before`, `after`, `diff`, `mutation_id`, and `index_state`, and leaves
-CodeGraph refresh explicitly pending. Call `refresh_repo_index` with the changed
-paths after a successful mutation to run CodeGraph sync, invalidate repo snapshot
+`write_file`, `apply_patch`, `move_path`, and `delete_path` are the general repo
+mutation tools. They are runtime-gated by the registered repo access mode and
+return `WRITE_DISABLED` for `read_only` repos. New files require
+`must_not_exist: true`; replacements, patches, moves, and deletes require
+`expected_sha256`; mismatches return `REVISION_CONFLICT` without writing.
+`apply_patch` operates on existing text files and accepts either structured
+`old_text`/`new_text` edits or guarded unified diff hunks. `move_path` moves one
+regular file only when the target also carries `must_not_exist: true`.
+`delete_path` deletes regular files only; directory creation, empty-directory
+mutation, and recursive delete are disabled in v1. A successful mutation returns
+`before`, `after`, `diff`, `mutation_id`, and `index_state`, and leaves CodeGraph
+refresh explicitly pending. Call `refresh_repo_index` with the changed paths
+after a successful mutation to run CodeGraph sync, invalidate repo snapshot
 caches, and receive the new `index_revision`, `snapshot_id`, `index_state`, and
 refresh strategy. The bundled CLI adapter uses repo-level `codegraph sync` when
 path-only refresh is unavailable and reports that tradeoff with

--- a/docs/repo-harness-chatgpt-mcp-setup.md
+++ b/docs/repo-harness-chatgpt-mcp-setup.md
@@ -126,7 +126,7 @@ Use ChatGPT for planning and review. Use Codex for local execution.
 1. Use the single configured Connector for workflow planning and repo tools.
 2. Call `discover_harness_repos` to list registered adopted repos, then pass `repo_path` when targeting a specific project.
 3. For registered repo document/code reading, call `list_allowed_roots` to get the stable `repo_id`, then use `get_repo_capabilities`, `repo_manifest`, `list_tree`, `stat_file`, `read_file`, `read_files`, and `search_text`.
-4. For registered repo writes, first check `get_repo_capabilities.write_tools`; only repos explicitly configured as `read_write` expose `write_file`.
+4. For registered repo writes, first check `get_repo_capabilities.write_tools`; only repos explicitly configured as `read_write` expose `write_file` and `refresh_repo_index`.
 5. Ask ChatGPT to turn the idea into a PRD with `write_prd_from_idea`.
 6. Ask ChatGPT to turn the PRD into a checklist Sprint with `write_checklist_sprint`.
 7. Ask ChatGPT to prepare a Codex Goal with `prepare_codex_goal_from_sprint`.
@@ -157,7 +157,12 @@ New files require `must_not_exist: true`; replacements require
 `expected_sha256`; mismatches return `REVISION_CONFLICT` without writing. A
 successful write uses a same-directory temporary file plus atomic rename,
 returns `before`, `after`, `diff`, `mutation_id`, and `index_state`, and leaves
-CodeGraph refresh explicitly pending until the index-sync slice handles it.
+CodeGraph refresh explicitly pending. Call `refresh_repo_index` with the changed
+paths after a successful write to run CodeGraph sync, invalidate repo snapshot
+caches, and receive the new `index_revision`, `snapshot_id`, `index_state`, and
+refresh strategy. The bundled CLI adapter uses repo-level `codegraph sync` when
+path-only refresh is unavailable and reports that tradeoff with
+`path_refresh_supported:false`.
 
 When a repo has a CodeGraph index, `repo_manifest`, `list_tree`, `stat_file`,
 `read_file`, `read_files`, and `search_text` share a deterministic

--- a/docs/repo-harness-chatgpt-mcp-setup.md
+++ b/docs/repo-harness-chatgpt-mcp-setup.md
@@ -149,7 +149,9 @@ normal manifest entry.
 
 Authorized file content is not implicitly redacted in `read_file`,
 `read_files`, or `search_text` responses. The MCP audit path records tool name,
-target path, input hash, status, and errors, but not file bodies.
+target path, input hash, actor/profile, repo id, operation, relative paths,
+hash summary, status, result, error code, duration, and mutation/index event ids,
+but not file bodies or patch text.
 
 `write_file`, `apply_patch`, `move_path`, and `delete_path` are the general repo
 mutation tools. They are runtime-gated by the registered repo access mode and
@@ -162,12 +164,17 @@ regular file only when the target also carries `must_not_exist: true`.
 `delete_path` deletes regular files only; directory creation, empty-directory
 mutation, and recursive delete are disabled in v1. A successful mutation returns
 `before`, `after`, `diff`, `mutation_id`, and `index_state`, and leaves CodeGraph
-refresh explicitly pending. Call `refresh_repo_index` with the changed paths
-after a successful mutation to run CodeGraph sync, invalidate repo snapshot
-caches, and receive the new `index_revision`, `snapshot_id`, `index_state`, and
-refresh strategy. The bundled CLI adapter uses repo-level `codegraph sync` when
-path-only refresh is unavailable and reports that tradeoff with
-`path_refresh_supported:false`.
+refresh explicitly pending. It also appends an index invalidation event to
+`.ai/harness/mcp/index-events.jsonl`. Call `refresh_repo_index` with the changed
+paths and, when available, the returned `mutation_id` after a successful mutation
+to run CodeGraph sync, invalidate repo snapshot caches, append refresh success or
+dead-letter failure to the same event log, and receive the new `index_revision`,
+`snapshot_id`, `index_state`, refresh strategy, and mutation-to-refresh lag. The
+bundled CLI adapter uses repo-level `codegraph sync` when path-only refresh is
+unavailable and reports that tradeoff with `path_refresh_supported:false`. Manual
+recovery for a dead-letter refresh is to rerun `refresh_repo_index`; if the
+adapter stays unavailable, run `bash scripts/ensure-codegraph.sh --sync` and then
+retry the tool.
 
 When a repo has a CodeGraph index, `repo_manifest`, `list_tree`, `stat_file`,
 `read_file`, `read_files`, and `search_text` share a deterministic

--- a/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
+++ b/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
@@ -525,9 +525,9 @@ Sprint 2 adapter/snapshot evidence:
 - [x] **S3-CAP-003** 写请求复用同一 Path Guard 和 IgnorePolicy。
 - [x] **S3-API-001** 实现 `write_file` create/replace。
 - [x] **S3-API-002** 实现 `apply_patch`，优先结构化 edits，必要时支持 unified diff。
-- [ ] **S3-API-003** 实现 `move_path`。
-- [ ] **S3-API-004** 实现 `delete_path`。
-- [ ] **S3-API-005** 定义目录创建、空目录和递归删除策略；递归删除建议首版默认关闭或要求显式参数。
+- [x] **S3-API-003** 实现 `move_path`。
+- [x] **S3-API-004** 实现 `delete_path`。
+- [x] **S3-API-005** 定义目录创建、空目录和递归删除策略；递归删除建议首版默认关闭或要求显式参数。
 - [x] **S3-API-006** 写响应返回 before/after hash、diff、mutation id 和 index state。
 
 ## 10.2 乐观并发与原子写
@@ -539,7 +539,7 @@ Sprint 2 adapter/snapshot evidence:
 - [x] **S3-MUT-005** 写临时文件 → fsync → atomic rename。
 - [x] **S3-MUT-006** 保留原文件权限和必要 metadata，策略写入 ADR。
 - [x] **S3-MUT-007** patch 应验证每个 hunk 或精确文本 precondition。
-- [ ] **S3-MUT-008** move/delete 同样进行版本和目标存在性检查。
+- [x] **S3-MUT-008** move/delete 同样进行版本和目标存在性检查。
 - [ ] **S3-MUT-009** 写失败不得留下半文件或跨 repo 临时文件。
 - [ ] **S3-MUT-010** 对写入过程进行故障注入测试：磁盘满、权限变化、进程中断、rename 失败。
 
@@ -586,9 +586,9 @@ Sprint 3 write_file evidence:
 - Verified in this slice: success and precondition-conflict paths leave no
   `.repo-harness-*` temporary files in the target directory. Full write-failure
   injection remains open under `S3-MUT-009/010`.
-- Explicitly still open: `move_path`, `delete_path`, recursive directory policy,
-  full index retry/dead-letter, index-lag monitoring, and complete write
-  audit/runbook coverage.
+- Explicitly still open: full write-failure injection, full index
+  retry/dead-letter, index-lag monitoring, and complete write audit/runbook
+  coverage.
 
 Sprint 3 index-sync evidence:
 
@@ -630,6 +630,29 @@ Sprint 3 apply_patch evidence:
 - Metadata policy: existing file mode bits are preserved. Filesystem mtime
   changes as part of the commit; ownership, xattrs, and platform-specific
   metadata are out of scope for the portable v1 mutation layer.
+
+Sprint 3 move/delete path mutation evidence:
+
+- Runtime: `src/cli/mcp/general-repo-access.ts`
+- Tests: `tests/cli/mcp-reader-tools.test.ts`,
+  `tests/cli/mcp-codegraph-contract.test.ts`
+- Schema/docs: `assets/mcp/general-repo-reader-tools.v1.schema.json`,
+  `README.md`, `docs/repo-harness-chatgpt-mcp-setup.md`,
+  `docs/architecture/decisions/20260622-general-repo-codegraph-access.md`,
+  `tasks/notes/20260622-repo-harness-codegraph.notes.md`
+- Completed slice: `move_path` and `delete_path` are exposed only for
+  `read_write` repos and reuse the same repo registry, Path Guard, `.ignore`,
+  snapshot invalidation, audit hash, and pending CodeGraph refresh contract as
+  `write_file` and `apply_patch`.
+- `move_path` is regular-file only, requires the source `expected_sha256`,
+  rejects stale hashes, requires an existing target parent directory, and
+  requires `must_not_exist: true` so target collisions return `TARGET_EXISTS`
+  before `rename`.
+- `delete_path` is regular-file only, requires `expected_sha256`, returns the
+  deleted metadata, and rejects stale hashes before removing the file.
+- Directory policy for v1 is now explicit: write tools do not create parent
+  directories; empty-directory mutation is unsupported; recursive delete is
+  disabled and returns a stable policy error before any filesystem mutation.
 
 ---
 

--- a/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
+++ b/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
@@ -520,10 +520,10 @@ Sprint 2 adapter/snapshot evidence:
 
 ## 10.1 写 capability 与 API
 
-- [ ] **S3-CAP-001** repo 默认保持 `read_only`。
-- [ ] **S3-CAP-002** 只有现有授权系统显式配置 `read_write` 时才注册/允许写工具。
-- [ ] **S3-CAP-003** 写请求复用同一 Path Guard 和 IgnorePolicy。
-- [ ] **S3-API-001** 实现 `write_file` create/replace。
+- [x] **S3-CAP-001** repo 默认保持 `read_only`。
+- [x] **S3-CAP-002** 只有现有授权系统显式配置 `read_write` 时才注册/允许写工具。
+- [x] **S3-CAP-003** 写请求复用同一 Path Guard 和 IgnorePolicy。
+- [x] **S3-API-001** 实现 `write_file` create/replace。
 - [ ] **S3-API-002** 实现 `apply_patch`，优先结构化 edits，必要时支持 unified diff。
 - [ ] **S3-API-003** 实现 `move_path`。
 - [ ] **S3-API-004** 实现 `delete_path`。
@@ -532,11 +532,11 @@ Sprint 2 adapter/snapshot evidence:
 
 ## 10.2 乐观并发与原子写
 
-- [ ] **S3-MUT-001** 覆盖已有文件必须提交 `expected_sha256`。
-- [ ] **S3-MUT-002** 新建必须提交 `must_not_exist: true`。
-- [ ] **S3-MUT-003** hash 不匹配返回 `REVISION_CONFLICT`，禁止自动覆盖。
-- [ ] **S3-MUT-004** 临时文件必须位于目标同一文件系统/目录边界。
-- [ ] **S3-MUT-005** 写临时文件 → fsync → atomic rename。
+- [x] **S3-MUT-001** 覆盖已有文件必须提交 `expected_sha256`。
+- [x] **S3-MUT-002** 新建必须提交 `must_not_exist: true`。
+- [x] **S3-MUT-003** hash 不匹配返回 `REVISION_CONFLICT`，禁止自动覆盖。
+- [x] **S3-MUT-004** 临时文件必须位于目标同一文件系统/目录边界。
+- [x] **S3-MUT-005** 写临时文件 → fsync → atomic rename。
 - [ ] **S3-MUT-006** 保留原文件权限和必要 metadata，策略写入 ADR。
 - [ ] **S3-MUT-007** patch 应验证每个 hunk 或精确文本 precondition。
 - [ ] **S3-MUT-008** move/delete 同样进行版本和目标存在性检查。
@@ -572,6 +572,23 @@ Sprint 2 adapter/snapshot evidence:
 - [ ] 写后 search 在定义的 index lag SLO 内可见，或明确返回 pending。
 - [ ] move/delete 后 manifest 与索引最终一致。
 - [ ] 所有写操作可通过 mutation id 审计。
+
+Sprint 3 write_file evidence:
+
+- Runtime: `src/cli/mcp/general-repo-access.ts`
+- Tests: `tests/cli/mcp-reader-tools.test.ts`
+- Schema/docs: `assets/mcp/general-repo-reader-tools.v1.schema.json`, `README.md`, `docs/repo-harness-chatgpt-mcp-setup.md`
+- Completed slice: `write_file` create/replace is gated by registered repo
+  `read_write`, reuses the general repo Path Guard and `.ignore` policy,
+  requires `must_not_exist` for create and `expected_sha256` for replace,
+  writes through a same-directory temporary file plus fsync/atomic rename, and
+  returns `mutation_id`, `before`, `after`, `diff`, and `index_state`.
+- Verified in this slice: success and precondition-conflict paths leave no
+  `.repo-harness-*` temporary files in the target directory. Full write-failure
+  injection remains open under `S3-MUT-009/010`.
+- Explicitly still open: `apply_patch`, `move_path`, `delete_path`,
+  `refresh_repo_index`, recursive directory policy, full index retry/dead-letter,
+  and complete write audit/runbook coverage.
 
 ---
 

--- a/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
+++ b/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
@@ -524,7 +524,7 @@ Sprint 2 adapter/snapshot evidence:
 - [x] **S3-CAP-002** 只有现有授权系统显式配置 `read_write` 时才注册/允许写工具。
 - [x] **S3-CAP-003** 写请求复用同一 Path Guard 和 IgnorePolicy。
 - [x] **S3-API-001** 实现 `write_file` create/replace。
-- [ ] **S3-API-002** 实现 `apply_patch`，优先结构化 edits，必要时支持 unified diff。
+- [x] **S3-API-002** 实现 `apply_patch`，优先结构化 edits，必要时支持 unified diff。
 - [ ] **S3-API-003** 实现 `move_path`。
 - [ ] **S3-API-004** 实现 `delete_path`。
 - [ ] **S3-API-005** 定义目录创建、空目录和递归删除策略；递归删除建议首版默认关闭或要求显式参数。
@@ -537,8 +537,8 @@ Sprint 2 adapter/snapshot evidence:
 - [x] **S3-MUT-003** hash 不匹配返回 `REVISION_CONFLICT`，禁止自动覆盖。
 - [x] **S3-MUT-004** 临时文件必须位于目标同一文件系统/目录边界。
 - [x] **S3-MUT-005** 写临时文件 → fsync → atomic rename。
-- [ ] **S3-MUT-006** 保留原文件权限和必要 metadata，策略写入 ADR。
-- [ ] **S3-MUT-007** patch 应验证每个 hunk 或精确文本 precondition。
+- [x] **S3-MUT-006** 保留原文件权限和必要 metadata，策略写入 ADR。
+- [x] **S3-MUT-007** patch 应验证每个 hunk 或精确文本 precondition。
 - [ ] **S3-MUT-008** move/delete 同样进行版本和目标存在性检查。
 - [ ] **S3-MUT-009** 写失败不得留下半文件或跨 repo 临时文件。
 - [ ] **S3-MUT-010** 对写入过程进行故障注入测试：磁盘满、权限变化、进程中断、rename 失败。
@@ -586,9 +586,9 @@ Sprint 3 write_file evidence:
 - Verified in this slice: success and precondition-conflict paths leave no
   `.repo-harness-*` temporary files in the target directory. Full write-failure
   injection remains open under `S3-MUT-009/010`.
-- Explicitly still open: `apply_patch`, `move_path`, `delete_path`,
-  recursive directory policy, full index retry/dead-letter, index-lag monitoring,
-  and complete write audit/runbook coverage.
+- Explicitly still open: `move_path`, `delete_path`, recursive directory policy,
+  full index retry/dead-letter, index-lag monitoring, and complete write
+  audit/runbook coverage.
 
 Sprint 3 index-sync evidence:
 
@@ -609,6 +609,27 @@ Sprint 3 index-sync evidence:
 - Pending-state reads/stat use filesystem truth and return the latest hash;
   `search_text` keeps the explicit CodeGraph-metadata plus guarded filesystem
   fallback backend instead of claiming the changed path is already indexed.
+
+Sprint 3 apply_patch evidence:
+
+- Runtime: `src/cli/mcp/general-repo-access.ts`
+- Tests: `tests/cli/mcp-reader-tools.test.ts`,
+  `tests/cli/mcp-codegraph-contract.test.ts`
+- Schema/docs: `assets/mcp/general-repo-reader-tools.v1.schema.json`,
+  `README.md`, `docs/repo-harness-chatgpt-mcp-setup.md`,
+  `docs/architecture/decisions/20260622-general-repo-codegraph-access.md`,
+  `tasks/notes/20260622-repo-harness-codegraph.notes.md`
+- Completed slice: `apply_patch` is exposed only for `read_write` repos,
+  targets existing text files, requires `expected_sha256`, supports structured
+  `old_text`/`new_text` edits plus guarded unified diff hunks, and returns the
+  shared mutation readback with `before`, `after`, `diff`, `mutation_id`, and
+  `index_state`.
+- Patch preconditions are fail-closed: stale file hash, ambiguous structured
+  match without `occurrence`, missing text, and hunk mismatch return
+  `REVISION_CONFLICT` before writing.
+- Metadata policy: existing file mode bits are preserved. Filesystem mtime
+  changes as part of the commit; ownership, xattrs, and platform-specific
+  metadata are out of scope for the portable v1 mutation layer.
 
 ---
 

--- a/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
+++ b/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
@@ -540,38 +540,38 @@ Sprint 2 adapter/snapshot evidence:
 - [x] **S3-MUT-006** 保留原文件权限和必要 metadata，策略写入 ADR。
 - [x] **S3-MUT-007** patch 应验证每个 hunk 或精确文本 precondition。
 - [x] **S3-MUT-008** move/delete 同样进行版本和目标存在性检查。
-- [ ] **S3-MUT-009** 写失败不得留下半文件或跨 repo 临时文件。
-- [ ] **S3-MUT-010** 对写入过程进行故障注入测试：磁盘满、权限变化、进程中断、rename 失败。
+- [x] **S3-MUT-009** 写失败不得留下半文件或跨 repo 临时文件。
+- [x] **S3-MUT-010** 对写入过程进行故障注入测试：磁盘满、权限变化、进程中断、rename 失败。
 
 ## 10.3 Index Sync
 
-- [ ] **S3-IDX-001** 每次成功 mutation 产生 index invalidation event。
+- [x] **S3-IDX-001** 每次成功 mutation 产生 index invalidation event。
 - [x] **S3-IDX-002** 能按 path 增量 reindex 时优先使用；否则明确使用 repo refresh。
 - [x] **S3-IDX-003** 写后返回 `index_state: pending|ready|failed`。
 - [x] **S3-IDX-004** 索引完成后生成新 `codegraph_revision` 和 snapshot。
 - [x] **S3-IDX-005** 在索引 pending 时，changed path 的 read/stat 走安全直读并返回最新 hash。
 - [x] **S3-IDX-006** search 必须明确使用旧索引还是等待新索引；禁止假装已可搜。
 - [x] **S3-IDX-007** 实现 `refresh_repo_index` 或内部等价管理接口。
-- [ ] **S3-IDX-008** 定义 reindex retry、dead-letter 和人工恢复流程。
-- [ ] **S3-IDX-009** 监控 mutation commit 到 CodeGraph 可搜索的 index lag。
+- [x] **S3-IDX-008** 定义 reindex retry、dead-letter 和人工恢复流程。
+- [x] **S3-IDX-009** 监控 mutation commit 到 CodeGraph 可搜索的 index lag。
 
 ## 10.4 审计
 
-- [ ] **S3-AUD-001** 审计 actor、repo_id、operation、relative paths、hash、结果和耗时。
-- [ ] **S3-AUD-002** 不记录文件正文、patch 全文或 secret。
-- [ ] **S3-AUD-003** 审计日志与应用日志分离并设置保留策略。
-- [ ] **S3-AUD-004** mutation id 可追踪到索引刷新状态。
-- [ ] **S3-AUD-005** 对拒绝的写请求记录错误码，不记录内容。
+- [x] **S3-AUD-001** 审计 actor、repo_id、operation、relative paths、hash、结果和耗时。
+- [x] **S3-AUD-002** 不记录文件正文、patch 全文或 secret。
+- [x] **S3-AUD-003** 审计日志与应用日志分离并设置保留策略。
+- [x] **S3-AUD-004** mutation id 可追踪到索引刷新状态。
+- [x] **S3-AUD-005** 对拒绝的写请求记录错误码，不记录内容。
 
 ## 10.5 Sprint 3 退出标准
 
-- [ ] 所有写工具在 read-only repo 中可靠拒绝。
-- [ ] 100% 检测并发覆盖冲突，无 lost update。
-- [ ] 原子写故障注入不产生半写文件。
-- [ ] 写后 stat/read 立即可见最新内容。
-- [ ] 写后 search 在定义的 index lag SLO 内可见，或明确返回 pending。
-- [ ] move/delete 后 manifest 与索引最终一致。
-- [ ] 所有写操作可通过 mutation id 审计。
+- [x] 所有写工具在 read-only repo 中可靠拒绝。
+- [x] 100% 检测并发覆盖冲突，无 lost update。
+- [x] 原子写故障注入不产生半写文件。
+- [x] 写后 stat/read 立即可见最新内容。
+- [x] 写后 search 在定义的 index lag SLO 内可见，或明确返回 pending。
+- [x] move/delete 后 manifest 与索引最终一致。
+- [x] 所有写操作可通过 mutation id 审计。
 
 Sprint 3 write_file evidence:
 
@@ -583,12 +583,13 @@ Sprint 3 write_file evidence:
   requires `must_not_exist` for create and `expected_sha256` for replace,
   writes through a same-directory temporary file plus fsync/atomic rename, and
   returns `mutation_id`, `before`, `after`, `diff`, and `index_state`.
-- Verified in this slice: success and precondition-conflict paths leave no
-  `.repo-harness-*` temporary files in the target directory. Full write-failure
-  injection remains open under `S3-MUT-009/010`.
-- Explicitly still open: full write-failure injection, full index
-  retry/dead-letter, index-lag monitoring, and complete write audit/runbook
-  coverage.
+- Verified in this slice: success, precondition-conflict, and injected
+  pre-commit fault paths leave no `.repo-harness-*` temporary files in the
+  target directory and preserve the old file or absent target state.
+- Fault coverage: deterministic fault points cover temp-write-after-fsync before
+  rename, move before rename, and delete before unlink. These model disk-full,
+  permission-change, interrupted-process, and rename-failure boundaries before a
+  filesystem commit.
 
 Sprint 3 index-sync evidence:
 
@@ -609,6 +610,15 @@ Sprint 3 index-sync evidence:
 - Pending-state reads/stat use filesystem truth and return the latest hash;
   `search_text` keeps the explicit CodeGraph-metadata plus guarded filesystem
   fallback backend instead of claiming the changed path is already indexed.
+- Successful mutations now append `.ai/harness/mcp/index-events.jsonl`
+  invalidation events with mutation id, invalidation id, relative paths, hash
+  summaries, retry metadata, and the refresh tool. `refresh_repo_index` accepts
+  the returned `mutation_id`, accepts recently deleted paths for move/delete
+  refresh, records refresh success or dead-letter failure, and reports
+  mutation-to-refresh lag when the source event is in the recent event window.
+- Manual recovery for dead-letter refresh is documented as retrying
+  `refresh_repo_index`, then running `bash scripts/ensure-codegraph.sh --sync`
+  before retrying the tool if the adapter remains unavailable.
 
 Sprint 3 apply_patch evidence:
 
@@ -653,6 +663,27 @@ Sprint 3 move/delete path mutation evidence:
 - Directory policy for v1 is now explicit: write tools do not create parent
   directories; empty-directory mutation is unsupported; recursive delete is
   disabled and returns a stable policy error before any filesystem mutation.
+
+Sprint 3 failure-injection and audit evidence:
+
+- Runtime: `src/cli/mcp/general-repo-access.ts`, `src/cli/mcp/types.ts`,
+  `src/cli/mcp/setup.ts`
+- Tests: `tests/cli/mcp-reader-tools.test.ts`,
+  `tests/cli/mcp-codegraph-contract.test.ts`, `tests/cli/mcp-setup.test.ts`
+- Docs/schema: `assets/mcp/general-repo-reader-tools.v1.schema.json`,
+  `.gitignore`, `README.md`, `docs/repo-harness-chatgpt-mcp-setup.md`,
+  `docs/architecture/decisions/20260622-general-repo-codegraph-access.md`
+- Completed slice: deterministic test-only mutation fault points verify
+  create/replace/patch abort after temp fsync but before rename, move aborts
+  before rename, and delete aborts before unlink. All fault cases leave no
+  committed partial file and no same-directory repo-harness temp residue.
+- The MCP audit log remains separate at `.ai/harness/mcp/audit.log`; the index
+  event/recovery log is separate ignored runtime state at
+  `.ai/harness/mcp/index-events.jsonl`. Both are managed by MCP setup ignore
+  entries. Audit records actor/profile, repo id, operation, relative paths, hash
+  summaries, result, duration, mutation id, index invalidation id, index event id,
+  and rejection error code without storing file bodies, patch text, or secret
+  error strings.
 
 ---
 

--- a/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
+++ b/plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md
@@ -528,7 +528,7 @@ Sprint 2 adapter/snapshot evidence:
 - [ ] **S3-API-003** 实现 `move_path`。
 - [ ] **S3-API-004** 实现 `delete_path`。
 - [ ] **S3-API-005** 定义目录创建、空目录和递归删除策略；递归删除建议首版默认关闭或要求显式参数。
-- [ ] **S3-API-006** 写响应返回 before/after hash、diff、mutation id 和 index state。
+- [x] **S3-API-006** 写响应返回 before/after hash、diff、mutation id 和 index state。
 
 ## 10.2 乐观并发与原子写
 
@@ -546,12 +546,12 @@ Sprint 2 adapter/snapshot evidence:
 ## 10.3 Index Sync
 
 - [ ] **S3-IDX-001** 每次成功 mutation 产生 index invalidation event。
-- [ ] **S3-IDX-002** 能按 path 增量 reindex 时优先使用；否则明确使用 repo refresh。
-- [ ] **S3-IDX-003** 写后返回 `index_state: pending|ready|failed`。
-- [ ] **S3-IDX-004** 索引完成后生成新 `codegraph_revision` 和 snapshot。
-- [ ] **S3-IDX-005** 在索引 pending 时，changed path 的 read/stat 走安全直读并返回最新 hash。
-- [ ] **S3-IDX-006** search 必须明确使用旧索引还是等待新索引；禁止假装已可搜。
-- [ ] **S3-IDX-007** 实现 `refresh_repo_index` 或内部等价管理接口。
+- [x] **S3-IDX-002** 能按 path 增量 reindex 时优先使用；否则明确使用 repo refresh。
+- [x] **S3-IDX-003** 写后返回 `index_state: pending|ready|failed`。
+- [x] **S3-IDX-004** 索引完成后生成新 `codegraph_revision` 和 snapshot。
+- [x] **S3-IDX-005** 在索引 pending 时，changed path 的 read/stat 走安全直读并返回最新 hash。
+- [x] **S3-IDX-006** search 必须明确使用旧索引还是等待新索引；禁止假装已可搜。
+- [x] **S3-IDX-007** 实现 `refresh_repo_index` 或内部等价管理接口。
 - [ ] **S3-IDX-008** 定义 reindex retry、dead-letter 和人工恢复流程。
 - [ ] **S3-IDX-009** 监控 mutation commit 到 CodeGraph 可搜索的 index lag。
 
@@ -587,8 +587,28 @@ Sprint 3 write_file evidence:
   `.repo-harness-*` temporary files in the target directory. Full write-failure
   injection remains open under `S3-MUT-009/010`.
 - Explicitly still open: `apply_patch`, `move_path`, `delete_path`,
-  `refresh_repo_index`, recursive directory policy, full index retry/dead-letter,
+  recursive directory policy, full index retry/dead-letter, index-lag monitoring,
   and complete write audit/runbook coverage.
+
+Sprint 3 index-sync evidence:
+
+- Runtime: `src/cli/mcp/general-repo-access.ts`,
+  `src/cli/mcp/codegraph-adapter.ts`
+- Tests: `tests/cli/mcp-reader-tools.test.ts`,
+  `tests/cli/mcp-codegraph-contract.test.ts`
+- Schema/docs: `assets/mcp/general-repo-reader-tools.v1.schema.json`,
+  `README.md`, `docs/repo-harness-chatgpt-mcp-setup.md`,
+  `docs/architecture/decisions/20260622-general-repo-codegraph-access.md`,
+  `tasks/notes/20260622-repo-harness-codegraph.notes.md`
+- Completed slice: `refresh_repo_index` is exposed only for `read_write` repos,
+  validates requested paths through the same guard/`.ignore` policy, calls
+  CodeGraph refresh, invalidates local snapshots, and returns before/after index
+  revisions plus a fresh snapshot.
+- The bundled adapter uses repo-level `codegraph sync` when path incremental
+  refresh is unavailable and reports `path_refresh_supported:false`.
+- Pending-state reads/stat use filesystem truth and return the latest hash;
+  `search_text` keeps the explicit CodeGraph-metadata plus guarded filesystem
+  fallback backend instead of claiming the changed path is already indexed.
 
 ---
 

--- a/src/cli/mcp/codegraph-adapter.ts
+++ b/src/cli/mcp/codegraph-adapter.ts
@@ -23,6 +23,21 @@ export interface CodeGraphRepoSnapshot {
     retryable: boolean;
   };
 }
+
+export interface CodeGraphRefreshResult {
+  available: boolean;
+  refreshed: boolean;
+  integrated: boolean;
+  source: CodeGraphRepoSnapshot['source'];
+  indexRevision: string | 0;
+  latencyMs: number;
+  strategy: 'repo-sync' | 'path-sync' | 'unsupported';
+  requestedPaths: string[];
+  pathRefreshSupported: boolean;
+  files: number;
+  error?: CodeGraphRepoSnapshot['error'];
+}
+
 export interface CodeGraphTextSearchMatch {
   path: string;
   line?: number;
@@ -40,6 +55,7 @@ export interface CodeGraphTextSearchResult {
 
 export interface GeneralRepoCodeGraphAdapter {
   discoverRepo(repoRoot: string): CodeGraphRepoSnapshot;
+  refreshRepo?(repoRoot: string, opts?: { paths?: string[] }): CodeGraphRefreshResult;
   searchText?(repoRoot: string, query: string, opts: { mode: 'literal' | 'regex'; paths: string[]; maxResults: number }): CodeGraphTextSearchResult;
 }
 
@@ -96,6 +112,80 @@ function revisionFor(files: CodeGraphIndexedFile[]): string {
   return `index_${sha256(JSON.stringify(stable)).slice(0, 16)}`;
 }
 
+function discoverCodeGraphRepo(repoRoot: string, env: NodeJS.ProcessEnv, timeoutMs: number): CodeGraphRepoSnapshot {
+  const start = Date.now();
+  if (!existsSync(join(repoRoot, '.codegraph'))) {
+    return unavailable('CodeGraph index is not initialized for this repo', 0, false);
+  }
+
+  const bin = codegraphBin(repoRoot, env);
+  const result = spawnSync(bin, ['files', '--path', repoRoot, '--format', 'flat', '--json'], {
+    cwd: repoRoot,
+    env,
+    encoding: 'utf-8',
+    timeout: timeoutMs,
+    maxBuffer: MAX_STDOUT_BYTES,
+  });
+  const latencyMs = Date.now() - start;
+
+  if (result.error) {
+    const code = result.error.message.includes('ETIMEDOUT') ? 'INDEX_UNAVAILABLE' : 'INTERNAL_ADAPTER_ERROR';
+    return {
+      available: false,
+      integrated: false,
+      source: 'unavailable',
+      indexRevision: 0,
+      files: [],
+      latencyMs,
+      error: { code, message: result.error.message, retryable: code === 'INDEX_UNAVAILABLE' },
+    };
+  }
+  if (result.status !== 0) {
+    return {
+      available: false,
+      integrated: false,
+      source: 'unavailable',
+      indexRevision: 0,
+      files: [],
+      latencyMs,
+      error: {
+        code: 'INDEX_UNAVAILABLE',
+        message: (result.stderr || result.stdout || `codegraph exited with ${result.status}`).trim(),
+        retryable: true,
+      },
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(result.stdout);
+    const files = Array.isArray(parsed)
+      ? parsed.map(normalizeIndexedFile).filter((file): file is CodeGraphIndexedFile => file !== null)
+      : [];
+    return {
+      available: true,
+      integrated: true,
+      source: 'codegraph-cli',
+      indexRevision: revisionFor(files),
+      files,
+      latencyMs,
+    };
+  } catch (error) {
+    return {
+      available: false,
+      integrated: false,
+      source: 'unavailable',
+      indexRevision: 0,
+      files: [],
+      latencyMs,
+      error: {
+        code: 'INTERNAL_ADAPTER_ERROR',
+        message: error instanceof Error ? error.message : String(error),
+        retryable: false,
+      },
+    };
+  }
+}
+
 export function createCodeGraphCliAdapter(opts: {
   env?: NodeJS.ProcessEnv;
   timeoutMs?: number;
@@ -105,41 +195,65 @@ export function createCodeGraphCliAdapter(opts: {
 
   return {
     discoverRepo(repoRoot: string): CodeGraphRepoSnapshot {
+      return discoverCodeGraphRepo(repoRoot, env, timeoutMs);
+    },
+    refreshRepo(repoRoot: string, opts: { paths?: string[] } = {}): CodeGraphRefreshResult {
       const start = Date.now();
       if (!existsSync(join(repoRoot, '.codegraph'))) {
-        return unavailable('CodeGraph index is not initialized for this repo', 0, false);
+        const snapshot = unavailable('CodeGraph index is not initialized for this repo', 0, false);
+        return {
+          available: false,
+          refreshed: false,
+          integrated: false,
+          source: snapshot.source,
+          indexRevision: snapshot.indexRevision,
+          latencyMs: snapshot.latencyMs,
+          strategy: 'unsupported',
+          requestedPaths: opts.paths ?? [],
+          pathRefreshSupported: false,
+          files: 0,
+          error: snapshot.error,
+        };
       }
 
       const bin = codegraphBin(repoRoot, env);
-      const result = spawnSync(bin, ['files', '--path', repoRoot, '--format', 'flat', '--json'], {
+      const result = spawnSync(bin, ['sync', repoRoot], {
         cwd: repoRoot,
         env,
         encoding: 'utf-8',
-        timeout: timeoutMs,
+        timeout: Math.max(timeoutMs, 30_000),
         maxBuffer: MAX_STDOUT_BYTES,
       });
-      const latencyMs = Date.now() - start;
+      const syncLatencyMs = Date.now() - start;
 
       if (result.error) {
         const code = result.error.message.includes('ETIMEDOUT') ? 'INDEX_UNAVAILABLE' : 'INTERNAL_ADAPTER_ERROR';
         return {
           available: false,
+          refreshed: false,
           integrated: false,
           source: 'unavailable',
           indexRevision: 0,
-          files: [],
-          latencyMs,
+          latencyMs: syncLatencyMs,
+          strategy: 'repo-sync',
+          requestedPaths: opts.paths ?? [],
+          pathRefreshSupported: false,
+          files: 0,
           error: { code, message: result.error.message, retryable: code === 'INDEX_UNAVAILABLE' },
         };
       }
       if (result.status !== 0) {
         return {
           available: false,
+          refreshed: false,
           integrated: false,
           source: 'unavailable',
           indexRevision: 0,
-          files: [],
-          latencyMs,
+          latencyMs: syncLatencyMs,
+          strategy: 'repo-sync',
+          requestedPaths: opts.paths ?? [],
+          pathRefreshSupported: false,
+          files: 0,
           error: {
             code: 'INDEX_UNAVAILABLE',
             message: (result.stderr || result.stdout || `codegraph exited with ${result.status}`).trim(),
@@ -148,34 +262,20 @@ export function createCodeGraphCliAdapter(opts: {
         };
       }
 
-      try {
-        const parsed = JSON.parse(result.stdout);
-        const files = Array.isArray(parsed)
-          ? parsed.map(normalizeIndexedFile).filter((file): file is CodeGraphIndexedFile => file !== null)
-          : [];
-        return {
-          available: true,
-          integrated: true,
-          source: 'codegraph-cli',
-          indexRevision: revisionFor(files),
-          files,
-          latencyMs,
-        };
-      } catch (error) {
-        return {
-          available: false,
-          integrated: false,
-          source: 'unavailable',
-          indexRevision: 0,
-          files: [],
-          latencyMs,
-          error: {
-            code: 'INTERNAL_ADAPTER_ERROR',
-            message: error instanceof Error ? error.message : String(error),
-            retryable: false,
-          },
-        };
-      }
+      const snapshot = discoverCodeGraphRepo(repoRoot, env, timeoutMs);
+      return {
+        available: snapshot.available,
+        refreshed: snapshot.available,
+        integrated: snapshot.integrated,
+        source: snapshot.source,
+        indexRevision: snapshot.indexRevision,
+        latencyMs: syncLatencyMs + snapshot.latencyMs,
+        strategy: 'repo-sync',
+        requestedPaths: opts.paths ?? [],
+        pathRefreshSupported: false,
+        files: snapshot.files.length,
+        error: snapshot.error,
+      };
     },
   };
 }

--- a/src/cli/mcp/general-repo-access.ts
+++ b/src/cli/mcp/general-repo-access.ts
@@ -1,11 +1,12 @@
 import { createHash, randomBytes } from 'crypto';
-import { closeSync, constants, existsSync, fstatSync, fsyncSync, lstatSync, openSync, readFileSync, readdirSync, realpathSync, renameSync, rmSync, statSync, writeSync, type Dirent } from 'fs';
-import { basename, dirname, isAbsolute, relative, resolve, sep } from 'path';
+import { appendFileSync, closeSync, constants, existsSync, fstatSync, fsyncSync, lstatSync, mkdirSync, openSync, readFileSync, readdirSync, realpathSync, renameSync, rmSync, statSync, writeSync, type Dirent } from 'fs';
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'path';
 import { readRegisteredRepoHarnessRepos, repoHarnessRepoIdFor, type RepoHarnessAccessMode } from '../../effects/repo-registry';
 import { hashMcpInput, tryWriteMcpAuditEntry } from './audit';
 import { createCodeGraphCliAdapter, type CodeGraphRefreshResult, type CodeGraphRepoSnapshot, type GeneralRepoCodeGraphAdapter } from './codegraph-adapter';
 import { globMatches, isPathInside } from './paths';
-import type { McpPolicy } from './types';
+import { redactMcpText } from './redaction';
+import type { McpAuditEntry, McpPolicy } from './types';
 
 export interface GeneralRepoToolDefinition {
   name: string;
@@ -193,6 +194,8 @@ const DEFAULT_CODEGRAPH_ADAPTER = createCodeGraphCliAdapter();
 const SNAPSHOT_CACHE = new Map<string, VisibleEntrySnapshot>();
 const ENTRY_METADATA_CACHE = new Map<string, EntryMetadataCacheValue>();
 const WRITE_TOOLS = new Set<string>(['write_file', 'apply_patch', 'move_path', 'delete_path', 'refresh_repo_index']);
+const MCP_INDEX_EVENTS_RELATIVE_PATH = '.ai/harness/mcp/index-events.jsonl';
+const MUTATION_FAULT_ENV = 'REPO_HARNESS_MCP_MUTATION_FAULT_POINT';
 
 export type GeneralRepoToolName = typeof GENERAL_REPO_TOOLS[number];
 
@@ -224,13 +227,16 @@ function errorResult(code: string, message: string, details?: unknown, retryable
   };
 }
 
-function audit(ctx: GeneralRepoToolContext, tool: string, status: 'ok' | 'blocked' | 'failed', input: unknown, targetPath?: string, error?: string): void {
+function audit(ctx: GeneralRepoToolContext, tool: string, status: 'ok' | 'blocked' | 'failed', input: unknown, targetPath?: string, error?: string, details: Partial<McpAuditEntry> = {}): void {
   tryWriteMcpAuditEntry(ctx.repoRoot, {
     timestamp: new Date().toISOString(),
     tool,
     status,
+    actor: `mcp:${ctx.policy.profile}`,
+    result: status,
     targetPath,
     inputHash: hashMcpInput(input),
+    ...details,
     error,
   });
 }
@@ -239,6 +245,76 @@ function auditTargetPath(input: Record<string, unknown>): string | undefined {
   if (typeof input.path === 'string') return input.path;
   if (typeof input.from_path === 'string' && typeof input.to_path === 'string') return `${input.from_path} -> ${input.to_path}`;
   return undefined;
+}
+
+function auditPaths(input: Record<string, unknown>): string[] {
+  const paths = new Set<string>();
+  if (typeof input.path === 'string') paths.add(input.path);
+  if (typeof input.from_path === 'string') paths.add(input.from_path);
+  if (typeof input.to_path === 'string') paths.add(input.to_path);
+  if (Array.isArray(input.paths)) {
+    for (const path of input.paths) {
+      if (typeof path === 'string') paths.add(path);
+    }
+  }
+  return [...paths];
+}
+
+function recordObject(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function stringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const values = value.filter((entry): entry is string => typeof entry === 'string');
+  return values.length > 0 ? values : undefined;
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === 'string' && value ? value : undefined;
+}
+
+function auditDetailsFromResult(result: GeneralRepoToolResult, input: Record<string, unknown>, durationMs: number, tool: string): Partial<McpAuditEntry> {
+  const payload = recordObject(result.structuredContent);
+  if (!payload) {
+    return {
+      repoId: stringField(input.repo_id),
+      operation: tool,
+      relativePaths: auditPaths(input),
+      durationMs,
+    };
+  }
+  const index = recordObject(payload.index);
+  const diff = recordObject(payload.diff);
+  const relativePaths = stringArray(index?.changed_paths)
+    ?? stringArray(index?.refreshed_paths)
+    ?? stringArray(payload.paths)
+    ?? auditPaths(input);
+  return {
+    repoId: stringField(payload.repo_id) ?? stringField(input.repo_id),
+    operation: stringField(payload.operation) ?? stringField(input.operation) ?? tool,
+    relativePaths,
+    mutationId: stringField(payload.mutation_id) ?? stringField(index?.mutation_id),
+    indexInvalidationId: stringField(index?.invalidation_id),
+    indexEventId: stringField(index?.event_id),
+    indexState: stringField(payload.index_state) ?? stringField(index?.state),
+    fileHashes: diff ? {
+      before_sha256: typeof diff.before_sha256 === 'string' ? diff.before_sha256 : diff.before_sha256 === null ? null : undefined,
+      after_sha256: typeof diff.after_sha256 === 'string' ? diff.after_sha256 : diff.after_sha256 === null ? null : undefined,
+    } : undefined,
+    durationMs,
+  };
+}
+
+function auditDetailsFromError(error: GeneralRepoAccessError, input: Record<string, unknown>, durationMs: number, tool: string): Partial<McpAuditEntry> {
+  return {
+    repoId: stringField(input.repo_id),
+    operation: tool,
+    relativePaths: auditPaths(input),
+    durationMs,
+    errorCode: error.code,
+  };
 }
 
 function sha256(value: string | Buffer): string {
@@ -274,6 +350,99 @@ function cachePaths(paths: string[] | undefined): string[] {
   const normalized = (paths && paths.length > 0 ? paths : ['.'])
     .map((path) => toPosixPath(String(path || '.')).replace(/^\.\/+/, '') || '.');
   return [...new Set(normalized)].sort((a, b) => a.localeCompare(b));
+}
+
+function mcpIndexEventsPath(repoRoot: string): string {
+  return join(repoRoot, MCP_INDEX_EVENTS_RELATIVE_PATH);
+}
+
+function indexEventId(repo: RepoRecord, eventType: string, seed: string): string {
+  return `idxevt_${sha256(`${repo.repoId}\0${eventType}\0${seed}\0${Date.now()}\0${randomBytes(4).toString('hex')}`).slice(0, 16)}`;
+}
+
+function safeEventError(error: CodeGraphRefreshResult['error'] | undefined): Record<string, unknown> | undefined {
+  if (!error) return undefined;
+  return {
+    code: error.code,
+    message: redactMcpText(error.message).text,
+    retryable: error.retryable,
+  };
+}
+
+function tryWriteIndexEvent(ctx: GeneralRepoToolContext, repo: RepoRecord, event: Record<string, unknown>): string | null {
+  const eventId = typeof event.event_id === 'string'
+    ? event.event_id
+    : indexEventId(repo, String(event.event_type ?? 'index_event'), JSON.stringify(event));
+  try {
+    const logPath = mcpIndexEventsPath(ctx.repoRoot);
+    mkdirSync(dirname(logPath), { recursive: true });
+    appendFileSync(logPath, `${JSON.stringify({
+      schema_version: 1,
+      timestamp: new Date().toISOString(),
+      event_id: eventId,
+      repo_id: repo.repoId,
+      ...event,
+    })}\n`, 'utf-8');
+    return eventId;
+  } catch (_error) {
+    return null;
+  }
+}
+
+function readRecentIndexEvents(repoRoot: string): Record<string, unknown>[] {
+  const logPath = mcpIndexEventsPath(repoRoot);
+  if (!existsSync(logPath)) return [];
+  try {
+    return readFileSync(logPath, 'utf-8')
+      .trimEnd()
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .slice(-1000)
+      .map((line) => JSON.parse(line))
+      .filter((entry): entry is Record<string, unknown> => typeof entry === 'object' && entry !== null && !Array.isArray(entry));
+  } catch (_error) {
+    return [];
+  }
+}
+
+function eventPathsOverlap(eventPaths: unknown, paths: string[]): boolean {
+  const values = stringArray(eventPaths);
+  if (!values) return false;
+  const refreshPaths = new Set(cachePaths(paths));
+  return values.some((path) => refreshPaths.has(path) || refreshPaths.has('.') || path === '.');
+}
+
+function latestIndexInvalidationEvent(ctx: GeneralRepoToolContext, repo: RepoRecord, mutationId: string, paths: string[]): Record<string, unknown> | null {
+  const events = readRecentIndexEvents(ctx.repoRoot);
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index];
+    if (event?.event_type !== 'index_invalidation' || event.repo_id !== repo.repoId) continue;
+    if (mutationId && event.mutation_id === mutationId) return event;
+    if (!mutationId && eventPathsOverlap(event.relative_paths, paths)) return event;
+  }
+  return null;
+}
+
+function indexLagMsFrom(event: Record<string, unknown> | null, nowMs = Date.now()): number | undefined {
+  if (!event || typeof event.timestamp !== 'string') return undefined;
+  const startedAt = Date.parse(event.timestamp);
+  if (!Number.isFinite(startedAt)) return undefined;
+  return Math.max(0, nowMs - startedAt);
+}
+
+function indexRecovery(paths: string[], retryable = true): Record<string, unknown> {
+  return {
+    retryable,
+    retry_tool: 'refresh_repo_index',
+    retry_paths: paths,
+    dead_letter_log: MCP_INDEX_EVENTS_RELATIVE_PATH,
+    manual_recovery: 'bash scripts/ensure-codegraph.sh --sync',
+  };
+}
+
+function injectMutationFault(point: string): void {
+  if ((process.env[MUTATION_FAULT_ENV] ?? '').trim() !== point) return;
+  throw new GeneralRepoAccessError('INJECTED_MUTATION_FAULT', `injected mutation fault at ${point}`, { fault_point: point }, true);
 }
 
 function responseCacheKey(repo: RepoRecord, ignore: IgnorePolicy, snapshot: VisibleEntrySnapshot, scope: { tool: string; paths?: string[] }): { key: string; paths: string[]; pathDigest: string } {
@@ -582,8 +751,20 @@ function refreshPathsArg(repo: RepoRecord, ignore: IgnorePolicy, value: unknown)
     if (typeof item !== 'string') {
       throw new GeneralRepoAccessError('INVALID_RELATIVE_PATH', 'paths must contain only strings');
     }
-    const resolved = resolveRepoPath(repo, item, ignore, { allowRoot: true, allowExternalSymlinkMetadata: true });
-    paths.add(resolved.relativePath);
+    const relativePath = normalizeRepoRelativePath(item, { allowRoot: true });
+    if (relativePath !== '.' && isIgnored(ignore, relativePath)) {
+      throw new GeneralRepoAccessError('PATH_IGNORED', 'path is excluded by .ignore', { path: relativePath });
+    }
+    const absolutePath = relativePath === '.' ? repo.canonicalRoot : resolve(repo.canonicalRoot, relativePath);
+    if (!isPathInside(repo.canonicalRoot, absolutePath)) {
+      throw new GeneralRepoAccessError('PATH_OUTSIDE_REPO', 'path escapes repo root', { path: relativePath });
+    }
+    if (existsSync(absolutePath)) {
+      const resolved = resolveRepoPath(repo, relativePath, ignore, { allowRoot: true, allowExternalSymlinkMetadata: true });
+      paths.add(resolved.relativePath);
+    } else {
+      paths.add(relativePath);
+    }
   }
   return [...paths].sort((a, b) => a.localeCompare(b));
 }
@@ -1525,6 +1706,7 @@ function atomicWriteFile(target: ResolvedRepoWritePath, raw: Buffer, mode: numbe
     } finally {
       closeSync(fd);
     }
+    injectMutationFault('atomic_write_before_rename');
     renameSync(tempPath, target.canonicalPath);
     renamed = true;
     fsyncDirectoryBestEffort(target.parentCanonicalPath);
@@ -1580,6 +1762,21 @@ function mutationResult(ctx: GeneralRepoToolContext, repo: RepoRecord, ignore: I
   const mutationTool = opts.tool ?? (opts.operation === 'patch' ? 'apply_patch' : 'write_file');
   const mutationId = `mut_${sha256(`${repo.repoId}\0${changedPaths.join('\0')}\0${opts.beforeHash ?? 'new'}\0${afterHash}\0${Date.now()}`).slice(0, 16)}`;
   const invalidationId = `idxinv_${sha256(`${mutationId}\0${snapshot.codeGraph.indexRevision}\0${target.relativePath}`).slice(0, 16)}`;
+  const indexEventId = tryWriteIndexEvent(ctx, repo, {
+    event_type: 'index_invalidation',
+    status: 'pending',
+    operation: opts.operation,
+    mutation_id: mutationId,
+    invalidation_id: invalidationId,
+    relative_paths: changedPaths,
+    index_state: indexState,
+    before_index_revision: snapshot.codeGraph.indexRevision,
+    file_hashes: {
+      before_sha256: opts.beforeHash,
+      after_sha256: afterHash,
+    },
+    retry: indexRecovery(changedPaths, snapshot.codeGraph.available),
+  });
 
   return textResult({
     ...commonFields(repo, ignore, snapshot, { tool: mutationTool, paths: changedPaths }),
@@ -1615,6 +1812,8 @@ function mutationResult(ctx: GeneralRepoToolContext, repo: RepoRecord, ignore: I
       changed_paths: changedPaths,
       mutation_id: mutationId,
       invalidation_id: invalidationId,
+      event_id: indexEventId,
+      event_log: MCP_INDEX_EVENTS_RELATIVE_PATH,
       refresh_tool: 'refresh_repo_index',
       before_index_revision: snapshot.codeGraph.indexRevision,
     },
@@ -1627,6 +1826,21 @@ function deleteMutationResult(ctx: GeneralRepoToolContext, repo: RepoRecord, ign
   const indexState = mutationIndexState(snapshot);
   const mutationId = `mut_${sha256(`${repo.repoId}\0${deleted.path}\0${beforeHash}\0deleted\0${Date.now()}`).slice(0, 16)}`;
   const invalidationId = `idxinv_${sha256(`${mutationId}\0${snapshot.codeGraph.indexRevision}\0${deleted.path}`).slice(0, 16)}`;
+  const indexEventId = tryWriteIndexEvent(ctx, repo, {
+    event_type: 'index_invalidation',
+    status: 'pending',
+    operation: 'delete',
+    mutation_id: mutationId,
+    invalidation_id: invalidationId,
+    relative_paths: [deleted.path],
+    index_state: indexState,
+    before_index_revision: snapshot.codeGraph.indexRevision,
+    file_hashes: {
+      before_sha256: beforeHash,
+      after_sha256: null,
+    },
+    retry: indexRecovery([deleted.path], snapshot.codeGraph.available),
+  });
 
   return textResult({
     ...commonFields(repo, ignore, snapshot, { tool: 'delete_path', paths: [deleted.path] }),
@@ -1659,6 +1873,8 @@ function deleteMutationResult(ctx: GeneralRepoToolContext, repo: RepoRecord, ign
       changed_paths: [deleted.path],
       mutation_id: mutationId,
       invalidation_id: invalidationId,
+      event_id: indexEventId,
+      event_log: MCP_INDEX_EVENTS_RELATIVE_PATH,
       refresh_tool: 'refresh_repo_index',
       before_index_revision: snapshot.codeGraph.indexRevision,
     },
@@ -1915,6 +2131,7 @@ function movePathTool(ctx: GeneralRepoToolContext, args: Record<string, unknown>
     });
   }
 
+  injectMutationFault('move_before_rename');
   renameSync(source.canonicalPath, target.canonicalPath);
   fsyncDirectoryBestEffort(dirname(source.canonicalPath));
   if (dirname(source.canonicalPath) !== target.parentCanonicalPath) fsyncDirectoryBestEffort(target.parentCanonicalPath);
@@ -1977,6 +2194,7 @@ function deletePathTool(ctx: GeneralRepoToolContext, args: Record<string, unknow
   }
   const deleted = metadataForResolved(target, ignore, undefined, { contentHash: true, cache: false });
 
+  injectMutationFault('delete_before_unlink');
   rmSync(target.canonicalPath);
   fsyncDirectoryBestEffort(dirname(target.canonicalPath));
   invalidateRepoCaches(repo);
@@ -1990,21 +2208,101 @@ function refreshRepoIndex(ctx: GeneralRepoToolContext, args: Record<string, unkn
   const ignore = readIgnorePolicy(repo.canonicalRoot);
   const paths = refreshPathsArg(repo, ignore, args.paths);
   const refreshScope = paths.length > 0 ? paths : ['.'];
+  const mutationId = typeof args.mutation_id === 'string' ? args.mutation_id.trim() : '';
+  const sourceEvent = latestIndexInvalidationEvent(ctx, repo, mutationId, refreshScope);
+  const sourceEventId = typeof sourceEvent?.event_id === 'string' ? sourceEvent.event_id : undefined;
+  const sourceMutationId = typeof sourceEvent?.mutation_id === 'string' ? sourceEvent.mutation_id : mutationId || undefined;
+  const sourceInvalidationId = typeof sourceEvent?.invalidation_id === 'string' ? sourceEvent.invalidation_id : undefined;
   const before = buildVisibleEntrySnapshot(ctx, repo, ignore, { contentHash: false });
   const adapter = ctx.codeGraphAdapter ?? DEFAULT_CODEGRAPH_ADAPTER;
   if (!adapter.refreshRepo) {
+    tryWriteIndexEvent(ctx, repo, {
+      event_type: 'index_refresh',
+      status: 'failed',
+      operation: 'refresh_repo_index',
+      mutation_id: sourceMutationId,
+      source_event_id: sourceEventId,
+      invalidation_id: sourceInvalidationId,
+      relative_paths: refreshScope,
+      before_index_revision: before.codeGraph.indexRevision,
+      strategy: 'unsupported',
+      index_lag_ms: indexLagMsFrom(sourceEvent),
+      error: { code: 'INDEX_UNAVAILABLE', message: 'CodeGraph adapter does not support explicit refresh', retryable: true },
+      dead_letter: indexRecovery(refreshScope, true),
+    });
     throw new GeneralRepoAccessError('INDEX_UNAVAILABLE', 'CodeGraph adapter does not support explicit refresh', {
       paths: refreshScope,
     }, true);
   }
 
-  const refresh = adapter.refreshRepo(repo.canonicalRoot, { paths });
+  let refresh: CodeGraphRefreshResult;
+  try {
+    refresh = adapter.refreshRepo(repo.canonicalRoot, { paths });
+  } catch (error) {
+    tryWriteIndexEvent(ctx, repo, {
+      event_type: 'index_refresh',
+      status: 'failed',
+      operation: 'refresh_repo_index',
+      mutation_id: sourceMutationId,
+      source_event_id: sourceEventId,
+      invalidation_id: sourceInvalidationId,
+      relative_paths: refreshScope,
+      before_index_revision: before.codeGraph.indexRevision,
+      strategy: 'repo-sync',
+      index_lag_ms: indexLagMsFrom(sourceEvent),
+      error: {
+        code: 'INTERNAL_ADAPTER_ERROR',
+        message: redactMcpText(error instanceof Error ? error.message : String(error)).text,
+        retryable: false,
+      },
+      dead_letter: indexRecovery(refreshScope, false),
+    });
+    throw error;
+  }
   invalidateRepoCaches(repo);
   if (!refresh.available || !refresh.refreshed) {
+    tryWriteIndexEvent(ctx, repo, {
+      event_type: 'index_refresh',
+      status: 'failed',
+      operation: 'refresh_repo_index',
+      mutation_id: sourceMutationId,
+      source_event_id: sourceEventId,
+      invalidation_id: sourceInvalidationId,
+      relative_paths: refreshScope,
+      before_index_revision: before.codeGraph.indexRevision,
+      adapter_index_revision: refresh.indexRevision,
+      strategy: refresh.strategy,
+      path_refresh_supported: refresh.pathRefreshSupported,
+      latency_ms: refresh.latencyMs,
+      index_lag_ms: indexLagMsFrom(sourceEvent),
+      error: safeEventError(refresh.error),
+      dead_letter: indexRecovery(refreshScope, refresh.error?.retryable ?? true),
+    });
     throw indexRefreshError(refresh);
   }
   const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore, { contentHash: false });
   const indexState = refreshedIndexState(snapshot);
+  const indexLagMs = indexLagMsFrom(sourceEvent);
+  const indexEventId = tryWriteIndexEvent(ctx, repo, {
+    event_type: 'index_refresh',
+    status: indexState,
+    operation: 'refresh_repo_index',
+    mutation_id: sourceMutationId,
+    source_event_id: sourceEventId,
+    invalidation_id: sourceInvalidationId,
+    relative_paths: refreshScope,
+    before_index_revision: before.codeGraph.indexRevision,
+    adapter_index_revision: refresh.indexRevision,
+    after_index_revision: snapshot.codeGraph.indexRevision,
+    strategy: refresh.strategy,
+    path_refresh_supported: refresh.pathRefreshSupported,
+    latency_ms: refresh.latencyMs,
+    indexed_files: refresh.files,
+    index_lag_ms: indexLagMs,
+    lagging_path_count: snapshot.codeGraphLaggingPaths.length,
+    lagging_paths: snapshot.codeGraphLaggingPaths.slice(0, MAX_LAGGING_PATHS_RETURNED),
+    recovery: indexState === 'ready' ? undefined : indexRecovery(refreshScope, true),
+  });
 
   return textResult({
     ...commonFields(repo, ignore, snapshot, { tool: 'refresh_repo_index', paths: refreshScope }),
@@ -2020,11 +2318,20 @@ function refreshRepoIndex(ctx: GeneralRepoToolContext, args: Record<string, unkn
       adapter_index_revision: refresh.indexRevision,
       after_index_revision: snapshot.codeGraph.indexRevision,
       indexed_files: refresh.files,
+      source_event_id: sourceEventId,
+      mutation_id: sourceMutationId,
+      index_lag_ms: indexLagMs,
     },
     index: {
       state: indexState,
       action: indexState === 'ready' ? 'refresh_complete' : 'refresh_complete_with_lag',
       refreshed_paths: refreshScope,
+      mutation_id: sourceMutationId,
+      source_event_id: sourceEventId,
+      event_id: indexEventId,
+      event_log: MCP_INDEX_EVENTS_RELATIVE_PATH,
+      index_lag_ms: indexLagMs,
+      lagging_path_count: snapshot.codeGraphLaggingPaths.length,
       before_index_revision: before.codeGraph.indexRevision,
       after_index_revision: snapshot.codeGraph.indexRevision,
     },
@@ -2454,6 +2761,7 @@ export function buildGeneralRepoToolDefinitions(): GeneralRepoToolDefinition[] {
         properties: {
           repo_id: { type: 'string' },
           paths: { type: 'array', items: { type: 'string' } },
+          mutation_id: { type: 'string' },
         },
         required: ['repo_id'],
         additionalProperties: false,
@@ -2464,6 +2772,7 @@ export function buildGeneralRepoToolDefinitions(): GeneralRepoToolDefinition[] {
 }
 
 export async function callGeneralRepoTool(ctx: GeneralRepoToolContext, name: string, args: Record<string, unknown> = {}): Promise<GeneralRepoToolResult> {
+  const startedAtMs = Date.now();
   try {
     let result: GeneralRepoToolResult;
     switch (name) {
@@ -2506,14 +2815,20 @@ export async function callGeneralRepoTool(ctx: GeneralRepoToolContext, name: str
       default:
         return errorResult('INTERNAL_ADAPTER_ERROR', `tool is not a general repo reader tool: ${name}`);
     }
-    audit(ctx, name, 'ok', args, auditTargetPath(args));
+    audit(ctx, name, 'ok', args, auditTargetPath(args), undefined, auditDetailsFromResult(result, args, Date.now() - startedAtMs, name));
     return result;
   } catch (error) {
     if (error instanceof GeneralRepoAccessError) {
-      audit(ctx, name, 'blocked', args, auditTargetPath(args), error.message);
+      audit(ctx, name, 'blocked', args, auditTargetPath(args), error.message, auditDetailsFromError(error, args, Date.now() - startedAtMs, name));
       return errorResult(error.code, error.message, error.details, error.retryable);
     }
-    audit(ctx, name, 'failed', args, auditTargetPath(args), error instanceof Error ? error.message : String(error));
+    audit(ctx, name, 'failed', args, auditTargetPath(args), error instanceof Error ? error.message : String(error), {
+      repoId: stringField(args.repo_id),
+      operation: name,
+      relativePaths: auditPaths(args),
+      durationMs: Date.now() - startedAtMs,
+      errorCode: 'INTERNAL_ADAPTER_ERROR',
+    });
     return errorResult('INTERNAL_ADAPTER_ERROR', error instanceof Error ? error.message : String(error));
   }
 }

--- a/src/cli/mcp/general-repo-access.ts
+++ b/src/cli/mcp/general-repo-access.ts
@@ -1,5 +1,5 @@
-import { createHash } from 'crypto';
-import { closeSync, constants, existsSync, fstatSync, lstatSync, openSync, readFileSync, readdirSync, realpathSync, statSync, type Dirent } from 'fs';
+import { createHash, randomBytes } from 'crypto';
+import { closeSync, constants, existsSync, fstatSync, fsyncSync, lstatSync, openSync, readFileSync, readdirSync, realpathSync, renameSync, rmSync, statSync, writeSync, type Dirent } from 'fs';
 import { basename, dirname, isAbsolute, relative, resolve, sep } from 'path';
 import { readRegisteredRepoHarnessRepos, repoHarnessRepoIdFor, type RepoHarnessAccessMode } from '../../effects/repo-registry';
 import { hashMcpInput, tryWriteMcpAuditEntry } from './audit';
@@ -69,6 +69,16 @@ interface ResolvedRepoPath {
   readable: boolean;
   identity?: string;
   parentIdentity?: string;
+}
+
+interface ResolvedRepoWritePath {
+  repo: RepoRecord;
+  relativePath: string;
+  absolutePath: string;
+  canonicalPath: string;
+  parentRelativePath: string;
+  parentCanonicalPath: string;
+  existing?: ResolvedRepoPath;
 }
 
 interface ManifestEntry {
@@ -159,6 +169,7 @@ const GENERAL_REPO_TOOLS = [
   'read_file',
   'read_files',
   'stat_file',
+  'write_file',
 ] as const;
 
 const DEFAULT_PAGE_SIZE = 300;
@@ -236,6 +247,16 @@ function numberArg(value: unknown, fallback: number, min: number, max: number): 
   const parsed = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN;
   if (!Number.isFinite(parsed)) return fallback;
   return Math.min(Math.max(Math.trunc(parsed), min), max);
+}
+
+function booleanArg(value: unknown, fallback = false): boolean {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
+    if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
+  }
+  return fallback;
 }
 
 function cachePaths(paths: string[] | undefined): string[] {
@@ -518,6 +539,75 @@ function resolveRepoPath(repo: RepoRecord, inputPath: unknown, ignore: IgnorePol
     readable,
     identity: readable ? statIdentity(fileStat) : undefined,
     parentIdentity: statIdentity(parentStat),
+  };
+}
+
+function parentRelativePath(relativePath: string): string {
+  const index = relativePath.lastIndexOf('/');
+  return index < 0 ? '.' : relativePath.slice(0, index) || '.';
+}
+
+function leafName(relativePath: string): string {
+  const index = relativePath.lastIndexOf('/');
+  return index < 0 ? relativePath : relativePath.slice(index + 1);
+}
+
+function assertRepoWriteEnabled(repo: RepoRecord): void {
+  if (repo.accessMode !== 'read_write') {
+    throw new GeneralRepoAccessError('WRITE_DISABLED', 'repo is read_only; write_file requires read_write capability', {
+      repo_id: repo.repoId,
+      access_mode: repo.accessMode,
+    });
+  }
+}
+
+function resolveRepoWritePath(repo: RepoRecord, inputPath: unknown, ignore: IgnorePolicy): ResolvedRepoWritePath {
+  const relativePath = normalizeRepoRelativePath(inputPath);
+  if (isIgnored(ignore, relativePath)) {
+    throw new GeneralRepoAccessError('PATH_IGNORED', 'path is excluded by .ignore', { path: relativePath });
+  }
+  const absolutePath = resolve(repo.canonicalRoot, relativePath);
+  if (!isPathInside(repo.canonicalRoot, absolutePath)) {
+    throw new GeneralRepoAccessError('PATH_OUTSIDE_REPO', 'path escapes repo root', { path: relativePath });
+  }
+
+  if (existsSync(absolutePath)) {
+    const existing = resolveRepoPath(repo, relativePath, ignore, { requireFile: true });
+    if (existing.type === 'symlink') {
+      throw new GeneralRepoAccessError('SYMLINK_ESCAPE', 'write_file does not write through symlinks', { path: relativePath });
+    }
+    return {
+      repo,
+      relativePath,
+      absolutePath,
+      canonicalPath: existing.canonicalPath,
+      parentRelativePath: parentRelativePath(relativePath),
+      parentCanonicalPath: realpathSync(dirname(existing.canonicalPath)),
+      existing,
+    };
+  }
+
+  const parentRelative = parentRelativePath(relativePath);
+  const parent = resolveRepoPath(repo, parentRelative, ignore, { allowRoot: true, requireDirectory: true });
+  if (!parent.readable || parent.symlinkTargetKind === 'external') {
+    throw new GeneralRepoAccessError('PATH_OUTSIDE_REPO', 'write parent escapes repo root', { path: relativePath });
+  }
+  const canonicalPath = resolve(parent.canonicalPath, leafName(relativePath));
+  if (!isPathInside(repo.canonicalRoot, canonicalPath)) {
+    throw new GeneralRepoAccessError('PATH_OUTSIDE_REPO', 'path escapes repo root', { path: relativePath });
+  }
+  const physicalRelative = toPosixPath(relative(repo.canonicalRoot, canonicalPath)) || '.';
+  if (physicalRelative !== '.' && isIgnored(ignore, physicalRelative)) {
+    throw new GeneralRepoAccessError('PATH_IGNORED', 'write target is excluded by .ignore', { path: relativePath });
+  }
+
+  return {
+    repo,
+    relativePath,
+    absolutePath,
+    canonicalPath,
+    parentRelativePath: parent.relativePath,
+    parentCanonicalPath: parent.canonicalPath,
   };
 }
 
@@ -1186,6 +1276,62 @@ function assertSnapshotEntryCurrent(snapshot: VisibleEntrySnapshot, path: string
   }
 }
 
+function writeContentBuffer(args: Record<string, unknown>): { raw: Buffer; encoding: 'utf-8' | 'base64' } {
+  if (typeof args.content !== 'string') {
+    throw new GeneralRepoAccessError('INVALID_RANGE', 'content must be a string');
+  }
+  const encoding = args.encoding === 'base64' ? 'base64' : args.encoding === undefined || args.encoding === 'utf-8' ? 'utf-8' : null;
+  if (!encoding) throw new GeneralRepoAccessError('INVALID_RANGE', 'encoding must be utf-8 or base64');
+  return { raw: Buffer.from(args.content, encoding), encoding };
+}
+
+function fsyncDirectoryBestEffort(path: string): void {
+  let fd: number | null = null;
+  try {
+    fd = openSync(path, 'r');
+    fsyncSync(fd);
+  } catch (_error) {
+    // Some filesystems/platforms do not allow directory fsync; the same-directory rename remains atomic.
+  } finally {
+    if (fd !== null) {
+      try {
+        closeSync(fd);
+      } catch (_error) {
+        // Ignore close failures on best-effort directory fsync.
+      }
+    }
+  }
+}
+
+function atomicWriteFile(target: ResolvedRepoWritePath, raw: Buffer, mode: number): void {
+  const tempPath = resolve(target.parentCanonicalPath, `.${leafName(target.relativePath)}.repo-harness-${process.pid}-${Date.now()}-${randomBytes(4).toString('hex')}.tmp`);
+  if (!isPathInside(target.parentCanonicalPath, tempPath)) {
+    throw new GeneralRepoAccessError('PATH_OUTSIDE_REPO', 'temporary write path escapes parent directory', { path: target.relativePath });
+  }
+  const fd = openSync(tempPath, 'wx', mode);
+  let renamed = false;
+  try {
+    try {
+      writeSync(fd, raw, 0, raw.length, 0);
+      fsyncSync(fd);
+    } finally {
+      closeSync(fd);
+    }
+    renameSync(tempPath, target.canonicalPath);
+    renamed = true;
+    fsyncDirectoryBestEffort(target.parentCanonicalPath);
+  } finally {
+    if (!renamed) rmSync(tempPath, { force: true });
+  }
+}
+
+function invalidateRepoCaches(repo: RepoRecord): void {
+  for (const [key, snapshot] of SNAPSHOT_CACHE) {
+    if (snapshot.repoId === repo.repoId && snapshot.repoRoot === repo.canonicalRoot) SNAPSHOT_CACHE.delete(key);
+  }
+  ENTRY_METADATA_CACHE.clear();
+}
+
 function readFilePayload(repo: RepoRecord, ignore: IgnorePolicy, snapshot: VisibleEntrySnapshot, args: Record<string, unknown>, maxBytes = HARD_READ_BYTES, tool = 'read_file', verifySnapshotEntry = false): Record<string, unknown> {
   if (args.line_range !== undefined && args.byte_range !== undefined) {
     throw new GeneralRepoAccessError('INVALID_RANGE', 'line_range and byte_range are mutually exclusive');
@@ -1290,8 +1436,8 @@ function getRepoCapabilities(ctx: GeneralRepoToolContext, args: Record<string, u
     display_name: repo.displayName,
     registry_revision: repo.registryRevision,
     source: repo.source,
-    read_tools: GENERAL_REPO_TOOLS.filter((tool) => tool !== 'get_repo_capabilities'),
-    write_tools: repo.accessMode === 'read_write' ? [] : [],
+    read_tools: GENERAL_REPO_TOOLS.filter((tool) => tool !== 'get_repo_capabilities' && tool !== 'write_file'),
+    write_tools: repo.accessMode === 'read_write' ? ['write_file'] : [],
     codegraph: {
       primary_backend: true,
       ...codeGraphSummary(snapshot),
@@ -1304,6 +1450,96 @@ function getRepoCapabilities(ctx: GeneralRepoToolContext, args: Record<string, u
       max_read_bytes: HARD_READ_BYTES,
       max_read_lines: MAX_READ_LINES,
     },
+  });
+}
+
+function writeFileTool(ctx: GeneralRepoToolContext, args: Record<string, unknown>): GeneralRepoToolResult {
+  const repo = resolveRepo(ctx, args.repo_id);
+  assertRepoWriteEnabled(repo);
+  const ignore = readIgnorePolicy(repo.canonicalRoot);
+  const target = resolveRepoWritePath(repo, args.path, ignore);
+  const { raw, encoding } = writeContentBuffer(args);
+  const expectedHash = typeof args.expected_sha256 === 'string' ? args.expected_sha256.trim() : '';
+  const mustNotExist = booleanArg(args.must_not_exist, false);
+  const existed = target.existing !== undefined;
+
+  let beforeHash: string | null = null;
+  let beforeSize = 0;
+  let mode = 0o666;
+  if (target.existing) {
+    if (mustNotExist) {
+      throw new GeneralRepoAccessError('TARGET_EXISTS', 'target already exists', { path: target.relativePath });
+    }
+    const beforeRaw = readFileSync(target.existing.canonicalPath);
+    beforeHash = sha256(beforeRaw);
+    beforeSize = beforeRaw.length;
+    mode = statSync(target.existing.canonicalPath).mode & 0o777;
+    if (!expectedHash) {
+      throw new GeneralRepoAccessError('REVISION_CONFLICT', 'expected_sha256 is required when replacing an existing file', {
+        path: target.relativePath,
+        actual_sha256: beforeHash,
+      });
+    }
+    if (expectedHash !== beforeHash) {
+      throw new GeneralRepoAccessError('REVISION_CONFLICT', 'file changed after it was read', {
+        path: target.relativePath,
+        expected_sha256: expectedHash,
+        actual_sha256: beforeHash,
+      });
+    }
+  } else if (!mustNotExist) {
+    throw new GeneralRepoAccessError('REVISION_CONFLICT', 'must_not_exist: true is required when creating a new file', {
+      path: target.relativePath,
+    });
+  }
+
+  atomicWriteFile(target, raw, mode);
+  invalidateRepoCaches(repo);
+
+  const after = resolveRepoPath(repo, target.relativePath, ignore, { requireFile: true });
+  const afterRaw = readFileSync(after.canonicalPath);
+  const afterHash = sha256(afterRaw);
+  const afterEntry = metadataForResolved(after, ignore);
+  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore, { contentHash: false });
+  const indexedEntry = snapshot.entriesByPath.get(target.relativePath);
+  const indexState = snapshot.codeGraph.available ? 'pending' : 'failed';
+  const mutationId = `mut_${sha256(`${repo.repoId}\0${target.relativePath}\0${beforeHash ?? 'new'}\0${afterHash}\0${Date.now()}`).slice(0, 16)}`;
+
+  return textResult({
+    ...commonFields(repo, ignore, snapshot, { tool: 'write_file', paths: [target.relativePath] }),
+    path: target.relativePath,
+    operation: existed ? 'replace' : 'create',
+    mutation_id: mutationId,
+    encoding,
+    before: {
+      existed,
+      sha256: beforeHash,
+      size: beforeSize,
+    },
+    after: {
+      ...afterEntry,
+      indexed: indexedEntry?.indexed ?? false,
+      codegraph_language: indexedEntry?.codegraph_language,
+      codegraph_node_count: indexedEntry?.codegraph_node_count,
+      codegraph_size: indexedEntry?.codegraph_size,
+      codegraph_index_lagging: indexedEntry?.codegraph_index_lagging,
+    },
+    diff: {
+      format: 'summary',
+      bytes_before: beforeSize,
+      bytes_after: afterRaw.length,
+      bytes_delta: afterRaw.length - beforeSize,
+      before_sha256: beforeHash,
+      after_sha256: afterHash,
+    },
+    index_state: indexState,
+    index: {
+      state: indexState,
+      action: snapshot.codeGraph.available ? 'refresh_repo_index_required' : 'codegraph_unavailable',
+      changed_paths: [target.relativePath],
+      mutation_id: mutationId,
+    },
+    codegraph: codeGraphSummary(snapshot),
   });
 }
 
@@ -1566,6 +1802,7 @@ export function hasGeneralRepoArgs(args: Record<string, unknown>): boolean {
 
 export function buildGeneralRepoToolDefinitions(): GeneralRepoToolDefinition[] {
   const readOnly = { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false };
+  const writeTool = { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false };
   const repoSchema = {
     type: 'object',
     properties: { repo_id: { type: 'string' } },
@@ -1640,6 +1877,24 @@ export function buildGeneralRepoToolDefinitions(): GeneralRepoToolDefinition[] {
       },
       annotations: readOnly,
     },
+    {
+      name: 'write_file',
+      description: 'Create or replace one repo-relative file in a read_write repo using revision preconditions and atomic same-directory rename.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          repo_id: { type: 'string' },
+          path: { type: 'string' },
+          content: { type: 'string' },
+          encoding: { enum: ['utf-8', 'base64'] },
+          expected_sha256: { type: 'string' },
+          must_not_exist: { type: 'boolean' },
+        },
+        required: ['repo_id', 'path', 'content'],
+        additionalProperties: false,
+      },
+      annotations: writeTool,
+    },
   ];
 }
 
@@ -1667,6 +1922,9 @@ export async function callGeneralRepoTool(ctx: GeneralRepoToolContext, name: str
         break;
       case 'stat_file':
         result = statFile(ctx, args);
+        break;
+      case 'write_file':
+        result = writeFileTool(ctx, args);
         break;
       default:
         return errorResult('INTERNAL_ADAPTER_ERROR', `tool is not a general repo reader tool: ${name}`);

--- a/src/cli/mcp/general-repo-access.ts
+++ b/src/cli/mcp/general-repo-access.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes } from 'crypto';
-import { appendFileSync, closeSync, constants, existsSync, fstatSync, fsyncSync, lstatSync, mkdirSync, openSync, readFileSync, readdirSync, realpathSync, renameSync, rmSync, statSync, writeSync, type Dirent } from 'fs';
+import { appendFileSync, closeSync, constants, existsSync, fstatSync, fsyncSync, linkSync, lstatSync, mkdirSync, openSync, readFileSync, readdirSync, realpathSync, renameSync, rmSync, statSync, writeSync, type Dirent } from 'fs';
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'path';
 import { readRegisteredRepoHarnessRepos, repoHarnessRepoIdFor, type RepoHarnessAccessMode } from '../../effects/repo-registry';
 import { hashMcpInput, tryWriteMcpAuditEntry } from './audit';
@@ -21,6 +21,7 @@ export interface GeneralRepoToolContext {
   codeGraphAdapter?: GeneralRepoCodeGraphAdapter;
   testHooks?: {
     afterSnapshotWalk?: (event: { repoRoot: string; kind: 'complete' | 'manifest_page'; attempt: number }) => void;
+    beforeMutationCommit?: (event: { repoRoot: string; tool: string; paths: string[] }) => void;
   };
 }
 
@@ -195,6 +196,7 @@ const SNAPSHOT_CACHE = new Map<string, VisibleEntrySnapshot>();
 const ENTRY_METADATA_CACHE = new Map<string, EntryMetadataCacheValue>();
 const WRITE_TOOLS = new Set<string>(['write_file', 'apply_patch', 'move_path', 'delete_path', 'refresh_repo_index']);
 const MCP_INDEX_EVENTS_RELATIVE_PATH = '.ai/harness/mcp/index-events.jsonl';
+const MCP_LOCKS_RELATIVE_PATH = '.ai/harness/mcp/locks';
 const MUTATION_FAULT_ENV = 'REPO_HARNESS_MCP_MUTATION_FAULT_POINT';
 
 export type GeneralRepoToolName = typeof GENERAL_REPO_TOOLS[number];
@@ -450,6 +452,74 @@ function responseCacheKey(repo: RepoRecord, ignore: IgnorePolicy, snapshot: Visi
   const pathDigest = `sha256:${sha256(JSON.stringify(paths))}`;
   const key = `cache_${sha256(`${repo.repoId}\0${repo.registryRevision}\0${ignore.digest}\0${snapshot.id}\0${scope.tool}\0${pathDigest}`).slice(0, 16)}`;
   return { key, paths, pathDigest };
+}
+
+interface MutationPathLock {
+  relativePath: string;
+  lockPath: string;
+  fd: number;
+}
+
+function mutationLockPath(repo: RepoRecord, relativePath: string): string {
+  const lockDir = resolve(repo.canonicalRoot, MCP_LOCKS_RELATIVE_PATH);
+  return resolve(lockDir, `${sha256(relativePath).slice(0, 32)}.lock`);
+}
+
+function acquireMutationLocks(repo: RepoRecord, paths: string[]): MutationPathLock[] {
+  const lockDir = resolve(repo.canonicalRoot, MCP_LOCKS_RELATIVE_PATH);
+  mkdirSync(lockDir, { recursive: true });
+  const locks: MutationPathLock[] = [];
+  for (const relativePath of cachePaths(paths)) {
+    const lockPath = mutationLockPath(repo, relativePath);
+    try {
+      const fd = openSync(lockPath, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY, 0o600);
+      const payload = `${JSON.stringify({
+        repo_id: repo.repoId,
+        path: relativePath,
+        pid: process.pid,
+        created_at: new Date().toISOString(),
+      })}\n`;
+      writeSync(fd, payload, 0, 'utf-8');
+      try {
+        fsyncSync(fd);
+      } catch (_error) {
+        // Lock visibility, not durability, is the concurrency guard here.
+      }
+      locks.push({ relativePath, lockPath, fd });
+    } catch (error) {
+      releaseMutationLocks(locks);
+      const code = typeof error === 'object' && error !== null && 'code' in error ? String((error as { code?: unknown }).code) : '';
+      if (code === 'EEXIST') {
+        throw new GeneralRepoAccessError('REVISION_CONFLICT', 'path is locked by another repo mutation', { path: relativePath }, true);
+      }
+      throw error;
+    }
+  }
+  return locks;
+}
+
+function releaseMutationLocks(locks: MutationPathLock[]): void {
+  for (const lock of locks.reverse()) {
+    try {
+      closeSync(lock.fd);
+    } catch (_error) {
+      // Ignore close failures while releasing best-effort mutation locks.
+    }
+    rmSync(lock.lockPath, { force: true });
+  }
+}
+
+function withMutationLocks<T>(repo: RepoRecord, paths: string[], fn: () => T): T {
+  const locks = acquireMutationLocks(repo, paths);
+  try {
+    return fn();
+  } finally {
+    releaseMutationLocks(locks);
+  }
+}
+
+function beforeMutationCommit(ctx: GeneralRepoToolContext, repo: RepoRecord, tool: string, paths: string[]): void {
+  ctx.testHooks?.beforeMutationCommit?.({ repoRoot: repo.canonicalRoot, tool, paths: cachePaths(paths) });
 }
 
 function toPosixPath(value: string): string {
@@ -1692,13 +1762,13 @@ function fsyncDirectoryBestEffort(path: string): void {
   }
 }
 
-function atomicWriteFile(target: ResolvedRepoWritePath, raw: Buffer, mode: number): void {
+function atomicWriteFile(target: ResolvedRepoWritePath, raw: Buffer, mode: number, opts: { noOverwrite?: boolean; beforeCommit?: () => void } = {}): void {
   const tempPath = resolve(target.parentCanonicalPath, `.${leafName(target.relativePath)}.repo-harness-${process.pid}-${Date.now()}-${randomBytes(4).toString('hex')}.tmp`);
   if (!isPathInside(target.parentCanonicalPath, tempPath)) {
     throw new GeneralRepoAccessError('PATH_OUTSIDE_REPO', 'temporary write path escapes parent directory', { path: target.relativePath });
   }
   const fd = openSync(tempPath, 'wx', mode);
-  let renamed = false;
+  let committed = false;
   try {
     try {
       writeSync(fd, raw, 0, raw.length, 0);
@@ -1706,13 +1776,82 @@ function atomicWriteFile(target: ResolvedRepoWritePath, raw: Buffer, mode: numbe
     } finally {
       closeSync(fd);
     }
+    opts.beforeCommit?.();
     injectMutationFault('atomic_write_before_rename');
-    renameSync(tempPath, target.canonicalPath);
-    renamed = true;
+    if (opts.noOverwrite) {
+      try {
+        linkSync(tempPath, target.canonicalPath);
+      } catch (error) {
+        const code = typeof error === 'object' && error !== null && 'code' in error ? String((error as { code?: unknown }).code) : '';
+        if (code === 'EEXIST') {
+          throw new GeneralRepoAccessError('TARGET_EXISTS', 'target already exists at commit time', { path: target.relativePath }, true);
+        }
+        throw error;
+      }
+    } else {
+      renameSync(tempPath, target.canonicalPath);
+    }
+    committed = true;
     fsyncDirectoryBestEffort(target.parentCanonicalPath);
   } finally {
-    if (!renamed) rmSync(tempPath, { force: true });
+    if (!committed || opts.noOverwrite) rmSync(tempPath, { force: true });
   }
+}
+
+function readMutationFile(resolved: ResolvedRepoPath, ignore: IgnorePolicy): { raw: Buffer; sha256: string; mode: number } {
+  const raw = readStableResolvedFile(resolved, ignore);
+  return {
+    raw,
+    sha256: sha256(raw),
+    mode: statSync(resolved.canonicalPath).mode & 0o777,
+  };
+}
+
+function revisionConflict(path: string, expectedHash: string, actualHash?: string | null): GeneralRepoAccessError {
+  return new GeneralRepoAccessError('REVISION_CONFLICT', 'file changed before mutation commit', {
+    path,
+    expected_sha256: expectedHash,
+    actual_sha256: actualHash ?? null,
+  }, true);
+}
+
+function assertExpectedHash(path: string, expectedHash: string, actualHash: string): void {
+  if (expectedHash !== actualHash) {
+    throw revisionConflict(path, expectedHash, actualHash);
+  }
+}
+
+function readExpectedExistingWriteTarget(repo: RepoRecord, ignore: IgnorePolicy, path: unknown, expectedHash: string): { target: ResolvedRepoWritePath; raw: Buffer; beforeHash: string; mode: number } {
+  const target = resolveRepoWritePath(repo, path, ignore);
+  if (!target.existing) {
+    throw revisionConflict(target.relativePath, expectedHash, null);
+  }
+  const current = readMutationFile(target.existing, ignore);
+  assertExpectedHash(target.relativePath, expectedHash, current.sha256);
+  return { target, raw: current.raw, beforeHash: current.sha256, mode: current.mode };
+}
+
+function assertWriteTargetAbsent(target: ResolvedRepoWritePath): void {
+  if (target.existing || existsSync(target.absolutePath) || existsSync(target.canonicalPath)) {
+    throw new GeneralRepoAccessError('TARGET_EXISTS', 'target already exists', { path: target.relativePath }, true);
+  }
+}
+
+function commitMoveNoOverwrite(source: ResolvedRepoPath, target: ResolvedRepoWritePath, beforeCommit: () => void): void {
+  beforeCommit();
+  injectMutationFault('move_before_rename');
+  try {
+    linkSync(source.canonicalPath, target.canonicalPath);
+  } catch (error) {
+    const code = typeof error === 'object' && error !== null && 'code' in error ? String((error as { code?: unknown }).code) : '';
+    if (code === 'EEXIST') {
+      throw new GeneralRepoAccessError('TARGET_EXISTS', 'move target already exists at commit time', { path: target.relativePath }, true);
+    }
+    throw error;
+  }
+  rmSync(source.canonicalPath);
+  fsyncDirectoryBestEffort(dirname(source.canonicalPath));
+  if (dirname(source.canonicalPath) !== target.parentCanonicalPath) fsyncDirectoryBestEffort(target.parentCanonicalPath);
 }
 
 function invalidateRepoCaches(repo: RepoRecord): void {
@@ -2007,50 +2146,64 @@ function writeFileTool(ctx: GeneralRepoToolContext, args: Record<string, unknown
   const repo = resolveRepo(ctx, args.repo_id);
   assertRepoWriteEnabled(repo);
   const ignore = readIgnorePolicy(repo.canonicalRoot);
-  const target = resolveRepoWritePath(repo, args.path, ignore);
+  const initialTarget = resolveRepoWritePath(repo, args.path, ignore);
   const { raw, encoding } = writeContentBuffer(args);
   const expectedHash = typeof args.expected_sha256 === 'string' ? args.expected_sha256.trim() : '';
   const mustNotExist = booleanArg(args.must_not_exist, false);
-  const existed = target.existing !== undefined;
 
-  let beforeHash: string | null = null;
-  let beforeSize = 0;
-  let mode = 0o666;
-  if (target.existing) {
-    if (mustNotExist) {
-      throw new GeneralRepoAccessError('TARGET_EXISTS', 'target already exists', { path: target.relativePath });
-    }
-    const beforeRaw = readFileSync(target.existing.canonicalPath);
-    beforeHash = sha256(beforeRaw);
-    beforeSize = beforeRaw.length;
-    mode = statSync(target.existing.canonicalPath).mode & 0o777;
-    if (!expectedHash) {
-      throw new GeneralRepoAccessError('REVISION_CONFLICT', 'expected_sha256 is required when replacing an existing file', {
-        path: target.relativePath,
-        actual_sha256: beforeHash,
+  return withMutationLocks(repo, [initialTarget.relativePath], () => {
+    const target = resolveRepoWritePath(repo, args.path, ignore);
+    const existed = target.existing !== undefined;
+    let beforeHash: string | null = null;
+    let beforeSize = 0;
+    let mode = 0o666;
+
+    if (target.existing) {
+      if (mustNotExist) {
+        throw new GeneralRepoAccessError('TARGET_EXISTS', 'target already exists', { path: target.relativePath });
+      }
+      const current = readMutationFile(target.existing, ignore);
+      beforeHash = current.sha256;
+      beforeSize = current.raw.length;
+      mode = current.mode;
+      if (!expectedHash) {
+        throw new GeneralRepoAccessError('REVISION_CONFLICT', 'expected_sha256 is required when replacing an existing file', {
+          path: target.relativePath,
+          actual_sha256: beforeHash,
+        });
+      }
+      assertExpectedHash(target.relativePath, expectedHash, beforeHash);
+      atomicWriteFile(target, raw, mode, {
+        beforeCommit: () => {
+          beforeMutationCommit(ctx, repo, 'write_file', [target.relativePath]);
+          readExpectedExistingWriteTarget(repo, ignore, target.relativePath, expectedHash);
+        },
+      });
+    } else {
+      if (!mustNotExist) {
+        throw new GeneralRepoAccessError('REVISION_CONFLICT', 'must_not_exist: true is required when creating a new file', {
+          path: target.relativePath,
+        });
+      }
+      assertWriteTargetAbsent(target);
+      atomicWriteFile(target, raw, mode, {
+        noOverwrite: true,
+        beforeCommit: () => {
+          beforeMutationCommit(ctx, repo, 'write_file', [target.relativePath]);
+          const latest = resolveRepoWritePath(repo, target.relativePath, ignore);
+          assertWriteTargetAbsent(latest);
+        },
       });
     }
-    if (expectedHash !== beforeHash) {
-      throw new GeneralRepoAccessError('REVISION_CONFLICT', 'file changed after it was read', {
-        path: target.relativePath,
-        expected_sha256: expectedHash,
-        actual_sha256: beforeHash,
-      });
-    }
-  } else if (!mustNotExist) {
-    throw new GeneralRepoAccessError('REVISION_CONFLICT', 'must_not_exist: true is required when creating a new file', {
-      path: target.relativePath,
+
+    invalidateRepoCaches(repo);
+
+    return mutationResult(ctx, repo, ignore, target, {
+      operation: existed ? 'replace' : 'create',
+      beforeHash,
+      beforeSize,
+      extra: { encoding },
     });
-  }
-
-  atomicWriteFile(target, raw, mode);
-  invalidateRepoCaches(repo);
-
-  return mutationResult(ctx, repo, ignore, target, {
-    operation: existed ? 'replace' : 'create',
-    beforeHash,
-    beforeSize,
-    extra: { encoding },
   });
 }
 
@@ -2058,41 +2211,43 @@ function applyPatchTool(ctx: GeneralRepoToolContext, args: Record<string, unknow
   const repo = resolveRepo(ctx, args.repo_id);
   assertRepoWriteEnabled(repo);
   const ignore = readIgnorePolicy(repo.canonicalRoot);
-  const target = resolveRepoWritePath(repo, args.path, ignore);
-  if (!target.existing) {
-    throw new GeneralRepoAccessError('NOT_FOUND', 'apply_patch requires an existing file', { path: target.relativePath });
-  }
+  const initialTarget = resolveRepoWritePath(repo, args.path, ignore);
   const expectedHash = typeof args.expected_sha256 === 'string' ? args.expected_sha256.trim() : '';
-  if (!expectedHash) {
-    throw new GeneralRepoAccessError('REVISION_CONFLICT', 'expected_sha256 is required when applying a patch', { path: target.relativePath });
-  }
-  const beforeRaw = readFileSync(target.existing.canonicalPath);
-  const beforeHash = sha256(beforeRaw);
-  if (expectedHash !== beforeHash) {
-    throw new GeneralRepoAccessError('REVISION_CONFLICT', 'file changed after it was read', {
-      path: target.relativePath,
-      expected_sha256: expectedHash,
-      actual_sha256: beforeHash,
-    });
-  }
-  const beforeText = assertTextPatchable(beforeRaw, target.relativePath);
-  const patched = applyPatchContent(beforeText, args);
-  const mode = statSync(target.existing.canonicalPath).mode & 0o777;
 
-  atomicWriteFile(target, patched.raw, mode);
-  invalidateRepoCaches(repo);
+  return withMutationLocks(repo, [initialTarget.relativePath], () => {
+    const target = resolveRepoWritePath(repo, args.path, ignore);
+    if (!target.existing) {
+      throw new GeneralRepoAccessError('NOT_FOUND', 'apply_patch requires an existing file', { path: target.relativePath });
+    }
+    if (!expectedHash) {
+      throw new GeneralRepoAccessError('REVISION_CONFLICT', 'expected_sha256 is required when applying a patch', { path: target.relativePath });
+    }
+    const current = readMutationFile(target.existing, ignore);
+    const beforeHash = current.sha256;
+    assertExpectedHash(target.relativePath, expectedHash, beforeHash);
+    const beforeText = assertTextPatchable(current.raw, target.relativePath);
+    const patched = applyPatchContent(beforeText, args);
 
-  return mutationResult(ctx, repo, ignore, target, {
-    operation: 'patch',
-    beforeHash,
-    beforeSize: beforeRaw.length,
-    extra: {
-      patch: {
-        format: patched.format,
-        applied_count: patched.applied.length,
-        applied: patched.applied,
+    atomicWriteFile(target, patched.raw, current.mode, {
+      beforeCommit: () => {
+        beforeMutationCommit(ctx, repo, 'apply_patch', [target.relativePath]);
+        readExpectedExistingWriteTarget(repo, ignore, target.relativePath, expectedHash);
       },
-    },
+    });
+    invalidateRepoCaches(repo);
+
+    return mutationResult(ctx, repo, ignore, target, {
+      operation: 'patch',
+      beforeHash,
+      beforeSize: current.raw.length,
+      extra: {
+        patch: {
+          format: patched.format,
+          applied_count: patched.applied.length,
+          applied: patched.applied,
+        },
+      },
+    });
   });
 }
 
@@ -2100,58 +2255,59 @@ function movePathTool(ctx: GeneralRepoToolContext, args: Record<string, unknown>
   const repo = resolveRepo(ctx, args.repo_id);
   assertRepoWriteEnabled(repo);
   const ignore = readIgnorePolicy(repo.canonicalRoot);
-  const source = resolveRepoPath(repo, args.from_path, ignore, { requireFile: true });
-  if (source.type === 'symlink') {
-    throw new GeneralRepoAccessError('SYMLINK_ESCAPE', 'move_path does not move symlinks', { path: source.relativePath });
-  }
-  const beforeRaw = readFileSync(source.canonicalPath);
-  const beforeHash = sha256(beforeRaw);
+  const initialSource = resolveRepoPath(repo, args.from_path, ignore, { requireFile: true });
+  const initialTarget = resolveRepoWritePath(repo, args.to_path, ignore);
   const expectedHash = typeof args.expected_sha256 === 'string' ? args.expected_sha256.trim() : '';
-  if (!expectedHash) {
-    throw new GeneralRepoAccessError('REVISION_CONFLICT', 'expected_sha256 is required when moving a file', {
-      path: source.relativePath,
-      actual_sha256: beforeHash,
-    });
-  }
-  if (expectedHash !== beforeHash) {
-    throw new GeneralRepoAccessError('REVISION_CONFLICT', 'file changed after it was read', {
-      path: source.relativePath,
-      expected_sha256: expectedHash,
-      actual_sha256: beforeHash,
-    });
-  }
   const mustNotExist = booleanArg(args.must_not_exist, false);
-  const target = resolveRepoWritePath(repo, args.to_path, ignore);
-  if (target.existing) {
-    throw new GeneralRepoAccessError('TARGET_EXISTS', 'move target already exists', { path: target.relativePath });
-  }
-  if (!mustNotExist) {
-    throw new GeneralRepoAccessError('REVISION_CONFLICT', 'must_not_exist: true is required when moving to a new target', {
-      path: target.relativePath,
+
+  return withMutationLocks(repo, [initialSource.relativePath, initialTarget.relativePath], () => {
+    const source = resolveRepoPath(repo, args.from_path, ignore, { requireFile: true });
+    if (source.type === 'symlink') {
+      throw new GeneralRepoAccessError('SYMLINK_ESCAPE', 'move_path does not move symlinks', { path: source.relativePath });
+    }
+    const current = readMutationFile(source, ignore);
+    const beforeHash = current.sha256;
+    if (!expectedHash) {
+      throw new GeneralRepoAccessError('REVISION_CONFLICT', 'expected_sha256 is required when moving a file', {
+        path: source.relativePath,
+        actual_sha256: beforeHash,
+      });
+    }
+    assertExpectedHash(source.relativePath, expectedHash, beforeHash);
+    const target = resolveRepoWritePath(repo, args.to_path, ignore);
+    if (!mustNotExist) {
+      throw new GeneralRepoAccessError('REVISION_CONFLICT', 'must_not_exist: true is required when moving to a new target', {
+        path: target.relativePath,
+      });
+    }
+    assertWriteTargetAbsent(target);
+
+    commitMoveNoOverwrite(source, target, () => {
+      beforeMutationCommit(ctx, repo, 'move_path', [source.relativePath, target.relativePath]);
+      const latestSource = resolveRepoPath(repo, source.relativePath, ignore, { requireFile: true });
+      const latest = readMutationFile(latestSource, ignore);
+      assertExpectedHash(source.relativePath, expectedHash, latest.sha256);
+      const latestTarget = resolveRepoWritePath(repo, target.relativePath, ignore);
+      assertWriteTargetAbsent(latestTarget);
     });
-  }
+    invalidateRepoCaches(repo);
 
-  injectMutationFault('move_before_rename');
-  renameSync(source.canonicalPath, target.canonicalPath);
-  fsyncDirectoryBestEffort(dirname(source.canonicalPath));
-  if (dirname(source.canonicalPath) !== target.parentCanonicalPath) fsyncDirectoryBestEffort(target.parentCanonicalPath);
-  invalidateRepoCaches(repo);
-
-  return mutationResult(ctx, repo, ignore, target, {
-    operation: 'move',
-    tool: 'move_path',
-    responsePath: target.relativePath,
-    changedPaths: [source.relativePath, target.relativePath],
-    beforeHash,
-    beforeSize: beforeRaw.length,
-    extra: {
-      from_path: source.relativePath,
-      to_path: target.relativePath,
-      move: {
-        source_sha256: beforeHash,
-        target_must_not_exist: true,
+    return mutationResult(ctx, repo, ignore, target, {
+      operation: 'move',
+      tool: 'move_path',
+      responsePath: target.relativePath,
+      changedPaths: [source.relativePath, target.relativePath],
+      beforeHash,
+      beforeSize: current.raw.length,
+      extra: {
+        from_path: source.relativePath,
+        to_path: target.relativePath,
+        move: {
+          source_sha256: beforeHash,
+          target_must_not_exist: true,
+        },
       },
-    },
+    });
   });
 }
 
@@ -2159,47 +2315,49 @@ function deletePathTool(ctx: GeneralRepoToolContext, args: Record<string, unknow
   const repo = resolveRepo(ctx, args.repo_id);
   assertRepoWriteEnabled(repo);
   const ignore = readIgnorePolicy(repo.canonicalRoot);
-  const target = resolveRepoPath(repo, args.path, ignore);
   const recursive = booleanArg(args.recursive, false);
-  if (target.type === 'directory') {
-    if (recursive) {
-      throw new GeneralRepoAccessError('INVALID_RANGE', 'recursive delete is disabled in v1', { path: target.relativePath, recursive });
-    }
-    throw new GeneralRepoAccessError('NOT_A_FILE', 'delete_path only deletes regular files; directory deletion is disabled', {
-      path: target.relativePath,
-      recursive: false,
-    });
-  }
-  if (target.type === 'symlink') {
-    throw new GeneralRepoAccessError('SYMLINK_ESCAPE', 'delete_path does not delete symlinks', { path: target.relativePath });
-  }
-  if (!target.contentFile) {
-    throw new GeneralRepoAccessError('NOT_A_FILE', 'delete_path only deletes regular files', { path: target.relativePath });
-  }
-  const beforeRaw = readFileSync(target.canonicalPath);
-  const beforeHash = sha256(beforeRaw);
+  const initialTarget = resolveRepoPath(repo, args.path, ignore);
   const expectedHash = typeof args.expected_sha256 === 'string' ? args.expected_sha256.trim() : '';
-  if (!expectedHash) {
-    throw new GeneralRepoAccessError('REVISION_CONFLICT', 'expected_sha256 is required when deleting a file', {
-      path: target.relativePath,
-      actual_sha256: beforeHash,
-    });
-  }
-  if (expectedHash !== beforeHash) {
-    throw new GeneralRepoAccessError('REVISION_CONFLICT', 'file changed after it was read', {
-      path: target.relativePath,
-      expected_sha256: expectedHash,
-      actual_sha256: beforeHash,
-    });
-  }
-  const deleted = metadataForResolved(target, ignore, undefined, { contentHash: true, cache: false });
 
-  injectMutationFault('delete_before_unlink');
-  rmSync(target.canonicalPath);
-  fsyncDirectoryBestEffort(dirname(target.canonicalPath));
-  invalidateRepoCaches(repo);
+  return withMutationLocks(repo, [initialTarget.relativePath], () => {
+    const target = resolveRepoPath(repo, args.path, ignore);
+    if (target.type === 'directory') {
+      if (recursive) {
+        throw new GeneralRepoAccessError('INVALID_RANGE', 'recursive delete is disabled in v1', { path: target.relativePath, recursive });
+      }
+      throw new GeneralRepoAccessError('NOT_A_FILE', 'delete_path only deletes regular files; directory deletion is disabled', {
+        path: target.relativePath,
+        recursive: false,
+      });
+    }
+    if (target.type === 'symlink') {
+      throw new GeneralRepoAccessError('SYMLINK_ESCAPE', 'delete_path does not delete symlinks', { path: target.relativePath });
+    }
+    if (!target.contentFile) {
+      throw new GeneralRepoAccessError('NOT_A_FILE', 'delete_path only deletes regular files', { path: target.relativePath });
+    }
+    const current = readMutationFile(target, ignore);
+    const beforeHash = current.sha256;
+    if (!expectedHash) {
+      throw new GeneralRepoAccessError('REVISION_CONFLICT', 'expected_sha256 is required when deleting a file', {
+        path: target.relativePath,
+        actual_sha256: beforeHash,
+      });
+    }
+    assertExpectedHash(target.relativePath, expectedHash, beforeHash);
+    const deleted = metadataForResolved(target, ignore, undefined, { contentHash: true, cache: false });
 
-  return deleteMutationResult(ctx, repo, ignore, deleted, beforeHash, beforeRaw.length);
+    beforeMutationCommit(ctx, repo, 'delete_path', [target.relativePath]);
+    const latest = resolveRepoPath(repo, target.relativePath, ignore, { requireFile: true });
+    const latestFile = readMutationFile(latest, ignore);
+    assertExpectedHash(target.relativePath, expectedHash, latestFile.sha256);
+    injectMutationFault('delete_before_unlink');
+    rmSync(target.canonicalPath);
+    fsyncDirectoryBestEffort(dirname(target.canonicalPath));
+    invalidateRepoCaches(repo);
+
+    return deleteMutationResult(ctx, repo, ignore, deleted, beforeHash, current.raw.length);
+  });
 }
 
 function refreshRepoIndex(ctx: GeneralRepoToolContext, args: Record<string, unknown>): GeneralRepoToolResult {

--- a/src/cli/mcp/general-repo-access.ts
+++ b/src/cli/mcp/general-repo-access.ts
@@ -171,6 +171,8 @@ const GENERAL_REPO_TOOLS = [
   'stat_file',
   'write_file',
   'apply_patch',
+  'move_path',
+  'delete_path',
   'refresh_repo_index',
 ] as const;
 
@@ -190,7 +192,7 @@ const MAX_SNAPSHOT_BUILD_ATTEMPTS = 2;
 const DEFAULT_CODEGRAPH_ADAPTER = createCodeGraphCliAdapter();
 const SNAPSHOT_CACHE = new Map<string, VisibleEntrySnapshot>();
 const ENTRY_METADATA_CACHE = new Map<string, EntryMetadataCacheValue>();
-const WRITE_TOOLS = new Set<string>(['write_file', 'apply_patch', 'refresh_repo_index']);
+const WRITE_TOOLS = new Set<string>(['write_file', 'apply_patch', 'move_path', 'delete_path', 'refresh_repo_index']);
 
 export type GeneralRepoToolName = typeof GENERAL_REPO_TOOLS[number];
 
@@ -231,6 +233,12 @@ function audit(ctx: GeneralRepoToolContext, tool: string, status: 'ok' | 'blocke
     inputHash: hashMcpInput(input),
     error,
   });
+}
+
+function auditTargetPath(input: Record<string, unknown>): string | undefined {
+  if (typeof input.path === 'string') return input.path;
+  if (typeof input.from_path === 'string' && typeof input.to_path === 'string') return `${input.from_path} -> ${input.to_path}`;
+  return undefined;
 }
 
 function sha256(value: string | Buffer): string {
@@ -1552,9 +1560,12 @@ function indexRefreshError(refresh: CodeGraphRefreshResult): GeneralRepoAccessEr
 }
 
 function mutationResult(ctx: GeneralRepoToolContext, repo: RepoRecord, ignore: IgnorePolicy, target: ResolvedRepoWritePath, opts: {
-  operation: 'create' | 'replace' | 'patch';
+  operation: 'create' | 'replace' | 'patch' | 'move';
   beforeHash: string | null;
   beforeSize: number;
+  tool?: string;
+  responsePath?: string;
+  changedPaths?: string[];
   extra?: Record<string, unknown>;
 }): GeneralRepoToolResult {
   const after = resolveRepoPath(repo, target.relativePath, ignore, { requireFile: true });
@@ -1564,12 +1575,15 @@ function mutationResult(ctx: GeneralRepoToolContext, repo: RepoRecord, ignore: I
   const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore, { contentHash: false });
   const indexedEntry = snapshot.entriesByPath.get(target.relativePath);
   const indexState = mutationIndexState(snapshot);
-  const mutationId = `mut_${sha256(`${repo.repoId}\0${target.relativePath}\0${opts.beforeHash ?? 'new'}\0${afterHash}\0${Date.now()}`).slice(0, 16)}`;
+  const changedPaths = cachePaths(opts.changedPaths ?? [target.relativePath]);
+  const responsePath = opts.responsePath ?? target.relativePath;
+  const mutationTool = opts.tool ?? (opts.operation === 'patch' ? 'apply_patch' : 'write_file');
+  const mutationId = `mut_${sha256(`${repo.repoId}\0${changedPaths.join('\0')}\0${opts.beforeHash ?? 'new'}\0${afterHash}\0${Date.now()}`).slice(0, 16)}`;
   const invalidationId = `idxinv_${sha256(`${mutationId}\0${snapshot.codeGraph.indexRevision}\0${target.relativePath}`).slice(0, 16)}`;
 
   return textResult({
-    ...commonFields(repo, ignore, snapshot, { tool: opts.operation === 'patch' ? 'apply_patch' : 'write_file', paths: [target.relativePath] }),
-    path: target.relativePath,
+    ...commonFields(repo, ignore, snapshot, { tool: mutationTool, paths: changedPaths }),
+    path: responsePath,
     operation: opts.operation,
     mutation_id: mutationId,
     before: {
@@ -1598,7 +1612,51 @@ function mutationResult(ctx: GeneralRepoToolContext, repo: RepoRecord, ignore: I
     index: {
       state: indexState,
       action: snapshot.codeGraph.available ? 'refresh_repo_index_required' : 'codegraph_unavailable',
-      changed_paths: [target.relativePath],
+      changed_paths: changedPaths,
+      mutation_id: mutationId,
+      invalidation_id: invalidationId,
+      refresh_tool: 'refresh_repo_index',
+      before_index_revision: snapshot.codeGraph.indexRevision,
+    },
+    codegraph: codeGraphSummary(snapshot),
+  });
+}
+
+function deleteMutationResult(ctx: GeneralRepoToolContext, repo: RepoRecord, ignore: IgnorePolicy, deleted: ManifestEntry, beforeHash: string, beforeSize: number): GeneralRepoToolResult {
+  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore, { contentHash: false });
+  const indexState = mutationIndexState(snapshot);
+  const mutationId = `mut_${sha256(`${repo.repoId}\0${deleted.path}\0${beforeHash}\0deleted\0${Date.now()}`).slice(0, 16)}`;
+  const invalidationId = `idxinv_${sha256(`${mutationId}\0${snapshot.codeGraph.indexRevision}\0${deleted.path}`).slice(0, 16)}`;
+
+  return textResult({
+    ...commonFields(repo, ignore, snapshot, { tool: 'delete_path', paths: [deleted.path] }),
+    path: deleted.path,
+    operation: 'delete',
+    mutation_id: mutationId,
+    before: {
+      existed: true,
+      sha256: beforeHash,
+      size: beforeSize,
+    },
+    after: {
+      existed: false,
+      sha256: null,
+      size: 0,
+    },
+    deleted,
+    diff: {
+      format: 'summary',
+      bytes_before: beforeSize,
+      bytes_after: 0,
+      bytes_delta: -beforeSize,
+      before_sha256: beforeHash,
+      after_sha256: null,
+    },
+    index_state: indexState,
+    index: {
+      state: indexState,
+      action: snapshot.codeGraph.available ? 'refresh_repo_index_required' : 'codegraph_unavailable',
+      changed_paths: [deleted.path],
       mutation_id: mutationId,
       invalidation_id: invalidationId,
       refresh_tool: 'refresh_repo_index',
@@ -1820,6 +1878,110 @@ function applyPatchTool(ctx: GeneralRepoToolContext, args: Record<string, unknow
       },
     },
   });
+}
+
+function movePathTool(ctx: GeneralRepoToolContext, args: Record<string, unknown>): GeneralRepoToolResult {
+  const repo = resolveRepo(ctx, args.repo_id);
+  assertRepoWriteEnabled(repo);
+  const ignore = readIgnorePolicy(repo.canonicalRoot);
+  const source = resolveRepoPath(repo, args.from_path, ignore, { requireFile: true });
+  if (source.type === 'symlink') {
+    throw new GeneralRepoAccessError('SYMLINK_ESCAPE', 'move_path does not move symlinks', { path: source.relativePath });
+  }
+  const beforeRaw = readFileSync(source.canonicalPath);
+  const beforeHash = sha256(beforeRaw);
+  const expectedHash = typeof args.expected_sha256 === 'string' ? args.expected_sha256.trim() : '';
+  if (!expectedHash) {
+    throw new GeneralRepoAccessError('REVISION_CONFLICT', 'expected_sha256 is required when moving a file', {
+      path: source.relativePath,
+      actual_sha256: beforeHash,
+    });
+  }
+  if (expectedHash !== beforeHash) {
+    throw new GeneralRepoAccessError('REVISION_CONFLICT', 'file changed after it was read', {
+      path: source.relativePath,
+      expected_sha256: expectedHash,
+      actual_sha256: beforeHash,
+    });
+  }
+  const mustNotExist = booleanArg(args.must_not_exist, false);
+  const target = resolveRepoWritePath(repo, args.to_path, ignore);
+  if (target.existing) {
+    throw new GeneralRepoAccessError('TARGET_EXISTS', 'move target already exists', { path: target.relativePath });
+  }
+  if (!mustNotExist) {
+    throw new GeneralRepoAccessError('REVISION_CONFLICT', 'must_not_exist: true is required when moving to a new target', {
+      path: target.relativePath,
+    });
+  }
+
+  renameSync(source.canonicalPath, target.canonicalPath);
+  fsyncDirectoryBestEffort(dirname(source.canonicalPath));
+  if (dirname(source.canonicalPath) !== target.parentCanonicalPath) fsyncDirectoryBestEffort(target.parentCanonicalPath);
+  invalidateRepoCaches(repo);
+
+  return mutationResult(ctx, repo, ignore, target, {
+    operation: 'move',
+    tool: 'move_path',
+    responsePath: target.relativePath,
+    changedPaths: [source.relativePath, target.relativePath],
+    beforeHash,
+    beforeSize: beforeRaw.length,
+    extra: {
+      from_path: source.relativePath,
+      to_path: target.relativePath,
+      move: {
+        source_sha256: beforeHash,
+        target_must_not_exist: true,
+      },
+    },
+  });
+}
+
+function deletePathTool(ctx: GeneralRepoToolContext, args: Record<string, unknown>): GeneralRepoToolResult {
+  const repo = resolveRepo(ctx, args.repo_id);
+  assertRepoWriteEnabled(repo);
+  const ignore = readIgnorePolicy(repo.canonicalRoot);
+  const target = resolveRepoPath(repo, args.path, ignore);
+  const recursive = booleanArg(args.recursive, false);
+  if (target.type === 'directory') {
+    if (recursive) {
+      throw new GeneralRepoAccessError('INVALID_RANGE', 'recursive delete is disabled in v1', { path: target.relativePath, recursive });
+    }
+    throw new GeneralRepoAccessError('NOT_A_FILE', 'delete_path only deletes regular files; directory deletion is disabled', {
+      path: target.relativePath,
+      recursive: false,
+    });
+  }
+  if (target.type === 'symlink') {
+    throw new GeneralRepoAccessError('SYMLINK_ESCAPE', 'delete_path does not delete symlinks', { path: target.relativePath });
+  }
+  if (!target.contentFile) {
+    throw new GeneralRepoAccessError('NOT_A_FILE', 'delete_path only deletes regular files', { path: target.relativePath });
+  }
+  const beforeRaw = readFileSync(target.canonicalPath);
+  const beforeHash = sha256(beforeRaw);
+  const expectedHash = typeof args.expected_sha256 === 'string' ? args.expected_sha256.trim() : '';
+  if (!expectedHash) {
+    throw new GeneralRepoAccessError('REVISION_CONFLICT', 'expected_sha256 is required when deleting a file', {
+      path: target.relativePath,
+      actual_sha256: beforeHash,
+    });
+  }
+  if (expectedHash !== beforeHash) {
+    throw new GeneralRepoAccessError('REVISION_CONFLICT', 'file changed after it was read', {
+      path: target.relativePath,
+      expected_sha256: expectedHash,
+      actual_sha256: beforeHash,
+    });
+  }
+  const deleted = metadataForResolved(target, ignore, undefined, { contentHash: true, cache: false });
+
+  rmSync(target.canonicalPath);
+  fsyncDirectoryBestEffort(dirname(target.canonicalPath));
+  invalidateRepoCaches(repo);
+
+  return deleteMutationResult(ctx, repo, ignore, deleted, beforeHash, beforeRaw.length);
 }
 
 function refreshRepoIndex(ctx: GeneralRepoToolContext, args: Record<string, unknown>): GeneralRepoToolResult {
@@ -2252,6 +2414,39 @@ export function buildGeneralRepoToolDefinitions(): GeneralRepoToolDefinition[] {
       annotations: writeTool,
     },
     {
+      name: 'move_path',
+      description: 'Move one existing repo-relative file to a new repo-relative path using source hash and target-existence preconditions.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          repo_id: { type: 'string' },
+          from_path: { type: 'string' },
+          to_path: { type: 'string' },
+          expected_sha256: { type: 'string' },
+          must_not_exist: { type: 'boolean' },
+        },
+        required: ['repo_id', 'from_path', 'to_path', 'expected_sha256', 'must_not_exist'],
+        additionalProperties: false,
+      },
+      annotations: writeTool,
+    },
+    {
+      name: 'delete_path',
+      description: 'Delete one existing repo-relative regular file using an expected_sha256 precondition; directory and recursive deletes are disabled in v1.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          repo_id: { type: 'string' },
+          path: { type: 'string' },
+          expected_sha256: { type: 'string' },
+          recursive: { type: 'boolean' },
+        },
+        required: ['repo_id', 'path', 'expected_sha256'],
+        additionalProperties: false,
+      },
+      annotations: writeTool,
+    },
+    {
       name: 'refresh_repo_index',
       description: 'Synchronize CodeGraph for a read_write repo after mutations and return the new index/snapshot state.',
       inputSchema: {
@@ -2299,20 +2494,26 @@ export async function callGeneralRepoTool(ctx: GeneralRepoToolContext, name: str
       case 'apply_patch':
         result = applyPatchTool(ctx, args);
         break;
+      case 'move_path':
+        result = movePathTool(ctx, args);
+        break;
+      case 'delete_path':
+        result = deletePathTool(ctx, args);
+        break;
       case 'refresh_repo_index':
         result = refreshRepoIndex(ctx, args);
         break;
       default:
         return errorResult('INTERNAL_ADAPTER_ERROR', `tool is not a general repo reader tool: ${name}`);
     }
-    audit(ctx, name, 'ok', args, typeof args.path === 'string' ? args.path : undefined);
+    audit(ctx, name, 'ok', args, auditTargetPath(args));
     return result;
   } catch (error) {
     if (error instanceof GeneralRepoAccessError) {
-      audit(ctx, name, 'blocked', args, typeof args.path === 'string' ? args.path : undefined, error.message);
+      audit(ctx, name, 'blocked', args, auditTargetPath(args), error.message);
       return errorResult(error.code, error.message, error.details, error.retryable);
     }
-    audit(ctx, name, 'failed', args, typeof args.path === 'string' ? args.path : undefined, error instanceof Error ? error.message : String(error));
+    audit(ctx, name, 'failed', args, auditTargetPath(args), error instanceof Error ? error.message : String(error));
     return errorResult('INTERNAL_ADAPTER_ERROR', error instanceof Error ? error.message : String(error));
   }
 }

--- a/src/cli/mcp/general-repo-access.ts
+++ b/src/cli/mcp/general-repo-access.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes } from 'crypto';
-import { appendFileSync, closeSync, constants, existsSync, fstatSync, fsyncSync, linkSync, lstatSync, mkdirSync, openSync, readFileSync, readdirSync, realpathSync, renameSync, rmSync, statSync, writeSync, type Dirent } from 'fs';
+import { appendFileSync, closeSync, constants, existsSync, fstatSync, fsyncSync, linkSync, lstatSync, mkdirSync, openSync, readFileSync, readdirSync, realpathSync, renameSync, rmSync, statSync, writeFileSync, writeSync, type Dirent } from 'fs';
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'path';
 import { readRegisteredRepoHarnessRepos, repoHarnessRepoIdFor, type RepoHarnessAccessMode } from '../../effects/repo-registry';
 import { hashMcpInput, tryWriteMcpAuditEntry } from './audit';
@@ -457,7 +457,6 @@ function responseCacheKey(repo: RepoRecord, ignore: IgnorePolicy, snapshot: Visi
 interface MutationPathLock {
   relativePath: string;
   lockPath: string;
-  fd: number;
 }
 
 function mutationLockPath(repo: RepoRecord, relativePath: string): string {
@@ -471,22 +470,20 @@ function acquireMutationLocks(repo: RepoRecord, paths: string[]): MutationPathLo
   const locks: MutationPathLock[] = [];
   for (const relativePath of cachePaths(paths)) {
     const lockPath = mutationLockPath(repo, relativePath);
+    let created = false;
     try {
-      const fd = openSync(lockPath, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY, 0o600);
+      mkdirSync(lockPath, { mode: 0o700 });
+      created = true;
       const payload = `${JSON.stringify({
         repo_id: repo.repoId,
         path: relativePath,
         pid: process.pid,
         created_at: new Date().toISOString(),
       })}\n`;
-      writeSync(fd, payload, 0, 'utf-8');
-      try {
-        fsyncSync(fd);
-      } catch (_error) {
-        // Lock visibility, not durability, is the concurrency guard here.
-      }
-      locks.push({ relativePath, lockPath, fd });
+      writeFileSync(resolve(lockPath, 'owner.json'), payload, { encoding: 'utf-8', mode: 0o600 });
+      locks.push({ relativePath, lockPath });
     } catch (error) {
+      if (created) rmSync(lockPath, { recursive: true, force: true });
       releaseMutationLocks(locks);
       const code = typeof error === 'object' && error !== null && 'code' in error ? String((error as { code?: unknown }).code) : '';
       if (code === 'EEXIST') {
@@ -501,11 +498,10 @@ function acquireMutationLocks(repo: RepoRecord, paths: string[]): MutationPathLo
 function releaseMutationLocks(locks: MutationPathLock[]): void {
   for (const lock of locks.reverse()) {
     try {
-      closeSync(lock.fd);
+      rmSync(lock.lockPath, { recursive: true, force: true });
     } catch (_error) {
-      // Ignore close failures while releasing best-effort mutation locks.
+      // Best-effort cleanup: never hide the mutation result behind lock cleanup.
     }
-    rmSync(lock.lockPath, { force: true });
   }
 }
 

--- a/src/cli/mcp/general-repo-access.ts
+++ b/src/cli/mcp/general-repo-access.ts
@@ -3,7 +3,7 @@ import { closeSync, constants, existsSync, fstatSync, fsyncSync, lstatSync, open
 import { basename, dirname, isAbsolute, relative, resolve, sep } from 'path';
 import { readRegisteredRepoHarnessRepos, repoHarnessRepoIdFor, type RepoHarnessAccessMode } from '../../effects/repo-registry';
 import { hashMcpInput, tryWriteMcpAuditEntry } from './audit';
-import { createCodeGraphCliAdapter, type CodeGraphRepoSnapshot, type GeneralRepoCodeGraphAdapter } from './codegraph-adapter';
+import { createCodeGraphCliAdapter, type CodeGraphRefreshResult, type CodeGraphRepoSnapshot, type GeneralRepoCodeGraphAdapter } from './codegraph-adapter';
 import { globMatches, isPathInside } from './paths';
 import type { McpPolicy } from './types';
 
@@ -170,6 +170,7 @@ const GENERAL_REPO_TOOLS = [
   'read_files',
   'stat_file',
   'write_file',
+  'refresh_repo_index',
 ] as const;
 
 const DEFAULT_PAGE_SIZE = 300;
@@ -188,6 +189,7 @@ const MAX_SNAPSHOT_BUILD_ATTEMPTS = 2;
 const DEFAULT_CODEGRAPH_ADAPTER = createCodeGraphCliAdapter();
 const SNAPSHOT_CACHE = new Map<string, VisibleEntrySnapshot>();
 const ENTRY_METADATA_CACHE = new Map<string, EntryMetadataCacheValue>();
+const WRITE_TOOLS = new Set<string>(['write_file', 'refresh_repo_index']);
 
 export type GeneralRepoToolName = typeof GENERAL_REPO_TOOLS[number];
 
@@ -554,11 +556,27 @@ function leafName(relativePath: string): string {
 
 function assertRepoWriteEnabled(repo: RepoRecord): void {
   if (repo.accessMode !== 'read_write') {
-    throw new GeneralRepoAccessError('WRITE_DISABLED', 'repo is read_only; write_file requires read_write capability', {
+    throw new GeneralRepoAccessError('WRITE_DISABLED', 'repo is read_only; mutation tools require read_write capability', {
       repo_id: repo.repoId,
       access_mode: repo.accessMode,
     });
   }
+}
+
+function refreshPathsArg(repo: RepoRecord, ignore: IgnorePolicy, value: unknown): string[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) {
+    throw new GeneralRepoAccessError('INVALID_RANGE', 'paths must be an array of repo-relative paths');
+  }
+  const paths = new Set<string>();
+  for (const item of value) {
+    if (typeof item !== 'string') {
+      throw new GeneralRepoAccessError('INVALID_RELATIVE_PATH', 'paths must contain only strings');
+    }
+    const resolved = resolveRepoPath(repo, item, ignore, { allowRoot: true, allowExternalSymlinkMetadata: true });
+    paths.add(resolved.relativePath);
+  }
+  return [...paths].sort((a, b) => a.localeCompare(b));
 }
 
 function resolveRepoWritePath(repo: RepoRecord, inputPath: unknown, ignore: IgnorePolicy): ResolvedRepoWritePath {
@@ -1332,6 +1350,25 @@ function invalidateRepoCaches(repo: RepoRecord): void {
   ENTRY_METADATA_CACHE.clear();
 }
 
+function mutationIndexState(snapshot: VisibleEntrySnapshot): 'pending' | 'failed' {
+  return snapshot.codeGraph.available ? 'pending' : 'failed';
+}
+
+function refreshedIndexState(snapshot: VisibleEntrySnapshot): 'ready' | 'index_lagging' | 'failed' {
+  if (!snapshot.codeGraph.available) return 'failed';
+  return snapshot.codeGraphLaggingPaths.length > 0 ? 'index_lagging' : 'ready';
+}
+
+function indexRefreshError(refresh: CodeGraphRefreshResult): GeneralRepoAccessError {
+  const error = refresh.error;
+  return new GeneralRepoAccessError(error?.code ?? 'INDEX_UNAVAILABLE', error?.message ?? 'CodeGraph refresh failed', {
+    strategy: refresh.strategy,
+    requested_paths: refresh.requestedPaths,
+    path_refresh_supported: refresh.pathRefreshSupported,
+    index_revision: refresh.indexRevision,
+  }, error?.retryable ?? true);
+}
+
 function readFilePayload(repo: RepoRecord, ignore: IgnorePolicy, snapshot: VisibleEntrySnapshot, args: Record<string, unknown>, maxBytes = HARD_READ_BYTES, tool = 'read_file', verifySnapshotEntry = false): Record<string, unknown> {
   if (args.line_range !== undefined && args.byte_range !== undefined) {
     throw new GeneralRepoAccessError('INVALID_RANGE', 'line_range and byte_range are mutually exclusive');
@@ -1436,8 +1473,8 @@ function getRepoCapabilities(ctx: GeneralRepoToolContext, args: Record<string, u
     display_name: repo.displayName,
     registry_revision: repo.registryRevision,
     source: repo.source,
-    read_tools: GENERAL_REPO_TOOLS.filter((tool) => tool !== 'get_repo_capabilities' && tool !== 'write_file'),
-    write_tools: repo.accessMode === 'read_write' ? ['write_file'] : [],
+    read_tools: GENERAL_REPO_TOOLS.filter((tool) => tool !== 'get_repo_capabilities' && !WRITE_TOOLS.has(tool)),
+    write_tools: repo.accessMode === 'read_write' ? [...WRITE_TOOLS] : [],
     codegraph: {
       primary_backend: true,
       ...codeGraphSummary(snapshot),
@@ -1502,8 +1539,9 @@ function writeFileTool(ctx: GeneralRepoToolContext, args: Record<string, unknown
   const afterEntry = metadataForResolved(after, ignore);
   const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore, { contentHash: false });
   const indexedEntry = snapshot.entriesByPath.get(target.relativePath);
-  const indexState = snapshot.codeGraph.available ? 'pending' : 'failed';
+  const indexState = mutationIndexState(snapshot);
   const mutationId = `mut_${sha256(`${repo.repoId}\0${target.relativePath}\0${beforeHash ?? 'new'}\0${afterHash}\0${Date.now()}`).slice(0, 16)}`;
+  const invalidationId = `idxinv_${sha256(`${mutationId}\0${snapshot.codeGraph.indexRevision}\0${target.relativePath}`).slice(0, 16)}`;
 
   return textResult({
     ...commonFields(repo, ignore, snapshot, { tool: 'write_file', paths: [target.relativePath] }),
@@ -1538,6 +1576,57 @@ function writeFileTool(ctx: GeneralRepoToolContext, args: Record<string, unknown
       action: snapshot.codeGraph.available ? 'refresh_repo_index_required' : 'codegraph_unavailable',
       changed_paths: [target.relativePath],
       mutation_id: mutationId,
+      invalidation_id: invalidationId,
+      refresh_tool: 'refresh_repo_index',
+      before_index_revision: snapshot.codeGraph.indexRevision,
+    },
+    codegraph: codeGraphSummary(snapshot),
+  });
+}
+
+function refreshRepoIndex(ctx: GeneralRepoToolContext, args: Record<string, unknown>): GeneralRepoToolResult {
+  const repo = resolveRepo(ctx, args.repo_id);
+  assertRepoWriteEnabled(repo);
+  const ignore = readIgnorePolicy(repo.canonicalRoot);
+  const paths = refreshPathsArg(repo, ignore, args.paths);
+  const refreshScope = paths.length > 0 ? paths : ['.'];
+  const before = buildVisibleEntrySnapshot(ctx, repo, ignore, { contentHash: false });
+  const adapter = ctx.codeGraphAdapter ?? DEFAULT_CODEGRAPH_ADAPTER;
+  if (!adapter.refreshRepo) {
+    throw new GeneralRepoAccessError('INDEX_UNAVAILABLE', 'CodeGraph adapter does not support explicit refresh', {
+      paths: refreshScope,
+    }, true);
+  }
+
+  const refresh = adapter.refreshRepo(repo.canonicalRoot, { paths });
+  invalidateRepoCaches(repo);
+  if (!refresh.available || !refresh.refreshed) {
+    throw indexRefreshError(refresh);
+  }
+  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore, { contentHash: false });
+  const indexState = refreshedIndexState(snapshot);
+
+  return textResult({
+    ...commonFields(repo, ignore, snapshot, { tool: 'refresh_repo_index', paths: refreshScope }),
+    paths: refreshScope,
+    refreshed: true,
+    index_state: indexState,
+    refresh: {
+      strategy: refresh.strategy,
+      requested_paths: refresh.requestedPaths,
+      path_refresh_supported: refresh.pathRefreshSupported,
+      latency_ms: refresh.latencyMs,
+      before_index_revision: before.codeGraph.indexRevision,
+      adapter_index_revision: refresh.indexRevision,
+      after_index_revision: snapshot.codeGraph.indexRevision,
+      indexed_files: refresh.files,
+    },
+    index: {
+      state: indexState,
+      action: indexState === 'ready' ? 'refresh_complete' : 'refresh_complete_with_lag',
+      refreshed_paths: refreshScope,
+      before_index_revision: before.codeGraph.indexRevision,
+      after_index_revision: snapshot.codeGraph.indexRevision,
     },
     codegraph: codeGraphSummary(snapshot),
   });
@@ -1895,6 +1984,20 @@ export function buildGeneralRepoToolDefinitions(): GeneralRepoToolDefinition[] {
       },
       annotations: writeTool,
     },
+    {
+      name: 'refresh_repo_index',
+      description: 'Synchronize CodeGraph for a read_write repo after mutations and return the new index/snapshot state.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          repo_id: { type: 'string' },
+          paths: { type: 'array', items: { type: 'string' } },
+        },
+        required: ['repo_id'],
+        additionalProperties: false,
+      },
+      annotations: writeTool,
+    },
   ];
 }
 
@@ -1925,6 +2028,9 @@ export async function callGeneralRepoTool(ctx: GeneralRepoToolContext, name: str
         break;
       case 'write_file':
         result = writeFileTool(ctx, args);
+        break;
+      case 'refresh_repo_index':
+        result = refreshRepoIndex(ctx, args);
         break;
       default:
         return errorResult('INTERNAL_ADAPTER_ERROR', `tool is not a general repo reader tool: ${name}`);

--- a/src/cli/mcp/general-repo-access.ts
+++ b/src/cli/mcp/general-repo-access.ts
@@ -170,6 +170,7 @@ const GENERAL_REPO_TOOLS = [
   'read_files',
   'stat_file',
   'write_file',
+  'apply_patch',
   'refresh_repo_index',
 ] as const;
 
@@ -189,7 +190,7 @@ const MAX_SNAPSHOT_BUILD_ATTEMPTS = 2;
 const DEFAULT_CODEGRAPH_ADAPTER = createCodeGraphCliAdapter();
 const SNAPSHOT_CACHE = new Map<string, VisibleEntrySnapshot>();
 const ENTRY_METADATA_CACHE = new Map<string, EntryMetadataCacheValue>();
-const WRITE_TOOLS = new Set<string>(['write_file', 'refresh_repo_index']);
+const WRITE_TOOLS = new Set<string>(['write_file', 'apply_patch', 'refresh_repo_index']);
 
 export type GeneralRepoToolName = typeof GENERAL_REPO_TOOLS[number];
 
@@ -1303,6 +1304,187 @@ function writeContentBuffer(args: Record<string, unknown>): { raw: Buffer; encod
   return { raw: Buffer.from(args.content, encoding), encoding };
 }
 
+function assertTextPatchable(raw: Buffer, path: string): string {
+  if (raw.subarray(0, BINARY_PROBE_BYTES).includes(0)) {
+    throw new GeneralRepoAccessError('BINARY_CONTENT', 'apply_patch requires text content', { path });
+  }
+  return raw.toString('utf-8');
+}
+
+function findOccurrences(text: string, needle: string): number[] {
+  const matches: number[] = [];
+  let index = text.indexOf(needle);
+  while (index >= 0) {
+    matches.push(index);
+    index = text.indexOf(needle, index + Math.max(needle.length, 1));
+  }
+  return matches;
+}
+
+function replaceTextAt(text: string, start: number, oldText: string, newText: string): string {
+  return `${text.slice(0, start)}${newText}${text.slice(start + oldText.length)}`;
+}
+
+function patchOccurrenceArg(value: unknown, matchCount: number, editIndex: number): number {
+  if (value === undefined) {
+    if (matchCount !== 1) {
+      throw new GeneralRepoAccessError('REVISION_CONFLICT', 'patch edit precondition is ambiguous or missing', {
+        edit_index: editIndex,
+        match_count: matchCount,
+      });
+    }
+    return 1;
+  }
+  const parsed = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN;
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new GeneralRepoAccessError('INVALID_RANGE', 'edit occurrence must be a positive integer', { edit_index: editIndex });
+  }
+  if (parsed > matchCount) {
+    throw new GeneralRepoAccessError('REVISION_CONFLICT', 'patch edit occurrence does not exist', {
+      edit_index: editIndex,
+      occurrence: parsed,
+      match_count: matchCount,
+    });
+  }
+  return parsed;
+}
+
+function applyStructuredPatchEdits(beforeText: string, edits: unknown): { text: string; applied: Array<Record<string, unknown>>; format: 'structured_edits' } {
+  if (!Array.isArray(edits) || edits.length === 0) {
+    throw new GeneralRepoAccessError('INVALID_RANGE', 'edits must be a non-empty array');
+  }
+  let text = beforeText;
+  const applied: Array<Record<string, unknown>> = [];
+  for (let index = 0; index < edits.length; index += 1) {
+    const editIndex = index + 1;
+    const edit = edits[index];
+    if (typeof edit !== 'object' || edit === null || Array.isArray(edit)) {
+      throw new GeneralRepoAccessError('INVALID_RANGE', 'each edit must be an object', { edit_index: editIndex });
+    }
+    const raw = edit as Record<string, unknown>;
+    if (typeof raw.old_text !== 'string' || raw.old_text.length === 0 || typeof raw.new_text !== 'string') {
+      throw new GeneralRepoAccessError('INVALID_RANGE', 'each edit requires non-empty old_text and string new_text', { edit_index: editIndex });
+    }
+    const matches = findOccurrences(text, raw.old_text);
+    const occurrence = patchOccurrenceArg(raw.occurrence, matches.length, editIndex);
+    const start = matches[occurrence - 1];
+    if (start === undefined) {
+      throw new GeneralRepoAccessError('REVISION_CONFLICT', 'patch edit precondition does not match', { edit_index: editIndex });
+    }
+    text = replaceTextAt(text, start, raw.old_text, raw.new_text);
+    applied.push({
+      edit_index: editIndex,
+      mode: 'old_text',
+      occurrence,
+      old_sha256: sha256(raw.old_text),
+      new_sha256: sha256(raw.new_text),
+      bytes_before: Buffer.byteLength(raw.old_text, 'utf-8'),
+      bytes_after: Buffer.byteLength(raw.new_text, 'utf-8'),
+    });
+  }
+  return { text, applied, format: 'structured_edits' };
+}
+
+function lineStartOffset(text: string, lineNumber: number): number {
+  if (lineNumber <= 1) return 0;
+  let offset = 0;
+  let currentLine = 1;
+  while (currentLine < lineNumber) {
+    const next = text.indexOf('\n', offset);
+    if (next < 0) return text.length;
+    offset = next + 1;
+    currentLine += 1;
+  }
+  return offset;
+}
+
+function applyUnifiedDiffPatch(beforeText: string, diff: unknown): { text: string; applied: Array<Record<string, unknown>>; format: 'unified_diff' } {
+  if (typeof diff !== 'string' || diff.trim().length === 0) {
+    throw new GeneralRepoAccessError('INVALID_RANGE', 'unified_diff must be a non-empty string');
+  }
+  const lines = diff.replace(/\r\n/g, '\n').split('\n');
+  let text = beforeText;
+  let lineDelta = 0;
+  const applied: Array<Record<string, unknown>> = [];
+  let cursor = 0;
+  while (cursor < lines.length) {
+    const header = lines[cursor] ?? '';
+    if (!header || header.startsWith('--- ') || header.startsWith('+++ ')) {
+      cursor += 1;
+      continue;
+    }
+    const match = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/.exec(header);
+    if (!match) {
+      throw new GeneralRepoAccessError('INVALID_RANGE', 'unified_diff contains an unsupported line', { line: cursor + 1 });
+    }
+    const oldStart = Number(match[1]);
+    const oldLines: string[] = [];
+    const newLines: string[] = [];
+    cursor += 1;
+    while (cursor < lines.length && !(lines[cursor] ?? '').startsWith('@@ ')) {
+      const line = lines[cursor] ?? '';
+      if (line.startsWith('--- ') || line.startsWith('+++ ')) break;
+      if (line.startsWith('\\ No newline at end of file')) {
+        cursor += 1;
+        continue;
+      }
+      if (line.startsWith(' ')) {
+        oldLines.push(line.slice(1));
+        newLines.push(line.slice(1));
+      } else if (line.startsWith('-')) {
+        oldLines.push(line.slice(1));
+      } else if (line.startsWith('+')) {
+        newLines.push(line.slice(1));
+      } else if (line === '' && cursor === lines.length - 1) {
+        cursor += 1;
+        break;
+      } else {
+        throw new GeneralRepoAccessError('INVALID_RANGE', 'unified_diff hunk contains an unsupported line', { line: cursor + 1 });
+      }
+      cursor += 1;
+    }
+    if (oldLines.length === 0) {
+      throw new GeneralRepoAccessError('INVALID_RANGE', 'unified_diff pure insertion hunks require surrounding context');
+    }
+    const oldBlock = oldLines.join('\n');
+    const newBlock = newLines.join('\n');
+    const expectedOffset = lineStartOffset(text, oldStart + lineDelta);
+    if (!text.startsWith(oldBlock, expectedOffset)) {
+      throw new GeneralRepoAccessError('REVISION_CONFLICT', 'unified_diff hunk precondition does not match', {
+        hunk_index: applied.length + 1,
+        old_start: oldStart,
+      });
+    }
+    text = replaceTextAt(text, expectedOffset, oldBlock, newBlock);
+    lineDelta += newLines.length - oldLines.length;
+    applied.push({
+      hunk_index: applied.length + 1,
+      old_start: oldStart,
+      old_lines: oldLines.length,
+      new_lines: newLines.length,
+      old_sha256: sha256(oldBlock),
+      new_sha256: sha256(newBlock),
+    });
+  }
+  if (applied.length === 0) {
+    throw new GeneralRepoAccessError('INVALID_RANGE', 'unified_diff contains no hunks');
+  }
+  return { text, applied, format: 'unified_diff' };
+}
+
+function applyPatchContent(beforeText: string, args: Record<string, unknown>): { raw: Buffer; format: 'structured_edits' | 'unified_diff'; applied: Array<Record<string, unknown>> } {
+  const hasEdits = args.edits !== undefined;
+  const hasUnifiedDiff = args.unified_diff !== undefined;
+  if (hasEdits === hasUnifiedDiff) {
+    throw new GeneralRepoAccessError('INVALID_RANGE', 'provide exactly one of edits or unified_diff');
+  }
+  const patched = hasEdits ? applyStructuredPatchEdits(beforeText, args.edits) : applyUnifiedDiffPatch(beforeText, args.unified_diff);
+  if (patched.text === beforeText) {
+    throw new GeneralRepoAccessError('REVISION_CONFLICT', 'patch produced no content change');
+  }
+  return { raw: Buffer.from(patched.text, 'utf-8'), format: patched.format, applied: patched.applied };
+}
+
 function fsyncDirectoryBestEffort(path: string): void {
   let fd: number | null = null;
   try {
@@ -1367,6 +1549,63 @@ function indexRefreshError(refresh: CodeGraphRefreshResult): GeneralRepoAccessEr
     path_refresh_supported: refresh.pathRefreshSupported,
     index_revision: refresh.indexRevision,
   }, error?.retryable ?? true);
+}
+
+function mutationResult(ctx: GeneralRepoToolContext, repo: RepoRecord, ignore: IgnorePolicy, target: ResolvedRepoWritePath, opts: {
+  operation: 'create' | 'replace' | 'patch';
+  beforeHash: string | null;
+  beforeSize: number;
+  extra?: Record<string, unknown>;
+}): GeneralRepoToolResult {
+  const after = resolveRepoPath(repo, target.relativePath, ignore, { requireFile: true });
+  const afterRaw = readFileSync(after.canonicalPath);
+  const afterHash = sha256(afterRaw);
+  const afterEntry = metadataForResolved(after, ignore);
+  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore, { contentHash: false });
+  const indexedEntry = snapshot.entriesByPath.get(target.relativePath);
+  const indexState = mutationIndexState(snapshot);
+  const mutationId = `mut_${sha256(`${repo.repoId}\0${target.relativePath}\0${opts.beforeHash ?? 'new'}\0${afterHash}\0${Date.now()}`).slice(0, 16)}`;
+  const invalidationId = `idxinv_${sha256(`${mutationId}\0${snapshot.codeGraph.indexRevision}\0${target.relativePath}`).slice(0, 16)}`;
+
+  return textResult({
+    ...commonFields(repo, ignore, snapshot, { tool: opts.operation === 'patch' ? 'apply_patch' : 'write_file', paths: [target.relativePath] }),
+    path: target.relativePath,
+    operation: opts.operation,
+    mutation_id: mutationId,
+    before: {
+      existed: opts.beforeHash !== null,
+      sha256: opts.beforeHash,
+      size: opts.beforeSize,
+    },
+    after: {
+      ...afterEntry,
+      indexed: indexedEntry?.indexed ?? false,
+      codegraph_language: indexedEntry?.codegraph_language,
+      codegraph_node_count: indexedEntry?.codegraph_node_count,
+      codegraph_size: indexedEntry?.codegraph_size,
+      codegraph_index_lagging: indexedEntry?.codegraph_index_lagging,
+    },
+    diff: {
+      format: 'summary',
+      bytes_before: opts.beforeSize,
+      bytes_after: afterRaw.length,
+      bytes_delta: afterRaw.length - opts.beforeSize,
+      before_sha256: opts.beforeHash,
+      after_sha256: afterHash,
+    },
+    ...opts.extra,
+    index_state: indexState,
+    index: {
+      state: indexState,
+      action: snapshot.codeGraph.available ? 'refresh_repo_index_required' : 'codegraph_unavailable',
+      changed_paths: [target.relativePath],
+      mutation_id: mutationId,
+      invalidation_id: invalidationId,
+      refresh_tool: 'refresh_repo_index',
+      before_index_revision: snapshot.codeGraph.indexRevision,
+    },
+    codegraph: codeGraphSummary(snapshot),
+  });
 }
 
 function readFilePayload(repo: RepoRecord, ignore: IgnorePolicy, snapshot: VisibleEntrySnapshot, args: Record<string, unknown>, maxBytes = HARD_READ_BYTES, tool = 'read_file', verifySnapshotEntry = false): Record<string, unknown> {
@@ -1533,54 +1772,53 @@ function writeFileTool(ctx: GeneralRepoToolContext, args: Record<string, unknown
   atomicWriteFile(target, raw, mode);
   invalidateRepoCaches(repo);
 
-  const after = resolveRepoPath(repo, target.relativePath, ignore, { requireFile: true });
-  const afterRaw = readFileSync(after.canonicalPath);
-  const afterHash = sha256(afterRaw);
-  const afterEntry = metadataForResolved(after, ignore);
-  const snapshot = buildVisibleEntrySnapshot(ctx, repo, ignore, { contentHash: false });
-  const indexedEntry = snapshot.entriesByPath.get(target.relativePath);
-  const indexState = mutationIndexState(snapshot);
-  const mutationId = `mut_${sha256(`${repo.repoId}\0${target.relativePath}\0${beforeHash ?? 'new'}\0${afterHash}\0${Date.now()}`).slice(0, 16)}`;
-  const invalidationId = `idxinv_${sha256(`${mutationId}\0${snapshot.codeGraph.indexRevision}\0${target.relativePath}`).slice(0, 16)}`;
-
-  return textResult({
-    ...commonFields(repo, ignore, snapshot, { tool: 'write_file', paths: [target.relativePath] }),
-    path: target.relativePath,
+  return mutationResult(ctx, repo, ignore, target, {
     operation: existed ? 'replace' : 'create',
-    mutation_id: mutationId,
-    encoding,
-    before: {
-      existed,
-      sha256: beforeHash,
-      size: beforeSize,
+    beforeHash,
+    beforeSize,
+    extra: { encoding },
+  });
+}
+
+function applyPatchTool(ctx: GeneralRepoToolContext, args: Record<string, unknown>): GeneralRepoToolResult {
+  const repo = resolveRepo(ctx, args.repo_id);
+  assertRepoWriteEnabled(repo);
+  const ignore = readIgnorePolicy(repo.canonicalRoot);
+  const target = resolveRepoWritePath(repo, args.path, ignore);
+  if (!target.existing) {
+    throw new GeneralRepoAccessError('NOT_FOUND', 'apply_patch requires an existing file', { path: target.relativePath });
+  }
+  const expectedHash = typeof args.expected_sha256 === 'string' ? args.expected_sha256.trim() : '';
+  if (!expectedHash) {
+    throw new GeneralRepoAccessError('REVISION_CONFLICT', 'expected_sha256 is required when applying a patch', { path: target.relativePath });
+  }
+  const beforeRaw = readFileSync(target.existing.canonicalPath);
+  const beforeHash = sha256(beforeRaw);
+  if (expectedHash !== beforeHash) {
+    throw new GeneralRepoAccessError('REVISION_CONFLICT', 'file changed after it was read', {
+      path: target.relativePath,
+      expected_sha256: expectedHash,
+      actual_sha256: beforeHash,
+    });
+  }
+  const beforeText = assertTextPatchable(beforeRaw, target.relativePath);
+  const patched = applyPatchContent(beforeText, args);
+  const mode = statSync(target.existing.canonicalPath).mode & 0o777;
+
+  atomicWriteFile(target, patched.raw, mode);
+  invalidateRepoCaches(repo);
+
+  return mutationResult(ctx, repo, ignore, target, {
+    operation: 'patch',
+    beforeHash,
+    beforeSize: beforeRaw.length,
+    extra: {
+      patch: {
+        format: patched.format,
+        applied_count: patched.applied.length,
+        applied: patched.applied,
+      },
     },
-    after: {
-      ...afterEntry,
-      indexed: indexedEntry?.indexed ?? false,
-      codegraph_language: indexedEntry?.codegraph_language,
-      codegraph_node_count: indexedEntry?.codegraph_node_count,
-      codegraph_size: indexedEntry?.codegraph_size,
-      codegraph_index_lagging: indexedEntry?.codegraph_index_lagging,
-    },
-    diff: {
-      format: 'summary',
-      bytes_before: beforeSize,
-      bytes_after: afterRaw.length,
-      bytes_delta: afterRaw.length - beforeSize,
-      before_sha256: beforeHash,
-      after_sha256: afterHash,
-    },
-    index_state: indexState,
-    index: {
-      state: indexState,
-      action: snapshot.codeGraph.available ? 'refresh_repo_index_required' : 'codegraph_unavailable',
-      changed_paths: [target.relativePath],
-      mutation_id: mutationId,
-      invalidation_id: invalidationId,
-      refresh_tool: 'refresh_repo_index',
-      before_index_revision: snapshot.codeGraph.indexRevision,
-    },
-    codegraph: codeGraphSummary(snapshot),
   });
 }
 
@@ -1985,6 +2223,35 @@ export function buildGeneralRepoToolDefinitions(): GeneralRepoToolDefinition[] {
       annotations: writeTool,
     },
     {
+      name: 'apply_patch',
+      description: 'Apply structured text edits or a guarded unified diff to one existing repo-relative file using an expected_sha256 precondition.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          repo_id: { type: 'string' },
+          path: { type: 'string' },
+          expected_sha256: { type: 'string' },
+          edits: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                old_text: { type: 'string' },
+                new_text: { type: 'string' },
+                occurrence: { type: 'number' },
+              },
+              required: ['old_text', 'new_text'],
+              additionalProperties: false,
+            },
+          },
+          unified_diff: { type: 'string' },
+        },
+        required: ['repo_id', 'path', 'expected_sha256'],
+        additionalProperties: false,
+      },
+      annotations: writeTool,
+    },
+    {
       name: 'refresh_repo_index',
       description: 'Synchronize CodeGraph for a read_write repo after mutations and return the new index/snapshot state.',
       inputSchema: {
@@ -2028,6 +2295,9 @@ export async function callGeneralRepoTool(ctx: GeneralRepoToolContext, name: str
         break;
       case 'write_file':
         result = writeFileTool(ctx, args);
+        break;
+      case 'apply_patch':
+        result = applyPatchTool(ctx, args);
         break;
       case 'refresh_repo_index':
         result = refreshRepoIndex(ctx, args);

--- a/src/cli/mcp/setup.ts
+++ b/src/cli/mcp/setup.ts
@@ -614,6 +614,7 @@ export function runMcpSetupChatgpt(opts: {
       '.repo-harness/mcp.oauth.json',
       '.repo-harness/mcp.oauth-tokens.json',
       '.ai/harness/mcp/audit.log',
+      '.ai/harness/mcp/index-events.jsonl',
     ], changed);
   }
 

--- a/src/cli/mcp/types.ts
+++ b/src/cli/mcp/types.ts
@@ -37,6 +37,21 @@ export interface McpAuditEntry {
   timestamp: string;
   tool: string;
   status: 'ok' | 'blocked' | 'failed';
+  actor?: string;
+  repoId?: string;
+  operation?: string;
+  relativePaths?: string[];
+  mutationId?: string;
+  indexInvalidationId?: string;
+  indexEventId?: string;
+  indexState?: string;
+  fileHashes?: {
+    before_sha256?: string | null;
+    after_sha256?: string | null;
+  };
+  result?: 'ok' | 'blocked' | 'failed';
+  durationMs?: number;
+  errorCode?: string;
   targetPath?: string;
   inputHash?: string;
   error?: string;

--- a/tasks/notes/20260622-repo-harness-codegraph.notes.md
+++ b/tasks/notes/20260622-repo-harness-codegraph.notes.md
@@ -151,3 +151,23 @@ Sprint 0 contract freeze for `plans/sprints/20260622-repo-harness-codegraph-spri
   available, or `failed` when no index is available. The process-local snapshot
   and metadata caches are invalidated after successful writes so immediate
   read/stat calls see filesystem truth.
+
+## 2026-06-23 refresh_repo_index slice
+
+- The index-sync slice adds `refresh_repo_index` as a read_write-gated mutation
+  companion rather than making `write_file` block on CodeGraph. This keeps the
+  filesystem commit boundary small and makes index lag explicit to the caller.
+- Requested refresh paths are repo-relative, deduplicated, and resolved through
+  the same canonical root, symlink, and `.ignore` guard used by read/write
+  tools. Empty `paths` means repo-level refresh.
+- The CLI adapter uses `codegraph sync <repo>` and then reads
+  `codegraph files --format flat --json` for the new revision. Path-only
+  refresh is reported as unsupported with `path_refresh_supported:false` because
+  the local CodeGraph CLI does not expose a stable path incremental contract.
+- `write_file` now returns an `index.invalidation_id` and
+  `index.refresh_tool`. `refresh_repo_index` returns before/after index
+  revisions, the adapter revision, refresh strategy, snapshot id, and
+  `index_state: ready|index_lagging|failed`.
+- Search still uses the existing CodeGraph-metadata plus guarded filesystem
+  fallback path. This slice makes the index state observable; it does not claim
+  a CodeGraph-only full-text backend.

--- a/tasks/notes/20260622-repo-harness-codegraph.notes.md
+++ b/tasks/notes/20260622-repo-harness-codegraph.notes.md
@@ -171,3 +171,22 @@ Sprint 0 contract freeze for `plans/sprints/20260622-repo-harness-codegraph-spri
 - Search still uses the existing CodeGraph-metadata plus guarded filesystem
   fallback path. This slice makes the index state observable; it does not claim
   a CodeGraph-only full-text backend.
+
+## 2026-06-23 apply_patch slice
+
+- `apply_patch` is implemented as an existing-file text mutation, not as a
+  create/update hybrid. Missing files return `NOT_FOUND`; binary targets return
+  `BINARY_CONTENT`.
+- The tool requires `expected_sha256` for the whole file before any patch
+  preconditions are evaluated. Stale file hashes, missing `old_text`, ambiguous
+  structured edits, and mismatched unified diff hunks all fail before writing.
+- Structured edits are the primary API shape: each edit replaces one exact
+  `old_text` with `new_text`. Repeated text requires a 1-based `occurrence` so
+  the caller cannot accidentally patch an ambiguous match.
+- Unified diff support is intentionally constrained to guarded hunks with
+  surrounding old/context lines. Pure insertion hunks without context are
+  rejected until there is a stronger insertion precondition shape.
+- The write path reuses the `write_file` atomic same-directory temp + fsync +
+  rename commit and shared mutation response. Existing file mode bits are
+  preserved; mtime changes and platform-specific metadata are not preserved in
+  the portable v1 mutation layer.

--- a/tasks/notes/20260622-repo-harness-codegraph.notes.md
+++ b/tasks/notes/20260622-repo-harness-codegraph.notes.md
@@ -190,3 +190,18 @@ Sprint 0 contract freeze for `plans/sprints/20260622-repo-harness-codegraph-spri
   rename commit and shared mutation response. Existing file mode bits are
   preserved; mtime changes and platform-specific metadata are not preserved in
   the portable v1 mutation layer.
+
+## 2026-06-23 move/delete path mutation slice
+
+- `move_path` and `delete_path` deliberately target regular files only. Moving
+  or deleting symlinks, directories, empty directories, or recursive trees stays
+  disabled in v1 so the first path-mutation surface does not create unbounded
+  tree semantics.
+- `move_path` requires the source `expected_sha256`, requires the target parent
+  directory to already exist, and requires `must_not_exist: true` for the target.
+  Stale source hashes and existing targets fail before `rename`.
+- `delete_path` requires `expected_sha256` and returns the deleted file metadata.
+  Directory targets fail before any filesystem mutation; `recursive: true`
+  returns an explicit unsupported-policy error.
+- Successful move/delete mutations invalidate snapshots and return the same
+  pending CodeGraph refresh contract as `write_file` and `apply_patch`.

--- a/tasks/notes/20260622-repo-harness-codegraph.notes.md
+++ b/tasks/notes/20260622-repo-harness-codegraph.notes.md
@@ -205,3 +205,28 @@ Sprint 0 contract freeze for `plans/sprints/20260622-repo-harness-codegraph-spri
   returns an explicit unsupported-policy error.
 - Successful move/delete mutations invalidate snapshots and return the same
   pending CodeGraph refresh contract as `write_file` and `apply_patch`.
+
+## 2026-06-23 failure injection, index recovery, and audit slice
+
+- Mutation fault injection is intentionally test-only and env-gated through
+  `REPO_HARNESS_MCP_MUTATION_FAULT_POINT`. The supported fault points sit after
+  temp-file fsync and before atomic rename, before move rename, and before
+  delete unlink. They model the pre-commit boundaries for disk/permission,
+  interrupted-process, and rename/delete failures without adding a public MCP
+  option.
+- Successful mutations now append `.ai/harness/mcp/index-events.jsonl`
+  invalidation events. The event log is ignored runtime state, separate from
+  `.ai/harness/mcp/audit.log`, and carries mutation id, invalidation id, relative
+  paths, hash summaries, index revision, and retry metadata without file bodies
+  or patch text.
+- `refresh_repo_index` accepts an optional `mutation_id` so callers can trace
+  the refresh back to the invalidation event and measure mutation-to-refresh lag.
+  It also accepts recently deleted repo-relative paths so move/delete old paths
+  can be synchronized instead of failing `NOT_FOUND` before refresh.
+- Refresh failures write dead-letter index events with retry metadata and the
+  manual recovery command `bash scripts/ensure-codegraph.sh --sync`; the tool
+  still returns the adapter error to the caller.
+- General repo MCP audit entries now include actor/profile, repo id, operation,
+  relative paths, mutation id, index invalidation/event ids, hash summaries,
+  result, duration, and rejection error code. The logged input remains hashed,
+  not embedded, so file contents and patch bodies do not enter the audit log.

--- a/tasks/notes/20260622-repo-harness-codegraph.notes.md
+++ b/tasks/notes/20260622-repo-harness-codegraph.notes.md
@@ -129,3 +129,25 @@ Sprint 0 contract freeze for `plans/sprints/20260622-repo-harness-codegraph-spri
   `counts.content_deferred=499010`. This records the Sprint 2 baseline and
   leaves 500k latency as a future optimization target rather than an open S2
   checklist item.
+
+## 2026-06-23 write_file slice
+
+- The first Sprint 3 mutation slice adds only `write_file` create/replace. It
+  reuses the general repo registry, Path Guard, `.ignore` policy, audit writer,
+  snapshot fields, and filesystem fallback path instead of adding a parallel
+  write service.
+- `read_only` repos return `WRITE_DISABLED`. `read_write` is sourced only from
+  the registered repo entry and surfaced through `get_repo_capabilities`.
+- New files require `must_not_exist: true`; replacing existing files requires
+  `expected_sha256`. Missing or stale preconditions return
+  `REVISION_CONFLICT`, and `must_not_exist` on an existing file returns
+  `TARGET_EXISTS`.
+- Writes use a temporary file in the same canonical parent directory, fsync the
+  file, then atomically rename into place. The first slice requires the parent
+  directory to already exist; directory creation, recursive delete, patch,
+  move, and delete stay out of scope.
+- CodeGraph refresh is explicit pending state in this slice:
+  `index_state: "pending"` with `refresh_repo_index_required` when CodeGraph is
+  available, or `failed` when no index is available. The process-local snapshot
+  and metadata caches are invalidated after successful writes so immediate
+  read/stat calls see filesystem truth.

--- a/tests/cli/mcp-codegraph-contract.test.ts
+++ b/tests/cli/mcp-codegraph-contract.test.ts
@@ -378,10 +378,11 @@ describe('general repo CodeGraph contract', () => {
         } else if (tool.name === 'delete_path') {
           expect(tool.input_schema.required).toEqual(['repo_id', 'path', 'expected_sha256']);
           expect(tool.input_schema.properties.recursive).toEqual({ type: 'boolean' });
-        } else {
-          expect(tool.input_schema.required).toEqual(['repo_id']);
-          expect(tool.input_schema.properties.paths.items).toEqual({ type: 'string' });
-        }
+	        } else {
+	          expect(tool.input_schema.required).toEqual(['repo_id']);
+	          expect(tool.input_schema.properties.paths.items).toEqual({ type: 'string' });
+	          expect(tool.input_schema.properties.mutation_id).toEqual({ type: 'string' });
+	        }
       } else {
         expect(tool.annotations).toEqual({
           readOnlyHint: true,

--- a/tests/cli/mcp-codegraph-contract.test.ts
+++ b/tests/cli/mcp-codegraph-contract.test.ts
@@ -17,6 +17,7 @@ const TOOL_NAMES = [
   'read_file',
   'read_files',
   'stat_file',
+  'write_file',
 ];
 
 const COMMON_RESPONSE_FIELDS = [
@@ -153,6 +154,16 @@ function sampleSuccessPayload(toolName: string): Record<string, unknown> {
       return { ...common, results: [] };
     case 'stat_file':
       return { ...common, path: 'README.md', type: 'file', indexed: true, readable: true };
+    case 'write_file':
+      return {
+        ...common,
+        path: 'README.md',
+        mutation_id: `mut_${'c'.repeat(16)}`,
+        before: { existed: false, sha256: null, size: 0 },
+        after: { sha256: 'd'.repeat(64), size: 2 },
+        diff: { format: 'summary', bytes_before: 0, bytes_after: 2, bytes_delta: 2, before_sha256: null, after_sha256: 'd'.repeat(64) },
+        index_state: 'pending',
+      };
     default:
       throw new Error(`Missing sample payload for ${toolName}`);
   }
@@ -283,7 +294,7 @@ function manifestFromSecureWalker(root: string, indexedPaths: Set<string>): { ig
 }
 
 describe('general repo CodeGraph contract', () => {
-  test('versioned schema freezes the Sprint 0 reader tool surface', () => {
+  test('versioned schema freezes the general repo reader plus initial write_file surface', () => {
     const schema = readJson(SCHEMA_PATH);
     expect(schema.properties.version.const).toBe('1');
     expect(schema.properties.policy.properties.content_exclusion.const).toBe('.ignore');
@@ -294,12 +305,24 @@ describe('general repo CodeGraph contract', () => {
 
     for (const tool of schema.tools) {
       expect(validateJsonSchema(schema.$defs.tool, tool, schema).errors).toEqual([]);
-      expect(tool.annotations).toEqual({
-        readOnlyHint: true,
-        destructiveHint: false,
-        idempotentHint: true,
-        openWorldHint: false,
-      });
+      if (tool.name === 'write_file') {
+        expect(tool.annotations).toEqual({
+          readOnlyHint: false,
+          destructiveHint: true,
+          idempotentHint: false,
+          openWorldHint: false,
+        });
+        expect(tool.input_schema.required).toEqual(['repo_id', 'path', 'content']);
+        expect(tool.input_schema.properties.expected_sha256).toEqual({ type: 'string' });
+        expect(tool.input_schema.properties.must_not_exist).toEqual({ type: 'boolean' });
+      } else {
+        expect(tool.annotations).toEqual({
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: false,
+        });
+      }
       expect(tool.input_schema.additionalProperties).toBe(false);
       expect(tool.input_schema.properties.repo_id).toEqual({ type: 'string' });
       expect(validateJsonSchema(tool.output_schema, sampleSuccessPayload(tool.name), schema).errors).toEqual([]);

--- a/tests/cli/mcp-codegraph-contract.test.ts
+++ b/tests/cli/mcp-codegraph-contract.test.ts
@@ -19,6 +19,8 @@ const TOOL_NAMES = [
   'stat_file',
   'write_file',
   'apply_patch',
+  'move_path',
+  'delete_path',
   'refresh_repo_index',
 ];
 
@@ -178,6 +180,32 @@ function sampleSuccessPayload(toolName: string): Record<string, unknown> {
         patch: { mode: 'edits', edit_count: 1 },
         index_state: 'pending',
       };
+    case 'move_path':
+      return {
+        ...common,
+        path: 'docs/moved.md',
+        from_path: 'docs/source.md',
+        to_path: 'docs/moved.md',
+        operation: 'move',
+        mutation_id: `mut_${'1'.repeat(16)}`,
+        before: { existed: true, sha256: 'b'.repeat(64), size: 2 },
+        after: { sha256: 'b'.repeat(64), size: 2 },
+        diff: { format: 'summary', bytes_before: 2, bytes_after: 2, bytes_delta: 0, before_sha256: 'b'.repeat(64), after_sha256: 'b'.repeat(64) },
+        move: { source_sha256: 'b'.repeat(64), target_must_not_exist: true },
+        index_state: 'pending',
+      };
+    case 'delete_path':
+      return {
+        ...common,
+        path: 'docs/delete.md',
+        operation: 'delete',
+        mutation_id: `mut_${'2'.repeat(16)}`,
+        before: { existed: true, sha256: 'b'.repeat(64), size: 2 },
+        after: { existed: false, sha256: null, size: 0 },
+        diff: { format: 'summary', bytes_before: 2, bytes_after: 0, bytes_delta: -2, before_sha256: 'b'.repeat(64), after_sha256: null },
+        deleted: { path: 'docs/delete.md', sha256: 'b'.repeat(64), size: 2 },
+        index_state: 'pending',
+      };
     case 'refresh_repo_index':
       return {
         ...common,
@@ -328,7 +356,7 @@ describe('general repo CodeGraph contract', () => {
 
     for (const tool of schema.tools) {
       expect(validateJsonSchema(schema.$defs.tool, tool, schema).errors).toEqual([]);
-      if (tool.name === 'write_file' || tool.name === 'apply_patch' || tool.name === 'refresh_repo_index') {
+      if (tool.name === 'write_file' || tool.name === 'apply_patch' || tool.name === 'move_path' || tool.name === 'delete_path' || tool.name === 'refresh_repo_index') {
         expect(tool.annotations).toEqual({
           readOnlyHint: false,
           destructiveHint: true,
@@ -343,6 +371,13 @@ describe('general repo CodeGraph contract', () => {
           expect(tool.input_schema.required).toEqual(['repo_id', 'path', 'expected_sha256']);
           expect(tool.input_schema.properties.edits.items.required).toEqual(['old_text', 'new_text']);
           expect(tool.input_schema.properties.unified_diff).toEqual({ type: 'string' });
+        } else if (tool.name === 'move_path') {
+          expect(tool.input_schema.required).toEqual(['repo_id', 'from_path', 'to_path', 'expected_sha256', 'must_not_exist']);
+          expect(tool.input_schema.properties.from_path).toEqual({ type: 'string' });
+          expect(tool.input_schema.properties.to_path).toEqual({ type: 'string' });
+        } else if (tool.name === 'delete_path') {
+          expect(tool.input_schema.required).toEqual(['repo_id', 'path', 'expected_sha256']);
+          expect(tool.input_schema.properties.recursive).toEqual({ type: 'boolean' });
         } else {
           expect(tool.input_schema.required).toEqual(['repo_id']);
           expect(tool.input_schema.properties.paths.items).toEqual({ type: 'string' });

--- a/tests/cli/mcp-codegraph-contract.test.ts
+++ b/tests/cli/mcp-codegraph-contract.test.ts
@@ -18,6 +18,7 @@ const TOOL_NAMES = [
   'read_files',
   'stat_file',
   'write_file',
+  'refresh_repo_index',
 ];
 
 const COMMON_RESPONSE_FIELDS = [
@@ -164,6 +165,15 @@ function sampleSuccessPayload(toolName: string): Record<string, unknown> {
         diff: { format: 'summary', bytes_before: 0, bytes_after: 2, bytes_delta: 2, before_sha256: null, after_sha256: 'd'.repeat(64) },
         index_state: 'pending',
       };
+    case 'refresh_repo_index':
+      return {
+        ...common,
+        paths: ['README.md'],
+        refreshed: true,
+        index_state: 'ready',
+        refresh: { strategy: 'repo-sync', requested_paths: ['README.md'], path_refresh_supported: false },
+        index: { state: 'ready', action: 'refresh_complete', refreshed_paths: ['README.md'] },
+      };
     default:
       throw new Error(`Missing sample payload for ${toolName}`);
   }
@@ -294,7 +304,7 @@ function manifestFromSecureWalker(root: string, indexedPaths: Set<string>): { ig
 }
 
 describe('general repo CodeGraph contract', () => {
-  test('versioned schema freezes the general repo reader plus initial write_file surface', () => {
+  test('versioned schema freezes the general repo reader plus write/index-sync surface', () => {
     const schema = readJson(SCHEMA_PATH);
     expect(schema.properties.version.const).toBe('1');
     expect(schema.properties.policy.properties.content_exclusion.const).toBe('.ignore');
@@ -305,16 +315,21 @@ describe('general repo CodeGraph contract', () => {
 
     for (const tool of schema.tools) {
       expect(validateJsonSchema(schema.$defs.tool, tool, schema).errors).toEqual([]);
-      if (tool.name === 'write_file') {
+      if (tool.name === 'write_file' || tool.name === 'refresh_repo_index') {
         expect(tool.annotations).toEqual({
           readOnlyHint: false,
           destructiveHint: true,
           idempotentHint: false,
           openWorldHint: false,
         });
-        expect(tool.input_schema.required).toEqual(['repo_id', 'path', 'content']);
-        expect(tool.input_schema.properties.expected_sha256).toEqual({ type: 'string' });
-        expect(tool.input_schema.properties.must_not_exist).toEqual({ type: 'boolean' });
+        if (tool.name === 'write_file') {
+          expect(tool.input_schema.required).toEqual(['repo_id', 'path', 'content']);
+          expect(tool.input_schema.properties.expected_sha256).toEqual({ type: 'string' });
+          expect(tool.input_schema.properties.must_not_exist).toEqual({ type: 'boolean' });
+        } else {
+          expect(tool.input_schema.required).toEqual(['repo_id']);
+          expect(tool.input_schema.properties.paths.items).toEqual({ type: 'string' });
+        }
       } else {
         expect(tool.annotations).toEqual({
           readOnlyHint: true,

--- a/tests/cli/mcp-codegraph-contract.test.ts
+++ b/tests/cli/mcp-codegraph-contract.test.ts
@@ -18,6 +18,7 @@ const TOOL_NAMES = [
   'read_files',
   'stat_file',
   'write_file',
+  'apply_patch',
   'refresh_repo_index',
 ];
 
@@ -163,6 +164,18 @@ function sampleSuccessPayload(toolName: string): Record<string, unknown> {
         before: { existed: false, sha256: null, size: 0 },
         after: { sha256: 'd'.repeat(64), size: 2 },
         diff: { format: 'summary', bytes_before: 0, bytes_after: 2, bytes_delta: 2, before_sha256: null, after_sha256: 'd'.repeat(64) },
+        index_state: 'pending',
+      };
+    case 'apply_patch':
+      return {
+        ...common,
+        path: 'README.md',
+        operation: 'patch',
+        mutation_id: `mut_${'e'.repeat(16)}`,
+        before: { existed: true, sha256: 'b'.repeat(64), size: 2 },
+        after: { sha256: 'f'.repeat(64), size: 3 },
+        diff: { format: 'summary', bytes_before: 2, bytes_after: 3, bytes_delta: 1, before_sha256: 'b'.repeat(64), after_sha256: 'f'.repeat(64) },
+        patch: { mode: 'edits', edit_count: 1 },
         index_state: 'pending',
       };
     case 'refresh_repo_index':
@@ -315,7 +328,7 @@ describe('general repo CodeGraph contract', () => {
 
     for (const tool of schema.tools) {
       expect(validateJsonSchema(schema.$defs.tool, tool, schema).errors).toEqual([]);
-      if (tool.name === 'write_file' || tool.name === 'refresh_repo_index') {
+      if (tool.name === 'write_file' || tool.name === 'apply_patch' || tool.name === 'refresh_repo_index') {
         expect(tool.annotations).toEqual({
           readOnlyHint: false,
           destructiveHint: true,
@@ -326,6 +339,10 @@ describe('general repo CodeGraph contract', () => {
           expect(tool.input_schema.required).toEqual(['repo_id', 'path', 'content']);
           expect(tool.input_schema.properties.expected_sha256).toEqual({ type: 'string' });
           expect(tool.input_schema.properties.must_not_exist).toEqual({ type: 'boolean' });
+        } else if (tool.name === 'apply_patch') {
+          expect(tool.input_schema.required).toEqual(['repo_id', 'path', 'expected_sha256']);
+          expect(tool.input_schema.properties.edits.items.required).toEqual(['old_text', 'new_text']);
+          expect(tool.input_schema.properties.unified_diff).toEqual({ type: 'string' });
         } else {
           expect(tool.input_schema.required).toEqual(['repo_id']);
           expect(tool.input_schema.properties.paths.items).toEqual({ type: 'string' });

--- a/tests/cli/mcp-reader-tools.test.ts
+++ b/tests/cli/mcp-reader-tools.test.ts
@@ -90,9 +90,10 @@ describe('MCP reader tools', () => {
         'read_files',
         'stat_file',
         'write_file',
+        'refresh_repo_index',
       ]);
       for (const definition of definitions) {
-        if (definition.name === 'write_file') {
+        if (definition.name === 'write_file' || definition.name === 'refresh_repo_index') {
           expect(definition.annotations).toMatchObject({
             readOnlyHint: false,
             destructiveHint: true,
@@ -182,6 +183,8 @@ describe('MCP reader tools', () => {
         });
         expect(readOnlyWrite.error.code).toBe('WRITE_DISABLED');
         expect(existsSync(join(repoRoot, 'docs', 'created-by-write.txt'))).toBe(false);
+        const readOnlyRefresh = await jsonTool(ctx, 'refresh_repo_index', { repo_id: repoId, paths: ['docs/design.md'] });
+        expect(readOnlyRefresh.error.code).toBe('WRITE_DISABLED');
 
         const manifest = await jsonTool(ctx, 'repo_manifest', { repo_id: repoId, page_size: 1000 });
         const visiblePaths = manifest.entries.map((entry: { path: string }) => entry.path);
@@ -308,15 +311,36 @@ describe('MCP reader tools', () => {
   test('write_file is capability-gated, atomic, and guarded by revision preconditions', async () => {
     await withReaderRepo(async (repoRoot, ctx) => {
       writeFileSync(join(repoRoot, '.ignore'), 'ignored.md\n');
+      let indexedAfterRefresh = false;
+      const refreshCalls: string[][] = [];
       const fakeCodeGraph: GeneralRepoCodeGraphAdapter = {
         discoverRepo() {
+          const generatedPath = join(repoRoot, 'docs', 'generated.txt');
           return {
             available: true,
             integrated: true,
             source: 'test-double',
-            indexRevision: 'index_before_write',
+            indexRevision: indexedAfterRefresh ? 'index_after_write' : 'index_before_write',
             latencyMs: 1,
-            files: [],
+            files: indexedAfterRefresh && existsSync(generatedPath)
+              ? [{ path: 'docs/generated.txt', language: 'text', nodeCount: 1, size: readFileSync(generatedPath).length }]
+              : [],
+          };
+        },
+        refreshRepo(_repoRoot, opts = {}) {
+          refreshCalls.push(opts.paths ?? []);
+          indexedAfterRefresh = true;
+          return {
+            available: true,
+            refreshed: true,
+            integrated: true,
+            source: 'test-double',
+            indexRevision: 'index_after_write',
+            latencyMs: 2,
+            strategy: 'repo-sync',
+            requestedPaths: opts.paths ?? [],
+            pathRefreshSupported: false,
+            files: 1,
           };
         },
       };
@@ -329,7 +353,7 @@ describe('MCP reader tools', () => {
       const repoId = (await jsonTool(writeCtx, 'list_allowed_roots')).roots[0].repo_id;
       const capabilities = await jsonTool(writeCtx, 'get_repo_capabilities', { repo_id: repoId });
       expect(capabilities.access_mode).toBe('read_write');
-      expect(capabilities.write_tools).toEqual(['write_file']);
+      expect(capabilities.write_tools).toEqual(['write_file', 'refresh_repo_index']);
 
       const missingCreatePrecondition = await jsonTool(writeCtx, 'write_file', {
         repo_id: repoId,
@@ -354,6 +378,8 @@ describe('MCP reader tools', () => {
         index: { action: 'refresh_repo_index_required', changed_paths: ['docs/generated.txt'] },
       });
       expect(created.mutation_id).toMatch(/^mut_[a-f0-9]{16}$/);
+      expect(created.index.invalidation_id).toMatch(/^idxinv_[a-f0-9]{16}$/);
+      expect(created.index.refresh_tool).toBe('refresh_repo_index');
       expect(created.after.sha256).toMatch(/^[a-f0-9]{64}$/);
       expect(created.diff.after_sha256).toBe(created.after.sha256);
       expect(readFileSync(join(repoRoot, 'docs', 'generated.txt'), 'utf-8')).toBe('first\n');
@@ -401,6 +427,46 @@ describe('MCP reader tools', () => {
       expect(readdirSync(join(repoRoot, 'docs')).some((name) => name.includes('.repo-harness-'))).toBe(false);
       const statReplaced = await jsonTool(writeCtx, 'stat_file', { repo_id: repoId, path: 'docs/generated.txt' });
       expect(statReplaced.sha256).toBe(replaced.after.sha256);
+      expect(statReplaced.indexed).toBe(false);
+      const searchBeforeRefresh = await jsonTool(writeCtx, 'search_text', {
+        repo_id: repoId,
+        query: 'second',
+        paths: ['docs/generated.txt'],
+      });
+      expect(searchBeforeRefresh.backend).toBe('codegraph-metadata+filesystem-fallback');
+      expect(searchBeforeRefresh.matches).toMatchObject([{ path: 'docs/generated.txt', indexed: false }]);
+
+      const refreshed = await jsonTool(writeCtx, 'refresh_repo_index', {
+        repo_id: repoId,
+        paths: ['docs/generated.txt'],
+      });
+      expect(refreshed).toMatchObject({
+        paths: ['docs/generated.txt'],
+        refreshed: true,
+        index_state: 'ready',
+        refresh: {
+          strategy: 'repo-sync',
+          requested_paths: ['docs/generated.txt'],
+          path_refresh_supported: false,
+          before_index_revision: 'index_before_write',
+          adapter_index_revision: 'index_after_write',
+          after_index_revision: 'index_after_write',
+          indexed_files: 1,
+        },
+        index: {
+          state: 'ready',
+          action: 'refresh_complete',
+          refreshed_paths: ['docs/generated.txt'],
+        },
+      });
+      expect(refreshCalls).toEqual([['docs/generated.txt']]);
+      const statAfterRefresh = await jsonTool(writeCtx, 'stat_file', { repo_id: repoId, path: 'docs/generated.txt' });
+      expect(statAfterRefresh).toMatchObject({
+        indexed: true,
+        codegraph_language: 'text',
+        codegraph_node_count: 1,
+        codegraph_size: 'second\n'.length,
+      });
 
       const ignored = await jsonTool(writeCtx, 'write_file', {
         repo_id: repoId,

--- a/tests/cli/mcp-reader-tools.test.ts
+++ b/tests/cli/mcp-reader-tools.test.ts
@@ -90,10 +90,11 @@ describe('MCP reader tools', () => {
         'read_files',
         'stat_file',
         'write_file',
+        'apply_patch',
         'refresh_repo_index',
       ]);
       for (const definition of definitions) {
-        if (definition.name === 'write_file' || definition.name === 'refresh_repo_index') {
+        if (definition.name === 'write_file' || definition.name === 'apply_patch' || definition.name === 'refresh_repo_index') {
           expect(definition.annotations).toMatchObject({
             readOnlyHint: false,
             destructiveHint: true,
@@ -183,6 +184,13 @@ describe('MCP reader tools', () => {
         });
         expect(readOnlyWrite.error.code).toBe('WRITE_DISABLED');
         expect(existsSync(join(repoRoot, 'docs', 'created-by-write.txt'))).toBe(false);
+        const readOnlyPatch = await jsonTool(ctx, 'apply_patch', {
+          repo_id: repoId,
+          path: 'docs/design.md',
+          expected_sha256: 'unused',
+          edits: [{ old_text: 'authentication', new_text: 'authorization' }],
+        });
+        expect(readOnlyPatch.error.code).toBe('WRITE_DISABLED');
         const readOnlyRefresh = await jsonTool(ctx, 'refresh_repo_index', { repo_id: repoId, paths: ['docs/design.md'] });
         expect(readOnlyRefresh.error.code).toBe('WRITE_DISABLED');
 
@@ -353,7 +361,7 @@ describe('MCP reader tools', () => {
       const repoId = (await jsonTool(writeCtx, 'list_allowed_roots')).roots[0].repo_id;
       const capabilities = await jsonTool(writeCtx, 'get_repo_capabilities', { repo_id: repoId });
       expect(capabilities.access_mode).toBe('read_write');
-      expect(capabilities.write_tools).toEqual(['write_file', 'refresh_repo_index']);
+      expect(capabilities.write_tools).toEqual(['write_file', 'apply_patch', 'refresh_repo_index']);
 
       const missingCreatePrecondition = await jsonTool(writeCtx, 'write_file', {
         repo_id: repoId,
@@ -468,6 +476,76 @@ describe('MCP reader tools', () => {
         codegraph_size: 'second\n'.length,
       });
 
+      const patched = await jsonTool(writeCtx, 'apply_patch', {
+        repo_id: repoId,
+        path: 'docs/generated.txt',
+        expected_sha256: statAfterRefresh.sha256,
+        edits: [{ old_text: 'second\n', new_text: 'second patched\n' }],
+      });
+      expect(patched.error).toBeUndefined();
+      expect(patched).toMatchObject({
+        path: 'docs/generated.txt',
+        operation: 'patch',
+        before: { sha256: statAfterRefresh.sha256, size: 'second\n'.length },
+        patch: { format: 'structured_edits', applied_count: 1 },
+        index: { action: 'refresh_repo_index_required', changed_paths: ['docs/generated.txt'] },
+      });
+      expect(patched.mutation_id).toMatch(/^mut_[a-f0-9]{16}$/);
+      expect(patched.index.invalidation_id).toMatch(/^idxinv_[a-f0-9]{16}$/);
+      expect(patched.after.sha256).not.toBe(statAfterRefresh.sha256);
+      expect(readFileSync(join(repoRoot, 'docs', 'generated.txt'), 'utf-8')).toBe('second patched\n');
+      expect(readdirSync(join(repoRoot, 'docs')).some((name) => name.includes('.repo-harness-'))).toBe(false);
+
+      const stalePatch = await jsonTool(writeCtx, 'apply_patch', {
+        repo_id: repoId,
+        path: 'docs/generated.txt',
+        expected_sha256: statAfterRefresh.sha256,
+        edits: [{ old_text: 'second patched', new_text: 'stale write' }],
+      });
+      expect(stalePatch.error.code).toBe('REVISION_CONFLICT');
+      expect(stalePatch.error.details.actual_sha256).toBe(patched.after.sha256);
+      expect(readFileSync(join(repoRoot, 'docs', 'generated.txt'), 'utf-8')).toBe('second patched\n');
+
+      writeFileSync(join(repoRoot, 'docs', 'ambiguous.txt'), 'same\nsame\n');
+      const ambiguousStat = await jsonTool(writeCtx, 'stat_file', { repo_id: repoId, path: 'docs/ambiguous.txt' });
+      const ambiguousPatch = await jsonTool(writeCtx, 'apply_patch', {
+        repo_id: repoId,
+        path: 'docs/ambiguous.txt',
+        expected_sha256: ambiguousStat.sha256,
+        edits: [{ old_text: 'same', new_text: 'changed' }],
+      });
+      expect(ambiguousPatch.error.code).toBe('REVISION_CONFLICT');
+      expect(readFileSync(join(repoRoot, 'docs', 'ambiguous.txt'), 'utf-8')).toBe('same\nsame\n');
+
+      const occurrencePatch = await jsonTool(writeCtx, 'apply_patch', {
+        repo_id: repoId,
+        path: 'docs/ambiguous.txt',
+        expected_sha256: ambiguousStat.sha256,
+        edits: [{ old_text: 'same', new_text: 'changed', occurrence: 2 }],
+      });
+      expect(occurrencePatch.error).toBeUndefined();
+      expect(readFileSync(join(repoRoot, 'docs', 'ambiguous.txt'), 'utf-8')).toBe('same\nchanged\n');
+
+      writeFileSync(join(repoRoot, 'docs', 'unified.txt'), 'alpha\nbeta\ngamma\n');
+      const unifiedStat = await jsonTool(writeCtx, 'stat_file', { repo_id: repoId, path: 'docs/unified.txt' });
+      const unifiedPatch = await jsonTool(writeCtx, 'apply_patch', {
+        repo_id: repoId,
+        path: 'docs/unified.txt',
+        expected_sha256: unifiedStat.sha256,
+        unified_diff: [
+          '--- a/docs/unified.txt',
+          '+++ b/docs/unified.txt',
+          '@@ -1,3 +1,3 @@',
+          ' alpha',
+          '-beta',
+          '+bravo',
+          ' gamma',
+        ].join('\n'),
+      });
+      expect(unifiedPatch.error).toBeUndefined();
+      expect(unifiedPatch.patch).toMatchObject({ format: 'unified_diff', applied_count: 1 });
+      expect(readFileSync(join(repoRoot, 'docs', 'unified.txt'), 'utf-8')).toBe('alpha\nbravo\ngamma\n');
+
       const ignored = await jsonTool(writeCtx, 'write_file', {
         repo_id: repoId,
         path: 'ignored.md',
@@ -485,10 +563,13 @@ describe('MCP reader tools', () => {
 
       const auditText = readFileSync(join(repoRoot, '.ai', 'harness', 'mcp', 'audit.log'), 'utf-8');
       expect(auditText).toContain('"tool":"write_file"');
+      expect(auditText).toContain('"tool":"apply_patch"');
       expect(auditText).toContain('"status":"ok"');
       expect(auditText).toContain('"status":"blocked"');
       expect(auditText).not.toContain('first\n');
       expect(auditText).not.toContain('second\n');
+      expect(auditText).not.toContain('second patched\n');
+      expect(auditText).not.toContain('bravo');
       expect(auditText).not.toContain('stale\n');
     }, { accessMode: 'read_write' });
   });

--- a/tests/cli/mcp-reader-tools.test.ts
+++ b/tests/cli/mcp-reader-tools.test.ts
@@ -865,6 +865,100 @@ describe('MCP reader tools', () => {
 	    }, { accessMode: 'read_write' });
 	  });
 
+	  test('write mutations revalidate locked preconditions immediately before commit', async () => {
+	    await withReaderRepo(async (repoRoot, ctx) => {
+	      const tripped = new Set<string>();
+	      const raceCtx = createReaderToolContext(
+	        repoRoot,
+	        ctx.policy,
+	        new WorkspaceManager({ allowedRoots: [repoRoot], policy: ctx.policy }),
+	        undefined,
+	        {
+	          beforeMutationCommit(event) {
+	            const trip = (name: string, fn: () => void): void => {
+	              if (tripped.has(name)) return;
+	              tripped.add(name);
+	              fn();
+	            };
+	            if (event.tool === 'write_file' && event.paths.includes('docs/replace-race.txt')) {
+	              trip('replace', () => writeFileSync(join(repoRoot, 'docs', 'replace-race.txt'), 'external replace\n'));
+	            }
+	            if (event.tool === 'write_file' && event.paths.includes('docs/create-race.txt')) {
+	              trip('create', () => writeFileSync(join(repoRoot, 'docs', 'create-race.txt'), 'external create\n'));
+	            }
+	            if (event.tool === 'apply_patch' && event.paths.includes('docs/patch-race.txt')) {
+	              trip('patch', () => writeFileSync(join(repoRoot, 'docs', 'patch-race.txt'), 'external patch\n'));
+	            }
+	            if (event.tool === 'move_path' && event.paths.includes('docs/move-target-race.txt')) {
+	              trip('move', () => writeFileSync(join(repoRoot, 'docs', 'move-target-race.txt'), 'external move target\n'));
+	            }
+	            if (event.tool === 'delete_path' && event.paths.includes('docs/delete-race.txt')) {
+	              trip('delete', () => writeFileSync(join(repoRoot, 'docs', 'delete-race.txt'), 'external delete\n'));
+	            }
+	          },
+	        },
+	      );
+	      const repoId = (await jsonTool(raceCtx, 'list_allowed_roots')).roots[0].repo_id;
+
+	      writeFileSync(join(repoRoot, 'docs', 'replace-race.txt'), 'old replace\n');
+	      const replaceStat = await jsonTool(raceCtx, 'stat_file', { repo_id: repoId, path: 'docs/replace-race.txt' });
+	      const replaceRace = await jsonTool(raceCtx, 'write_file', {
+	        repo_id: repoId,
+	        path: 'docs/replace-race.txt',
+	        content: 'tool replace\n',
+	        expected_sha256: replaceStat.sha256,
+	      });
+	      expect(replaceRace.error.code).toBe('REVISION_CONFLICT');
+	      expect(readFileSync(join(repoRoot, 'docs', 'replace-race.txt'), 'utf-8')).toBe('external replace\n');
+
+	      const createRace = await jsonTool(raceCtx, 'write_file', {
+	        repo_id: repoId,
+	        path: 'docs/create-race.txt',
+	        content: 'tool create\n',
+	        must_not_exist: true,
+	      });
+	      expect(createRace.error.code).toBe('TARGET_EXISTS');
+	      expect(readFileSync(join(repoRoot, 'docs', 'create-race.txt'), 'utf-8')).toBe('external create\n');
+
+	      writeFileSync(join(repoRoot, 'docs', 'patch-race.txt'), 'old patch\n');
+	      const patchStat = await jsonTool(raceCtx, 'stat_file', { repo_id: repoId, path: 'docs/patch-race.txt' });
+	      const patchRace = await jsonTool(raceCtx, 'apply_patch', {
+	        repo_id: repoId,
+	        path: 'docs/patch-race.txt',
+	        expected_sha256: patchStat.sha256,
+	        edits: [{ old_text: 'old patch\n', new_text: 'tool patch\n' }],
+	      });
+	      expect(patchRace.error.code).toBe('REVISION_CONFLICT');
+	      expect(readFileSync(join(repoRoot, 'docs', 'patch-race.txt'), 'utf-8')).toBe('external patch\n');
+
+	      writeFileSync(join(repoRoot, 'docs', 'move-source-race.txt'), 'move source\n');
+	      const moveStat = await jsonTool(raceCtx, 'stat_file', { repo_id: repoId, path: 'docs/move-source-race.txt' });
+	      const moveRace = await jsonTool(raceCtx, 'move_path', {
+	        repo_id: repoId,
+	        from_path: 'docs/move-source-race.txt',
+	        to_path: 'docs/move-target-race.txt',
+	        expected_sha256: moveStat.sha256,
+	        must_not_exist: true,
+	      });
+	      expect(moveRace.error.code).toBe('TARGET_EXISTS');
+	      expect(readFileSync(join(repoRoot, 'docs', 'move-source-race.txt'), 'utf-8')).toBe('move source\n');
+	      expect(readFileSync(join(repoRoot, 'docs', 'move-target-race.txt'), 'utf-8')).toBe('external move target\n');
+
+	      writeFileSync(join(repoRoot, 'docs', 'delete-race.txt'), 'delete source\n');
+	      const deleteStat = await jsonTool(raceCtx, 'stat_file', { repo_id: repoId, path: 'docs/delete-race.txt' });
+	      const deleteRace = await jsonTool(raceCtx, 'delete_path', {
+	        repo_id: repoId,
+	        path: 'docs/delete-race.txt',
+	        expected_sha256: deleteStat.sha256,
+	      });
+	      expect(deleteRace.error.code).toBe('REVISION_CONFLICT');
+	      expect(readFileSync(join(repoRoot, 'docs', 'delete-race.txt'), 'utf-8')).toBe('external delete\n');
+	      expect(readdirSync(join(repoRoot, 'docs')).some((name) => name.includes('.repo-harness-'))).toBe(false);
+	      const locksDir = join(repoRoot, '.ai', 'harness', 'mcp', 'locks');
+	      expect(existsSync(locksDir) ? readdirSync(locksDir) : []).toEqual([]);
+	    }, { accessMode: 'read_write' });
+	  });
+
 	  test('write mutations cleanly abort injected pre-commit filesystem faults', async () => {
 	    await withReaderRepo(async (repoRoot, ctx) => {
 	      const writeCtx = createReaderToolContext(

--- a/tests/cli/mcp-reader-tools.test.ts
+++ b/tests/cli/mcp-reader-tools.test.ts
@@ -13,6 +13,29 @@ async function jsonTool(ctx: ReaderToolContext, name: string, args: Record<strin
   return JSON.parse(result.content[0].text);
 }
 
+function readJsonLines(path: string): Record<string, unknown>[] {
+  if (!existsSync(path)) return [];
+  return readFileSync(path, 'utf-8')
+    .trimEnd()
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+async function withMutationFault<T>(point: string, fn: () => Promise<T>): Promise<T> {
+  const previous = process.env.REPO_HARNESS_MCP_MUTATION_FAULT_POINT;
+  try {
+    process.env.REPO_HARNESS_MCP_MUTATION_FAULT_POINT = point;
+    return await fn();
+  } finally {
+    if (previous === undefined) {
+      delete process.env.REPO_HARNESS_MCP_MUTATION_FAULT_POINT;
+    } else {
+      process.env.REPO_HARNESS_MCP_MUTATION_FAULT_POINT = previous;
+    }
+  }
+}
+
 async function withReaderRepo<T>(fn: (repoRoot: string, ctx: ReaderToolContext) => Promise<T>, opts: { accessMode?: RepoHarnessAccessMode } = {}): Promise<T> {
   const repoRoot = mkdtempSync(join(tmpdir(), 'repo-harness-mcp-reader-tools-'));
   const repoHarnessHome = mkdtempSync(join(tmpdir(), 'repo-harness-mcp-home-'));
@@ -405,12 +428,32 @@ describe('MCP reader tools', () => {
       expect(created.index.invalidation_id).toMatch(/^idxinv_[a-f0-9]{16}$/);
       expect(created.index.refresh_tool).toBe('refresh_repo_index');
       expect(created.after.sha256).toMatch(/^[a-f0-9]{64}$/);
-      expect(created.diff.after_sha256).toBe(created.after.sha256);
-      expect(readFileSync(join(repoRoot, 'docs', 'generated.txt'), 'utf-8')).toBe('first\n');
-      expect(readdirSync(join(repoRoot, 'docs')).some((name) => name.includes('.repo-harness-'))).toBe(false);
+	      expect(created.diff.after_sha256).toBe(created.after.sha256);
+	      expect(readFileSync(join(repoRoot, 'docs', 'generated.txt'), 'utf-8')).toBe('first\n');
+	      expect(readdirSync(join(repoRoot, 'docs')).some((name) => name.includes('.repo-harness-'))).toBe(false);
+	      const indexEventsAfterCreate = readJsonLines(join(repoRoot, '.ai', 'harness', 'mcp', 'index-events.jsonl'));
+	      const createdIndexEvent = indexEventsAfterCreate.find((entry) => entry.mutation_id === created.mutation_id);
+	      expect(created.index.event_id).toBe(createdIndexEvent?.event_id);
+	      expect(createdIndexEvent).toMatchObject({
+	        event_type: 'index_invalidation',
+	        status: 'pending',
+	        repo_id: repoId,
+	        operation: 'create',
+	        mutation_id: created.mutation_id,
+	        invalidation_id: created.index.invalidation_id,
+	        relative_paths: ['docs/generated.txt'],
+	        before_index_revision: 'index_before_write',
+	        retry: {
+	          retryable: true,
+	          retry_tool: 'refresh_repo_index',
+	          retry_paths: ['docs/generated.txt'],
+	          manual_recovery: 'bash scripts/ensure-codegraph.sh --sync',
+	        },
+	      });
+	      expect(JSON.stringify(createdIndexEvent)).not.toContain('first\n');
 
-      const readCreated = await jsonTool(writeCtx, 'read_file', { repo_id: repoId, path: 'docs/generated.txt' });
-      expect(readCreated.content).toBe('first\n');
+	      const readCreated = await jsonTool(writeCtx, 'read_file', { repo_id: repoId, path: 'docs/generated.txt' });
+	      expect(readCreated.content).toBe('first\n');
       expect(readCreated.sha256).toBe(created.after.sha256);
 
       const targetExists = await jsonTool(writeCtx, 'write_file', {
@@ -460,31 +503,56 @@ describe('MCP reader tools', () => {
       expect(searchBeforeRefresh.backend).toBe('codegraph-metadata+filesystem-fallback');
       expect(searchBeforeRefresh.matches).toMatchObject([{ path: 'docs/generated.txt', indexed: false }]);
 
-      const refreshed = await jsonTool(writeCtx, 'refresh_repo_index', {
-        repo_id: repoId,
-        paths: ['docs/generated.txt'],
-      });
-      expect(refreshed).toMatchObject({
-        paths: ['docs/generated.txt'],
-        refreshed: true,
+	      const refreshed = await jsonTool(writeCtx, 'refresh_repo_index', {
+	        repo_id: repoId,
+	        paths: ['docs/generated.txt'],
+	        mutation_id: replaced.mutation_id,
+	      });
+	      const refreshedEventId = refreshed.index.event_id;
+	      const refreshedSourceEventId = refreshed.refresh.source_event_id;
+	      expect(typeof refreshedEventId).toBe('string');
+	      expect(typeof refreshedSourceEventId).toBe('string');
+	      expect(refreshed).toMatchObject({
+	        paths: ['docs/generated.txt'],
+	        refreshed: true,
         index_state: 'ready',
         refresh: {
           strategy: 'repo-sync',
           requested_paths: ['docs/generated.txt'],
           path_refresh_supported: false,
-          before_index_revision: 'index_before_write',
-          adapter_index_revision: 'index_after_write',
-          after_index_revision: 'index_after_write',
-          indexed_files: 1,
-        },
-        index: {
-          state: 'ready',
-          action: 'refresh_complete',
-          refreshed_paths: ['docs/generated.txt'],
-        },
-      });
-      expect(refreshCalls).toEqual([['docs/generated.txt']]);
-      const statAfterRefresh = await jsonTool(writeCtx, 'stat_file', { repo_id: repoId, path: 'docs/generated.txt' });
+	          before_index_revision: 'index_before_write',
+	          adapter_index_revision: 'index_after_write',
+	          after_index_revision: 'index_after_write',
+	          indexed_files: 1,
+	          source_event_id: refreshedSourceEventId,
+	          mutation_id: replaced.mutation_id,
+	          index_lag_ms: expect.any(Number),
+	        },
+	        index: {
+	          state: 'ready',
+	          action: 'refresh_complete',
+	          refreshed_paths: ['docs/generated.txt'],
+	          mutation_id: replaced.mutation_id,
+	          event_id: refreshedEventId,
+	          event_log: '.ai/harness/mcp/index-events.jsonl',
+	          index_lag_ms: expect.any(Number),
+	        },
+	      });
+	      expect(refreshCalls).toEqual([['docs/generated.txt']]);
+	      const indexEventsAfterRefresh = readJsonLines(join(repoRoot, '.ai', 'harness', 'mcp', 'index-events.jsonl'));
+	      const refreshEvent = indexEventsAfterRefresh.find((entry) => entry.event_type === 'index_refresh' && entry.mutation_id === replaced.mutation_id);
+	      expect(refreshEvent?.event_id).toBe(refreshedEventId);
+	      expect(refreshEvent).toMatchObject({
+	        event_type: 'index_refresh',
+	        status: 'ready',
+	        repo_id: repoId,
+	        operation: 'refresh_repo_index',
+	        mutation_id: replaced.mutation_id,
+	        source_event_id: refreshedSourceEventId,
+	        relative_paths: ['docs/generated.txt'],
+	        index_lag_ms: expect.any(Number),
+	      });
+	      const statAfterRefresh = await jsonTool(writeCtx, 'stat_file', { repo_id: repoId, path: 'docs/generated.txt' });
       expect(statAfterRefresh).toMatchObject({
         indexed: true,
         codegraph_language: 'text',
@@ -637,19 +705,36 @@ describe('MCP reader tools', () => {
         expected_sha256: deleteStat.sha256,
       });
       expect(deleted.error).toBeUndefined();
-      expect(deleted).toMatchObject({
-        path: 'docs/moved.txt',
-        operation: 'delete',
-        before: { existed: true, sha256: deleteStat.sha256, size: 'move me\n'.length },
+	      expect(deleted).toMatchObject({
+	        path: 'docs/moved.txt',
+	        operation: 'delete',
+	        before: { existed: true, sha256: deleteStat.sha256, size: 'move me\n'.length },
         after: { existed: false, sha256: null, size: 0 },
         deleted: { path: 'docs/moved.txt', type: 'file' },
         index: { action: 'refresh_repo_index_required', changed_paths: ['docs/moved.txt'] },
-      });
-      expect(existsSync(join(repoRoot, 'docs', 'moved.txt'))).toBe(false);
-      const readDeleted = await jsonTool(writeCtx, 'read_file', { repo_id: repoId, path: 'docs/moved.txt' });
-      expect(readDeleted.error.code).toBe('NOT_FOUND');
+	      });
+	      expect(existsSync(join(repoRoot, 'docs', 'moved.txt'))).toBe(false);
+	      const readDeleted = await jsonTool(writeCtx, 'read_file', { repo_id: repoId, path: 'docs/moved.txt' });
+	      expect(readDeleted.error.code).toBe('NOT_FOUND');
+	      const refreshedAfterDelete = await jsonTool(writeCtx, 'refresh_repo_index', {
+	        repo_id: repoId,
+	        paths: ['docs/moved.txt'],
+	        mutation_id: deleted.mutation_id,
+	      });
+	      expect(refreshedAfterDelete.error).toBeUndefined();
+	      expect(refreshedAfterDelete).toMatchObject({
+	        paths: ['docs/moved.txt'],
+	        refreshed: true,
+	        index: {
+	          action: 'refresh_complete',
+	          refreshed_paths: ['docs/moved.txt'],
+	          mutation_id: deleted.mutation_id,
+	          source_event_id: deleted.index.event_id,
+	        },
+	      });
+	      expect(refreshCalls.at(-1)).toEqual(['docs/moved.txt']);
 
-      const directoryDelete = await jsonTool(writeCtx, 'delete_path', {
+	      const directoryDelete = await jsonTool(writeCtx, 'delete_path', {
         repo_id: repoId,
         path: 'docs',
         expected_sha256: 'unused',
@@ -670,16 +755,74 @@ describe('MCP reader tools', () => {
         must_not_exist: true,
       });
       expect(ignored.error.code).toBe('PATH_IGNORED');
-      const missingParent = await jsonTool(writeCtx, 'write_file', {
-        repo_id: repoId,
-        path: 'missing-dir/file.txt',
-        content: 'blocked\n',
-        must_not_exist: true,
-      });
-      expect(missingParent.error.code).toBe('NOT_FOUND');
+	      const missingParent = await jsonTool(writeCtx, 'write_file', {
+	        repo_id: repoId,
+	        path: 'missing-dir/file.txt',
+	        content: 'blocked\n',
+	        must_not_exist: true,
+	      });
+	      expect(missingParent.error.code).toBe('NOT_FOUND');
 
-      const auditText = readFileSync(join(repoRoot, '.ai', 'harness', 'mcp', 'audit.log'), 'utf-8');
-      expect(auditText).toContain('"tool":"write_file"');
+	      const failingCodeGraph: GeneralRepoCodeGraphAdapter = {
+	        discoverRepo() {
+	          return {
+	            available: true,
+	            integrated: true,
+	            source: 'test-double',
+	            indexRevision: 'index_before_failed_refresh',
+	            latencyMs: 1,
+	            files: [],
+	          };
+	        },
+	        refreshRepo(_repoRoot, opts = {}) {
+	          return {
+	            available: false,
+	            refreshed: false,
+	            integrated: true,
+	            source: 'test-double',
+	            indexRevision: 'index_before_failed_refresh',
+	            latencyMs: 4,
+	            strategy: 'repo-sync',
+	            requestedPaths: opts.paths ?? [],
+	            pathRefreshSupported: false,
+	            files: 0,
+	            error: {
+	              code: 'INDEX_UNAVAILABLE',
+	              message: 'OPENAI_API_KEY=sk-testsecret refresh failed',
+	              retryable: true,
+	            },
+	          };
+	        },
+	      };
+	      const failingCtx = createReaderToolContext(
+	        repoRoot,
+	        ctx.policy,
+	        new WorkspaceManager({ allowedRoots: [repoRoot], policy: ctx.policy }),
+	        failingCodeGraph,
+	      );
+	      const failedRefresh = await jsonTool(failingCtx, 'refresh_repo_index', {
+	        repo_id: repoId,
+	        paths: ['docs/generated.txt'],
+	        mutation_id: patched.mutation_id,
+	      });
+	      expect(failedRefresh.error.code).toBe('INDEX_UNAVAILABLE');
+	      expect(failedRefresh.error.retryable).toBe(true);
+	      const failedRefreshEvent = readJsonLines(join(repoRoot, '.ai', 'harness', 'mcp', 'index-events.jsonl'))
+	        .find((entry) => entry.event_type === 'index_refresh' && entry.status === 'failed' && entry.mutation_id === patched.mutation_id);
+	      expect(failedRefreshEvent).toMatchObject({
+	        operation: 'refresh_repo_index',
+	        relative_paths: ['docs/generated.txt'],
+	        error: { code: 'INDEX_UNAVAILABLE', retryable: true },
+	        dead_letter: {
+	          retry_tool: 'refresh_repo_index',
+	          retry_paths: ['docs/generated.txt'],
+	          manual_recovery: 'bash scripts/ensure-codegraph.sh --sync',
+	        },
+	      });
+	      expect(JSON.stringify(failedRefreshEvent)).not.toContain('sk-testsecret');
+
+	      const auditText = readFileSync(join(repoRoot, '.ai', 'harness', 'mcp', 'audit.log'), 'utf-8');
+	      expect(auditText).toContain('"tool":"write_file"');
       expect(auditText).toContain('"tool":"apply_patch"');
       expect(auditText).toContain('"tool":"move_path"');
       expect(auditText).toContain('"tool":"delete_path"');
@@ -689,13 +832,111 @@ describe('MCP reader tools', () => {
       expect(auditText).not.toContain('second\n');
       expect(auditText).not.toContain('second patched\n');
       expect(auditText).not.toContain('bravo');
-      expect(auditText).not.toContain('move me\n');
-      expect(auditText).not.toContain('changed\n');
-      expect(auditText).not.toContain('stale\n');
-    }, { accessMode: 'read_write' });
-  });
+	      expect(auditText).not.toContain('move me\n');
+	      expect(auditText).not.toContain('changed\n');
+	      expect(auditText).not.toContain('stale\n');
+	      const auditEntries = readJsonLines(join(repoRoot, '.ai', 'harness', 'mcp', 'audit.log'));
+	      const createdAudit = auditEntries.find((entry) => entry.tool === 'write_file' && entry.mutationId === created.mutation_id);
+	      expect(createdAudit).toMatchObject({
+	        status: 'ok',
+	        actor: 'mcp:planner',
+	        repoId,
+	        operation: 'create',
+	        relativePaths: ['docs/generated.txt'],
+	        mutationId: created.mutation_id,
+	        indexInvalidationId: created.index.invalidation_id,
+	        indexEventId: created.index.event_id,
+	        result: 'ok',
+	        fileHashes: {
+	          before_sha256: null,
+	          after_sha256: created.after.sha256,
+	        },
+	      });
+	      expect(typeof createdAudit?.durationMs).toBe('number');
+	      const blockedDeleteAudit = auditEntries.find((entry) => entry.tool === 'delete_path' && entry.errorCode === 'REVISION_CONFLICT');
+	      expect(blockedDeleteAudit).toMatchObject({
+	        status: 'blocked',
+	        repoId,
+	        relativePaths: ['docs/moved.txt'],
+	        result: 'blocked',
+	        errorCode: 'REVISION_CONFLICT',
+	      });
+	      expect(JSON.stringify(auditEntries)).not.toContain('OPENAI_API_KEY=sk-testsecret refresh failed');
+	    }, { accessMode: 'read_write' });
+	  });
 
-  test('general repo tools merge CodeGraph metadata under the same guarded snapshot', async () => {
+	  test('write mutations cleanly abort injected pre-commit filesystem faults', async () => {
+	    await withReaderRepo(async (repoRoot, ctx) => {
+	      const writeCtx = createReaderToolContext(
+	        repoRoot,
+	        ctx.policy,
+	        new WorkspaceManager({ allowedRoots: [repoRoot], policy: ctx.policy }),
+	      );
+	      const repoId = (await jsonTool(writeCtx, 'list_allowed_roots')).roots[0].repo_id;
+
+	      const createFault = await withMutationFault('atomic_write_before_rename', () => jsonTool(writeCtx, 'write_file', {
+	        repo_id: repoId,
+	        path: 'docs/fault-create.txt',
+	        content: 'new\n',
+	        must_not_exist: true,
+	      }));
+	      expect(createFault.error.code).toBe('INJECTED_MUTATION_FAULT');
+	      expect(existsSync(join(repoRoot, 'docs', 'fault-create.txt'))).toBe(false);
+	      expect(readdirSync(join(repoRoot, 'docs')).some((name) => name.includes('.repo-harness-'))).toBe(false);
+
+	      writeFileSync(join(repoRoot, 'docs', 'fault-replace.txt'), 'old\n');
+	      const replaceStat = await jsonTool(writeCtx, 'stat_file', { repo_id: repoId, path: 'docs/fault-replace.txt' });
+	      const replaceFault = await withMutationFault('atomic_write_before_rename', () => jsonTool(writeCtx, 'write_file', {
+	        repo_id: repoId,
+	        path: 'docs/fault-replace.txt',
+	        content: 'new\n',
+	        expected_sha256: replaceStat.sha256,
+	      }));
+	      expect(replaceFault.error.code).toBe('INJECTED_MUTATION_FAULT');
+	      expect(readFileSync(join(repoRoot, 'docs', 'fault-replace.txt'), 'utf-8')).toBe('old\n');
+	      expect(readdirSync(join(repoRoot, 'docs')).some((name) => name.includes('.repo-harness-'))).toBe(false);
+
+	      const patchFault = await withMutationFault('atomic_write_before_rename', () => jsonTool(writeCtx, 'apply_patch', {
+	        repo_id: repoId,
+	        path: 'docs/fault-replace.txt',
+	        expected_sha256: replaceStat.sha256,
+	        edits: [{ old_text: 'old\n', new_text: 'patched\n' }],
+	      }));
+	      expect(patchFault.error.code).toBe('INJECTED_MUTATION_FAULT');
+	      expect(readFileSync(join(repoRoot, 'docs', 'fault-replace.txt'), 'utf-8')).toBe('old\n');
+	      expect(readdirSync(join(repoRoot, 'docs')).some((name) => name.includes('.repo-harness-'))).toBe(false);
+
+	      writeFileSync(join(repoRoot, 'docs', 'fault-move.txt'), 'move\n');
+	      const moveStat = await jsonTool(writeCtx, 'stat_file', { repo_id: repoId, path: 'docs/fault-move.txt' });
+	      const moveFault = await withMutationFault('move_before_rename', () => jsonTool(writeCtx, 'move_path', {
+	        repo_id: repoId,
+	        from_path: 'docs/fault-move.txt',
+	        to_path: 'docs/fault-moved.txt',
+	        expected_sha256: moveStat.sha256,
+	        must_not_exist: true,
+	      }));
+	      expect(moveFault.error.code).toBe('INJECTED_MUTATION_FAULT');
+	      expect(readFileSync(join(repoRoot, 'docs', 'fault-move.txt'), 'utf-8')).toBe('move\n');
+	      expect(existsSync(join(repoRoot, 'docs', 'fault-moved.txt'))).toBe(false);
+
+	      const deleteFault = await withMutationFault('delete_before_unlink', () => jsonTool(writeCtx, 'delete_path', {
+	        repo_id: repoId,
+	        path: 'docs/fault-move.txt',
+	        expected_sha256: moveStat.sha256,
+	      }));
+	      expect(deleteFault.error.code).toBe('INJECTED_MUTATION_FAULT');
+	      expect(readFileSync(join(repoRoot, 'docs', 'fault-move.txt'), 'utf-8')).toBe('move\n');
+	      expect(readJsonLines(join(repoRoot, '.ai', 'harness', 'mcp', 'index-events.jsonl'))).toEqual([]);
+
+	      const auditText = readFileSync(join(repoRoot, '.ai', 'harness', 'mcp', 'audit.log'), 'utf-8');
+	      expect(auditText).toContain('"errorCode":"INJECTED_MUTATION_FAULT"');
+	      expect(auditText).not.toContain('new\n');
+	      expect(auditText).not.toContain('patched\n');
+	      expect(auditText).not.toContain('move\n');
+	    }, { accessMode: 'read_write' });
+	  });
+
+	  test('general repo tools merge CodeGraph metadata under the same guarded snapshot', async () => {
     await withReaderRepo(async (repoRoot, ctx) => {
       writeFileSync(join(repoRoot, '.ignore'), 'ignored.md\n');
       const fakeCodeGraph: GeneralRepoCodeGraphAdapter = {

--- a/tests/cli/mcp-reader-tools.test.ts
+++ b/tests/cli/mcp-reader-tools.test.ts
@@ -91,10 +91,12 @@ describe('MCP reader tools', () => {
         'stat_file',
         'write_file',
         'apply_patch',
+        'move_path',
+        'delete_path',
         'refresh_repo_index',
       ]);
       for (const definition of definitions) {
-        if (definition.name === 'write_file' || definition.name === 'apply_patch' || definition.name === 'refresh_repo_index') {
+        if (definition.name === 'write_file' || definition.name === 'apply_patch' || definition.name === 'move_path' || definition.name === 'delete_path' || definition.name === 'refresh_repo_index') {
           expect(definition.annotations).toMatchObject({
             readOnlyHint: false,
             destructiveHint: true,
@@ -191,6 +193,20 @@ describe('MCP reader tools', () => {
           edits: [{ old_text: 'authentication', new_text: 'authorization' }],
         });
         expect(readOnlyPatch.error.code).toBe('WRITE_DISABLED');
+        const readOnlyMove = await jsonTool(ctx, 'move_path', {
+          repo_id: repoId,
+          from_path: 'docs/design.md',
+          to_path: 'docs/moved.md',
+          expected_sha256: 'unused',
+          must_not_exist: true,
+        });
+        expect(readOnlyMove.error.code).toBe('WRITE_DISABLED');
+        const readOnlyDelete = await jsonTool(ctx, 'delete_path', {
+          repo_id: repoId,
+          path: 'docs/design.md',
+          expected_sha256: 'unused',
+        });
+        expect(readOnlyDelete.error.code).toBe('WRITE_DISABLED');
         const readOnlyRefresh = await jsonTool(ctx, 'refresh_repo_index', { repo_id: repoId, paths: ['docs/design.md'] });
         expect(readOnlyRefresh.error.code).toBe('WRITE_DISABLED');
 
@@ -361,7 +377,7 @@ describe('MCP reader tools', () => {
       const repoId = (await jsonTool(writeCtx, 'list_allowed_roots')).roots[0].repo_id;
       const capabilities = await jsonTool(writeCtx, 'get_repo_capabilities', { repo_id: repoId });
       expect(capabilities.access_mode).toBe('read_write');
-      expect(capabilities.write_tools).toEqual(['write_file', 'apply_patch', 'refresh_repo_index']);
+      expect(capabilities.write_tools).toEqual(['write_file', 'apply_patch', 'move_path', 'delete_path', 'refresh_repo_index']);
 
       const missingCreatePrecondition = await jsonTool(writeCtx, 'write_file', {
         repo_id: repoId,
@@ -546,6 +562,107 @@ describe('MCP reader tools', () => {
       expect(unifiedPatch.patch).toMatchObject({ format: 'unified_diff', applied_count: 1 });
       expect(readFileSync(join(repoRoot, 'docs', 'unified.txt'), 'utf-8')).toBe('alpha\nbravo\ngamma\n');
 
+      writeFileSync(join(repoRoot, 'docs', 'move-source.txt'), 'move me\n');
+      const moveStat = await jsonTool(writeCtx, 'stat_file', { repo_id: repoId, path: 'docs/move-source.txt' });
+      const moveWithoutTargetPrecondition = await jsonTool(writeCtx, 'move_path', {
+        repo_id: repoId,
+        from_path: 'docs/move-source.txt',
+        to_path: 'docs/moved.txt',
+        expected_sha256: moveStat.sha256,
+      });
+      expect(moveWithoutTargetPrecondition.error.code).toBe('REVISION_CONFLICT');
+      expect(existsSync(join(repoRoot, 'docs', 'move-source.txt'))).toBe(true);
+      expect(existsSync(join(repoRoot, 'docs', 'moved.txt'))).toBe(false);
+
+      const moved = await jsonTool(writeCtx, 'move_path', {
+        repo_id: repoId,
+        from_path: 'docs/move-source.txt',
+        to_path: 'docs/moved.txt',
+        expected_sha256: moveStat.sha256,
+        must_not_exist: true,
+      });
+      expect(moved.error).toBeUndefined();
+      expect(moved).toMatchObject({
+        path: 'docs/moved.txt',
+        operation: 'move',
+        from_path: 'docs/move-source.txt',
+        to_path: 'docs/moved.txt',
+        before: { sha256: moveStat.sha256, size: 'move me\n'.length },
+        index: { action: 'refresh_repo_index_required', changed_paths: ['docs/move-source.txt', 'docs/moved.txt'] },
+      });
+      expect(moved.after.sha256).toBe(moveStat.sha256);
+      expect(existsSync(join(repoRoot, 'docs', 'move-source.txt'))).toBe(false);
+      expect(readFileSync(join(repoRoot, 'docs', 'moved.txt'), 'utf-8')).toBe('move me\n');
+      expect(readdirSync(join(repoRoot, 'docs')).some((name) => name.includes('.repo-harness-'))).toBe(false);
+
+      writeFileSync(join(repoRoot, 'docs', 'stale-move.txt'), 'original\n');
+      const staleMoveStat = await jsonTool(writeCtx, 'stat_file', { repo_id: repoId, path: 'docs/stale-move.txt' });
+      writeFileSync(join(repoRoot, 'docs', 'stale-move.txt'), 'changed\n');
+      const staleMove = await jsonTool(writeCtx, 'move_path', {
+        repo_id: repoId,
+        from_path: 'docs/stale-move.txt',
+        to_path: 'docs/stale-moved.txt',
+        expected_sha256: staleMoveStat.sha256,
+        must_not_exist: true,
+      });
+      expect(staleMove.error.code).toBe('REVISION_CONFLICT');
+      expect(readFileSync(join(repoRoot, 'docs', 'stale-move.txt'), 'utf-8')).toBe('changed\n');
+      expect(existsSync(join(repoRoot, 'docs', 'stale-moved.txt'))).toBe(false);
+
+      writeFileSync(join(repoRoot, 'docs', 'existing-target.txt'), 'target\n');
+      const targetExistsMove = await jsonTool(writeCtx, 'move_path', {
+        repo_id: repoId,
+        from_path: 'docs/stale-move.txt',
+        to_path: 'docs/existing-target.txt',
+        expected_sha256: staleMove.error.details.actual_sha256,
+        must_not_exist: true,
+      });
+      expect(targetExistsMove.error.code).toBe('TARGET_EXISTS');
+      expect(readFileSync(join(repoRoot, 'docs', 'stale-move.txt'), 'utf-8')).toBe('changed\n');
+      expect(readFileSync(join(repoRoot, 'docs', 'existing-target.txt'), 'utf-8')).toBe('target\n');
+
+      const deleteStat = await jsonTool(writeCtx, 'stat_file', { repo_id: repoId, path: 'docs/moved.txt' });
+      const staleDelete = await jsonTool(writeCtx, 'delete_path', {
+        repo_id: repoId,
+        path: 'docs/moved.txt',
+        expected_sha256: 'bad',
+      });
+      expect(staleDelete.error.code).toBe('REVISION_CONFLICT');
+      expect(staleDelete.error.details.actual_sha256).toBe(deleteStat.sha256);
+      expect(readFileSync(join(repoRoot, 'docs', 'moved.txt'), 'utf-8')).toBe('move me\n');
+
+      const deleted = await jsonTool(writeCtx, 'delete_path', {
+        repo_id: repoId,
+        path: 'docs/moved.txt',
+        expected_sha256: deleteStat.sha256,
+      });
+      expect(deleted.error).toBeUndefined();
+      expect(deleted).toMatchObject({
+        path: 'docs/moved.txt',
+        operation: 'delete',
+        before: { existed: true, sha256: deleteStat.sha256, size: 'move me\n'.length },
+        after: { existed: false, sha256: null, size: 0 },
+        deleted: { path: 'docs/moved.txt', type: 'file' },
+        index: { action: 'refresh_repo_index_required', changed_paths: ['docs/moved.txt'] },
+      });
+      expect(existsSync(join(repoRoot, 'docs', 'moved.txt'))).toBe(false);
+      const readDeleted = await jsonTool(writeCtx, 'read_file', { repo_id: repoId, path: 'docs/moved.txt' });
+      expect(readDeleted.error.code).toBe('NOT_FOUND');
+
+      const directoryDelete = await jsonTool(writeCtx, 'delete_path', {
+        repo_id: repoId,
+        path: 'docs',
+        expected_sha256: 'unused',
+      });
+      expect(directoryDelete.error.code).toBe('NOT_A_FILE');
+      const recursiveDelete = await jsonTool(writeCtx, 'delete_path', {
+        repo_id: repoId,
+        path: 'docs',
+        expected_sha256: 'unused',
+        recursive: true,
+      });
+      expect(recursiveDelete.error.code).toBe('INVALID_RANGE');
+
       const ignored = await jsonTool(writeCtx, 'write_file', {
         repo_id: repoId,
         path: 'ignored.md',
@@ -564,12 +681,16 @@ describe('MCP reader tools', () => {
       const auditText = readFileSync(join(repoRoot, '.ai', 'harness', 'mcp', 'audit.log'), 'utf-8');
       expect(auditText).toContain('"tool":"write_file"');
       expect(auditText).toContain('"tool":"apply_patch"');
+      expect(auditText).toContain('"tool":"move_path"');
+      expect(auditText).toContain('"tool":"delete_path"');
       expect(auditText).toContain('"status":"ok"');
       expect(auditText).toContain('"status":"blocked"');
       expect(auditText).not.toContain('first\n');
       expect(auditText).not.toContain('second\n');
       expect(auditText).not.toContain('second patched\n');
       expect(auditText).not.toContain('bravo');
+      expect(auditText).not.toContain('move me\n');
+      expect(auditText).not.toContain('changed\n');
       expect(auditText).not.toContain('stale\n');
     }, { accessMode: 'read_write' });
   });

--- a/tests/cli/mcp-reader-tools.test.ts
+++ b/tests/cli/mcp-reader-tools.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from 'bun:test';
-import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { repoHarnessRepoIdFor, type RepoHarnessAccessMode } from '../../src/effects/repo-registry';
 import { getMcpPolicy } from '../../src/cli/mcp/policy';
 import { buildReaderToolDefinitions, callReaderTool, createReaderToolContext, type ReaderToolContext } from '../../src/cli/mcp/reader-tools';
 import { WorkspaceManager } from '../../src/cli/mcp/workspaces';
@@ -12,9 +13,12 @@ async function jsonTool(ctx: ReaderToolContext, name: string, args: Record<strin
   return JSON.parse(result.content[0].text);
 }
 
-async function withReaderRepo<T>(fn: (repoRoot: string, ctx: ReaderToolContext) => Promise<T>): Promise<T> {
+async function withReaderRepo<T>(fn: (repoRoot: string, ctx: ReaderToolContext) => Promise<T>, opts: { accessMode?: RepoHarnessAccessMode } = {}): Promise<T> {
   const repoRoot = mkdtempSync(join(tmpdir(), 'repo-harness-mcp-reader-tools-'));
+  const repoHarnessHome = mkdtempSync(join(tmpdir(), 'repo-harness-mcp-home-'));
+  const previousRepoHarnessHome = process.env.REPO_HARNESS_HOME;
   try {
+    process.env.REPO_HARNESS_HOME = repoHarnessHome;
     mkdirSync(join(repoRoot, 'docs'), { recursive: true });
     mkdirSync(join(repoRoot, 'src'), { recursive: true });
     mkdirSync(join(repoRoot, 'secrets'), { recursive: true });
@@ -32,6 +36,23 @@ async function withReaderRepo<T>(fn: (repoRoot: string, ctx: ReaderToolContext) 
     writeFileSync(join(repoRoot, '.ssh', 'id_rsa'), 'private\n');
     writeFileSync(join(repoRoot, 'ignored.md'), '# Ignored\n');
     writeFileSync(join(repoRoot, 'ignored-dir', 'note.md'), '# Ignored child\n');
+    if (opts.accessMode) {
+      const canonicalRoot = realpathSync(repoRoot);
+      mkdirSync(join(repoRoot, '.ai', 'harness'), { recursive: true });
+      writeFileSync(join(repoRoot, '.ai', 'harness', 'policy.json'), '{}\n');
+      mkdirSync(repoHarnessHome, { recursive: true });
+      writeFileSync(join(repoHarnessHome, 'registered-repos.json'), `${JSON.stringify({
+        version: 1,
+        repos: [{
+          id: repoHarnessRepoIdFor(canonicalRoot),
+          path: canonicalRoot,
+          accessMode: opts.accessMode,
+          source: 'manual',
+          registeredAt: '2026-06-23T00:00:00.000Z',
+          lastSeenAt: '2026-06-23T00:00:00.000Z',
+        }],
+      }, null, 2)}\n`);
+    }
     try {
       symlinkSync(repoRoot, join(repoRoot, 'docs', 'loop'));
     } catch (_error) {
@@ -41,12 +62,18 @@ async function withReaderRepo<T>(fn: (repoRoot: string, ctx: ReaderToolContext) 
     const ctx = createReaderToolContext(repoRoot, policy, new WorkspaceManager({ allowedRoots: [repoRoot], policy }));
     return await fn(repoRoot, ctx);
   } finally {
+    if (previousRepoHarnessHome === undefined) {
+      delete process.env.REPO_HARNESS_HOME;
+    } else {
+      process.env.REPO_HARNESS_HOME = previousRepoHarnessHome;
+    }
     rmSync(repoRoot, { recursive: true, force: true });
+    rmSync(repoHarnessHome, { recursive: true, force: true });
   }
 }
 
 describe('MCP reader tools', () => {
-  test('exposes exactly the read-only reader tool registry and session-local workspaces', async () => {
+  test('exposes reader and gated general repo tool registry with session-local workspaces', async () => {
     await withReaderRepo(async (repoRoot, ctx) => {
       const definitions = buildReaderToolDefinitions();
       expect(definitions.map((tool) => tool.name)).toEqual([
@@ -62,14 +89,24 @@ describe('MCP reader tools', () => {
         'read_file',
         'read_files',
         'stat_file',
+        'write_file',
       ]);
       for (const definition of definitions) {
-        expect(definition.annotations).toMatchObject({
-          readOnlyHint: true,
-          destructiveHint: false,
-          idempotentHint: true,
-          openWorldHint: false,
-        });
+        if (definition.name === 'write_file') {
+          expect(definition.annotations).toMatchObject({
+            readOnlyHint: false,
+            destructiveHint: true,
+            idempotentHint: false,
+            openWorldHint: false,
+          });
+        } else {
+          expect(definition.annotations).toMatchObject({
+            readOnlyHint: true,
+            destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
+          });
+        }
         expect(definition.inputSchema.additionalProperties).toBe(false);
       }
 
@@ -133,8 +170,18 @@ describe('MCP reader tools', () => {
 
         const capabilities = await jsonTool(ctx, 'get_repo_capabilities', { repo_id: repoId });
         expect(capabilities.access_mode).toBe('read_only');
+        expect(capabilities.write_tools).toEqual([]);
         expect(capabilities.repo_id).toBe(repoId);
         expect(capabilities.registry_revision).toMatch(/^registry_/);
+
+        const readOnlyWrite = await jsonTool(ctx, 'write_file', {
+          repo_id: repoId,
+          path: 'docs/created-by-write.txt',
+          content: 'blocked\n',
+          must_not_exist: true,
+        });
+        expect(readOnlyWrite.error.code).toBe('WRITE_DISABLED');
+        expect(existsSync(join(repoRoot, 'docs', 'created-by-write.txt'))).toBe(false);
 
         const manifest = await jsonTool(ctx, 'repo_manifest', { repo_id: repoId, page_size: 1000 });
         const visiblePaths = manifest.entries.map((entry: { path: string }) => entry.path);
@@ -256,6 +303,128 @@ describe('MCP reader tools', () => {
         rmSync(outside, { recursive: true, force: true });
       }
     });
+  });
+
+  test('write_file is capability-gated, atomic, and guarded by revision preconditions', async () => {
+    await withReaderRepo(async (repoRoot, ctx) => {
+      writeFileSync(join(repoRoot, '.ignore'), 'ignored.md\n');
+      const fakeCodeGraph: GeneralRepoCodeGraphAdapter = {
+        discoverRepo() {
+          return {
+            available: true,
+            integrated: true,
+            source: 'test-double',
+            indexRevision: 'index_before_write',
+            latencyMs: 1,
+            files: [],
+          };
+        },
+      };
+      const writeCtx = createReaderToolContext(
+        repoRoot,
+        ctx.policy,
+        new WorkspaceManager({ allowedRoots: [repoRoot], policy: ctx.policy }),
+        fakeCodeGraph,
+      );
+      const repoId = (await jsonTool(writeCtx, 'list_allowed_roots')).roots[0].repo_id;
+      const capabilities = await jsonTool(writeCtx, 'get_repo_capabilities', { repo_id: repoId });
+      expect(capabilities.access_mode).toBe('read_write');
+      expect(capabilities.write_tools).toEqual(['write_file']);
+
+      const missingCreatePrecondition = await jsonTool(writeCtx, 'write_file', {
+        repo_id: repoId,
+        path: 'docs/generated.txt',
+        content: 'first\n',
+      });
+      expect(missingCreatePrecondition.error.code).toBe('REVISION_CONFLICT');
+      expect(existsSync(join(repoRoot, 'docs', 'generated.txt'))).toBe(false);
+
+      const created = await jsonTool(writeCtx, 'write_file', {
+        repo_id: repoId,
+        path: 'docs/generated.txt',
+        content: 'first\n',
+        must_not_exist: true,
+      });
+      expect(created.error).toBeUndefined();
+      expect(created).toMatchObject({
+        path: 'docs/generated.txt',
+        operation: 'create',
+        index_state: 'pending',
+        before: { existed: false, sha256: null, size: 0 },
+        index: { action: 'refresh_repo_index_required', changed_paths: ['docs/generated.txt'] },
+      });
+      expect(created.mutation_id).toMatch(/^mut_[a-f0-9]{16}$/);
+      expect(created.after.sha256).toMatch(/^[a-f0-9]{64}$/);
+      expect(created.diff.after_sha256).toBe(created.after.sha256);
+      expect(readFileSync(join(repoRoot, 'docs', 'generated.txt'), 'utf-8')).toBe('first\n');
+      expect(readdirSync(join(repoRoot, 'docs')).some((name) => name.includes('.repo-harness-'))).toBe(false);
+
+      const readCreated = await jsonTool(writeCtx, 'read_file', { repo_id: repoId, path: 'docs/generated.txt' });
+      expect(readCreated.content).toBe('first\n');
+      expect(readCreated.sha256).toBe(created.after.sha256);
+
+      const targetExists = await jsonTool(writeCtx, 'write_file', {
+        repo_id: repoId,
+        path: 'docs/generated.txt',
+        content: 'duplicate\n',
+        must_not_exist: true,
+      });
+      expect(targetExists.error.code).toBe('TARGET_EXISTS');
+      expect(readFileSync(join(repoRoot, 'docs', 'generated.txt'), 'utf-8')).toBe('first\n');
+      expect(readdirSync(join(repoRoot, 'docs')).some((name) => name.includes('.repo-harness-'))).toBe(false);
+
+      const conflict = await jsonTool(writeCtx, 'write_file', {
+        repo_id: repoId,
+        path: 'docs/generated.txt',
+        content: 'stale\n',
+        expected_sha256: 'bad',
+      });
+      expect(conflict.error.code).toBe('REVISION_CONFLICT');
+      expect(conflict.error.details.actual_sha256).toBe(created.after.sha256);
+      expect(readFileSync(join(repoRoot, 'docs', 'generated.txt'), 'utf-8')).toBe('first\n');
+
+      const replaced = await jsonTool(writeCtx, 'write_file', {
+        repo_id: repoId,
+        path: 'docs/generated.txt',
+        content: 'second\n',
+        expected_sha256: created.after.sha256,
+      });
+      expect(replaced.error).toBeUndefined();
+      expect(replaced.operation).toBe('replace');
+      expect(replaced.before.sha256).toBe(created.after.sha256);
+      expect(replaced.after.sha256).not.toBe(created.after.sha256);
+      expect(replaced.diff.bytes_delta).toBe('second\n'.length - 'first\n'.length);
+
+      const readReplaced = await jsonTool(writeCtx, 'read_file', { repo_id: repoId, path: 'docs/generated.txt' });
+      expect(readReplaced.content).toBe('second\n');
+      expect(readReplaced.sha256).toBe(replaced.after.sha256);
+      expect(readdirSync(join(repoRoot, 'docs')).some((name) => name.includes('.repo-harness-'))).toBe(false);
+      const statReplaced = await jsonTool(writeCtx, 'stat_file', { repo_id: repoId, path: 'docs/generated.txt' });
+      expect(statReplaced.sha256).toBe(replaced.after.sha256);
+
+      const ignored = await jsonTool(writeCtx, 'write_file', {
+        repo_id: repoId,
+        path: 'ignored.md',
+        content: 'blocked\n',
+        must_not_exist: true,
+      });
+      expect(ignored.error.code).toBe('PATH_IGNORED');
+      const missingParent = await jsonTool(writeCtx, 'write_file', {
+        repo_id: repoId,
+        path: 'missing-dir/file.txt',
+        content: 'blocked\n',
+        must_not_exist: true,
+      });
+      expect(missingParent.error.code).toBe('NOT_FOUND');
+
+      const auditText = readFileSync(join(repoRoot, '.ai', 'harness', 'mcp', 'audit.log'), 'utf-8');
+      expect(auditText).toContain('"tool":"write_file"');
+      expect(auditText).toContain('"status":"ok"');
+      expect(auditText).toContain('"status":"blocked"');
+      expect(auditText).not.toContain('first\n');
+      expect(auditText).not.toContain('second\n');
+      expect(auditText).not.toContain('stale\n');
+    }, { accessMode: 'read_write' });
   });
 
   test('general repo tools merge CodeGraph metadata under the same guarded snapshot', async () => {

--- a/tests/cli/mcp-setup.test.ts
+++ b/tests/cli/mcp-setup.test.ts
@@ -62,6 +62,7 @@ describe('mcp setup', () => {
       expect(ignore).toContain('.repo-harness/mcp.oauth.json');
       expect(ignore).toContain('.repo-harness/mcp.oauth-tokens.json');
       expect(ignore).toContain('.ai/harness/mcp/audit.log');
+      expect(ignore).toContain('.ai/harness/mcp/index-events.jsonl');
 
       const doctor = JSON.parse(runMcpDoctor({ repo: repoRoot, json: true }).lines[0]);
       expect(doctor.mcp.packageVersion).toBe(repoHarnessPackageVersion());


### PR DESCRIPTION
## Module boundary
S3 replaces the incremental PRs for write_file, refresh_repo_index, guarded apply_patch, move_path/delete_path, mutation recovery, and audit/index-state handling.

## Verification scope
- Sprint plan S3 checklist is marked complete in plans/sprints/20260622-repo-harness-codegraph-sprint-plan.md.
- Existing branch head is the prior S3 tail commit 43cd5b3, preserving the tested implementation history.
- Supersedes PRs #25, #26, #27, #28, and #29.