### PR TITLE
docs: add external verification evidence contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ rollback. Then inspect the active contract, latest trace in
 review recommends pass, the card verdict is pass, and external acceptance is
 pass, `not_required`, or an explicit manual override.
 
+Runtime-heavy validators such as Unity, browser E2E, mobile simulators, hardware
+rigs, or staging smoke tests can publish external verification manifests under
+the ignored run-evidence surface. See
+[`docs/reference-configs/external-tooling.md`](docs/reference-configs/external-tooling.md#external-verification-evidence).
+
 ## Agent Tracking Path
 
 Agents read source artifacts before derived summaries:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -52,6 +52,11 @@ verdict、change type、预期/实际改动文件、已通过命令、external a
 recommend pass、card verdict 为 pass，且 external acceptance 为 pass、not_required
 或明确 manual override 时，才进入 closeout。
 
+Unity、浏览器 E2E、mobile simulator、硬件测试和 staging smoke test 这类
+运行时重验证器，可以把 external verification manifest 写到被忽略的 run-evidence
+surface。详见
+[`docs/reference-configs/external-tooling.md`](docs/reference-configs/external-tooling.md#external-verification-evidence)。
+
 ## Agent Tracking Path
 
 Agent 先读 source artifacts，再读派生摘要：

--- a/assets/reference-configs/external-tooling.md
+++ b/assets/reference-configs/external-tooling.md
@@ -267,6 +267,98 @@ not rewrite Bash commands, require RTK, or suggest compression for failed
 commands. Failed command output stays raw so test, build, and review evidence is
 not hidden by a compressor.
 
+## External Verification Evidence
+
+Runtime-heavy projects often prove work outside normal source files and unit
+test output. Unity, browser E2E, mobile simulators, hardware rigs, and staging
+smoke tests can all produce logs, screenshots, traces, or device output that
+belongs in the harness review flow without making `repo-harness` run those
+tools directly.
+
+The v1 contract is evidence ingestion, not provider invocation:
+
+- external validators run under the project's own tooling and trust boundary
+- providers publish a small manifest plus artifact references
+- `repo-harness` consumes the manifest as check/review/handoff evidence
+- missing, skipped, or partial manifests are validation gaps, not implicit
+  passes
+
+Recommended runtime layout:
+
+```text
+.ai/harness/runs/external/<task-id>/<run-id>/manifest.json
+.ai/harness/runs/external/<task-id>/<run-id>/artifacts/...
+```
+
+This uses the existing ignored run-evidence surface. Durable conclusions should
+be promoted into `tasks/reviews/<task>.review.md`, `tasks/contracts/`,
+`tasks/notes/`, or project documentation instead of committing raw provider
+artifacts by default.
+
+Minimal manifest shape:
+
+```json
+{
+  "schema_version": "repo-harness.external-evidence.v1",
+  "task_id": "20260629-runtime-heavy-ui",
+  "run_id": "20260629T023507Z-aibridge-screenshot",
+  "provider": {
+    "name": "aibridge",
+    "version": "1.5.0"
+  },
+  "subject": {
+    "task_type": "unity.ui",
+    "branch": "feat/example",
+    "commit": "optional",
+    "worktree_dirty": true
+  },
+  "operations": [
+    {
+      "kind": "unity.compile",
+      "command_display": "AIBridgeCLI compile unity",
+      "started_at": "2026-06-29T02:35:07Z",
+      "ended_at": "2026-06-29T02:36:10Z",
+      "exit_code": 0,
+      "outcome": "pass"
+    }
+  ],
+  "artifacts": [
+    {
+      "type": "log",
+      "path": "artifacts/compile.log",
+      "summary": "Unity compile passed with no Console errors",
+      "sha256": "optional",
+      "redacted": true
+    }
+  ],
+  "outcome": {
+    "status": "pass",
+    "summary": "Compile and Console validation passed"
+  },
+  "validation_gaps": [
+    {
+      "severity": "medium",
+      "description": "No PlayMode scenario was run"
+    }
+  ],
+  "safety": {
+    "side_effects": "read_only",
+    "privacy_reviewed": true
+  }
+}
+```
+
+Manifests should prefer repo-relative paths and summaries over absolute local
+paths. Providers should mark whether artifacts are redacted, avoid storing
+secrets or private payloads in durable summaries, and record skipped validation
+explicitly so reviewers can see what was not exercised.
+
+Global agent skills that wrap external validators should be project-gated:
+activate only when the current repo has an explicit local marker or CLI, no-op
+outside that repo, and keep the repo's own AGENTS/CLAUDE/repo-harness routing in
+control. Treat this as activation and DX isolation, not a complete security
+boundary for untrusted repositories.
+
 ## Update
 
 ### gstack

--- a/docs/reference-configs/external-tooling.md
+++ b/docs/reference-configs/external-tooling.md
@@ -267,6 +267,98 @@ not rewrite Bash commands, require RTK, or suggest compression for failed
 commands. Failed command output stays raw so test, build, and review evidence is
 not hidden by a compressor.
 
+## External Verification Evidence
+
+Runtime-heavy projects often prove work outside normal source files and unit
+test output. Unity, browser E2E, mobile simulators, hardware rigs, and staging
+smoke tests can all produce logs, screenshots, traces, or device output that
+belongs in the harness review flow without making `repo-harness` run those
+tools directly.
+
+The v1 contract is evidence ingestion, not provider invocation:
+
+- external validators run under the project's own tooling and trust boundary
+- providers publish a small manifest plus artifact references
+- `repo-harness` consumes the manifest as check/review/handoff evidence
+- missing, skipped, or partial manifests are validation gaps, not implicit
+  passes
+
+Recommended runtime layout:
+
+```text
+.ai/harness/runs/external/<task-id>/<run-id>/manifest.json
+.ai/harness/runs/external/<task-id>/<run-id>/artifacts/...
+```
+
+This uses the existing ignored run-evidence surface. Durable conclusions should
+be promoted into `tasks/reviews/<task>.review.md`, `tasks/contracts/`,
+`tasks/notes/`, or project documentation instead of committing raw provider
+artifacts by default.
+
+Minimal manifest shape:
+
+```json
+{
+  "schema_version": "repo-harness.external-evidence.v1",
+  "task_id": "20260629-runtime-heavy-ui",
+  "run_id": "20260629T023507Z-aibridge-screenshot",
+  "provider": {
+    "name": "aibridge",
+    "version": "1.5.0"
+  },
+  "subject": {
+    "task_type": "unity.ui",
+    "branch": "feat/example",
+    "commit": "optional",
+    "worktree_dirty": true
+  },
+  "operations": [
+    {
+      "kind": "unity.compile",
+      "command_display": "AIBridgeCLI compile unity",
+      "started_at": "2026-06-29T02:35:07Z",
+      "ended_at": "2026-06-29T02:36:10Z",
+      "exit_code": 0,
+      "outcome": "pass"
+    }
+  ],
+  "artifacts": [
+    {
+      "type": "log",
+      "path": "artifacts/compile.log",
+      "summary": "Unity compile passed with no Console errors",
+      "sha256": "optional",
+      "redacted": true
+    }
+  ],
+  "outcome": {
+    "status": "pass",
+    "summary": "Compile and Console validation passed"
+  },
+  "validation_gaps": [
+    {
+      "severity": "medium",
+      "description": "No PlayMode scenario was run"
+    }
+  ],
+  "safety": {
+    "side_effects": "read_only",
+    "privacy_reviewed": true
+  }
+}
+```
+
+Manifests should prefer repo-relative paths and summaries over absolute local
+paths. Providers should mark whether artifacts are redacted, avoid storing
+secrets or private payloads in durable summaries, and record skipped validation
+explicitly so reviewers can see what was not exercised.
+
+Global agent skills that wrap external validators should be project-gated:
+activate only when the current repo has an explicit local marker or CLI, no-op
+outside that repo, and keep the repo's own AGENTS/CLAUDE/repo-harness routing in
+control. Treat this as activation and DX isolation, not a complete security
+boundary for untrusted repositories.
+
 ## Update
 
 ### gstack

--- a/docs/researches/20260629-external-verification-evidence-contract.md
+++ b/docs/researches/20260629-external-verification-evidence-contract.md
@@ -1,0 +1,43 @@
+# External Verification Evidence Contract
+
+## Context
+
+Runtime-heavy projects can prove completion outside ordinary source files and
+unit test output. Unity, browser E2E, mobile simulators, hardware rigs, games,
+and staging smoke tests may produce the relevant logs, screenshots, traces, or
+device output. The existing harness already has review evidence, checks, run
+traces, and external acceptance surfaces, but it does not name how external
+validators should hand evidence back to those surfaces.
+
+## Decision
+
+Document a v1 external verification evidence convention as provider-generated
+evidence ingestion, not provider invocation. External tools keep their own
+runtime, trust boundary, command execution, and cleanup. `repo-harness` only
+needs a small manifest plus relative artifact references that review and
+handoff flows can cite.
+
+The recommended path uses the existing ignored runtime evidence surface:
+
+```text
+.ai/harness/runs/external/<task-id>/<run-id>/manifest.json
+.ai/harness/runs/external/<task-id>/<run-id>/artifacts/...
+```
+
+This fits the current information lifecycle better than adding a new committed
+evidence directory. Durable conclusions still belong in `tasks/reviews/`,
+`tasks/contracts/`, `tasks/notes/`, or project documentation after redaction.
+
+## Non-goals
+
+- Do not add Unity, Playwright, mobile, hardware, or staging-specific execution
+  logic to repo-harness.
+- Do not define a full plugin permission system in this slice.
+- Do not make missing external evidence count as a pass. Missing, skipped, or
+  partial external manifests remain validation gaps.
+
+## Follow-up
+
+Future implementation work could teach `repo-harness check` or review rendering
+to discover `repo-harness.external-evidence.v1` manifests and summarize their
+outcomes, artifacts, and validation gaps.

--- a/tests/readme-dx.test.ts
+++ b/tests/readme-dx.test.ts
@@ -146,6 +146,7 @@ describe("README DX contract", () => {
     const zhReadme = read("README.zh-CN.md");
     const spec = read("docs/spec.md");
     const flow = read("docs/reference-configs/agentic-development-flow.md");
+    const externalTooling = read("docs/reference-configs/external-tooling.md");
 
     expect(spec).toContain("## Product Outcome");
     expect(spec).toContain("## Core Invariants");
@@ -159,6 +160,11 @@ describe("README DX contract", () => {
     expect(zhReadme).toContain("## Agent Tracking Path");
     expect(flow).toContain("Agent reads first");
     expect(flow).toContain("Human reviews first");
+    expect(readme).toContain("external verification manifests");
+    expect(zhReadme).toContain("external verification manifest");
+    expect(externalTooling).toContain("## External Verification Evidence");
+    expect(externalTooling).toContain("evidence ingestion, not provider invocation");
+    expect(externalTooling).toContain(".ai/harness/runs/external/<task-id>/<run-id>/manifest.json");
   });
 
   test("localized READMEs track the current English release surface", () => {


### PR DESCRIPTION
## Summary
- document a v1 external verification evidence convention for runtime-heavy projects
- keep the scope to evidence ingestion, not provider invocation
- point README review flow to the external tooling reference and add a design note

## Why
Unity, browser E2E, mobile simulator, hardware, and staging validation can produce completion evidence outside ordinary source/test output. This gives external validators a small manifest shape that repo-harness review/check/handoff flows can cite without repo-harness owning those tools.

## Tests
- bun test tests/readme-dx.test.ts
- bun test tests/workflow-contract.test.ts
- bash scripts/check-task-sync.sh
- bash scripts/check-architecture-sync.sh
- bash scripts/check-deploy-sql-order.sh
- bun scripts/inspect-project-state.ts --repo . --format text
- bash scripts/migrate-project-template.sh --repo . --dry-run

## Notes
- Full `bun test` was attempted before dependencies were installed and produced environment failures for missing local packages / CodeGraph-related timeouts, so I used targeted tests after `bun install` for this docs-only change.