### PR TITLE
feat(delegation): point codex-delegation-advisor at the contract brief (Phase 2 slice 2)

### DIFF
--- a/.ai/harness/policy.json
+++ b/.ai/harness/policy.json
@@ -198,6 +198,10 @@
     "allow_parallel_writers": false,
     "stop_fallback": true,
     "state_file": ".ai/harness/delegation/latest.json",
+    "preferred_runners": ["subagent", "codex-exec", "main-thread"],
+    "fallback_runner": "main-thread",
+    "brief_source": "tasks/contracts/<stem>.contract.md",
+    "runner_rule": "the active task contract is the authoritative execution brief consumed by contract-run; native subagent is an optional parallelism accelerator. Degrade to codex-exec or sequential main-thread on the SAME contract when spawn is unavailable, sandboxed, or unreliable. Runner-availability fallback MUST be recorded in the contract-run manifest and MUST NOT silently succeed; it is a runner-availability fallback, not a product-semantics compatibility fallback.",
     "rule": "UserPromptSubmit.delegation only injects bounded subagent context after explicit user authorization such as /delegate, /parallel, spawn subagents, or parallel investigation"
   },
   "sidecar_research": {

--- a/.ai/hooks/.projection.json
+++ b/.ai/hooks/.projection.json
@@ -3,6 +3,6 @@
   "canonical_root": "assets/hooks",
   "projection_target": ".ai/hooks",
   "manifest": "assets/hooks/projection.json",
-  "digest": "sha256:bc0f603cddcba1b8febcf16e1c2e125d83545300e7a7ddc2dfb2939ff9d520ca",
+  "digest": "sha256:5a72d26df4bfa06c623ab24126738c046f33085751617999d9043c77c2537132",
   "file_count": 25
 }

--- a/.ai/hooks/AGENTS.md
+++ b/.ai/hooks/AGENTS.md
@@ -43,21 +43,21 @@ Owns the runtime-harness-hook-adapters capability boundary declared in .ai/conte
 <!-- BEGIN ARCHITECTURE CONTRACT -->
 ## Architecture Contract
 
-- Functional block: `.ai/hooks`
+- Functional block: `assets/hooks`
 - Capability ID: `runtime-harness-hook-adapters`
-- Matched prefix: `.ai/hooks`
+- Matched prefix: `assets/hooks`
 - Architecture domain: `runtime-harness`
 - Architecture capability: `hook-adapters`
 - Architecture module: `docs/architecture/modules/runtime-harness/hook-adapters.md`
-- Last architecture event: 2026-06-13T00:04:13+0800
-- Last changed path: `.ai/hooks/post-tool-observer.sh`
+- Last architecture event: 2026-07-05T13:45:11+0800
+- Last changed path: `assets/hooks/codex-delegation-advisor.sh`
 - Severity: high
 - Change type: workflow-surface
 - Module responsibility: Keep this block aligned with the local boundary described by surrounding human-owned context.
-- Entrypoints: `.ai/hooks`
+- Entrypoints: `assets/hooks`
 - Allowed dependencies: Follow root `AGENTS.md` / `CLAUDE.md` and this local contract.
 - Forbidden dependencies: Do not cross sibling app/service/package boundaries without an architecture snapshot or explicit plan.
-- Runtime path: `.ai/hooks`
+- Runtime path: `assets/hooks`
 - LSP/tooling profile: `typescript-lsp`
 - Verification: Use root required checks plus local commands recorded in this capability contract.
 - Latest snapshot: `(none yet)`

--- a/.ai/hooks/CLAUDE.md
+++ b/.ai/hooks/CLAUDE.md
@@ -43,21 +43,21 @@ Owns the runtime-harness-hook-adapters capability boundary declared in .ai/conte
 <!-- BEGIN ARCHITECTURE CONTRACT -->
 ## Architecture Contract
 
-- Functional block: `.ai/hooks`
+- Functional block: `assets/hooks`
 - Capability ID: `runtime-harness-hook-adapters`
-- Matched prefix: `.ai/hooks`
+- Matched prefix: `assets/hooks`
 - Architecture domain: `runtime-harness`
 - Architecture capability: `hook-adapters`
 - Architecture module: `docs/architecture/modules/runtime-harness/hook-adapters.md`
-- Last architecture event: 2026-06-13T00:04:13+0800
-- Last changed path: `.ai/hooks/post-tool-observer.sh`
+- Last architecture event: 2026-07-05T13:45:11+0800
+- Last changed path: `assets/hooks/codex-delegation-advisor.sh`
 - Severity: high
 - Change type: workflow-surface
 - Module responsibility: Keep this block aligned with the local boundary described by surrounding human-owned context.
-- Entrypoints: `.ai/hooks`
+- Entrypoints: `assets/hooks`
 - Allowed dependencies: Follow root `AGENTS.md` / `CLAUDE.md` and this local contract.
 - Forbidden dependencies: Do not cross sibling app/service/package boundaries without an architecture snapshot or explicit plan.
-- Runtime path: `.ai/hooks`
+- Runtime path: `assets/hooks`
 - LSP/tooling profile: `typescript-lsp`
 - Verification: Use root required checks plus local commands recorded in this capability contract.
 - Latest snapshot: `(none yet)`

--- a/.ai/hooks/codex-delegation-advisor.sh
+++ b/.ai/hooks/codex-delegation-advisor.sh
@@ -94,6 +94,25 @@ JSON_INPUT="$input" REPO_ROOT="${HOOK_REPO_ROOT:-$(pwd)}" bun -e '
   if (!trigger) process.exit(0);
 
   const repoRoot = process.env.REPO_ROOT || process.cwd();
+
+  let policyDelegation = {};
+  try {
+    policyDelegation =
+      JSON.parse(fs.readFileSync(path.join(repoRoot, ".ai", "harness", "policy.json"), "utf8")).delegation || {};
+  } catch {
+    policyDelegation = {};
+  }
+  const maxAgents = Number.isInteger(policyDelegation.max_agents) ? policyDelegation.max_agents : 3;
+  const maxDepth = Number.isInteger(policyDelegation.max_depth) ? policyDelegation.max_depth : 1;
+  const preferredRunners =
+    Array.isArray(policyDelegation.preferred_runners) && policyDelegation.preferred_runners.length
+      ? policyDelegation.preferred_runners
+      : ["subagent"];
+  const fallbackRunner =
+    typeof policyDelegation.fallback_runner === "string" && policyDelegation.fallback_runner
+      ? policyDelegation.fallback_runner
+      : null;
+
   const stateDir = path.join(repoRoot, ".ai", "harness", "delegation");
   fs.mkdirSync(stateDir, { recursive: true });
 
@@ -107,10 +126,12 @@ JSON_INPUT="$input" REPO_ROOT="${HOOK_REPO_ROOT:-$(pwd)}" bun -e '
     spawned: false,
     fallback_used: false,
     mode: "explicit",
-    max_agents: 3,
-    max_depth: 1,
+    max_agents: maxAgents,
+    max_depth: maxDepth,
     allow_parallel_writers: false,
     stop_fallback: true,
+    preferred_runners: preferredRunners,
+    fallback_runner: fallbackRunner,
     trigger: trigger.name,
     prompt_hash: crypto.createHash("sha1").update(prompt).digest("hex"),
     scope_source: scope?.source || "unscoped",
@@ -132,15 +153,19 @@ JSON_INPUT="$input" REPO_ROOT="${HOOK_REPO_ROOT:-$(pwd)}" bun -e '
     "",
     "The current user prompt explicitly enabled bounded delegation.",
     "",
-    "If this task contains at least two independent, bounded workstreams, call spawn_agent before doing the corresponding work in the parent.",
+    "Treat the active task contract (tasks/contracts/<active-plan-stem>.contract.md) as the authoritative execution brief: Goal, Scope, Allowed Paths, and Exit Criteria. Do not re-derive scope from this conversation.",
+    "",
+    `Runner preference (policy delegation.preferred_runners): ${preferredRunners.join(", ")}. Native subagent (spawn_agent) is the preferred parallelism accelerator that consumes the contract brief. When spawn_agent is unavailable, sandboxed, or unreliable, degrade to ${fallbackRunner || "main-thread"} on the SAME contract via contract-run. Runner-availability degradation MUST be recorded in the contract-run manifest and MUST NOT silently succeed; it is a runner-availability fallback, not a product-semantics change.`,
+    "",
+    "If this task contains at least two independent, bounded workstreams, dispatch per the contract before doing the corresponding work in the parent; otherwise run it sequentially.",
     "",
     "Rules:",
-    "- Spawn no more than 3 agents.",
+    `- Spawn no more than ${maxAgents} agents.`,
     "- Use explorer for read-only code mapping.",
     "- Use worker only for an isolated implementation slice.",
     "- Use reviewer for correctness, regression, security, and missing-test review.",
     "- Never give two agents overlapping write ownership.",
-    "- Keep max spawn depth at 1.",
+    `- Keep max spawn depth at ${maxDepth}.`,
     "- Give every agent a precise scope and required return format.",
     "- Wait for all requested agents.",
     "- Reconcile contradictory findings in the parent.",

--- a/.claude/templates/contract.template.md
+++ b/.claude/templates/contract.template.md
@@ -70,6 +70,13 @@ delegation:
     verifier:
       mode: read_only
       purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+      - codex-exec
+      - main-thread
+    fallback: main-thread
+    brief_is_authoritative: true
 ```
 
 ## Exit Criteria (Machine Verifiable)

--- a/assets/AGENTS.md
+++ b/assets/AGENTS.md
@@ -37,10 +37,10 @@ Owns the workflow-engine-contract-assets capability boundary declared in .ai/con
 - Architecture domain: `workflow-engine`
 - Architecture capability: `contract-assets`
 - Architecture module: `docs/architecture/modules/workflow-engine/contract-assets.md`
-- Last architecture event: 2026-05-29T02:15:07+0800
-- Last changed path: `tasks/workstreams/workflow-engine/contract-assets/cleanup-script-policy.md`
-- Severity: medium
-- Change type: workstream-sync
+- Last architecture event: 2026-07-05T04:35:33+0800
+- Last changed path: `.ai/harness/policy.json`
+- Severity: high
+- Change type: workflow-surface
 - Module responsibility: Keep this block aligned with the local boundary described by surrounding human-owned context.
 - Entrypoints: `.ai/harness/policy.json`
 - Allowed dependencies: Follow root `AGENTS.md` / `CLAUDE.md` and this local contract.
@@ -63,6 +63,6 @@ Owns the workflow-engine-contract-assets capability boundary declared in .ai/con
 ## Current Session Projection
 
 - Durable progress lives under `tasks/workstreams/workflow-engine/contract-assets`.
-- `tasks/current.md` is a tracked derived status snapshot, not a live lock or task source.
+- `tasks/current.md` is the tracked derived status snapshot; it is not a live lock or task source.
 - `tasks/todos.md` is the deferred-goal ledger; current execution slices stay in the active plan's `## Task Breakdown`.
 <!-- END ARCHITECTURE CONTRACT -->

--- a/assets/CLAUDE.md
+++ b/assets/CLAUDE.md
@@ -37,10 +37,10 @@ Owns the workflow-engine-contract-assets capability boundary declared in .ai/con
 - Architecture domain: `workflow-engine`
 - Architecture capability: `contract-assets`
 - Architecture module: `docs/architecture/modules/workflow-engine/contract-assets.md`
-- Last architecture event: 2026-05-29T02:15:07+0800
-- Last changed path: `tasks/workstreams/workflow-engine/contract-assets/cleanup-script-policy.md`
-- Severity: medium
-- Change type: workstream-sync
+- Last architecture event: 2026-07-05T04:35:33+0800
+- Last changed path: `.ai/harness/policy.json`
+- Severity: high
+- Change type: workflow-surface
 - Module responsibility: Keep this block aligned with the local boundary described by surrounding human-owned context.
 - Entrypoints: `.ai/harness/policy.json`
 - Allowed dependencies: Follow root `AGENTS.md` / `CLAUDE.md` and this local contract.
@@ -63,6 +63,6 @@ Owns the workflow-engine-contract-assets capability boundary declared in .ai/con
 ## Current Session Projection
 
 - Durable progress lives under `tasks/workstreams/workflow-engine/contract-assets`.
-- `tasks/current.md` is a tracked derived status snapshot, not a live lock or task source.
+- `tasks/current.md` is the tracked derived status snapshot; it is not a live lock or task source.
 - `tasks/todos.md` is the deferred-goal ledger; current execution slices stay in the active plan's `## Task Breakdown`.
 <!-- END ARCHITECTURE CONTRACT -->

--- a/assets/hooks/AGENTS.md
+++ b/assets/hooks/AGENTS.md
@@ -43,21 +43,21 @@ Owns the runtime-harness-hook-adapters capability boundary declared in .ai/conte
 <!-- BEGIN ARCHITECTURE CONTRACT -->
 ## Architecture Contract
 
-- Functional block: `.ai/hooks`
+- Functional block: `assets/hooks`
 - Capability ID: `runtime-harness-hook-adapters`
-- Matched prefix: `.ai/hooks`
+- Matched prefix: `assets/hooks`
 - Architecture domain: `runtime-harness`
 - Architecture capability: `hook-adapters`
 - Architecture module: `docs/architecture/modules/runtime-harness/hook-adapters.md`
-- Last architecture event: 2026-06-13T00:04:13+0800
-- Last changed path: `.ai/hooks/post-tool-observer.sh`
+- Last architecture event: 2026-07-05T13:45:11+0800
+- Last changed path: `assets/hooks/codex-delegation-advisor.sh`
 - Severity: high
 - Change type: workflow-surface
 - Module responsibility: Keep this block aligned with the local boundary described by surrounding human-owned context.
-- Entrypoints: `.ai/hooks`
+- Entrypoints: `assets/hooks`
 - Allowed dependencies: Follow root `AGENTS.md` / `CLAUDE.md` and this local contract.
 - Forbidden dependencies: Do not cross sibling app/service/package boundaries without an architecture snapshot or explicit plan.
-- Runtime path: `.ai/hooks`
+- Runtime path: `assets/hooks`
 - LSP/tooling profile: `typescript-lsp`
 - Verification: Use root required checks plus local commands recorded in this capability contract.
 - Latest snapshot: `(none yet)`

--- a/assets/hooks/CLAUDE.md
+++ b/assets/hooks/CLAUDE.md
@@ -43,21 +43,21 @@ Owns the runtime-harness-hook-adapters capability boundary declared in .ai/conte
 <!-- BEGIN ARCHITECTURE CONTRACT -->
 ## Architecture Contract
 
-- Functional block: `.ai/hooks`
+- Functional block: `assets/hooks`
 - Capability ID: `runtime-harness-hook-adapters`
-- Matched prefix: `.ai/hooks`
+- Matched prefix: `assets/hooks`
 - Architecture domain: `runtime-harness`
 - Architecture capability: `hook-adapters`
 - Architecture module: `docs/architecture/modules/runtime-harness/hook-adapters.md`
-- Last architecture event: 2026-06-13T00:04:13+0800
-- Last changed path: `.ai/hooks/post-tool-observer.sh`
+- Last architecture event: 2026-07-05T13:45:11+0800
+- Last changed path: `assets/hooks/codex-delegation-advisor.sh`
 - Severity: high
 - Change type: workflow-surface
 - Module responsibility: Keep this block aligned with the local boundary described by surrounding human-owned context.
-- Entrypoints: `.ai/hooks`
+- Entrypoints: `assets/hooks`
 - Allowed dependencies: Follow root `AGENTS.md` / `CLAUDE.md` and this local contract.
 - Forbidden dependencies: Do not cross sibling app/service/package boundaries without an architecture snapshot or explicit plan.
-- Runtime path: `.ai/hooks`
+- Runtime path: `assets/hooks`
 - LSP/tooling profile: `typescript-lsp`
 - Verification: Use root required checks plus local commands recorded in this capability contract.
 - Latest snapshot: `(none yet)`

--- a/assets/hooks/codex-delegation-advisor.sh
+++ b/assets/hooks/codex-delegation-advisor.sh
@@ -94,6 +94,25 @@ JSON_INPUT="$input" REPO_ROOT="${HOOK_REPO_ROOT:-$(pwd)}" bun -e '
   if (!trigger) process.exit(0);
 
   const repoRoot = process.env.REPO_ROOT || process.cwd();
+
+  let policyDelegation = {};
+  try {
+    policyDelegation =
+      JSON.parse(fs.readFileSync(path.join(repoRoot, ".ai", "harness", "policy.json"), "utf8")).delegation || {};
+  } catch {
+    policyDelegation = {};
+  }
+  const maxAgents = Number.isInteger(policyDelegation.max_agents) ? policyDelegation.max_agents : 3;
+  const maxDepth = Number.isInteger(policyDelegation.max_depth) ? policyDelegation.max_depth : 1;
+  const preferredRunners =
+    Array.isArray(policyDelegation.preferred_runners) && policyDelegation.preferred_runners.length
+      ? policyDelegation.preferred_runners
+      : ["subagent"];
+  const fallbackRunner =
+    typeof policyDelegation.fallback_runner === "string" && policyDelegation.fallback_runner
+      ? policyDelegation.fallback_runner
+      : null;
+
   const stateDir = path.join(repoRoot, ".ai", "harness", "delegation");
   fs.mkdirSync(stateDir, { recursive: true });
 
@@ -107,10 +126,12 @@ JSON_INPUT="$input" REPO_ROOT="${HOOK_REPO_ROOT:-$(pwd)}" bun -e '
     spawned: false,
     fallback_used: false,
     mode: "explicit",
-    max_agents: 3,
-    max_depth: 1,
+    max_agents: maxAgents,
+    max_depth: maxDepth,
     allow_parallel_writers: false,
     stop_fallback: true,
+    preferred_runners: preferredRunners,
+    fallback_runner: fallbackRunner,
     trigger: trigger.name,
     prompt_hash: crypto.createHash("sha1").update(prompt).digest("hex"),
     scope_source: scope?.source || "unscoped",
@@ -132,15 +153,19 @@ JSON_INPUT="$input" REPO_ROOT="${HOOK_REPO_ROOT:-$(pwd)}" bun -e '
     "",
     "The current user prompt explicitly enabled bounded delegation.",
     "",
-    "If this task contains at least two independent, bounded workstreams, call spawn_agent before doing the corresponding work in the parent.",
+    "Treat the active task contract (tasks/contracts/<active-plan-stem>.contract.md) as the authoritative execution brief: Goal, Scope, Allowed Paths, and Exit Criteria. Do not re-derive scope from this conversation.",
+    "",
+    `Runner preference (policy delegation.preferred_runners): ${preferredRunners.join(", ")}. Native subagent (spawn_agent) is the preferred parallelism accelerator that consumes the contract brief. When spawn_agent is unavailable, sandboxed, or unreliable, degrade to ${fallbackRunner || "main-thread"} on the SAME contract via contract-run. Runner-availability degradation MUST be recorded in the contract-run manifest and MUST NOT silently succeed; it is a runner-availability fallback, not a product-semantics change.`,
+    "",
+    "If this task contains at least two independent, bounded workstreams, dispatch per the contract before doing the corresponding work in the parent; otherwise run it sequentially.",
     "",
     "Rules:",
-    "- Spawn no more than 3 agents.",
+    `- Spawn no more than ${maxAgents} agents.`,
     "- Use explorer for read-only code mapping.",
     "- Use worker only for an isolated implementation slice.",
     "- Use reviewer for correctness, regression, security, and missing-test review.",
     "- Never give two agents overlapping write ownership.",
-    "- Keep max spawn depth at 1.",
+    `- Keep max spawn depth at ${maxDepth}.`,
     "- Give every agent a precise scope and required return format.",
     "- Wait for all requested agents.",
     "- Reconcile contradictory findings in the parent.",

--- a/assets/templates/contract.template.md
+++ b/assets/templates/contract.template.md
@@ -70,6 +70,13 @@ delegation:
     verifier:
       mode: read_only
       purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+      - codex-exec
+      - main-thread
+    fallback: main-thread
+    brief_is_authoritative: true
 ```
 
 ## Exit Criteria (Machine Verifiable)

--- a/assets/templates/helpers/contract-run.ts
+++ b/assets/templates/helpers/contract-run.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { dirname, isAbsolute, join, relative, resolve } from "path";
 import { spawnSync } from "child_process";
 
-type Mode = "dry-run" | "run";
+type Mode = "dry-run" | "run" | "preflight";
 
 interface Options {
   mode: Mode;
@@ -22,6 +22,12 @@ interface DelegationBudget {
   wall_time_minutes: number | null;
 }
 
+interface RunnerContract {
+  preferred: string[];
+  fallback: string | null;
+  brief_is_authoritative: boolean;
+}
+
 interface DelegationContract {
   budget: DelegationBudget;
   permission_scope: {
@@ -30,6 +36,12 @@ interface DelegationContract {
     network: string;
   };
   roles: Record<string, DelegationRole>;
+  runner: RunnerContract;
+}
+
+interface BriefPreflight {
+  ok: boolean;
+  issues: string[];
 }
 
 interface DelegationRole {
@@ -49,15 +61,23 @@ interface ChildResult {
 function usage(): string {
   return [
     "Usage:",
+    "  bun scripts/contract-run.ts preflight --contract <contract-file> [--repo <path>] [--json]",
     "  bun scripts/contract-run.ts dry-run --contract <contract-file> [--repo <path>] [--out <dir>] [--json]",
     "  bun scripts/contract-run.ts run --contract <contract-file> --worker-command <cmd> --verifier-command <cmd> [--repo <path>] [--out <dir>] [--max-tool-calls <n>] [--json]",
+    "",
+    "preflight asserts the contract is a self-sufficient execution brief (Goal, Scope,",
+    "Allowed Paths, Exit Criteria are filled in, not template placeholders) and exits",
+    "non-zero otherwise. run enforces the same gate before dispatching the worker.",
+    "",
+    "A file-coupled runner consumes the generated prompt from $CONTRACT_RUN_PROMPT, e.g.:",
+    "  --worker-command 'codex exec --json \"$(cat \\\"$CONTRACT_RUN_PROMPT\\\")\"'",
   ].join("\n");
 }
 
 function parseArgs(argv: string[]): Options {
   let mode: Mode = "dry-run";
   let index = 0;
-  if (argv[0] === "run" || argv[0] === "dry-run") {
+  if (argv[0] === "run" || argv[0] === "dry-run" || argv[0] === "preflight") {
     mode = argv[0];
     index = 1;
   }
@@ -256,7 +276,64 @@ function parseDelegation(markdown: string): DelegationContract {
       verifier: { mode: "read_only", purpose: "exit_criteria_review" },
       ...parseRoles(block),
     },
+    runner: parseRunner(block),
   };
+}
+
+function parseRunner(block: string): RunnerContract {
+  const preferred = parseList(block, "preferred");
+  const fallback = parseScalar(block, "fallback");
+  const briefAuthoritative = parseScalar(block, "brief_is_authoritative");
+  return {
+    preferred: preferred.length > 0 ? preferred : ["subagent"],
+    fallback: fallback && fallback !== "null" ? fallback : null,
+    brief_is_authoritative: briefAuthoritative === null ? true : briefAuthoritative === "true",
+  };
+}
+
+function sectionBody(markdown: string, heading: string): string {
+  const headingPattern = new RegExp(`^##\\s+${heading}\\s*$`);
+  const lines = markdown.split("\n");
+  const body: string[] = [];
+  let inSection = false;
+  for (const line of lines) {
+    if (headingPattern.test(line)) {
+      inSection = true;
+      continue;
+    }
+    if (inSection && /^##\s/.test(line)) break;
+    if (inSection) body.push(line);
+  }
+  return body.join("\n");
+}
+
+function isConcreteBrief(text: string): boolean {
+  const body = text.trim();
+  if (!body) return false;
+  if (/\{\{[^}]+\}\}/.test(body)) return false;
+  const withoutPlaceholders = body
+    .replace(/Describe the exact outcome this task must deliver\./g, "")
+    .replace(/^\s*-\s*In scope:\s*$/gm, "")
+    .replace(/^\s*-\s*Out of scope:\s*$/gm, "")
+    .trim();
+  return withoutPlaceholders.length > 0;
+}
+
+function runBriefPreflight(markdown: string): BriefPreflight {
+  const issues: string[] = [];
+  if (!isConcreteBrief(sectionBody(markdown, "Goal"))) {
+    issues.push("Goal section is empty or still a template placeholder");
+  }
+  if (!isConcreteBrief(sectionBody(markdown, "Scope"))) {
+    issues.push("Scope section is empty or still a template placeholder");
+  }
+  if (parseList(fencedYamlBlock(markdown, "allowed_paths"), "allowed_paths").length === 0) {
+    issues.push("Allowed Paths is empty");
+  }
+  if (!fencedYamlBlock(markdown, "exit_criteria").trim()) {
+    issues.push("Exit Criteria block is missing");
+  }
+  return { ok: issues.length === 0, issues };
 }
 
 function runChild(
@@ -307,6 +384,21 @@ function buildRun(opts: Options) {
   const exitCriteria = fencedYamlBlock(contractText, "exit_criteria");
   const delegation = parseDelegation(contractText);
   const allowedPaths = parseList(fencedYamlBlock(contractText, "allowed_paths"), "allowed_paths");
+  const briefPreflight = runBriefPreflight(contractText);
+
+  if (opts.mode === "preflight") {
+    const manifest = {
+      version: 1,
+      kind: "repo-harness-contract-run",
+      status: briefPreflight.ok ? "preflight_pass" : "fail",
+      failure_class: briefPreflight.ok ? null : "incomplete_brief",
+      repo,
+      contract: repoRelative(repo, contractPath),
+      brief_preflight: briefPreflight,
+    };
+    return { manifest, manifestPath: "" };
+  }
+
   const toolLimit = opts.maxToolCalls ?? delegation.budget.tool_calls;
   const slug = contractPath
     .split("/")
@@ -383,7 +475,12 @@ function buildRun(opts: Options) {
     return true;
   };
 
-  if (opts.mode === "run") {
+  if (opts.mode === "run" && !briefPreflight.ok) {
+    status = "fail";
+    failureClass = "incomplete_brief";
+  }
+
+  if (opts.mode === "run" && briefPreflight.ok) {
     if (consume("worker")) {
       const worker = runChild("worker", opts.workerCommand!, repo, runDir, {
         ...baseEnv,
@@ -416,6 +513,7 @@ function buildRun(opts: Options) {
     kind: "repo-harness-contract-run",
     status,
     failure_class: failureClass || null,
+    brief_preflight: briefPreflight,
     repo,
     contract: repoRelative(repo, contractPath),
     plan,
@@ -454,7 +552,9 @@ try {
     console.log(JSON.stringify(manifest, null, 2));
   } else {
     console.log(`[ContractRun] ${manifest.status}: ${manifest.contract}`);
-    console.log(`[ContractRun] manifest: ${repoRelative(resolve(opts.repo), manifestPath)}`);
+    if (manifestPath) {
+      console.log(`[ContractRun] manifest: ${repoRelative(resolve(opts.repo), manifestPath)}`);
+    }
     if (manifest.failure_class) console.log(`[ContractRun] failure_class: ${manifest.failure_class}`);
   }
   process.exit(manifest.status === "fail" ? 1 : 0);

--- a/assets/templates/helpers/ensure-task-workflow.sh
+++ b/assets/templates/helpers/ensure-task-workflow.sh
@@ -936,6 +936,10 @@ ARCHITECTURE_INDEX_EOF
     "allow_parallel_writers": false,
     "stop_fallback": true,
     "state_file": ".ai/harness/delegation/latest.json",
+    "preferred_runners": ["subagent", "codex-exec", "main-thread"],
+    "fallback_runner": "main-thread",
+    "brief_source": "tasks/contracts/<stem>.contract.md",
+    "runner_rule": "the active task contract is the authoritative execution brief consumed by contract-run; native subagent is an optional parallelism accelerator. Degrade to codex-exec or sequential main-thread on the SAME contract when spawn is unavailable, sandboxed, or unreliable. Runner-availability fallback MUST be recorded in the contract-run manifest and MUST NOT silently succeed; it is a runner-availability fallback, not a product-semantics compatibility fallback.",
     "rule": "UserPromptSubmit.delegation only injects bounded subagent context after explicit user authorization such as /delegate, /parallel, spawn subagents, or parallel investigation"
   },
   "sidecar_research": {

--- a/docs/architecture/requests/archive/2026/20260705-044147-root.md
+++ b/docs/architecture/requests/archive/2026/20260705-044147-root.md
@@ -1,0 +1,67 @@
+# Architecture Queue Card: root
+
+> **Status**: No architecture change
+> **Detected**: 2026-07-05T04:35:37+0800
+> **Updated**: 2026-07-05T04:35:37+0800
+> **Severity**: high
+> **Change Type**: workflow-surface
+> **File**: `scripts/ensure-task-workflow.sh`
+> **Functional Block**: `root`
+> **Capability ID**: `root`
+> **Matched Prefix**: `root`
+> **Architecture Domain**: `root`
+> **Architecture Capability**: `_root`
+> **Architecture Module**: `docs/architecture/index.md`
+> **Workstream Directory**: `tasks/workstreams/root/_root`
+> **Contract Files**: `none`, `none`
+> **Contract Sync Required**: false
+> **Spawn Recommended**: true
+> **Open Edits**: 1
+
+## Required Follow-up
+
+- Read root `AGENTS.md` / `CLAUDE.md`.
+- If functional block is not `root`, read its local `AGENTS.md` / `CLAUDE.md`.
+- Decide whether this change affects module boundaries, entrypoints, dependency rules, runtime paths, or verification commands.
+- For substantial changes, write a snapshot under `docs/architecture/snapshots/`.
+- When a visual explains the boundary better than prose, add or update a Mermaid fenced block in the relevant architecture module or snapshot Markdown first; that Markdown is the semantic source for LLM readers.
+- When a human-readable rendering is useful, generate a matching `$mermaid` architecture HTML file under `docs/architecture/diagrams/` and link it back to the Markdown semantic source.
+- Treat `mermaid` as an external installed skill dependency at `~/.codex/skills/mermaid`; do not copy, vendor, or inline its templates into this repo.
+- If this starts or advances durable execution, run `repo-harness run workstream-sync ensure --block "root" --request "docs/architecture/requests/root.md"`.
+- After the snapshot or diagram is produced, run `repo-harness run context-contract-sync sync-latest` so the local architecture contract block links to the latest artifacts.
+
+## Touched Files
+
+| Last Event | Severity | Change Type | File |
+| --- | --- | --- | --- |
+| 2026-07-05T04:35:37+0800 | high | workflow-surface | `scripts/ensure-task-workflow.sh` |
+
+## Event Fields
+
+```json
+{
+  "ts": "2026-07-05T04:35:37+0800",
+  "file_path": "scripts/ensure-task-workflow.sh",
+  "severity": "high",
+  "functional_block": "root",
+  "capability_id": "root",
+  "matched_prefix": "root",
+  "architecture_domain": "root",
+  "architecture_capability": "_root",
+  "architecture_module": "docs/architecture/index.md",
+  "workstream_dir": "tasks/workstreams/root/_root",
+  "contract_agents": "",
+  "contract_claude": "",
+  "change_type": "workflow-surface",
+  "request_file": "docs/architecture/requests/root.md",
+  "spawn_recommended": true,
+  "contract_sync_required": false
+}
+```
+
+## Archive Resolution
+
+- Status: No architecture change
+- Archived: 2026-07-05T04:41:47+0800
+- Artifacts: (none)
+- Note: Added preferred_runners/fallback_runner/runner_rule to policy delegation block (file-coupled delegation Phase 2 slice A). Config addition within existing boundary; no module boundary, entrypoint, dependency, or runtime-path change.

--- a/docs/architecture/requests/archive/2026/20260705-044147-workflow-engine-contract-assets.md
+++ b/docs/architecture/requests/archive/2026/20260705-044147-workflow-engine-contract-assets.md
@@ -1,0 +1,67 @@
+# Architecture Queue Card: workflow-engine-contract-assets
+
+> **Status**: No architecture change
+> **Detected**: 2026-07-05T04:35:33+0800
+> **Updated**: 2026-07-05T04:35:33+0800
+> **Severity**: high
+> **Change Type**: workflow-surface
+> **File**: `.ai/harness/policy.json`
+> **Functional Block**: `.ai/harness/policy.json`
+> **Capability ID**: `workflow-engine-contract-assets`
+> **Matched Prefix**: `.ai/harness/policy.json`
+> **Architecture Domain**: `workflow-engine`
+> **Architecture Capability**: `contract-assets`
+> **Architecture Module**: `docs/architecture/modules/workflow-engine/contract-assets.md`
+> **Workstream Directory**: `tasks/workstreams/workflow-engine/contract-assets`
+> **Contract Files**: `assets/AGENTS.md`, `assets/CLAUDE.md`
+> **Contract Sync Required**: true
+> **Spawn Recommended**: true
+> **Open Edits**: 1
+
+## Required Follow-up
+
+- Read root `AGENTS.md` / `CLAUDE.md`.
+- If functional block is not `root`, read its local `AGENTS.md` / `CLAUDE.md`.
+- Decide whether this change affects module boundaries, entrypoints, dependency rules, runtime paths, or verification commands.
+- For substantial changes, write a snapshot under `docs/architecture/snapshots/`.
+- When a visual explains the boundary better than prose, add or update a Mermaid fenced block in the relevant architecture module or snapshot Markdown first; that Markdown is the semantic source for LLM readers.
+- When a human-readable rendering is useful, generate a matching `$mermaid` architecture HTML file under `docs/architecture/diagrams/` and link it back to the Markdown semantic source.
+- Treat `mermaid` as an external installed skill dependency at `~/.codex/skills/mermaid`; do not copy, vendor, or inline its templates into this repo.
+- If this starts or advances durable execution, run `repo-harness run workstream-sync ensure --block ".ai/harness/policy.json" --request "docs/architecture/requests/workflow-engine-contract-assets.md"`.
+- After the snapshot or diagram is produced, run `repo-harness run context-contract-sync sync-latest` so the local architecture contract block links to the latest artifacts.
+
+## Touched Files
+
+| Last Event | Severity | Change Type | File |
+| --- | --- | --- | --- |
+| 2026-07-05T04:35:33+0800 | high | workflow-surface | `.ai/harness/policy.json` |
+
+## Event Fields
+
+```json
+{
+  "ts": "2026-07-05T04:35:33+0800",
+  "file_path": ".ai/harness/policy.json",
+  "severity": "high",
+  "functional_block": ".ai/harness/policy.json",
+  "capability_id": "workflow-engine-contract-assets",
+  "matched_prefix": ".ai/harness/policy.json",
+  "architecture_domain": "workflow-engine",
+  "architecture_capability": "contract-assets",
+  "architecture_module": "docs/architecture/modules/workflow-engine/contract-assets.md",
+  "workstream_dir": "tasks/workstreams/workflow-engine/contract-assets",
+  "contract_agents": "assets/AGENTS.md",
+  "contract_claude": "assets/CLAUDE.md",
+  "change_type": "workflow-surface",
+  "request_file": "docs/architecture/requests/workflow-engine-contract-assets.md",
+  "spawn_recommended": true,
+  "contract_sync_required": true
+}
+```
+
+## Archive Resolution
+
+- Status: No architecture change
+- Archived: 2026-07-05T04:41:47+0800
+- Artifacts: (none)
+- Note: Added preferred_runners/fallback_runner/runner_rule to policy delegation block (file-coupled delegation Phase 2 slice A). Config addition within existing boundary; no module boundary, entrypoint, dependency, or runtime-path change.

--- a/docs/architecture/requests/archive/2026/20260705-044147-workflow-engine-inspection-migration.md
+++ b/docs/architecture/requests/archive/2026/20260705-044147-workflow-engine-inspection-migration.md
@@ -1,0 +1,67 @@
+# Architecture Queue Card: workflow-engine-inspection-migration
+
+> **Status**: No architecture change
+> **Detected**: 2026-07-05T04:35:41+0800
+> **Updated**: 2026-07-05T04:35:41+0800
+> **Severity**: high
+> **Change Type**: workflow-surface
+> **File**: `scripts/lib/project-init-lib.sh`
+> **Functional Block**: `scripts/lib`
+> **Capability ID**: `workflow-engine-inspection-migration`
+> **Matched Prefix**: `scripts/lib`
+> **Architecture Domain**: `workflow-engine`
+> **Architecture Capability**: `inspection-migration`
+> **Architecture Module**: `docs/architecture/modules/workflow-engine/inspection-migration.md`
+> **Workstream Directory**: `tasks/workstreams/workflow-engine/inspection-migration`
+> **Contract Files**: `scripts/AGENTS.md`, `scripts/CLAUDE.md`
+> **Contract Sync Required**: true
+> **Spawn Recommended**: true
+> **Open Edits**: 1
+
+## Required Follow-up
+
+- Read root `AGENTS.md` / `CLAUDE.md`.
+- If functional block is not `root`, read its local `AGENTS.md` / `CLAUDE.md`.
+- Decide whether this change affects module boundaries, entrypoints, dependency rules, runtime paths, or verification commands.
+- For substantial changes, write a snapshot under `docs/architecture/snapshots/`.
+- When a visual explains the boundary better than prose, add or update a Mermaid fenced block in the relevant architecture module or snapshot Markdown first; that Markdown is the semantic source for LLM readers.
+- When a human-readable rendering is useful, generate a matching `$mermaid` architecture HTML file under `docs/architecture/diagrams/` and link it back to the Markdown semantic source.
+- Treat `mermaid` as an external installed skill dependency at `~/.codex/skills/mermaid`; do not copy, vendor, or inline its templates into this repo.
+- If this starts or advances durable execution, run `repo-harness run workstream-sync ensure --block "scripts/lib" --request "docs/architecture/requests/workflow-engine-inspection-migration.md"`.
+- After the snapshot or diagram is produced, run `repo-harness run context-contract-sync sync-latest` so the local architecture contract block links to the latest artifacts.
+
+## Touched Files
+
+| Last Event | Severity | Change Type | File |
+| --- | --- | --- | --- |
+| 2026-07-05T04:35:41+0800 | high | workflow-surface | `scripts/lib/project-init-lib.sh` |
+
+## Event Fields
+
+```json
+{
+  "ts": "2026-07-05T04:35:41+0800",
+  "file_path": "scripts/lib/project-init-lib.sh",
+  "severity": "high",
+  "functional_block": "scripts/lib",
+  "capability_id": "workflow-engine-inspection-migration",
+  "matched_prefix": "scripts/lib",
+  "architecture_domain": "workflow-engine",
+  "architecture_capability": "inspection-migration",
+  "architecture_module": "docs/architecture/modules/workflow-engine/inspection-migration.md",
+  "workstream_dir": "tasks/workstreams/workflow-engine/inspection-migration",
+  "contract_agents": "scripts/AGENTS.md",
+  "contract_claude": "scripts/CLAUDE.md",
+  "change_type": "workflow-surface",
+  "request_file": "docs/architecture/requests/workflow-engine-inspection-migration.md",
+  "spawn_recommended": true,
+  "contract_sync_required": true
+}
+```
+
+## Archive Resolution
+
+- Status: No architecture change
+- Archived: 2026-07-05T04:41:47+0800
+- Artifacts: (none)
+- Note: Added preferred_runners/fallback_runner/runner_rule to policy delegation block (file-coupled delegation Phase 2 slice A). Config addition within existing boundary; no module boundary, entrypoint, dependency, or runtime-path change.

--- a/docs/architecture/requests/archive/2026/20260705-134639-runtime-harness-hook-adapters.md
+++ b/docs/architecture/requests/archive/2026/20260705-134639-runtime-harness-hook-adapters.md
@@ -1,0 +1,67 @@
+# Architecture Queue Card: runtime-harness-hook-adapters
+
+> **Status**: No architecture change
+> **Detected**: 2026-07-05T13:44:57+0800
+> **Updated**: 2026-07-05T13:45:11+0800
+> **Severity**: high
+> **Change Type**: workflow-surface
+> **File**: `assets/hooks/codex-delegation-advisor.sh`
+> **Functional Block**: `assets/hooks`
+> **Capability ID**: `runtime-harness-hook-adapters`
+> **Matched Prefix**: `assets/hooks`
+> **Architecture Domain**: `runtime-harness`
+> **Architecture Capability**: `hook-adapters`
+> **Architecture Module**: `docs/architecture/modules/runtime-harness/hook-adapters.md`
+> **Workstream Directory**: `tasks/workstreams/runtime-harness/hook-adapters`
+> **Contract Files**: `assets/hooks/AGENTS.md`, `assets/hooks/CLAUDE.md`
+> **Contract Sync Required**: true
+> **Spawn Recommended**: true
+> **Open Edits**: 1
+
+## Required Follow-up
+
+- Read root `AGENTS.md` / `CLAUDE.md`.
+- If functional block is not `root`, read its local `AGENTS.md` / `CLAUDE.md`.
+- Decide whether this change affects module boundaries, entrypoints, dependency rules, runtime paths, or verification commands.
+- For substantial changes, write a snapshot under `docs/architecture/snapshots/`.
+- When a visual explains the boundary better than prose, add or update a Mermaid fenced block in the relevant architecture module or snapshot Markdown first; that Markdown is the semantic source for LLM readers.
+- When a human-readable rendering is useful, generate a matching `$mermaid` architecture HTML file under `docs/architecture/diagrams/` and link it back to the Markdown semantic source.
+- Treat `mermaid` as an external installed skill dependency at `~/.codex/skills/mermaid`; do not copy, vendor, or inline its templates into this repo.
+- If this starts or advances durable execution, run `repo-harness run workstream-sync ensure --block "assets/hooks" --request "docs/architecture/requests/runtime-harness-hook-adapters.md"`.
+- After the snapshot or diagram is produced, run `repo-harness run context-contract-sync sync-latest` so the local architecture contract block links to the latest artifacts.
+
+## Touched Files
+
+| Last Event | Severity | Change Type | File |
+| --- | --- | --- | --- |
+| 2026-07-05T13:45:11+0800 | high | workflow-surface | `assets/hooks/codex-delegation-advisor.sh` |
+
+## Event Fields
+
+```json
+{
+  "ts": "2026-07-05T13:45:11+0800",
+  "file_path": "assets/hooks/codex-delegation-advisor.sh",
+  "severity": "high",
+  "functional_block": "assets/hooks",
+  "capability_id": "runtime-harness-hook-adapters",
+  "matched_prefix": "assets/hooks",
+  "architecture_domain": "runtime-harness",
+  "architecture_capability": "hook-adapters",
+  "architecture_module": "docs/architecture/modules/runtime-harness/hook-adapters.md",
+  "workstream_dir": "tasks/workstreams/runtime-harness/hook-adapters",
+  "contract_agents": "assets/hooks/AGENTS.md",
+  "contract_claude": "assets/hooks/CLAUDE.md",
+  "change_type": "workflow-surface",
+  "request_file": "docs/architecture/requests/runtime-harness-hook-adapters.md",
+  "spawn_recommended": true,
+  "contract_sync_required": true
+}
+```
+
+## Archive Resolution
+
+- Status: No architecture change
+- Archived: 2026-07-05T13:46:39+0800
+- Artifacts: (none)
+- Note: codex-delegation-advisor now reads policy delegation limits/runners and points delegation at the contract brief with non-silent runner degradation. Behavior refinement within existing hook-adapters boundary; no new entrypoint, dependency, or runtime path.

--- a/docs/researches/20260705-superpowers-evaluation-file-coupled-delegation.md
+++ b/docs/researches/20260705-superpowers-evaluation-file-coupled-delegation.md
@@ -1,0 +1,53 @@
+# obra/superpowers 評估與 file-coupled delegation 決策
+
+> Date: 2026-07-05
+> Trigger: 使用者問「要不要把 obra/superpowers 整合進 repo-harness」,聚焦 subagent 分派(Claude 好、Codex 差)。
+> Method: WebFetch superpowers 原始碼 + 本地架構 map + deep-reasoner ×2 對立雙軌 + Codex peer review + 實測 `scripts/contract-run.ts` / `scripts/verify-contract.sh` / 真實 contract 檔。
+> Status: 決策已定;Phase 1 已實作(見末節)。
+
+## 決策(Verdict)
+
+不整合 superpowers 的 skills / plugin。Keep repo-harness 自有引擎,方法論交給 Waza `/think`/`/hunt`/`/check` 與 gstack。只採一個協定改動:把既有 `scripts/contract-run.ts`(file-coupled runner)補齊,讓 contract 檔成為權威執行 brief,`codex exec --json` 以 worker/verifier command 進場,原生 `spawn_agent` 降成可選加速器。目標宿主維持 Claude+Codex(不採 superpowers 的 per-harness reference-file 可移植層)。
+
+## 根因:耦合介質,不是 config 或成熟度
+
+使用者 Codex 已 `multi_agent = true`、`max_depth = 2`,仍「較差」。實測:repo-harness 的 parent↔child 兩個方向都騎在 Codex 原生 message-passing 上——下行 `.ai/hooks/codex-delegation-advisor.sh` 注入「先 call `spawn_agent`」,上行 `.ai/hooks/subagent-return-channel-guard.sh` 管原生 return。於是繼承 Codex 原生編排的弱。Claude 同一條 seam 騎在 Task 工具上,所以好。
+
+superpowers 的真正招數是**用檔案當耦合介質**(task-brief → child → review-package → ledger),原生 spawn 只負責「啟動 process」,對弱編排 by construction 免疫。誠實刻度:換成檔案耦合約 90% 是讓結果與派發品質脫鉤,約 10% 是 worker 指著 contract 當 brief 的實質改善;不會讓 Codex 原生 subagent 本身變好。
+
+## 為何不進口:檔全都在,只缺協定行為
+
+| superpowers | repo-harness 既有物 | 位置 |
+|---|---|---|
+| `scripts/task-brief` 輸出+消費 | `contract-run.ts` 讀 contract 產 worker-prompt(內嵌整份 contract) | `scripts/contract-run.ts:296` `buildRun` |
+| worker/reviewer 執行 | `runChild` spawnSync `workerCommand`/`verifierCommand` | `scripts/contract-run.ts:262` |
+| `scripts/review-package` | verifier-prompt(只嵌 exit_criteria)+ `tasks/reviews/*.review.md` + Waza `/check` | — |
+| progress ledger | `manifest.json` + Evidence Contract State/progress + workstream `current_slice` | `plan-to-todo.sh:130` |
+
+進口 superpowers 會製造兩套 plan/review/ledger 引擎搶擁有權 + `.superpowers/sdd/progress.md` 與 contract/workstream 雙份狀態,違反本倉 No-Fallback / 單一工作流原則。它也給不了 capability registry / architecture-drift / workstream 這層差異化。
+
+## Codex peer 的關鍵修正(已驗證併入)
+
+初版方向誤把 `codex exec` 塞進 policy 欄位 + hook。Codex peer 指出落點錯:`scripts/contract-run.ts` 已是 file-coupled runner,`codex exec --json` 天然是外部傳入的 `--worker-command`,不需新 engine、不進 hook(`docs/reference-configs/hook-operations.md` 明言 hooks 不啟動長任務)。實測 `scripts/verify-contract.sh:331-353` 只驗 `exit_criteria`、模板 Goal 是佔位——所以「brief 完整性檢查」是硬門檻、不是可選,且不能動 verify-contract 的 exit_criteria-only 相容承諾。
+
+## Phase 1 已實作(本次)
+
+落在 `scripts/contract-run.ts`(+ 產品源鏡像 `assets/templates/helpers/contract-run.ts`,byte 一致):
+
+- 新增 `preflight` 模式 + `runBriefPreflight`:斷言 Goal / Scope / Allowed Paths / Exit Criteria 非佔位、非空、自足;佔位偵測認 `{{...}}` token 與模板佔位句。
+- `run` 模式在派發 worker **之前** fail-closed:brief 不完整 → status `fail` / `failure_class: incomplete_brief`,不 dispatch(children 空),不靜默降級。
+- `dry-run` 只把 `brief_preflight` 記進 manifest(advisory,不擋),供 WIP 檢視。
+- Delegation Contract YAML 新增 `runner: { preferred, fallback, brief_is_authoritative }`,由 `parseDelegation` 消費、流進 manifest。舊無 `runner:` 的 contract 預設 `["subagent"]`,不改語義。
+- `codex exec --json` 走文檔化 command path(worker-prompt 由 env `CONTRACT_RUN_PROMPT` 提供),usage 附範例。
+- 模板 `assets/templates/contract.template.md` 與 `.claude/templates/contract.template.md` 同步加 runner 區塊。
+- `tests/contract-run.test.ts`:fixture 補真實 Goal/Scope + runner;新增 preflight 正/負、run fail-closed 不派 worker、runner metadata 進 manifest 共 4 測試。
+
+驗證:`bun test tests/contract-run.test.ts` 8/8 綠;`tsc --noEmit` 乾淨;preflight 對真實 fulfilled contract exit 0、對佔位模板 exit 1。
+
+## Phase 2(已入 todos,延後)
+
+policy `delegation.preferred_runners` / `fallback_runner`(語義=同一 contract 的 runner 可用性降級、必寫 manifest、不得靜默)+ `codex-delegation-advisor.sh` 瘦身為指向 active contract 的 nudge + 全面同步(policy 由 `ensure-task-workflow.sh` / `project-init-lib.sh` / `assets/templates/helpers/*` / 遷移測試共維護)。`subagent-stop-quality` host-agnostic 化為獨立品質閘,不綁本次。
+
+## 最脆弱假設
+
+contract 必須是「乾淨-context runner 可完成 slice」的自足 brief。Phase 1 的 preflight 硬門檻承接了它;`codex exec` fallback 可能與原生 spawn 共享 sandbox 失敗(detached HEAD、不能 branch/push),需在 manifest 記錄失敗而非靜默。

--- a/plans/plan-20260705-0426-file-coupled-delegation-phase2.md
+++ b/plans/plan-20260705-0426-file-coupled-delegation-phase2.md
@@ -1,0 +1,209 @@
+# Plan: File-coupled delegation Phase 2: policy runner degradation, advisor slim-down, preflight wiring
+
+> **Status**: Draft
+> **Created**: 20260705-0426
+> **Slug**: file-coupled-delegation-phase2
+> **Planning Source**: codex-plan-or-waza-think
+> **Orchestration Kind**: host-plan
+> **Source Ref**: (none)
+> **Artifact Level**: work-package
+> **Promotion Reason**: merge_boundary
+> **Verification Boundary**: Commands named in the captured planning output plus `repo-harness run verify-contract --contract tasks/contracts/20260705-0426-file-coupled-delegation-phase2.contract.md --strict`.
+> **Rollback Surface**: Before execution remove `plans/plan-20260705-0426-file-coupled-delegation-phase2.md`; after execution revert branch `codex/file-coupled-delegation-phase2` or the explicitly reviewed diff.
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260705-0426-file-coupled-delegation-phase2.contract.md`
+> **Task Review**: `tasks/reviews/20260705-0426-file-coupled-delegation-phase2.review.md`
+> **Implementation Notes**: `tasks/notes/20260705-0426-file-coupled-delegation-phase2.notes.md`
+
+## Agentic Routing
+- Selected route: waza:think
+- Routing reason: Captured from codex-plan-or-waza-think planning output.
+- Source ref: (none)
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260705-0426-file-coupled-delegation-phase2.md`
+- Sprint contract: `tasks/contracts/20260705-0426-file-coupled-delegation-phase2.contract.md`
+- Sprint review: `tasks/reviews/20260705-0426-file-coupled-delegation-phase2.review.md`
+- Implementation notes: `tasks/notes/20260705-0426-file-coupled-delegation-phase2.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260705-0426-file-coupled-delegation-phase2.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree; `.claude/.active-plan` is a legacy fallback during transition. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260705-0426-file-coupled-delegation-phase2.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260705-0426-file-coupled-delegation-phase2.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260705-0426-file-coupled-delegation-phase2.contract.md`
+- Review file: `tasks/reviews/20260705-0426-file-coupled-delegation-phase2.review.md`
+- Implementation notes file: `tasks/notes/20260705-0426-file-coupled-delegation-phase2.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260705-0426-file-coupled-delegation-phase2.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan`, the owning worktree is written to `.ai/harness/active-worktree`, and the plan is mirrored to `.claude/.active-plan` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260705-0426-file-coupled-delegation-phase2.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: Before execution remove `plans/plan-20260705-0426-file-coupled-delegation-phase2.md`; after execution revert branch `codex/file-coupled-delegation-phase2` or the explicitly reviewed diff.
+- **Verification boundary**: Commands named in the captured planning output plus `repo-harness run verify-contract --contract tasks/contracts/20260705-0426-file-coupled-delegation-phase2.contract.md --strict`.
+- **Review/acceptance boundary**: `tasks/reviews/20260705-0426-file-coupled-delegation-phase2.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: merge_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260705-0426-file-coupled-delegation-phase2.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260705-0426-file-coupled-delegation-phase2.contract.md`, `tasks/reviews/20260705-0426-file-coupled-delegation-phase2.review.md`, and `tasks/notes/20260705-0426-file-coupled-delegation-phase2.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260705-0426-file-coupled-delegation-phase2.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: Before execution remove `plans/plan-20260705-0426-file-coupled-delegation-phase2.md`; after execution revert branch `codex/file-coupled-delegation-phase2` or the explicitly reviewed diff.
+
+## Captured Planning Output
+
+## Context
+
+Phase 1(PR #39)讓 `scripts/contract-run.ts` 以 brief 完整性閘 file-coupled delegation,並加了 per-contract `runner` metadata。它交付了「檢查 + 每份 contract 的 runner 宣告」,但兩個缺口留給 Phase 2:
+
+1. 閘只在 `contract-run` 被呼叫時觸發,**沒接進工作流**(plan-to-todo / verify-sprint),所以不完整的 brief 仍可能繞過它進到 file-coupled run。
+2. 只有 per-contract runner metadata,**沒有全域 policy 預設**的 runner 偏好與可用性降級;`codex-delegation-advisor.sh` 仍硬編 max_agents/max_depth 且命令原生 `spawn_agent`。
+
+Phase 2 把 file-coupled runner 變成**跨宿主的預設降級路徑**:policy 宣告 runner 偏好 + fallback 語義,advisor 改成指向 contract brief 而非命令原生 spawn,preflight 閘接進工作流強制執行。根因回顧見 `docs/researches/20260705-superpowers-evaluation-file-coupled-delegation.md`。
+
+## Scope / Non-scope
+
+In scope:
+- `.ai/harness/policy.json` `delegation`:加 `preferred_runners`(如 `["subagent","codex-exec","main-thread"]`)+ `fallback_runner` + rule 字串。**語義嚴格 = 同一份 contract 下的 runner「可用性」降級,必須寫進 run manifest,不得靜默成功**;不是產品語義的 compatibility fallback(不違反 No-Fallback rule)。
+- policy 共維護面:寫/驗 policy.json 的 `scripts/ensure-task-workflow.sh`、`scripts/lib/project-init-lib.sh`、`assets/templates/helpers/*`、以及 migration/bootstrap 測試,全部要 emit 並 assert 新欄位。
+- `.ai/hooks/codex-delegation-advisor.sh`(產品源 `assets/hooks/`,經 `bun run sync:hooks` 投影):瘦身成 nudge——(a) 從 policy 讀 max_agents/max_depth,(b) 指向 active `tasks/contracts/<stem>.contract.md` 當 brief,(c) 依 `policy.delegation.preferred_runners` 選 runner、依 `fallback_runner` 降級。維持 Codex-only。
+- 把 Phase 1 preflight 接成**強制閘**:`plan-to-todo`(或 `contract-worktree start`)在 contract 將被當 file-coupled 執行 brief 時跑 `contract-run preflight`,不完整就 fail-closed。**不動** `verify-contract` 的 exit_criteria-only 相容承諾。
+
+Non-scope:
+- `subagent-stop-quality` host-agnostic 化(獨立品質閘改善,另開)。
+- 在 hook 裡自動選/啟動 runner(hooks 不啟動長任務,見 `docs/reference-configs/hook-operations.md`)。
+- Codex 原生編排可靠性(非本倉能修)。
+- 任何 superpowers 進口。
+
+## Approach
+
+### Strategy
+policy 宣告「偏好 + 降級」,advisor 從「命令原生 spawn」轉為「指向 contract + 依 policy 選 runner」,preflight 接進工作流當硬閘。三者合起來讓「不完整 brief 進不了 file-coupled run」且「runner 降級一定留痕」。原生 `spawn_agent` 保留為 `preferred_runners` 的首選,行為向後相容。
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| policy 全域 preferred_runners + advisor 指向 contract(本案) | file-coupled 成為預設降級;跨宿主一致;留痕 | 觸達 policy 共維護面(>8 檔) | 採用 |
+| 只留 Phase 1 per-contract metadata,不加全域 policy | 改動最小 | 每份 contract 要自己宣告;advisor 仍命令原生 spawn,Codex 仍弱 | 拒絕 |
+| 在 hook 內自動 `codex exec` | 全自動 | 違反「hook 不啟動長任務」;失敗難留痕 | 拒絕 |
+
+## Detailed Design
+
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| `.ai/harness/policy.json` | modify | `delegation` 加 `preferred_runners`、`fallback_runner`、rule(語義=runner 可用性降級、必寫 manifest、不得靜默) |
+| `scripts/ensure-task-workflow.sh` | modify | 生成/校驗 policy.json 時 emit 新欄位 |
+| `scripts/lib/project-init-lib.sh` | modify | 下游 repo 初始化的 policy 預設含新欄位 |
+| `assets/templates/helpers/*`(policy 相關) | modify | 與上同步 |
+| `.ai/hooks/codex-delegation-advisor.sh` + `assets/hooks/…` | modify | 瘦身為 contract-指向 nudge;`bun run sync:hooks` |
+| `scripts/plan-to-todo.sh`(或 `contract-worktree.sh start`) | modify | 接 `contract-run preflight` 硬閘 |
+| `tests/*`(policy shape、advisor、preflight-wiring、migration) | modify/add | 斷言新欄位、fail-closed、manifest 留痕 |
+
+### 關鍵語義:fallback_runner 不是 compatibility fallback
+`fallback_runner` 只表達「preferred runner 不可用時,換另一個 runner 執行**同一份 contract**」。它**不**改變任何產品語義、不再推導授權值。每次降級必須在 `manifest.json` 記錄實際使用的 runner 與降級原因,測試斷言「降級 → 非靜默」。
+
+### advisor before/after
+- Before:硬編 `max_agents:3/max_depth:1`,注入不指名 contract 的泛用 explorer/worker/reviewer 角色,命令「先 call spawn_agent」。
+- After:從 policy 讀 limits;注入「你的 brief 是當前 contract 檔;依 policy.preferred_runners 選 runner;spawn 不穩就依 fallback_runner 降級並在 manifest 記錄」。
+
+### preflight wiring point
+`plan-to-todo`(或 `contract-worktree start`)在把 contract 交付為 file-coupled 執行 brief 前呼叫 `contract-run preflight --contract <file>`;非零則 fail-closed 並提示補齊 Goal/Scope/Allowed Paths/Exit Criteria。normal `verify-contract`/`dry-run` 路徑不受影響。
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| policy schema 漂移,共維護面不同步 → migration 測試炸 | 中 | 高 | 同一 PR 更新所有 generator + 測試;跑 `migrate --dry-run` + `check-architecture-sync` |
+| preflight 接得太前面,擋掉合法 WIP 流程 | 中 | 中 | 只在 file-coupled RUN 交付路徑強制,不碰 dry-run/normal verify;既有 contract 已帶 Goal/Scope |
+| `fallback` 被誤解為產品 compatibility fallback | 低 | 中 | rule 字串 + manifest 留痕 + 測試斷言非靜默 |
+| advisor 改動影響 Codex 現行 delegation 行為 | 中 | 中 | 保 Codex-only;快照/測試 advisor 輸出;native 仍是 preferred 首選 |
+
+## Promotion Gate
+- **Merge/PR unit**: 是,單一 PR(policy + advisor + wiring + sync)。
+- **Rollback surface**: revert 本 Phase 2 分支;Phase 1(native 為 preferred 首選)仍可運作。
+- **Verification boundary**: `bun test` 全綠 + `migrate --dry-run` + `contract-run` manifest 顯示 runner/fallback。
+- **Review/acceptance boundary**: review 檔 recommend pass + 外部驗收。
+- **High-risk surface**: policy 共維護面 + 遷移相容。
+- **Why not checklist row**: 觸達 >8 檔、跨 policy/hook/工作流、有獨立驗證與回退邊界。
+
+## Evidence Contract
+- **State/progress path**: 本 plan `## Task Breakdown` + `tasks/contracts/<stem>.contract.md` 狀態 + `.ai/harness/runs/*/manifest.json` 的 runner/fallback 欄位。
+- **Verification evidence**: 全量 `bun test`、`migrate-project-template.sh --dry-run`、`contract-run run/preflight` manifest。
+- **Evaluator rubric**: contract exit_criteria 通過 + review recommend pass + 降級非靜默(manifest 有記錄實際 runner)。
+- **Stop condition**: policy 新欄位就位並全共維護面同步、advisor 瘦身、preflight 接進工作流、所有相關測試 + 全量套件綠。
+- **Rollback surface**: revert Phase 2 分支;無資料遷移。
+
+## Task Breakdown
+- [ ] `.ai/harness/policy.json` `delegation` 加 `preferred_runners` / `fallback_runner` / rule(runner 可用性降級、必寫 manifest、不得靜默)
+- [ ] 同步 policy 共維護面:`ensure-task-workflow.sh`、`project-init-lib.sh`、`assets/templates/helpers/*` + migration/bootstrap 測試 emit 並 assert 新欄位
+- [ ] 瘦身 `codex-delegation-advisor.sh`:從 policy 讀 limits、指向 active contract、runner-per-policy;`bun run sync:hooks` 投影 `.ai/hooks`
+- [ ] 把 `contract-run preflight` 接進 `plan-to-todo`(或 `contract-worktree start`)當 fail-closed 硬閘,`verify-contract` 相容承諾不變
+- [ ] 測試:policy shape、advisor 輸出、preflight-wiring fail-closed、manifest 記錄 runner+fallback 非靜默
+- [ ] 全量驗證:`bun test`、`migrate --dry-run`、`check-architecture-sync`、`check-task-workflow --strict`、`contract-run.ts` 兩份 parity
+
+## Verification
+```bash
+bun test
+bash scripts/migrate-project-template.sh --repo . --dry-run
+bash scripts/check-architecture-sync.sh
+repo-harness run check-task-workflow --strict
+diff -q scripts/contract-run.ts assets/templates/helpers/contract-run.ts
+# 手測:對一份完整 contract 跑 file-coupled run,確認 manifest 記錄實際 runner;
+# 對佔位 contract 走 plan-to-todo 交付路徑,確認 preflight fail-closed。
+```
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [ ] `.ai/harness/policy.json` `delegation` 加 `preferred_runners` / `fallback_runner` / rule(runner 可用性降級、必寫 manifest、不得靜默)
+- [ ] 同步 policy 共維護面:`ensure-task-workflow.sh`、`project-init-lib.sh`、`assets/templates/helpers/*` + migration/bootstrap 測試 emit 並 assert 新欄位
+- [ ] 瘦身 `codex-delegation-advisor.sh`:從 policy 讀 limits、指向 active contract、runner-per-policy;`bun run sync:hooks` 投影 `.ai/hooks`
+- [ ] 把 `contract-run preflight` 接進 `plan-to-todo`(或 `contract-worktree start`)當 fail-closed 硬閘,`verify-contract` 相容承諾不變
+- [ ] 測試:policy shape、advisor 輸出、preflight-wiring fail-closed、manifest 記錄 runner+fallback 非靜默
+- [ ] 全量驗證:`bun test`、`migrate --dry-run`、`check-architecture-sync`、`check-task-workflow --strict`、`contract-run.ts` 兩份 parity

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -31,21 +31,21 @@ Owns the workflow-engine-inspection-migration capability boundary declared in .a
 <!-- BEGIN ARCHITECTURE CONTRACT -->
 ## Architecture Contract
 
-- Functional block: `scripts/inspect-project-state.ts`
+- Functional block: `scripts/lib`
 - Capability ID: `workflow-engine-inspection-migration`
-- Matched prefix: `scripts/inspect-project-state.ts`
+- Matched prefix: `scripts/lib`
 - Architecture domain: `workflow-engine`
 - Architecture capability: `inspection-migration`
 - Architecture module: `docs/architecture/modules/workflow-engine/inspection-migration.md`
-- Last architecture event: 2026-07-03T15:45:36+0800
-- Last changed path: `docs/architecture/requests/archive/2026/workflow-engine-inspection-migration.md`
+- Last architecture event: 2026-07-05T04:35:41+0800
+- Last changed path: `scripts/lib/project-init-lib.sh`
 - Severity: high
-- Change type: architecture-closeout
+- Change type: workflow-surface
 - Module responsibility: Keep this block aligned with the local boundary described by surrounding human-owned context.
-- Entrypoints: `scripts/inspect-project-state.ts`
+- Entrypoints: `scripts/lib`
 - Allowed dependencies: Follow root `AGENTS.md` / `CLAUDE.md` and this local contract.
 - Forbidden dependencies: Do not cross sibling app/service/package boundaries without an architecture snapshot or explicit plan.
-- Runtime path: `scripts/inspect-project-state.ts`
+- Runtime path: `scripts/lib`
 - LSP/tooling profile: `typescript-lsp`
 - Verification: Use root required checks plus local commands recorded in this capability contract.
 - Latest snapshot: `(none yet)`

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -31,21 +31,21 @@ Owns the workflow-engine-inspection-migration capability boundary declared in .a
 <!-- BEGIN ARCHITECTURE CONTRACT -->
 ## Architecture Contract
 
-- Functional block: `scripts/inspect-project-state.ts`
+- Functional block: `scripts/lib`
 - Capability ID: `workflow-engine-inspection-migration`
-- Matched prefix: `scripts/inspect-project-state.ts`
+- Matched prefix: `scripts/lib`
 - Architecture domain: `workflow-engine`
 - Architecture capability: `inspection-migration`
 - Architecture module: `docs/architecture/modules/workflow-engine/inspection-migration.md`
-- Last architecture event: 2026-07-03T15:45:36+0800
-- Last changed path: `docs/architecture/requests/archive/2026/workflow-engine-inspection-migration.md`
+- Last architecture event: 2026-07-05T04:35:41+0800
+- Last changed path: `scripts/lib/project-init-lib.sh`
 - Severity: high
-- Change type: architecture-closeout
+- Change type: workflow-surface
 - Module responsibility: Keep this block aligned with the local boundary described by surrounding human-owned context.
-- Entrypoints: `scripts/inspect-project-state.ts`
+- Entrypoints: `scripts/lib`
 - Allowed dependencies: Follow root `AGENTS.md` / `CLAUDE.md` and this local contract.
 - Forbidden dependencies: Do not cross sibling app/service/package boundaries without an architecture snapshot or explicit plan.
-- Runtime path: `scripts/inspect-project-state.ts`
+- Runtime path: `scripts/lib`
 - LSP/tooling profile: `typescript-lsp`
 - Verification: Use root required checks plus local commands recorded in this capability contract.
 - Latest snapshot: `(none yet)`

--- a/scripts/contract-run.ts
+++ b/scripts/contract-run.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { dirname, isAbsolute, join, relative, resolve } from "path";
 import { spawnSync } from "child_process";
 
-type Mode = "dry-run" | "run";
+type Mode = "dry-run" | "run" | "preflight";
 
 interface Options {
   mode: Mode;
@@ -22,6 +22,12 @@ interface DelegationBudget {
   wall_time_minutes: number | null;
 }
 
+interface RunnerContract {
+  preferred: string[];
+  fallback: string | null;
+  brief_is_authoritative: boolean;
+}
+
 interface DelegationContract {
   budget: DelegationBudget;
   permission_scope: {
@@ -30,6 +36,12 @@ interface DelegationContract {
     network: string;
   };
   roles: Record<string, DelegationRole>;
+  runner: RunnerContract;
+}
+
+interface BriefPreflight {
+  ok: boolean;
+  issues: string[];
 }
 
 interface DelegationRole {
@@ -49,15 +61,23 @@ interface ChildResult {
 function usage(): string {
   return [
     "Usage:",
+    "  bun scripts/contract-run.ts preflight --contract <contract-file> [--repo <path>] [--json]",
     "  bun scripts/contract-run.ts dry-run --contract <contract-file> [--repo <path>] [--out <dir>] [--json]",
     "  bun scripts/contract-run.ts run --contract <contract-file> --worker-command <cmd> --verifier-command <cmd> [--repo <path>] [--out <dir>] [--max-tool-calls <n>] [--json]",
+    "",
+    "preflight asserts the contract is a self-sufficient execution brief (Goal, Scope,",
+    "Allowed Paths, Exit Criteria are filled in, not template placeholders) and exits",
+    "non-zero otherwise. run enforces the same gate before dispatching the worker.",
+    "",
+    "A file-coupled runner consumes the generated prompt from $CONTRACT_RUN_PROMPT, e.g.:",
+    "  --worker-command 'codex exec --json \"$(cat \\\"$CONTRACT_RUN_PROMPT\\\")\"'",
   ].join("\n");
 }
 
 function parseArgs(argv: string[]): Options {
   let mode: Mode = "dry-run";
   let index = 0;
-  if (argv[0] === "run" || argv[0] === "dry-run") {
+  if (argv[0] === "run" || argv[0] === "dry-run" || argv[0] === "preflight") {
     mode = argv[0];
     index = 1;
   }
@@ -256,7 +276,64 @@ function parseDelegation(markdown: string): DelegationContract {
       verifier: { mode: "read_only", purpose: "exit_criteria_review" },
       ...parseRoles(block),
     },
+    runner: parseRunner(block),
   };
+}
+
+function parseRunner(block: string): RunnerContract {
+  const preferred = parseList(block, "preferred");
+  const fallback = parseScalar(block, "fallback");
+  const briefAuthoritative = parseScalar(block, "brief_is_authoritative");
+  return {
+    preferred: preferred.length > 0 ? preferred : ["subagent"],
+    fallback: fallback && fallback !== "null" ? fallback : null,
+    brief_is_authoritative: briefAuthoritative === null ? true : briefAuthoritative === "true",
+  };
+}
+
+function sectionBody(markdown: string, heading: string): string {
+  const headingPattern = new RegExp(`^##\\s+${heading}\\s*$`);
+  const lines = markdown.split("\n");
+  const body: string[] = [];
+  let inSection = false;
+  for (const line of lines) {
+    if (headingPattern.test(line)) {
+      inSection = true;
+      continue;
+    }
+    if (inSection && /^##\s/.test(line)) break;
+    if (inSection) body.push(line);
+  }
+  return body.join("\n");
+}
+
+function isConcreteBrief(text: string): boolean {
+  const body = text.trim();
+  if (!body) return false;
+  if (/\{\{[^}]+\}\}/.test(body)) return false;
+  const withoutPlaceholders = body
+    .replace(/Describe the exact outcome this task must deliver\./g, "")
+    .replace(/^\s*-\s*In scope:\s*$/gm, "")
+    .replace(/^\s*-\s*Out of scope:\s*$/gm, "")
+    .trim();
+  return withoutPlaceholders.length > 0;
+}
+
+function runBriefPreflight(markdown: string): BriefPreflight {
+  const issues: string[] = [];
+  if (!isConcreteBrief(sectionBody(markdown, "Goal"))) {
+    issues.push("Goal section is empty or still a template placeholder");
+  }
+  if (!isConcreteBrief(sectionBody(markdown, "Scope"))) {
+    issues.push("Scope section is empty or still a template placeholder");
+  }
+  if (parseList(fencedYamlBlock(markdown, "allowed_paths"), "allowed_paths").length === 0) {
+    issues.push("Allowed Paths is empty");
+  }
+  if (!fencedYamlBlock(markdown, "exit_criteria").trim()) {
+    issues.push("Exit Criteria block is missing");
+  }
+  return { ok: issues.length === 0, issues };
 }
 
 function runChild(
@@ -307,6 +384,21 @@ function buildRun(opts: Options) {
   const exitCriteria = fencedYamlBlock(contractText, "exit_criteria");
   const delegation = parseDelegation(contractText);
   const allowedPaths = parseList(fencedYamlBlock(contractText, "allowed_paths"), "allowed_paths");
+  const briefPreflight = runBriefPreflight(contractText);
+
+  if (opts.mode === "preflight") {
+    const manifest = {
+      version: 1,
+      kind: "repo-harness-contract-run",
+      status: briefPreflight.ok ? "preflight_pass" : "fail",
+      failure_class: briefPreflight.ok ? null : "incomplete_brief",
+      repo,
+      contract: repoRelative(repo, contractPath),
+      brief_preflight: briefPreflight,
+    };
+    return { manifest, manifestPath: "" };
+  }
+
   const toolLimit = opts.maxToolCalls ?? delegation.budget.tool_calls;
   const slug = contractPath
     .split("/")
@@ -383,7 +475,12 @@ function buildRun(opts: Options) {
     return true;
   };
 
-  if (opts.mode === "run") {
+  if (opts.mode === "run" && !briefPreflight.ok) {
+    status = "fail";
+    failureClass = "incomplete_brief";
+  }
+
+  if (opts.mode === "run" && briefPreflight.ok) {
     if (consume("worker")) {
       const worker = runChild("worker", opts.workerCommand!, repo, runDir, {
         ...baseEnv,
@@ -416,6 +513,7 @@ function buildRun(opts: Options) {
     kind: "repo-harness-contract-run",
     status,
     failure_class: failureClass || null,
+    brief_preflight: briefPreflight,
     repo,
     contract: repoRelative(repo, contractPath),
     plan,
@@ -454,7 +552,9 @@ try {
     console.log(JSON.stringify(manifest, null, 2));
   } else {
     console.log(`[ContractRun] ${manifest.status}: ${manifest.contract}`);
-    console.log(`[ContractRun] manifest: ${repoRelative(resolve(opts.repo), manifestPath)}`);
+    if (manifestPath) {
+      console.log(`[ContractRun] manifest: ${repoRelative(resolve(opts.repo), manifestPath)}`);
+    }
     if (manifest.failure_class) console.log(`[ContractRun] failure_class: ${manifest.failure_class}`);
   }
   process.exit(manifest.status === "fail" ? 1 : 0);

--- a/scripts/ensure-task-workflow.sh
+++ b/scripts/ensure-task-workflow.sh
@@ -936,6 +936,10 @@ ARCHITECTURE_INDEX_EOF
     "allow_parallel_writers": false,
     "stop_fallback": true,
     "state_file": ".ai/harness/delegation/latest.json",
+    "preferred_runners": ["subagent", "codex-exec", "main-thread"],
+    "fallback_runner": "main-thread",
+    "brief_source": "tasks/contracts/<stem>.contract.md",
+    "runner_rule": "the active task contract is the authoritative execution brief consumed by contract-run; native subagent is an optional parallelism accelerator. Degrade to codex-exec or sequential main-thread on the SAME contract when spawn is unavailable, sandboxed, or unreliable. Runner-availability fallback MUST be recorded in the contract-run manifest and MUST NOT silently succeed; it is a runner-availability fallback, not a product-semantics compatibility fallback.",
     "rule": "UserPromptSubmit.delegation only injects bounded subagent context after explicit user authorization such as /delegate, /parallel, spawn subagents, or parallel investigation"
   },
   "sidecar_research": {

--- a/scripts/lib/project-init-lib.sh
+++ b/scripts/lib/project-init-lib.sh
@@ -1888,6 +1888,10 @@ pi_write_harness_policy() {
     "allow_parallel_writers": false,
     "stop_fallback": true,
     "state_file": ".ai/harness/delegation/latest.json",
+    "preferred_runners": ["subagent", "codex-exec", "main-thread"],
+    "fallback_runner": "main-thread",
+    "brief_source": "tasks/contracts/<stem>.contract.md",
+    "runner_rule": "the active task contract is the authoritative execution brief consumed by contract-run; native subagent is an optional parallelism accelerator. Degrade to codex-exec or sequential main-thread on the SAME contract when spawn is unavailable, sandboxed, or unreliable. Runner-availability fallback MUST be recorded in the contract-run manifest and MUST NOT silently succeed; it is a runner-availability fallback, not a product-semantics compatibility fallback.",
     "rule": "UserPromptSubmit.delegation only injects bounded subagent context after explicit user authorization such as /delegate, /parallel, spawn subagents, or parallel investigation"
   },
   "sidecar_research": {

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -11,4 +11,4 @@ Do not duplicate that execution checklist here. Record only work intentionally d
 
 | Goal | Why Deferred | Tradeoff | Revisit Trigger |
 |------|--------------|----------|-----------------|
-| (none) | No deferred medium/long-term goal recorded yet. | Keep the first sprint bounded. | Add a row when a real follow-up is postponed. |
+| file-coupled delegation Phase 2: policy `delegation.preferred_runners`/`fallback_runner`(語義=同一 contract 的 runner 可用性降級,必寫 manifest、不得靜默)+ `codex-delegation-advisor.sh` 瘦身為指向 active contract 的 nudge + 全面同步 | Phase 1(`contract-run` preflight + per-contract runner metadata)已獨立可合併並驗證;policy/advisor 文案改動觸達面廣(>8 檔,policy 由 `ensure-task-workflow.sh`/`project-init-lib.sh`/`assets/templates/helpers/*`/遷移測試共維護),分階段降風險 | 目前只有 per-contract runner metadata,沒有全域 policy 預設 runner 降級;advisor 仍硬編 max_agents/max_depth | `contract-run` 的 `codex exec` file-coupled 路徑實際投用後,或要把 runner 降級提升為全域預設時 |

--- a/tests/cli/hook.test.ts
+++ b/tests/cli/hook.test.ts
@@ -714,6 +714,8 @@ describe('hook command (Phase 1B)', () => {
       expect(parsed.hookSpecificOutput.hookEventName).toBe('UserPromptSubmit');
       expect(parsed.hookSpecificOutput.additionalContext).toContain('[repo-harness:delegation]');
       expect(parsed.hookSpecificOutput.additionalContext).toContain('Spawn no more than 3 agents');
+      expect(parsed.hookSpecificOutput.additionalContext).toContain('authoritative execution brief');
+      expect(parsed.hookSpecificOutput.additionalContext).toContain('MUST NOT silently succeed');
 
       const state = JSON.parse(
         fs.readFileSync(path.join(repoRoot, '.ai/harness/delegation/latest.json'), 'utf-8'),
@@ -721,6 +723,7 @@ describe('hook command (Phase 1B)', () => {
       expect(state.explicit).toBe(true);
       expect(state.spawned).toBe(false);
       expect(state.max_depth).toBe(1);
+      expect(state.preferred_runners).toContain('subagent');
       expect(state.scope_id).toBe('session-session-1');
       expect(state.state_file).toBe('turns/session-session-1.json');
       expect(fs.existsSync(path.join(repoRoot, '.ai/harness/delegation/turns/session-session-1.json'))).toBe(true);

--- a/tests/contract-run.test.ts
+++ b/tests/contract-run.test.ts
@@ -41,6 +41,15 @@ function writePilotContract(repo: string, toolCalls: string | number | null = 2)
       "> **Review File**: `tasks/reviews/pilot.review.md`",
       "> **Notes File**: `tasks/notes/pilot.notes.md`",
       "",
+      "## Goal",
+      "",
+      "Create src/pilot.txt containing worker-output so the verifier can confirm the exit criteria.",
+      "",
+      "## Scope",
+      "",
+      "- In scope: create src/pilot.txt with worker-output",
+      "- Out of scope: anything outside src/",
+      "",
       "## Allowed Paths",
       "",
       "```yaml",
@@ -74,6 +83,13 @@ function writePilotContract(repo: string, toolCalls: string | number | null = 2)
       "    verifier:",
       "      mode: read_only",
       "      purpose: exit_criteria_review",
+      "  runner:",
+      "    preferred:",
+      "      - subagent",
+      "      - codex-exec",
+      "      - main-thread",
+      "    fallback: main-thread",
+      "    brief_is_authoritative: true",
       "```",
       "",
       "## Exit Criteria (Machine Verifiable)",
@@ -338,5 +354,197 @@ describe("contract-run helper", () => {
     const res = runContractRun(ROOT, ["dry-run", "--bogus"]);
     expect(res.status).toBe(2);
     expect(res.stderr).toContain("unknown argument --bogus");
+  });
+
+  test("preflight passes for a self-sufficient brief", () => {
+    const repo = makeRepo("contract-run-preflight-ok-");
+    try {
+      writePilotContract(repo, 2);
+      const res = runContractRun(repo, [
+        "preflight",
+        "--repo",
+        repo,
+        "--contract",
+        "tasks/contracts/pilot.contract.md",
+        "--json",
+      ]);
+      expect(res.status).toBe(0);
+      const manifest = parseJson(res.stdout);
+      expect(manifest.status).toBe("preflight_pass");
+      expect((manifest.brief_preflight as { ok: boolean }).ok).toBe(true);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  test("preflight fails closed on a placeholder brief", () => {
+    const repo = makeRepo("contract-run-preflight-fail-");
+    try {
+      writeFileSync(
+        join(repo, "tasks/contracts/pilot.contract.md"),
+        [
+          "# Task Contract: pilot",
+          "",
+          "## Goal",
+          "",
+          "Describe the exact outcome this task must deliver.",
+          "",
+          "## Scope",
+          "",
+          "- In scope:",
+          "- Out of scope:",
+          "",
+          "## Allowed Paths",
+          "",
+          "```yaml",
+          "allowed_paths:",
+          "  - src/",
+          "```",
+          "",
+          "## Exit Criteria (Machine Verifiable)",
+          "",
+          "```yaml",
+          "exit_criteria:",
+          "  files_exist:",
+          "    - src/pilot.txt",
+          "```",
+          "",
+        ].join("\n"),
+      );
+      const res = runContractRun(repo, [
+        "preflight",
+        "--repo",
+        repo,
+        "--contract",
+        "tasks/contracts/pilot.contract.md",
+        "--json",
+      ]);
+      expect(res.status).toBe(1);
+      const manifest = parseJson(res.stdout);
+      expect(manifest.status).toBe("fail");
+      expect(manifest.failure_class).toBe("incomplete_brief");
+      expect((manifest.brief_preflight as { issues: string[] }).issues.length).toBeGreaterThanOrEqual(2);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  test("run refuses an incomplete brief before dispatching the worker", () => {
+    const repo = makeRepo("contract-run-incomplete-");
+    try {
+      writeFileSync(
+        join(repo, "tasks/contracts/pilot.contract.md"),
+        [
+          "# Task Contract: pilot",
+          "",
+          "> **Review File**: `tasks/reviews/pilot.review.md`",
+          "",
+          "## Goal",
+          "",
+          "Describe the exact outcome this task must deliver.",
+          "",
+          "## Scope",
+          "",
+          "- In scope:",
+          "- Out of scope:",
+          "",
+          "## Allowed Paths",
+          "",
+          "```yaml",
+          "allowed_paths:",
+          "  - src/",
+          "```",
+          "",
+          "## Delegation Contract",
+          "",
+          "```yaml",
+          "delegation:",
+          "  budget:",
+          "    tokens: null",
+          "    tool_calls: null",
+          "    wall_time_minutes: 5",
+          "  permission_scope:",
+          "    mode: inherit_allowed_paths",
+          "    writable_paths: []",
+          "    network: off",
+          "  roles:",
+          "    worker:",
+          "      mode: edit_within_allowed_paths",
+          "      purpose: implementation",
+          "```",
+          "",
+          "## Exit Criteria (Machine Verifiable)",
+          "",
+          "```yaml",
+          "exit_criteria:",
+          "  files_exist:",
+          "    - src/pilot.txt",
+          "```",
+          "",
+        ].join("\n"),
+      );
+      const workerCommand = writeExecutable(
+        repo,
+        "worker.sh",
+        ["#!/bin/bash", "set -euo pipefail", "mkdir -p src", "printf 'worker-output\\n' > src/pilot.txt", ""].join("\n"),
+      );
+      const verifierCommand = writeExecutable(
+        repo,
+        "verifier.sh",
+        ["#!/bin/bash", "set -euo pipefail", "printf 'ran\\n' > verifier-ran.txt", ""].join("\n"),
+      );
+      const res = runContractRun(repo, [
+        "run",
+        "--repo",
+        repo,
+        "--contract",
+        "tasks/contracts/pilot.contract.md",
+        "--worker-command",
+        workerCommand,
+        "--verifier-command",
+        verifierCommand,
+        "--out",
+        ".ai/harness/runs/incomplete",
+        "--json",
+      ]);
+      expect(res.status).toBe(1);
+      const manifest = parseJson(res.stdout);
+      expect(manifest.status).toBe("fail");
+      expect(manifest.failure_class).toBe("incomplete_brief");
+      expect(manifest.children as unknown[]).toEqual([]);
+      expect(existsSync(join(repo, "src/pilot.txt"))).toBe(false);
+      expect(existsSync(join(repo, "verifier-ran.txt"))).toBe(false);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  test("runner metadata from the contract flows into the manifest", () => {
+    const repo = makeRepo("contract-run-runner-");
+    try {
+      writePilotContract(repo, 2);
+      const res = runContractRun(repo, [
+        "dry-run",
+        "--repo",
+        repo,
+        "--contract",
+        "tasks/contracts/pilot.contract.md",
+        "--out",
+        ".ai/harness/runs/runner",
+        "--json",
+      ]);
+      expect(res.status).toBe(0);
+      const manifest = parseJson(res.stdout);
+      const runner = (
+        manifest.delegation as {
+          runner: { preferred: string[]; fallback: string | null; brief_is_authoritative: boolean };
+        }
+      ).runner;
+      expect(runner.preferred).toEqual(["subagent", "codex-exec", "main-thread"]);
+      expect(runner.fallback).toBe("main-thread");
+      expect(runner.brief_is_authoritative).toBe(true);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/create-project-dirs.runtime.test.ts
+++ b/tests/create-project-dirs.runtime.test.ts
@@ -387,6 +387,13 @@ describe("create-project-dirs runtime smoke", () => {
       expect(policy.sidecar_research.spawn_decision).toContain("do not ask the user");
       expect(policy.sidecar_research.fallback_runner).toBe("main-thread trace");
       expect(policy.sidecar_research.main_thread_policy).toContain("if spawning is not worthwhile");
+      expect(policy.delegation.preferred_runners).toEqual([
+        "subagent",
+        "codex-exec",
+        "main-thread",
+      ]);
+      expect(policy.delegation.fallback_runner).toBe("main-thread");
+      expect(policy.delegation.runner_rule).toContain("MUST NOT silently succeed");
       expect(policy.documentation.reference_configs).toContain("global-working-rules.md");
       expect(policy.documentation.reference_configs).toContain("minimal-change-hooks.md");
       expect(policy.upgrade.strategy_version).toBe(1);


### PR DESCRIPTION
> **Stacked on #40** (Phase 2 slice 1). Base = `codex/file-coupled-delegation-phase2`. Merge order: #39 → #40 → this.

## 這是什麼

file-coupled delegation **Phase 2 slice 2**:讓 `codex-delegation-advisor` **消費** slice 1 宣告的 policy——把 Codex delegation 從「命令原生 `spawn_agent` + 硬編 limits」改成「讀 policy + 指向 contract brief」。這是讓 slice 1 的 policy 真正生效的消費者。

## Before / After

- **Before**:硬編 `max_agents:3/max_depth:1`,注入「call spawn_agent、explorer/worker/reviewer」的泛用角色文字,不指名 contract。
- **After**:
  - 從 `.ai/harness/policy.json` 讀 `max_agents`/`max_depth`/`preferred_runners`/`fallback_runner`(缺失時退回 `3 / 1 / ["subagent"]`,舊 repo 行為不變)。
  - 注入 guidance 改為:(1) 把 active task contract 當權威 brief(Goal/Scope/Allowed Paths/Exit Criteria),不從對話重推 scope;(2) 原生 subagent 是消費 brief 的首選加速器,不穩就在**同一 contract** 上降級到 fallback runner,經 contract-run 執行;**降級必寫 manifest、不得靜默成功**。
  - delegation state 記錄 `preferred_runners`/`fallback_runner`。
  - 維持 Codex-only;改 `assets/hooks` source 再 `bun run sync:hooks` 投影。

## 驗證

- 針對性:`hook-contracts`、`cli/hook`(含新斷言)、`cli/route-registry`、`bootstrap-files`、`hook-runtime`、`hook-source-projection`、`output-parity`、`helper-scripts` 全綠。
- `bun run check:hooks`:projection OK(25 檔)。
- `check-architecture-sync`:blocking=0。
- 全量 `bun test`:clean 重跑 **1017 pass / 1 skip / 0 fail**。
  - 誠實標注:首次全量出現 3 fail,經查為 `tasks/lessons.md` 記載的**已知 env-leakage flake**(共享 process 併發、僅滿載偶發、子集不重現);clean 重跑 0 fail、所有受影響檔子集全綠,確認非本改動所致。

## Review 重點
- policy 讀取的 fallback(缺欄位 → 3/1/["subagent"])是 hook 的防禦式 config 載入,非產品語義 fallback;guidance 明文「不得靜默」。
- 維持 Codex-only 不對稱(Claude 靠原生 Task 工具 + 全域 routing)。

## 尚未包含 —— slice 3(preflight 接進工作流)
改 `scripts/plan-to-todo.sh`:交付 file-coupled 執行 brief 前跑 `contract-run preflight`,非零 fail-closed;不動 `verify-contract` 的 exit_criteria-only 承諾。blast radius 寬,單獨一刀。
