### PR TITLE
docs(todos): record tsconfig include debt surfaced by PR #36

### DIFF
--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -1,7 +1,7 @@
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: (initial)
+> **Updated**: 2026-07-05
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.
@@ -11,4 +11,4 @@ Do not duplicate that execution checklist here. Record only work intentionally d
 
 | Goal | Why Deferred | Tradeoff | Revisit Trigger |
 |------|--------------|----------|-----------------|
-| (none) | No deferred medium/long-term goal recorded for this projection. | Keep this sprint bounded. | Add a row when a real follow-up is postponed. |
+| Broaden `tsconfig.json` include to `src/**/*.ts` + `tests/**/*.ts` and fix the type errors it surfaces | PR #36 broadens the include without fixing the exposed errors; merging as-is turns the `check:type` CI gate red. Errors sit in actively developed surfaces (`src/cli/mcp`, `src/cli/hook`, `src/cli/chatgpt-browser`), so the fix belongs in a dedicated slice, not a drive-by. | Narrow include keeps `check:type` green today but lets type errors accumulate silently outside the covered set (22 exposed errors on 2026-06-27 grew to 62 by 2026-07-05). | PR #36 split lands the validators dedup, or the next slice touching `src/cli/mcp` / `src/cli/hook` / `src/cli/chatgpt-browser`. |


### PR DESCRIPTION
Records the deferred goal from PR #36 triage: broadening `tsconfig.json` include to `src/**` + `tests/**` currently surfaces 62 pre-existing type errors (22 on 2026-06-27, drifted to 62 by 2026-07-05), concentrated in `src/cli/mcp`, `src/cli/hook`, and `src/cli/chatgpt-browser`. The include broadening must land together with the error fixes in a dedicated slice.

Tasks-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)