### PR TITLE
feat(evals): add BDD² Phase E evaluation foundation

### DIFF
--- a/evals/bdd2/evaluation-manifest.json
+++ b/evals/bdd2/evaluation-manifest.json
@@ -7,7 +7,7 @@
   },
   "runner": {
     "path": "scripts/run-bdd2-evals.ts",
-    "sha256": "fc9297b6e5fdd74cda4988cfcfa0d1503a232c1086e4df9b6c52501c1b0bf398"
+    "sha256": "93fdf81cfbd5f54d9cb9517ed5b00b66315ce6b6c9f727e71e12a181f46efb19"
   },
   "output_root": ".ai/harness/runs/bdd2",
   "experiments": {

--- a/evals/bdd2/evaluation-manifest.json
+++ b/evals/bdd2/evaluation-manifest.json
@@ -5,6 +5,10 @@
     "state": "foundation",
     "sealed_at": null
   },
+  "runner": {
+    "path": "scripts/run-bdd2-evals.ts",
+    "sha256": "fc9297b6e5fdd74cda4988cfcfa0d1503a232c1086e4df9b6c52501c1b0bf398"
+  },
   "output_root": ".ai/harness/runs/bdd2",
   "experiments": {
     "S": {
@@ -44,7 +48,7 @@
     "rubric": "evals/bdd2/rubrics/blind-adjudication.md",
     "rubric_sha256": "96082f845dc67ad3db256b2ec40e1b66b9d5d7b748a2a0a8257c4b7b60e4dba1",
     "score_schema": "evals/bdd2/rubrics/score.schema.json",
-    "score_schema_sha256": "6627ccad7730f5281d74da9d4a546739fa9a67957562d61c4ed03e1379d881bb"
+    "score_schema_sha256": "a23b15a98b736c1abce9ba7bbaad4a5492d591907ff6d65e0f97d52018775f28"
   },
   "agents": {}
 }

--- a/evals/bdd2/evaluation-manifest.json
+++ b/evals/bdd2/evaluation-manifest.json
@@ -1,0 +1,50 @@
+{
+  "schema": "repo-harness-bdd2-evaluation.v1",
+  "freeze": {
+    "id": "bdd2-phase-e-foundation-v1",
+    "state": "foundation",
+    "sealed_at": null
+  },
+  "output_root": ".ai/harness/runs/bdd2",
+  "experiments": {
+    "S": {
+      "kind": "shape",
+      "repetitions": 3,
+      "held_out_task_count": 12,
+      "conditions": {
+        "baseline": { "prompt": "evals/bdd2/prompts/shape-baseline.md", "sha256": "d16899c22c6998e6b406c1dd493c75a468c31ec1c86b8e4514e15f56eb1e67af" },
+        "treatment": { "prompt": "evals/bdd2/prompts/shape-treatment.md", "sha256": "05041ac2129ee45c72012986ec6565454e7fe5ae0bb59d7fedd8852dc358b956" }
+      }
+    },
+    "A": {
+      "kind": "audit",
+      "repetitions": 2,
+      "held_out_task_count": 12,
+      "conditions": {
+        "baseline": { "prompt": "evals/bdd2/prompts/audit-baseline.md", "sha256": "61a312eb9848fa211bd81c01f439fdeba17f57f2b84aafabbba549db8fcc8b6c" },
+        "treatment": { "prompt": "evals/bdd2/prompts/audit-treatment.md", "sha256": "096ee79656f7863833aedf02ee6726ef1e050a5ef30ab42a7e69056e9d2a0f89" }
+      }
+    }
+  },
+  "partitions": {
+    "development": {
+      "tasks": "evals/bdd2/tasks/development.json",
+      "tasks_sha256": "fcdb7722c31e427b8e194fbd98a349b3781e5c0c3981cddeabfdcbc9ddbd353a",
+      "truth": "evals/bdd2/truth/development.json",
+      "truth_sha256": "26b1433012641619dc1e6af6a45f84f52ff724639c520cd4061f4671e0896123"
+    },
+    "held_out": {
+      "tasks": "evals/bdd2/tasks/held-out.json",
+      "tasks_sha256": "106679f572a60620f4124406ba5dfa5938c760f0e8ce1473519cf4434af00127",
+      "truth": "evals/bdd2/truth/held-out.json",
+      "truth_sha256": "f66f908b5f8819aa58c92d0f70e34ba1808863f2c27b200d2ebfc17ba4c8db9b"
+    }
+  },
+  "adjudication": {
+    "rubric": "evals/bdd2/rubrics/blind-adjudication.md",
+    "rubric_sha256": "96082f845dc67ad3db256b2ec40e1b66b9d5d7b748a2a0a8257c4b7b60e4dba1",
+    "score_schema": "evals/bdd2/rubrics/score.schema.json",
+    "score_schema_sha256": "6627ccad7730f5281d74da9d4a546739fa9a67957562d61c4ed03e1379d881bb"
+  },
+  "agents": {}
+}

--- a/evals/bdd2/prompts/audit-baseline.md
+++ b/evals/bdd2/prompts/audit-baseline.md
@@ -1,0 +1,6 @@
+Review the supplied implementation or design artifact. Identify correctness,
+usability, scope, maintainability, and YAGNI problems that could materially affect
+the requested change. Prioritize findings by consequence, cite concrete evidence
+from the supplied artifact, and recommend the smallest coherent correction.
+
+Do not modify the artifact. If no material problem is supported by evidence, say so.

--- a/evals/bdd2/prompts/audit-treatment.md
+++ b/evals/bdd2/prompts/audit-treatment.md
@@ -1,0 +1,17 @@
+Perform a read-only behavior audit of the supplied implementation or design artifact.
+Use any supplied Card, Brief, PRD, plan, or contract as behavior authority; if none is
+provided, mark authority-gap findings as lower confidence rather than inventing a
+requirement.
+
+Trace the primary actor from entry to observable outcome and recovery. Check whether
+each user-visible choice, concept, state, role, and interruption is authorized and
+necessary. Look specifically for unsupported expansion, backstage leakage, journey
+fragmentation, missing recovery, authority conflict, and protected-concern erosion.
+Complexity required for security, privacy, data integrity, accessibility, recovery,
+migration, rollback, or tests is not overengineering.
+
+For each material finding return: severity (P0-P3), taxonomy, concrete evidence,
+user consequence, governing authority or authority gap, confidence, and the minimum
+correction boundary. Report all P0/P1 and only the highest-value P2/P3 findings. Do
+not modify code or product scope. If the artifact is behaviorally sound, explicitly
+return no findings.

--- a/evals/bdd2/prompts/shape-baseline.md
+++ b/evals/bdd2/prompts/shape-baseline.md
@@ -1,0 +1,8 @@
+You are preparing a lightweight implementation proposal for a user-visible change.
+
+Use the repository facts supplied in the task. Describe the behavior to implement,
+the main user flow, important failure handling, and any scope limits needed to keep
+the change coherent. Do not write code. Do not invent evidence or claim user
+validation that was not supplied.
+
+Return a concise proposal that another coding agent could implement.

--- a/evals/bdd2/prompts/shape-treatment.md
+++ b/evals/bdd2/prompts/shape-treatment.md
@@ -1,0 +1,23 @@
+You are shaping the minimum sufficient behavior for a user-visible change. Do not
+generate a feature list and do not write code.
+
+First distinguish current repository truth from assumptions. Use one primary actor
+and one observable outcome. Cover the shortest critical journey plus a concrete
+recovery or negative example. Then define a decision envelope:
+
+- MUST: behavior or information required to complete the goal, understand the
+  result, control consequences, recover, or preserve an applicable protected concern.
+- MUST NOT: likely unsupported product expansion, backstage implementation leakage,
+  or added roles/concepts/choices that the task does not authorize.
+- MAY: narrow implementation or interaction freedom that preserves MUST/MUST NOT.
+- ESCALATE: decisions that change the user goal, commitment, role, data semantics,
+  main journey, product concept, or high-consequence boundary.
+
+Choose the lightest authority tier: inline Behavior Card for a single-session small
+change; tracked Brief only for cross-session freeze/handoff; existing PRD flow when
+one escalation axis is High or two are Medium. Engineering execution risk remains a
+separate decision. Protected security, privacy, data integrity, accessibility,
+recovery, migration, rollback, and test requirements outrank minimal-surface taste.
+
+Return only the shaped behavior, current-truth evidence references, examples,
+decision envelope, applicable protected concerns, and tier/escalation decision.

--- a/evals/bdd2/rubrics/blind-adjudication.md
+++ b/evals/bdd2/rubrics/blind-adjudication.md
@@ -1,0 +1,42 @@
+# BDD² Blind Adjudication Rubric v1
+
+Reviewers receive a task ID, the original task input, and one anonymized response.
+They must not receive the condition name, prompt path, run coordinate mapping, agent
+command, or another response for the same task until independent scoring is locked.
+
+## Shape scoring
+
+Count decisions, not UI objects. A decision is a distinct user choice, concept,
+commitment, role, or exposed state that changes what the user must understand or do.
+
+- `unsupported_expansion`: proposed decision or product behavior not supported by
+  current truth, the request, a protected concern, or a necessary recovery path.
+- `required_behavior_omission`: missing behavior needed for the stated outcome,
+  result comprehension, consequence control, or recovery.
+- `protected_concern_omission`: missing security, privacy, data integrity,
+  accessibility, recovery, migration, rollback, or test behavior that applies.
+- `authority_fit`: `inline`, `brief`, `prd`, or `incorrect`.
+- `correction_minutes`: reviewer estimate from first output to acceptable proposal.
+
+Record paired preference only after both anonymized outputs are scored. A shorter
+answer does not win unless it preserves required behavior and protected concerns.
+
+## Audit scoring
+
+Match each response finding to at most one truth-set issue. A finding is true positive
+only when its evidence and user consequence identify the seeded issue or a separately
+adjudicated real issue. Generic advice and unsupported preferences are false positives.
+
+- precision = true-positive findings / all findings.
+- seeded recall = detected seeded issues / all seeded issues.
+- clean false-positive rate = clean fixtures with any false finding / clean fixtures.
+- correct no-findings rate = clean fixtures correctly reported as sound / clean fixtures.
+- severity agreement = same or adjacent human severity, with no P0/P1 underestimation.
+
+## Reviewer protocol
+
+1. Score independently using `score.schema.json`.
+2. Lock the score before condition reveal or paired comparison.
+3. Resolve disagreements with a second reviewer who is also condition-blind.
+4. Record exclusions, ambiguity, and authority gaps; never silently discard a run.
+5. Keep raw scores and the reveal mapping separate until adjudication is complete.

--- a/evals/bdd2/rubrics/score.schema.json
+++ b/evals/bdd2/rubrics/score.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "repo-harness-bdd2-score.v1",
+  "title": "BDD2 blind adjudication score",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "packet_id", "task_id", "experiment", "reviewer_id", "locked_at", "score"],
+  "properties": {
+    "schema": { "const": "repo-harness-bdd2-score.v1" },
+    "packet_id": { "type": "string", "pattern": "^[a-f0-9]{16}$" },
+    "task_id": { "type": "string", "minLength": 4 },
+    "experiment": { "enum": ["S", "A"] },
+    "reviewer_id": { "type": "string", "minLength": 1 },
+    "locked_at": { "type": "string", "format": "date-time" },
+    "score": {
+      "oneOf": [
+        { "$ref": "#/$defs/shapeScore" },
+        { "$ref": "#/$defs/auditScore" }
+      ]
+    }
+  },
+  "$defs": {
+    "shapeScore": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "unsupported_expansion", "required_behavior_omission", "protected_concern_omission", "authority_fit", "correction_minutes"],
+      "properties": {
+        "kind": { "const": "shape" },
+        "unsupported_expansion": { "type": "integer", "minimum": 0 },
+        "required_behavior_omission": { "type": "integer", "minimum": 0 },
+        "protected_concern_omission": { "type": "integer", "minimum": 0 },
+        "authority_fit": { "enum": ["inline", "brief", "prd", "incorrect"] },
+        "correction_minutes": { "type": "number", "minimum": 0 },
+        "notes": { "type": "string" }
+      }
+    },
+    "auditScore": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "finding_count", "true_positive_issue_ids", "false_positive_count", "severity_agreement", "correct_no_findings"],
+      "properties": {
+        "kind": { "const": "audit" },
+        "finding_count": { "type": "integer", "minimum": 0 },
+        "true_positive_issue_ids": { "type": "array", "uniqueItems": true, "items": { "type": "string" } },
+        "false_positive_count": { "type": "integer", "minimum": 0 },
+        "severity_agreement": { "type": "boolean" },
+        "correct_no_findings": { "type": "boolean" },
+        "notes": { "type": "string" }
+      }
+    }
+  }
+}

--- a/evals/bdd2/rubrics/score.schema.json
+++ b/evals/bdd2/rubrics/score.schema.json
@@ -7,7 +7,7 @@
   "required": ["schema", "packet_id", "task_id", "experiment", "reviewer_id", "locked_at", "score"],
   "properties": {
     "schema": { "const": "repo-harness-bdd2-score.v1" },
-    "packet_id": { "type": "string", "pattern": "^[a-f0-9]{16}$" },
+    "packet_id": { "type": "string", "pattern": "^[a-f0-9]{32}$" },
     "task_id": { "type": "string", "minLength": 4 },
     "experiment": { "enum": ["S", "A"] },
     "reviewer_id": { "type": "string", "minLength": 1 },

--- a/evals/bdd2/tasks/development.json
+++ b/evals/bdd2/tasks/development.json
@@ -1,0 +1,30 @@
+{
+  "schema": "repo-harness-bdd2-task-set.v1",
+  "partition": "development",
+  "tasks": [
+    {
+      "id": "S-D-01",
+      "experiment": "S",
+      "title": "Retry a failed document upload",
+      "agent_input": "Current truth: the document page already shows upload state and one primary Upload action. Request: when a transient upload fails, let the user recover without leaving the page. Shape the behavior for implementation."
+    },
+    {
+      "id": "S-D-02",
+      "experiment": "S",
+      "title": "Rename one saved view",
+      "agent_input": "Current truth: saved views appear in an existing list and names are editable nowhere else. Request: allow the owner to rename one saved view from that list. Shape the behavior for implementation."
+    },
+    {
+      "id": "A-D-01",
+      "experiment": "A",
+      "title": "Queue settings leak into a retry flow",
+      "agent_input": "Authority: users must be able to retry one failed import and see whether it succeeded; queue policy remains internal. Artifact: the failed-import row adds Retry, Retry count, Queue priority, Worker pool, and Fallback region controls. Audit the artifact."
+    },
+    {
+      "id": "A-D-02",
+      "experiment": "A",
+      "title": "Clean destructive confirmation",
+      "agent_input": "Authority: deleting a draft is irreversible and requires a clear confirmation naming the draft. Artifact: the existing row action opens a confirmation dialog naming the draft, explains deletion is permanent, offers Cancel as default and Delete as destructive action, and returns focus to the list after cancellation. Audit the artifact."
+    }
+  ]
+}

--- a/evals/bdd2/tasks/held-out.json
+++ b/evals/bdd2/tasks/held-out.json
@@ -1,0 +1,30 @@
+{
+  "schema": "repo-harness-bdd2-task-set.v1",
+  "partition": "held_out",
+  "tasks": [
+    {
+      "id": "S-H-01",
+      "experiment": "S",
+      "title": "Empty-state CSV import entry",
+      "agent_input": "Current truth: the contacts page has an empty state and an existing backend CSV import endpoint. Request: let a first-time workspace owner import contacts from the empty state and understand invalid-row results. Shape the behavior for implementation."
+    },
+    {
+      "id": "S-H-02",
+      "experiment": "S",
+      "title": "Inline AI summary preview",
+      "agent_input": "Current truth: a report page has one existing Generate summary action and summaries can take up to 20 seconds. Request: show the generated summary on the same page and let the user recover from a timeout. Shape the behavior for implementation."
+    },
+    {
+      "id": "A-H-01",
+      "experiment": "A",
+      "title": "Automatic retry exposed as advanced configuration",
+      "agent_input": "Authority: transient save failures should recover automatically; users only need actionable status when recovery is exhausted. Artifact: the editor adds an always-visible Advanced retry panel with max attempts, backoff factor, transport fallback order, and replica selection, plus a Save button. Audit the artifact."
+    },
+    {
+      "id": "A-H-02",
+      "experiment": "A",
+      "title": "Accessible recovery kept despite extra structure",
+      "agent_input": "Authority: a keyboard-only user must understand and recover from a failed payment without duplicate charge risk. Artifact: the payment form keeps an aria-live error summary, moves focus to it on failure, preserves entered billing fields, disables resubmission while status is unknown, and offers one Retry after the provider confirms failure. Audit the artifact."
+    }
+  ]
+}

--- a/evals/bdd2/truth/development.json
+++ b/evals/bdd2/truth/development.json
@@ -1,0 +1,13 @@
+{
+  "schema": "repo-harness-bdd2-truth-set.v1",
+  "partition": "development",
+  "audit_tasks": {
+    "A-D-01": {
+      "clean": false,
+      "issues": [
+        { "id": "A-D-01-I1", "severity": "P1", "taxonomy": "BACKSTAGE_LEAK", "summary": "Internal queue and infrastructure policy is exposed as required user configuration." }
+      ]
+    },
+    "A-D-02": { "clean": true, "issues": [] }
+  }
+}

--- a/evals/bdd2/truth/held-out.json
+++ b/evals/bdd2/truth/held-out.json
@@ -1,0 +1,13 @@
+{
+  "schema": "repo-harness-bdd2-truth-set.v1",
+  "partition": "held_out",
+  "audit_tasks": {
+    "A-H-01": {
+      "clean": false,
+      "issues": [
+        { "id": "A-H-01-I1", "severity": "P1", "taxonomy": "BACKSTAGE_LEAK", "summary": "Automatic recovery internals are exposed as default user decisions without authority." }
+      ]
+    },
+    "A-H-02": { "clean": true, "issues": [] }
+  }
+}

--- a/plans/plan-20260712-0450-bdd2-eval-foundation.md
+++ b/plans/plan-20260712-0450-bdd2-eval-foundation.md
@@ -1,0 +1,181 @@
+# Plan: BDD² Phase E Evaluation Foundation
+
+> **Status**: Executing
+> **Created**: 2026-07-12
+> **Slug**: bdd2-eval-foundation
+> **Artifact Level**: work-package
+> **Promotion Reason**: merge_boundary
+> **Verification Boundary**: focused runner/contract tests + manifest validation + deterministic dry-run planning + strict workflow and root required checks
+> **Rollback Surface**: Revert branch `codex/bdd2-eval-foundation`; no data migration or runtime cutover.
+> **PRD**: `plans/prds/20260712-0409-bdd2-shape-audit.prd.md`
+> **Sprint**: `plans/sprints/20260712-bdd2-phase-e-evaluation.sprint.md`
+> **Task Contract**: `tasks/contracts/20260712-0450-bdd2-eval-foundation.contract.md`
+> **Task Review**: `tasks/reviews/20260712-0450-bdd2-eval-foundation.review.md`
+> **Implementation Notes**: `tasks/notes/20260712-0450-bdd2-eval-foundation.notes.md`
+
+## Goal
+
+Create the Phase E authority and execution foundation required to run reproducible,
+blind BDD² experiments without creating any public BDD product surface.
+
+## Agentic Routing
+
+- Selected route: `eval-only` task contract in an isolated worktree.
+- Routing reason: this slice establishes evaluation manifests, frozen treatments,
+  experiment execution, validation, and deterministic tests. It does not change
+  product runtime behavior.
+- Due diligence:
+  - P1 map: `evals/` owns committed benchmark authority; `scripts/` owns local
+    orchestration; ignored `.ai/harness/runs/` owns raw runtime evidence; task
+    review and notes own durable conclusions. Existing `run-skill-evals.ts` is a
+    skill-installation benchmark and is not the semantic authority for BDD².
+  - P2 trace: frozen experiment manifest -> selected task and condition -> exact
+    prompt materialization -> configured agent command -> raw response and run
+    metadata -> blinded output packet -> later human adjudication. Validation
+    fails before execution when prompt/rubric/task hashes drift.
+  - P3 decision rationale: use one BDD² evaluation manifest as the only committed
+    experiment authority and a dedicated eval-only runner because proposal/audit
+    experiments are text treatments, not skill-installation workspace mutations.
+    Do not generalize or retrofit the existing skill runner without a shared
+    runtime invariant. The first 10x failure would be silent treatment/data drift,
+    so content-addressed inputs and fail-closed validation are the protected
+    invariant.
+
+## In Scope
+
+- Approve and commit the BDD² PRD and Phase E Sprint.
+- Define a versioned evaluation manifest for experiments S and A.
+- Freeze baseline, shape, review, and audit treatment prompts.
+- Define development/held-out task partitions without exposing truth labels to
+  the agent execution packet.
+- Define the blind adjudication rubric and machine-readable score contract.
+- Implement an eval-only runner that validates hashes, supports deterministic
+  selection/repetition/dry-run, captures exact commands and outputs, and emits
+  blinded packets plus run metadata.
+- Add deterministic tests using stub agent commands.
+
+## Out of Scope
+
+- Public `repo-harness-bdd` skill, command registry, CLI/MCP product tools, hooks,
+  `/check` integration, Behavior Brief catalog/validator, sidecars, or lifecycle.
+- Experiment S/A held-out result claims; those are later work-packages.
+- Browser or ImageGen execution; their independent Experiment E remains a later
+  gated Sprint row.
+- Implementation Pilot I and any Phase P productization.
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - evals/bdd2
+  - scripts/run-bdd2-evals.ts
+  - tests/run-bdd2-evals.test.ts
+  - tests/bdd2-evals-contract.test.ts
+  - plans/prds/20260712-0409-bdd2-shape-audit.prd.md
+  - plans/sprints/20260712-bdd2-phase-e-evaluation.sprint.md
+  - plans/plan-20260712-0450-bdd2-eval-foundation.md
+  - tasks/contracts/20260712-0450-bdd2-eval-foundation.contract.md
+  - tasks/reviews/20260712-0450-bdd2-eval-foundation.review.md
+  - tasks/notes/20260712-0450-bdd2-eval-foundation.notes.md
+  - tasks/current.md
+  - .ai/harness/handoff/current.md
+  - .ai/harness/handoff/resume.md
+```
+
+## Authority Contract
+
+- `evals/bdd2/evaluation-manifest.json` is the sole committed machine-readable
+  authority for experiment IDs, conditions, repetitions, partitions, prompt
+  paths, rubric path, output schema, and content hashes.
+- Prompt, task, and rubric files are immutable within a recorded run. A changed
+  byte requires an explicit manifest hash update before execution.
+- Agent packets contain the task input and condition prompt only. Truth labels,
+  expected findings, condition aliases, and adjudication keys are excluded.
+- Run evidence is written under ignored `.ai/harness/runs/bdd2/`; only durable
+  decisions and aggregate reports are committed later.
+- No semantic fallback or legacy manifest parser is allowed.
+
+## Promotion Gate
+
+- **Merge/PR unit**: this evaluation authority and runner foundation is one
+  independently reviewable PR; experiment execution and result claims are not
+  part of the unit.
+- **Rollback surface**: revert branch `codex/bdd2-eval-foundation`; no data
+  migration or runtime cutover exists.
+- **Verification boundary**: focused runner/contract tests, manifest validation,
+  deterministic dry-run planning, strict workflow verification, and the root
+  required checks.
+- **Review/acceptance boundary**: `tasks/reviews/20260712-0450-bdd2-eval-foundation.review.md` must recommend pass against the frozen-authority and blind-packet criteria.
+- **High-risk surface**: leakage of truth/treatment identity and silent content
+  drift would invalidate later evaluation claims.
+- **Why not checklist row**: `merge_boundary` — this slice creates the shared
+  evidence authority and reproducibility boundary consumed by every later Phase E
+  experiment.
+
+## Evidence Contract
+
+- **State/progress path**: the `BDD2-E-01` row in
+  `plans/sprints/20260712-bdd2-phase-e-evaluation.sprint.md`, this plan's task
+  breakdown, and its generated contract/review/notes artifacts.
+- **Verification evidence**: focused Bun tests, `run-bdd2-evals.ts validate`, a
+  deterministic dry-run plan, strict task-workflow verification, and the root
+  repository required checks recorded in the task review.
+- **Evaluator rubric**: the review must confirm manifest/hash drift fails closed,
+  held-out truth and condition identity are absent from agent packets, repeated
+  runs produce stable coordinates, and no Phase P surface appears in the diff.
+- **Stop condition**: all task breakdown items pass, the task review recommends
+  pass, and the branch contains only the allowed Phase E foundation surfaces.
+- **Rollback surface**: revert the work-package commit; no product runtime,
+  migration, user data, or compatibility path exists.
+
+## Task Breakdown
+
+- [x] Approve the PRD and add the ordered Phase E Sprint backlog.
+- [x] Add frozen experiment authority, treatment prompts, datasets, and rubric.
+- [x] Implement strict manifest/hash validation and run selection.
+- [x] Implement agent execution, artifact capture, and blinded packet emission.
+- [x] Add contract and runner tests, including drift and data-leak failures.
+- [x] Run focused tests, strict workflow checks, and the repository required checks.
+- [ ] Complete task review/notes, commit, push, and open the module PR.
+
+## Exit Criteria
+
+```yaml
+exit_criteria:
+  files_exist:
+    - evals/bdd2/evaluation-manifest.json
+    - evals/bdd2/prompts/shape-baseline.md
+    - evals/bdd2/prompts/shape-treatment.md
+    - evals/bdd2/prompts/audit-baseline.md
+    - evals/bdd2/prompts/audit-treatment.md
+    - evals/bdd2/rubrics/blind-adjudication.md
+    - evals/bdd2/rubrics/score.schema.json
+    - evals/bdd2/tasks/development.json
+    - evals/bdd2/tasks/held-out.json
+    - evals/bdd2/truth/development.json
+    - evals/bdd2/truth/held-out.json
+    - scripts/run-bdd2-evals.ts
+    - tests/run-bdd2-evals.test.ts
+    - tests/bdd2-evals-contract.test.ts
+  commands_succeed:
+    - bun test tests/run-bdd2-evals.test.ts tests/bdd2-evals-contract.test.ts
+    - bun scripts/run-bdd2-evals.ts validate
+    - bun scripts/run-bdd2-evals.ts plan --experiment S --partition development --dry-run
+    - repo-harness run check-task-workflow --strict
+  manual_checks:
+    - "Review confirms no Phase P product surface was introduced"
+    - "Review confirms agent packets exclude truth and treatment identity"
+```
+
+## Stop Conditions
+
+- Stop if a runner design requires installing a BDD skill or mutating product
+  registry/runtime to execute the experiment.
+- Stop if held-out truth must be placed in the agent-visible task packet.
+- Stop if reproducibility requires a second handwritten authority beside the
+  evaluation manifest.
+
+## Rollback Surface
+
+Revert this work-package commit. No product runtime, migration, persistent user
+data, or compatibility path is created by this slice.

--- a/plans/plan-20260712-0450-bdd2-eval-foundation.md
+++ b/plans/plan-20260712-0450-bdd2-eval-foundation.md
@@ -136,7 +136,7 @@ allowed_paths:
 - [x] Implement agent execution, artifact capture, and blinded packet emission.
 - [x] Add contract and runner tests, including drift and data-leak failures.
 - [x] Run focused tests, strict workflow checks, and the repository required checks.
-- [ ] Complete task review/notes, commit, push, and open the module PR.
+- [x] Complete task review/notes, commit, push, and open the module PR.
 
 ## Exit Criteria
 

--- a/plans/plan-20260712-0450-bdd2-eval-foundation.md
+++ b/plans/plan-20260712-0450-bdd2-eval-foundation.md
@@ -137,6 +137,8 @@ allowed_paths:
 - [x] Add contract and runner tests, including drift and data-leak failures.
 - [x] Run focused tests, strict workflow checks, and the repository required checks.
 - [x] Complete task review/notes, commit, push, and open the module PR.
+- [x] Address PR #53 P1 by separating deterministic private coordinates from random blind packet IDs.
+- [x] Address PR #53 P2 by requiring every sealed authority input, including the manifest and runner, to be tracked at clean HEAD.
 
 ## Exit Criteria
 

--- a/plans/prds/20260712-0409-bdd2-shape-audit.prd.md
+++ b/plans/prds/20260712-0409-bdd2-shape-audit.prd.md
@@ -1,0 +1,787 @@
+# PRD: BDD² Lightweight Behavior Shaping and Audit
+
+> **Status**: Approved
+> **Slug**: bdd2-shape-audit
+> **Created**: 2026-07-12T04:09:00+08:00
+> **Updated**: 2026-07-12T04:53:00+08:00
+> **Revision**: V1.1 authority-and-evaluation
+> **Source Spec**: `docs/spec.md`
+> **Source V0**: local-only retained draft; not part of Phase E authority
+> **Tier**: standard
+
+## AI Quick-Read Card
+
+- Problem: 小型页面行为直接编码约束不足，完整 PRD 又过重；现有 code review 也缺少用户旅程、前后台暴露边界与心智成本审查。
+- Users: 使用 Coding Agent 实现用户可见功能的维护者、产品/设计/工程评审者、执行与审查任务的 Agent。
+- Platform: `repo-harness` skill facade；复用现有 repo 文件、Browser Evidence Adapter（Chrome MCP 为首个 provider）、ImageGen、plan、contract 与 review surface。
+- P0 surface: 一个公开 `repo-harness-bdd` skill，两个 intent route：`shape` 与 `audit`。
+- Core invariant: 在保证用户完成目标、理解结果、控制后果、从失败中恢复并满足 protected concerns 的前提下，最小化用户必须做出的决策和必须学习的概念。
+- Core metric: 同时降低 unsupported expansion 与 required behavior omission，而不是降低元素数量。
+- Hard constraint: 不建立与 PRD、plan、contract、review 平行的强制工作流；不把语义判断退化为按钮、文件、路由数量评分。
+- Key risk: BDD² 自身演化成新的文档官僚体系，或让 Agent 用更多材料为过度设计提供合理化叙事。
+- Unknowns: `[UNVERIFIED]` Behavior Card、Behavior Brief 与 behavior audit 是否能稳定减少 Agent 过度设计；Browser/ImageGen adapters 是否在特定风险下提升判断，还是扩大解空间。
+- Acceptance scenarios: 小页面轻量 shape、独立 execution-risk routing、跨会话 brief、PRD escalation、contract/heuristic audit、Browser 参考、ImageGen 原型、protected concern 反向保护。
+- Suggested next step: 只执行 Phase E evaluation protocol；在 recorded gate decision 前不得创建公开 skill、catalog、CLI、MCP、hook 或 `/check` integration。
+
+## Problem
+
+### Geju Thesis
+
+> BDD² 不应成为 PRD 前面的一层重型流程；它应成为可独立调用的行为边界操作器：实现前用 `shape` 给小功能足够但不过量的产品约束，实现后用 `audit` 检查页面、原型、运行时与 diff 是否增加了未经授权的用户决策。
+
+这是一个待验证的高杠杆假设，而不是已证实事实。
+
+### Current Gap
+
+当前 repo-harness 已有三类强能力：
+
+1. `repo-harness-prd` 适合产品级、多模块或高风险决策；
+2. plan、contract 与 anti-extras 条款适合工程执行范围；
+3. `/check`、review rubric 与 minimal-change hooks 适合 correctness、scope fidelity 和维护成本审查。
+
+但仍存在两个中间空档：
+
+- 一个单页面、单角色、单结果的用户可见改动，不值得进入完整 PRD，却需要明确 journey、exposure、no-go 和 recovery；
+- 现有 review 能发现代码和合同问题，但不会系统回答“这个控件是否必要”“后台概念是否泄露”“用户是否能从失败中恢复”。
+
+### Product Direction
+
+BDD² 只拥有两个行为：
+
+| Mode | Timing | Question | Default output |
+|---|---|---|---|
+| `shape` | 实现前 | 最少需要什么用户行为和可见决策？ | inline Behavior Card；必要时 tracked Behavior Brief 或 PRD escalation |
+| `audit` | 设计/实现中或完成后 | 当前页面、原型、运行时或 diff 是否符合行为边界？ | read-only findings；必要时投影进现有 review artifact |
+
+BDD² 不是新的计划层，也不安排工程任务。它可以在没有 PRD 的情况下工作，也可以作为 PRD、plan 或 contract 的行为输入。
+
+### Hard Constraints
+
+- 一个行为 datum 只有一个人工维护的 source of truth。
+- inline Card、tracked Brief 和 PRD 是按持久性与风险升级的三个层级，不要求同时存在。
+- Behavior Brief 升级为 PRD 后，PRD 成为产品意图权威，Brief 标记为 `Superseded`，不得双处维护。
+- Behavior artifact tier 只决定产品意图如何表达和持久化；工程执行仍由现有 plan/contract/worktree 风险规则独立决定。
+- `audit` 默认只读；不得静默改代码、改产品范围或审批 artifact。
+- ImageGen 和 Browser Evidence Adapter 是一等 evidence adapters，但只能回答已命名的不确定性。
+- 合成原型和竞品截图不能单独证明用户需求。
+- protected concerns 不因“less is more”而降级。
+- 语义 finding 的严重度按用户后果判断，不按元素数量判断。
+
+### Recommended Defaults
+
+- 单会话、单页面、单行为：inline Behavior Card。
+- 跨会话、需要 human freeze、多人交接或后续 audit baseline：tracked Behavior Brief。
+- 任一 escalation axis 为 High，或两个 axis 为 Medium：升级到现有 PRD flow。
+- 没有 prior Card/Brief/PRD 也允许 audit，但输出必须标记较低置信度和缺失 authority。
+- 参考与原型按风险触发，不作为每次 shape 的固定步骤。
+
+### Freedoms
+
+- Agent 可选择最适合当前仓库的 repo/browser/runtime provider。
+- Card 可嵌入 chat、active plan `## Task Breakdown` 或 task contract，只要不制造第二权威源。
+- Behavior Brief 可在 human review 后冻结，也可被 reshape、supersede 或删除。
+- audit 可单独运行，也可作为 `/check` 的产品行为维度被消费。
+
+### Behavior Authority Envelope
+
+每个 Card、Brief 或 PRD behavior section 必须显式定义四类空间：
+
+| Envelope | Meaning |
+|---|---|
+| `MUST` | 完成目标、理解结果、控制后果、恢复或 protected concerns 所必需的行为与信息 |
+| `MUST NOT` | 明确禁止的产品扩张、后台泄漏、角色/概念增加和 no-go |
+| `MAY` | 为满足 `MUST` 而允许执行者依据现有产品模式决定的实现、文案、可访问性和恢复细节 |
+| `ESCALATE` | 会改变用户目标、承诺、角色、数据语义、主旅程、产品概念或高后果边界的决策 |
+
+Silence rule：
+
+- 对新的用户可见 surface、选择、角色、概念和产品承诺，沉默不构成授权；必须落入 `MUST` 或 `MAY`。
+- `MAY` 必须是明确、有限的 freedom，不能被解释成增加相邻功能的许可。
+- security、privacy、data integrity、accessibility、recovery、migration 和 tests 等 protected concerns 即使未在每张 Card 重复，也受 repo/contract 的显式全局要求约束。
+- 超出 envelope 时 fail closed，返回 shape/authority owner，不由实现者自行补写 requirement。
+
+### Kill List
+
+MVP 明确不建设：
+
+- 强制每个任务创建 Behavior Brief；
+- 人工维护的 Markdown + JSON sidecar 双权威；
+- `raw → framed → evidenced → shaped → reviewed → frozen → exported` 十状态生命周期；
+- 七个公开 CLI/MCP mutation tools；
+- 通用按钮、文件、路由、设置计数 linter；
+- BDD 专属 Chrome extension、截图仓库或 ImageGen 原型仓库；
+- 基于启发式语义 finding 的 hook hard gate。
+
+这里删除的是重复基础设施，不是参考采集、原型生成、持久 brief 或 audit 能力。
+
+### First Proof Point
+
+先分别完成 Experiment S 与 Experiment A：证明 Behavior Card 能减少 unsupported expansion，并证明 behavior audit 能以可接受的 precision/recall 找到现有 review 漏掉的问题。组合效果、adapters 和实现结果都不是第一证明点；该证明不需要 CLI、MCP schema、hook 或 sidecar。
+
+### Falsifier
+
+出现以下任一结果，应停止独立 BDD² 产品化或收缩为 review prompt：
+
+- shape 不能稳定减少无依据的用户决策；
+- audit finding 大量被人类评审判为无效；
+- protected concerns 或主验收质量下降；
+- Behavior Brief 与现有 plan/contract/PRD 必须长期双处维护；
+- Browser/ImageGen 参考在目标任务上主要增加功能和视觉锚定，而不是减少关键不确定性；
+- 同等收益可由现有 PRD/contract 加一段短 prompt 获得。
+
+## Users
+
+### Primary Users
+
+- Maintainer / product-minded engineer
+  - Need: 在不写完整 PRD 的情况下，为一个用户可见功能锁定最小行为与 no-go。
+  - Success signal: Agent 实现主旅程和恢复路径，没有扩张到相邻页面、设置、角色或概念。
+- Reviewer / auditor
+  - Need: 从用户旅程和暴露边界审查现有页面、原型或 diff，而不仅是检查代码正确性。
+  - Success signal: finding 能指向具体用户后果、行为 authority 和最小修正边界。
+
+### Secondary Users
+
+- Coding Agent
+  - Need: 获得短、明确、可执行的行为约束，知道哪些内容不得自行补全。
+  - Success signal: 能从 Card/Brief/PRD 投影验收场景，不重新定义产品。
+- Designer / product manager
+  - Need: 用 Browser 参考与 ImageGen 原型验证一个具体 journey 或 exposure 假设。
+  - Success signal: 参考和原型附带 provenance、假设与淘汰条件，而不是成为复制功能的理由。
+
+## Success Criteria
+
+| Metric | Target | Measurement Method | Degradation Threshold |
+|---|---:|---|---:|
+| Unsupported expansion | paired task 中位数相比 baseline 减少至少 30%，且 win 多于 loss | Semantic Exposure Inventory + blind adjudication | 改善不足 15% 或 loss 多于 win |
+| Required behavior omission | 不高于 baseline | Given/When/Then、journey 与 recovery rubric | 任一稳定新增 omission |
+| Implementation pilot | 不出现 baseline 没有、由 BDD² 新增的严重验收失败 | 逐任务 paired report；不宣称正式 non-inferiority | 任一新增严重失败 |
+| Protected concern 严重遗漏 | 新增 P0/P1 遗漏为 0 | security/privacy/data/accessibility/recovery/migration/tests rubric | 任一新增 P0/P1 |
+| Audit precision / recall | precision ≥70%，overall seeded recall ≥80%，P0/P1 seeded recall =100% | seeded 与 clean held-out fixtures | 任一低于 target |
+| Audit false-positive / no-findings | clean-fixture false-positive ≤20%，correct no-findings ≥80% | clean held-out fixtures | 任一低于 target |
+| Severity agreement | 与盲评严重度相同或相邻等级 ≥85%，且不低估 P0/P1 | reviewer adjudication | P0/P1 被低估或 agreement 低于 target |
+| 人工纠正成本 | 中位纠正时间增加不超过 20% | 记录 reviewer 从初稿到接受的时间 | 增加超过 30% |
+| Artifact 负担 | 单会话小任务新增 tracked artifact 为 0 | 检查 workflow diff | 默认创建 Brief/PRD |
+
+这些阈值是 Phase E 的预注册产品决策门，不是普适 UX 定律。
+
+## Product Model
+
+### Output Tiers
+
+| Tier | Trigger | Authority | Persistence | Exit |
+|---|---|---|---|---|
+| Inline Behavior Card | 单会话、单页面、单角色、单结果、低风险 | 当前 prompt/plan/contract 中的 Card | 默认不新建文件 | 实现后 audit 或任务完成 |
+| Tracked Behavior Brief | 跨会话、需要 human freeze、多人交接或后续 audit baseline | `plans/behaviors/<timestamp>-<slug>.behavior.md` | tracked Markdown | Approved 后执行；升级 PRD 时 Superseded |
+| PRD | 跨模块、高风险或产品级边界 | 现有 `plans/prds/*.prd.md` | tracked Markdown | 进入 Sprint/plan/contract flow |
+
+这个层级只描述 behavior authority。它不得推导工程执行级别：Card 可以因 auth、payment 或 data risk 进入 contract/worktree；PRD 中的隔离文案改动也可以由现有 workflow 判定为 inline。
+
+### Escalation Matrix
+
+Escalation 按三个产品轴判断，而不是按技术对象类型判断：
+
+| Axis | Low | Medium | High |
+|---|---|---|---|
+| Behavioral blast radius | 单 actor、单页面、现有主旅程 | 多页面或相邻模块 | 多角色、跨模块或改变主旅程 |
+| Commitment and reversibility | 可逆、无新增承诺 | 影响持久偏好、通知或可见状态 | 付款、发布、删除、权限、外部承诺或不可逆后果 |
+| Product uncertainty | 沿用现有术语、语义和默认值 | 一个仍可局部验证的新概念 | 改变产品术语、数据语义、默认行为或用户心智模型 |
+
+Decision rule：
+
+- 任一轴为 High：PRD required。
+- 两个轴为 Medium：PRD required。
+- 其余情况：按 persistence 需要选择 Card 或 Brief。
+- 内部缓存、索引、临时同步状态或纯实现数据结构本身不触发 PRD；只有改变产品行为、承诺或语义时才升级。
+- 工程 risk 仍由现有 task profile、plan、contract 和 worktree 规则独立处理。
+
+## Behavior Card Contract
+
+Card 是以 concrete examples 和 decision envelope 为核心的轻量行为约束，不是缩小版 PRD，也不要求机械填写所有产品研究字段：
+
+```markdown
+## Behavior Card
+
+### Outcome
+<Actor> 在 <Situation> 下能够得到 <Observable outcome>。
+
+### Current truth
+- <repo/runtime fact + evidence reference>
+
+### Examples
+- Main:
+  Given ...
+  When ...
+  Then ...
+- Recovery / negative:
+  Given ...
+  When ...
+  Then ...
+
+### Decision envelope
+- MUST expose:
+  - <item → why>
+- MUST NOT expose:
+  - <item → why>
+- MAY decide:
+  - <bounded implementation/design freedom>
+- ESCALATE if:
+  - <decision boundary>
+
+### Protected concerns
+- <only concerns applicable to this behavior>
+
+### Material uncertainty
+- <optional; omit when none>
+```
+
+Rules:
+
+- 只允许一个 primary actor；价值流必需的 secondary actor 必须显式说明。
+- `Current truth` 来自现有 repo/runtime，不得把目标状态写成当前事实。
+- `MUST expose` 每项必须对应用户决策、理解、信任、成本、控制、恢复或 protected concern。
+- `MUST NOT expose` 是当前 actor 和任务的边界，不是跨产品的静态技术黑名单。
+- No-go 只记录当前任务中真实且高概率的 scope temptation，通常不超过三项；不得先发散大量功能再将其全部停放进 no-go。
+- `MAY` 只授权完成已批准行为所需的细节，不授权新的 product surface。
+- `Material uncertainty`、hypothesis 和 falsifier 仅在确有可能改变边界的风险时填写；没有则省略。
+- 未知内容标记 `[UNKNOWN]`；外部或经验性主张标记 `[UNVERIFIED]`。
+
+## Behavior Brief Contract
+
+Tracked Brief 只在 Card 无法跨会话承载 authority 时创建。
+
+```markdown
+---
+type: behavior-brief
+status: Draft
+slug: <slug>
+source: <prompt|plan|contract|prd>
+parent: <approved parent artifact or none>
+supersedes: <prior brief or none>
+created_at: <timestamp>
+---
+
+# Outcome
+# Current Truth
+# Critical Journey
+# Behavior Authority Envelope
+# Rules and Examples
+# Evidence and Provenance
+# Risk and Falsifier
+# Non-goals and Protected Concerns
+# Decision
+```
+
+状态只保留：
+
+- `Draft`: 仍可 reshape；
+- `Approved`: human freeze，可作为实现与 audit authority；
+- `Superseded`: 已由更新 Brief 或 PRD 接管。
+
+约束：
+
+- Markdown Brief 是唯一人工维护源；MVP 不创建 JSON sidecar。
+- 如果未来至少两个真实 machine consumers 需要结构化读取，可从 Markdown 确定性投影 sidecar，并增加 drift check；sidecar 永不成为人工 authority。
+- Brief 升级 PRD 后不得继续独立改变产品边界。
+- Governing authority 不是按 PRD/Brief/Card 类型做固定排名，而是选择 scope 覆盖当前行为、已批准、仍有效且最具体的 artifact；它可细化 parent，但不能违反未被 supersede 的 parent constraint。
+- lineage、scope match、approval 和 specificity 无法得出唯一 governing artifact 时，audit verdict 必须为 `inconclusive` 并要求 authority owner 处理冲突。
+
+## Evidence Adapters
+
+### Browser Evidence Adapter
+
+Browser Evidence Adapter 是 `shape` 与 `audit` 的一等可选能力，用于回答已命名的 pattern 或 usability 不确定性。产品 contract 定义能力，不绑定 provider：
+
+```text
+navigate
+inspect
+capture
+record provenance
+redact sensitive information
+```
+
+Chrome MCP 是首个可用 provider；browser MCP、Oracle/native browser 或 host-provided browser tool 在满足同一 contract 时也可使用。运行前必须做 capability discovery，缺失能力时明确降级审查范围。
+
+流程：
+
+1. 先写明要解决的 journey step、exposure decision 或 recovery question；
+2. 用户或 Agent 在授权的 browser provider 中定位相关页面；
+3. 截取视口或目标区域，并在保存前处理账号、密钥、客户和个人数据；
+4. 记录 source URL、页面标题、采集时间、viewport 和观察范围；
+5. 给出 `Adopt / Adapt / Avoid` 判断及适用约束；
+6. 将 Pattern Card 绑定到具体行为问题；
+7. 交给 `audit` 检查是否引入无依据的概念或控制。
+
+没有绑定问题的截图不进入正式 evidence。截图只能证明某个可观察模式存在，不能证明本产品用户需要它。
+
+MVP 复用现有 browser provider 与 evidence/run surface，不建设 BDD 专属 extension、抓取服务或截图 catalog。
+
+### ImageGen Prototype Loop
+
+ImageGen 用于行为边界基本稳定、但 interaction、information architecture 或 progressive disclosure 仍有明显不确定性的情况。
+
+默认围绕同一行为生成 2–3 个低保真方向：
+
+- Minimum Surface；
+- Progressive Disclosure；
+- 仅在 primary actor 为高频专家时生成 Expert Path。
+
+每个原型必须说明：
+
+- 减少了哪些用户决策；
+- 新增了哪些用户概念；
+- 隐藏了哪些后台状态；
+- 保留了哪些必要恢复与信任信息；
+- 哪个观察或测试会淘汰该方案。
+
+原型必须标记为 synthetic evidence。视觉完成度、AI persona 或 AI 推测反馈不能关闭 value/usability hypothesis。原型是 `audit` 输入，不是批准产品范围的 authority。
+
+## Audit Contract
+
+### Inputs
+
+`audit` 先把输入分成三类：
+
+- Contract basis: 用户明确指令与 scope-matched、approved、仍有效的 Card/Brief/PRD/contract。
+- Observed evidence: repo、runtime、screenshot、ImageGen prototype、tests 和 diff 中实际观察到的行为。
+- Brownfield constraint: 现有兼容、数据、迁移和用户习惯约束；它限制变更方式，但不自动证明当前设计正确。
+
+Governing authority 解析顺序是 scope match → approval → lineage → specificity → freshness。最具体的 approved descendant 可以细化 parent，但不能违反仍有效的 parent `MUST`/`MUST NOT`/`ESCALATE`。无法解析唯一 authority 时 verdict 为 `inconclusive`。
+
+没有 Card/Brief/PRD 时仍可运行 heuristic audit，但只能判断可观察的 journey break、recovery、backstage leak、protected concern 和明显认知负担；不得产生 `AUTHORITY_DRIFT` 或裁决相互竞争的产品目标。
+
+### Output
+
+Audit 必须先声明观察边界，再输出 finding：
+
+```text
+Behavior Audit
+
+Mode: contract | heuristic
+Governing authority: <artifact/ref or none>
+Authority envelope: MUST / MUST NOT / MAY / ESCALATE
+Observed evidence: <runtime, screenshot, diff, tests, repo paths>
+Brownfield constraints: <relevant existing constraints>
+Coverage gaps: <states, viewports, input methods or modalities not observed>
+Verdict: pass | findings | inconclusive
+Confidence: high | medium | low
+
+Findings:
+[P0|P1|P2|P3] <PRIMARY_TYPE>: <title>
+Secondary tags: <optional non-primary dimensions>
+Impact: <具体用户或系统后果>
+Contract basis: <violated MUST, MUST NOT or ESCALATE boundary>
+Observed evidence: <runtime, screenshot, diff or path>
+Smallest correction: <remove, hide, rename, restore or constrain>
+Verification: <可复现的行为检查>
+Confidence: high | medium | low
+```
+
+所有 P0/P1 必须报告；然后按用户价值排序补充 P2/P3，直到总计七项。若 P0/P1 已超过七项，不得截断。正确实现必须允许并奖励 `Verdict: pass`，不能为了显得有用而强制产生 finding。
+
+### Finding Taxonomy
+
+| Type | Meaning |
+|---|---|
+| `PROTECTED_CONCERN_REGRESSION` | 为追求简化而削弱安全、隐私、数据、可访问性、迁移、恢复或测试 |
+| `MISSING_RECOVERY` | 失败、取消、撤销、权限、冲突或不可逆后果缺少必要处理 |
+| `JOURNEY_BREAK` | 主旅程无法完成、出现无解释中断或顺序错误 |
+| `AUTHORITY_DRIFT` | 实现违反 governing envelope 或增加未经授权的产品 surface；仅 contract mode 可用 |
+| `BACKSTAGE_LEAK` | 实现概念在没有用户决策需要时进入前台 |
+| `UNNECESSARY_USER_DECISION` | 用户被要求决定不会改变其目标、承诺、成本、控制或恢复的事项 |
+| `UNNECESSARY_USER_CONCEPT` | 用户被迫学习对完成目标、理解结果或恢复无帮助的新名词、状态或模型 |
+
+每个问题只生成一个 primary finding，其他适用维度放入 secondary tags，避免重复报告。证据不足不作为 P0–P3 产品 finding；它进入 `Coverage gaps`，必要时使 verdict 成为 `inconclusive`。
+
+Finding 严重度只按现实用户后果、可恢复性和 contract 影响判断。多个低影响按钮不自动成为 P1；一个隐藏的不可逆动作可以是 P0/P1。
+
+## Acceptance Scenarios
+
+### Scenario 1: Small page behavior uses an inline Card
+
+- Given: 用户要求在现有页面增加一个可逆动作，沿用现有角色与数据。
+- When: Agent 运行 `repo-harness-bdd shape`。
+- Then: 返回轻量 Behavior Card；现有 workflow 另行判断该工程改动应 inline 还是进入 plan/contract/worktree。
+- Machine-checkable evidence: 没有由 Card 层级自动推导 execution tier，也没有创建 PRD、Brief、sidecar、CLI config 或新 workflow state。
+
+### Scenario 2: Cross-session work creates a tracked Brief
+
+- Given: 行为仍小于 PRD，但需要跨会话冻结并供后续 audit 对照。
+- When: 用户批准持久化 shape 结果。
+- Then: 创建一个 Draft Behavior Brief；human approval 后状态为 Approved。
+- Machine-checkable evidence: 仅有一个人工维护的 Markdown authority，且无 JSON sidecar。
+
+### Scenario 3: High-risk behavior escalates to PRD
+
+- Given: shape 发现任一 escalation axis 为 High，或两个 axis 为 Medium。
+- When: Agent 判断继续需要产品级决策。
+- Then: 停止轻量执行并路由到 `repo-harness-prd`。
+- Machine-checkable evidence: 没有从 Brief 直接启动 implementation；PRD 接管后 Brief 为 Superseded。
+
+### Scenario 4 (negative): Shape does not become a feature generator
+
+- Given: 用户只要求一个页面动作。
+- When: Agent 能想到批量模式、设置中心、历史记录或管理后台。
+- Then (must NOT): Card 不得把这些相邻想法加入 necessary exposure。
+- Machine-checkable evidence: 相邻想法只出现在 no-go 或 out-of-scope，不进入 acceptance。
+
+### Scenario 5: Audit compares implementation with authority
+
+- Given: 页面已有 Approved Card、Brief 或 PRD，且存在可检查的 diff/runtime。
+- When: Agent 运行 `repo-harness-bdd audit`。
+- Then: audit 声明 governing authority、envelope、observed evidence、brownfield constraints、coverage gaps、verdict 和 confidence，再输出 findings 或 pass。
+- Machine-checkable evidence: 输出符合 Audit Contract V2，且 audit 不修改文件。
+
+### Scenario 6: Audit without prior behavior artifact
+
+- Given: 现有页面没有 Card、Brief 或 PRD。
+- When: reviewer 要求进行 behavior audit。
+- Then: audit 进入 heuristic mode，基于用户目标、observed evidence 和 brownfield constraints 工作，并标记 coverage gap 与较低置信度。
+- Machine-checkable evidence: 不产生 `AUTHORITY_DRIFT`，不伪造冻结需求，也不因缺失 Brief 而拒绝只读审查。
+
+### Scenario 7: Browser reference remains bounded evidence
+
+- Given: 一个具体 journey step 存在 pattern 不确定性。
+- When: shape/audit 通过 capability discovery 选择 Chrome MCP 或其他满足 contract 的 Browser Evidence Adapter provider。
+- Then: Pattern Card 记录 provenance、隐私检查、绑定问题与 Adopt/Adapt/Avoid 判断。
+- Machine-checkable evidence: 没有问题绑定或隐私检查的截图不被引用为正式 evidence。
+
+### Scenario 8: ImageGen prototype remains synthetic evidence
+
+- Given: 行为边界稳定但 interaction 仍有风险。
+- When: 生成多个低保真原型并运行 audit。
+- Then: 每个原型带假设、概念成本、恢复信息和淘汰条件。
+- Machine-checkable evidence: 原型标记 synthetic，不能单独将 hypothesis 标为 validated。
+
+### Scenario 9 (negative): Audit protects necessary complexity
+
+- Given: 页面涉及权限、数据完整性、不可逆后果或可访问性。
+- When: reviewer 以 less-is-more 为理由建议删除相关处理。
+- Then (must NOT): audit 不得把必要校验、确认、恢复、审计或测试判为过度工程。
+- Machine-checkable evidence: 输出 `PROTECTED_CONCERN_REGRESSION` 或不接受该删除建议。
+
+### Scenario 10: Specific approved child refines its parent
+
+- Given: 一个 Approved Brief 针对本周页面行为细化了较早 PRD 未规定的交互，并且不违反 parent constraint。
+- When: audit 解析 governing authority。
+- Then: 该 Brief 作为最具体的 governing artifact，PRD 继续提供有效 parent constraints。
+- Machine-checkable evidence: authority 解析记录 scope match、approval、lineage、specificity 和 freshness；不会仅因文档类型而固定选择 PRD。
+
+## Non-goals
+
+- 不替代 `repo-harness-prd`、Sprint、plan、task contract、`/check` 或 human review。
+- 不用 Card/Brief/PRD 层级推导 inline/contract/worktree 工程执行级别。
+- 不要求所有用户可见改动创建 tracked Brief。
+- 不在 MVP 中实现独立 BDD CLI command tree 或七个 MCP mutation tools。
+- 不创建人工维护的 JSON sidecar、数据库或事件状态机。
+- 不自动抓取竞品、批量爬取页面或建立截图资产库。
+- 不将 Browser Evidence Adapter 永久绑定到 Chrome MCP provider。
+- 不把 ImageGen 原型、AI persona 或 AI 推测反馈视为真实用户验证。
+- 不按页面、按钮、路由、设置、文件、抽象或依赖数量直接评判产品质量。
+- 不基于语义启发式阻断 edit、Stop 或 merge。
+- 不为 secondary/admin/support 角色自动扩建独立产品 surface。
+- 不削弱认证、授权、验证、数据完整性、隐私、安全、可访问性、错误恢复、迁移、回滚或测试。
+- 不在 BDD² 中安排工程 backlog；需要实施计划时使用现有 workflow。
+- Phase E evaluation 不创建 public skill、command registry、Brief catalog、sidecar、hook 或 `/check` integration。
+
+## Module Behaviors (P0)
+
+### Module 1: Shape
+
+- Purpose: 将小型用户可见需求塑造成最小、可恢复、可证伪的行为边界，并决定 Card、Brief 或 PRD 层级。
+- Hard Constraints:
+  - 先读取 brownfield truth，再提出目标行为。
+  - 默认一个 primary actor。
+  - 未获授权的产品扩张进入 `MUST NOT` 或触发 `ESCALATE`；no-go 只记录真实高概率诱因。
+  - 参考和原型必须绑定已命名不确定性。
+- Recommended Defaults:
+  - 先产出 inline Card；只有跨会话或 freeze 需要才创建 Brief。
+  - 先定义 outcome、critical path、exposure 和 recovery，再考虑视觉方案。
+  - 对高风险边界 fail closed 并升级 PRD。
+- Freedoms:
+  - 可调用 repo reader、满足 contract 的 Browser Evidence Adapter provider 或 ImageGen。
+  - 可把 Card 投影进现有 plan/contract，而不新建 artifact。
+- Normal path: 读取当前事实 → frame outcome → trace journey → decide exposure/no-go → cover recovery/protected concerns → select output tier → human review。
+- Failure path 1: 缺少会改变主 journey 的产品决策 → 标记 `[UNKNOWN]` 并停止实现建议。
+- Failure path 2: 发现 escalation trigger → 路由 `repo-harness-prd`，不继续轻量执行。
+- States:
+  - Empty: 尚无足够用户目标或当前事实。
+  - Loading: 正在读取 repo/runtime 或收集被授权的参考证据。
+  - Ready: Card/Brief 已形成，边界与风险明确。
+  - Error: authority 冲突、关键事实不可读或高风险问题未决。
+- Dependencies: 当前 repo 文件；可选 Browser Evidence Adapter；可选 ImageGen；现有 PRD route。
+- Open decisions: `[UNVERIFIED]` tracked Brief 的真实使用频率是否足以支持 catalog。
+
+### Module 2: Audit
+
+- Purpose: 对页面、原型、运行时或 diff 进行用户行为、暴露边界、恢复和证据审查。
+- Hard Constraints:
+  - 默认 read-only。
+  - 先确定 authority，再判断 drift。
+  - finding 必须包含具体用户后果和证据。
+  - protected concern 优先级高于 minimal-surface 偏好。
+- Recommended Defaults:
+  - 有 Card/Brief/PRD 时做 contract comparison。
+  - 无行为 artifact 时做 brownfield heuristic audit 并降低置信度。
+  - 报告全部 P0/P1，再按价值补充 P2/P3 至通常七项；不得截断高严重度 finding。
+- Freedoms:
+  - 可读取 screenshot、prototype、runtime、diff 与现有 review evidence。
+  - 可被 `/check` 消费，但不替代 correctness/security review。
+- Normal path: resolve authority → trace primary journey → inspect exposure/recovery → inspect references/prototype provenance → classify findings → assign consequence-based severity → report。
+- Failure path 1: authority 相互冲突 → `Verdict: inconclusive` 并记录 coverage/authority gap，不自行选定产品方向。
+- Failure path 2: 无法观察运行时或关键页面 → 限定结论范围，不把静态推断写成已验证事实。
+- States:
+  - Empty: 没有可审查对象。
+  - Loading: 正在收集 authority、diff、runtime 或视觉证据。
+  - Ready: 完成 findings 或 no-findings verdict。
+  - Error: 关键输入不可访问、敏感数据边界不允许继续或证据互相矛盾。
+- Dependencies: repo/diff reader；现有 review rubric；可选 Browser Evidence Adapter；可选 ImageGen output。
+- Open decisions: `[UNVERIFIED]` behavior audit 是否应成为 `/check` 固定维度，或保持显式调用。
+
+## Data Model
+
+MVP 不新增数据库、持久服务或人工 sidecar。
+
+| Datum | Source of truth | Projection |
+|---|---|---|
+| Inline Behavior Card | 当前 chat、active plan 或 task contract 中唯一一处 | Agent context summary |
+| Tracked Behavior Brief | `plans/behaviors/*.behavior.md` | 后续可选的确定性 machine projection |
+| PRD-level behavior | `plans/prds/*.prd.md` | Sprint、plan 与 contract |
+| Audit finding | 当前 audit response；需要持久化时进入现有 `tasks/reviews/` | human review card / handoff summary |
+| Browser Pattern Card | 绑定问题的现有 evidence/run artifact | Brief 或 review 中的引用 |
+| ImageGen prototype | synthetic evidence artifact | audit input，不成为 requirement authority |
+
+任何未来 sidecar 必须由 authored Markdown 确定性生成，并有 drift check；不得反向覆盖人工文档。
+
+Requirement authority、observed evidence 与 brownfield constraint 是不同 datum classes，不得在 projection 中合并成一个 `authority` 字段。
+
+## Evidence and Provenance
+
+证据强度绑定具体 claim，不使用一个可被误解为全局真值的综合等级：
+
+| Evidence type | Can support | Cannot prove alone |
+|---|---|---|
+| 当前 repo/runtime 事实 | 当前行为、结构、状态与约束 | 用户价值或未来采用率 |
+| 用户访谈、支持记录、产品数据 | 特定问题、频率或结果 | 所有用户或所有情境 |
+| Browser 可观察参考 | 某产品采用了某种模式 | 本产品用户需要该功能 |
+| ImageGen 原型 | 一个可讨论的视觉/interaction 假设 | 可用性、价值或真实偏好 |
+| 可用性/小范围实验 | 特定样本和任务下的行为 | 超出样本与实验条件的普遍结论 |
+| Agent 推理 | 待验证假设和检查问题 | 关闭 hypothesis |
+
+每项正式 evidence 至少记录：来源、采集时间、对应 claim、适用范围、隐私限制、支持什么、不能证明什么。
+
+## Evaluation Plan
+
+### Evaluation Freeze
+
+开始实验前冻结并记录：
+
+- exact repo-harness tag 或 commit；
+- model name、version、effort 与 system prompt；
+- baseline、shape、audit 与 adapter prompts；
+- task/fixture manifests；
+- review rubric 与 reviewer instructions；
+- randomness/repetition policy；
+- allowed tools 与 runtime environment。
+
+不得以持续变化的 `main` 或“当前 latest”作为实验版本标识。
+
+### Dataset Split
+
+- Development fixtures: 用于调整 prompt、Card、taxonomy 与 seeded issue 编排；结果不用于通过判定。
+- Held-out evaluation tasks: 冻结后不得参与 prompt 调整；只用这些结果判断 hypothesis。
+- Clean fixtures 与 seeded fixtures 必须分开标记，以测量正确 no-findings 和 false-positive。
+
+### Semantic Exposure Inventory
+
+每个输出先识别新增或遗漏的语义单位：
+
+| Unit | Question |
+|---|---|
+| Decision | 用户被要求选择什么？ |
+| Concept | 用户必须学习什么新名词、状态或模型？ |
+| Navigation | 用户必须去哪里？ |
+| Status | 用户必须理解什么系统状态？ |
+| Recovery action | 用户失败后必须如何继续？ |
+
+每个单位标记为：
+
+- `REQUIRED`: 由明确需求、目标完成、控制、信任、恢复或 protected concern 要求；
+- `PERMITTED`: 落在 envelope 的 `MAY` 内，是完成已批准行为的合理细节；
+- `UNSUPPORTED_EXPANSION`: 增加产品选择、概念、角色、状态或 journey，但没有 authority；
+- `UNCLEAR`: 需要 reviewer adjudication。
+
+核心报告同时包含 unsupported expansion、required behavior omission、journey completion 和 protected concern omission。统计使用 paired win/tie/loss、每任务 delta、总体 effect size 与 reviewer agreement；30% 改善只作为产品门槛之一，不作为唯一结论。
+
+### Experiment S: Shape Hypothesis
+
+Hypothesis: Behavior Card 能否在方案/实现前减少未经依据的产品扩张？
+
+```text
+12 held-out tasks × 2 conditions × 3 runs = 72 proposal outputs
+```
+
+- S-A: 当前 repo-harness 轻量 prompt；
+- S-B: 相同 prompt + shape protocol。
+
+评价最终行为方案，不评价 Card 的形式完整度。若 S-B 未减少 unsupported expansion，或增加 required/protected omission，停止 shape 产品化。
+
+### Experiment A: Audit Hypothesis
+
+Hypothesis: behavior audit 能否比现有 review 更准确地发现 journey、exposure、concept 和 recovery 问题？
+
+```text
+12 held-out fixtures × 2 review conditions × 2 runs = 48 audit outputs
+```
+
+- A-A: 现有 review rubric；
+- A-B: 现有 review rubric + behavior audit。
+
+两组检查相同的 seeded/clean implementations。指标为 finding precision、seeded issue recall、clean-fixture false-positive rate、severity agreement 和 correct no-findings rate。
+
+### Experiment E: Evidence Adapter Hypotheses
+
+只有 Experiment S/A 通过后才运行；每个 adapter 只用于预注册的适用不确定性。
+
+Browser adapter：
+
+```text
+6 pattern-uncertainty tasks × 2 conditions × 2 runs = 24 decisions
+```
+
+- E-B0: 无 Browser Evidence Adapter；
+- E-B1: 使用 capability-matched Browser Evidence Adapter。
+
+ImageGen adapter：
+
+```text
+6 interaction-uncertainty tasks × 2 conditions × 2 runs = 24 decisions
+```
+
+- E-I0: 无 ImageGen；
+- E-I1: 使用带 synthetic-evidence contract 的 ImageGen。
+
+两项都测量：是否关闭原命名不确定性、是否降低 reviewer 分歧、是否新增 unsupported concepts、是否改变最终边界决策。不得把不适用 adapter 强加给任务。
+
+### Experiment I: Implementation Pilot
+
+只有 Shape 与 Audit hypotheses 分别通过后才运行：
+
+```text
+6 held-out tasks × 3 conditions × 2 runs = 36 implementation outputs
+```
+
+- I-A: baseline；
+- I-B: shape；
+- I-C: shape + audit。
+
+这是 pilot，不宣称正式 non-inferiority。一个 condition 有 12 个二元验收结果时，单个失败即约为 `1/12 = 8.33%`，无法支持“下降不超过 5 个百分点”的精度。通过标准改为：不得出现 baseline 没有、由 BDD² 新增的严重验收失败；逐任务报告所有结果、surface delta、protected concerns、人工纠正时间和后续删除比例。
+
+### Kill Criteria
+
+- Shape 未降低 unsupported expansion，或增加 required behavior omission；
+- Audit 的 recall、false-positive、severity agreement 或 correct no-findings 未达到预注册阈值；
+- protected concern 出现任何新增 P0/P1 退化；
+- 人工修订和 artifact 成本超过返工节省；
+- Brief catalog 大部分为空壳、一次性文件或与 plan/contract 重复；
+- Browser/ImageGen 的主要效果是扩大解空间而不是关闭不确定性；
+- 现有 workflow 增加一段短 rubric 即可获得等价收益。
+
+## Performance Targets
+
+| Target | Number | Measurement Method | Degradation Threshold |
+|---|---:|---|---:|
+| Inline Card 密度 | 一屏可审阅；只保留适用 section | reviewer completion time | 为满足模板而产生空泛字段 |
+| Audit 重点 findings | 全部 P0/P1 + 最高价值 P2/P3，通常总计 7 个 | 输出结构检查 | 截断 P0/P1 或无排序堆积 P2/P3 |
+| Hook 热路径新增耗时 | 0 | route registry 与 hook tests | 增加任何默认 BDD hook |
+| 默认网络调用 | 0 | shape/audit invocation trace | 未命名不确定性即调用 Browser/ImageGen |
+
+## Known Unknowns
+
+| Item | Impact | Resolution Path | Owner |
+|---|---|---|---|
+| `[UNVERIFIED]` BDD² 是否减少过度设计 | 决定模块是否值得产品化 | Experiments S/A/I | Maintainer |
+| Behavior Brief catalog 的真实需求频率 | 决定是否创建长期目录与 validator | 记录 Card 跨会话失败案例 | Maintainer |
+| Audit finding 的跨框架一致性 | 决定 rubric 能否通用 | Web、CLI、native UI fixtures | Reviewer |
+| Browser/ImageGen 的净收益 | 决定其默认触发和证据规则 | Experiment E | Product/design reviewer |
+| 无 prior authority 的 audit 置信度校准 | 影响 finding 可执行性 | seeded authority-gap fixtures | Reviewer |
+| 是否需要 machine-readable projection | 决定未来 sidecar/helper | 至少两个真实消费者后再决策 | Maintainer |
+| 是否并入 `/check` | 影响默认审查成本 | 显式 audit 使用数据与接受率 | Maintainer |
+
+## Adjacent Patterns
+
+- `assets/skill-commands/repo-harness-prd/SKILL.md`: 现有 PRD escalation、geju framing、negative scenarios、human approval 和 evidence 规则；BDD² 不复制该流程。
+- `assets/skill-commands/repo-harness-sprint/SKILL.md`: `inline` row 可留在 backlog/active plan，不产生完整 work-package；这是 lightweight Card 的现有 workflow precedent。
+- `docs/reference-configs/minimal-change-hooks.md`: advisory、fail-open、objective signals 与 protected concerns；BDD audit 不把语义 heuristic 升级为默认 hard gate。
+- `src/cli/hook/review-rubric.ts`: correctness、scope fidelity 与 YAGNI review；BDD audit 补充 journey、exposure 和 recovery，不替代该 rubric。
+- Cucumber BDD: <https://cucumber.io/docs/bdd/>。采用 concrete examples、Discovery/Formulation/Automation；避免把 BDD 宣称为完整产品发现系统。
+- Shape Up appetite: <https://basecamp.com/shapeup/1.2-chapter-03>。采用固定投入、可变范围和 problem narrowing；不把 appetite 错译成通用按钮/文件计数。
+- Local-only V0 draft: retains the original journey, exposure, evidence, prototype, and counter-risk research; V1.1 is the approved authority.
+
+## Developer Handoff
+
+### Phase E: Evaluation Only
+
+You are executing the BDD² evaluation protocol. Do not add any public product surface unless a recorded gate decision confirms the evaluation passed.
+
+Allowed outputs：
+
+- frozen evaluation manifest；
+- development 与 held-out task/fixture manifests；
+- frozen baseline、shape、audit 与 adapter prompts；
+- seeded issue truth set、clean fixtures 与 blind review rubric；
+- Experiment S/A/E/I run evidence 与 evaluation report。
+
+Forbidden during Phase E：
+
+- public `repo-harness-bdd` skill；
+- command registry、CLI 或 MCP mutation tools；
+- `plans/behaviors/` catalog 或 Brief validator；
+- sidecar、hook、Stop gate 或 `/check` integration；
+- product implementation hidden inside eval helpers。
+
+Do not reinterpret：
+
+- BDD² 是轻量行为操作器，不是 PRD 前置强制层；
+- `shape` 和 `audit` 是独立 hypotheses，必须分别验证；
+- Browser/ImageGen 是独立 adapter hypotheses，不得与核心 treatment 捆绑；
+- artifact tier 与 engineering execution tier 独立；
+- 新 product surface 的沉默不构成授权，执行者只可在显式 `MAY` 内决定细节；
+- protected concerns 优先于 minimal-surface 偏好。
+
+Phase E verification：
+
+- frozen commit/model/prompt/fixture/rubric 可复现；
+- development 与 held-out 数据无泄漏；
+- blind adjudication 不知道 treatment；
+- Semantic Exposure Inventory、audit precision/recall/false-positive/severity/no-findings 指标完整；
+- 每个 stage 的 stop/kill decision 有文件化证据；
+- `repo-harness run check-task-workflow --strict` 不因 evaluation artifacts 引入新失败。
+
+### Phase P: Conditional Productization
+
+Phase P 不属于当前批准范围。只有 Phase E 产生 recorded pass decision 后，另开 implementation plan 或 Sprint row，才可以考虑：
+
+- 一个 `repo-harness-bdd` skill facade；
+- `shape` 与 `audit` intent routes；
+- 有真实跨会话消费者时的 optional Behavior Brief template/catalog；
+- 将 audit finding 投影进现有 review；
+- 复用 provider-agnostic Browser Evidence Adapter 与 ImageGen。
+
+任何 CLI、MCP、sidecar、hook 或 `/check` integration 都需要独立消费者和 verification boundary，不随 Phase P 自动获批。
+
+### Acceptance Scripts
+
+1. Experiment S 单独比较 baseline 与 shape，不运行 audit 或 evidence adapters。
+2. Experiment A 在相同 seeded/clean fixtures 上比较现有 review 与 behavior audit，并计算 precision、recall、false-positive、severity agreement 和 correct no-findings。
+3. Experiment E 分别验证 Browser Evidence Adapter 与 ImageGen 的 provenance、synthetic evidence、问题绑定和净收益。
+4. Experiment I 仅在 S/A 通过后比较 baseline、shape 与 shape+audit，并逐任务报告新增严重失败。
+5. 对 authority fixtures 验证 MUST/MUST NOT/MAY/ESCALATE、specific child refinement、parent constraint 和 inconclusive conflict。
+6. 对 escalation fixtures 验证按 behavioral blast radius、commitment/reversibility 与 product uncertainty 决策，而不是按技术对象类型升级。
+7. 运行 workflow checks，确认 Phase E 未新增 public product surface、默认 hook 延迟或平行 authority。
+
+## Decision
+
+当前决策为：**Proceed to Phase E evaluation design and execution; productization is not approved**。
+
+V1.1 保留 Behavior Brief、Browser evidence 与 ImageGen 的潜在产品价值，但把它们放入独立 hypotheses 和 authority envelope。Phase E 先分别证明 shape、audit 和 adapters 的净收益；只有 recorded pass decision 才能授权新的 skill、catalog、CLI、MCP 或 projection surface。

--- a/plans/sprints/20260712-bdd2-phase-e-evaluation.sprint.md
+++ b/plans/sprints/20260712-bdd2-phase-e-evaluation.sprint.md
@@ -1,0 +1,64 @@
+# Sprint: BDD² Phase E Evaluation
+
+> **Status**: Approved
+> **Source PRD**: `plans/prds/20260712-0409-bdd2-shape-audit.prd.md`
+> **Decision**: Evaluation only; Phase P productization is not approved.
+
+```yaml
+sprint_id: 20260712-bdd2-phase-e-evaluation
+status: Approved
+target_branch: main
+risk: high
+owners:
+  product: kito
+  engineering: Codex
+  reviewer: human-blind-panel
+```
+
+## Sprint Goal
+
+Determine whether BDD² shape, audit, Browser evidence, and ImageGen prototype
+treatments produce net benefit before any public skill or workflow integration is
+built. Every hypothesis has its own gate and evidence; a failure stops dependent
+rows rather than being rationalized into product code.
+
+## PRD
+
+Execute only Phase E from the approved BDD² PRD. The Sprint must first establish a
+reproducible evaluation authority, then test Shape and Audit independently, and only
+then permit the Browser/ImageGen adapter experiments and implementation pilot. Phase
+P productization remains forbidden until the final recorded gate decision.
+
+## Backlog
+
+| # | Status | Task | Mode | Acceptance | Plan |
+|---:|---|---|---|---|---|
+| 1 | [ ] | BDD2-E-01 — Freeze evaluation authority and build reproducible runner foundation | contract | Manifest/hash drift fails closed; agent packets exclude truth and treatment identity; deterministic stub runs pass; no Phase P surface is added. | `plans/plan-20260712-0450-bdd2-eval-foundation.md` |
+| 2 | [ ] | BDD2-E-02 — Run Experiment S: shape hypothesis | contract | 12 held-out tasks × 2 conditions × 3 runs complete; blind adjudication reports unsupported expansion and required/protected omission; pass/kill decision is recorded. | capture after E-01 merge |
+| 3 | [ ] | BDD2-E-03 — Run Experiment A: audit hypothesis | contract | 12 seeded/clean held-out fixtures × 2 conditions × 2 runs complete; precision, recall, clean false-positive, severity agreement, and correct no-findings are reported with a pass/kill decision. | capture after E-01 merge |
+| 4 | [ ] | BDD2-E-04 — Run Experiment E: Browser and ImageGen adapter hypotheses | contract | Starts only after S and A pass; Browser and ImageGen run as separate 6 × 2 × 2 comparisons; provenance, synthetic-evidence labeling, uncertainty closure, reviewer disagreement, and unsupported concepts are reported independently. | gated by E-02 and E-03 |
+| 5 | [ ] | BDD2-E-05 — Run Experiment I: implementation pilot | contract | Starts only after S and A pass; 6 held-out tasks × 3 conditions × 2 runs complete; every new severe acceptance failure, protected-concern regression, surface delta, correction time, and later deletion is reported. | gated by E-02 and E-03 |
+| 6 | [ ] | BDD2-E-06 — Record Phase E gate decision | contract | One evidence-backed Proceed / Reshape / Defer / Kill decision is recorded per hypothesis; Phase P scope is authorized only for hypotheses that passed their pre-registered threshold. | gated by all applicable rows |
+
+## Ordering and Stop Rules
+
+- E-01 is the shared authority boundary and ships as its own PR.
+- E-02 and E-03 use the same frozen foundation but make separate product claims;
+  each ships as an independently reviewable PR.
+- E-04 does not run when either core hypothesis fails. Browser and ImageGen are
+  retained as first-class adapter experiments, not bundled into core treatment.
+- E-05 does not run until the separate shape and audit gates pass.
+- Any prompt, fixture, rubric, model, or sampling change after freeze creates a new
+  evaluation revision; it never silently updates an in-flight run.
+- No row may add public `repo-harness-bdd`, CLI/MCP mutation tools, hooks,
+  `/check` integration, Behavior Brief catalog/validator, sidecar, or lifecycle.
+
+## Definition of Done
+
+- [ ] All applicable experiment rows have immutable run coordinates and raw
+  evidence under ignored `.ai/harness/runs/bdd2/`.
+- [ ] Blind adjudication and aggregate reports contain every PRD metric, including
+  negative and protected-concern measures.
+- [ ] Development and held-out material are separated and leakage checks pass.
+- [ ] Every dependent gate records why it proceeded or stopped.
+- [ ] A human-approved Phase E decision exists before any Phase P plan is created.

--- a/scripts/run-bdd2-evals.ts
+++ b/scripts/run-bdd2-evals.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import { createHash } from "crypto";
+import { createHash, randomBytes } from "crypto";
 import { spawnSync } from "child_process";
 import {
   existsSync,
@@ -24,6 +24,11 @@ export type FreezeState = "foundation" | "sealed";
 
 interface PromptReference {
   prompt: string;
+  sha256: string;
+}
+
+interface FileReference {
+  path: string;
   sha256: string;
 }
 
@@ -56,6 +61,7 @@ export interface EvaluationManifest {
     state: FreezeState;
     sealed_at: string | null;
   };
+  runner: FileReference;
   output_root: string;
   experiments: Record<ExperimentId, ExperimentDefinition>;
   partitions: Record<PartitionId, PartitionDefinition>;
@@ -97,6 +103,7 @@ interface TruthSet {
 export interface ValidatedEvaluation {
   repoRoot: string;
   manifestPath: string;
+  authorityPaths: string[];
   manifest: EvaluationManifest;
   tasks: Record<PartitionId, EvaluationTask[]>;
 }
@@ -110,7 +117,7 @@ export interface PlanOptions {
 }
 
 export interface RunCoordinate {
-  packetId: string;
+  coordinateId: string;
   experiment: ExperimentId;
   partition: PartitionId;
   taskId: string;
@@ -206,12 +213,20 @@ function validatePromptReference(
   repoRoot: string,
   value: unknown,
   label: string
-): asserts value is PromptReference {
+): string {
   assertRecord(value, label);
   assertExactKeys(value, ["prompt", "sha256"], label);
   assertString(value.prompt, `${label}.prompt`);
   assertString(value.sha256, `${label}.sha256`);
-  verifyHash(repoRoot, value.prompt, value.sha256, label);
+  return verifyHash(repoRoot, value.prompt, value.sha256, label);
+}
+
+function validateFileReference(repoRoot: string, value: unknown, label: string): string {
+  assertRecord(value, label);
+  assertExactKeys(value, ["path", "sha256"], label);
+  assertString(value.path, `${label}.path`);
+  assertString(value.sha256, `${label}.sha256`);
+  return verifyHash(repoRoot, value.path, value.sha256, label);
 }
 
 function validateTaskSet(raw: unknown, partition: PartitionId): TaskSet {
@@ -323,13 +338,14 @@ export function validateEvaluation(
   const manifestPath = authorityPath(absoluteRoot, manifestRelativePath, "manifest");
   const raw = readJson(manifestPath);
   assertRecord(raw, "manifest");
-  assertExactKeys(raw, ["schema", "freeze", "output_root", "experiments", "partitions", "adjudication", "agents"], "manifest");
+  assertExactKeys(raw, ["schema", "freeze", "runner", "output_root", "experiments", "partitions", "adjudication", "agents"], "manifest");
   if (raw.schema !== "repo-harness-bdd2-evaluation.v1") fail("Unsupported evaluation manifest schema");
 
   assertRecord(raw.freeze, "freeze");
   assertExactKeys(raw.freeze, ["id", "state", "sealed_at"], "freeze");
   assertString(raw.freeze.id, "freeze.id");
   if (raw.freeze.state !== "foundation" && raw.freeze.state !== "sealed") fail("freeze.state must be foundation or sealed");
+  const authorityPaths = [manifestPath, validateFileReference(absoluteRoot, raw.runner, "runner")];
   assertString(raw.output_root, "output_root");
   assertRecord(raw.experiments, "experiments");
   assertExactKeys(raw.experiments, ["S", "A"], "experiments");
@@ -342,8 +358,10 @@ export function validateEvaluation(
     if (!Number.isInteger(experiment.held_out_task_count) || Number(experiment.held_out_task_count) < 1) fail(`experiments.${experimentId}.held_out_task_count must be positive`);
     assertRecord(experiment.conditions, `experiments.${experimentId}.conditions`);
     assertExactKeys(experiment.conditions, ["baseline", "treatment"], `experiments.${experimentId}.conditions`);
-    validatePromptReference(absoluteRoot, experiment.conditions.baseline, `experiments.${experimentId}.conditions.baseline`);
-    validatePromptReference(absoluteRoot, experiment.conditions.treatment, `experiments.${experimentId}.conditions.treatment`);
+    authorityPaths.push(
+      validatePromptReference(absoluteRoot, experiment.conditions.baseline, `experiments.${experimentId}.conditions.baseline`),
+      validatePromptReference(absoluteRoot, experiment.conditions.treatment, `experiments.${experimentId}.conditions.treatment`)
+    );
   }
 
   assertRecord(raw.partitions, "partitions");
@@ -359,6 +377,7 @@ export function validateEvaluation(
     assertString(partition.truth_sha256, `partitions.${partitionId}.truth_sha256`);
     const taskPath = verifyHash(absoluteRoot, partition.tasks, partition.tasks_sha256, `${partitionId} tasks`);
     const truthPath = verifyHash(absoluteRoot, partition.truth, partition.truth_sha256, `${partitionId} truth`);
+    authorityPaths.push(taskPath, truthPath);
     const taskSet = validateTaskSet(readJson(taskPath), partitionId);
     validateTruthSet(readJson(truthPath), partitionId, taskSet.tasks);
     tasks[partitionId] = taskSet.tasks;
@@ -376,8 +395,10 @@ export function validateEvaluation(
   const rubricSha256 = raw.adjudication.rubric_sha256 as string;
   const scoreSchema = raw.adjudication.score_schema as string;
   const scoreSchemaSha256 = raw.adjudication.score_schema_sha256 as string;
-  verifyHash(absoluteRoot, rubric, rubricSha256, "adjudication rubric");
-  verifyHash(absoluteRoot, scoreSchema, scoreSchemaSha256, "adjudication score schema");
+  authorityPaths.push(
+    verifyHash(absoluteRoot, rubric, rubricSha256, "adjudication rubric"),
+    verifyHash(absoluteRoot, scoreSchema, scoreSchemaSha256, "adjudication score schema")
+  );
 
   assertRecord(raw.agents, "agents");
   const manifest = raw as unknown as EvaluationManifest;
@@ -396,11 +417,20 @@ export function validateEvaluation(
     }
   }
 
-  return { repoRoot: absoluteRoot, manifestPath, manifest, tasks };
+  return { repoRoot: absoluteRoot, manifestPath, authorityPaths: [...new Set(authorityPaths)], manifest, tasks };
 }
 
-function opaquePacketId(parts: string[]): string {
+function privateCoordinateId(parts: string[]): string {
   return createHash("sha256").update(parts.join("\0")).digest("hex").slice(0, 16);
+}
+
+function randomBlindPacketId(used: Set<string>): string {
+  let packetId = "";
+  do {
+    packetId = randomBytes(16).toString("hex");
+  } while (used.has(packetId));
+  used.add(packetId);
+  return packetId;
 }
 
 export function buildRunPlan(evaluation: ValidatedEvaluation, options: PlanOptions): RunCoordinate[] {
@@ -427,7 +457,7 @@ export function buildRunPlan(evaluation: ValidatedEvaluation, options: PlanOptio
     for (const condition of conditions) {
       for (let repetition = 1; repetition <= repetitions; repetition += 1) {
         coordinates.push({
-          packetId: opaquePacketId([evaluation.manifest.freeze.id, options.experiment, options.partition, task.id, condition, String(repetition)]),
+          coordinateId: privateCoordinateId([evaluation.manifest.freeze.id, options.experiment, options.partition, task.id, condition, String(repetition)]),
           experiment: options.experiment,
           partition: options.partition,
           taskId: task.id,
@@ -492,11 +522,29 @@ function cleanHeadCommit(repoRoot: string): string {
   return commit;
 }
 
+function assertAuthorityTrackedAtHead(repoRoot: string, authorityPaths: string[]): void {
+  for (const path of authorityPaths) {
+    const relativePath = relative(repoRoot, path).replace(/\\/g, "/");
+    if (relativePath.startsWith("../") || isAbsolute(relativePath)) {
+      fail(`Evaluation authority escapes repository root: ${path}`);
+    }
+    const tracked = spawnSync(
+      "git",
+      ["ls-files", "--error-unmatch", "--", relativePath],
+      { cwd: repoRoot, encoding: "utf-8" }
+    );
+    if (tracked.status !== 0) {
+      fail(`Sealed evaluation authority must be tracked at HEAD: ${relativePath}`);
+    }
+  }
+}
+
 export function runEvaluation(evaluation: ValidatedEvaluation, options: RunOptions): RunReport {
   if (evaluation.manifest.freeze.state !== "sealed") fail("Evaluation manifest is foundation-only; seal commit, model, and agent profiles before execution");
   const profile = evaluation.manifest.agents[options.agent];
   if (!profile) fail(`Unknown frozen agent profile: ${options.agent}`);
   const sourceCommit = cleanHeadCommit(evaluation.repoRoot);
+  assertAuthorityTrackedAtHead(evaluation.repoRoot, evaluation.authorityPaths);
   const plan = buildRunPlan(evaluation, options);
   const outputPath = options.outputPath
     ? resolve(evaluation.repoRoot, options.outputPath)
@@ -520,8 +568,9 @@ export function runEvaluation(evaluation: ValidatedEvaluation, options: RunOptio
     packets: [],
   };
 
+  const blindPacketIds = new Set<string>();
   for (const coordinate of plan) {
-    const packetRoot = resolve(outputPath, "packets", coordinate.packetId);
+    const packetRoot = resolve(outputPath, "packets", coordinate.coordinateId);
     const promptPath = resolve(packetRoot, "agent-prompt.md");
     const responsePath = resolve(packetRoot, "response.md");
     const stderrPath = resolve(packetRoot, "stderr.txt");
@@ -541,25 +590,27 @@ export function runEvaluation(evaluation: ValidatedEvaluation, options: RunOptio
     writeJson(resolve(packetRoot, "command.json"), { command: profile.command, args, cwd: evaluation.repoRoot });
     const result = spawnSync(profile.command, args, { cwd: evaluation.repoRoot, encoding: "utf-8", env: process.env });
     writeFileSync(stderrPath, result.stderr ?? "", "utf-8");
-    if (result.error) fail(`Agent command failed to start for ${coordinate.packetId}: ${result.error.message}`);
-    if (result.status !== 0) fail(`Agent command failed for ${coordinate.packetId} with exit ${result.status}`);
+    if (result.error) fail(`Agent command failed to start for ${coordinate.coordinateId}: ${result.error.message}`);
+    if (result.status !== 0) fail(`Agent command failed for ${coordinate.coordinateId} with exit ${result.status}`);
 
     if (profile.response_source === "stdout") {
       writeFileSync(responsePath, result.stdout ?? "", "utf-8");
     } else if (!existsSync(responsePath)) {
-      fail(`Agent response file missing for ${coordinate.packetId}`);
+      fail(`Agent response file missing for ${coordinate.coordinateId}`);
     }
     const response = readFileSync(responsePath, "utf-8");
-    writeJson(resolve(outputPath, "blind", `${coordinate.packetId}.json`), {
+    const blindPacketId = randomBlindPacketId(blindPacketIds);
+    writeJson(resolve(outputPath, "blind", `${blindPacketId}.json`), {
       schema: "repo-harness-bdd2-blind-packet.v1",
-      packet_id: coordinate.packetId,
+      packet_id: blindPacketId,
       task_id: coordinate.taskId,
       experiment: coordinate.experiment,
       response,
     });
-    writeJson(resolve(outputPath, "private", `${coordinate.packetId}.json`), {
+    writeJson(resolve(outputPath, "private", `${blindPacketId}.json`), {
       schema: "repo-harness-bdd2-private-coordinate.v1",
-      packet_id: coordinate.packetId,
+      packet_id: blindPacketId,
+      coordinate_id: coordinate.coordinateId,
       task_id: coordinate.taskId,
       condition: coordinate.condition,
       repetition: coordinate.repetition,
@@ -569,7 +620,7 @@ export function runEvaluation(evaluation: ValidatedEvaluation, options: RunOptio
       sampling: profile.sampling,
       exit_code: result.status,
     });
-    report.packets.push({ packet_id: coordinate.packetId, task_id: coordinate.taskId, status: "success" });
+    report.packets.push({ packet_id: blindPacketId, task_id: coordinate.taskId, status: "success" });
   }
 
   writeJson(resolve(outputPath, "run.json"), report);

--- a/scripts/run-bdd2-evals.ts
+++ b/scripts/run-bdd2-evals.ts
@@ -1,0 +1,656 @@
+#!/usr/bin/env bun
+
+import { createHash } from "crypto";
+import { spawnSync } from "child_process";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  writeFileSync,
+} from "fs";
+import { dirname, isAbsolute, relative, resolve, sep } from "path";
+import { fileURLToPath } from "url";
+
+const SCRIPT_PATH = fileURLToPath(import.meta.url);
+export const REPO_ROOT = resolve(dirname(SCRIPT_PATH), "..");
+export const DEFAULT_MANIFEST_PATH = "evals/bdd2/evaluation-manifest.json";
+
+export type ExperimentId = "S" | "A";
+export type PartitionId = "development" | "held_out";
+export type ConditionId = "baseline" | "treatment";
+export type FreezeState = "foundation" | "sealed";
+
+interface PromptReference {
+  prompt: string;
+  sha256: string;
+}
+
+interface ExperimentDefinition {
+  kind: "shape" | "audit";
+  repetitions: number;
+  held_out_task_count: number;
+  conditions: Record<ConditionId, PromptReference>;
+}
+
+interface PartitionDefinition {
+  tasks: string;
+  tasks_sha256: string;
+  truth: string;
+  truth_sha256: string;
+}
+
+export interface AgentProfile {
+  command: string;
+  args: string[];
+  model: string;
+  sampling: Record<string, string | number | boolean | null>;
+  response_source: "stdout" | "file";
+}
+
+export interface EvaluationManifest {
+  schema: "repo-harness-bdd2-evaluation.v1";
+  freeze: {
+    id: string;
+    state: FreezeState;
+    sealed_at: string | null;
+  };
+  output_root: string;
+  experiments: Record<ExperimentId, ExperimentDefinition>;
+  partitions: Record<PartitionId, PartitionDefinition>;
+  adjudication: {
+    rubric: string;
+    rubric_sha256: string;
+    score_schema: string;
+    score_schema_sha256: string;
+  };
+  agents: Record<string, AgentProfile>;
+}
+
+export interface EvaluationTask {
+  id: string;
+  experiment: ExperimentId;
+  title: string;
+  agent_input: string;
+}
+
+interface TaskSet {
+  schema: "repo-harness-bdd2-task-set.v1";
+  partition: PartitionId;
+  tasks: EvaluationTask[];
+}
+
+interface TruthIssue {
+  id: string;
+  severity: "P0" | "P1" | "P2" | "P3";
+  taxonomy: string;
+  summary: string;
+}
+
+interface TruthSet {
+  schema: "repo-harness-bdd2-truth-set.v1";
+  partition: PartitionId;
+  audit_tasks: Record<string, { clean: boolean; issues: TruthIssue[] }>;
+}
+
+export interface ValidatedEvaluation {
+  repoRoot: string;
+  manifestPath: string;
+  manifest: EvaluationManifest;
+  tasks: Record<PartitionId, EvaluationTask[]>;
+}
+
+export interface PlanOptions {
+  experiment: ExperimentId;
+  partition: PartitionId;
+  taskIds?: string[];
+  conditions?: ConditionId[];
+  repetitions?: number;
+}
+
+export interface RunCoordinate {
+  packetId: string;
+  experiment: ExperimentId;
+  partition: PartitionId;
+  taskId: string;
+  condition: ConditionId;
+  repetition: number;
+  promptPath: string;
+}
+
+export interface RunOptions extends PlanOptions {
+  agent: string;
+  outputPath?: string;
+  now?: Date;
+}
+
+export interface RunReport {
+  schema: "repo-harness-bdd2-run.v1";
+  freeze_id: string;
+  source_commit: string;
+  manifest_sha256: string;
+  agent: string;
+  model: string;
+  sampling: Record<string, string | number | boolean | null>;
+  experiment: ExperimentId;
+  partition: PartitionId;
+  output_path: string;
+  packets: Array<{ packet_id: string; task_id: string; status: "success" }>;
+}
+
+function fail(message: string): never {
+  throw new Error(message);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function assertRecord(value: unknown, label: string): asserts value is Record<string, unknown> {
+  if (!isRecord(value)) fail(`${label} must be an object`);
+}
+
+function assertExactKeys(value: Record<string, unknown>, keys: string[], label: string): void {
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  if (actual.join("\n") !== expected.join("\n")) {
+    fail(`${label} keys must be exactly [${expected.join(", ")}], got [${actual.join(", ")}]`);
+  }
+}
+
+function assertString(value: unknown, label: string): asserts value is string {
+  if (typeof value !== "string" || value.length === 0) fail(`${label} must be a non-empty string`);
+}
+
+function readJson(path: string): unknown {
+  try {
+    return JSON.parse(readFileSync(path, "utf-8")) as unknown;
+  } catch (error) {
+    fail(`Cannot read JSON ${path}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+function authorityPath(repoRoot: string, relativePath: string, label: string): string {
+  assertString(relativePath, label);
+  if (isAbsolute(relativePath)) fail(`${label} must be repository-relative`);
+  const resolved = resolve(repoRoot, relativePath);
+  const rootPrefix = repoRoot.endsWith(sep) ? repoRoot : `${repoRoot}${sep}`;
+  if (resolved !== repoRoot && !resolved.startsWith(rootPrefix)) {
+    fail(`${label} escapes repository root: ${relativePath}`);
+  }
+  if (!existsSync(resolved)) fail(`${label} does not exist: ${relativePath}`);
+  if (lstatSync(resolved).isSymbolicLink()) fail(`${label} must not be a symbolic link: ${relativePath}`);
+  const realRoot = realpathSync(repoRoot);
+  const realResolved = realpathSync(resolved);
+  const realRootPrefix = realRoot.endsWith(sep) ? realRoot : `${realRoot}${sep}`;
+  if (realResolved !== realRoot && !realResolved.startsWith(realRootPrefix)) {
+    fail(`${label} resolves outside repository root: ${relativePath}`);
+  }
+  return resolved;
+}
+
+export function sha256File(path: string): string {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function verifyHash(repoRoot: string, relativePath: string, expected: string, label: string): string {
+  if (!/^[a-f0-9]{64}$/.test(expected)) fail(`${label} sha256 is not frozen`);
+  const path = authorityPath(repoRoot, relativePath, label);
+  const actual = sha256File(path);
+  if (actual !== expected) fail(`${label} sha256 drift: expected ${expected}, got ${actual}`);
+  return path;
+}
+
+function validatePromptReference(
+  repoRoot: string,
+  value: unknown,
+  label: string
+): asserts value is PromptReference {
+  assertRecord(value, label);
+  assertExactKeys(value, ["prompt", "sha256"], label);
+  assertString(value.prompt, `${label}.prompt`);
+  assertString(value.sha256, `${label}.sha256`);
+  verifyHash(repoRoot, value.prompt, value.sha256, label);
+}
+
+function validateTaskSet(raw: unknown, partition: PartitionId): TaskSet {
+  assertRecord(raw, `${partition} task set`);
+  assertExactKeys(raw, ["schema", "partition", "tasks"], `${partition} task set`);
+  if (raw.schema !== "repo-harness-bdd2-task-set.v1") fail(`${partition} task schema mismatch`);
+  if (raw.partition !== partition) fail(`${partition} task partition mismatch`);
+  if (!Array.isArray(raw.tasks) || raw.tasks.length === 0) fail(`${partition} tasks must be non-empty`);
+
+  const ids = new Set<string>();
+  const tasks = raw.tasks.map((candidate, index): EvaluationTask => {
+    const label = `${partition}.tasks[${index}]`;
+    assertRecord(candidate, label);
+    assertExactKeys(candidate, ["id", "experiment", "title", "agent_input"], label);
+    assertString(candidate.id, `${label}.id`);
+    assertString(candidate.title, `${label}.title`);
+    assertString(candidate.agent_input, `${label}.agent_input`);
+    if (candidate.experiment !== "S" && candidate.experiment !== "A") {
+      fail(`${label}.experiment must be S or A`);
+    }
+    if (ids.has(candidate.id)) fail(`Duplicate task id in ${partition}: ${candidate.id}`);
+    ids.add(candidate.id);
+    return candidate as unknown as EvaluationTask;
+  });
+
+  return { schema: "repo-harness-bdd2-task-set.v1", partition, tasks };
+}
+
+function validateTruthSet(raw: unknown, partition: PartitionId, tasks: EvaluationTask[]): void {
+  assertRecord(raw, `${partition} truth set`);
+  assertExactKeys(raw, ["schema", "partition", "audit_tasks"], `${partition} truth set`);
+  if (raw.schema !== "repo-harness-bdd2-truth-set.v1") fail(`${partition} truth schema mismatch`);
+  if (raw.partition !== partition) fail(`${partition} truth partition mismatch`);
+  assertRecord(raw.audit_tasks, `${partition}.audit_tasks`);
+
+  const auditTaskIds = new Set(tasks.filter((task) => task.experiment === "A").map((task) => task.id));
+  const truthIds = new Set(Object.keys(raw.audit_tasks));
+  if ([...auditTaskIds].sort().join("\n") !== [...truthIds].sort().join("\n")) {
+    fail(`${partition} truth keys must match audit task ids exactly`);
+  }
+
+  for (const [taskId, candidate] of Object.entries(raw.audit_tasks)) {
+    assertRecord(candidate, `${partition}.audit_tasks.${taskId}`);
+    assertExactKeys(candidate, ["clean", "issues"], `${partition}.audit_tasks.${taskId}`);
+    if (typeof candidate.clean !== "boolean" || !Array.isArray(candidate.issues)) {
+      fail(`${partition}.audit_tasks.${taskId} has invalid clean/issues`);
+    }
+    if (candidate.clean !== (candidate.issues.length === 0)) {
+      fail(`${partition}.audit_tasks.${taskId} clean flag disagrees with issues`);
+    }
+    for (const [index, issue] of candidate.issues.entries()) {
+      assertRecord(issue, `${taskId}.issues[${index}]`);
+      assertExactKeys(issue, ["id", "severity", "taxonomy", "summary"], `${taskId}.issues[${index}]`);
+      assertString(issue.id, `${taskId}.issues[${index}].id`);
+      assertString(issue.taxonomy, `${taskId}.issues[${index}].taxonomy`);
+      assertString(issue.summary, `${taskId}.issues[${index}].summary`);
+      if (!["P0", "P1", "P2", "P3"].includes(String(issue.severity))) {
+        fail(`${taskId}.issues[${index}].severity is invalid`);
+      }
+    }
+  }
+}
+
+function validateAgentProfiles(manifest: EvaluationManifest): void {
+  for (const [agent, raw] of Object.entries(manifest.agents)) {
+    assertRecord(raw, `agents.${agent}`);
+    assertExactKeys(raw, ["command", "args", "model", "sampling", "response_source"], `agents.${agent}`);
+    assertString(raw.command, `agents.${agent}.command`);
+    assertString(raw.model, `agents.${agent}.model`);
+    if (!Array.isArray(raw.args) || raw.args.some((entry) => typeof entry !== "string")) {
+      fail(`agents.${agent}.args must be an array of strings`);
+    }
+    if (raw.response_source !== "stdout" && raw.response_source !== "file") {
+      fail(`agents.${agent}.response_source must be stdout or file`);
+    }
+    assertRecord(raw.sampling, `agents.${agent}.sampling`);
+    for (const [key, value] of Object.entries(raw.sampling)) {
+      if (!["string", "number", "boolean"].includes(typeof value) && value !== null) {
+        fail(`agents.${agent}.sampling.${key} must be a scalar or null`);
+      }
+    }
+    const templates = (raw.args as string[]).join("\n");
+    for (const required of ["{prompt_path}", "{model}"]) {
+      if (!templates.includes(required)) fail(`agents.${agent}.args must apply ${required}`);
+    }
+    if (raw.response_source === "file" && !templates.includes("{response_path}")) {
+      fail(`agents.${agent}.args must apply {response_path} for file responses`);
+    }
+    for (const key of Object.keys(raw.sampling)) {
+      if (!templates.includes(`{sampling.${key}}`)) {
+        fail(`agents.${agent}.args must apply {sampling.${key}}`);
+      }
+    }
+    for (const placeholder of templates.matchAll(/\{([^}]+)\}/g)) {
+      const name = placeholder[1];
+      const knownSampling = name.startsWith("sampling.") && Object.hasOwn(raw.sampling, name.slice("sampling.".length));
+      if (!["prompt_path", "response_path", "workspace", "model"].includes(name) && !knownSampling) {
+        fail(`agents.${agent}.args contains unknown placeholder {${name}}`);
+      }
+    }
+  }
+}
+
+export function validateEvaluation(
+  repoRoot: string = REPO_ROOT,
+  manifestRelativePath: string = DEFAULT_MANIFEST_PATH
+): ValidatedEvaluation {
+  const absoluteRoot = resolve(repoRoot);
+  const manifestPath = authorityPath(absoluteRoot, manifestRelativePath, "manifest");
+  const raw = readJson(manifestPath);
+  assertRecord(raw, "manifest");
+  assertExactKeys(raw, ["schema", "freeze", "output_root", "experiments", "partitions", "adjudication", "agents"], "manifest");
+  if (raw.schema !== "repo-harness-bdd2-evaluation.v1") fail("Unsupported evaluation manifest schema");
+
+  assertRecord(raw.freeze, "freeze");
+  assertExactKeys(raw.freeze, ["id", "state", "sealed_at"], "freeze");
+  assertString(raw.freeze.id, "freeze.id");
+  if (raw.freeze.state !== "foundation" && raw.freeze.state !== "sealed") fail("freeze.state must be foundation or sealed");
+  assertString(raw.output_root, "output_root");
+  assertRecord(raw.experiments, "experiments");
+  assertExactKeys(raw.experiments, ["S", "A"], "experiments");
+  for (const experimentId of ["S", "A"] as const) {
+    const experiment = raw.experiments[experimentId];
+    assertRecord(experiment, `experiments.${experimentId}`);
+    assertExactKeys(experiment, ["kind", "repetitions", "held_out_task_count", "conditions"], `experiments.${experimentId}`);
+    if (experiment.kind !== (experimentId === "S" ? "shape" : "audit")) fail(`experiments.${experimentId}.kind mismatch`);
+    if (!Number.isInteger(experiment.repetitions) || Number(experiment.repetitions) < 1) fail(`experiments.${experimentId}.repetitions must be positive`);
+    if (!Number.isInteger(experiment.held_out_task_count) || Number(experiment.held_out_task_count) < 1) fail(`experiments.${experimentId}.held_out_task_count must be positive`);
+    assertRecord(experiment.conditions, `experiments.${experimentId}.conditions`);
+    assertExactKeys(experiment.conditions, ["baseline", "treatment"], `experiments.${experimentId}.conditions`);
+    validatePromptReference(absoluteRoot, experiment.conditions.baseline, `experiments.${experimentId}.conditions.baseline`);
+    validatePromptReference(absoluteRoot, experiment.conditions.treatment, `experiments.${experimentId}.conditions.treatment`);
+  }
+
+  assertRecord(raw.partitions, "partitions");
+  assertExactKeys(raw.partitions, ["development", "held_out"], "partitions");
+  const tasks = {} as Record<PartitionId, EvaluationTask[]>;
+  for (const partitionId of ["development", "held_out"] as const) {
+    const partition = raw.partitions[partitionId];
+    assertRecord(partition, `partitions.${partitionId}`);
+    assertExactKeys(partition, ["tasks", "tasks_sha256", "truth", "truth_sha256"], `partitions.${partitionId}`);
+    assertString(partition.tasks, `partitions.${partitionId}.tasks`);
+    assertString(partition.tasks_sha256, `partitions.${partitionId}.tasks_sha256`);
+    assertString(partition.truth, `partitions.${partitionId}.truth`);
+    assertString(partition.truth_sha256, `partitions.${partitionId}.truth_sha256`);
+    const taskPath = verifyHash(absoluteRoot, partition.tasks, partition.tasks_sha256, `${partitionId} tasks`);
+    const truthPath = verifyHash(absoluteRoot, partition.truth, partition.truth_sha256, `${partitionId} truth`);
+    const taskSet = validateTaskSet(readJson(taskPath), partitionId);
+    validateTruthSet(readJson(truthPath), partitionId, taskSet.tasks);
+    tasks[partitionId] = taskSet.tasks;
+  }
+
+  const allIds = [...tasks.development, ...tasks.held_out].map((task) => task.id);
+  if (new Set(allIds).size !== allIds.length) fail("Task ids must be unique across partitions");
+
+  assertRecord(raw.adjudication, "adjudication");
+  assertExactKeys(raw.adjudication, ["rubric", "rubric_sha256", "score_schema", "score_schema_sha256"], "adjudication");
+  for (const key of ["rubric", "rubric_sha256", "score_schema", "score_schema_sha256"] as const) {
+    assertString(raw.adjudication[key], `adjudication.${key}`);
+  }
+  const rubric = raw.adjudication.rubric as string;
+  const rubricSha256 = raw.adjudication.rubric_sha256 as string;
+  const scoreSchema = raw.adjudication.score_schema as string;
+  const scoreSchemaSha256 = raw.adjudication.score_schema_sha256 as string;
+  verifyHash(absoluteRoot, rubric, rubricSha256, "adjudication rubric");
+  verifyHash(absoluteRoot, scoreSchema, scoreSchemaSha256, "adjudication score schema");
+
+  assertRecord(raw.agents, "agents");
+  const manifest = raw as unknown as EvaluationManifest;
+  if (manifest.freeze.state === "foundation") {
+    if (manifest.freeze.sealed_at !== null || Object.keys(manifest.agents).length !== 0) {
+      fail("Foundation freeze cannot contain seal time or agents");
+    }
+  } else {
+    assertString(manifest.freeze.sealed_at, "freeze.sealed_at");
+    if (Object.keys(manifest.agents).length === 0) fail("Sealed freeze requires at least one agent profile");
+    validateAgentProfiles(manifest);
+    for (const experimentId of ["S", "A"] as const) {
+      const actual = tasks.held_out.filter((task) => task.experiment === experimentId).length;
+      const expected = manifest.experiments[experimentId].held_out_task_count;
+      if (actual !== expected) fail(`Sealed experiment ${experimentId} requires exactly ${expected} held-out tasks, got ${actual}`);
+    }
+  }
+
+  return { repoRoot: absoluteRoot, manifestPath, manifest, tasks };
+}
+
+function opaquePacketId(parts: string[]): string {
+  return createHash("sha256").update(parts.join("\0")).digest("hex").slice(0, 16);
+}
+
+export function buildRunPlan(evaluation: ValidatedEvaluation, options: PlanOptions): RunCoordinate[] {
+  const experiment = evaluation.manifest.experiments[options.experiment];
+  const candidates = evaluation.tasks[options.partition].filter((task) => task.experiment === options.experiment);
+  const wanted = new Set(options.taskIds ?? []);
+  const selected = wanted.size === 0 ? candidates : candidates.filter((task) => wanted.has(task.id));
+  if (selected.length === 0) fail("No tasks selected");
+  if (wanted.size > 0 && selected.length !== wanted.size) {
+    const selectedIds = new Set(selected.map((task) => task.id));
+    fail(`Unknown or mismatched task ids: ${[...wanted].filter((id) => !selectedIds.has(id)).join(", ")}`);
+  }
+
+  const conditions = options.conditions ?? (["baseline", "treatment"] as const);
+  if (conditions.length === 0 || conditions.some((condition) => condition !== "baseline" && condition !== "treatment")) fail("conditions must contain baseline and/or treatment");
+  if (new Set(conditions).size !== conditions.length) fail("conditions must not contain duplicates");
+  const repetitions = options.repetitions ?? experiment.repetitions;
+  if (!Number.isInteger(repetitions) || repetitions < 1 || repetitions > experiment.repetitions) {
+    fail(`repetitions must be between 1 and frozen maximum ${experiment.repetitions}`);
+  }
+
+  const coordinates: RunCoordinate[] = [];
+  for (const task of selected.sort((a, b) => a.id.localeCompare(b.id))) {
+    for (const condition of conditions) {
+      for (let repetition = 1; repetition <= repetitions; repetition += 1) {
+        coordinates.push({
+          packetId: opaquePacketId([evaluation.manifest.freeze.id, options.experiment, options.partition, task.id, condition, String(repetition)]),
+          experiment: options.experiment,
+          partition: options.partition,
+          taskId: task.id,
+          condition,
+          repetition,
+          promptPath: experiment.conditions[condition].prompt,
+        });
+      }
+    }
+  }
+  return coordinates;
+}
+
+export function buildAgentPacket(evaluation: ValidatedEvaluation, coordinate: RunCoordinate): string {
+  const task = evaluation.tasks[coordinate.partition].find((candidate) => candidate.id === coordinate.taskId);
+  if (!task) fail(`Task missing for coordinate: ${coordinate.taskId}`);
+  const prompt = readFileSync(authorityPath(evaluation.repoRoot, coordinate.promptPath, "condition prompt"), "utf-8").trim();
+  return `${prompt}\n\n## Task\n\nTask ID: ${task.id}\n\n${task.agent_input.trim()}\n`;
+}
+
+function expandArg(template: string, values: Record<string, string>): string {
+  return template.replace(/\{(prompt_path|response_path|workspace|model|sampling\.[^}]+)\}/g, (_, key: string) => values[key]);
+}
+
+function ensureNewDirectory(path: string): void {
+  if (existsSync(path)) fail(`Output path already exists: ${path}`);
+  mkdirSync(path, { recursive: true });
+}
+
+function assertWritePath(repoRoot: string, targetPath: string): void {
+  const realRoot = realpathSync(repoRoot);
+  let ancestor = dirname(targetPath);
+  while (!existsSync(ancestor)) {
+    const parent = dirname(ancestor);
+    if (parent === ancestor) fail(`Cannot resolve output ancestor: ${targetPath}`);
+    ancestor = parent;
+  }
+  const realAncestor = realpathSync(ancestor);
+  const rootPrefix = realRoot.endsWith(sep) ? realRoot : `${realRoot}${sep}`;
+  if (realAncestor !== realRoot && !realAncestor.startsWith(rootPrefix)) {
+    fail(`Output path resolves outside repository root: ${targetPath}`);
+  }
+}
+
+function writeJson(path: string, value: unknown): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, "utf-8");
+}
+
+function timestamp(date: Date): string {
+  return date.toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z");
+}
+
+function cleanHeadCommit(repoRoot: string): string {
+  const head = spawnSync("git", ["rev-parse", "HEAD"], { cwd: repoRoot, encoding: "utf-8" });
+  if (head.status !== 0) fail(`Cannot resolve evaluation source commit: ${(head.stderr ?? "").trim()}`);
+  const commit = (head.stdout ?? "").trim();
+  if (!/^[a-f0-9]{40}$/.test(commit)) fail("Evaluation source commit is not a full Git commit id");
+  const status = spawnSync("git", ["status", "--porcelain", "--untracked-files=all"], { cwd: repoRoot, encoding: "utf-8" });
+  if (status.status !== 0) fail(`Cannot inspect evaluation source worktree: ${(status.stderr ?? "").trim()}`);
+  if ((status.stdout ?? "").trim().length > 0) fail("Sealed evaluation requires a clean Git HEAD");
+  return commit;
+}
+
+export function runEvaluation(evaluation: ValidatedEvaluation, options: RunOptions): RunReport {
+  if (evaluation.manifest.freeze.state !== "sealed") fail("Evaluation manifest is foundation-only; seal commit, model, and agent profiles before execution");
+  const profile = evaluation.manifest.agents[options.agent];
+  if (!profile) fail(`Unknown frozen agent profile: ${options.agent}`);
+  const sourceCommit = cleanHeadCommit(evaluation.repoRoot);
+  const plan = buildRunPlan(evaluation, options);
+  const outputPath = options.outputPath
+    ? resolve(evaluation.repoRoot, options.outputPath)
+    : resolve(evaluation.repoRoot, evaluation.manifest.output_root, evaluation.manifest.freeze.id, timestamp(options.now ?? new Date()));
+  const rel = relative(evaluation.repoRoot, outputPath);
+  if (rel.startsWith("..") || isAbsolute(rel)) fail("Output path must remain inside repository root");
+  assertWritePath(evaluation.repoRoot, outputPath);
+  ensureNewDirectory(outputPath);
+
+  const report: RunReport = {
+    schema: "repo-harness-bdd2-run.v1",
+    freeze_id: evaluation.manifest.freeze.id,
+    source_commit: sourceCommit,
+    manifest_sha256: sha256File(evaluation.manifestPath),
+    agent: options.agent,
+    model: profile.model,
+    sampling: profile.sampling,
+    experiment: options.experiment,
+    partition: options.partition,
+    output_path: relative(evaluation.repoRoot, outputPath),
+    packets: [],
+  };
+
+  for (const coordinate of plan) {
+    const packetRoot = resolve(outputPath, "packets", coordinate.packetId);
+    const promptPath = resolve(packetRoot, "agent-prompt.md");
+    const responsePath = resolve(packetRoot, "response.md");
+    const stderrPath = resolve(packetRoot, "stderr.txt");
+    mkdirSync(packetRoot, { recursive: true });
+    writeFileSync(promptPath, buildAgentPacket(evaluation, coordinate), "utf-8");
+
+    const values = {
+      prompt_path: promptPath,
+      response_path: responsePath,
+      workspace: evaluation.repoRoot,
+      model: profile.model,
+      ...Object.fromEntries(
+        Object.entries(profile.sampling).map(([key, value]) => [`sampling.${key}`, String(value)])
+      ),
+    };
+    const args = profile.args.map((arg) => expandArg(arg, values));
+    writeJson(resolve(packetRoot, "command.json"), { command: profile.command, args, cwd: evaluation.repoRoot });
+    const result = spawnSync(profile.command, args, { cwd: evaluation.repoRoot, encoding: "utf-8", env: process.env });
+    writeFileSync(stderrPath, result.stderr ?? "", "utf-8");
+    if (result.error) fail(`Agent command failed to start for ${coordinate.packetId}: ${result.error.message}`);
+    if (result.status !== 0) fail(`Agent command failed for ${coordinate.packetId} with exit ${result.status}`);
+
+    if (profile.response_source === "stdout") {
+      writeFileSync(responsePath, result.stdout ?? "", "utf-8");
+    } else if (!existsSync(responsePath)) {
+      fail(`Agent response file missing for ${coordinate.packetId}`);
+    }
+    const response = readFileSync(responsePath, "utf-8");
+    writeJson(resolve(outputPath, "blind", `${coordinate.packetId}.json`), {
+      schema: "repo-harness-bdd2-blind-packet.v1",
+      packet_id: coordinate.packetId,
+      task_id: coordinate.taskId,
+      experiment: coordinate.experiment,
+      response,
+    });
+    writeJson(resolve(outputPath, "private", `${coordinate.packetId}.json`), {
+      schema: "repo-harness-bdd2-private-coordinate.v1",
+      packet_id: coordinate.packetId,
+      task_id: coordinate.taskId,
+      condition: coordinate.condition,
+      repetition: coordinate.repetition,
+      prompt_sha256: sha256File(authorityPath(evaluation.repoRoot, coordinate.promptPath, "condition prompt")),
+      agent: options.agent,
+      model: profile.model,
+      sampling: profile.sampling,
+      exit_code: result.status,
+    });
+    report.packets.push({ packet_id: coordinate.packetId, task_id: coordinate.taskId, status: "success" });
+  }
+
+  writeJson(resolve(outputPath, "run.json"), report);
+  return report;
+}
+
+interface CliOptions {
+  command: "validate" | "plan" | "run";
+  manifest: string;
+  experiment?: ExperimentId;
+  partition?: PartitionId;
+  tasks: string[];
+  conditions: ConditionId[];
+  repetitions?: number;
+  agent?: string;
+  output?: string;
+}
+
+export function parseCliArgs(args: string[]): CliOptions {
+  const command = args[0];
+  if (command !== "validate" && command !== "plan" && command !== "run") {
+    fail("Usage: run-bdd2-evals.ts <validate|plan|run> [--manifest path] [--experiment S|A] [--partition development|held_out] [--task id] [--condition baseline|treatment] [--repetitions n] [--agent name] [--output path] [--dry-run]");
+  }
+  const options: CliOptions = { command, manifest: DEFAULT_MANIFEST_PATH, tasks: [], conditions: [] };
+  for (let index = 1; index < args.length; index += 1) {
+    const flag = args[index];
+    const next = (): string => {
+      const value = args[index + 1];
+      if (!value || value.startsWith("--")) fail(`Missing value for ${flag}`);
+      index += 1;
+      return value;
+    };
+    switch (flag) {
+      case "--manifest": options.manifest = next(); break;
+      case "--experiment": options.experiment = next() as ExperimentId; break;
+      case "--partition": options.partition = next() as PartitionId; break;
+      case "--task": options.tasks.push(next()); break;
+      case "--condition": options.conditions.push(next() as ConditionId); break;
+      case "--repetitions": options.repetitions = Number(next()); break;
+      case "--agent": options.agent = next(); break;
+      case "--output": options.output = next(); break;
+      case "--dry-run": break;
+      default: fail(`Unknown argument: ${flag}`);
+    }
+  }
+  return options;
+}
+
+function requiredPlanOptions(options: CliOptions): PlanOptions {
+  if (options.experiment !== "S" && options.experiment !== "A") fail("--experiment must be S or A");
+  if (options.partition !== "development" && options.partition !== "held_out") fail("--partition must be development or held_out");
+  return {
+    experiment: options.experiment,
+    partition: options.partition,
+    taskIds: options.tasks.length > 0 ? options.tasks : undefined,
+    conditions: options.conditions.length > 0 ? options.conditions : undefined,
+    repetitions: options.repetitions,
+  };
+}
+
+export function main(args: string[] = process.argv.slice(2)): void {
+  const options = parseCliArgs(args);
+  const evaluation = validateEvaluation(REPO_ROOT, options.manifest);
+  if (options.command === "validate") {
+    console.log(JSON.stringify({ status: "valid", schema: evaluation.manifest.schema, freeze: evaluation.manifest.freeze, task_counts: { development: evaluation.tasks.development.length, held_out: evaluation.tasks.held_out.length } }, null, 2));
+    return;
+  }
+  const planOptions = requiredPlanOptions(options);
+  if (options.command === "plan") {
+    console.log(JSON.stringify({ freeze_id: evaluation.manifest.freeze.id, freeze_state: evaluation.manifest.freeze.state, coordinates: buildRunPlan(evaluation, planOptions) }, null, 2));
+    return;
+  }
+  if (!options.agent) fail("run requires --agent");
+  console.log(JSON.stringify(runEvaluation(evaluation, { ...planOptions, agent: options.agent, outputPath: options.output }), null, 2));
+}
+
+if (import.meta.main) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/scripts/run-bdd2-evals.ts
+++ b/scripts/run-bdd2-evals.ts
@@ -528,12 +528,13 @@ function assertAuthorityTrackedAtHead(repoRoot: string, authorityPaths: string[]
     if (relativePath.startsWith("../") || isAbsolute(relativePath)) {
       fail(`Evaluation authority escapes repository root: ${path}`);
     }
-    const tracked = spawnSync(
+    const atHead = spawnSync(
       "git",
-      ["ls-files", "--error-unmatch", "--", relativePath],
+      ["ls-tree", "-r", "--name-only", "-z", "HEAD", "--", relativePath],
       { cwd: repoRoot, encoding: "utf-8" }
     );
-    if (tracked.status !== 0) {
+    const headPaths = (atHead.stdout ?? "").split("\0").filter(Boolean);
+    if (atHead.status !== 0 || !headPaths.includes(relativePath)) {
       fail(`Sealed evaluation authority must be tracked at HEAD: ${relativePath}`);
     }
   }

--- a/tasks/contracts/20260712-0450-bdd2-eval-foundation.contract.md
+++ b/tasks/contracts/20260712-0450-bdd2-eval-foundation.contract.md
@@ -1,0 +1,195 @@
+# Task Contract: bdd2-eval-foundation
+
+> **Status**: Active
+> **Plan**: plans/plan-20260712-0450-bdd2-eval-foundation.md
+> **Task Profile**: eval-only
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: kito
+> **Capability ID**: root
+> **Last Updated**: 2026-07-12 04:52
+> **Review File**: `tasks/reviews/20260712-0450-bdd2-eval-foundation.review.md`
+> **Notes File**: `tasks/notes/20260712-0450-bdd2-eval-foundation.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+Every later BDD² claim depends on treatment, task, rubric, and run coordinates
+remaining stable and blind. If this foundation leaks truth labels, silently accepts
+drift, or creates product code before the hypothesis passes, Phase E results cannot
+authorize or kill productization.
+
+## Goal
+
+Create the sole committed evaluation authority and a deterministic eval-only runner
+for the separate Shape (S) and Audit (A) hypotheses. The runner must fail closed on
+input drift, keep truth and condition identity out of agent-visible packets, and
+capture reproducible raw evidence without adding public BDD product surface.
+
+## Scope
+
+- In scope: approved PRD/Sprint, versioned S/A manifest, frozen treatment prompts,
+  development/held-out task partitions, blind adjudication rubric/score schema,
+  strict validation, deterministic selection/repetition/dry-run, configured agent
+  execution, raw artifact capture, blinded packet emission, and stub-driven tests.
+- Out of scope: any public `repo-harness-bdd` skill/CLI/MCP/hook/check integration;
+  Behavior Brief catalog/validator, sidecar/lifecycle; S/A outcome claims;
+  Browser/ImageGen execution; implementation pilot; Phase P productization.
+- Taste constraints: one manifest authority; content-addressed inputs; no semantic
+  fallback, compatibility parser, shadow authority, or product implementation hidden
+  in evaluation helpers.
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+- Stop if execution requires installing or registering a BDD product skill.
+- Stop if held-out truth or the semantic treatment name must enter an agent packet.
+- Stop if reproducibility requires a second handwritten authority beside the manifest.
+
+## Falsifier
+
+The design is wrong if a byte change in a frozen input can execute without an
+explicit manifest update, or if an agent-visible packet contains truth/treatment
+identity. The cheapest proof is a focused test that mutates a prompt and injects a
+truth sentinel, then expects validation to fail before any agent command runs.
+
+## Root Cause Evidence
+
+Required when Task Profile is `bugfix`; leave as-is otherwise.
+
+- root_cause: one sentence naming file:line/condition (testable, not "a state issue").
+- repro: the command or UI path that reproduces the symptom.
+- regression_guard: path to a test that fails on the unfixed code and passes after the fix (must also appear under exit_criteria.tests_pass).
+- pre_fix_failure_artifact: path to a captured run of regression_guard on the UNFIXED code. Capture with `bun test <regression_guard> > <artifact> 2>&1; echo "PRE_FIX_EXIT=$?" >> <artifact>` (no pipes — pipes swallow the exit status). The gate requires a non-zero `PRE_FIX_EXIT=` line plus the regression_guard path string in the artifact (see the Root Cause Evidence Gate section in docs/reference-configs/sprint-contracts.md).
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260712-0450-bdd2-eval-foundation.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260712-0450-bdd2-eval-foundation.review.md`
+- Notes file: `tasks/notes/20260712-0450-bdd2-eval-foundation.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: `repo-harness run verify-sprint` must see this contract pass, the review recommend pass, and `## External Acceptance Advice` pass or record a manual override.
+
+## Execution Boundary
+
+The requirements and Allowed Paths below are exhaustive. Absent requirements are
+forbidden design space, not permission to improve adjacent evaluation or product
+systems. Unrequested extras fail closed and require an explicit contract revision.
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - evals/bdd2
+  - scripts/run-bdd2-evals.ts
+  - tests/run-bdd2-evals.test.ts
+  - tests/bdd2-evals-contract.test.ts
+  - plans/prds/20260712-0409-bdd2-shape-audit.prd.md
+  - plans/sprints/20260712-bdd2-phase-e-evaluation.sprint.md
+  - plans/plan-20260712-0450-bdd2-eval-foundation.md
+  - tasks/contracts/20260712-0450-bdd2-eval-foundation.contract.md
+  - tasks/reviews/20260712-0450-bdd2-eval-foundation.review.md
+  - tasks/notes/20260712-0450-bdd2-eval-foundation.notes.md
+  - tasks/current.md
+  - .ai/harness/handoff/current.md
+  - .ai/harness/handoff/resume.md
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    tool_calls: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+      - codex-exec
+      - main-thread
+    fallback: main-thread
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - evals/bdd2/evaluation-manifest.json
+    - evals/bdd2/prompts/shape-baseline.md
+    - evals/bdd2/prompts/shape-treatment.md
+    - evals/bdd2/prompts/audit-baseline.md
+    - evals/bdd2/prompts/audit-treatment.md
+    - evals/bdd2/rubrics/blind-adjudication.md
+    - evals/bdd2/rubrics/score.schema.json
+    - evals/bdd2/tasks/development.json
+    - evals/bdd2/tasks/held-out.json
+    - evals/bdd2/truth/development.json
+    - evals/bdd2/truth/held-out.json
+    - scripts/run-bdd2-evals.ts
+    - tests/run-bdd2-evals.test.ts
+    - tests/bdd2-evals-contract.test.ts
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260712-0450-bdd2-eval-foundation.notes.md
+  files_not_exist:
+    - assets/skill-commands/repo-harness-bdd/SKILL.md
+    - plans/behaviors
+    - src/cli/commands/bdd.ts
+    - src/cli/mcp/behavior-tools.ts
+  tests_pass:
+    - path: tests/run-bdd2-evals.test.ts
+    - path: tests/bdd2-evals-contract.test.ts
+  commands_succeed:
+    - bun test tests/run-bdd2-evals.test.ts tests/bdd2-evals-contract.test.ts
+    - bun scripts/run-bdd2-evals.ts validate
+    - bun scripts/run-bdd2-evals.ts plan --experiment S --partition development --dry-run
+    - repo-harness run check-task-workflow --strict
+  qa_scores:
+    - dimension: functionality
+      min: 9
+    - dimension: code quality
+      min: 9
+  manual_checks:
+    - "Evaluator review file recommends pass"
+```
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior: exact frozen coordinates produce exact execution plans and
+  blinded artifacts; drift and leakage fail before agent execution.
+- Edge cases: empty selection, unknown experiment/partition/condition, invalid
+  repetition count, duplicate IDs, path escape, missing file, checksum drift,
+  failed agent command, and pre-existing output path.
+- Regression risks: evaluation runner accidentally becomes product runtime or a
+  competing general benchmark authority; scope/review must reject both.
+
+## Rollback Point
+
+- Commit / checkpoint: branch `codex/bdd2-eval-foundation` from `origin/main` at
+  `788ba60cca5e0072febc19833002a3ffe497b0a1`.
+- Revert strategy: revert the module commit; no runtime cutover, migration, user
+  data, or compatibility path exists.

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,27 +1,27 @@
 # Current Status Snapshot
 
 <!-- generated-by: repo-harness refresh-current-status v1 -->
-<!-- updated_at: 2026-07-12T05:46:36+0800 -->
+<!-- updated_at: 2026-07-12T05:54:48+0800 -->
 <!-- stale_after: 24h -->
 
-> **Status**: ManualClearedWithActiveWork
-> **Updated At**: 2026-07-12T05:46:36+0800
-> **Source Branch**: codex/adoption-apply-cutover-v1
-> **Source Commit**: 788ba60
+> **Status**: Active
+> **Updated At**: 2026-07-12T05:54:48+0800
+> **Source Branch**: codex/bdd2-eval-foundation
+> **Source Commit**: b80238f
 > **Target Branch**: main
 > **Stale After**: 24h
-> **Reason**: archive-workflow
+> **Reason**: BDD2 E-01 rebased on origin/main after PR review
 > **Derived From**: active-plan, active-sprint, workstreams, handoff, checks, git status
 
 This file is a tracked mainline snapshot derived from repo artifacts. It is not a live lock, not a kanban board, and not an implementation gate. If it is stale, read the source artifacts below.
 
 ## Current Focus
 
-- Status: ManualClearedWithActiveWork
-- Active Plan: (none)
-- Plan Status: (none)
-- Next Task: inspect active worktree marker(s)
-- Clear Note: Manual clear requested, but active work markers still exist. Idle was not written.
+- Status: Active
+- Active Plan: plans/plan-20260712-0450-bdd2-eval-foundation.md
+- Plan Status: Executing
+- Next Task: (none)
+- Clear Note: (none)
 
 ## Mainline Snapshot Reading
 
@@ -31,8 +31,8 @@ This file is a tracked mainline snapshot derived from repo artifacts. It is not 
 
 ## Active Work
 
-- /Users/kito/Projects/repo-harness-worktrees/bdd2-eval-foundation: plans/plan-20260712-0450-bdd2-eval-foundation.md
-- /Users/kito/Projects/repo-harness-worktrees/bdd2-eval-foundation: active-worktree owner -> /Users/kito/Projects/repo-harness-worktrees/bdd2-eval-foundation
+- .: plans/plan-20260712-0450-bdd2-eval-foundation.md
+- .: active-worktree owner -> /Users/kito/Projects/repo-harness-worktrees/bdd2-eval-foundation
 - /Users/kito/Projects/repo-harness-worktrees/chatgpt-coding-mcp-integration: plans/plan-20260712-0301-chatgpt-coding-mcp-integration.md
 - /Users/kito/Projects/repo-harness-worktrees/chatgpt-coding-mcp-integration: active-worktree owner -> /Users/kito/Projects/repo-harness-worktrees/chatgpt-coding-mcp-integration
 - /Users/kito/Projects/repo-harness-worktrees/native-role-capability-gate: plans/plan-20260712-0219-native-role-capability-gate.md
@@ -48,57 +48,18 @@ This file is a tracked mainline snapshot derived from repo artifacts. It is not 
 - `tasks/workstreams/workflow-engine/inspection-migration/20260703-inspection-migration.md`: status=active, current_slice=completed-20260703-architecture-closeout, source_plan=(none)
 ## Handoff
 
-- Exact Next Step: (none)
+- Exact Next Step: Stage the completed module diff first; then External acceptance is unavailable; expected pass from Claude via claude-review. Run external acceptance via claude-review and record ## External Acceptance Advice in tasks/reviews/20260712-0450-bdd2-eval-foundation.review.md. Command: /check
 
 ## Checks
 
-- status=pass, source=verify-sprint, exit_code=0, file=.ai/harness/checks/latest.json
+- status=(none), source=(none), exit_code=(none), file=.ai/harness/checks/latest.json
 
 ## Git Status
 
-- Summary: 69 changed/untracked path(s)
+- Summary: clean
 
 ```
- M .ai/context/capabilities.json
- M .ai/harness/workflow-contract.json
- M AGENTS.md
- M CLAUDE.md
- M README.es.md
- M README.fr.md
- M README.ja.md
- M README.md
- M README.zh-CN.md
- M SKILL.md
- M assets/reference-configs/harness-overview.md
- M assets/reference-configs/hook-operations.md
- M assets/skill-commands/manifest.json
- M assets/skill-commands/repo-harness-architecture/SKILL.md
- M assets/skill-commands/repo-harness-capability/SKILL.md
- M assets/skill-commands/repo-harness-check/SKILL.md
- M assets/skill-commands/repo-harness-init/SKILL.md
- M assets/skill-commands/repo-harness-migrate/SKILL.md
- M assets/templates/helpers/architecture-queue.sh
- M assets/templates/helpers/check-task-workflow.sh
- D assets/templates/helpers/migrate-project-template.sh
- D assets/templates/helpers/migrate-workflow-docs.ts
- M assets/workflow-contract.v1.json
- M docs/architecture/domains/public-surface.md
- M docs/architecture/domains/verification.md
- M docs/architecture/domains/workflow-engine.md
- M docs/architecture/index.md
- M docs/architecture/modules/public-surface/adoption.md
- M docs/architecture/modules/public-surface/root-router.md
- M docs/architecture/modules/verification/evals-checks.md
- M docs/architecture/modules/workflow-engine/inspection-migration.md
- M docs/architecture/transactional-adoption-planner.md
- M docs/reference-configs/harness-overview.md
- M docs/reference-configs/hook-operations.md
- M evals/evals.json
- M references/evaluation-playbook.md
- M references/migration-guide.md
- M scripts/AGENTS.md
- M scripts/CLAUDE.md
- M scripts/architecture-queue.sh
+(none)
 ```
 
 ## Source Artifacts

--- a/tasks/notes/20260712-0450-bdd2-eval-foundation.notes.md
+++ b/tasks/notes/20260712-0450-bdd2-eval-foundation.notes.md
@@ -63,9 +63,10 @@
 - Dry-run plan: `bun scripts/run-bdd2-evals.ts plan --experiment S --partition development --dry-run` — deterministic coordinates emitted.
 - Required checks: deploy SQL, architecture sync, task sync, inspector, and direct migration dry-run passed.
 - Module PR: <https://github.com/Ancienttwo/repo-harness/pull/53>.
-- Known baseline blocker: strict workflow reaches only the pre-existing brain mirror drift
-  (`docs/reference-configs/harness-overview.md` -> `brain/repo-harness/references/harness-overview.md`);
-  the same failure reproduces on `origin/main` and is outside this contract.
+- Post-review rebase: branch rebased onto `origin/main` at `8e16032` after PR #54
+  advanced the base. The refreshed handoff plus `LC_ALL=C repo-harness run
+  check-task-workflow --strict` now pass; the former brain mirror drift was resolved
+  upstream and was not copied into this branch.
 - Advisory environment gaps: Codex Waza `health`/`check` installed-copy paths and the
   worktree-local CodeGraph index are absent; focused/full tests and source checks are
   unaffected, and no user-level environment mutation was authorized by this contract.

--- a/tasks/notes/20260712-0450-bdd2-eval-foundation.notes.md
+++ b/tasks/notes/20260712-0450-bdd2-eval-foundation.notes.md
@@ -1,0 +1,73 @@
+# Implementation Notes: bdd2-eval-foundation
+
+> **Status**: Active
+> **Plan**: plans/plan-20260712-0450-bdd2-eval-foundation.md
+> **Contract**: tasks/contracts/20260712-0450-bdd2-eval-foundation.contract.md
+> **Review**: tasks/reviews/20260712-0450-bdd2-eval-foundation.review.md
+> **Last Updated**: 2026-07-12 04:52
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- The existing `run-skill-evals.ts` remains unchanged. It measures skill installation
+  and workspace mutation, while BDD² S/A measure text proposals and audits. Sharing
+  them would create a false abstraction without a common semantic contract.
+- `evaluation-manifest.json` is the only committed machine authority. Prompt, task,
+  truth, and rubric bytes are pinned by SHA-256; unknown keys, path escapes,
+  symlinks, duplicate IDs, hash drift, and truth fields in agent task sets fail closed.
+- `foundation` is intentionally non-executable. A later experiment row must expand
+  each held-out arm to the preregistered 12 tasks, freeze agent model/sampling/command
+  profiles, set `sealed_at`, commit the authority, and run from a clean Git HEAD.
+- The runner records the clean source commit and manifest hash at execution time.
+  This avoids an impossible self-referential commit hash inside the commit being
+  pinned while still producing an immutable run coordinate.
+- Model and sampling authority lives only in the sealed agent profile; `freeze` does
+  not duplicate it. Blind packets exclude condition, repetition, prompt, agent,
+  model, sampling, truth, and private coordinate fields.
+- Browser and ImageGen remain first-class later experiments in Sprint row BDD2-E-04.
+  They were not deleted or bundled into the S/A foundation.
+
+## Deviations From Plan Or Spec
+
+- None recorded.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| Refit `run-skill-evals.ts` into a generic core | Rejected | Its workspace/skill semantics do not match proposal/audit treatments; refactoring would risk the existing benchmark for no proven reuse. |
+| Permit real runs from the foundation manifest | Rejected | Model, full held-out set, commit, and final seal are not frozen yet; accepting a run would create non-authoritative evidence. |
+| Store truth beside agent tasks | Rejected | A renderer bug could leak seeded answers; exact task schemas and separate truth files make the boundary testable. |
+| Put model in both `freeze` and agent profile | Rejected | Dual authority can drift; the sealed agent profile owns model, sampling, command, and response source. |
+| Create product skill/CLI now | Rejected | The approved PRD authorizes Phase E only and explicitly forbids Phase P surface before a recorded pass decision. |
+
+## Open Questions
+
+- None.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Full suite: `bun test` — 1146 passed, 1 platform skip, 0 failed.
+- Focused suite: `bun test tests/run-bdd2-evals.test.ts tests/bdd2-evals-contract.test.ts` — 10 passed.
+- Typecheck: `bun run check:type` — passed.
+- Foundation validation: `bun scripts/run-bdd2-evals.ts validate` — valid.
+- Dry-run plan: `bun scripts/run-bdd2-evals.ts plan --experiment S --partition development --dry-run` — deterministic coordinates emitted.
+- Required checks: deploy SQL, architecture sync, task sync, inspector, and direct migration dry-run passed.
+- Known baseline blocker: strict workflow reaches only the pre-existing brain mirror drift
+  (`docs/reference-configs/harness-overview.md` -> `brain/repo-harness/references/harness-overview.md`);
+  the same failure reproduces on `origin/main` and is outside this contract.
+- Advisory environment gaps: Codex Waza `health`/`check` installed-copy paths and the
+  worktree-local CodeGraph index are absent; focused/full tests and source checks are
+  unaffected, and no user-level environment mutation was authorized by this contract.
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/notes/20260712-0450-bdd2-eval-foundation.notes.md
+++ b/tasks/notes/20260712-0450-bdd2-eval-foundation.notes.md
@@ -55,6 +55,7 @@
 - Foundation validation: `bun scripts/run-bdd2-evals.ts validate` — valid.
 - Dry-run plan: `bun scripts/run-bdd2-evals.ts plan --experiment S --partition development --dry-run` — deterministic coordinates emitted.
 - Required checks: deploy SQL, architecture sync, task sync, inspector, and direct migration dry-run passed.
+- Module PR: <https://github.com/Ancienttwo/repo-harness/pull/53>.
 - Known baseline blocker: strict workflow reaches only the pre-existing brain mirror drift
   (`docs/reference-configs/harness-overview.md` -> `brain/repo-harness/references/harness-overview.md`);
   the same failure reproduces on `origin/main` and is outside this contract.

--- a/tasks/notes/20260712-0450-bdd2-eval-foundation.notes.md
+++ b/tasks/notes/20260712-0450-bdd2-eval-foundation.notes.md
@@ -24,6 +24,13 @@
 - Model and sampling authority lives only in the sealed agent profile; `freeze` does
   not duplicate it. Blind packets exclude condition, repetition, prompt, agent,
   model, sampling, truth, and private coordinate fields.
+- PR #53 review remediation removes the deterministic public packet ID entirely.
+  Deterministic 16-hex coordinates remain private for reproducible execution;
+  adjudication packets receive independent 128-bit IDs from `crypto.randomBytes`.
+- A sealed run now treats the manifest, runner, every treatment prompt, both task
+  and truth partitions, rubric, and score schema as one committed authority set.
+  It refuses any member that is ignored/untracked even when the worktree otherwise
+  appears clean.
 - Browser and ImageGen remain first-class later experiments in Sprint row BDD2-E-04.
   They were not deleted or bundled into the S/A foundation.
 
@@ -50,7 +57,7 @@
 - Checks: `.ai/harness/checks/latest.json`
 - Run snapshots: `.ai/harness/runs/`
 - Full suite: `bun test` — 1146 passed, 1 platform skip, 0 failed.
-- Focused suite: `bun test tests/run-bdd2-evals.test.ts tests/bdd2-evals-contract.test.ts` — 10 passed.
+- Focused suite: `bun test tests/run-bdd2-evals.test.ts tests/bdd2-evals-contract.test.ts` — 11 passed after PR review remediation.
 - Typecheck: `bun run check:type` — passed.
 - Foundation validation: `bun scripts/run-bdd2-evals.ts validate` — valid.
 - Dry-run plan: `bun scripts/run-bdd2-evals.ts plan --experiment S --partition development --dry-run` — deterministic coordinates emitted.
@@ -72,3 +79,21 @@ Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset 
 - Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
 - Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
 - Promote to harness asset files only after verification across more than one task or fixture.
+
+## Minimal-change Audit
+
+- New dependencies: none. Random blinding uses the Node/Bun standard-library
+  `crypto.randomBytes`; hashing, filesystem, process, and Git behavior continue to
+  use existing standard-library/platform surfaces.
+- New files: each committed file owns a distinct Phase E datum or evidence boundary:
+  one manifest, four treatment prompts, two task partitions, two separate truth
+  partitions, one human rubric, one score schema, one runner, two focused tests, and
+  the repository-required PRD/Sprint/plan/contract/review/notes/current projections.
+  Combining task and truth files would violate blinding; adding a sidecar/catalog or
+  shared package would add authority without a second consumer and was rejected.
+- New abstractions: no shared package, provider wrapper, compatibility parser, or
+  extension registry was added. `FileReference` and the local authority-path list
+  protect one cross-file invariant inside the single runner.
+- Deleted/shrunk behavior: the reversible deterministic public `packetId` path was
+  removed rather than retained behind an alias. There is no compatibility fallback;
+  old 16-hex score packet IDs now fail the v1 schema explicitly.

--- a/tasks/reviews/20260712-0450-bdd2-eval-foundation.review.md
+++ b/tasks/reviews/20260712-0450-bdd2-eval-foundation.review.md
@@ -5,10 +5,10 @@
 > **Contract**: tasks/contracts/20260712-0450-bdd2-eval-foundation.contract.md
 > **Notes File**: tasks/notes/20260712-0450-bdd2-eval-foundation.notes.md
 > **Checks File**: .ai/harness/checks/latest.json
-> **Last Updated**: 2026-07-12 05:22
+> **Last Updated**: 2026-07-12 05:43
 > **Recommendation**: pass
 > **Review Rubric Version**: 2
-> **Reviewed Diff Fingerprint**: sha256:d220f33ab2da5f2757e3768a1cd44b93b02bdf443ca153226326cdc784607aed
+> **Reviewed Diff Fingerprint**: sha256:67fe53d2ba2ffce0d1bff8c8861df7590e1ad89633e1a0b31cdea72c2b10364b
 > **Reviewed Scope**: branch+staged+unstaged+untracked
 
 ## Human Review Card
@@ -41,11 +41,13 @@
   orchestration; raw runs remain ignored; review/notes hold durable conclusions.
 - P2 trace: manifest validation -> task/condition/repetition coordinates ->
   agent-visible prompt without truth/condition metadata -> frozen agent command ->
-  private coordinate + blinded response -> later condition-blind adjudication.
+  deterministic private coordinate + random 128-bit blind packet -> later
+  condition-blind adjudication.
 - P3 decision: a dedicated BDD² text-treatment runner is smaller and safer than
   refactoring the existing skill-installation benchmark. `foundation` permits only
   validation/planning; `sealed` requires exact held-out counts, frozen model/sampling
-  profiles, and a clean Git HEAD whose commit and manifest hash are recorded.
+  profiles, and a clean Git HEAD whose commit and manifest hash are recorded. Every
+  authority member, including the runner itself, must also be tracked at that HEAD.
 - Plan evidence: approved PRD Phase E handoff explicitly forbids public product
   surface before a recorded evaluation pass.
 
@@ -54,7 +56,7 @@
 | Command | Result |
 |---|---|
 | `bun test` | 1146 pass, 1 platform skip, 0 fail; 11540 expectations across 99 files |
-| `bun test tests/run-bdd2-evals.test.ts tests/bdd2-evals-contract.test.ts` | 10 pass, 0 fail after final runner hardening |
+| `bun test tests/run-bdd2-evals.test.ts tests/bdd2-evals-contract.test.ts` | 11 pass, 0 fail after PR #53 review remediation |
 | `bun run check:type` | pass |
 | `bun scripts/run-bdd2-evals.ts validate` | pass; foundation authority valid and unsealed |
 | `bun scripts/run-bdd2-evals.ts plan --experiment S --partition development --dry-run` | pass; stable opaque coordinates emitted |
@@ -77,6 +79,10 @@
   blind packets contain no private condition/agent/model/sampling coordinates;
   no public skill, CLI/MCP mutation tool, hook/check integration, Brief catalog,
   sidecar, or lifecycle exists in the diff.
+- PR #53 automated review P1 is covered by random, non-enumerable public packet IDs
+  while reproducible condition-derived coordinates remain private. Automated review
+  P2 is covered by a sealed-run check that every manifest-listed authority path is
+  tracked at clean HEAD; an ignored alternate manifest now has a regression test.
 
 ## External Acceptance Advice
 
@@ -86,12 +92,15 @@
 > **External Started**: 2026-07-12T05:27:00+08:00
 > **External Completed**: pending
 > **Review Rubric Version**: 2
-> **Reviewed Diff Fingerprint**: sha256:d220f33ab2da5f2757e3768a1cd44b93b02bdf443ca153226326cdc784607aed
+> **Reviewed Diff Fingerprint**: sha256:67fe53d2ba2ffce0d1bff8c8861df7590e1ad89633e1a0b31cdea72c2b10364b
 > **Reviewed Scope**: branch+staged+unstaged+untracked
 
-- P1 blockers: none in the reviewed diff.
+- P1 blockers: none after local remediation; GitHub re-review is still pending.
 - P2 advisories: E-02/E-03 must expand the held-out sets to 12 tasks per hypothesis
   and seal actual agent profiles before any real execution. The runner enforces this.
+- Review threads addressed locally: non-reversible blind IDs and tracked sealed
+  authority. No GitHub reply or manual thread resolution was performed without
+  explicit user authorization.
 - Acceptance checklist: verify prompt fairness, task/truth separation, condition
   blinding, clean-HEAD provenance, manifest/hash fail-closed behavior, and Phase E
   product-surface prohibition.
@@ -105,8 +114,12 @@
   sealed.
 - Agent-visible tasks use an exact schema that rejects truth or condition fields.
   Truth sets are separate hashed files; symlinks and repository escapes fail closed.
-- Blind response packets omit treatment identity and execution metadata; private
-  coordinates retain condition/repetition/model/sampling for later reveal.
+- Blind response packets receive independent 128-bit random IDs and omit treatment
+  identity and execution metadata; deterministic coordinates remain only in the
+  private reveal map with condition/repetition/model/sampling.
+- The manifest now pins the runner hash as well as prompt/task/truth/rubric/schema
+  hashes. Sealed execution rejects ignored or untracked manifests and authority
+  inputs even when ordinary Git status is otherwise clean.
 - Browser and ImageGen are explicitly retained in BDD2-E-04, gated on separate S/A
   passes. No adapter was deleted or prematurely productized.
 
@@ -128,7 +141,7 @@
 | Functionality | 9/10 | All in-scope execution, validation, blinding, and provenance paths are covered; real evidence is correctly blocked until seal. |
 | Product depth | 9/10 | Preserves Browser/ImageGen and Brief value as tested hypotheses while preventing unvalidated product surface. |
 | Design quality | 9/10 | One authority, separate truth boundary, opaque packets, and explicit foundation/sealed lifecycle only where evaluation requires it. |
-| Code quality | 9/10 | Exact schemas, hashes, clean Git provenance, symlink/path protection, applied model/sampling placeholders, deterministic tests, no compatibility path. |
+| Code quality | 9/10 | Exact schemas, runner/input hashes, tracked clean-HEAD provenance, CSPRNG blinding, symlink/path protection, applied model/sampling placeholders, deterministic private coordinates, no compatibility path. |
 
 ## Failing Items
 
@@ -149,7 +162,8 @@
 Pass. E-01 creates an evaluation-only, content-addressed, blind runner foundation
 without any BDD product surface. It fails closed on drift, leakage, symlink/path
 escape, incomplete held-out arms, unapplied model/sampling profiles, dirty source
-state, and attempted execution before seal. The full repository suite and focused
-tests pass. Browser/ImageGen and Behavior Brief remain explicitly preserved for
-their gated hypotheses; the only red workflow signal is an unrelated base BrainSync
-drift that this contract correctly does not absorb.
+state, untracked/ignored authority, reversible blind IDs, and attempted execution
+before seal. The full repository suite and focused tests pass. Browser/ImageGen and
+Behavior Brief remain explicitly preserved for their gated hypotheses; the only red
+workflow signal is an unrelated base BrainSync drift that this contract correctly
+does not absorb.

--- a/tasks/reviews/20260712-0450-bdd2-eval-foundation.review.md
+++ b/tasks/reviews/20260712-0450-bdd2-eval-foundation.review.md
@@ -8,7 +8,7 @@
 > **Last Updated**: 2026-07-12 05:43
 > **Recommendation**: pass
 > **Review Rubric Version**: 2
-> **Reviewed Diff Fingerprint**: sha256:67fe53d2ba2ffce0d1bff8c8861df7590e1ad89633e1a0b31cdea72c2b10364b
+> **Reviewed Diff Fingerprint**: sha256:077fe6e0295b56e4c72f6ab916e798f523b2857fc2fc0d4344f9ac20cd2a01cf
 > **Reviewed Scope**: branch+staged+unstaged+untracked
 
 ## Human Review Card
@@ -92,7 +92,7 @@
 > **External Started**: 2026-07-12T05:27:00+08:00
 > **External Completed**: pending
 > **Review Rubric Version**: 2
-> **Reviewed Diff Fingerprint**: sha256:67fe53d2ba2ffce0d1bff8c8861df7590e1ad89633e1a0b31cdea72c2b10364b
+> **Reviewed Diff Fingerprint**: sha256:077fe6e0295b56e4c72f6ab916e798f523b2857fc2fc0d4344f9ac20cd2a01cf
 > **Reviewed Scope**: branch+staged+unstaged+untracked
 
 - P1 blockers: none after local remediation; GitHub re-review is still pending.

--- a/tasks/reviews/20260712-0450-bdd2-eval-foundation.review.md
+++ b/tasks/reviews/20260712-0450-bdd2-eval-foundation.review.md
@@ -8,7 +8,7 @@
 > **Last Updated**: 2026-07-12 05:22
 > **Recommendation**: pass
 > **Review Rubric Version**: 2
-> **Reviewed Diff Fingerprint**: sha256:26500a377b722eff1541ec9e61cb707aaa317c3de69fe16fc815df0b8d287876
+> **Reviewed Diff Fingerprint**: sha256:d220f33ab2da5f2757e3768a1cd44b93b02bdf443ca153226326cdc784607aed
 > **Reviewed Scope**: branch+staged+unstaged+untracked
 
 ## Human Review Card
@@ -82,11 +82,11 @@
 
 > **External Acceptance**: unavailable
 > **External Reviewer**: pending PR reviewer
-> **External Source**: GitHub PR
-> **External Started**: pending
+> **External Source**: https://github.com/Ancienttwo/repo-harness/pull/53
+> **External Started**: 2026-07-12T05:27:00+08:00
 > **External Completed**: pending
 > **Review Rubric Version**: 2
-> **Reviewed Diff Fingerprint**: sha256:26500a377b722eff1541ec9e61cb707aaa317c3de69fe16fc815df0b8d287876
+> **Reviewed Diff Fingerprint**: sha256:d220f33ab2da5f2757e3768a1cd44b93b02bdf443ca153226326cdc784607aed
 > **Reviewed Scope**: branch+staged+unstaged+untracked
 
 - P1 blockers: none in the reviewed diff.

--- a/tasks/reviews/20260712-0450-bdd2-eval-foundation.review.md
+++ b/tasks/reviews/20260712-0450-bdd2-eval-foundation.review.md
@@ -1,0 +1,155 @@
+# Task Review: bdd2-eval-foundation
+
+> **Status**: Done
+> **Plan**: plans/plan-20260712-0450-bdd2-eval-foundation.md
+> **Contract**: tasks/contracts/20260712-0450-bdd2-eval-foundation.contract.md
+> **Notes File**: tasks/notes/20260712-0450-bdd2-eval-foundation.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-07-12 05:22
+> **Recommendation**: pass
+> **Review Rubric Version**: 2
+> **Reviewed Diff Fingerprint**: sha256:26500a377b722eff1541ec9e61cb707aaa317c3de69fe16fc815df0b8d287876
+> **Reviewed Scope**: branch+staged+unstaged+untracked
+
+## Human Review Card
+
+- Verdict: pass
+- Change type: eval-only
+- Intended files changed: BDD² PRD/Sprint/work-package artifacts;
+  `evals/bdd2/**`; `scripts/run-bdd2-evals.ts`; focused tests; tracked current
+  status and ignored handoff evidence.
+- Actual files changed: the 20 non-review paths in the reviewed fingerprint — 11
+  `evals/bdd2` authority files, PRD/Sprint/plan, runner, contract/current/notes,
+  and two tests. This review is excluded from the fingerprint by design.
+- Commands passed: full `bun test`; focused BDD² tests; typecheck; manifest
+  validation; deterministic dry-run plan; deploy SQL; architecture sync; task
+  sync; inspector; direct migration dry-run.
+- External acceptance: unavailable before PR; the PR is the human acceptance surface.
+- Residual risks: full 12-task arms and actual model profiles are intentionally not
+  sealed in E-01; strict workflow has a pre-existing brain-mirror drift; local Codex
+  Waza installed-copy and worktree CodeGraph index readiness are partial.
+- Reviewer action required: review the PR's treatment prompts, leakage boundary,
+  sealed-run contract, and decision to keep Browser/ImageGen in gated E-04.
+- Rollback: revert the E-01 commit; no runtime cutover, migration, user data, or
+  compatibility path exists.
+
+## Mode Evidence
+
+- Selected route: `eval-only` isolated contract worktree.
+- P1 map: `evals/bdd2/evaluation-manifest.json` is the sole machine authority;
+  prompts/tasks/truth/rubric are hashed inputs; the script is local experiment
+  orchestration; raw runs remain ignored; review/notes hold durable conclusions.
+- P2 trace: manifest validation -> task/condition/repetition coordinates ->
+  agent-visible prompt without truth/condition metadata -> frozen agent command ->
+  private coordinate + blinded response -> later condition-blind adjudication.
+- P3 decision: a dedicated BDD² text-treatment runner is smaller and safer than
+  refactoring the existing skill-installation benchmark. `foundation` permits only
+  validation/planning; `sealed` requires exact held-out counts, frozen model/sampling
+  profiles, and a clean Git HEAD whose commit and manifest hash are recorded.
+- Plan evidence: approved PRD Phase E handoff explicitly forbids public product
+  surface before a recorded evaluation pass.
+
+## Verification Evidence
+
+| Command | Result |
+|---|---|
+| `bun test` | 1146 pass, 1 platform skip, 0 fail; 11540 expectations across 99 files |
+| `bun test tests/run-bdd2-evals.test.ts tests/bdd2-evals-contract.test.ts` | 10 pass, 0 fail after final runner hardening |
+| `bun run check:type` | pass |
+| `bun scripts/run-bdd2-evals.ts validate` | pass; foundation authority valid and unsealed |
+| `bun scripts/run-bdd2-evals.ts plan --experiment S --partition development --dry-run` | pass; stable opaque coordinates emitted |
+| `repo-harness run check-deploy-sql-order` | pass |
+| `repo-harness run check-architecture-sync` | pass; advisory, 0 blocking |
+| `repo-harness run check-task-sync` | pass |
+| `bun scripts/inspect-project-state.ts --repo . --format text` | pass; no drift signals or required decisions |
+| `bash scripts/migrate-project-template.sh --repo . --dry-run` | pass |
+| `LC_ALL=C repo-harness run check-task-workflow --strict` | baseline fail only: `harness-overview.md` differs from its brain mirror |
+
+- Strict workflow finding is not introduced by this branch: both flagged files are
+  unchanged from `origin/main`, and the same BrainSync failure occurs on the base.
+  Syncing the brain mirror would edit an unrelated path outside this contract.
+- Default-locale `awk` also failed on Unicode PRD prose; `LC_ALL=C` reaches the real
+  check and leaves only the baseline BrainSync finding. This is a workflow-tooling
+  locale limitation, not a malformed PRD.
+- Full suite ran before the final bounded path/placeholder hardening; the focused
+  suite and typecheck were rerun after those edits and directly cover them.
+- Manual checks: agent packets contain no truth issue IDs or condition labels;
+  blind packets contain no private condition/agent/model/sampling coordinates;
+  no public skill, CLI/MCP mutation tool, hook/check integration, Brief catalog,
+  sidecar, or lifecycle exists in the diff.
+
+## External Acceptance Advice
+
+> **External Acceptance**: unavailable
+> **External Reviewer**: pending PR reviewer
+> **External Source**: GitHub PR
+> **External Started**: pending
+> **External Completed**: pending
+> **Review Rubric Version**: 2
+> **Reviewed Diff Fingerprint**: sha256:26500a377b722eff1541ec9e61cb707aaa317c3de69fe16fc815df0b8d287876
+> **Reviewed Scope**: branch+staged+unstaged+untracked
+
+- P1 blockers: none in the reviewed diff.
+- P2 advisories: E-02/E-03 must expand the held-out sets to 12 tasks per hypothesis
+  and seal actual agent profiles before any real execution. The runner enforces this.
+- Acceptance checklist: verify prompt fairness, task/truth separation, condition
+  blinding, clean-HEAD provenance, manifest/hash fail-closed behavior, and Phase E
+  product-surface prohibition.
+
+## Behavior Diff Notes
+
+- The approved PRD and ordered Sprint now make `shape`, `audit`, Browser evidence,
+  ImageGen prototypes, and implementation pilot separate hypotheses and gates.
+- Foundation manifests are content-addressed and non-executable. Real execution is
+  impossible until the full held-out sets and model/sampling/command profiles are
+  sealed.
+- Agent-visible tasks use an exact schema that rejects truth or condition fields.
+  Truth sets are separate hashed files; symlinks and repository escapes fail closed.
+- Blind response packets omit treatment identity and execution metadata; private
+  coordinates retain condition/repetition/model/sampling for later reveal.
+- Browser and ImageGen are explicitly retained in BDD2-E-04, gated on separate S/A
+  passes. No adapter was deleted or prematurely productized.
+
+## Residual Risks / Follow-ups
+
+- E-01 proves reproducibility mechanics, not BDD² product value. It contains small
+  development/held-out seed sets only; no effectiveness claim is authorized.
+- Prompt fairness and the full 12-task composition require human review during the
+  E-02/E-03 sealing PRs.
+- The pre-existing brain mirror drift prevents a green strict workflow trace until
+  its owning work-package syncs the mirror.
+- Advisory tooling reports Codex Waza installed copies and the linked-worktree
+  CodeGraph index as partial; neither affected this source diff or its tests.
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|---|---:|---|
+| Functionality | 9/10 | All in-scope execution, validation, blinding, and provenance paths are covered; real evidence is correctly blocked until seal. |
+| Product depth | 9/10 | Preserves Browser/ImageGen and Brief value as tested hypotheses while preventing unvalidated product surface. |
+| Design quality | 9/10 | One authority, separate truth boundary, opaque packets, and explicit foundation/sealed lifecycle only where evaluation requires it. |
+| Code quality | 9/10 | Exact schemas, hashes, clean Git provenance, symlink/path protection, applied model/sampling placeholders, deterministic tests, no compatibility path. |
+
+## Failing Items
+
+- None in the reviewed diff.
+- Out-of-scope base failure: brain mirror drift in strict workflow.
+
+## Retest Steps
+
+1. `bun test tests/run-bdd2-evals.test.ts tests/bdd2-evals-contract.test.ts`
+2. `bun run check:type`
+3. `bun scripts/run-bdd2-evals.ts validate`
+4. `bun scripts/run-bdd2-evals.ts plan --experiment S --partition development --dry-run`
+5. After the baseline brain mirror is fixed, rerun
+   `LC_ALL=C repo-harness run check-task-workflow --strict`.
+
+## Summary
+
+Pass. E-01 creates an evaluation-only, content-addressed, blind runner foundation
+without any BDD product surface. It fails closed on drift, leakage, symlink/path
+escape, incomplete held-out arms, unapplied model/sampling profiles, dirty source
+state, and attempted execution before seal. The full repository suite and focused
+tests pass. Browser/ImageGen and Behavior Brief remain explicitly preserved for
+their gated hypotheses; the only red workflow signal is an unrelated base BrainSync
+drift that this contract correctly does not absorb.

--- a/tasks/reviews/20260712-0450-bdd2-eval-foundation.review.md
+++ b/tasks/reviews/20260712-0450-bdd2-eval-foundation.review.md
@@ -8,7 +8,7 @@
 > **Last Updated**: 2026-07-12 05:43
 > **Recommendation**: pass
 > **Review Rubric Version**: 2
-> **Reviewed Diff Fingerprint**: sha256:077fe6e0295b56e4c72f6ab916e798f523b2857fc2fc0d4344f9ac20cd2a01cf
+> **Reviewed Diff Fingerprint**: sha256:1d4a2bd11cd06a4efc6ac5d09ec724365f0cb208b76cadcb3ea9cb6b6cd2459c
 > **Reviewed Scope**: branch+staged+unstaged+untracked
 
 ## Human Review Card
@@ -26,8 +26,8 @@
   sync; inspector; direct migration dry-run.
 - External acceptance: unavailable before PR; the PR is the human acceptance surface.
 - Residual risks: full 12-task arms and actual model profiles are intentionally not
-  sealed in E-01; strict workflow has a pre-existing brain-mirror drift; local Codex
-  Waza installed-copy and worktree CodeGraph index readiness are partial.
+  sealed in E-01; local Codex Waza installed-copy and worktree CodeGraph index
+  readiness are partial.
 - Reviewer action required: review the PR's treatment prompts, leakage boundary,
   sealed-run contract, and decision to keep Browser/ImageGen in gated E-04.
 - Rollback: revert the E-01 commit; no runtime cutover, migration, user data, or
@@ -65,14 +65,14 @@
 | `repo-harness run check-task-sync` | pass |
 | `bun scripts/inspect-project-state.ts --repo . --format text` | pass; no drift signals or required decisions |
 | `bash scripts/migrate-project-template.sh --repo . --dry-run` | pass |
-| `LC_ALL=C repo-harness run check-task-workflow --strict` | baseline fail only: `harness-overview.md` differs from its brain mirror |
+| `LC_ALL=C repo-harness run check-task-workflow --strict` | pass after rebase onto `origin/main` `8e16032` and handoff refresh |
 
-- Strict workflow finding is not introduced by this branch: both flagged files are
-  unchanged from `origin/main`, and the same BrainSync failure occurs on the base.
-  Syncing the brain mirror would edit an unrelated path outside this contract.
-- Default-locale `awk` also failed on Unicode PRD prose; `LC_ALL=C` reaches the real
-  check and leaves only the baseline BrainSync finding. This is a workflow-tooling
-  locale limitation, not a malformed PRD.
+- PR #54 advanced `origin/main` while this PR was under review. The branch was
+  rebased onto `8e16032`; `tasks/current.md` conflicts were resolved by preserving
+  the new base projection and regenerating the BDD² current snapshot afterward.
+- Default-locale `awk` still cannot safely process all Unicode PRD prose, so the
+  recorded strict workflow command pins `LC_ALL=C`; with that locale and a refreshed
+  handoff, BrainSync and workflow checks both pass.
 - Full suite ran before the final bounded path/placeholder hardening; the focused
   suite and typecheck were rerun after those edits and directly cover them.
 - Manual checks: agent packets contain no truth issue IDs or condition labels;
@@ -92,7 +92,7 @@
 > **External Started**: 2026-07-12T05:27:00+08:00
 > **External Completed**: pending
 > **Review Rubric Version**: 2
-> **Reviewed Diff Fingerprint**: sha256:077fe6e0295b56e4c72f6ab916e798f523b2857fc2fc0d4344f9ac20cd2a01cf
+> **Reviewed Diff Fingerprint**: sha256:1d4a2bd11cd06a4efc6ac5d09ec724365f0cb208b76cadcb3ea9cb6b6cd2459c
 > **Reviewed Scope**: branch+staged+unstaged+untracked
 
 - P1 blockers: none after local remediation; GitHub re-review is still pending.
@@ -129,8 +129,6 @@
   development/held-out seed sets only; no effectiveness claim is authorized.
 - Prompt fairness and the full 12-task composition require human review during the
   E-02/E-03 sealing PRs.
-- The pre-existing brain mirror drift prevents a green strict workflow trace until
-  its owning work-package syncs the mirror.
 - Advisory tooling reports Codex Waza installed copies and the linked-worktree
   CodeGraph index as partial; neither affected this source diff or its tests.
 
@@ -145,8 +143,7 @@
 
 ## Failing Items
 
-- None in the reviewed diff.
-- Out-of-scope base failure: brain mirror drift in strict workflow.
+- None in the reviewed diff or strict workflow gate.
 
 ## Retest Steps
 
@@ -154,8 +151,7 @@
 2. `bun run check:type`
 3. `bun scripts/run-bdd2-evals.ts validate`
 4. `bun scripts/run-bdd2-evals.ts plan --experiment S --partition development --dry-run`
-5. After the baseline brain mirror is fixed, rerun
-   `LC_ALL=C repo-harness run check-task-workflow --strict`.
+5. `LC_ALL=C repo-harness run check-task-workflow --strict`
 
 ## Summary
 
@@ -164,6 +160,6 @@ without any BDD product surface. It fails closed on drift, leakage, symlink/path
 escape, incomplete held-out arms, unapplied model/sampling profiles, dirty source
 state, untracked/ignored authority, reversible blind IDs, and attempted execution
 before seal. The full repository suite and focused tests pass. Browser/ImageGen and
-Behavior Brief remain explicitly preserved for their gated hypotheses; the only red
-workflow signal is an unrelated base BrainSync drift that this contract correctly
-does not absorb.
+Behavior Brief remain explicitly preserved for their gated hypotheses. The rebased
+strict workflow check also passes without adding any unrelated mirror change to this
+branch.

--- a/tests/bdd2-evals-contract.test.ts
+++ b/tests/bdd2-evals-contract.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+import {
+  buildAgentPacket,
+  buildRunPlan,
+  validateEvaluation,
+} from "../scripts/run-bdd2-evals";
+
+const ROOT = join(import.meta.dir, "..");
+
+describe("BDD2 Phase E evaluation contract", () => {
+  const evaluation = validateEvaluation(ROOT);
+
+  test("foundation authority is valid but deliberately unsealed", () => {
+    expect(evaluation.manifest.schema).toBe("repo-harness-bdd2-evaluation.v1");
+    expect(evaluation.manifest.freeze.state).toBe("foundation");
+    expect(evaluation.manifest.agents).toEqual({});
+  });
+
+  test("development and held-out sets cover both independent hypotheses", () => {
+    for (const partition of ["development", "held_out"] as const) {
+      expect(evaluation.tasks[partition].some((task) => task.experiment === "S")).toBe(true);
+      expect(evaluation.tasks[partition].some((task) => task.experiment === "A")).toBe(true);
+    }
+  });
+
+  test("agent packets contain treatment instructions and task input but no truth payload", () => {
+    const coordinate = buildRunPlan(evaluation, {
+      experiment: "A",
+      partition: "held_out",
+      taskIds: ["A-H-01"],
+      conditions: ["treatment"],
+      repetitions: 1,
+    })[0];
+    const packet = buildAgentPacket(evaluation, coordinate);
+
+    expect(packet).toContain("Perform a read-only behavior audit");
+    expect(packet).toContain("A-H-01");
+    expect(packet).not.toContain("A-H-01-I1");
+    expect(packet).not.toContain("repo-harness-bdd2-truth-set");
+    expect(packet).not.toContain("condition: treatment");
+  });
+
+  test("Phase E files do not create a public BDD product surface", () => {
+    for (const path of [
+      "assets/skill-commands/repo-harness-bdd/SKILL.md",
+      "plans/behaviors",
+      "src/cli/commands/bdd.ts",
+      "src/cli/mcp/behavior-tools.ts",
+    ]) {
+      expect(existsSync(join(ROOT, path))).toBe(false);
+    }
+
+    const manifest = readFileSync(join(ROOT, "evals/bdd2/evaluation-manifest.json"), "utf-8");
+    expect(manifest).not.toContain("hook");
+    expect(manifest).not.toContain("sidecar");
+  });
+});

--- a/tests/run-bdd2-evals.test.ts
+++ b/tests/run-bdd2-evals.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, test } from "bun:test";
+import {
+  cpSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { spawnSync } from "child_process";
+import {
+  buildRunPlan,
+  runEvaluation,
+  validateEvaluation,
+} from "../scripts/run-bdd2-evals";
+
+const ROOT = join(import.meta.dir, "..");
+
+function tempRepo(prefix: string): string {
+  const root = mkdtempSync(join(tmpdir(), `${prefix}-`));
+  cpSync(join(ROOT, "evals/bdd2"), join(root, "evals/bdd2"), { recursive: true });
+  return root;
+}
+
+function readManifest(root: string): any {
+  return JSON.parse(readFileSync(join(root, "evals/bdd2/evaluation-manifest.json"), "utf-8"));
+}
+
+function writeManifest(root: string, manifest: unknown): void {
+  writeFileSync(
+    join(root, "evals/bdd2/evaluation-manifest.json"),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+    "utf-8"
+  );
+}
+
+describe("run-bdd2-evals validation and planning", () => {
+  test("builds stable opaque coordinates", () => {
+    const evaluation = validateEvaluation(ROOT);
+    const options = {
+      experiment: "S" as const,
+      partition: "development" as const,
+      taskIds: ["S-D-01"],
+      repetitions: 2,
+    };
+    const first = buildRunPlan(evaluation, options);
+    const second = buildRunPlan(evaluation, options);
+
+    expect(first).toEqual(second);
+    expect(first).toHaveLength(4);
+    expect(first.every((entry) => /^[a-f0-9]{16}$/.test(entry.packetId))).toBe(true);
+    expect(new Set(first.map((entry) => entry.packetId)).size).toBe(4);
+    expect(() =>
+      buildRunPlan(evaluation, {
+        ...options,
+        conditions: ["baseline", "baseline"],
+      })
+    ).toThrow("must not contain duplicates");
+  });
+
+  test("fails closed when a frozen prompt drifts", () => {
+    const root = tempRepo("bdd2-drift");
+    try {
+      writeFileSync(join(root, "evals/bdd2/prompts/shape-baseline.md"), "changed\n", "utf-8");
+      expect(() => validateEvaluation(root)).toThrow("sha256 drift");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects truth fields placed in an agent-visible task set", () => {
+    const root = tempRepo("bdd2-leak");
+    try {
+      const taskPath = join(root, "evals/bdd2/tasks/development.json");
+      const tasks = JSON.parse(readFileSync(taskPath, "utf-8"));
+      tasks.tasks[0].truth = "must not reach the agent";
+      writeFileSync(taskPath, `${JSON.stringify(tasks, null, 2)}\n`, "utf-8");
+
+      const manifest = readManifest(root);
+      const hash = spawnSync("shasum", ["-a", "256", taskPath], { encoding: "utf-8" }).stdout.split(/\s+/)[0];
+      manifest.partitions.development.tasks_sha256 = hash;
+      writeManifest(root, manifest);
+
+      expect(() => validateEvaluation(root)).toThrow("keys must be exactly");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects a frozen authority file that is a symlink", () => {
+    const root = tempRepo("bdd2-symlink");
+    const external = join(tmpdir(), `bdd2-external-${Date.now()}.md`);
+    try {
+      writeFileSync(external, "external prompt\n", "utf-8");
+      const link = join(root, "evals/bdd2/prompts/escape.md");
+      symlinkSync(external, link);
+      const manifest = readManifest(root);
+      manifest.experiments.S.conditions.baseline.prompt = "evals/bdd2/prompts/escape.md";
+      manifest.experiments.S.conditions.baseline.sha256 = spawnSync(
+        "shasum",
+        ["-a", "256", external],
+        { encoding: "utf-8" }
+      ).stdout.split(/\s+/)[0];
+      writeManifest(root, manifest);
+
+      expect(() => validateEvaluation(root)).toThrow("must not be a symbolic link");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+      rmSync(external, { force: true });
+    }
+  });
+
+  test("foundation authority cannot execute a model command", () => {
+    const evaluation = validateEvaluation(ROOT);
+    expect(() =>
+      runEvaluation(evaluation, {
+        experiment: "S",
+        partition: "development",
+        taskIds: ["S-D-01"],
+        conditions: ["baseline"],
+        repetitions: 1,
+        agent: "stub",
+      })
+    ).toThrow("foundation-only");
+  });
+});
+
+describe("run-bdd2-evals sealed execution", () => {
+  test("captures private coordinates separately from blind response packets", () => {
+    const root = tempRepo("bdd2-run");
+    try {
+      const stub = join(root, "agent-stub.sh");
+      writeFileSync(
+        stub,
+        "#!/usr/bin/env bash\nset -euo pipefail\nprompt_path=\"$1\"\nresponse_path=\"$2\"\nmodel=\"$3\"\ntemperature=\"$4\"\ntest \"$model\" = \"stub-model-v1\"\ntest \"$temperature\" = \"0\"\nprintf 'stub response from %s\\n' \"$(basename \"$prompt_path\")\" > \"$response_path\"\n",
+        "utf-8"
+      );
+      spawnSync("chmod", ["+x", stub]);
+
+      const manifest = readManifest(root);
+      manifest.freeze = {
+        id: "bdd2-test-sealed-v1",
+        state: "sealed",
+        sealed_at: "2026-07-12T00:00:00Z",
+      };
+      manifest.experiments.S.held_out_task_count = 2;
+      manifest.experiments.A.held_out_task_count = 2;
+      manifest.agents = {
+        stub: {
+          command: stub,
+          args: ["{prompt_path}", "{response_path}", "{model}", "{sampling.temperature}"],
+          model: "stub-model-v1",
+          sampling: { temperature: 0 },
+          response_source: "file",
+        },
+      };
+      writeManifest(root, manifest);
+      for (const args of [
+        ["init"],
+        ["config", "user.name", "BDD2 Test"],
+        ["config", "user.email", "bdd2-test@example.com"],
+        ["add", "."],
+        ["commit", "-m", "sealed evaluation fixture"],
+      ]) {
+        const result = spawnSync("git", args, { cwd: root, encoding: "utf-8" });
+        expect(result.status).toBe(0);
+      }
+
+      const evaluation = validateEvaluation(root);
+      const report = runEvaluation(evaluation, {
+        experiment: "A",
+        partition: "held_out",
+        taskIds: ["A-H-01"],
+        conditions: ["treatment"],
+        repetitions: 1,
+        agent: "stub",
+        outputPath: ".ai/harness/runs/bdd2/test-run",
+      });
+
+      expect(report.packets).toHaveLength(1);
+      const packetId = report.packets[0].packet_id;
+      const blind = JSON.parse(
+        readFileSync(join(root, ".ai/harness/runs/bdd2/test-run/blind", `${packetId}.json`), "utf-8")
+      );
+      const privateCoordinate = JSON.parse(
+        readFileSync(join(root, ".ai/harness/runs/bdd2/test-run/private", `${packetId}.json`), "utf-8")
+      );
+
+      expect(blind).toEqual({
+        schema: "repo-harness-bdd2-blind-packet.v1",
+        packet_id: packetId,
+        task_id: "A-H-01",
+        experiment: "A",
+        response: "stub response from agent-prompt.md\n",
+      });
+      expect(JSON.stringify(blind)).not.toContain("treatment");
+      expect(Object.keys(blind)).not.toContain("model");
+      expect(privateCoordinate.condition).toBe("treatment");
+      expect(privateCoordinate.model).toBe("stub-model-v1");
+      expect(privateCoordinate.sampling).toEqual({ temperature: 0 });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/run-bdd2-evals.test.ts
+++ b/tests/run-bdd2-evals.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   cpSync,
   mkdtempSync,
+  mkdirSync,
   readFileSync,
   rmSync,
   symlinkSync,
@@ -21,6 +22,8 @@ const ROOT = join(import.meta.dir, "..");
 function tempRepo(prefix: string): string {
   const root = mkdtempSync(join(tmpdir(), `${prefix}-`));
   cpSync(join(ROOT, "evals/bdd2"), join(root, "evals/bdd2"), { recursive: true });
+  mkdirSync(join(root, "scripts"), { recursive: true });
+  cpSync(join(ROOT, "scripts/run-bdd2-evals.ts"), join(root, "scripts/run-bdd2-evals.ts"));
   return root;
 }
 
@@ -50,8 +53,8 @@ describe("run-bdd2-evals validation and planning", () => {
 
     expect(first).toEqual(second);
     expect(first).toHaveLength(4);
-    expect(first.every((entry) => /^[a-f0-9]{16}$/.test(entry.packetId))).toBe(true);
-    expect(new Set(first.map((entry) => entry.packetId)).size).toBe(4);
+    expect(first.every((entry) => /^[a-f0-9]{16}$/.test(entry.coordinateId))).toBe(true);
+    expect(new Set(first.map((entry) => entry.coordinateId)).size).toBe(4);
     expect(() =>
       buildRunPlan(evaluation, {
         ...options,
@@ -65,6 +68,16 @@ describe("run-bdd2-evals validation and planning", () => {
     try {
       writeFileSync(join(root, "evals/bdd2/prompts/shape-baseline.md"), "changed\n", "utf-8");
       expect(() => validateEvaluation(root)).toThrow("sha256 drift");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("fails closed when the frozen runner drifts", () => {
+    const root = tempRepo("bdd2-runner-drift");
+    try {
+      writeFileSync(join(root, "scripts/run-bdd2-evals.ts"), "changed runner\n", "utf-8");
+      expect(() => validateEvaluation(root)).toThrow("runner sha256 drift");
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -157,6 +170,7 @@ describe("run-bdd2-evals sealed execution", () => {
         },
       };
       writeManifest(root, manifest);
+      writeFileSync(join(root, ".gitignore"), ".ai/\n.ignored/\n", "utf-8");
       for (const args of [
         ["init"],
         ["config", "user.name", "BDD2 Test"],
@@ -169,6 +183,13 @@ describe("run-bdd2-evals sealed execution", () => {
       }
 
       const evaluation = validateEvaluation(root);
+      const privateCoordinateId = buildRunPlan(evaluation, {
+        experiment: "A",
+        partition: "held_out",
+        taskIds: ["A-H-01"],
+        conditions: ["treatment"],
+        repetitions: 1,
+      })[0].coordinateId;
       const report = runEvaluation(evaluation, {
         experiment: "A",
         partition: "held_out",
@@ -181,6 +202,8 @@ describe("run-bdd2-evals sealed execution", () => {
 
       expect(report.packets).toHaveLength(1);
       const packetId = report.packets[0].packet_id;
+      expect(packetId).toMatch(/^[a-f0-9]{32}$/);
+      expect(packetId).not.toBe(privateCoordinateId);
       const blind = JSON.parse(
         readFileSync(join(root, ".ai/harness/runs/bdd2/test-run/blind", `${packetId}.json`), "utf-8")
       );
@@ -198,8 +221,28 @@ describe("run-bdd2-evals sealed execution", () => {
       expect(JSON.stringify(blind)).not.toContain("treatment");
       expect(Object.keys(blind)).not.toContain("model");
       expect(privateCoordinate.condition).toBe("treatment");
+      expect(privateCoordinate.coordinate_id).toBe(privateCoordinateId);
       expect(privateCoordinate.model).toBe("stub-model-v1");
       expect(privateCoordinate.sampling).toEqual({ temperature: 0 });
+
+      mkdirSync(join(root, ".ignored"), { recursive: true });
+      writeFileSync(
+        join(root, ".ignored/evaluation-manifest.json"),
+        `${JSON.stringify(manifest, null, 2)}\n`,
+        "utf-8"
+      );
+      const ignoredEvaluation = validateEvaluation(root, ".ignored/evaluation-manifest.json");
+      expect(() =>
+        runEvaluation(ignoredEvaluation, {
+          experiment: "A",
+          partition: "held_out",
+          taskIds: ["A-H-01"],
+          conditions: ["treatment"],
+          repetitions: 1,
+          agent: "stub",
+          outputPath: ".ai/harness/runs/bdd2/ignored-manifest-run",
+        })
+      ).toThrow("must be tracked at HEAD");
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

- approve the BDD² authority/evaluation PRD and add an ordered Phase E Sprint
- add content-addressed Shape/Audit prompts, task/truth partitions, blind rubric, and score schema
- add a fail-closed eval-only runner with foundation/sealed execution, clean-HEAD provenance, opaque packets, and separate private coordinates
- keep Browser and ImageGen as gated Experiment E hypotheses; add no public BDD skill, CLI/MCP, hook, sidecar, or Brief catalog

## Verification

- `bun test`: 1146 pass, 1 platform skip, 0 fail
- focused BDD² tests: 10 pass, 0 fail
- `bun run check:type`: pass
- manifest validate + deterministic dry-run plan: pass
- deploy SQL / architecture sync / task sync / inspector / migration dry-run: pass

## Known base issue

`check-task-workflow --strict` reaches a pre-existing BrainSync drift for `docs/reference-configs/harness-overview.md` and its brain mirror. Neither file is changed by this branch; the contract records this as an out-of-scope base failure.