### PR TITLE
chore(agents): move fast-worker to Luna xhigh

### DIFF
--- a/.codex/agents/fast-worker.toml
+++ b/.codex/agents/fast-worker.toml
@@ -1,7 +1,7 @@
 name = "fast-worker"
-description = "Fast execution worker on GPT-5.6 Sol at high reasoning. Use for well-scoped implementation, tests, refactoring, documentation, and mechanical changes; verifies with the project's real commands and returns `RESULT: DONE/PARTIAL/BLOCKED` with the evidence. Not for planning, architecture, or high-risk judgment — those go to deep-reasoner or stay with the orchestrator."
-model = "gpt-5.6-sol"
-model_reasoning_effort = "high"
+description = "Fast execution worker on GPT-5.6 Luna at extra high reasoning. Use for well-scoped implementation, tests, refactoring, documentation, and mechanical changes; verifies with the project's real commands and returns `RESULT: DONE/PARTIAL/BLOCKED` with the evidence. Not for planning, architecture, or high-risk judgment — those go to deep-reasoner or stay with the orchestrator."
+model = "gpt-5.6-luna"
+model_reasoning_effort = "xhigh"
 sandbox_mode = "workspace-write"
 developer_instructions = '''You are a fast execution worker. An orchestrator hands you well-scoped tasks — implementation, tests, refactoring, documentation, mechanical changes — and you execute them directly and return. You do not plan, decide architecture, or ship.
 

--- a/assets/reference-configs/external-tooling.md
+++ b/assets/reference-configs/external-tooling.md
@@ -496,7 +496,7 @@ guessed mapping.
 | Upstream frontmatter | Codex TOML |
 |---|---|
 | `model: opus`, `effort: max` | `model = "gpt-5.6-sol"`, `model_reasoning_effort = "xhigh"` |
-| `model: sonnet`, `effort: max` | `model = "gpt-5.6-sol"`, `model_reasoning_effort = "high"` |
+| `model: sonnet`, `effort: max` | `model = "gpt-5.6-luna"`, `model_reasoning_effort = "xhigh"` |
 | generated role is `fast-worker` | `sandbox_mode = "workspace-write"` |
 | `tools: [...]` present | `sandbox_mode = "read-only"` |
 

--- a/assets/templates/helpers/install-agent-fleet.sh
+++ b/assets/templates/helpers/install-agent-fleet.sh
@@ -97,10 +97,10 @@ const MODEL_EFFORT_MAP = {
   },
   sonnet: {
     max: {
-      model: "gpt-5.6-sol",
-      effort: "high",
+      model: "gpt-5.6-luna",
+      effort: "xhigh",
       sourceDescription: "Sonnet 5 at max effort",
-      targetDescription: "GPT-5.6 Sol at high reasoning",
+      targetDescription: "GPT-5.6 Luna at extra high reasoning",
     },
   },
 };

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,10 +6,10 @@ All notable changes to this skill are documented here.
 
 ### Changed
 
-- Mapped the generated Codex `fast-worker` to GPT-5.6 Sol with `high`
-  reasoning and `workspace-write` sandboxing, while keeping Terra/medium for
-  read-heavy explorer work and keeping native MultiAgentV2 role selection
-  behind a runtime canary instead of treating installed TOML as proof. The
+- Mapped the generated Codex `fast-worker` to GPT-5.6 Luna with `xhigh`
+  reasoning and `workspace-write` sandboxing, while keeping native
+  MultiAgentV2 role selection behind a runtime canary instead of treating
+  installed TOML as proof. The
   installer now also rejects source files whose frontmatter role name does not
   match the managed filename before deriving sandbox permissions, exits
   non-zero for unresolved identity failure, and checks every installed managed

--- a/docs/reference-configs/external-tooling.md
+++ b/docs/reference-configs/external-tooling.md
@@ -496,7 +496,7 @@ guessed mapping.
 | Upstream frontmatter | Codex TOML |
 |---|---|
 | `model: opus`, `effort: max` | `model = "gpt-5.6-sol"`, `model_reasoning_effort = "xhigh"` |
-| `model: sonnet`, `effort: max` | `model = "gpt-5.6-sol"`, `model_reasoning_effort = "high"` |
+| `model: sonnet`, `effort: max` | `model = "gpt-5.6-luna"`, `model_reasoning_effort = "xhigh"` |
 | generated role is `fast-worker` | `sandbox_mode = "workspace-write"` |
 | `tools: [...]` present | `sandbox_mode = "read-only"` |
 

--- a/scripts/install-agent-fleet.sh
+++ b/scripts/install-agent-fleet.sh
@@ -97,10 +97,10 @@ const MODEL_EFFORT_MAP = {
   },
   sonnet: {
     max: {
-      model: "gpt-5.6-sol",
-      effort: "high",
+      model: "gpt-5.6-luna",
+      effort: "xhigh",
       sourceDescription: "Sonnet 5 at max effort",
-      targetDescription: "GPT-5.6 Sol at high reasoning",
+      targetDescription: "GPT-5.6 Luna at extra high reasoning",
     },
   },
 };

--- a/tasks/notes/luna-xhigh-fast-worker.notes.md
+++ b/tasks/notes/luna-xhigh-fast-worker.notes.md
@@ -1,0 +1,27 @@
+# Implementation Notes: luna-xhigh-fast-worker
+
+> **Status**: Complete
+> **Plan**: user-approved direct configuration change
+> **Contract**: (none)
+> **Review**: deterministic installer and projection tests
+> **Last Updated**: 2026-07-12
+> **Lifecycle**: configuration notes
+
+## Decision
+
+- Map upstream `sonnet` / `max` frontmatter to Codex `gpt-5.6-luna` with
+  `xhigh` reasoning. `fast-worker` remains the only generated role using the
+  existing `workspace-write` sandbox.
+- Keep the upstream Claude source unchanged: it is the external authority for
+  provider frontmatter; the local installer owns only the Codex projection.
+- Update the generated golden TOML, template projection, mapping reference, and
+  assertions together so no second model mapping can drift.
+
+## Evidence
+
+- Local Codex 0.144.1 advertises `gpt-5.6-luna` with `xhigh` support.
+- `bun test tests/install-agent-fleet.test.ts tests/bootstrap-files.test.ts`
+  passed (33 tests).
+- `bun test` passed (1111 pass / 1 skipped / 0 fail).
+- `bun scripts/sync-helper-sources.ts --check` and `bun run check:helpers`
+  passed.

--- a/tests/bootstrap-files.test.ts
+++ b/tests/bootstrap-files.test.ts
@@ -37,7 +37,7 @@ describe("Bootstrap Script Contracts", () => {
   test("Codex fleet subagent TOML definitions should exist with required keys", () => {
     const specs: Array<{ name: string; model: string; effort: string; sandboxMode?: string }> = [
       { name: "deep-reasoner", model: "gpt-5.6-sol", effort: "xhigh" },
-      { name: "fast-worker", model: "gpt-5.6-sol", effort: "high", sandboxMode: "workspace-write" },
+      { name: "fast-worker", model: "gpt-5.6-luna", effort: "xhigh", sandboxMode: "workspace-write" },
       { name: "gatekeeper", model: "gpt-5.6-sol", effort: "xhigh", sandboxMode: "read-only" },
     ];
 

--- a/tests/install-agent-fleet.test.ts
+++ b/tests/install-agent-fleet.test.ts
@@ -16,9 +16,9 @@ const CODEX_EXPECTATIONS: Record<string, { model: string; effort: string; descri
     descriptionLabel: "GPT-5.6 Sol at extra high reasoning",
   },
   "fast-worker": {
-    model: "gpt-5.6-sol",
-    effort: "high",
-    descriptionLabel: "GPT-5.6 Sol at high reasoning",
+    model: "gpt-5.6-luna",
+    effort: "xhigh",
+    descriptionLabel: "GPT-5.6 Luna at extra high reasoning",
     sandboxMode: "workspace-write",
   },
   gatekeeper: {


### PR DESCRIPTION
## Summary
- map the generated Codex `fast-worker` from the upstream `sonnet/max` source to `gpt-5.6-luna` with `xhigh` reasoning
- preserve the existing `workspace-write` sandbox and fail-closed provider-label validation
- update the deterministic helper/reference projections, golden TOML, assertions, changelog, and task note

## Verification
- post-rebase: `bun test tests/install-agent-fleet.test.ts tests/bootstrap-files.test.ts` — 33 pass, 0 fail
- post-rebase: `bun scripts/sync-helper-sources.ts --check`, `bun run check:helpers`, `bun run check:type`, `git diff origin/main...HEAD --check`
- implementation tree full suite before the non-overlapping base update: `bun test` — 1111 pass, 1 skip, 0 fail
- installed `$HOME/.codex/agents/fast-worker.toml` is byte-identical to the repo golden

## Baseline note
`check-task-workflow --strict` is independently blocked on `main` by `plans/prds/20260712-0409-bdd2-shape-audit.prd.md` (malformed UTF-8/placeholder Problem gate); this PR does not touch that active BDD work.