### PR TITLE
Document external verification evidence manifests / 补充外部验证证据 manifest 文档约定

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ pass, `not_required`, or an explicit manual override.
 
 Runtime-heavy validators such as Unity, browser E2E, mobile simulators, hardware
 rigs, or staging smoke tests can publish external verification manifests under
-the ignored run-evidence surface. See
+the ignored run-evidence surface. This is a manual convention today, not an
+automatic `repo-harness check` discovery or gate. See
 [`docs/reference-configs/external-tooling.md`](docs/reference-configs/external-tooling.md#external-verification-evidence).
 
 ## Agent Tracking Path

--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ rollback. Then inspect the active contract, latest trace in
 review recommends pass, the card verdict is pass, and external acceptance is
 pass, `not_required`, or an explicit manual override.
 
+Runtime-heavy validators such as Unity, browser E2E, mobile simulators, hardware
+rigs, or staging smoke tests can publish external verification manifests under
+the ignored run-evidence surface. See
+[`docs/reference-configs/external-tooling.md`](docs/reference-configs/external-tooling.md#external-verification-evidence).
+
 ## Agent Tracking Path
 
 Agents read source artifacts before derived summaries:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -52,6 +52,11 @@ verdict、change type、预期/实际改动文件、已通过命令、external a
 recommend pass、card verdict 为 pass，且 external acceptance 为 pass、not_required
 或明确 manual override 时，才进入 closeout。
 
+Unity、浏览器 E2E、mobile simulator、硬件测试和 staging smoke test 这类
+运行时重验证器，可以把 external verification manifest 写到被忽略的 run-evidence
+surface。详见
+[`docs/reference-configs/external-tooling.md`](docs/reference-configs/external-tooling.md#external-verification-evidence)。
+
 ## Agent Tracking Path
 
 Agent 先读 source artifacts，再读派生摘要：

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -54,7 +54,8 @@ recommend pass、card verdict 为 pass，且 external acceptance 为 pass、not_
 
 Unity、浏览器 E2E、mobile simulator、硬件测试和 staging smoke test 这类
 运行时重验证器，可以把 external verification manifest 写到被忽略的 run-evidence
-surface。详见
+surface。当前这只是手动约定，不是 `repo-harness check` 已经会自动发现或 gate
+的能力。详见
 [`docs/reference-configs/external-tooling.md`](docs/reference-configs/external-tooling.md#external-verification-evidence)。
 
 ## Agent Tracking Path

--- a/assets/reference-configs/external-tooling.md
+++ b/assets/reference-configs/external-tooling.md
@@ -348,16 +348,21 @@ Minimal manifest shape:
     }
   ],
   "safety": {
-    "side_effects": "read_only",
+    "side_effects": "writes_ignored_runtime_state",
     "privacy_reviewed": true
   }
 }
 ```
 
-Manifests should prefer repo-relative paths and summaries over absolute local
-paths. Providers should mark whether artifacts are redacted, avoid storing
-secrets or private payloads in durable summaries, and record skipped validation
-explicitly so reviewers can see what was not exercised.
+Manifest locations are repo-relative when cited from durable reviews. Artifact
+paths inside a manifest are relative to the manifest directory unless explicitly
+documented otherwise. Providers should prefer summaries over absolute local
+paths, mark whether artifacts are redacted, avoid storing secrets or private
+payloads in durable summaries, and record skipped validation explicitly so
+reviewers can see what was not exercised.
+
+Use `read_only` only when the provider did not mutate project files, runtime
+caches, devices, external services, or build outputs.
 
 Global agent skills that wrap external validators should be project-gated:
 activate only when the current repo has an explicit local marker or CLI, no-op

--- a/assets/reference-configs/external-tooling.md
+++ b/assets/reference-configs/external-tooling.md
@@ -267,6 +267,98 @@ not rewrite Bash commands, require RTK, or suggest compression for failed
 commands. Failed command output stays raw so test, build, and review evidence is
 not hidden by a compressor.
 
+## External Verification Evidence
+
+Runtime-heavy projects often prove work outside normal source files and unit
+test output. Unity, browser E2E, mobile simulators, hardware rigs, and staging
+smoke tests can all produce logs, screenshots, traces, or device output that
+belongs in the harness review flow without making `repo-harness` run those
+tools directly.
+
+The v1 contract is evidence ingestion, not provider invocation:
+
+- external validators run under the project's own tooling and trust boundary
+- providers publish a small manifest plus artifact references
+- `repo-harness` consumes the manifest as check/review/handoff evidence
+- missing, skipped, or partial manifests are validation gaps, not implicit
+  passes
+
+Recommended runtime layout:
+
+```text
+.ai/harness/runs/external/<task-id>/<run-id>/manifest.json
+.ai/harness/runs/external/<task-id>/<run-id>/artifacts/...
+```
+
+This uses the existing ignored run-evidence surface. Durable conclusions should
+be promoted into `tasks/reviews/<task>.review.md`, `tasks/contracts/`,
+`tasks/notes/`, or project documentation instead of committing raw provider
+artifacts by default.
+
+Minimal manifest shape:
+
+```json
+{
+  "schema_version": "repo-harness.external-evidence.v1",
+  "task_id": "20260629-runtime-heavy-ui",
+  "run_id": "20260629T023507Z-aibridge-screenshot",
+  "provider": {
+    "name": "aibridge",
+    "version": "1.5.0"
+  },
+  "subject": {
+    "task_type": "unity.ui",
+    "branch": "feat/example",
+    "commit": "optional",
+    "worktree_dirty": true
+  },
+  "operations": [
+    {
+      "kind": "unity.compile",
+      "command_display": "AIBridgeCLI compile unity",
+      "started_at": "2026-06-29T02:35:07Z",
+      "ended_at": "2026-06-29T02:36:10Z",
+      "exit_code": 0,
+      "outcome": "pass"
+    }
+  ],
+  "artifacts": [
+    {
+      "type": "log",
+      "path": "artifacts/compile.log",
+      "summary": "Unity compile passed with no Console errors",
+      "sha256": "optional",
+      "redacted": true
+    }
+  ],
+  "outcome": {
+    "status": "pass",
+    "summary": "Compile and Console validation passed"
+  },
+  "validation_gaps": [
+    {
+      "severity": "medium",
+      "description": "No PlayMode scenario was run"
+    }
+  ],
+  "safety": {
+    "side_effects": "read_only",
+    "privacy_reviewed": true
+  }
+}
+```
+
+Manifests should prefer repo-relative paths and summaries over absolute local
+paths. Providers should mark whether artifacts are redacted, avoid storing
+secrets or private payloads in durable summaries, and record skipped validation
+explicitly so reviewers can see what was not exercised.
+
+Global agent skills that wrap external validators should be project-gated:
+activate only when the current repo has an explicit local marker or CLI, no-op
+outside that repo, and keep the repo's own AGENTS/CLAUDE/repo-harness routing in
+control. Treat this as activation and DX isolation, not a complete security
+boundary for untrusted repositories.
+
 ## Update
 
 ### gstack

--- a/assets/reference-configs/external-tooling.md
+++ b/assets/reference-configs/external-tooling.md
@@ -275,13 +275,19 @@ smoke tests can all produce logs, screenshots, traces, or device output that
 belongs in the harness review flow without making `repo-harness` run those
 tools directly.
 
-The v1 contract is evidence ingestion, not provider invocation:
+Today this is a convention only: `repo-harness` does not automatically discover,
+summarize, or gate on these manifests yet.
+
+The recommended v1 convention is evidence ingestion, not provider invocation.
+It is not yet an automatic `repo-harness check` gate:
 
 - external validators run under the project's own tooling and trust boundary
 - providers publish a small manifest plus artifact references
-- `repo-harness` consumes the manifest as check/review/handoff evidence
-- missing, skipped, or partial manifests are validation gaps, not implicit
-  passes
+- reviewers can cite these manifests from check/review/handoff artifacts
+- automatic manifest discovery and summarization are follow-up implementation
+  work
+- missing, skipped, or partial external evidence should be recorded as
+  validation gaps, not treated as implicit passes
 
 Recommended runtime layout:
 
@@ -309,7 +315,7 @@ Minimal manifest shape:
   "subject": {
     "task_type": "unity.ui",
     "branch": "feat/example",
-    "commit": "optional",
+    "commit": "26eff6fc70b2c24cc3a00616204d3611f61df18e",
     "worktree_dirty": true
   },
   "operations": [
@@ -327,7 +333,7 @@ Minimal manifest shape:
       "type": "log",
       "path": "artifacts/compile.log",
       "summary": "Unity compile passed with no Console errors",
-      "sha256": "optional",
+      "sha256": "b6e3f4a6a1c2d5e8f0b9c7d6a4e3f2b1c0d9e8f7a6b5c4d3e2f1a0b9c8d7e6f5",
       "redacted": true
     }
   ],

--- a/docs/reference-configs/external-tooling.md
+++ b/docs/reference-configs/external-tooling.md
@@ -348,16 +348,21 @@ Minimal manifest shape:
     }
   ],
   "safety": {
-    "side_effects": "read_only",
+    "side_effects": "writes_ignored_runtime_state",
     "privacy_reviewed": true
   }
 }
 ```
 
-Manifests should prefer repo-relative paths and summaries over absolute local
-paths. Providers should mark whether artifacts are redacted, avoid storing
-secrets or private payloads in durable summaries, and record skipped validation
-explicitly so reviewers can see what was not exercised.
+Manifest locations are repo-relative when cited from durable reviews. Artifact
+paths inside a manifest are relative to the manifest directory unless explicitly
+documented otherwise. Providers should prefer summaries over absolute local
+paths, mark whether artifacts are redacted, avoid storing secrets or private
+payloads in durable summaries, and record skipped validation explicitly so
+reviewers can see what was not exercised.
+
+Use `read_only` only when the provider did not mutate project files, runtime
+caches, devices, external services, or build outputs.
 
 Global agent skills that wrap external validators should be project-gated:
 activate only when the current repo has an explicit local marker or CLI, no-op

--- a/docs/reference-configs/external-tooling.md
+++ b/docs/reference-configs/external-tooling.md
@@ -267,6 +267,98 @@ not rewrite Bash commands, require RTK, or suggest compression for failed
 commands. Failed command output stays raw so test, build, and review evidence is
 not hidden by a compressor.
 
+## External Verification Evidence
+
+Runtime-heavy projects often prove work outside normal source files and unit
+test output. Unity, browser E2E, mobile simulators, hardware rigs, and staging
+smoke tests can all produce logs, screenshots, traces, or device output that
+belongs in the harness review flow without making `repo-harness` run those
+tools directly.
+
+The v1 contract is evidence ingestion, not provider invocation:
+
+- external validators run under the project's own tooling and trust boundary
+- providers publish a small manifest plus artifact references
+- `repo-harness` consumes the manifest as check/review/handoff evidence
+- missing, skipped, or partial manifests are validation gaps, not implicit
+  passes
+
+Recommended runtime layout:
+
+```text
+.ai/harness/runs/external/<task-id>/<run-id>/manifest.json
+.ai/harness/runs/external/<task-id>/<run-id>/artifacts/...
+```
+
+This uses the existing ignored run-evidence surface. Durable conclusions should
+be promoted into `tasks/reviews/<task>.review.md`, `tasks/contracts/`,
+`tasks/notes/`, or project documentation instead of committing raw provider
+artifacts by default.
+
+Minimal manifest shape:
+
+```json
+{
+  "schema_version": "repo-harness.external-evidence.v1",
+  "task_id": "20260629-runtime-heavy-ui",
+  "run_id": "20260629T023507Z-aibridge-screenshot",
+  "provider": {
+    "name": "aibridge",
+    "version": "1.5.0"
+  },
+  "subject": {
+    "task_type": "unity.ui",
+    "branch": "feat/example",
+    "commit": "optional",
+    "worktree_dirty": true
+  },
+  "operations": [
+    {
+      "kind": "unity.compile",
+      "command_display": "AIBridgeCLI compile unity",
+      "started_at": "2026-06-29T02:35:07Z",
+      "ended_at": "2026-06-29T02:36:10Z",
+      "exit_code": 0,
+      "outcome": "pass"
+    }
+  ],
+  "artifacts": [
+    {
+      "type": "log",
+      "path": "artifacts/compile.log",
+      "summary": "Unity compile passed with no Console errors",
+      "sha256": "optional",
+      "redacted": true
+    }
+  ],
+  "outcome": {
+    "status": "pass",
+    "summary": "Compile and Console validation passed"
+  },
+  "validation_gaps": [
+    {
+      "severity": "medium",
+      "description": "No PlayMode scenario was run"
+    }
+  ],
+  "safety": {
+    "side_effects": "read_only",
+    "privacy_reviewed": true
+  }
+}
+```
+
+Manifests should prefer repo-relative paths and summaries over absolute local
+paths. Providers should mark whether artifacts are redacted, avoid storing
+secrets or private payloads in durable summaries, and record skipped validation
+explicitly so reviewers can see what was not exercised.
+
+Global agent skills that wrap external validators should be project-gated:
+activate only when the current repo has an explicit local marker or CLI, no-op
+outside that repo, and keep the repo's own AGENTS/CLAUDE/repo-harness routing in
+control. Treat this as activation and DX isolation, not a complete security
+boundary for untrusted repositories.
+
 ## Update
 
 ### gstack

--- a/docs/reference-configs/external-tooling.md
+++ b/docs/reference-configs/external-tooling.md
@@ -275,13 +275,19 @@ smoke tests can all produce logs, screenshots, traces, or device output that
 belongs in the harness review flow without making `repo-harness` run those
 tools directly.
 
-The v1 contract is evidence ingestion, not provider invocation:
+Today this is a convention only: `repo-harness` does not automatically discover,
+summarize, or gate on these manifests yet.
+
+The recommended v1 convention is evidence ingestion, not provider invocation.
+It is not yet an automatic `repo-harness check` gate:
 
 - external validators run under the project's own tooling and trust boundary
 - providers publish a small manifest plus artifact references
-- `repo-harness` consumes the manifest as check/review/handoff evidence
-- missing, skipped, or partial manifests are validation gaps, not implicit
-  passes
+- reviewers can cite these manifests from check/review/handoff artifacts
+- automatic manifest discovery and summarization are follow-up implementation
+  work
+- missing, skipped, or partial external evidence should be recorded as
+  validation gaps, not treated as implicit passes
 
 Recommended runtime layout:
 
@@ -309,7 +315,7 @@ Minimal manifest shape:
   "subject": {
     "task_type": "unity.ui",
     "branch": "feat/example",
-    "commit": "optional",
+    "commit": "26eff6fc70b2c24cc3a00616204d3611f61df18e",
     "worktree_dirty": true
   },
   "operations": [
@@ -327,7 +333,7 @@ Minimal manifest shape:
       "type": "log",
       "path": "artifacts/compile.log",
       "summary": "Unity compile passed with no Console errors",
-      "sha256": "optional",
+      "sha256": "b6e3f4a6a1c2d5e8f0b9c7d6a4e3f2b1c0d9e8f7a6b5c4d3e2f1a0b9c8d7e6f5",
       "redacted": true
     }
   ],

--- a/docs/researches/20260629-external-verification-evidence-contract.md
+++ b/docs/researches/20260629-external-verification-evidence-contract.md
@@ -17,6 +17,11 @@ runtime, trust boundary, command execution, and cleanup. `repo-harness` only
 needs a small manifest plus relative artifact references that review and
 handoff flows can cite.
 
+The public reference should say explicitly that this is a convention only today:
+`repo-harness` does not yet discover, summarize, or gate on these manifests
+automatically. That wording avoids implying an implemented check gate before
+manifest ingestion exists in code.
+
 The recommended path uses the existing ignored runtime evidence surface:
 
 ```text

--- a/docs/researches/20260629-external-verification-evidence-contract.md
+++ b/docs/researches/20260629-external-verification-evidence-contract.md
@@ -1,0 +1,43 @@
+# External Verification Evidence Contract
+
+## Context
+
+Runtime-heavy projects can prove completion outside ordinary source files and
+unit test output. Unity, browser E2E, mobile simulators, hardware rigs, games,
+and staging smoke tests may produce the relevant logs, screenshots, traces, or
+device output. The existing harness already has review evidence, checks, run
+traces, and external acceptance surfaces, but it does not name how external
+validators should hand evidence back to those surfaces.
+
+## Decision
+
+Document a v1 external verification evidence convention as provider-generated
+evidence ingestion, not provider invocation. External tools keep their own
+runtime, trust boundary, command execution, and cleanup. `repo-harness` only
+needs a small manifest plus relative artifact references that review and
+handoff flows can cite.
+
+The recommended path uses the existing ignored runtime evidence surface:
+
+```text
+.ai/harness/runs/external/<task-id>/<run-id>/manifest.json
+.ai/harness/runs/external/<task-id>/<run-id>/artifacts/...
+```
+
+This fits the current information lifecycle better than adding a new committed
+evidence directory. Durable conclusions still belong in `tasks/reviews/`,
+`tasks/contracts/`, `tasks/notes/`, or project documentation after redaction.
+
+## Non-goals
+
+- Do not add Unity, Playwright, mobile, hardware, or staging-specific execution
+  logic to repo-harness.
+- Do not define a full plugin permission system in this slice.
+- Do not make missing external evidence count as a pass. Missing, skipped, or
+  partial external manifests remain validation gaps.
+
+## Follow-up
+
+Future implementation work could teach `repo-harness check` or review rendering
+to discover `repo-harness.external-evidence.v1` manifests and summarize their
+outcomes, artifacts, and validation gaps.

--- a/docs/researches/20260629-external-verification-evidence-contract.md
+++ b/docs/researches/20260629-external-verification-evidence-contract.md
@@ -32,6 +32,11 @@ The recommended path uses the existing ignored runtime evidence surface:
 This fits the current information lifecycle better than adding a new committed
 evidence directory. Durable conclusions still belong in `tasks/reviews/`,
 `tasks/contracts/`, `tasks/notes/`, or project documentation after redaction.
+The manifest is cited by repo-relative path from durable review files, while
+artifact paths inside the manifest stay relative to the manifest directory.
+Provider examples should not call typical Unity/browser/mobile validation
+`read_only` when those tools write ignored runtime state, caches, logs, or build
+outputs.
 
 ## Non-goals
 

--- a/tests/readme-dx.test.ts
+++ b/tests/readme-dx.test.ts
@@ -147,6 +147,7 @@ describe("README DX contract", () => {
     const spec = read("docs/spec.md");
     const flow = read("docs/reference-configs/agentic-development-flow.md");
     const externalTooling = read("docs/reference-configs/external-tooling.md");
+    const externalToolingAsset = read("assets/reference-configs/external-tooling.md");
 
     expect(spec).toContain("## Product Outcome");
     expect(spec).toContain("## Core Invariants");
@@ -162,8 +163,9 @@ describe("README DX contract", () => {
     expect(flow).toContain("Human reviews first");
     expect(readme).toContain("external verification manifests");
     expect(zhReadme).toContain("external verification manifest");
+    expect(externalToolingAsset).toBe(externalTooling);
     expect(externalTooling).toContain("## External Verification Evidence");
-    expect(externalTooling).toContain("evidence ingestion, not provider invocation");
+    expect(externalTooling).toContain("not yet an automatic `repo-harness check` gate");
     expect(externalTooling).toContain(".ai/harness/runs/external/<task-id>/<run-id>/manifest.json");
   });
 

--- a/tests/readme-dx.test.ts
+++ b/tests/readme-dx.test.ts
@@ -146,6 +146,7 @@ describe("README DX contract", () => {
     const zhReadme = read("README.zh-CN.md");
     const spec = read("docs/spec.md");
     const flow = read("docs/reference-configs/agentic-development-flow.md");
+    const externalTooling = read("docs/reference-configs/external-tooling.md");
 
     expect(spec).toContain("## Product Outcome");
     expect(spec).toContain("## Core Invariants");
@@ -159,6 +160,11 @@ describe("README DX contract", () => {
     expect(zhReadme).toContain("## Agent Tracking Path");
     expect(flow).toContain("Agent reads first");
     expect(flow).toContain("Human reviews first");
+    expect(readme).toContain("external verification manifests");
+    expect(zhReadme).toContain("external verification manifest");
+    expect(externalTooling).toContain("## External Verification Evidence");
+    expect(externalTooling).toContain("evidence ingestion, not provider invocation");
+    expect(externalTooling).toContain(".ai/harness/runs/external/<task-id>/<run-id>/manifest.json");
   });
 
   test("localized READMEs track the current English release surface", () => {

--- a/tests/readme-dx.test.ts
+++ b/tests/readme-dx.test.ts
@@ -162,11 +162,19 @@ describe("README DX contract", () => {
     expect(flow).toContain("Agent reads first");
     expect(flow).toContain("Human reviews first");
     expect(readme).toContain("external verification manifests");
+    expect(readme).toContain("manual convention today");
+    expect(readme).toContain("automatic `repo-harness check` discovery or gate");
     expect(zhReadme).toContain("external verification manifest");
+    expect(zhReadme).toContain("手动约定");
+    expect(zhReadme).toContain("`repo-harness check` 已经会自动发现或 gate");
     expect(externalToolingAsset).toBe(externalTooling);
     expect(externalTooling).toContain("## External Verification Evidence");
+    expect(externalTooling).toContain("convention only");
+    expect(externalTooling).toContain("does not automatically discover");
     expect(externalTooling).toContain("not yet an automatic `repo-harness check` gate");
     expect(externalTooling).toContain(".ai/harness/runs/external/<task-id>/<run-id>/manifest.json");
+    expect(externalTooling).toContain("relative to the manifest directory");
+    expect(externalTooling).toContain("\"side_effects\": \"writes_ignored_runtime_state\"");
   });
 
   test("localized READMEs track the current English release surface", () => {


### PR DESCRIPTION
## Summary / 摘要

EN:
This PR documents a v1 convention for external verification evidence manifests for runtime-heavy projects such as Unity, browser E2E, mobile simulators, hardware rigs, and staging smoke tests.

The goal is to let project-owned validators publish reviewable evidence into the repo-harness workflow without making `repo-harness` run those tools directly.

This is intentionally docs-only:
- no provider/plugin/runner is added
- no Unity, Playwright, mobile, hardware, or staging-specific logic is added
- no automatic manifest discovery, summarization, schema validation, or check gating is implemented in this PR
- missing, skipped, or partial external evidence remains a validation gap that reviewers must record manually today

ZH:
这个 PR 为 Unity、browser E2E、mobile simulator、hardware rig、staging smoke test 这类运行时重项目补充一个 v1 文档约定：external verification evidence manifests。

目标是让项目自己的外部验证器把可审查证据交回 repo-harness workflow，而不是让 `repo-harness` 直接运行 Unity、Playwright、移动端模拟器、硬件测试脚本或 staging 工具。

这个 PR 有意保持 docs-only：
- 不新增 provider / plugin / runner
- 不新增 Unity、Playwright、mobile、hardware、staging 的领域逻辑
- 不实现自动 manifest discovery、summarization、schema validation 或 check gating
- 缺失、skipped、partial external evidence 今天仍然只是 validation gap，需要 reviewer 手动记录

## What changed / 改动内容

EN:
- Added an `External Verification Evidence` section to `docs/reference-configs/external-tooling.md`
- Kept `assets/reference-configs/external-tooling.md` in sync
- Added README / README.zh-CN pointers from the Human Review Path
- Added a short decision note under `docs/researches/20260629-external-verification-evidence-contract.md`
- Extended README DX assertions for the reference surface, asset/doc parity, path semantics, and non-gating wording

ZH:
- 在 `docs/reference-configs/external-tooling.md` 增加 `External Verification Evidence` 小节
- 同步 `assets/reference-configs/external-tooling.md`
- 在 README / README.zh-CN 的 Human Review Path 增加入口链接
- 增加一份轻量 decision note：`docs/researches/20260629-external-verification-evidence-contract.md`
- 扩展 README DX 测试，覆盖 reference doc、asset/doc parity、路径语义和非自动 gate 措辞

## Convention / 约定

EN:
External validators can publish manifests under the ignored run-evidence surface:

```text
.ai/harness/runs/external/<task-id>/<run-id>/manifest.json
.ai/harness/runs/external/<task-id>/<run-id>/artifacts/...
```

Manifest locations are cited by repo-relative path from durable review files. Artifact paths inside the manifest are relative to the manifest directory unless documented otherwise. Durable conclusions should still be promoted into `tasks/reviews/`, `tasks/contracts/`, `tasks/notes/`, or project documentation after review and redaction.

ZH:
外部验证器可以把 manifest 写到被忽略的 run-evidence surface：

```text
.ai/harness/runs/external/<task-id>/<run-id>/manifest.json
.ai/harness/runs/external/<task-id>/<run-id>/artifacts/...
```

durable review file 引用 manifest 时使用 repo-relative path。manifest 内部的 artifact path 默认相对 manifest 所在目录，除非另有说明。经过 review 和脱敏后的 durable conclusion 仍然应该进入 `tasks/reviews/`、`tasks/contracts/`、`tasks/notes/` 或项目文档。

## Non-goals / 非目标

EN:
- Do not make repo-harness execute external validators
- Do not add a provider permission model in this slice
- Do not make missing external evidence count as pass
- Do not add automatic `repo-harness check` discovery or gating yet

ZH:
- 不让 repo-harness 执行外部验证器
- 不在这个切片里设计完整 provider 权限模型
- 不把缺失 external evidence 当作 pass
- 不在当前 PR 实现自动 `repo-harness check` discovery 或 gating

## Follow-up / 后续方向

EN:
A later implementation could teach `repo-harness check` or review rendering to discover `repo-harness.external-evidence.v1` manifests and summarize outcomes, artifacts, and validation gaps.

ZH:
后续可以让 `repo-harness check` 或 review rendering 自动发现 `repo-harness.external-evidence.v1` manifest，并汇总 outcome、artifacts 和 validation gaps。

## Verification / 验证

Passed:
- `bun test tests/readme-dx.test.ts`
- `bun test tests/workflow-contract.test.ts`
- `bash scripts/check-task-sync.sh`
- `bash scripts/check-architecture-sync.sh`
- `bash scripts/check-deploy-sql-order.sh`
- `bun scripts/inspect-project-state.ts --repo . --format text`
- `cmp -s docs/reference-configs/external-tooling.md assets/reference-configs/external-tooling.md`
- `git diff --check`

Not rerun:
- `bun test`

Earlier full `bun test` was attempted before local dependencies were installed and failed because `node_modules` / MCP SDK / commander / express were missing and CodeGraph-related tests timed out. This PR only changes documentation and targeted doc/workflow checks now pass.