### PR TITLE
feat(contract-run): resolve worker role to fleet profile with Sol-High fallback

### DIFF
--- a/.ai/context/capabilities.json
+++ b/.ai/context/capabilities.json
@@ -101,6 +101,7 @@
         ".ai/context/capabilities.json",
         "scripts/capability-resolver.ts",
         "scripts/capability-config.ts",
+        "scripts/contract-run.ts",
         "src/cli/commands/capability-context.ts",
         "assets/templates",
         "assets/reference-configs",

--- a/assets/templates/helpers/contract-run.ts
+++ b/assets/templates/helpers/contract-run.ts
@@ -15,6 +15,7 @@ interface Options {
   json: boolean;
   maxToolCalls?: number;
   runner?: string;
+  effort?: string;
 }
 
 interface DelegationBudget {
@@ -78,8 +79,8 @@ function usage(): string {
   return [
     "Usage:",
     "  bun scripts/contract-run.ts preflight --contract <contract-file> [--repo <path>] [--json]",
-    "  bun scripts/contract-run.ts dry-run --contract <contract-file> [--repo <path>] [--out <dir>] [--runner <label>] [--json]",
-    "  bun scripts/contract-run.ts run --contract <contract-file> --worker-command <cmd> --verifier-command <cmd> [--repo <path>] [--out <dir>] [--max-tool-calls <n>] [--runner <label>] [--json]",
+    "  bun scripts/contract-run.ts dry-run --contract <contract-file> [--repo <path>] [--out <dir>] [--runner <label>] [--effort <tier>] [--json]",
+    "  bun scripts/contract-run.ts run --contract <contract-file> --worker-command <cmd> --verifier-command <cmd> [--repo <path>] [--out <dir>] [--max-tool-calls <n>] [--runner <label>] [--effort <tier>] [--json]",
     "",
     "preflight asserts the contract is a self-sufficient execution brief (Goal, Scope,",
     "Allowed Paths, Exit Criteria are filled in, not template placeholders) and exits",
@@ -88,6 +89,10 @@ function usage(): string {
     "--runner records which runner label actually ran this contract (manifest.runner_usage);",
     "it defaults to the contract's own delegation.runner.preferred[0] and does not itself",
     "select, spawn, or degrade a runner.",
+    "",
+    "--effort records the worker effort tier (manifest.runner_usage.effort); it defaults to",
+    "\"high\" only when the resolved runner is the contract's worker fallback, and does not",
+    "itself select, spawn, or enforce an effort tier.",
     "",
     "A file-coupled runner consumes the generated prompt from $CONTRACT_RUN_PROMPT, e.g.:",
     "  --worker-command 'codex exec --json \"$(cat \\\"$CONTRACT_RUN_PROMPT\\\")\"'",
@@ -140,6 +145,10 @@ function parseArgs(argv: string[]): Options {
         opts.runner = requireValue(argv, ++index, arg);
         index++;
         break;
+      case "--effort":
+        opts.effort = parseEffort(requireValue(argv, ++index, arg), arg);
+        index++;
+        break;
       case "--json":
         opts.json = true;
         index++;
@@ -176,6 +185,19 @@ function parsePositiveInt(value: string, flag: string): number {
     throw new CliError(`contract-run: ${flag} must be a positive integer`, 2);
   }
   return parsed;
+}
+
+// Closed effort-tier vocabulary shared in spirit with buildFamilyEffortMap() in
+// scripts/install-agent-fleet.sh; that copy lives inside an embedded Node.js heredoc in a
+// bash script, not an importable module, so this is a local literal list rather than a
+// shared import.
+const EFFORT_TIERS = ["low", "medium", "high", "xhigh", "max"] as const;
+
+function parseEffort(value: string, flag: string): string {
+  if (!(EFFORT_TIERS as readonly string[]).includes(value)) {
+    throw new CliError(`contract-run: ${flag} must be one of ${EFFORT_TIERS.join(", ")}`, 2);
+  }
+  return value;
 }
 
 class CliError extends Error {
@@ -731,6 +753,11 @@ function buildRun(opts: Options) {
 
   const usedRunner = opts.runner ?? delegation.runner.preferred[0];
   const offPolicy = !delegation.runner.preferred.includes(usedRunner) && usedRunner !== delegation.runner.fallback;
+  const onWorkerFallback = delegation.runner.fallback !== null && usedRunner === delegation.runner.fallback;
+  const workerProfile = usedRunner === "main-thread"
+    ? "sol-high"
+    : (usedRunner === "codex-subagent" || usedRunner === "codex-exec" ? usedRunner : "fast-worker");
+  const effortUsed = opts.effort ?? (onWorkerFallback ? "high" : null);
 
   const manifest = {
     version: 1,
@@ -752,6 +779,8 @@ function buildRun(opts: Options) {
     runner_usage: {
       used: usedRunner,
       off_policy: offPolicy,
+      path: onWorkerFallback ? "worker_fallback" : "worker_preferred",
+      effort: effortUsed,
     },
     delegation_plan: {
       parent_owner: delegation.roles.parent,
@@ -762,6 +791,12 @@ function buildRun(opts: Options) {
       verifier_rubric: "contract exit_criteria",
       budget_semantics: "null uses session default; explicit numbers are enforced where the runner supports that dimension",
       permission_semantics: "explorer and verifier are read-only; worker is constrained to allowed_paths or narrower writable_paths",
+      role_profiles: {
+        parent: "orchestrator",
+        explorer: "explorer",
+        worker: workerProfile,
+        verifier: "gatekeeper",
+      },
     },
     budget_usage: {
       tool_calls: toolCalls,

--- a/docs/architecture/modules/workflow-engine/contract-assets.md
+++ b/docs/architecture/modules/workflow-engine/contract-assets.md
@@ -1,7 +1,7 @@
 # Architecture Module: workflow-engine/contract-assets
 
 > **Capability ID**: `workflow-engine-contract-assets`
-> **Matched Prefixes**: `assets/workflow-contract.v1.json`, `.ai/harness/workflow-contract.json`, `.ai/harness/policy.json`, `.ai/context/context-map.json`, `.ai/context/capabilities.json`, `scripts/capability-resolver.ts`, `scripts/capability-config.ts`, `src/cli/commands/capability-context.ts`, `assets/templates`, `assets/reference-configs`, `docs/reference-configs`
+> **Matched Prefixes**: `assets/workflow-contract.v1.json`, `.ai/harness/workflow-contract.json`, `.ai/harness/policy.json`, `.ai/context/context-map.json`, `.ai/context/capabilities.json`, `scripts/capability-resolver.ts`, `scripts/capability-config.ts`, `scripts/contract-run.ts`, `src/cli/commands/capability-context.ts`, `assets/templates`, `assets/reference-configs`, `docs/reference-configs`
 > **Local Contracts**: `AGENTS.md`, `CLAUDE.md`
 
 ## P1 Map
@@ -116,6 +116,22 @@ self-migration dry-run.
 - These gates reuse the existing workflow-state, verify-sprint, architecture
   queue, and freshness authorities. No new dependency or compatibility parser
   was added.
+
+## 2026-07-12 Agent Fleet Worker Routing Telemetry Closeout
+
+- `scripts/contract-run.ts` (mirrored byte-for-byte to `assets/templates/helpers/contract-run.ts` through the existing helper projection route) is now a matched prefix of this capability. It is the task-delegation contract runner: it reads a `tasks/contracts/*.contract.md` execution brief, preflights it, generates worker/verifier prompts, optionally dispatches them, and writes a run manifest. This is a distinct "contract" concept from `assets/workflow-contract.v1.json` (the install/workflow contract this capability already owned) — the two share the word by coincidence, not by schema or lifecycle, but both are contract-lifecycle tooling this capability already narrates (compare the pre-existing `scripts/contract-worktree.sh` mention in the 2026-05-29 closeout above).
+- Contract roles (`parent`/`explorer`/`worker`/`verifier`; existing generic mode/purpose defaults at `scripts/contract-run.ts:340-346`, unchanged) now also map to the four fixed, model-pinned fleet profiles (`explorer`, `fast-worker`, `deep-reasoner`, `gatekeeper`) through a new `delegation_plan.role_profiles` manifest field (`scripts/contract-run.ts:792-797`):
+  - `parent` -> `"orchestrator"`: never model-assigned; not one of the 4 profiles.
+  - `explorer` -> `"explorer"` (fixed).
+  - `worker` -> derived in `buildRun()` (`scripts/contract-run.ts:754-758`) from the resolved runner dispatch value, without renaming `RunnerContract.preferred`/`fallback`'s pre-existing dispatch-mechanism vocabulary (`subagent` / `codex-subagent` / `codex-exec` / `main-thread`): dispatch `main-thread` -> `"sol-high"`; dispatch `codex-subagent` or `codex-exec` -> the raw dispatch label passed through unchanged (Codex is an independent peer provider, not one of the 4 profiles); any other dispatch (e.g. `subagent`) -> `"fast-worker"`.
+  - `verifier` -> `"gatekeeper"` (fixed).
+  - `deep-reasoner` sits outside this role table entirely, as an independent escalation path not bound to any single contract role.
+- New `--effort <tier>` CLI flag (parsed at `scripts/contract-run.ts:148-151`; validated by the local `EFFORT_TIERS`/`parseEffort()` pair at `scripts/contract-run.ts:190-201` against the closed vocabulary `low`/`medium`/`high`/`xhigh`/`max`, the same tiers `buildFamilyEffortMap()` in `scripts/install-agent-fleet.sh` already uses — kept as a local literal list rather than a shared import because that copy lives inside an embedded Node.js heredoc, not an importable module). Record-only, matching the pre-existing `--runner` philosophy: `contract-run.ts` never itself selects, spawns, or degrades a runner or effort tier. Defaults to `"high"` only when the resolved dispatch is the contract's worker fallback and no explicit `--effort` is passed (`scripts/contract-run.ts:758`).
+- New manifest telemetry fields are additive only; `RunnerContract`, `parseRunner()`, `runChild()`, and the run-mode control flow are unchanged:
+  - `runner_usage.path`: `"worker_preferred"` | `"worker_fallback"` (`scripts/contract-run.ts:780`).
+  - `runner_usage.effort`: resolved effort tier string or `null` (`scripts/contract-run.ts:781`).
+  - `delegation_plan.role_profiles`: `{ parent, explorer, worker, verifier }` as derived above (`scripts/contract-run.ts:792-797`).
+- Regression coverage lives in `tests/contract-run.test.ts`: the preferred path, the `codex-subagent`/off-policy runner passthrough, the `main-thread` worker-fallback path (`sol-high` plus default effort `"high"`), the `codex-exec` passthrough, and an explicit `--effort xhigh` override sharing one scenario, `"runner metadata from the contract flows into the manifest"` (`tests/contract-run.test.ts:742-891`); invalid `--effort` rejection is `"invalid --effort value exits with usage error"` (`tests/contract-run.test.ts:893-897`).
 
 ## Workstream Ledger
 

--- a/plans/plan-20260712-2103-agent-fleet-worker-routing-telemetry.md
+++ b/plans/plan-20260712-2103-agent-fleet-worker-routing-telemetry.md
@@ -1,0 +1,139 @@
+# Plan: Agent Fleet Worker Role Fallback & Routing Telemetry
+
+> **Status**: Executing
+> **Created**: 20260712-2103
+> **Slug**: agent-fleet-worker-routing-telemetry
+> **Planning Source**: repo-harness-plan
+> **Orchestration Kind**: fable-orchestrated
+> **Source Ref**: deep-reasoner design + user AskUserQuestion confirmation (this session)
+> **Artifact Level**: work-package
+> **Promotion Reason**: human_decision_boundary
+> **Verification Boundary**: Commands named in the captured planning output plus `repo-harness run verify-contract --contract tasks/contracts/20260712-2103-agent-fleet-worker-routing-telemetry.contract.md --strict`.
+> **Rollback Surface**: Before execution remove `plans/plan-20260712-2103-agent-fleet-worker-routing-telemetry.md`; after execution revert branch `codex/agent-fleet-worker-routing-telemetry` or the explicitly reviewed diff.
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260712-2103-agent-fleet-worker-routing-telemetry.contract.md`
+> **Task Review**: `tasks/reviews/20260712-2103-agent-fleet-worker-routing-telemetry.review.md`
+> **Implementation Notes**: `tasks/notes/20260712-2103-agent-fleet-worker-routing-telemetry.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from repo-harness-plan planning output.
+- Source ref: deep-reasoner design + user AskUserQuestion confirmation (this session)
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260712-2103-agent-fleet-worker-routing-telemetry.md`
+- Sprint contract: `tasks/contracts/20260712-2103-agent-fleet-worker-routing-telemetry.contract.md`
+- Sprint review: `tasks/reviews/20260712-2103-agent-fleet-worker-routing-telemetry.review.md`
+- Implementation notes: `tasks/notes/20260712-2103-agent-fleet-worker-routing-telemetry.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260712-2103-agent-fleet-worker-routing-telemetry.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree; `.claude/.active-plan` is a legacy fallback during transition. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260712-2103-agent-fleet-worker-routing-telemetry.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260712-2103-agent-fleet-worker-routing-telemetry.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260712-2103-agent-fleet-worker-routing-telemetry.contract.md`
+- Review file: `tasks/reviews/20260712-2103-agent-fleet-worker-routing-telemetry.review.md`
+- Implementation notes file: `tasks/notes/20260712-2103-agent-fleet-worker-routing-telemetry.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260712-2103-agent-fleet-worker-routing-telemetry.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan`, the owning worktree is written to `.ai/harness/active-worktree`, and the plan is mirrored to `.claude/.active-plan` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260712-2103-agent-fleet-worker-routing-telemetry.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: Before execution remove `plans/plan-20260712-2103-agent-fleet-worker-routing-telemetry.md`; after execution revert branch `codex/agent-fleet-worker-routing-telemetry` or the explicitly reviewed diff.
+- **Verification boundary**: Commands named in the captured planning output plus `repo-harness run verify-contract --contract tasks/contracts/20260712-2103-agent-fleet-worker-routing-telemetry.contract.md --strict`.
+- **Review/acceptance boundary**: `tasks/reviews/20260712-2103-agent-fleet-worker-routing-telemetry.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: human_decision_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260712-2103-agent-fleet-worker-routing-telemetry.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260712-2103-agent-fleet-worker-routing-telemetry.contract.md`, `tasks/reviews/20260712-2103-agent-fleet-worker-routing-telemetry.review.md`, and `tasks/notes/20260712-2103-agent-fleet-worker-routing-telemetry.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260712-2103-agent-fleet-worker-routing-telemetry.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: Before execution remove `plans/plan-20260712-2103-agent-fleet-worker-routing-telemetry.md`; after execution revert branch `codex/agent-fleet-worker-routing-telemetry` or the explicitly reviewed diff.
+
+## Captured Planning Output
+
+## Summary
+
+Continuation of the Agent Fleet routing refactor (four named, model-pinned subagent profiles: explorer, fast-worker, deep-reasoner, gatekeeper — already implemented and tested earlier this session). This plan captures the four remaining items that were approved in an earlier, uncaptured planning conversation and were re-specified in this session after an explorer sweep confirmed no file-backed plan artifact existed for them (the only match in `plans/` was an unrelated, already-archived, narrower slice: `plan-20260711-1402-agent-fleet-role-tier-alignment.md`, which explicitly disclaims this scope).
+
+## Confirmed Role Mapping
+
+Contract role (scripts/contract-run.ts `roles` block) -> fleet profile:
+- `parent` -> the orchestrator itself; never assigned a model; not one of the 4 profiles.
+- `explorer` -> `explorer` profile (fixed).
+- `worker` -> `fast-worker` profile (preferred) or a `sol-high` single-shot escalation (fallback), DERIVED from the resolved runner dispatch value — not by renaming `RunnerContract.preferred`/`fallback`'s existing dispatch-mechanism vocabulary (`subagent`/`codex-subagent`/`codex-exec`/`main-thread`, confirmed via tests/contract-run.test.ts:100-106, 763-764):
+  - dispatch `main-thread` -> worker profile `sol-high` (Opus + High effort, occasionally manually bumped higher by the user).
+  - dispatch `codex-subagent`/`codex-exec` -> pass the raw dispatch label through unchanged (Codex is an independent peer provider, not one of the 4 profiles).
+  - any other dispatch (e.g. `subagent`) -> worker profile `fast-worker`.
+- `verifier` -> `gatekeeper` profile (fixed).
+- `deep-reasoner` sits outside this role table entirely as an independent escalation path, not bound to any single contract role.
+
+## Design (deep-reasoner proposal, confirmed by user across two clarification rounds)
+
+- The fallback mechanism is record-only: scripts/contract-run.ts never itself selects/spawns/degrades a runner (existing philosophy at ~88-90); it only classifies and records which path was used. Escalation from fast-worker to Sol-High is orchestrator-driven (the caller passes `--runner main-thread`), not auto-degraded by the script on failure.
+- New `--effort <tier>` CLI flag (mirrors `--runner`), validated against the closed vocabulary low/medium/high/xhigh/max (same tiers established earlier this session in scripts/install-agent-fleet.sh's `buildFamilyEffortMap()`), record-only. Defaults to `"high"` when the worker fallback path is used and no explicit `--effort` is passed.
+- New manifest telemetry fields (additive only, no existing field renamed or repurposed):
+  - `runner_usage.path`: `"worker_preferred"` | `"worker_fallback"`.
+  - `runner_usage.effort`: resolved effort tier string or `null`.
+  - `delegation_plan.role_profiles`: `{ parent: "orchestrator", explorer: "explorer", worker: <derived per mapping above>, verifier: "gatekeeper" }`.
+- `RunnerContract` type and `parseRunner`/`parseDelegation` are reused as-is (no field renaming). `runChild` and the run-mode control flow are untouched (no auto-degrade, no second worker execution, no verifier-skip).
+
+## Task Breakdown
+- [x] Map contract-run.ts generic roles (`parent`/`explorer`/`worker`/`verifier`) to the four fleet profiles via a new `delegation_plan.role_profiles` manifest field.
+- [x] Implement the Sol-High single-shot worker-fallback classification (`--effort` flag, `onWorkerFallback` derivation, `runner_usage.path`/`effort` fields) in scripts/contract-run.ts, plus regression tests in tests/contract-run.test.ts covering the preferred path, the `main-thread` fallback path, the `codex-exec` pass-through case, an `--effort` override, and invalid `--effort` rejection.
+- [x] Extend the run manifest with the telemetry fields above and verify additive-safety against the existing partial-cast assertions in tests/contract-run.test.ts (~241-243/766/784/802).
+- [x] Document the resulting routing architecture as a new module doc under docs/architecture/modules/, following the docs/architecture/modules/workflow-engine/inspection-migration.md template, and register the capability in .ai/context/capabilities.json plus a pending-request entry in docs/architecture/index.md. (Extended existing `workflow-engine-contract-assets` capability instead of minting a new one; `docs/architecture/index.md` intentionally left untouched since the drift hook does not cover contract-run.ts — see `docs/architecture/modules/workflow-engine/contract-assets.md` 2026-07-12 closeout section.)
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [x] Map contract-run.ts generic roles (`parent`/`explorer`/`worker`/`verifier`) to the four fleet profiles via a new `delegation_plan.role_profiles` manifest field.
+- [x] Implement the Sol-High single-shot worker-fallback classification (`--effort` flag, `onWorkerFallback` derivation, `runner_usage.path`/`effort` fields) in scripts/contract-run.ts, plus regression tests in tests/contract-run.test.ts covering the preferred path, the `main-thread` fallback path, the `codex-exec` pass-through case, an `--effort` override, and invalid `--effort` rejection.
+- [x] Extend the run manifest with the telemetry fields above and verify additive-safety against the existing partial-cast assertions in tests/contract-run.test.ts (~241-243/766/784/802).
+- [x] Document the resulting routing architecture as a new module doc under docs/architecture/modules/, following the docs/architecture/modules/workflow-engine/inspection-migration.md template, and register the capability in .ai/context/capabilities.json plus a pending-request entry in docs/architecture/index.md. (Extended existing `workflow-engine-contract-assets` capability instead of minting a new one; `docs/architecture/index.md` intentionally left untouched since the drift hook does not cover contract-run.ts — see `docs/architecture/modules/workflow-engine/contract-assets.md` 2026-07-12 closeout section.)

--- a/scripts/contract-run.ts
+++ b/scripts/contract-run.ts
@@ -15,6 +15,7 @@ interface Options {
   json: boolean;
   maxToolCalls?: number;
   runner?: string;
+  effort?: string;
 }
 
 interface DelegationBudget {
@@ -78,8 +79,8 @@ function usage(): string {
   return [
     "Usage:",
     "  bun scripts/contract-run.ts preflight --contract <contract-file> [--repo <path>] [--json]",
-    "  bun scripts/contract-run.ts dry-run --contract <contract-file> [--repo <path>] [--out <dir>] [--runner <label>] [--json]",
-    "  bun scripts/contract-run.ts run --contract <contract-file> --worker-command <cmd> --verifier-command <cmd> [--repo <path>] [--out <dir>] [--max-tool-calls <n>] [--runner <label>] [--json]",
+    "  bun scripts/contract-run.ts dry-run --contract <contract-file> [--repo <path>] [--out <dir>] [--runner <label>] [--effort <tier>] [--json]",
+    "  bun scripts/contract-run.ts run --contract <contract-file> --worker-command <cmd> --verifier-command <cmd> [--repo <path>] [--out <dir>] [--max-tool-calls <n>] [--runner <label>] [--effort <tier>] [--json]",
     "",
     "preflight asserts the contract is a self-sufficient execution brief (Goal, Scope,",
     "Allowed Paths, Exit Criteria are filled in, not template placeholders) and exits",
@@ -88,6 +89,10 @@ function usage(): string {
     "--runner records which runner label actually ran this contract (manifest.runner_usage);",
     "it defaults to the contract's own delegation.runner.preferred[0] and does not itself",
     "select, spawn, or degrade a runner.",
+    "",
+    "--effort records the worker effort tier (manifest.runner_usage.effort); it defaults to",
+    "\"high\" only when the resolved runner is the contract's worker fallback, and does not",
+    "itself select, spawn, or enforce an effort tier.",
     "",
     "A file-coupled runner consumes the generated prompt from $CONTRACT_RUN_PROMPT, e.g.:",
     "  --worker-command 'codex exec --json \"$(cat \\\"$CONTRACT_RUN_PROMPT\\\")\"'",
@@ -140,6 +145,10 @@ function parseArgs(argv: string[]): Options {
         opts.runner = requireValue(argv, ++index, arg);
         index++;
         break;
+      case "--effort":
+        opts.effort = parseEffort(requireValue(argv, ++index, arg), arg);
+        index++;
+        break;
       case "--json":
         opts.json = true;
         index++;
@@ -176,6 +185,19 @@ function parsePositiveInt(value: string, flag: string): number {
     throw new CliError(`contract-run: ${flag} must be a positive integer`, 2);
   }
   return parsed;
+}
+
+// Closed effort-tier vocabulary shared in spirit with buildFamilyEffortMap() in
+// scripts/install-agent-fleet.sh; that copy lives inside an embedded Node.js heredoc in a
+// bash script, not an importable module, so this is a local literal list rather than a
+// shared import.
+const EFFORT_TIERS = ["low", "medium", "high", "xhigh", "max"] as const;
+
+function parseEffort(value: string, flag: string): string {
+  if (!(EFFORT_TIERS as readonly string[]).includes(value)) {
+    throw new CliError(`contract-run: ${flag} must be one of ${EFFORT_TIERS.join(", ")}`, 2);
+  }
+  return value;
 }
 
 class CliError extends Error {
@@ -731,6 +753,11 @@ function buildRun(opts: Options) {
 
   const usedRunner = opts.runner ?? delegation.runner.preferred[0];
   const offPolicy = !delegation.runner.preferred.includes(usedRunner) && usedRunner !== delegation.runner.fallback;
+  const onWorkerFallback = delegation.runner.fallback !== null && usedRunner === delegation.runner.fallback;
+  const workerProfile = usedRunner === "main-thread"
+    ? "sol-high"
+    : (usedRunner === "codex-subagent" || usedRunner === "codex-exec" ? usedRunner : "fast-worker");
+  const effortUsed = opts.effort ?? (onWorkerFallback ? "high" : null);
 
   const manifest = {
     version: 1,
@@ -752,6 +779,8 @@ function buildRun(opts: Options) {
     runner_usage: {
       used: usedRunner,
       off_policy: offPolicy,
+      path: onWorkerFallback ? "worker_fallback" : "worker_preferred",
+      effort: effortUsed,
     },
     delegation_plan: {
       parent_owner: delegation.roles.parent,
@@ -762,6 +791,12 @@ function buildRun(opts: Options) {
       verifier_rubric: "contract exit_criteria",
       budget_semantics: "null uses session default; explicit numbers are enforced where the runner supports that dimension",
       permission_semantics: "explorer and verifier are read-only; worker is constrained to allowed_paths or narrower writable_paths",
+      role_profiles: {
+        parent: "orchestrator",
+        explorer: "explorer",
+        worker: workerProfile,
+        verifier: "gatekeeper",
+      },
     },
     budget_usage: {
       tool_calls: toolCalls,

--- a/tasks/contracts/20260712-2103-agent-fleet-worker-routing-telemetry.contract.md
+++ b/tasks/contracts/20260712-2103-agent-fleet-worker-routing-telemetry.contract.md
@@ -1,0 +1,142 @@
+# Task Contract: agent-fleet-worker-routing-telemetry
+
+> **Status**: Partial
+> **Plan**: plans/plan-20260712-2103-agent-fleet-worker-routing-telemetry.md
+> **Task Profile**: code-change
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: kito
+> **Capability ID**: workflow-engine-contract-assets
+> **Last Updated**: 2026-07-12 21:36
+> **Review File**: `tasks/reviews/20260712-2103-agent-fleet-worker-routing-telemetry.review.md`
+> **Notes File**: `tasks/notes/20260712-2103-agent-fleet-worker-routing-telemetry.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+The Agent Fleet routing refactor (four named, model-pinned subagent profiles: explorer/fast-worker/deep-reasoner/gatekeeper) left contract-run.ts's generic `parent`/`explorer`/`worker`/`verifier` role labels with no deterministic binding to those profiles, and no way to record or escalate a worker-role execution beyond the default fast-worker/Sonnet tier. Without this, delegation-contract manifests can't tell which concrete model actually executed a role, and there is no supported path to a higher-capability single-shot execution when a worker task warrants it.
+
+## Goal
+
+Deterministically resolve contract roles to the four fleet profiles in the run manifest (`delegation_plan.role_profiles`), add a record-only worker-role fallback/escalation path to a Sol-High (Opus + High effort) single-shot identity driven by the existing `RunnerContract.preferred`/`fallback` dispatch labels, add a matching `--effort` telemetry flag, and document the resulting architecture — without changing `RunnerContract`'s existing dispatch-mechanism vocabulary or `contract-run.ts`'s established record-only philosophy (it never itself selects/spawns/degrades a runner).
+
+## Scope
+
+- In scope: `scripts/contract-run.ts` (Options/parseArgs/usage/manifest construction), `tests/contract-run.test.ts` (regression coverage), `assets/templates/helpers/contract-run.ts` (synced mirror, via `bun run sync:helpers`), `.ai/context/capabilities.json` (extend `workflow-engine-contract-assets.prefixes`), `docs/architecture/modules/workflow-engine/contract-assets.md` (dated closeout section).
+- Out of scope: `docs/architecture/index.md` (drift-hook-generated only, `scripts/contract-run.ts` is not in `architecture-queue.sh`'s severity whitelist — confirmed empirically, not hand-authored here), the pre-existing `check-task-sync.sh` repo-wide dirty-tree failure (predates this work), `.claude/agents/*.md`/`.codex/agents/*.toml` (fleet profile definitions, already implemented in an earlier slice of this session), `RunnerContract`'s type/parser (reused as-is, no field renaming), `runChild`/run-mode control flow (no auto-degrade added).
+- Taste constraints: additive manifest fields only; no existing field renamed or repurposed; no new abstraction beyond the one Sol-High fallback path.
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+
+## Falsifier
+
+What observable evidence would prove this task's direction wrong, and the cheapest proof point to check first. Leave as-is if not applicable.
+
+## Root Cause Evidence
+
+Required when Task Profile is `bugfix`; leave as-is otherwise.
+
+- root_cause: one sentence naming file:line/condition (testable, not "a state issue").
+- repro: the command or UI path that reproduces the symptom.
+- regression_guard: path to a test that fails on the unfixed code and passes after the fix (must also appear under exit_criteria.tests_pass).
+- pre_fix_failure_artifact: path to a captured run of regression_guard on the UNFIXED code. Capture with `bun test <regression_guard> > <artifact> 2>&1; echo "PRE_FIX_EXIT=$?" >> <artifact>` (no pipes — pipes swallow the exit status). The gate requires a non-zero `PRE_FIX_EXIT=` line plus the regression_guard path string in the artifact (see the Root Cause Evidence Gate section in docs/reference-configs/sprint-contracts.md).
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260712-2103-agent-fleet-worker-routing-telemetry.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260712-2103-agent-fleet-worker-routing-telemetry.review.md`
+- Notes file: `tasks/notes/20260712-2103-agent-fleet-worker-routing-telemetry.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: `repo-harness run verify-sprint` must see this contract pass, the review recommend pass, and `## External Acceptance Advice` pass or record a manual override.
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - docs/spec.md
+  - plans/
+  - tasks/todos.md
+  - tasks/contracts/20260712-2103-agent-fleet-worker-routing-telemetry.contract.md
+  - tasks/reviews/20260712-2103-agent-fleet-worker-routing-telemetry.review.md
+  - tasks/notes/20260712-2103-agent-fleet-worker-routing-telemetry.notes.md
+  - .ai/context/capabilities.json
+  - .claude/templates/
+  - scripts/contract-run.ts
+  - tests/contract-run.test.ts
+  - assets/templates/helpers/contract-run.ts
+  - docs/architecture/modules/workflow-engine/contract-assets.md
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    tool_calls: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+      - codex-exec
+      - main-thread
+    fallback: main-thread
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - docs/spec.md
+    - docs/architecture/modules/workflow-engine/contract-assets.md
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260712-2103-agent-fleet-worker-routing-telemetry.notes.md
+  tests_pass:
+    - path: tests/contract-run.test.ts
+  commands_succeed:
+    - bun run check:type
+    - bash scripts/check-architecture-sync.sh
+    - bun scripts/sync-helper-sources.ts --check
+  qa_scores:
+    - dimension: functionality
+      min: 7
+  manual_checks:
+    - "Evaluator review file recommends pass"
+```
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior: `delegation_plan.role_profiles` resolves parent/explorer/worker/verifier to orchestrator/explorer/fast-worker-or-sol-high/gatekeeper; `runner_usage.path`/`effort` record which path and tier the worker used; `--effort` flag validated against low/medium/high/xhigh/max. Verified via `tests/contract-run.test.ts` (preferred path, `main-thread` fallback, `codex-exec` pass-through, `--effort xhigh` override, invalid `--effort` rejection).
+- Edge cases: `RunnerContract.fallback === null` (no fallback declared) never classifies as worker_fallback; `codex-subagent`/`codex-exec` dispatch passes through unchanged rather than being coerced into fast-worker/sol-high, since Codex is a separate provider.
+- Regression risks: full suite re-verified at 1116 pass / 1 skip / 0 fail after both the code change and the helper-sync mirror fix, matching the pre-change pass count plus the one newly-fixed test — no other test moved. `check-task-sync.sh` still fails but was independently confirmed pre-existing (fails identically on a clean baseline before this task's edits).
+
+## Rollback Point
+
+- Commit / checkpoint: not yet committed as of contract creation; working-tree diff on `scripts/contract-run.ts`, `tests/contract-run.test.ts`, `assets/templates/helpers/contract-run.ts`, `.ai/context/capabilities.json`, `docs/architecture/modules/workflow-engine/contract-assets.md`.
+- Revert strategy: `git checkout -- <file>` per file above (all additive changes, no renamed/removed fields); or revert the eventual commit wholesale since this task's diff is self-contained and does not touch `RunnerContract`'s type/parser or `runChild`.

--- a/tasks/notes/20260712-2103-agent-fleet-worker-routing-telemetry.notes.md
+++ b/tasks/notes/20260712-2103-agent-fleet-worker-routing-telemetry.notes.md
@@ -1,0 +1,45 @@
+# Implementation Notes: agent-fleet-worker-routing-telemetry
+
+> **Status**: Active
+> **Plan**: plans/plan-20260712-2103-agent-fleet-worker-routing-telemetry.md
+> **Contract**: tasks/contracts/20260712-2103-agent-fleet-worker-routing-telemetry.contract.md
+> **Review**: tasks/reviews/20260712-2103-agent-fleet-worker-routing-telemetry.review.md
+> **Last Updated**: 2026-07-12 21:36
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- `role_profiles.worker` identity must key on the resolved dispatch label's literal value (`usedRunner === "main-thread"` -> `sol-high`; Codex labels pass through; else -> `fast-worker`), NOT on whether `usedRunner` matches the contract's declared `runner.fallback`. Those are two independent questions: "what does this dispatch label mean" vs. "did we land on the contract's declared fallback." The first implementation conflated them (kept `workerProfile` behind `onWorkerFallback`), which is correct only by coincidence for contracts that happen to declare `fallback: main-thread` (true of every template-generated contract today, but not a structural guarantee — `fallback: null` is the parser's own default when no `runner:` block is declared). Caught by external Codex review as P1, independently re-traced and confirmed by the orchestrator, fixed by decoupling the two checks. `onWorkerFallback` still correctly drives only `runner_usage.path`/`effort`.
+- Did not rename or repurpose `RunnerContract.preferred`/`fallback`'s existing dispatch-mechanism vocabulary (`subagent`/`codex-subagent`/`codex-exec`/`main-thread`) to carry model-tier meaning, even though that would have been a simpler single-field design — user confirmed `main-thread` dispatch specifically represents "no subagent spawned, orchestrator executes directly," which is a fixed, derivable signal for the Sol-High identity rather than a field worth renaming.
+- Extended the existing `workflow-engine-contract-assets` capability rather than minting a new one for `scripts/contract-run.ts`; that capability already narrates other contract-lifecycle tooling outside its formal prefix list (e.g. `scripts/contract-worktree.sh`), so this is precedent-consistent, not scope creep.
+
+## Deviations From Plan Or Spec
+
+- None recorded — the P1 fix stayed within the original plan's stated design (worker resolves to `fast-worker` or `sol-high`, derived from dispatch), it corrected an implementation bug against that design, not a design change itself.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| Repurpose `runner.preferred`/`fallback` values to mean model identity directly | Rejected | Would silently redefine already-tested dispatch-mechanism semantics (`subagent`/`codex-exec`/`main-thread`) with no confirmed need to touch that vocabulary; user confirmed deriving from the existing values instead. |
+| Add a second, parallel `runner.worker_tier` field | Rejected | User confirmed the single-derivation approach (`main-thread` -> `sol-high`) is sufficient; a second field would be unused speculative surface. |
+| Let contract-run.ts itself auto-degrade/retry the worker at a higher tier on failure | Rejected | Contradicts the script's established "never selects, spawns, or degrades a runner" record-only philosophy (existing code comment); escalation stays orchestrator-driven via explicit `--runner main-thread`. |
+
+## Open Questions
+
+- None outstanding. Two of deep-reasoner's original five flagged open questions were trivial defaults accepted as-is (parent marker value, `--effort` record-only-on-preferred-path); the one genuine fork (repurpose vs. derive) was resolved by the user before implementation.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/reviews/20260712-2103-agent-fleet-worker-routing-telemetry.review.md
+++ b/tasks/reviews/20260712-2103-agent-fleet-worker-routing-telemetry.review.md
@@ -1,0 +1,97 @@
+# Task Review: agent-fleet-worker-routing-telemetry
+
+> **Status**: Pass
+> **Plan**: plans/plan-20260712-2103-agent-fleet-worker-routing-telemetry.md
+> **Contract**: tasks/contracts/20260712-2103-agent-fleet-worker-routing-telemetry.contract.md
+> **Notes File**: tasks/notes/20260712-2103-agent-fleet-worker-routing-telemetry.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-07-12 22:12
+> **Recommendation**: pass
+> **Review Rubric Version**: 2
+> **Reviewed Diff Fingerprint**: sha256:92e4279ae748b9dc1abdffb0551771771d0010890781aec195409ae29a977d6b
+> **Reviewed Scope**: branch+staged+unstaged+untracked
+
+## Human Review Card
+
+- Verdict: PASS (recommend ship)
+- Change type: code-change (additive telemetry) + docs closeout + capability-registry extension
+- Intended files changed: `scripts/contract-run.ts`, `tests/contract-run.test.ts`, `assets/templates/helpers/contract-run.ts`, `.ai/context/capabilities.json`, `docs/architecture/modules/workflow-engine/contract-assets.md` (per contract `allowed_paths`), plus plan/contract/review/notes/todos workflow artifacts.
+- Actual files changed: matches intended exactly — no out-of-scope path touched (confirmed by gatekeeper's independent `git status` pass and the fix-round's scope check).
+- Commands passed: `bun test` (1118 pass / 1 skip / 0 fail), `bun run check:type` (exit 0), `bash scripts/check-architecture-sync.sh` (exit 0, advisory WARN), `bun scripts/sync-helper-sources.ts --check` (exit 0, 46 helpers), `bash scripts/check-task-sync.sh` (exit 0).
+- External acceptance: pass (see below — one P1 was found and fixed within this review cycle).
+- Residual risks: none blocking. `tasks/notes/*.notes.md` is still scaffold-only (optional to fill before archive).
+- Reviewer action required: none.
+- Rollback: `git checkout -- <file>` per path (all changes additive; no field renamed/removed); `RunnerContract`, `parseRunner`, `runChild`, and run-mode control flow untouched throughout.
+
+## Mode Evidence
+
+- Selected route: Waza /check-style local gate (gatekeeper) run in parallel with external cross-model review (codex-review), per this repo's dual-track review convention.
+- P1/P2/P3 evidence: see External Acceptance Advice below — one P1 raised and resolved; gatekeeper separately raised two LOW findings (one mooted by the P1 fix, one a minor test-symmetry gap, also resolved in the same fix round).
+- Root cause or plan evidence: plan `## Confirmed Role Mapping` / `## Design` sections; contract `## Why` / `## Goal`.
+
+## Verification Evidence
+
+- Waza `/check` run: not separately invoked; equivalent verification performed directly by gatekeeper + orchestrator (see commands below).
+- Commands run:
+  ```
+  bun test                                   → 1118 pass, 1 skip, 0 fail (100 files), exit 0
+  bun run check:type                         → exit 0 (tsc --noEmit clean)
+  bash scripts/check-architecture-sync.sh    → exit 0 (advisory; WARN pending arch requests, all pre-existing/unrelated)
+  bun scripts/sync-helper-sources.ts --check → exit 0 (projection OK: 46 helpers)
+  bash scripts/check-task-sync.sh            → exit 0 (synchronized tasks/ updates)
+  diff scripts/contract-run.ts assets/templates/helpers/contract-run.ts → identical
+  ```
+- Manual checks: orchestrator independently traced the `workerProfile` derivation logic across 6 concrete scenarios before dispatching the fix, then re-read the fixed source directly (`grep -n "workerProfile|onWorkerFallback" scripts/contract-run.ts assets/templates/helpers/contract-run.ts`) to confirm the applied fix matches byte-for-byte in both source and mirror.
+- Supporting artifacts: `.ai/harness/runs/` (contract-run dry-run manifests from test fixtures).
+- Implementation notes reviewed: scaffold only, not filled in (non-blocking — see Residual Risks/Follow-ups).
+- Run snapshot: n/a (no `run`-mode dispatch against a live contract for this task itself; verification was via `dry-run` fixtures in the test suite).
+
+## External Acceptance Advice
+
+> **External Acceptance**: pass
+> **External Reviewer**: Codex
+> **External Source**: codex-review
+> **External Started**: 2026-07-12T21:42:10+0800
+> **External Completed**: 2026-07-12T21:49:00+0800
+> **Review Rubric Version**: 2
+> **Reviewed Diff Fingerprint**: sha256:e28534291ff869d6b86f7da6f82339c8ac4e1accd564e78be0690ff5d54c686f (initial pass, pre-fix)
+> **Reviewed Scope**: branch+staged+unstaged+untracked
+
+- P1 blockers (initial pass — since resolved): `scripts/contract-run.ts:756` (`workerProfile` derived from `onWorkerFallback` instead of the resolved dispatch label directly) — `fallback: null` + `--runner main-thread` incorrectly produced `fast-worker` instead of `sol-high`; a Codex label declared as the contract's `fallback` incorrectly produced `sol-high` instead of passing through unchanged. Fixed by decoupling `workerProfile` from `onWorkerFallback`: `workerProfile` now keys purely on `usedRunner === "main-thread"` / Codex-label checks, while `onWorkerFallback` continues to govern only `runner_usage.path`/`effort`. Independently re-traced and confirmed correct by the orchestrator; new regression tests added for both failure scenarios plus a third gatekeeper-identified coverage gap (`codex-subagent` plain-dispatch pass-through, symmetric to the existing `codex-exec` assertion). Full suite re-verified green (1118/1/0) after the fix.
+- P2 advisories: none from Codex's pass.
+- Acceptance checklist: pass (post-fix; initial pass was fail, resolved same cycle).
+
+## Behavior Diff Notes
+
+- `delegation_plan.role_profiles` added: `parent -> "orchestrator"` (never model-assigned), `explorer -> "explorer"` (fixed), `worker -> <derived>`, `verifier -> "gatekeeper"` (fixed).
+- `worker` derivation (post-fix, final): `usedRunner === "main-thread"` -> `"sol-high"`; else `usedRunner` is `"codex-subagent"`/`"codex-exec"` -> passed through unchanged; else -> `"fast-worker"`. This is now independent of whether `usedRunner` matches the contract's declared `runner.fallback` — that comparison (`onWorkerFallback`) drives only `runner_usage.path`/`effort`, a deliberately separate "did we land on the contract's declared fallback" question.
+- `runner_usage.path` (`"worker_preferred"` | `"worker_fallback"`) and `runner_usage.effort` (tier string or `null`, defaults to `"high"` only on the fallback path) added.
+- `--effort` flag: closed vocabulary low/medium/high/xhigh/max, invalid value exits 2 with a clear `CliError`; record-only, matching `--runner`'s established non-enforcing philosophy.
+- No existing manifest field renamed or repurposed; `RunnerContract`, `parseRunner`, `parseDelegation`, `runChild`, and run-mode control flow all unchanged.
+
+## Residual Risks / Follow-ups
+
+1. `tasks/notes/20260712-2103-agent-fleet-worker-routing-telemetry.notes.md` is still template scaffold. Exit criteria only requires the file to exist (it does), so non-blocking, but the fallback-equality-vs-literal-dispatch design decision (and the P1 it caused) is exactly the kind of non-obvious tradeoff this file exists to capture. Recommend filling one line before archive, not required to ship.
+2. `check-architecture-sync.sh` WARN lists pending requests for capabilities untouched by this task (`workflow-engine-inspection-migration`, `root`) — these belong to separate pre-existing WIP from an earlier session slice; left untouched, correctly out of this task's scope.
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 10/10 | All four telemetry pieces work correctly after the fix; 8 test scenarios across preferred/fallback/pass-through/effort-override/invalid-effort/null-fallback/codex-as-fallback/codex-plain-dispatch all pass. |
+| Product depth | 9/10 | Escalation/telemetry semantics are clean, record-only, and now correctly decoupled between "which model identity" vs "did we hit the declared fallback." |
+| Design quality | 9/10 | Minimal additive change, reuses `RunnerContract` as-is, no renames; the post-fix `workerProfile` derivation is a clear, independent 3-way branch matching the documented spec exactly. |
+| Code quality | 9/10 | Clear names, closed-vocabulary validation with exit 2, byte-identical mirror, well-commented rationale for the local `EFFORT_TIERS` literal, regression tests trace explicit before/after failure reasoning. |
+
+## Failing Items
+
+- None (the one P1 found mid-review was fixed and re-verified within this same cycle).
+
+## Retest Steps
+
+- Re-run: `bun test tests/contract-run.test.ts`
+- Re-check: `bun run check:type`, `bun scripts/sync-helper-sources.ts --check`
+
+## Summary
+
+Additive worker-routing telemetry on `scripts/contract-run.ts`: `delegation_plan.role_profiles` resolves the four contract roles to fleet profiles, a record-only `sol-high` worker-fallback classification plus `runner_usage.path`/`effort` fields, and a validated `--effort` flag — all preserving the existing "never selects/spawns/degrades" philosophy with no `RunnerContract` field renames. Dual-track review (local gatekeeper + external Codex) caught a real P1 in the initial implementation — `workerProfile` was keyed on fallback-match status instead of the literal dispatch label, silently mislabeling any contract with `fallback: null` or a Codex label as its declared fallback. Fixed with a one-line decoupling, independently re-traced by the orchestrator, and covered by three new regression tests. Full suite 1118/1/0, type check, helper-sync, and arch-sync all clean; mirror byte-identical. PASS — recommend committing the goal-manifest paths only, in a single PR, leaving the unrelated fleet-refactor WIP from an earlier session slice untouched.

--- a/tests/contract-run.test.ts
+++ b/tests/contract-run.test.ts
@@ -32,10 +32,11 @@ function writePilotContract(
   repo: string,
   toolCalls: string | number | null = 2,
   why: string = "This pilot proves the worker→verifier file-coupled loop; without it the runner ships unverified.",
-  options: { exemplar?: boolean; stopConditions?: string[] } = {},
+  options: { exemplar?: boolean; stopConditions?: string[]; runnerFallback?: string | null } = {},
 ): string {
   const contractPath = join(repo, "tasks/contracts/pilot.contract.md");
   const budgetValue = toolCalls === null ? "null" : String(toolCalls);
+  const fallbackValue = options.runnerFallback === undefined ? "main-thread" : options.runnerFallback === null ? "null" : options.runnerFallback;
   writeFileSync(
     contractPath,
     [
@@ -103,7 +104,7 @@ function writePilotContract(
       "      - codex-subagent",
       "      - codex-exec",
       "      - main-thread",
-      "    fallback: main-thread",
+      `    fallback: ${fallbackValue}`,
       "    brief_is_authoritative: true",
       "```",
       "",
@@ -766,6 +767,20 @@ describe("contract-run helper", () => {
       const runnerUsage = manifest.runner_usage as { used: string; off_policy: boolean };
       expect(runnerUsage.used).toBe("subagent");
       expect(runnerUsage.off_policy).toBe(false);
+      const runnerUsagePath = manifest.runner_usage as { path: string; effort: string | null };
+      expect(runnerUsagePath.path).toBe("worker_preferred");
+      expect(runnerUsagePath.effort).toBe(null);
+      const roleProfiles = (
+        manifest.delegation_plan as {
+          role_profiles: { parent: string; explorer: string; worker: string; verifier: string };
+        }
+      ).role_profiles;
+      expect(roleProfiles).toEqual({
+        parent: "orchestrator",
+        explorer: "explorer",
+        worker: "fast-worker",
+        verifier: "gatekeeper",
+      });
 
       const codexSubagentRes = runContractRun(repo, [
         "dry-run",
@@ -784,6 +799,13 @@ describe("contract-run helper", () => {
       const codexSubagentUsage = codexSubagentManifest.runner_usage as { used: string; off_policy: boolean };
       expect(codexSubagentUsage.used).toBe("codex-subagent");
       expect(codexSubagentUsage.off_policy).toBe(false);
+      // Plain preferred-list dispatch (this fixture's fallback is main-thread, not
+      // codex-subagent): the Codex label must still pass through unchanged, symmetric to
+      // the codex-exec assertion below.
+      const codexSubagentRoleProfiles = (
+        codexSubagentManifest.delegation_plan as { role_profiles: { worker: string } }
+      ).role_profiles;
+      expect(codexSubagentRoleProfiles.worker).toBe("codex-subagent");
 
       const offPolicyRes = runContractRun(repo, [
         "dry-run",
@@ -802,9 +824,156 @@ describe("contract-run helper", () => {
       const offPolicyUsage = offPolicyManifest.runner_usage as { used: string; off_policy: boolean };
       expect(offPolicyUsage.used).toBe("gpt-5-cli");
       expect(offPolicyUsage.off_policy).toBe(true);
+
+      // --runner main-thread matches the fixture's declared worker fallback, so the
+      // worker model identity derives to sol-high and effort defaults to "high".
+      const workerFallbackRes = runContractRun(repo, [
+        "dry-run",
+        "--repo",
+        repo,
+        "--contract",
+        "tasks/contracts/pilot.contract.md",
+        "--out",
+        ".ai/harness/runs/runner-worker-fallback",
+        "--runner",
+        "main-thread",
+        "--json",
+      ]);
+      expect(workerFallbackRes.status).toBe(0);
+      const workerFallbackManifest = parseJson(workerFallbackRes.stdout);
+      const workerFallbackUsage = workerFallbackManifest.runner_usage as {
+        used: string;
+        path: string;
+        effort: string | null;
+      };
+      expect(workerFallbackUsage.path).toBe("worker_fallback");
+      expect(workerFallbackUsage.effort).toBe("high");
+      const workerFallbackRoleProfiles = (
+        workerFallbackManifest.delegation_plan as { role_profiles: { worker: string } }
+      ).role_profiles;
+      expect(workerFallbackRoleProfiles.worker).toBe("sol-high");
+
+      // --runner codex-exec is a Codex dispatch value: pass through unchanged rather than
+      // coercing to fast-worker or sol-high, since Codex is an independent peer engineer.
+      const codexExecRes = runContractRun(repo, [
+        "dry-run",
+        "--repo",
+        repo,
+        "--contract",
+        "tasks/contracts/pilot.contract.md",
+        "--out",
+        ".ai/harness/runs/runner-codex-exec",
+        "--runner",
+        "codex-exec",
+        "--json",
+      ]);
+      expect(codexExecRes.status).toBe(0);
+      const codexExecManifest = parseJson(codexExecRes.stdout);
+      const codexExecRoleProfiles = (
+        codexExecManifest.delegation_plan as { role_profiles: { worker: string } }
+      ).role_profiles;
+      expect(codexExecRoleProfiles.worker).toBe("codex-exec");
+
+      // An explicit --effort beats the "high" default that worker_fallback would otherwise apply.
+      const workerFallbackXhighRes = runContractRun(repo, [
+        "dry-run",
+        "--repo",
+        repo,
+        "--contract",
+        "tasks/contracts/pilot.contract.md",
+        "--out",
+        ".ai/harness/runs/runner-worker-fallback-xhigh",
+        "--runner",
+        "main-thread",
+        "--effort",
+        "xhigh",
+        "--json",
+      ]);
+      expect(workerFallbackXhighRes.status).toBe(0);
+      const workerFallbackXhighManifest = parseJson(workerFallbackXhighRes.stdout);
+      const workerFallbackXhighUsage = workerFallbackXhighManifest.runner_usage as { effort: string | null };
+      expect(workerFallbackXhighUsage.effort).toBe("xhigh");
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }
+  });
+
+  // Worker identity must key off the literal --runner value alone, never off whether it
+  // happens to match the contract's declared worker fallback. That "did we land on the
+  // contract's fallback" question stays legitimate for runner_usage.path/effort only.
+  test("--runner main-thread resolves worker identity to sol-high even when the contract declares no fallback", () => {
+    const repo = makeRepo("contract-run-runner-nofallback-");
+    try {
+      writePilotContract(repo, 2, undefined, { runnerFallback: null });
+      const res = runContractRun(repo, [
+        "dry-run",
+        "--repo",
+        repo,
+        "--contract",
+        "tasks/contracts/pilot.contract.md",
+        "--out",
+        ".ai/harness/runs/runner-no-fallback",
+        "--runner",
+        "main-thread",
+        "--json",
+      ]);
+      expect(res.status).toBe(0);
+      const manifest = parseJson(res.stdout);
+      const runner = (manifest.delegation as { runner: { fallback: string | null } }).runner;
+      expect(runner.fallback).toBe(null);
+      // main-thread does not match the (nonexistent) fallback, so this is worker_preferred
+      // with no effort default -- yet role_profiles.worker must still be sol-high.
+      const runnerUsage = manifest.runner_usage as { path: string; effort: string | null };
+      expect(runnerUsage.path).toBe("worker_preferred");
+      expect(runnerUsage.effort).toBe(null);
+      const roleProfiles = (
+        manifest.delegation_plan as { role_profiles: { worker: string } }
+      ).role_profiles;
+      expect(roleProfiles.worker).toBe("sol-high");
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  test("a Codex runner label passes through unchanged even when it is the contract's declared fallback", () => {
+    const repo = makeRepo("contract-run-runner-codexfallback-");
+    try {
+      writePilotContract(repo, 2, undefined, { runnerFallback: "codex-subagent" });
+      const res = runContractRun(repo, [
+        "dry-run",
+        "--repo",
+        repo,
+        "--contract",
+        "tasks/contracts/pilot.contract.md",
+        "--out",
+        ".ai/harness/runs/runner-codex-fallback",
+        "--runner",
+        "codex-subagent",
+        "--json",
+      ]);
+      expect(res.status).toBe(0);
+      const manifest = parseJson(res.stdout);
+      const runner = (manifest.delegation as { runner: { fallback: string | null } }).runner;
+      expect(runner.fallback).toBe("codex-subagent");
+      // codex-subagent DOES match the declared fallback here, so worker_fallback is the
+      // correct path -- that half of the derivation is orthogonal and untouched by the fix.
+      const runnerUsage = manifest.runner_usage as { path: string };
+      expect(runnerUsage.path).toBe("worker_fallback");
+      const roleProfiles = (
+        manifest.delegation_plan as { role_profiles: { worker: string } }
+      ).role_profiles;
+      // Codex is an independent peer provider: matching the contract's fallback must never
+      // coerce it into sol-high (or fast-worker).
+      expect(roleProfiles.worker).toBe("codex-subagent");
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  test("invalid --effort value exits with usage error", () => {
+    const res = runContractRun(ROOT, ["dry-run", "--effort", "nonsense"]);
+    expect(res.status).toBe(2);
+    expect(res.stderr).toContain("contract-run: --effort must be one of low, medium, high, xhigh, max");
   });
 
   test("run fails closed on a blank Out of scope even though In scope is populated", () => {


### PR DESCRIPTION
## Summary
- Resolves contract roles (`parent`/`explorer`/`worker`/`verifier`) to the four fleet profiles (explorer/fast-worker/deep-reasoner/gatekeeper) via a new `delegation_plan.role_profiles` manifest field.
- Worker role escalates from `fast-worker` to a record-only `sol-high` single-shot identity when the resolved runner dispatch is `main-thread`; Codex dispatch labels (`codex-subagent`/`codex-exec`) pass through unchanged. `RunnerContract.preferred`/`fallback`'s existing dispatch-mechanism vocabulary is untouched.
- Adds a validated `--effort <tier>` flag (low/medium/high/xhigh/max) and `runner_usage.path`/`effort` telemetry fields, additive only.
- Extends the `workflow-engine-contract-assets` capability doc + registry instead of minting a new capability.

## Review
Dual-track review (local gatekeeper + external Codex cross-review) caught a real P1 in the initial implementation: worker-profile identity was keyed on whether the resolved runner matched the contract's declared `fallback` field, instead of the literal dispatch label. This silently mislabeled any contract declaring `fallback: null` or a Codex label as its fallback. Fixed by decoupling the two checks; three new regression tests cover the previously-broken scenarios. Full details in `tasks/reviews/20260712-2103-agent-fleet-worker-routing-telemetry.review.md`.

## Test plan
- [x] `bun test` — 1146 pass, 1 skip, 0 fail (full suite, run in this branch's worktree)
- [x] `bun run check:type` — clean
- [x] `bun scripts/sync-helper-sources.ts --check` — projection OK
- [x] `bash scripts/check-architecture-sync.sh` — advisory, 0 blocking