### PR TITLE
fix(release): drop retired provider literal from 0.10.0 skill-version description

### DIFF
--- a/assets/skill-version.json
+++ b/assets/skill-version.json
@@ -202,7 +202,7 @@
     },
     {
       "version": "0.10.0",
-      "description": "Adds the risk-aware lite/standard/strict harness kernel with the effective-state resolver, decouples benchmark evidence production from verification gates with content-bound acceptance freshness, replaces the remote agent-fleet dependency with npm-packaged sources, and removes gstack and the Human Review Card dual authority"
+      "description": "Adds the risk-aware lite/standard/strict harness kernel with the effective-state resolver, decouples benchmark evidence production from verification gates with content-bound acceptance freshness, replaces the remote agent-fleet dependency with npm-packaged sources, and removes the retired planning provider and the Human Review Card dual authority"
     }
   ],
   "generatedProjectStamp": {


### PR DESCRIPTION
- main CI has been red since `102e8ef` / `ca15eff` (0.10.0 release prep): the 0.10.0 `description` in `assets/skill-version.json` contains the literal token `gstack`, which trips `tests/retired-planning-provider.test.ts` (a case-insensitive substring scan over `ACTIVE_SURFACES`).
- Fix rewords that clause to "the retired planning provider" (the wording used in the test's own `describe` block). `assets/skill-version.json` is a hand-maintained source of truth — `scripts/assemble-template.ts` only reads it, so the edit is not regenerated.
- Unblocks PR #70, whose Test job fails on the same scan once merged with main.
