### PR TITLE
feat(contract-run): gate file-coupled delegation on brief completeness

### DIFF
--- a/.claude/templates/contract.template.md
+++ b/.claude/templates/contract.template.md
@@ -70,6 +70,13 @@ delegation:
     verifier:
       mode: read_only
       purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+      - codex-exec
+      - main-thread
+    fallback: main-thread
+    brief_is_authoritative: true
 ```
 
 ## Exit Criteria (Machine Verifiable)

--- a/assets/templates/contract.template.md
+++ b/assets/templates/contract.template.md
@@ -70,6 +70,13 @@ delegation:
     verifier:
       mode: read_only
       purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+      - codex-exec
+      - main-thread
+    fallback: main-thread
+    brief_is_authoritative: true
 ```
 
 ## Exit Criteria (Machine Verifiable)

--- a/assets/templates/helpers/contract-run.ts
+++ b/assets/templates/helpers/contract-run.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { dirname, isAbsolute, join, relative, resolve } from "path";
 import { spawnSync } from "child_process";
 
-type Mode = "dry-run" | "run";
+type Mode = "dry-run" | "run" | "preflight";
 
 interface Options {
   mode: Mode;
@@ -22,6 +22,12 @@ interface DelegationBudget {
   wall_time_minutes: number | null;
 }
 
+interface RunnerContract {
+  preferred: string[];
+  fallback: string | null;
+  brief_is_authoritative: boolean;
+}
+
 interface DelegationContract {
   budget: DelegationBudget;
   permission_scope: {
@@ -30,6 +36,12 @@ interface DelegationContract {
     network: string;
   };
   roles: Record<string, DelegationRole>;
+  runner: RunnerContract;
+}
+
+interface BriefPreflight {
+  ok: boolean;
+  issues: string[];
 }
 
 interface DelegationRole {
@@ -49,15 +61,23 @@ interface ChildResult {
 function usage(): string {
   return [
     "Usage:",
+    "  bun scripts/contract-run.ts preflight --contract <contract-file> [--repo <path>] [--json]",
     "  bun scripts/contract-run.ts dry-run --contract <contract-file> [--repo <path>] [--out <dir>] [--json]",
     "  bun scripts/contract-run.ts run --contract <contract-file> --worker-command <cmd> --verifier-command <cmd> [--repo <path>] [--out <dir>] [--max-tool-calls <n>] [--json]",
+    "",
+    "preflight asserts the contract is a self-sufficient execution brief (Goal, Scope,",
+    "Allowed Paths, Exit Criteria are filled in, not template placeholders) and exits",
+    "non-zero otherwise. run enforces the same gate before dispatching the worker.",
+    "",
+    "A file-coupled runner consumes the generated prompt from $CONTRACT_RUN_PROMPT, e.g.:",
+    "  --worker-command 'codex exec --json \"$(cat \\\"$CONTRACT_RUN_PROMPT\\\")\"'",
   ].join("\n");
 }
 
 function parseArgs(argv: string[]): Options {
   let mode: Mode = "dry-run";
   let index = 0;
-  if (argv[0] === "run" || argv[0] === "dry-run") {
+  if (argv[0] === "run" || argv[0] === "dry-run" || argv[0] === "preflight") {
     mode = argv[0];
     index = 1;
   }
@@ -256,7 +276,64 @@ function parseDelegation(markdown: string): DelegationContract {
       verifier: { mode: "read_only", purpose: "exit_criteria_review" },
       ...parseRoles(block),
     },
+    runner: parseRunner(block),
   };
+}
+
+function parseRunner(block: string): RunnerContract {
+  const preferred = parseList(block, "preferred");
+  const fallback = parseScalar(block, "fallback");
+  const briefAuthoritative = parseScalar(block, "brief_is_authoritative");
+  return {
+    preferred: preferred.length > 0 ? preferred : ["subagent"],
+    fallback: fallback && fallback !== "null" ? fallback : null,
+    brief_is_authoritative: briefAuthoritative === null ? true : briefAuthoritative === "true",
+  };
+}
+
+function sectionBody(markdown: string, heading: string): string {
+  const headingPattern = new RegExp(`^##\\s+${heading}\\s*$`);
+  const lines = markdown.split("\n");
+  const body: string[] = [];
+  let inSection = false;
+  for (const line of lines) {
+    if (headingPattern.test(line)) {
+      inSection = true;
+      continue;
+    }
+    if (inSection && /^##\s/.test(line)) break;
+    if (inSection) body.push(line);
+  }
+  return body.join("\n");
+}
+
+function isConcreteBrief(text: string): boolean {
+  const body = text.trim();
+  if (!body) return false;
+  if (/\{\{[^}]+\}\}/.test(body)) return false;
+  const withoutPlaceholders = body
+    .replace(/Describe the exact outcome this task must deliver\./g, "")
+    .replace(/^\s*-\s*In scope:\s*$/gm, "")
+    .replace(/^\s*-\s*Out of scope:\s*$/gm, "")
+    .trim();
+  return withoutPlaceholders.length > 0;
+}
+
+function runBriefPreflight(markdown: string): BriefPreflight {
+  const issues: string[] = [];
+  if (!isConcreteBrief(sectionBody(markdown, "Goal"))) {
+    issues.push("Goal section is empty or still a template placeholder");
+  }
+  if (!isConcreteBrief(sectionBody(markdown, "Scope"))) {
+    issues.push("Scope section is empty or still a template placeholder");
+  }
+  if (parseList(fencedYamlBlock(markdown, "allowed_paths"), "allowed_paths").length === 0) {
+    issues.push("Allowed Paths is empty");
+  }
+  if (!fencedYamlBlock(markdown, "exit_criteria").trim()) {
+    issues.push("Exit Criteria block is missing");
+  }
+  return { ok: issues.length === 0, issues };
 }
 
 function runChild(
@@ -307,6 +384,21 @@ function buildRun(opts: Options) {
   const exitCriteria = fencedYamlBlock(contractText, "exit_criteria");
   const delegation = parseDelegation(contractText);
   const allowedPaths = parseList(fencedYamlBlock(contractText, "allowed_paths"), "allowed_paths");
+  const briefPreflight = runBriefPreflight(contractText);
+
+  if (opts.mode === "preflight") {
+    const manifest = {
+      version: 1,
+      kind: "repo-harness-contract-run",
+      status: briefPreflight.ok ? "preflight_pass" : "fail",
+      failure_class: briefPreflight.ok ? null : "incomplete_brief",
+      repo,
+      contract: repoRelative(repo, contractPath),
+      brief_preflight: briefPreflight,
+    };
+    return { manifest, manifestPath: "" };
+  }
+
   const toolLimit = opts.maxToolCalls ?? delegation.budget.tool_calls;
   const slug = contractPath
     .split("/")
@@ -383,7 +475,12 @@ function buildRun(opts: Options) {
     return true;
   };
 
-  if (opts.mode === "run") {
+  if (opts.mode === "run" && !briefPreflight.ok) {
+    status = "fail";
+    failureClass = "incomplete_brief";
+  }
+
+  if (opts.mode === "run" && briefPreflight.ok) {
     if (consume("worker")) {
       const worker = runChild("worker", opts.workerCommand!, repo, runDir, {
         ...baseEnv,
@@ -416,6 +513,7 @@ function buildRun(opts: Options) {
     kind: "repo-harness-contract-run",
     status,
     failure_class: failureClass || null,
+    brief_preflight: briefPreflight,
     repo,
     contract: repoRelative(repo, contractPath),
     plan,
@@ -454,7 +552,9 @@ try {
     console.log(JSON.stringify(manifest, null, 2));
   } else {
     console.log(`[ContractRun] ${manifest.status}: ${manifest.contract}`);
-    console.log(`[ContractRun] manifest: ${repoRelative(resolve(opts.repo), manifestPath)}`);
+    if (manifestPath) {
+      console.log(`[ContractRun] manifest: ${repoRelative(resolve(opts.repo), manifestPath)}`);
+    }
     if (manifest.failure_class) console.log(`[ContractRun] failure_class: ${manifest.failure_class}`);
   }
   process.exit(manifest.status === "fail" ? 1 : 0);

--- a/docs/researches/20260705-superpowers-evaluation-file-coupled-delegation.md
+++ b/docs/researches/20260705-superpowers-evaluation-file-coupled-delegation.md
@@ -1,0 +1,53 @@
+# obra/superpowers 評估與 file-coupled delegation 決策
+
+> Date: 2026-07-05
+> Trigger: 使用者問「要不要把 obra/superpowers 整合進 repo-harness」,聚焦 subagent 分派(Claude 好、Codex 差)。
+> Method: WebFetch superpowers 原始碼 + 本地架構 map + deep-reasoner ×2 對立雙軌 + Codex peer review + 實測 `scripts/contract-run.ts` / `scripts/verify-contract.sh` / 真實 contract 檔。
+> Status: 決策已定;Phase 1 已實作(見末節)。
+
+## 決策(Verdict)
+
+不整合 superpowers 的 skills / plugin。Keep repo-harness 自有引擎,方法論交給 Waza `/think`/`/hunt`/`/check` 與 gstack。只採一個協定改動:把既有 `scripts/contract-run.ts`(file-coupled runner)補齊,讓 contract 檔成為權威執行 brief,`codex exec --json` 以 worker/verifier command 進場,原生 `spawn_agent` 降成可選加速器。目標宿主維持 Claude+Codex(不採 superpowers 的 per-harness reference-file 可移植層)。
+
+## 根因:耦合介質,不是 config 或成熟度
+
+使用者 Codex 已 `multi_agent = true`、`max_depth = 2`,仍「較差」。實測:repo-harness 的 parent↔child 兩個方向都騎在 Codex 原生 message-passing 上——下行 `.ai/hooks/codex-delegation-advisor.sh` 注入「先 call `spawn_agent`」,上行 `.ai/hooks/subagent-return-channel-guard.sh` 管原生 return。於是繼承 Codex 原生編排的弱。Claude 同一條 seam 騎在 Task 工具上,所以好。
+
+superpowers 的真正招數是**用檔案當耦合介質**(task-brief → child → review-package → ledger),原生 spawn 只負責「啟動 process」,對弱編排 by construction 免疫。誠實刻度:換成檔案耦合約 90% 是讓結果與派發品質脫鉤,約 10% 是 worker 指著 contract 當 brief 的實質改善;不會讓 Codex 原生 subagent 本身變好。
+
+## 為何不進口:檔全都在,只缺協定行為
+
+| superpowers | repo-harness 既有物 | 位置 |
+|---|---|---|
+| `scripts/task-brief` 輸出+消費 | `contract-run.ts` 讀 contract 產 worker-prompt(內嵌整份 contract) | `scripts/contract-run.ts:296` `buildRun` |
+| worker/reviewer 執行 | `runChild` spawnSync `workerCommand`/`verifierCommand` | `scripts/contract-run.ts:262` |
+| `scripts/review-package` | verifier-prompt(只嵌 exit_criteria)+ `tasks/reviews/*.review.md` + Waza `/check` | — |
+| progress ledger | `manifest.json` + Evidence Contract State/progress + workstream `current_slice` | `plan-to-todo.sh:130` |
+
+進口 superpowers 會製造兩套 plan/review/ledger 引擎搶擁有權 + `.superpowers/sdd/progress.md` 與 contract/workstream 雙份狀態,違反本倉 No-Fallback / 單一工作流原則。它也給不了 capability registry / architecture-drift / workstream 這層差異化。
+
+## Codex peer 的關鍵修正(已驗證併入)
+
+初版方向誤把 `codex exec` 塞進 policy 欄位 + hook。Codex peer 指出落點錯:`scripts/contract-run.ts` 已是 file-coupled runner,`codex exec --json` 天然是外部傳入的 `--worker-command`,不需新 engine、不進 hook(`docs/reference-configs/hook-operations.md` 明言 hooks 不啟動長任務)。實測 `scripts/verify-contract.sh:331-353` 只驗 `exit_criteria`、模板 Goal 是佔位——所以「brief 完整性檢查」是硬門檻、不是可選,且不能動 verify-contract 的 exit_criteria-only 相容承諾。
+
+## Phase 1 已實作(本次)
+
+落在 `scripts/contract-run.ts`(+ 產品源鏡像 `assets/templates/helpers/contract-run.ts`,byte 一致):
+
+- 新增 `preflight` 模式 + `runBriefPreflight`:斷言 Goal / Scope / Allowed Paths / Exit Criteria 非佔位、非空、自足;佔位偵測認 `{{...}}` token 與模板佔位句。
+- `run` 模式在派發 worker **之前** fail-closed:brief 不完整 → status `fail` / `failure_class: incomplete_brief`,不 dispatch(children 空),不靜默降級。
+- `dry-run` 只把 `brief_preflight` 記進 manifest(advisory,不擋),供 WIP 檢視。
+- Delegation Contract YAML 新增 `runner: { preferred, fallback, brief_is_authoritative }`,由 `parseDelegation` 消費、流進 manifest。舊無 `runner:` 的 contract 預設 `["subagent"]`,不改語義。
+- `codex exec --json` 走文檔化 command path(worker-prompt 由 env `CONTRACT_RUN_PROMPT` 提供),usage 附範例。
+- 模板 `assets/templates/contract.template.md` 與 `.claude/templates/contract.template.md` 同步加 runner 區塊。
+- `tests/contract-run.test.ts`:fixture 補真實 Goal/Scope + runner;新增 preflight 正/負、run fail-closed 不派 worker、runner metadata 進 manifest 共 4 測試。
+
+驗證:`bun test tests/contract-run.test.ts` 8/8 綠;`tsc --noEmit` 乾淨;preflight 對真實 fulfilled contract exit 0、對佔位模板 exit 1。
+
+## Phase 2(已入 todos,延後)
+
+policy `delegation.preferred_runners` / `fallback_runner`(語義=同一 contract 的 runner 可用性降級、必寫 manifest、不得靜默)+ `codex-delegation-advisor.sh` 瘦身為指向 active contract 的 nudge + 全面同步(policy 由 `ensure-task-workflow.sh` / `project-init-lib.sh` / `assets/templates/helpers/*` / 遷移測試共維護)。`subagent-stop-quality` host-agnostic 化為獨立品質閘,不綁本次。
+
+## 最脆弱假設
+
+contract 必須是「乾淨-context runner 可完成 slice」的自足 brief。Phase 1 的 preflight 硬門檻承接了它;`codex exec` fallback 可能與原生 spawn 共享 sandbox 失敗(detached HEAD、不能 branch/push),需在 manifest 記錄失敗而非靜默。

--- a/scripts/contract-run.ts
+++ b/scripts/contract-run.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { dirname, isAbsolute, join, relative, resolve } from "path";
 import { spawnSync } from "child_process";
 
-type Mode = "dry-run" | "run";
+type Mode = "dry-run" | "run" | "preflight";
 
 interface Options {
   mode: Mode;
@@ -22,6 +22,12 @@ interface DelegationBudget {
   wall_time_minutes: number | null;
 }
 
+interface RunnerContract {
+  preferred: string[];
+  fallback: string | null;
+  brief_is_authoritative: boolean;
+}
+
 interface DelegationContract {
   budget: DelegationBudget;
   permission_scope: {
@@ -30,6 +36,12 @@ interface DelegationContract {
     network: string;
   };
   roles: Record<string, DelegationRole>;
+  runner: RunnerContract;
+}
+
+interface BriefPreflight {
+  ok: boolean;
+  issues: string[];
 }
 
 interface DelegationRole {
@@ -49,15 +61,23 @@ interface ChildResult {
 function usage(): string {
   return [
     "Usage:",
+    "  bun scripts/contract-run.ts preflight --contract <contract-file> [--repo <path>] [--json]",
     "  bun scripts/contract-run.ts dry-run --contract <contract-file> [--repo <path>] [--out <dir>] [--json]",
     "  bun scripts/contract-run.ts run --contract <contract-file> --worker-command <cmd> --verifier-command <cmd> [--repo <path>] [--out <dir>] [--max-tool-calls <n>] [--json]",
+    "",
+    "preflight asserts the contract is a self-sufficient execution brief (Goal, Scope,",
+    "Allowed Paths, Exit Criteria are filled in, not template placeholders) and exits",
+    "non-zero otherwise. run enforces the same gate before dispatching the worker.",
+    "",
+    "A file-coupled runner consumes the generated prompt from $CONTRACT_RUN_PROMPT, e.g.:",
+    "  --worker-command 'codex exec --json \"$(cat \\\"$CONTRACT_RUN_PROMPT\\\")\"'",
   ].join("\n");
 }
 
 function parseArgs(argv: string[]): Options {
   let mode: Mode = "dry-run";
   let index = 0;
-  if (argv[0] === "run" || argv[0] === "dry-run") {
+  if (argv[0] === "run" || argv[0] === "dry-run" || argv[0] === "preflight") {
     mode = argv[0];
     index = 1;
   }
@@ -256,7 +276,64 @@ function parseDelegation(markdown: string): DelegationContract {
       verifier: { mode: "read_only", purpose: "exit_criteria_review" },
       ...parseRoles(block),
     },
+    runner: parseRunner(block),
   };
+}
+
+function parseRunner(block: string): RunnerContract {
+  const preferred = parseList(block, "preferred");
+  const fallback = parseScalar(block, "fallback");
+  const briefAuthoritative = parseScalar(block, "brief_is_authoritative");
+  return {
+    preferred: preferred.length > 0 ? preferred : ["subagent"],
+    fallback: fallback && fallback !== "null" ? fallback : null,
+    brief_is_authoritative: briefAuthoritative === null ? true : briefAuthoritative === "true",
+  };
+}
+
+function sectionBody(markdown: string, heading: string): string {
+  const headingPattern = new RegExp(`^##\\s+${heading}\\s*$`);
+  const lines = markdown.split("\n");
+  const body: string[] = [];
+  let inSection = false;
+  for (const line of lines) {
+    if (headingPattern.test(line)) {
+      inSection = true;
+      continue;
+    }
+    if (inSection && /^##\s/.test(line)) break;
+    if (inSection) body.push(line);
+  }
+  return body.join("\n");
+}
+
+function isConcreteBrief(text: string): boolean {
+  const body = text.trim();
+  if (!body) return false;
+  if (/\{\{[^}]+\}\}/.test(body)) return false;
+  const withoutPlaceholders = body
+    .replace(/Describe the exact outcome this task must deliver\./g, "")
+    .replace(/^\s*-\s*In scope:\s*$/gm, "")
+    .replace(/^\s*-\s*Out of scope:\s*$/gm, "")
+    .trim();
+  return withoutPlaceholders.length > 0;
+}
+
+function runBriefPreflight(markdown: string): BriefPreflight {
+  const issues: string[] = [];
+  if (!isConcreteBrief(sectionBody(markdown, "Goal"))) {
+    issues.push("Goal section is empty or still a template placeholder");
+  }
+  if (!isConcreteBrief(sectionBody(markdown, "Scope"))) {
+    issues.push("Scope section is empty or still a template placeholder");
+  }
+  if (parseList(fencedYamlBlock(markdown, "allowed_paths"), "allowed_paths").length === 0) {
+    issues.push("Allowed Paths is empty");
+  }
+  if (!fencedYamlBlock(markdown, "exit_criteria").trim()) {
+    issues.push("Exit Criteria block is missing");
+  }
+  return { ok: issues.length === 0, issues };
 }
 
 function runChild(
@@ -307,6 +384,21 @@ function buildRun(opts: Options) {
   const exitCriteria = fencedYamlBlock(contractText, "exit_criteria");
   const delegation = parseDelegation(contractText);
   const allowedPaths = parseList(fencedYamlBlock(contractText, "allowed_paths"), "allowed_paths");
+  const briefPreflight = runBriefPreflight(contractText);
+
+  if (opts.mode === "preflight") {
+    const manifest = {
+      version: 1,
+      kind: "repo-harness-contract-run",
+      status: briefPreflight.ok ? "preflight_pass" : "fail",
+      failure_class: briefPreflight.ok ? null : "incomplete_brief",
+      repo,
+      contract: repoRelative(repo, contractPath),
+      brief_preflight: briefPreflight,
+    };
+    return { manifest, manifestPath: "" };
+  }
+
   const toolLimit = opts.maxToolCalls ?? delegation.budget.tool_calls;
   const slug = contractPath
     .split("/")
@@ -383,7 +475,12 @@ function buildRun(opts: Options) {
     return true;
   };
 
-  if (opts.mode === "run") {
+  if (opts.mode === "run" && !briefPreflight.ok) {
+    status = "fail";
+    failureClass = "incomplete_brief";
+  }
+
+  if (opts.mode === "run" && briefPreflight.ok) {
     if (consume("worker")) {
       const worker = runChild("worker", opts.workerCommand!, repo, runDir, {
         ...baseEnv,
@@ -416,6 +513,7 @@ function buildRun(opts: Options) {
     kind: "repo-harness-contract-run",
     status,
     failure_class: failureClass || null,
+    brief_preflight: briefPreflight,
     repo,
     contract: repoRelative(repo, contractPath),
     plan,
@@ -454,7 +552,9 @@ try {
     console.log(JSON.stringify(manifest, null, 2));
   } else {
     console.log(`[ContractRun] ${manifest.status}: ${manifest.contract}`);
-    console.log(`[ContractRun] manifest: ${repoRelative(resolve(opts.repo), manifestPath)}`);
+    if (manifestPath) {
+      console.log(`[ContractRun] manifest: ${repoRelative(resolve(opts.repo), manifestPath)}`);
+    }
     if (manifest.failure_class) console.log(`[ContractRun] failure_class: ${manifest.failure_class}`);
   }
   process.exit(manifest.status === "fail" ? 1 : 0);

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -11,4 +11,4 @@ Do not duplicate that execution checklist here. Record only work intentionally d
 
 | Goal | Why Deferred | Tradeoff | Revisit Trigger |
 |------|--------------|----------|-----------------|
-| (none) | No deferred medium/long-term goal recorded yet. | Keep the first sprint bounded. | Add a row when a real follow-up is postponed. |
+| file-coupled delegation Phase 2: policy `delegation.preferred_runners`/`fallback_runner`(語義=同一 contract 的 runner 可用性降級,必寫 manifest、不得靜默)+ `codex-delegation-advisor.sh` 瘦身為指向 active contract 的 nudge + 全面同步 | Phase 1(`contract-run` preflight + per-contract runner metadata)已獨立可合併並驗證;policy/advisor 文案改動觸達面廣(>8 檔,policy 由 `ensure-task-workflow.sh`/`project-init-lib.sh`/`assets/templates/helpers/*`/遷移測試共維護),分階段降風險 | 目前只有 per-contract runner metadata,沒有全域 policy 預設 runner 降級;advisor 仍硬編 max_agents/max_depth | `contract-run` 的 `codex exec` file-coupled 路徑實際投用後,或要把 runner 降級提升為全域預設時 |

--- a/tests/contract-run.test.ts
+++ b/tests/contract-run.test.ts
@@ -41,6 +41,15 @@ function writePilotContract(repo: string, toolCalls: string | number | null = 2)
       "> **Review File**: `tasks/reviews/pilot.review.md`",
       "> **Notes File**: `tasks/notes/pilot.notes.md`",
       "",
+      "## Goal",
+      "",
+      "Create src/pilot.txt containing worker-output so the verifier can confirm the exit criteria.",
+      "",
+      "## Scope",
+      "",
+      "- In scope: create src/pilot.txt with worker-output",
+      "- Out of scope: anything outside src/",
+      "",
       "## Allowed Paths",
       "",
       "```yaml",
@@ -74,6 +83,13 @@ function writePilotContract(repo: string, toolCalls: string | number | null = 2)
       "    verifier:",
       "      mode: read_only",
       "      purpose: exit_criteria_review",
+      "  runner:",
+      "    preferred:",
+      "      - subagent",
+      "      - codex-exec",
+      "      - main-thread",
+      "    fallback: main-thread",
+      "    brief_is_authoritative: true",
       "```",
       "",
       "## Exit Criteria (Machine Verifiable)",
@@ -338,5 +354,197 @@ describe("contract-run helper", () => {
     const res = runContractRun(ROOT, ["dry-run", "--bogus"]);
     expect(res.status).toBe(2);
     expect(res.stderr).toContain("unknown argument --bogus");
+  });
+
+  test("preflight passes for a self-sufficient brief", () => {
+    const repo = makeRepo("contract-run-preflight-ok-");
+    try {
+      writePilotContract(repo, 2);
+      const res = runContractRun(repo, [
+        "preflight",
+        "--repo",
+        repo,
+        "--contract",
+        "tasks/contracts/pilot.contract.md",
+        "--json",
+      ]);
+      expect(res.status).toBe(0);
+      const manifest = parseJson(res.stdout);
+      expect(manifest.status).toBe("preflight_pass");
+      expect((manifest.brief_preflight as { ok: boolean }).ok).toBe(true);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  test("preflight fails closed on a placeholder brief", () => {
+    const repo = makeRepo("contract-run-preflight-fail-");
+    try {
+      writeFileSync(
+        join(repo, "tasks/contracts/pilot.contract.md"),
+        [
+          "# Task Contract: pilot",
+          "",
+          "## Goal",
+          "",
+          "Describe the exact outcome this task must deliver.",
+          "",
+          "## Scope",
+          "",
+          "- In scope:",
+          "- Out of scope:",
+          "",
+          "## Allowed Paths",
+          "",
+          "```yaml",
+          "allowed_paths:",
+          "  - src/",
+          "```",
+          "",
+          "## Exit Criteria (Machine Verifiable)",
+          "",
+          "```yaml",
+          "exit_criteria:",
+          "  files_exist:",
+          "    - src/pilot.txt",
+          "```",
+          "",
+        ].join("\n"),
+      );
+      const res = runContractRun(repo, [
+        "preflight",
+        "--repo",
+        repo,
+        "--contract",
+        "tasks/contracts/pilot.contract.md",
+        "--json",
+      ]);
+      expect(res.status).toBe(1);
+      const manifest = parseJson(res.stdout);
+      expect(manifest.status).toBe("fail");
+      expect(manifest.failure_class).toBe("incomplete_brief");
+      expect((manifest.brief_preflight as { issues: string[] }).issues.length).toBeGreaterThanOrEqual(2);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  test("run refuses an incomplete brief before dispatching the worker", () => {
+    const repo = makeRepo("contract-run-incomplete-");
+    try {
+      writeFileSync(
+        join(repo, "tasks/contracts/pilot.contract.md"),
+        [
+          "# Task Contract: pilot",
+          "",
+          "> **Review File**: `tasks/reviews/pilot.review.md`",
+          "",
+          "## Goal",
+          "",
+          "Describe the exact outcome this task must deliver.",
+          "",
+          "## Scope",
+          "",
+          "- In scope:",
+          "- Out of scope:",
+          "",
+          "## Allowed Paths",
+          "",
+          "```yaml",
+          "allowed_paths:",
+          "  - src/",
+          "```",
+          "",
+          "## Delegation Contract",
+          "",
+          "```yaml",
+          "delegation:",
+          "  budget:",
+          "    tokens: null",
+          "    tool_calls: null",
+          "    wall_time_minutes: 5",
+          "  permission_scope:",
+          "    mode: inherit_allowed_paths",
+          "    writable_paths: []",
+          "    network: off",
+          "  roles:",
+          "    worker:",
+          "      mode: edit_within_allowed_paths",
+          "      purpose: implementation",
+          "```",
+          "",
+          "## Exit Criteria (Machine Verifiable)",
+          "",
+          "```yaml",
+          "exit_criteria:",
+          "  files_exist:",
+          "    - src/pilot.txt",
+          "```",
+          "",
+        ].join("\n"),
+      );
+      const workerCommand = writeExecutable(
+        repo,
+        "worker.sh",
+        ["#!/bin/bash", "set -euo pipefail", "mkdir -p src", "printf 'worker-output\\n' > src/pilot.txt", ""].join("\n"),
+      );
+      const verifierCommand = writeExecutable(
+        repo,
+        "verifier.sh",
+        ["#!/bin/bash", "set -euo pipefail", "printf 'ran\\n' > verifier-ran.txt", ""].join("\n"),
+      );
+      const res = runContractRun(repo, [
+        "run",
+        "--repo",
+        repo,
+        "--contract",
+        "tasks/contracts/pilot.contract.md",
+        "--worker-command",
+        workerCommand,
+        "--verifier-command",
+        verifierCommand,
+        "--out",
+        ".ai/harness/runs/incomplete",
+        "--json",
+      ]);
+      expect(res.status).toBe(1);
+      const manifest = parseJson(res.stdout);
+      expect(manifest.status).toBe("fail");
+      expect(manifest.failure_class).toBe("incomplete_brief");
+      expect(manifest.children as unknown[]).toEqual([]);
+      expect(existsSync(join(repo, "src/pilot.txt"))).toBe(false);
+      expect(existsSync(join(repo, "verifier-ran.txt"))).toBe(false);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  test("runner metadata from the contract flows into the manifest", () => {
+    const repo = makeRepo("contract-run-runner-");
+    try {
+      writePilotContract(repo, 2);
+      const res = runContractRun(repo, [
+        "dry-run",
+        "--repo",
+        repo,
+        "--contract",
+        "tasks/contracts/pilot.contract.md",
+        "--out",
+        ".ai/harness/runs/runner",
+        "--json",
+      ]);
+      expect(res.status).toBe(0);
+      const manifest = parseJson(res.stdout);
+      const runner = (
+        manifest.delegation as {
+          runner: { preferred: string[]; fallback: string | null; brief_is_authoritative: boolean };
+        }
+      ).runner;
+      expect(runner.preferred).toEqual(["subagent", "codex-exec", "main-thread"]);
+      expect(runner.fallback).toBe("main-thread");
+      expect(runner.brief_is_authoritative).toBe(true);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## 為什麼

`repo-harness` 的 subagent 分派在 Claude 上好、在 Codex 上弱。實測根因不是 config(Codex 已 `multi_agent=true`/`max_depth=2`)也不是成熟度,而是**耦合介質**:parent↔child 兩個方向都騎在宿主原生 message-passing 上(`codex-delegation-advisor.sh` 下行注入 `spawn_agent`、`subagent-return-channel-guard.sh` 上行管 return),於是繼承了 Codex 原生編排的弱。

評估了 `obra/superpowers` 後決定**不整合它的 skills/plugin**(會製造兩套 plan/review/ledger 引擎),只採它證明過、而本倉已半成型的協定:**用檔案當耦合介質**。既有 `scripts/contract-run.ts` 已經是這個 runner(讀 contract → 產 worker/verifier prompt → spawnSync 執行 command → 寫 manifest),缺的只是「把 contract 當權威 brief 的完整性閘 + runner 宣告」。完整評估見 `docs/researches/20260705-superpowers-evaluation-file-coupled-delegation.md`。

## 改了什麼(Phase 1)

- `preflight` 模式 + `runBriefPreflight`:斷言 Goal / Scope / Allowed Paths / Exit Criteria 非佔位(擋 `{{...}}` token 與模板佔位句)。`run` 模式在派 worker **之前** fail-closed(`failure_class: incomplete_brief`,不 dispatch),`dry-run` 只記 advisory。**不動** `verify-contract` 的 exit_criteria-only 相容承諾。
- Delegation Contract YAML 加 `runner: { preferred, fallback, brief_is_authoritative }`,parse 進 manifest;舊無 runner 的 contract 預設 `["subagent"]`,不改語義。
- `codex exec --json` 走文檔化 `--worker-command` 路徑(prompt 由 env `CONTRACT_RUN_PROMPT` 提供),無新 runner engine。
- `scripts/contract-run.ts` ↔ `assets/templates/helpers/contract-run.ts` byte 一致;兩份 contract 模板同步加 runner 區塊。

## 驗證

- `bun test` 全綠:**1017 pass / 1 skip / 0 fail**(93 檔,1018 測試)。
- `tsc --noEmit` 乾淨。
- 新增 4 測試:preflight 正/負、run 拒絕不完整 brief 且不派 worker、runner metadata 進 manifest。
- 手測:preflight 對真實 fulfilled contract exit 0、對佔位模板 exit 1。

## Review 重點

- `isConcreteBrief` 的佔位偵測啟發式(認 `{{...}}` + 模板句 + 空 scope bullets)——會不會過嚴/過鬆?
- run 模式 fail-closed 的邊界:確認不會誤擋合法 contract(現有 run/budget 測試已補真實 Goal/Scope 通過)。
- 向後相容:無 `runner:` 區塊的既有 contract 預設 `["subagent"]`。

## 不在本 PR(Phase 2,已入 `tasks/todos.md`)

policy `delegation.preferred_runners`/`fallback_runner`(語義=同一 contract 的 runner 可用性降級,必寫 manifest、不得靜默)+ `codex-delegation-advisor.sh` 瘦身 + 全面同步。觸達面廣(>8 檔含遷移測試),分階段降風險。
