### PR TITLE
fix: close 0.10.0 release blockers

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -18,8 +18,8 @@ Treat that JSON as the state authority. Read Plan, Contract, checks, handoff, ar
 
 ## Actions
 
-1. **setup** — install, adopt, migrate, repair, or scaffold the harness. Inspect first with `repo-harness adopt --repo . --dry-run`; load `references/harness-overview.md` only when setup detail is needed.
-2. **plan** — create or capture a decision-complete plan. Use `repo-harness-plan`; load `docs/reference-configs/agentic-development-flow.md` for promotion boundaries.
+1. **setup** — install, adopt, migrate, repair, or scaffold the harness. Inspect first with `repo-harness adopt --repo . --dry-run`; run `repo-harness docs show harness-overview` when setup detail is needed.
+2. **plan** — create or capture a decision-complete plan. Use `repo-harness-plan`; run `repo-harness docs show agentic-development-flow` for promotion boundaries.
 3. **execute** — continue the active task using its resolved profile and allowed paths. Lite uses brief → edit → targeted test; Standard uses plan → edit → verify → at most one review; Strict follows the Contract/worktree/checks/external-acceptance chain.
 4. **verify** — run targeted tests and the profile-required gates. Use `repo-harness-check`; never infer provider-owned evidence.
 5. **handoff** — refresh compact recovery state with `repo-harness-handoff`; inject references and deltas, not full artifact copies.

--- a/bun.lock
+++ b/bun.lock
@@ -17,9 +17,6 @@
         "archctx-contracts": "0.2.2",
         "typescript": "^7.0.2",
       },
-      "optionalDependencies": {
-        "node-pty": "^1.1.0",
-      },
     },
   },
   "packages": {
@@ -222,10 +219,6 @@
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
-
-    "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
-
-    "node-pty": ["node-pty@1.1.0", "", { "dependencies": { "node-addon-api": "^7.1.0" } }, "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 

--- a/deploy/release-checklists/260714-repo-harness-0.10.0.md
+++ b/deploy/release-checklists/260714-repo-harness-0.10.0.md
@@ -6,10 +6,11 @@
 - Release scope: minor release for the risk-aware harness kernel
   (lite/standard/strict profiles plus the effective-state resolver), the
   verification/evidence decoupling of contract gates, the npm-packaged agent
-  fleet authority, and gstack removal.
-- Publish status: **prepared, not published**. Version surfaces, changelog,
-  and this filing are bumped on `main`; npm publish, the `v0.10.0` tag, and
-  the GitHub release have not been executed.
+  fleet authority, gstack removal, and the release-blocker hardening below.
+- Publish status: **release-blocker candidate, not published**. The source
+  branch still requires merge plus green CI. npm publish, the `v0.10.0` tag,
+  and the GitHub release require a separate explicit release authorization and
+  have not been executed.
 
 ## Scope
 
@@ -26,6 +27,11 @@
 - Replaces the remote `Fable-agents` fleet dependency with the npm-packaged
   `agents/fleet/*.md` authority and removes gstack from planning routes,
   policy, and install/update guidance.
+- Preserves the installed profile through update, rejects non-canonical
+  install ownership paths, resolves root-Skill guidance through packaged docs,
+  commits coding grants only after validation/config write, bounds OAuth
+  request/client state, and removes the unreachable Bun PTY contract and
+  dependency.
 
 ## Preflight Evidence
 
@@ -33,7 +39,7 @@
   https://registry.npmjs.org/` returned `version: 0.9.2` and
   `dist-tags.latest: 0.9.2` at prepare time.
 - `npm pack --dry-run --json --ignore-scripts` reported
-  `repo-harness-0.10.0.tgz` with 382 files.
+  `repo-harness-0.10.0.tgz` with 393 files on the frozen source candidate.
 - Version parity: `package.json`, `assets/skill-version.json`
   (version + templateVersion + 0.10.0 ledger entry), `.claude/.skill-version`
   stamp, and the five README variants all read `0.10.0`.
@@ -49,9 +55,33 @@
 - At prepare time: `bun scripts/check-skill-version.ts --project .` and
   `repo-harness run check-task-workflow --strict` pass on the bumped tree
   (recorded below after global refresh).
-- Deferred to publish time: `bun run check:release` (full release gate
-  including package dry-run and tarball install smoke on the release commit),
-  CI green on the pushed commit.
+- Candidate freeze: `bun run check:release` passed, including the complete CI
+  gate, package dry-run, and tarball install smoke. GitHub CI on the pushed
+  commit remains the remote merge gate.
+
+## Release-blocker Candidate Evidence
+
+- Pre-fix regressions are recorded in
+  `.ai/harness/runs/20260714-0.10.0-release-blockers-pre-fix.log`: the prior
+  source deletes a crafted external ownership path, loses `strict` on update,
+  leaks `read_write` after invalid endpoint validation, exposes PTY fields,
+  and lacks the bounded HTTP/OAuth seams.
+- Focused candidate verification covered the global runtime, install profiles,
+  status readback, MCP setup/HTTP/OAuth/process/coding tools, registry failure
+  compensation, docs, and bootstrap surfaces with 0 failures; typecheck also
+  passed.
+- The frozen local source passed `bun run check:release`; package count is 393
+  and installed tarball CLI bins start. Exact commit, PR/CI result, and merge
+  commit remain pending until the candidate is committed and pushed.
+
+## Accepted Residual Availability Risks
+
+- One tunnel socket shares an OAuth rate-limit identity because no trusted
+  proxy contract exists; forwarded headers remain intentionally untrusted.
+- Unauthenticated dynamic client registration can fill the fixed 64-client,
+  30-day capacity. The bound prevents unbounded state growth and does not grant
+  authorization, but a filled capacity can deny new registrations until state
+  expires or an operator resets the local OAuth state.
 
 ## Publish Checklist
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,19 @@ All notable changes to this skill are documented here.
 
 ### Fixed
 
+- Preserved the recorded install profile during ordinary `repo-harness update`
+  instead of silently projecting `minimal`, and rejected persisted ownership
+  paths outside the exact managed-surface allowlist before profile-switch
+  deletion.
+- Made the packaged root Skill resolve detailed guidance through
+  `repo-harness docs show <id>` and added installed-tarball smoke coverage for
+  both referenced documents.
+- Hardened the unshipped coding MCP surface: setup now validates every grant
+  and fallible option before committing `read_write`; OAuth rate limits use
+  direct-socket, canonical-route identities with bounded buckets; dynamic
+  clients have fixed expiry/capacity; and the unreachable Bun PTY schema and
+  `node-pty` dependency were removed while pipe stdin, polling, SIGINT, and
+  process-tree cleanup remain supported.
 - Removed the external `gbrain` tooling dependency from setup/adoption policy,
   install choices, readiness detection, generated guidance, and migration
   routing. Brain-vault export remains an explicit operator command, while

--- a/docs/architecture/modules/runtime-harness/hook-adapters.md
+++ b/docs/architecture/modules/runtime-harness/hook-adapters.md
@@ -18,6 +18,9 @@ Authoritative split:
   scripts under repo-local `scripts/` or `.ai/harness/scripts/`. The self-host
   repo keeps source helpers under root `scripts/`.
 - `src/cli/installer/targets/*`: user-level adapter writers for `~/.claude/settings.json` and `~/.codex/hooks.json`.
+- `~/.repo-harness/install-state.json`: sole installed-profile authority. Its
+  `components` field is the exact ordered projection of `profile`; only
+  canonical host mutation paths with coherent ownership proofs may be removed.
 - `src/cli/hook/*`: public route registry and compatibility runtime bridge.
 - `src/cli/hook-entry.ts`: minimal hook-only entrypoint that checks repo opt-in and dispatches ordered `.ai/hooks/*` scripts without loading the full CLI.
 - `src/cli/commands/security.ts`: read-only security scan for user-level hook config and VS Code folder-open task injection surfaces.
@@ -101,6 +104,10 @@ Error paths:
 - Hook input parsing falls back across stdin JSON, env, and argv compatibility.
 - Worktree guard warns by default and blocks only when marker policy is enabled.
 - Runtime write failures should produce structured warnings or failure logs without corrupting the repo contract.
+- `repo-harness update` resolves command environment -> persisted install state
+  -> exact profile component projection before runtime mutation. Missing state
+  alone selects `minimal`; malformed, conflicting, or non-canonical ownership
+  state fails closed before any host path is changed.
 
 ## 2026-07-14 Review Subject and Acceptance Authority Cutover
 
@@ -304,6 +311,12 @@ At 10x hook events, the first failure is cold-loading the full CLI on every
 hook event. The invariant is that host adapters point at the minimal
 hook-only entrypoint and then `.ai/hooks`, instead of creating separate
 per-host implementation trees or loading non-hook command modules.
+
+Install/update keeps the same one-authority invariant: profile selects the
+component set, and the ownership manifest proves only concrete paths eligible
+for deletion. At 10x managed surfaces, the first unsafe failure would be a
+forged or stale manifest widening deletion scope; exact canonical-path
+membership plus type/hash/marker coherence rejects that state before mutation.
 
 ## 2026-06-12 Architecture Queue Closeout
 

--- a/docs/architecture/modules/runtime-harness/mcp-sidecar.md
+++ b/docs/architecture/modules/runtime-harness/mcp-sidecar.md
@@ -12,8 +12,9 @@ operator-managed HTTPS tunnel.
 - `setup.ts`, `auth.ts`, and `repo-registry.ts` own ignored v3 config, stable
   repo ids, access modes, and the monotonically increasing authorization
   revision.
-- `oauth.ts` issues an opaque identity for each coding authorization grant and
-  preserves it across refresh-token rotation.
+- `oauth.ts` issues an opaque identity for each coding authorization grant,
+  preserves it across refresh-token rotation, and bounds dynamic clients by
+  capacity and expiry.
 - `transports/http.ts` owns Streamable HTTP, Host/CORS, OAuth discovery,
   DCR/PKCE, redirect allowlists, transport-session lifecycle, and the bounded
   authorization-runtime registry.
@@ -23,7 +24,7 @@ operator-managed HTTPS tunnel.
   worktrees, instruction discovery, and local cleanup metadata.
 - `coding-tools.ts` owns workspace-relative read and rollback-capable guarded
   file mutation plus mutation/audit/index evidence.
-- `process-sessions.ts` owns local-user Bash/optional PTY sessions, output bounds,
+- `process-sessions.ts` owns pipe-only local-user Bash sessions, output bounds,
   process-tree cleanup, environment scrubbing, and ownership isolation.
 - CodeGraph remains an optional index adapter. The filesystem and repo registry
   remain authorization and content truth.
@@ -51,11 +52,14 @@ repo-grant change, coding disable, 30-minute authorization idle expiry, process
 timeout, or server shutdown. Managed worktrees remain for local inspection and
 require a clean, merged state before local cleanup.
 
-Error paths fail closed: missing grant, stale OAuth revision, invalid Host,
+OAuth request limits use the direct socket plus canonical route as identity;
+forwarded headers never mint new buckets. Error paths fail closed: missing
+grant, stale OAuth revision, dynamic-client or rate-bucket capacity, invalid Host,
 wildcard/foreign Origin, unregistered redirect, traversal, secret path,
-symlink, stale file revision, process ownership mismatch, environment secret,
-and unavailable PTY return explicit errors without changing profile or falling
-back to a weaker execution mode.
+symlink, stale file revision, process ownership mismatch, and environment
+secrets return explicit errors without changing profile or falling back to a
+weaker execution mode. PTY and terminal resize are not public contracts under
+the Bun runtime; stdin, polling, SIGINT, and process-tree cleanup remain supported.
 
 ## Semantic Diagram
 

--- a/docs/architecture/modules/workflow-engine/contract-assets.md
+++ b/docs/architecture/modules/workflow-engine/contract-assets.md
@@ -25,6 +25,9 @@ Authoritative files:
 - `scripts/ship-worktrees.sh`: PR push choke point and final receipt revalidation.
 - `assets/skills/merge-gate/`: semantic review protocol installed only on the declared local gatekeeper host.
 - `src/cli/commands/capability-context.ts`: one-way projection of registered capability context into controlled agent blocks.
+- `src/cli/commands/global-runtime.ts`: install/update entrypoint that preserves
+  the persisted install profile rather than creating a second CLI-default
+  authority.
 - `assets/templates/` and `.claude/templates/`: generated workflow document templates.
 - `assets/reference-configs/` and `docs/reference-configs/`: repo-local and installable reference config corpus.
 
@@ -55,6 +58,10 @@ Error paths:
   review, handoff, and resume freshness bind exact content fingerprints.
 - `.claude/.active-plan` is not a steady-state reader or writer. The only
   reader is the explicit `state migrate-legacy-active-plan` one-shot command.
+- Global update resolves its command environment, reads the installed-profile
+  authority, validates the exact profile-to-components projection, and only
+  then invokes the runtime projection. Invalid state stops before package,
+  adapter, skill, or hook mutation.
 
 ## P3 Decision
 
@@ -71,6 +78,12 @@ ignored effective-state cache cannot roll the version backward.
 At 10x generated repos, the first failure would be self-host behavior diverging
 from generated output. The smallest coherent guard is parity tests plus
 self-migration dry-run.
+
+The install profile remains one datum with one authored authority: `profile`.
+`components` is a deterministic drift-checked projection, while ownership is a
+separate concrete filesystem proof. This prevents contract/runtime updates from
+silently downgrading Strict installs or trusting component labels as deletion
+authority.
 
 ## 2026-07-14 Local Merge Gate Enforcement
 

--- a/docs/reference-configs/chatgpt-coding-mcp.md
+++ b/docs/reference-configs/chatgpt-coding-mcp.md
@@ -128,8 +128,8 @@ an invocation.
 - `read` accepts workspace-relative paths and returns a SHA-256 revision.
 - `apply_patch` performs guarded create/replace/delete/move operations as one
   rollback-capable transaction.
-- `exec_command` starts pipe or requested PTY sessions. `write_stdin` polls,
-  writes input, resizes PTY, or sends Ctrl-C.
+- `exec_command` starts pipe-only Bash sessions. `write_stdin` polls, writes
+  input, or sends Ctrl-C/SIGINT.
 - ChatGPT may initialize a fresh MCP transport for each tool call. Workspace and
   process ids remain usable across those transports only while they present
   tokens from the same OAuth authorization grant; another grant cannot reuse a
@@ -161,9 +161,9 @@ cookies, and private/API keys are always rejected. The name filter is
 conservative: any configured key containing `KEY`, `PASS`, or `AUTH` is denied,
 including compact forms such as `APIKEY`, `PASSWD`, and `BASICAUTH`.
 
-`node-pty` is optional. Under Bun 1.3.x its event delivery is unreliable, so a
-PTY request returns `PTY_UNAVAILABLE` instead of hanging or silently changing to
-pipe execution. Pipe sessions and the PTY manager contract remain supported.
+PTY and terminal resize are not part of the Bun coding-process contract. Pipe
+sessions retain stdin, polling, Ctrl-C/SIGINT, output bounds, and process-tree
+cleanup.
 
 Audit records hashes and metadata only: actor/session, command hash, relative
 cwd, duration, exit/signal, and byte counts. They do not store raw command,

--- a/package.json
+++ b/package.json
@@ -67,8 +67,5 @@
     "@modelcontextprotocol/sdk": "^1.28.0",
     "commander": "^15.0.0",
     "express": "^5.2.1"
-  },
-  "optionalDependencies": {
-    "node-pty": "^1.1.0"
   }
 }

--- a/plans/archive/plan-20260714-2128-3p-cli-skill-mcp-boundary.md
+++ b/plans/archive/plan-20260714-2128-3p-cli-skill-mcp-boundary.md
@@ -1,6 +1,6 @@
 # Plan: 3P CLI/Skill/MCP boundary optimization
 
-> **Status**: Executing
+> **Status**: Archived
 > **Created**: 20260714-2128
 > **Slug**: 3p-cli-skill-mcp-boundary
 > **Planning Source**: repo-harness-plan

--- a/plans/plan-20260714-2318-repo-harness-0-10-0-release-blockers.md
+++ b/plans/plan-20260714-2318-repo-harness-0-10-0-release-blockers.md
@@ -1,0 +1,167 @@
+# Plan: repo-harness 0.10.0 release-blocker closeout
+
+> **Status**: Executing
+> **Created**: 20260714-2318
+> **Slug**: repo-harness-0-10-0-release-blockers
+> **Planning Source**: repo-harness-plan
+> **Orchestration Kind**: host-plan
+> **Source Ref**: (none)
+> **Artifact Level**: work-package
+> **Promotion Reason**: risk_boundary
+> **Verification Boundary**: Focused regressions, deep review, frozen-HEAD release gate, CI, npm and installed-runtime readback must agree
+> **Rollback Surface**: Revert the release-blocker commit before publish; after npm publish use a patch release
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260714-2318-repo-harness-0-10-0-release-blockers.contract.md`
+> **Task Review**: `tasks/reviews/20260714-2318-repo-harness-0-10-0-release-blockers.review.md`
+> **Implementation Notes**: `tasks/notes/20260714-2318-repo-harness-0-10-0-release-blockers.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from repo-harness-plan planning output.
+- Source ref: (none)
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260714-2318-repo-harness-0-10-0-release-blockers.md`
+- Sprint contract: `tasks/contracts/20260714-2318-repo-harness-0-10-0-release-blockers.contract.md`
+- Sprint review: `tasks/reviews/20260714-2318-repo-harness-0-10-0-release-blockers.review.md`
+- Implementation notes: `tasks/notes/20260714-2318-repo-harness-0-10-0-release-blockers.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260714-2318-repo-harness-0-10-0-release-blockers.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260714-2318-repo-harness-0-10-0-release-blockers.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260714-2318-repo-harness-0-10-0-release-blockers.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260714-2318-repo-harness-0-10-0-release-blockers.contract.md`
+- Review file: `tasks/reviews/20260714-2318-repo-harness-0-10-0-release-blockers.review.md`
+- Implementation notes file: `tasks/notes/20260714-2318-repo-harness-0-10-0-release-blockers.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260714-2318-repo-harness-0-10-0-release-blockers.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260714-2318-repo-harness-0-10-0-release-blockers.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: Revert the release-blocker commit before publish; after npm publish use a patch release
+- **Verification boundary**: Focused regressions, deep review, frozen-HEAD release gate, CI, npm and installed-runtime readback must agree
+- **Review/acceptance boundary**: `tasks/reviews/20260714-2318-repo-harness-0-10-0-release-blockers.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: risk_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260714-2318-repo-harness-0-10-0-release-blockers.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260714-2318-repo-harness-0-10-0-release-blockers.contract.md`, `tasks/reviews/20260714-2318-repo-harness-0-10-0-release-blockers.review.md`, and `tasks/notes/20260714-2318-repo-harness-0-10-0-release-blockers.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260714-2318-repo-harness-0-10-0-release-blockers.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: Revert the release-blocker commit before publish; after npm publish use a patch release
+
+## Captured Planning Output
+
+# repo-harness 0.10.0 release-blocker closeout
+
+## Goal
+
+Remove every confirmed P1 release blocker and the bounded safety P2 findings from the `v0.9.2..HEAD` deep review, freeze one coherent `0.10.0` source commit, then publish npm and GitHub release surfaces only after focused regression, full release-gate, CI, package, and installed-runtime evidence agree.
+
+## P1: Architecture Map
+
+- Global runtime update path: `src/cli/index.ts` parses `update`; `src/cli/commands/global-runtime.ts` projects the selected install profile into packaged Skills and host adapters; `src/cli/installer/install-profile.ts` owns recorded profile authority and managed-surface ownership.
+- Packaged Skill docs: root `SKILL.md` is shipped, `assets/reference-configs/` is the packaged documentation authority, and `src/cli/commands/docs.ts` is the stable runtime resolver.
+- Coding MCP setup: `src/cli/mcp/setup.ts` validates and writes ignored user config; `src/effects/repo-registry.ts` owns persisted repo access mode/revision; general-repo mutation exposure consumes only that registry authority.
+- HTTP/OAuth: `src/cli/mcp/transports/http.ts` owns request identity and rate buckets; `src/cli/mcp/oauth.ts` owns dynamic client persistence and token limits.
+- Distribution: `docs/CHANGELOG.md`, the dated release filing, `package.json`/lockfile, npm tarball contents, tag, GitHub Release, and the PATH-visible Bun install are distinct release surfaces.
+
+Out of scope: compatibility aliases/fallbacks, dual install-profile authority, heuristic semantic recovery, new proxy configuration knobs, broad MCP redesign, unrelated PR #75, and speculative refactors.
+
+## P2: Concrete Traces
+
+1. A recorded `strict` install runs ordinary `repo-harness update`; the CLI omits `profile`, global runtime defaults to `minimal`, and adapter projection deletes strict-only managed routes. Preserve the recorded profile; use `minimal` only when no recorded state exists.
+2. An installed agent reads shipped root `SKILL.md`; its relative `references/...` and `docs/reference-configs/...` targets are absent from the npm archive. Route both references through `repo-harness docs show <id>` and smoke them from the packed install.
+3. Coding setup receives a valid read-write grant plus an invalid later option; current code persists `read_write` before endpoint/root/server/config validation fails. Preflight every fallible input/grant first, atomically write inert config, and commit registry access last so failure cannot expose mutation tools.
+4. A crafted install-state manifest points a retired owned surface at an arbitrary absolute path with a matching hash/marker; profile switch trusts it and recursively deletes outside the canonical managed allowlist. Strictly validate persisted state against exact canonical managed surfaces and revalidate immediately before removal.
+5. HTTP trusts `X-Forwarded-For` unconditionally and retains unbounded IP/path buckets; DCR clients are also unbounded. Use direct socket identity, prune expired buckets, cap bucket/client collections, and fail closed at capacity.
+6. The official CLI runs under Bun while `defaultPtyFactory` always rejects Bun before importing optional `node-pty`; the public `tty/rows/columns` fields therefore advertise an unreachable feature. Cut the unshipped PTY contract and dependency rather than add a fallback runtime.
+
+## P3: Design Decision
+
+Preserve the existing authorities and remove the unsafe ordering/invalid surfaces at their narrowest boundaries. Recorded install state remains the sole profile authority; bundled docs remain the sole packaged reference authority; registry mode remains the sole mutation authority; direct socket identity remains the rate-limit identity until an explicit trusted-proxy contract exists. Validation rejects malformed state rather than translating it. The unshipped PTY branch is deleted in the same release package so no compatibility shim survives.
+
+At 10x scale, the first pressure point is HTTP/DCR state cardinality; fixed TTL/caps bound it. Update/profile and setup permissions are correctness/security invariants independent of scale.
+
+## Task Breakdown
+
+- [ ] Capture pre-fix regression evidence for update profile loss, coding setup permission leak, crafted install-state deletion, forwarded-header bucket bypass, packaged Skill references, and Bun PTY unreachability.
+- [ ] Preserve the recorded install profile through `update` and add strict/product-planning CLI regressions.
+- [ ] Replace root Skill file references with packaged docs resolver commands and extend tarball smoke.
+- [ ] Reorder coding setup into full preflight, inert config write, then registry authorization commit; prove every late failure leaves mode/revision unchanged.
+- [ ] Strictly validate install-state schema and canonical managed paths before any profile-switch deletion; prove crafted external paths survive and fail closed.
+- [ ] Bound HTTP rate buckets and dynamic OAuth clients using direct socket identity, TTL, and caps; prove direct XFF spoofing cannot create identities.
+- [ ] Remove the unreachable PTY option/dependency from the unshipped coding MCP surface and keep pipe sessions fail-closed and covered.
+- [ ] Refresh `0.10.0` changelog/release filing with coding MCP scope, exact frozen commit, package contents, verification, and residual risk.
+- [ ] Run focused tests, `git diff --check`, dependency/package inspection, architecture/task/workflow checks, deep security/architecture re-review, and one final `bun run check:release` after code freeze.
+- [ ] Commit and push the reviewed slice; require green GitHub CI; publish npm; read registry tarball back; create annotated `v0.10.0`; create GitHub Release using the prior release format; reinstall from npm under Bun; run published-release/setup/CLI readbacks.
+
+## Verification Boundary
+
+- Focused: global runtime/update, install profiles, MCP setup, MCP HTTP/OAuth/process sessions, CLI docs, package/readme/skill contracts, tarball smoke.
+- Full: project Required Checks plus `bun run check:release`, current GitHub CI, `bash scripts/check-release-published.sh 0.10.0`, npm archive readback, and PATH-visible Bun registry install proof.
+- Review: fresh `/check` deep review with zero P1/P2 blockers on the frozen diff.
+
+## Rollback Surface
+
+Before publish, revert the single release-blocker commit. After npm publish, npm is immutable: roll back through a new patch release; the Git tag/Release must continue pointing at the exact published source commit.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [ ] Capture pre-fix regression evidence for update profile loss, coding setup permission leak, crafted install-state deletion, forwarded-header bucket bypass, packaged Skill references, and Bun PTY unreachability.
+- [ ] Preserve the recorded install profile through `update` and add strict/product-planning CLI regressions.
+- [ ] Replace root Skill file references with packaged docs resolver commands and extend tarball smoke.
+- [ ] Reorder coding setup into full preflight, inert config write, then registry authorization commit; prove every late failure leaves mode/revision unchanged.
+- [ ] Strictly validate install-state schema and canonical managed paths before any profile-switch deletion; prove crafted external paths survive and fail closed.
+- [ ] Bound HTTP rate buckets and dynamic OAuth clients using direct socket identity, TTL, and caps; prove direct XFF spoofing cannot create identities.
+- [ ] Remove the unreachable PTY option/dependency from the unshipped coding MCP surface and keep pipe sessions fail-closed and covered.
+- [ ] Refresh `0.10.0` changelog/release filing with coding MCP scope, exact frozen commit, package contents, verification, and residual risk.
+- [ ] Run focused tests, `git diff --check`, dependency/package inspection, architecture/task/workflow checks, deep security/architecture re-review, and one final `bun run check:release` after code freeze.
+- [ ] Commit and push the reviewed slice; require green GitHub CI; publish npm; read registry tarball back; create annotated `v0.10.0`; create GitHub Release using the prior release format; reinstall from npm under Bun; run published-release/setup/CLI readbacks.

--- a/plans/plan-20260714-2318-repo-harness-0-10-0-release-blockers.md
+++ b/plans/plan-20260714-2318-repo-harness-0-10-0-release-blockers.md
@@ -130,16 +130,16 @@ At 10x scale, the first pressure point is HTTP/DCR state cardinality; fixed TTL/
 
 ## Task Breakdown
 
-- [ ] Capture pre-fix regression evidence for update profile loss, coding setup permission leak, crafted install-state deletion, forwarded-header bucket bypass, packaged Skill references, and Bun PTY unreachability.
-- [ ] Preserve the recorded install profile through `update` and add strict/product-planning CLI regressions.
-- [ ] Replace root Skill file references with packaged docs resolver commands and extend tarball smoke.
-- [ ] Reorder coding setup into full preflight, inert config write, then registry authorization commit; prove every late failure leaves mode/revision unchanged.
-- [ ] Strictly validate install-state schema and canonical managed paths before any profile-switch deletion; prove crafted external paths survive and fail closed.
-- [ ] Bound HTTP rate buckets and dynamic OAuth clients using direct socket identity, TTL, and caps; prove direct XFF spoofing cannot create identities.
-- [ ] Remove the unreachable PTY option/dependency from the unshipped coding MCP surface and keep pipe sessions fail-closed and covered.
-- [ ] Refresh `0.10.0` changelog/release filing with coding MCP scope, exact frozen commit, package contents, verification, and residual risk.
-- [ ] Run focused tests, `git diff --check`, dependency/package inspection, architecture/task/workflow checks, deep security/architecture re-review, and one final `bun run check:release` after code freeze.
-- [ ] Commit and push the reviewed slice; require green GitHub CI; publish npm; read registry tarball back; create annotated `v0.10.0`; create GitHub Release using the prior release format; reinstall from npm under Bun; run published-release/setup/CLI readbacks.
+- [x] Capture pre-fix regression evidence for update profile loss, coding setup permission leak, crafted install-state deletion, forwarded-header bucket bypass, packaged Skill references, and Bun PTY unreachability.
+- [x] Preserve the recorded install profile through `update` and add strict/product-planning CLI regressions.
+- [x] Replace root Skill file references with packaged docs resolver commands and extend tarball smoke.
+- [x] Reorder coding setup into full preflight, inert config write, then registry authorization commit; prove every late validation failure leaves mode/revision unchanged.
+- [x] Strictly validate install-state schema and canonical managed paths before any profile-switch deletion; prove crafted external paths survive and fail closed.
+- [x] Bound HTTP rate buckets and dynamic OAuth clients using direct socket identity, TTL, and caps; prove direct XFF spoofing cannot create identities.
+- [x] Remove the unreachable PTY option/dependency from the unshipped coding MCP surface and keep pipe sessions fail-closed and covered.
+- [x] Refresh `0.10.0` changelog/release filing with coding MCP scope, candidate verification, package expectations, and residual risk; the exact published commit remains a publish-time fact.
+- [x] Run focused tests, `git diff --check`, dependency/package inspection, architecture/task/workflow checks, deep security/architecture re-review, and one final `bun run check:release` after code freeze.
+- [ ] Commit and push the reviewed slice, open/merge the PR after green GitHub CI, and clean the branch/worktree. Record npm publish, registry readback, tag, GitHub Release, and installed-public-runtime proof as pending separate explicit release authorization.
 
 ## Verification Boundary
 
@@ -155,13 +155,13 @@ Before publish, revert the single release-blocker commit. After npm publish, npm
 <!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
 
 ## Task Breakdown
-- [ ] Capture pre-fix regression evidence for update profile loss, coding setup permission leak, crafted install-state deletion, forwarded-header bucket bypass, packaged Skill references, and Bun PTY unreachability.
-- [ ] Preserve the recorded install profile through `update` and add strict/product-planning CLI regressions.
-- [ ] Replace root Skill file references with packaged docs resolver commands and extend tarball smoke.
-- [ ] Reorder coding setup into full preflight, inert config write, then registry authorization commit; prove every late failure leaves mode/revision unchanged.
-- [ ] Strictly validate install-state schema and canonical managed paths before any profile-switch deletion; prove crafted external paths survive and fail closed.
-- [ ] Bound HTTP rate buckets and dynamic OAuth clients using direct socket identity, TTL, and caps; prove direct XFF spoofing cannot create identities.
-- [ ] Remove the unreachable PTY option/dependency from the unshipped coding MCP surface and keep pipe sessions fail-closed and covered.
-- [ ] Refresh `0.10.0` changelog/release filing with coding MCP scope, exact frozen commit, package contents, verification, and residual risk.
-- [ ] Run focused tests, `git diff --check`, dependency/package inspection, architecture/task/workflow checks, deep security/architecture re-review, and one final `bun run check:release` after code freeze.
-- [ ] Commit and push the reviewed slice; require green GitHub CI; publish npm; read registry tarball back; create annotated `v0.10.0`; create GitHub Release using the prior release format; reinstall from npm under Bun; run published-release/setup/CLI readbacks.
+- [x] Capture pre-fix regression evidence for update profile loss, coding setup permission leak, crafted install-state deletion, forwarded-header bucket bypass, packaged Skill references, and Bun PTY unreachability.
+- [x] Preserve the recorded install profile through `update` and add strict/product-planning CLI regressions.
+- [x] Replace root Skill file references with packaged docs resolver commands and extend tarball smoke.
+- [x] Reorder coding setup into full preflight, inert config write, then registry authorization commit; prove every late validation failure leaves mode/revision unchanged.
+- [x] Strictly validate install-state schema and canonical managed paths before any profile-switch deletion; prove crafted external paths survive and fail closed.
+- [x] Bound HTTP rate buckets and dynamic OAuth clients using direct socket identity, TTL, and caps; prove direct XFF spoofing cannot create identities.
+- [x] Remove the unreachable PTY option/dependency from the unshipped coding MCP surface and keep pipe sessions fail-closed and covered.
+- [x] Refresh `0.10.0` changelog/release filing with coding MCP scope, candidate verification, package expectations, and residual risk; the exact published commit remains a publish-time fact.
+- [x] Run focused tests, `git diff --check`, dependency/package inspection, architecture/task/workflow checks, deep security/architecture re-review, and one final `bun run check:release` after code freeze.
+- [ ] Commit and push the reviewed slice, open/merge the PR after green GitHub CI, and clean the branch/worktree. Record npm publish, registry readback, tag, GitHub Release, and installed-public-runtime proof as pending separate explicit release authorization.

--- a/scripts/check-tarball-install-smoke.sh
+++ b/scripts/check-tarball-install-smoke.sh
@@ -62,6 +62,13 @@ if [[ "$VERSION" != "$PACKAGE_VERSION" ]]; then
   exit 1
 fi
 
+for doc_id in harness-overview agentic-development-flow; do
+  if ! "$CLI" docs show "$doc_id" >/dev/null; then
+    echo "[tarball-smoke] ERROR: packaged docs registry cannot resolve $doc_id" >&2
+    exit 1
+  fi
+done
+
 (cd "$TARGET_REPO" && "$CLI" status --json >/dev/null)
 "$CLI" adopt --repo "$TARGET_REPO" --dry-run --json >"$TMP_DIR/adopt-plan.json"
 bun - "$TMP_DIR/adopt-plan.json" <<'JS_EOF'

--- a/src/cli/commands/global-runtime.ts
+++ b/src/cli/commands/global-runtime.ts
@@ -12,7 +12,7 @@ import { runInstall, type InstallTargetSpec } from "./install";
 import { compareVersions, readLatestPackageVersion } from "./doctor";
 import { configureCodegraph } from "../tools/codegraph";
 import { runProcess as runBoundedProcess } from "../../effects/process-runner";
-import type { InstallProfile } from "../installer/install-profile";
+import { readInstalledProfile, type InstallProfile } from "../installer/install-profile";
 
 export interface GlobalRuntimeOptions {
   sourceRoot?: string;
@@ -614,9 +614,9 @@ export function runGlobalRuntimeSetup(
   const sourceRoot = opts.sourceRoot ?? defaultSourceRoot();
   const cwd = opts.cwd ?? process.cwd();
   const target = opts.target ?? "both";
-  const profile = opts.profile ?? "minimal";
   const bunExecutable = resolveBunExecutable(opts.env);
   const env = bindBunRuntimeEnv(commandEnv(sourceRoot, opts.env), bunExecutable);
+  const profile = opts.profile ?? readInstalledProfile(env)?.profile ?? "minimal";
   const steps: GlobalRuntimeStep[] = [];
 
   const bunRuntime = ensureSupportedBunRuntime(cwd, env, bunExecutable);

--- a/src/cli/installer/install-profile.ts
+++ b/src/cli/installer/install-profile.ts
@@ -641,28 +641,83 @@ export function readInstalledProfile(env: NodeJS.ProcessEnv = process.env): Inst
   if (!Array.isArray(parsed.ownership_manifest)) {
     throw new Error(`installed profile state has no ownership manifest; rerun repo-harness install --profile <profile>: ${path}`);
   }
-  const legacyManifest = parsed.ownership_manifest as unknown as Array<Record<string, unknown>>;
-  if (legacyManifest.every((entry) => (
+  if (!Array.isArray(parsed.components)) {
+    throw new Error(`installed profile state has invalid components; rerun repo-harness install --profile <profile>: ${path}`);
+  }
+  if (typeof parsed.transaction_id !== 'string' || typeof parsed.applied_at !== 'string') {
+    throw new Error(`installed profile state has invalid metadata; rerun repo-harness install --profile <profile>: ${path}`);
+  }
+  const isLegacyManifest = (manifest: readonly unknown[]): boolean => manifest.length > 0 && manifest.every((rawEntry) => {
+    const entry = rawEntry as Record<string, unknown>;
+    return (
     typeof entry.component === 'string'
     && entry.authority === 'repo-harness-install-transaction'
     && entry.removal === 'managed-surfaces-only'
     && entry.path === undefined
-  ))) {
-    // One-shot migration: old component labels never proved filesystem
-    // ownership. Preserve the profile selection but claim no managed surface;
-    // the next successful sync preflights the host and writes concrete proofs.
-    return { ...parsed, ownership_manifest: [] };
-  }
-  if (parsed.ownership_manifest.some((surface) => (
+    );
+  });
+  const invalidComponents = (profile: InstallProfile, components: readonly InstallComponent[]): boolean => {
+    const expected = PROFILE_COMPONENTS[profile];
+    return components.length !== expected.length
+      || components.some((component, index) => component !== expected[index]);
+  };
+  const allowedPaths = new Set(installProfileHostMutationPaths(env));
+  const invalidSurface = (surface: ManagedInstallSurface): boolean => (
     !Array.isArray(surface.components)
+    || surface.components.some((component: unknown) => !ALL_COMPONENTS.includes(component as InstallComponent))
     || surface.authority !== 'repo-harness-install-transaction'
     || surface.removal !== 'managed-surfaces-only'
     || typeof surface.path !== 'string'
+    || !allowedPaths.has(surface.path)
     || !['directory-copy', 'symlink', 'managed-file'].includes(surface.type)
-  ))) {
+    || (surface.content_hash !== null && typeof surface.content_hash !== 'string')
+    || (surface.managed_marker !== null && typeof surface.managed_marker !== 'string')
+    || (surface.symlink_target !== null && typeof surface.symlink_target !== 'string')
+    || (surface.type === 'symlink'
+      ? surface.symlink_target === null || surface.content_hash !== null || surface.managed_marker !== null
+      : surface.symlink_target !== null || surface.content_hash === null || surface.managed_marker === null)
+  );
+  const normalizedPrevious = (() => {
+    if (parsed.previous === null) return null;
+    const previous = parsed.previous;
+    if (
+      typeof previous !== 'object'
+      || Array.isArray(previous)
+      || previous.protocol !== 1
+      || !INSTALL_PROFILES.includes(previous.profile)
+      || !Array.isArray(previous.components)
+      || typeof previous.transaction_id !== 'string'
+      || typeof previous.applied_at !== 'string'
+      || !Array.isArray(previous.ownership_manifest)
+    ) {
+      throw new Error(`installed profile state has invalid previous state; rerun repo-harness install --profile <profile>: ${path}`);
+    }
+    if (isLegacyManifest(previous.ownership_manifest)) {
+      return { ...previous, components: PROFILE_COMPONENTS[previous.profile], ownership_manifest: [] };
+    }
+    if (invalidComponents(previous.profile, previous.components) || previous.ownership_manifest.some(invalidSurface)) {
+      throw new Error(`installed profile state has invalid previous state; rerun repo-harness install --profile <profile>: ${path}`);
+    }
+    return previous;
+  })();
+  if (isLegacyManifest(parsed.ownership_manifest)) {
+    // One-shot migration: old component labels never proved filesystem
+    // ownership. Preserve the validated profile history but claim no managed
+    // surface; the next successful sync writes concrete ownership proofs.
+    return {
+      ...parsed,
+      components: PROFILE_COMPONENTS[parsed.profile],
+      ownership_manifest: [],
+      previous: normalizedPrevious,
+    };
+  }
+  if (invalidComponents(parsed.profile, parsed.components)) {
+    throw new Error(`installed profile state components do not match profile ${parsed.profile}: ${path}`);
+  }
+  if (parsed.ownership_manifest.some(invalidSurface)) {
     throw new Error(`installed profile state has an invalid ownership surface; rerun repo-harness install --profile <profile>: ${path}`);
   }
-  return parsed;
+  return { ...parsed, previous: normalizedPrevious };
 }
 
 function existing(paths: readonly string[]): string[] {

--- a/src/cli/mcp/coding-tools.ts
+++ b/src/cli/mcp/coding-tools.ts
@@ -307,9 +307,6 @@ export function buildCodingToolDefinitions(): CodingToolDefinition[] {
         properties: {
           workspace_id: { type: 'string' },
           cmd: { type: 'string' },
-          tty: { type: 'boolean', default: false },
-          columns: { type: 'number', minimum: 1, maximum: 1000 },
-          rows: { type: 'number', minimum: 1, maximum: 1000 },
           working_directory: { type: 'string', default: '.' },
           yield_time_ms: { type: 'number', minimum: 0, maximum: 30000 },
           max_output_tokens: { type: 'number', minimum: 1, maximum: 100000 },
@@ -321,15 +318,13 @@ export function buildCodingToolDefinitions(): CodingToolDefinition[] {
     },
     {
       name: 'write_stdin',
-      description: 'Poll or interact with a running coding process session, including input, Ctrl-C bytes, and PTY resize.',
+      description: 'Poll or interact with a running pipe process session, including stdin input and Ctrl-C/SIGINT.',
       inputSchema: {
         type: 'object',
         properties: {
           session_id: { type: 'number' },
           chars: { type: 'string' },
           interrupt: { type: 'boolean', description: 'Send Ctrl-C/SIGINT to the owned process session.' },
-          columns: { type: 'number', minimum: 1, maximum: 1000 },
-          rows: { type: 'number', minimum: 1, maximum: 1000 },
           yield_time_ms: { type: 'number', minimum: 0, maximum: 30000 },
           max_output_tokens: { type: 'number', minimum: 1, maximum: 100000 },
         },
@@ -580,7 +575,6 @@ function processResult(snapshot: ProcessSnapshot): CodingToolResult {
   return textResult({
     session_id: snapshot.sessionId,
     running: snapshot.running,
-    tty: snapshot.tty,
     exit_code: snapshot.exitCode,
     signal: snapshot.signal,
     reason: snapshot.reason,
@@ -616,9 +610,6 @@ export async function callCodingTool(ctx: CodingToolContext, name: string, args:
         command,
         cwd,
         workspaceRoot: workspace.root,
-        tty: args.tty === true,
-        columns: integer(args.columns, 80, 1, 1000),
-        rows: integer(args.rows, 24, 1, 1000),
         yieldTimeMs: integer(args.yield_time_ms, 10_000, 0, 30_000),
         maxOutputTokens: integer(args.max_output_tokens, 10_000, 1, 100_000),
       });
@@ -630,8 +621,6 @@ export async function callCodingTool(ctx: CodingToolContext, name: string, args:
         sessionId: integer(args.session_id, -1, -1, Number.MAX_SAFE_INTEGER),
         chars: typeof args.chars === 'string' ? args.chars : undefined,
         interrupt: args.interrupt === true,
-        columns: args.columns === undefined ? undefined : integer(args.columns, 80, 1, 1000),
-        rows: args.rows === undefined ? undefined : integer(args.rows, 24, 1, 1000),
         yieldTimeMs: integer(args.yield_time_ms, 1_000, 0, 30_000),
         maxOutputTokens: integer(args.max_output_tokens, 10_000, 1, 100_000),
       });

--- a/src/cli/mcp/oauth.ts
+++ b/src/cli/mcp/oauth.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'crypto';
 import { existsSync, mkdirSync, readFileSync, writeFileSync, chmodSync, renameSync } from 'fs';
 import { dirname } from 'path';
 import type { OAuthRegisteredClientsStore } from '@modelcontextprotocol/sdk/server/auth/clients.js';
-import { InvalidGrantError, InvalidScopeError, InvalidTokenError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
+import { InvalidGrantError, InvalidScopeError, InvalidTokenError, ServerError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
 import type { AuthorizationParams, OAuthServerProvider } from '@modelcontextprotocol/sdk/server/auth/provider.js';
 import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
 import type {
@@ -51,12 +51,44 @@ export class McpOAuthTokenStore implements OAuthRegisteredClientsStore {
   private accessTokens = new Map<string, McpStoredAuthInfo>();
   private refreshTokens = new Map<string, RefreshTokenRecord>();
   private clients = new Map<string, OAuthClientInformationFull>();
-  private clock: () => number = nowSeconds;
+  private clock: () => number;
+  private readonly dynamicClientTtlSeconds: number;
+  private readonly maxDynamicClients: number;
 
-  constructor(private readonly path: string) {}
+  constructor(
+    private readonly path: string,
+    opts: {
+      readonly nowSeconds?: () => number;
+      readonly dynamicClientTtlSeconds?: number;
+      readonly maxDynamicClients?: number;
+    } = {},
+  ) {
+    this.clock = opts.nowSeconds ?? nowSeconds;
+    this.dynamicClientTtlSeconds = opts.dynamicClientTtlSeconds ?? 30 * 24 * 60 * 60;
+    this.maxDynamicClients = opts.maxDynamicClients ?? 64;
+    if (!Number.isInteger(this.dynamicClientTtlSeconds) || this.dynamicClientTtlSeconds < 1) {
+      throw new Error('dynamicClientTtlSeconds must be a positive integer');
+    }
+    if (!Number.isInteger(this.maxDynamicClients) || this.maxDynamicClients < 1) {
+      throw new Error('maxDynamicClients must be a positive integer');
+    }
+  }
 
   setClock(clock: () => number): void {
     this.clock = clock;
+  }
+
+  private cleanupExpiredClients(flush = true): void {
+    const now = this.clock();
+    let changed = false;
+    for (const [clientId, client] of this.clients) {
+      const issuedAt = client.client_id_issued_at;
+      if (typeof issuedAt !== 'number' || !Number.isInteger(issuedAt) || issuedAt <= 0 || issuedAt > now || issuedAt + this.dynamicClientTtlSeconds <= now) {
+        this.clients.delete(clientId);
+        changed = true;
+      }
+    }
+    if (changed && flush) this.flush();
   }
 
   load(): void {
@@ -72,10 +104,22 @@ export class McpOAuthTokenStore implements OAuthRegisteredClientsStore {
       for (const [token, record] of Object.entries(data.refreshTokens ?? {})) {
         this.refreshTokens.set(token, typeof record === 'string' ? { accessToken: record } : record);
       }
-      for (const [clientId, client] of Object.entries(data.clients ?? {})) {
-        this.clients.set(clientId, client);
+      const clients = new Map(Object.entries(data.clients ?? {}));
+      const persistedClientCount = clients.size;
+      const now = this.clock();
+      for (const [clientId, client] of clients) {
+        const issuedAt = client.client_id_issued_at;
+        if (typeof issuedAt !== 'number' || !Number.isInteger(issuedAt) || issuedAt <= 0 || issuedAt > now || issuedAt + this.dynamicClientTtlSeconds <= now) {
+          clients.delete(clientId);
+        }
       }
-    } catch (_error) {
+      if (clients.size > this.maxDynamicClients) {
+        throw new ServerError('Dynamic OAuth client capacity reached');
+      }
+      this.clients = clients;
+      if (clients.size !== persistedClientCount) this.flush();
+    } catch (error) {
+      if (error instanceof ServerError) throw error;
       // Corrupt local auth state should not prevent starting the server.
     }
   }
@@ -95,15 +139,20 @@ export class McpOAuthTokenStore implements OAuthRegisteredClientsStore {
   }
 
   getClient(clientId: string): OAuthClientInformationFull | undefined {
+    this.cleanupExpiredClients();
     return this.clients.get(clientId);
   }
 
   registerClient(client: Omit<OAuthClientInformationFull, 'client_id' | 'client_id_issued_at'>): OAuthClientInformationFull {
+    this.cleanupExpiredClients();
+    if (this.clients.size >= this.maxDynamicClients) {
+      throw new ServerError('Dynamic OAuth client capacity reached');
+    }
     const candidate = client as Partial<OAuthClientInformationFull>;
     const full: OAuthClientInformationFull = {
       ...client,
       client_id: candidate.client_id ?? randomUUID(),
-      client_id_issued_at: candidate.client_id_issued_at ?? nowSeconds(),
+      client_id_issued_at: this.clock(),
     };
     this.clients.set(full.client_id, full);
     this.flush();

--- a/src/cli/mcp/process-sessions.ts
+++ b/src/cli/mcp/process-sessions.ts
@@ -1,8 +1,7 @@
 import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from 'child_process';
 import { createHash } from 'crypto';
-import { chmodSync, existsSync, realpathSync, statSync } from 'fs';
-import { createRequire } from 'module';
-import { dirname, isAbsolute, join, relative, resolve } from 'path';
+import { realpathSync, statSync } from 'fs';
+import { isAbsolute, relative } from 'path';
 
 const DEFAULT_MAX_CONCURRENT = 4;
 const DEFAULT_MAX_RUNTIME_MS = 30 * 60 * 1_000;
@@ -69,9 +68,6 @@ export interface ProcessStartInput {
   command: string;
   cwd: string;
   workspaceRoot: string;
-  tty?: boolean;
-  columns?: number;
-  rows?: number;
   yieldTimeMs?: number;
   maxOutputTokens?: number;
 }
@@ -82,8 +78,6 @@ export interface ProcessWriteInput {
   sessionId: number;
   chars?: string;
   interrupt?: boolean;
-  columns?: number;
-  rows?: number;
   yieldTimeMs?: number;
   maxOutputTokens?: number;
 }
@@ -101,7 +95,6 @@ export interface ProcessAuditMetadata {
   workspaceId: string;
   commandHash: string;
   commandLength: number;
-  tty: boolean;
   startedAt: string;
 }
 
@@ -120,7 +113,6 @@ export interface ProcessCompletionEvent extends ProcessAuditMetadata {
 export interface ProcessSnapshot {
   sessionId: number;
   running: boolean;
-  tty: boolean;
   output: string;
   outputTruncated: boolean;
   droppedOutputBytes: number;
@@ -132,26 +124,6 @@ export interface ProcessSnapshot {
   audit: ProcessAuditMetadata;
 }
 
-export interface ProcessPty {
-  readonly pid: number;
-  write(data: string): void;
-  resize(columns: number, rows: number): void;
-  kill(signal?: string): void;
-  onData(listener: (data: string) => void): { dispose?(): void } | void;
-  onExit(listener: (event: { exitCode: number; signal?: number }) => void): { dispose?(): void } | void;
-}
-
-export interface ProcessPtySpawnInput {
-  shellPath: string;
-  args: string[];
-  cwd: string;
-  env: Record<string, string>;
-  columns: number;
-  rows: number;
-}
-
-export type ProcessPtyFactory = (input: ProcessPtySpawnInput) => Promise<ProcessPty>;
-
 export interface McpProcessSessionManagerOptions {
   maxConcurrent?: number;
   maxRuntimeMs?: number;
@@ -162,7 +134,6 @@ export interface McpProcessSessionManagerOptions {
   baseEnv?: NodeJS.ProcessEnv;
   configuredEnv?: Record<string, string>;
   now?: () => number;
-  ptyFactory?: ProcessPtyFactory;
   onComplete?: (event: ProcessCompletionEvent) => void | Promise<void>;
   onCompletionError?: (error: unknown, event: ProcessCompletionEvent) => void;
 }
@@ -170,7 +141,6 @@ export interface McpProcessSessionManagerOptions {
 interface ManagedProcess {
   readonly pid?: number;
   write(data: string): void;
-  resize?(columns: number, rows: number): void;
   signal(signal: NodeJS.Signals): void;
 }
 
@@ -183,9 +153,6 @@ interface ProcessSession {
   commandLength: number;
   cwd: string;
   workspaceRoot: string;
-  tty: boolean;
-  columns: number;
-  rows: number;
   startedAtMs: number;
   completedAtMs?: number;
   process?: ManagedProcess;
@@ -301,14 +268,6 @@ function boundedPositiveOption(value: number | undefined, fallback: number, maxi
   return Math.min(value, maximum);
 }
 
-function terminalDimension(value: number | undefined, fallback: number, name: string): number {
-  if (value === undefined) return fallback;
-  if (!Number.isInteger(value) || value < 1 || value > 1_000) {
-    throw new McpProcessError('INVALID_TERMINAL_SIZE', `${name} must be an integer between 1 and 1000`);
-  }
-  return value;
-}
-
 function deniedEnvironmentKey(key: string): boolean {
   const upper = key.toUpperCase();
   return DENIED_ENV_KEY_PARTS.some((part) => upper.includes(part));
@@ -317,7 +276,6 @@ function deniedEnvironmentKey(key: string): boolean {
 export function buildMcpProcessEnvironment(options: {
   baseEnv?: NodeJS.ProcessEnv;
   configuredEnv?: Record<string, string>;
-  tty?: boolean;
 } = {}): Record<string, string> {
   const baseEnv = options.baseEnv ?? process.env;
   const env: Record<string, string> = {};
@@ -338,7 +296,7 @@ export function buildMcpProcessEnvironment(options: {
   env.PAGER = 'cat';
   env.GIT_PAGER = 'cat';
   env.GH_PAGER = 'cat';
-  env.TERM = options.tty ? 'xterm-256color' : 'dumb';
+  env.TERM = 'dumb';
   return env;
 }
 
@@ -364,43 +322,6 @@ function defaultShellPath(): string {
   return process.platform === 'win32' ? 'bash.exe' : '/bin/bash';
 }
 
-function ensureNodePtySpawnHelperExecutable(): void {
-  if (process.platform === 'win32') return;
-  const require = createRequire(import.meta.url);
-  const packageRoot = resolve(dirname(require.resolve('node-pty')), '..');
-  const candidates = [
-    join(packageRoot, 'prebuilds', `${process.platform}-${process.arch}`, 'spawn-helper'),
-    join(packageRoot, 'build', 'Release', 'spawn-helper'),
-  ];
-  for (const candidate of candidates) {
-    if (existsSync(candidate)) chmodSync(candidate, 0o755);
-  }
-}
-
-async function defaultPtyFactory(input: ProcessPtySpawnInput): Promise<ProcessPty> {
-  if (process.versions.bun) {
-    throw new McpProcessError('PTY_UNAVAILABLE', 'node-pty is unavailable in the Bun runtime');
-  }
-  let nodePty: typeof import('node-pty');
-  try {
-    nodePty = await import('node-pty');
-  } catch (_error) {
-    throw new McpProcessError('PTY_UNAVAILABLE', 'PTY support requires the optional node-pty dependency');
-  }
-  try {
-    ensureNodePtySpawnHelperExecutable();
-    return nodePty.spawn(input.shellPath, input.args, {
-      cwd: input.cwd,
-      env: input.env,
-      name: 'xterm-256color',
-      cols: input.columns,
-      rows: input.rows,
-    });
-  } catch (_error) {
-    throw new McpProcessError('PTY_UNAVAILABLE', 'PTY could not be started');
-  }
-}
-
 export class McpProcessSessionManager {
   private readonly sessions = new Map<number, ProcessSession>();
   private readonly maxConcurrent: number;
@@ -411,7 +332,6 @@ export class McpProcessSessionManager {
   private readonly shellPath: string;
   private readonly environment: Record<string, string>;
   private readonly now: () => number;
-  private readonly ptyFactory: ProcessPtyFactory;
   private readonly onComplete?: McpProcessSessionManagerOptions['onComplete'];
   private readonly onCompletionError?: McpProcessSessionManagerOptions['onCompletionError'];
   private startingCount = 0;
@@ -441,7 +361,6 @@ export class McpProcessSessionManager {
     this.shellPath = options.shellPath ?? defaultShellPath();
     this.environment = buildMcpProcessEnvironment({ baseEnv: options.baseEnv, configuredEnv: options.configuredEnv });
     this.now = options.now ?? Date.now;
-    this.ptyFactory = options.ptyFactory ?? defaultPtyFactory;
     this.onComplete = options.onComplete;
     this.onCompletionError = options.onCompletionError;
   }
@@ -466,8 +385,7 @@ export class McpProcessSessionManager {
     try {
       const paths = canonicalWorkingDirectory(input.cwd, input.workspaceRoot);
       const session = this.createSession(input, paths);
-      if (input.tty) await this.startPty(session);
-      else this.startPipe(session);
+      this.startPipe(session);
       this.sessions.set(session.id, session);
       this.startingCount -= 1;
       reservationHeld = false;
@@ -483,31 +401,17 @@ export class McpProcessSessionManager {
 
   async write(input: ProcessWriteInput): Promise<ProcessSnapshot> {
     const session = this.getOwnedSession(input.ownerId, input.workspaceId, input.sessionId);
-    const columns = input.columns === undefined ? undefined : terminalDimension(input.columns, session.columns, 'columns');
-    const rows = input.rows === undefined ? undefined : terminalDimension(input.rows, session.rows, 'rows');
     const chars = input.chars ?? '';
-    const interactionRequested = Boolean(input.interrupt || chars.length > 0 || columns !== undefined || rows !== undefined);
+    const interactionRequested = Boolean(input.interrupt || chars.length > 0);
     if (!session.running && interactionRequested) {
       throw new McpProcessError('PROCESS_NOT_RUNNING', 'completed process sessions only support output polling');
-    }
-    if ((columns !== undefined || rows !== undefined) && !session.process?.resize) {
-      throw new McpProcessError('PTY_REQUIRED', 'terminal resize requires a PTY process');
-    }
-    if (columns !== undefined || rows !== undefined) {
-      session.columns = columns ?? session.columns;
-      session.rows = rows ?? session.rows;
-      session.process?.resize?.(session.columns, session.rows);
     }
     if (Buffer.byteLength(chars, 'utf-8') > MAX_STDIN_BYTES) {
       throw new McpProcessError('STDIN_TOO_LARGE', `write_stdin input exceeds ${MAX_STDIN_BYTES} bytes`);
     }
     const containsCtrlC = chars.includes('\u0003');
     if (session.running && (input.interrupt || containsCtrlC)) {
-      if (session.tty && session.process) {
-        session.process.write('\u0003');
-      } else {
-        session.process?.signal('SIGINT');
-      }
+      session.process?.signal('SIGINT');
     }
     const writable = containsCtrlC ? chars.replaceAll('\u0003', '') : chars;
     if (session.running && writable.length > 0) session.process?.write(writable);
@@ -569,8 +473,6 @@ export class McpProcessSessionManager {
     if (Buffer.byteLength(input.command, 'utf-8') > MAX_COMMAND_BYTES) {
       throw new McpProcessError('COMMAND_TOO_LARGE', `command exceeds ${MAX_COMMAND_BYTES} bytes`);
     }
-    terminalDimension(input.columns, 80, 'columns');
-    terminalDimension(input.rows, 24, 'rows');
   }
 
   private createSession(
@@ -590,9 +492,6 @@ export class McpProcessSessionManager {
       commandLength: input.command.length,
       cwd: paths.cwd,
       workspaceRoot: paths.workspaceRoot,
-      tty: input.tty === true,
-      columns: terminalDimension(input.columns, 80, 'columns'),
-      rows: terminalDimension(input.rows, 24, 'rows'),
       startedAtMs: this.now(),
       ring: new ByteRingBuffer(this.ringBytes),
       totalOutputBytes: 0,
@@ -637,33 +536,6 @@ export class McpProcessSessionManager {
     });
     child.on('close', (code, signal) => {
       this.finish(session, code ?? undefined, signal ?? undefined);
-    });
-  }
-
-  private async startPty(session: ProcessSession): Promise<void> {
-    let pty: ProcessPty;
-    try {
-      pty = await this.ptyFactory({
-        shellPath: this.shellPath,
-        args: ['-c', session.command],
-        cwd: session.cwd,
-        env: { ...this.environment, TERM: 'xterm-256color' },
-        columns: session.columns,
-        rows: session.rows,
-      });
-    } catch (error) {
-      if (error instanceof McpProcessError) throw error;
-      throw new McpProcessError('PTY_UNAVAILABLE', 'PTY could not be started');
-    }
-    session.process = {
-      pid: pty.pid,
-      write: (data) => pty.write(data),
-      resize: (columns, rows) => pty.resize(columns, rows),
-      signal: (signal) => signalPtyTree(pty, signal),
-    };
-    pty.onData((data) => this.appendOutput(session, Buffer.from(data)));
-    pty.onExit(({ exitCode, signal }) => {
-      this.finish(session, exitCode, signal ? String(signal) : undefined);
     });
   }
 
@@ -825,7 +697,6 @@ export class McpProcessSessionManager {
     return {
       sessionId: session.id,
       running: session.running,
-      tty: session.tty,
       output: drained.output,
       outputTruncated: drained.droppedBytes > 0,
       droppedOutputBytes: drained.droppedBytes,
@@ -845,7 +716,6 @@ export class McpProcessSessionManager {
       workspaceId: session.workspaceId,
       commandHash: session.commandHash,
       commandLength: session.commandLength,
-      tty: session.tty,
       startedAt: new Date(session.startedAtMs).toISOString(),
     };
   }
@@ -890,21 +760,5 @@ function signalProcessTree(
     } catch (_childError) {
       // The process has already exited.
     }
-  }
-}
-
-function signalPtyTree(pty: ProcessPty, signal: NodeJS.Signals): void {
-  if (process.platform !== 'win32' && pty.pid > 0) {
-    try {
-      process.kill(-pty.pid, signal);
-      return;
-    } catch (_error) {
-      // node-pty may not expose a process-group leader on every platform.
-    }
-  }
-  try {
-    pty.kill(signal);
-  } catch (_error) {
-    // The process has already exited.
   }
 }

--- a/src/cli/mcp/server.ts
+++ b/src/cli/mcp/server.ts
@@ -3,7 +3,11 @@ import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprot
 import { randomUUID } from 'crypto';
 import { realpathSync, statSync } from 'fs';
 import { resolve } from 'path';
-import { readRegisteredRepoHarnessRepos, registeredRepoHarnessRoots } from '../../effects/repo-registry';
+import {
+  readRegisteredRepoHarnessRepos,
+  registeredRepoHarnessRoots,
+  repoHarnessAuthorizationRevision,
+} from '../../effects/repo-registry';
 import { loadMcpLocalConfig } from './auth';
 import { recordCodingProcessCompletion } from './coding-tools';
 import { createCodeGraphCliAdapter } from './codegraph-adapter';
@@ -183,6 +187,9 @@ export function createMcpToolContext(opts: McpServerOptions): McpToolContext {
     }
     if (!readRegisteredRepoHarnessRepos({ adoptedOnly: true }).some((repo) => repo.accessMode === 'read_write')) {
       throw new Error('coding MCP requires at least one adopted repo with an explicit read_write grant');
+    }
+    if (config.authorizationRevision !== repoHarnessAuthorizationRevision()) {
+      throw new Error('coding MCP authorization revision is stale; rerun user-scoped coding setup');
     }
   }
   const envDevRunner = parseBooleanSetting(process.env.REPO_HARNESS_MCP_DEV_RUNNER);

--- a/src/cli/mcp/setup.ts
+++ b/src/cli/mcp/setup.ts
@@ -1,14 +1,12 @@
 import { createHash, randomBytes } from 'crypto';
-import { existsSync, mkdirSync, readFileSync, realpathSync, renameSync, statSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, writeFileSync } from 'fs';
 import { isIP } from 'net';
 import { homedir } from 'os';
 import { dirname, join, relative, resolve } from 'path';
 import {
-  bumpRepoHarnessAuthorizationRevision,
+  applyRepoHarnessRegistryBatch,
   readRegisteredRepoHarnessRepos,
-  registerRepoHarnessRepo,
   repoHarnessAuthorizationRevision,
-  setRepoHarnessAccessMode,
 } from '../../effects/repo-registry';
 import {
   ensureMcpBearerToken,
@@ -621,9 +619,9 @@ export function runMcpSetupChatgpt(opts: {
     throw new Error('coding profile setup requires at least one explicit --grant-read-write <repo>');
   }
   for (const grantRoot of grantReadWrite) {
-    const grant = setRepoHarnessAccessMode(grantRoot, 'read_write');
-    if (!grant.registered) throw new Error(`cannot grant coding access: ${grant.reason ?? grant.path}`);
-    if (grant.changed) changed.push(grant.registryPath);
+    if (!isRepoHarnessAdopted(grantRoot)) {
+      throw new Error(`cannot grant coding access: repo is not repo-harness adopted: ${grantRoot}`);
+    }
   }
   const requestedRoots = normalizeAllowedRoots(opts.allowRoot ?? []);
   const existingRoots = normalizeAllowedRoots(existingConfig?.permissions?.allowedRoots ?? []);
@@ -631,15 +629,13 @@ export function runMcpSetupChatgpt(opts: {
     ...(requestedRoots.length > 0 ? requestedRoots : existingRoots),
   ]));
   const currentRepoAdopted = isRepoHarnessAdopted(repoRoot);
-  const registered = scope === 'user'
-    ? registerRepoHarnessRepo(repoRoot, 'mcp-setup')
-    : { registered: false, changed: false, registryPath: '', path: repoRoot };
-  if (registered.changed) changed.push(registered.registryPath);
-  const registeredRepoCount = readRegisteredRepoHarnessRepos({ adoptedOnly: true }).length;
+  const existingRegisteredRepos = readRegisteredRepoHarnessRepos({ adoptedOnly: true });
+  const registeredRepoCount = existingRegisteredRepos.length + (
+    scope === 'user' && currentRepoAdopted && !existingRegisteredRepos.some((entry) => entry.path === repoRoot) ? 1 : 0
+  );
   const readerEnabled = requestedProfile !== 'coding' && opts.enableReader !== false && (
     allowedRoots.length > 0 ||
     currentRepoAdopted ||
-    registered.registered ||
     registeredRepoCount > 0 ||
     existingConfig?.capabilities?.workspaceReader === true
   );
@@ -649,6 +645,7 @@ export function runMcpSetupChatgpt(opts: {
   const serverName = normalizeChatgptMcpServerName(opts.serverName ?? existingConfig?.chatgpt?.serverName);
   const endpoint = normalizePublicMcpEndpoint(opts.endpoint ?? existingConfig?.chatgpt?.endpoint);
   const configPath = mcpLocalConfigPath(repoRoot, scope);
+  const existingConfigBytes = existsSync(configPath) ? readFileSync(configPath, 'utf-8') : null;
   const guidePath = join(repoRoot, 'docs', 'repo-harness-chatgpt-mcp-setup.md');
   const token = ensureMcpBearerToken(repoRoot, scope);
   const oauth = ensureMcpOAuthPassphrase(repoRoot, scope);
@@ -669,9 +666,7 @@ export function runMcpSetupChatgpt(opts: {
         allowedRedirectHosts: existingConfig?.auth?.allowedRedirectHosts ?? defaultRedirectHosts,
       };
   const profile = requestedProfile;
-  if (existingConfig && (existingConfig.coding?.enabled === true) !== (profile === 'coding')) {
-    bumpRepoHarnessAuthorizationRevision();
-  }
+  const profileAuthorizationChanged = (existingConfig?.coding?.enabled === true) !== (profile === 'coding');
   const { reader: _legacyReader, ...existingCapabilities } = existingConfig?.capabilities ?? {};
   const config = {
     version: 3,
@@ -700,7 +695,6 @@ export function runMcpSetupChatgpt(opts: {
       fullDiskRead: false,
     },
     profile,
-    authorizationRevision: repoHarnessAuthorizationRevision(),
     coding: {
       ...existingConfig?.coding,
       enabled: profile === 'coding',
@@ -712,7 +706,6 @@ export function runMcpSetupChatgpt(opts: {
       timeoutMs: 120000,
     },
   };
-  writePrivateFileAtomicIfChanged(configPath, `${JSON.stringify(config, null, 2)}\n`, changed);
   if (scope === 'repo') {
     writeFileIfChanged(guidePath, chatgptGuideMarkdown(), changed);
     ensureGitignoreEntries(repoRoot, [
@@ -726,6 +719,25 @@ export function runMcpSetupChatgpt(opts: {
       '.ai/harness/mcp/trace.jsonl',
     ], changed);
   }
+  const registryEntries = [
+    ...(scope === 'user' && currentRepoAdopted ? [{ repoRoot, source: 'mcp-setup' as const }] : []),
+    ...grantReadWrite.map((grantRoot) => ({ repoRoot: grantRoot, source: 'manual' as const, accessMode: 'read_write' as const })),
+  ];
+  const registryBatch = applyRepoHarnessRegistryBatch(registryEntries, {
+    bumpAuthorizationRevision: profileAuthorizationChanged,
+    beforeCommit: (authorizationRevision) => {
+      writePrivateFileAtomicIfChanged(configPath, `${JSON.stringify({ ...config, authorizationRevision }, null, 2)}\n`, changed);
+    },
+    onCommitFailure: () => {
+      if (existingConfigBytes === null) rmSync(configPath, { force: true });
+      else writePrivateFileAtomicIfChanged(configPath, existingConfigBytes, []);
+    },
+  });
+  if (registryBatch.changed) changed.push(registryBatch.registryPath);
+  const registered = {
+    registered: scope === 'user' && currentRepoAdopted,
+    path: repoRoot,
+  };
 
   return {
     status: 'ok',
@@ -958,7 +970,7 @@ When consuming \`.ai/harness/handoff/codex-goal.md\`:
 - ChatGPT auth loops: prefer \`allow once\`; persistent \`allow always\` may require OAuth/session follow-up.
 - Tool scan misses tools: restart \`repo-harness mcp serve\` and rescan the Connector.
 - Coding is disabled: verify user-scoped v3 config, a live \`read_write\` grant, and current OAuth authorization revision.
-- PTY returns \`PTY_UNAVAILABLE\`: keep the failure explicit; do not silently downgrade a requested PTY to pipe execution.
+- Coding process sessions are pipe-only under Bun; stdin, polling, Ctrl-C/SIGINT, and process-tree cleanup remain supported.
 - Codex cannot see the MCP server: rerun \`repo-harness mcp setup codex --repo . --scope project\`.
 - Sprint is prose-only: regenerate with \`write_checklist_sprint\` before execution.
 `;
@@ -1170,7 +1182,7 @@ export function runMcpDoctor(opts: { repo?: string; json?: boolean }): McpSetupR
         agentRunner: localConfig?.capabilities?.agentRunner === true,
         workspaceCoder: localConfig?.capabilities?.workspaceCoder === true,
       },
-      authorizationRevision: localConfig?.authorizationRevision ?? 0,
+      authorizationRevision: repoHarnessAuthorizationRevision(),
       devMode: {
         agentRunner: localConfig?.devMode?.agentRunner === true,
         allowedAgents: localConfig?.devMode?.allowedAgents ?? ['codex'],

--- a/src/cli/mcp/transports/http.ts
+++ b/src/cli/mcp/transports/http.ts
@@ -306,13 +306,27 @@ function oauthAuthorizationHandler(provider: ReturnType<typeof createMcpOAuthPro
   };
 }
 
-function rateLimitMiddleware(opts: { windowMs: number; maxRequests: number }) {
+export function createOAuthRateLimitMiddleware(opts: {
+  windowMs: number;
+  maxRequests: number;
+  maxBuckets?: number;
+  now?: () => number;
+}) {
   const buckets = new Map<string, { windowStart: number; count: number }>();
+  const maxBuckets = opts.maxBuckets ?? 1_024;
+  const clock = opts.now ?? Date.now;
   return (req: Request, res: Response, next: NextFunction) => {
-    const now = Date.now();
-    const key = `${req.ip ?? 'unknown'}:${req.path}`;
+    const now = clock();
+    for (const [bucketKey, bucket] of buckets) {
+      if (now - bucket.windowStart >= opts.windowMs) buckets.delete(bucketKey);
+    }
+    const key = `${req.socket.remoteAddress ?? 'unknown'}:${req.baseUrl}`;
     const current = buckets.get(key);
-    if (!current || now - current.windowStart > opts.windowMs) {
+    if (!current) {
+      if (buckets.size >= maxBuckets) {
+        res.status(429).json({ error: 'rate_limited', error_description: 'Too many OAuth request identities' });
+        return;
+      }
       buckets.set(key, { windowStart: now, count: 1 });
       next();
       return;
@@ -528,7 +542,15 @@ export async function startMcpHttp(opts: McpHttpOptions): Promise<void> {
     throw new Error('REPO_HARNESS_MCP_PUBLIC_ORIGIN is required when binding MCP HTTP to a non-loopback host');
   }
   const coding = profile === 'coding';
-  if (coding && (configScope !== 'user' || localConfig?.profile !== 'coding' || localConfig.coding?.enabled !== true)) {
+  if (
+    coding
+    && (
+      configScope !== 'user'
+      || localConfig?.profile !== 'coding'
+      || localConfig.coding?.enabled !== true
+      || localConfig.authorizationRevision !== repoHarnessAuthorizationRevision()
+    )
+  ) {
     throw new Error('coding profile requires enabled user-scoped v3 setup');
   }
   const readWriteRepos = readRegisteredRepoHarnessRepos({ adoptedOnly: true }).filter((repo) => repo.accessMode === 'read_write');
@@ -590,13 +612,17 @@ export async function startMcpHttp(opts: McpHttpOptions): Promise<void> {
   }, Math.min(sessionTtlMs, 60_000));
   cleanupTimer.unref?.();
   const app = express();
-  app.set('trust proxy', 1);
 
   app.use((req, res, next) => {
     if (coding) {
       const liveConfig = loadMcpLocalConfig(repoRoot, 'user');
       const hasGrant = readRegisteredRepoHarnessRepos({ adoptedOnly: true }).some((repo) => repo.accessMode === 'read_write');
-      if (liveConfig?.profile !== 'coding' || liveConfig.coding?.enabled !== true || !hasGrant) {
+      if (
+        liveConfig?.profile !== 'coding'
+        || liveConfig.coding?.enabled !== true
+        || liveConfig.authorizationRevision !== repoHarnessAuthorizationRevision()
+        || !hasGrant
+      ) {
         closeStaleCodingState();
         res.status(503).json({ error: 'coding_disabled' });
         return;
@@ -648,7 +674,7 @@ export async function startMcpHttp(opts: McpHttpOptions): Promise<void> {
   });
 
   if (authMode === 'oauth' && oauthProvider) {
-    const oauthRateLimit = rateLimitMiddleware({ windowMs: 60_000, maxRequests: 120 });
+    const oauthRateLimit = createOAuthRateLimitMiddleware({ windowMs: 60_000, maxRequests: 120 });
     app.use(['/authorize', '/token', '/revoke', '/register'], oauthRateLimit);
     app.use('/authorize', express.urlencoded({ extended: false, limit: '10kb' }));
     app.use('/authorize', requirePassphrase(oauthPassphrase ?? '', { coding, repoNames: readWriteRepos.map((repo) => basename(repo.path)) }));

--- a/src/effects/repo-registry.ts
+++ b/src/effects/repo-registry.ts
@@ -44,6 +44,19 @@ export interface RepoHarnessRegisterResult {
   readonly reason?: string;
 }
 
+export interface RepoHarnessRegistryBatchEntry {
+  readonly repoRoot: string;
+  readonly source: RepoHarnessRegistrySource;
+  readonly accessMode?: RepoHarnessAccessMode;
+}
+
+export interface RepoHarnessRegistryBatchResult {
+  readonly registryPath: string;
+  readonly changed: boolean;
+  readonly authorizationRevision: number;
+  readonly repos: readonly RepoHarnessRegisteredRepo[];
+}
+
 function repoHarnessHome(env: NodeJS.ProcessEnv = process.env): string {
   return resolve(env.REPO_HARNESS_HOME ?? join(env.HOME ?? env.USERPROFILE ?? homedir(), ".repo-harness"));
 }
@@ -244,6 +257,60 @@ export function bumpRepoHarnessAuthorizationRevision(env: NodeJS.ProcessEnv = pr
     const next = registry.authorizationRevision + 1;
     writeRegistryFile(path, registry.repos, next);
     return next;
+  });
+}
+
+export function applyRepoHarnessRegistryBatch(
+  entries: readonly RepoHarnessRegistryBatchEntry[],
+  opts: {
+    readonly env?: NodeJS.ProcessEnv;
+    readonly requireAdopted?: boolean;
+    readonly bumpAuthorizationRevision?: boolean;
+    readonly beforeCommit?: (authorizationRevision: number) => void;
+    readonly onCommitFailure?: () => void;
+  } = {},
+): RepoHarnessRegistryBatchResult {
+  const registryPath = repoHarnessRegisteredReposPath(opts.env);
+  const canonicalEntries = entries.map((entry) => ({ ...entry, repoRoot: canonicalRepoPath(entry.repoRoot) }));
+  return withRegistryMutationLock(registryPath, () => {
+    if (opts.requireAdopted !== false) {
+      const unadopted = canonicalEntries.find((entry) => !isRepoHarnessAdoptedPath(entry.repoRoot));
+      if (unadopted) throw new Error(`repo is not repo-harness adopted: ${unadopted.repoRoot}`);
+    }
+    const registry = readRegistryFile(registryPath);
+    const now = new Date().toISOString();
+    let repos = dedupeRepos(registry.repos);
+    let accessChanged = false;
+    for (const entry of canonicalEntries) {
+      const previous = repos.find((repo) => repo.path === entry.repoRoot);
+      const accessMode = entry.accessMode ?? previous?.accessMode ?? 'read_only';
+      if (accessMode !== (previous?.accessMode ?? 'read_only')) accessChanged = true;
+      const next: RepoHarnessRegisteredRepo = {
+        id: previous?.id ?? repoHarnessRepoIdFor(entry.repoRoot),
+        path: entry.repoRoot,
+        accessMode,
+        source: entry.source,
+        registeredAt: previous?.registeredAt ?? now,
+        lastSeenAt: now,
+      };
+      repos = previous
+        ? repos.map((repo) => repo.path === entry.repoRoot ? next : repo)
+        : [...repos, next];
+    }
+    repos = dedupeRepos(repos);
+    const revisionChanged = accessChanged || opts.bumpAuthorizationRevision === true;
+    const authorizationRevision = registry.authorizationRevision + (revisionChanged ? 1 : 0);
+    const changed = JSON.stringify(repos) !== JSON.stringify(dedupeRepos(registry.repos)) || revisionChanged;
+    let prepared = false;
+    try {
+      opts.beforeCommit?.(authorizationRevision);
+      prepared = true;
+      if (changed) writeRegistryFile(registryPath, repos, authorizationRevision);
+    } catch (error) {
+      if (prepared) opts.onCommitFailure?.();
+      throw error;
+    }
+    return { registryPath, changed, authorizationRevision, repos };
   });
 }
 

--- a/tasks/archive/contract-20260714-2315-3p-cli-skill-mcp-boundary.md
+++ b/tasks/archive/contract-20260714-2315-3p-cli-skill-mcp-boundary.md
@@ -1,3 +1,9 @@
+> **Archived**: 2026-07-14 23:15
+> **Related Plan**: plans/archive/plan-20260714-2128-3p-cli-skill-mcp-boundary.md
+> **Outcome**: Superseded
+> **Lifecycle**: contract
+> **Parent Run ID**: run-20260714-2315
+
 # Task Contract: 3p-cli-skill-mcp-boundary
 
 > **Status**: Partial

--- a/tasks/archive/notes-20260714-2315-3p-cli-skill-mcp-boundary.md
+++ b/tasks/archive/notes-20260714-2315-3p-cli-skill-mcp-boundary.md
@@ -1,3 +1,9 @@
+> **Archived**: 2026-07-14 23:15
+> **Related Plan**: plans/archive/plan-20260714-2128-3p-cli-skill-mcp-boundary.md
+> **Outcome**: Superseded
+> **Lifecycle**: notes
+> **Parent Run ID**: run-20260714-2315
+
 # Implementation Notes: 3p-cli-skill-mcp-boundary
 
 > **Status**: Active

--- a/tasks/archive/review-20260714-2315-3p-cli-skill-mcp-boundary.md
+++ b/tasks/archive/review-20260714-2315-3p-cli-skill-mcp-boundary.md
@@ -1,3 +1,9 @@
+> **Archived**: 2026-07-14 23:15
+> **Related Plan**: plans/archive/plan-20260714-2128-3p-cli-skill-mcp-boundary.md
+> **Outcome**: Superseded
+> **Lifecycle**: review
+> **Parent Run ID**: run-20260714-2315
+
 # Task Review: 3p-cli-skill-mcp-boundary
 
 > **Status**: Pending

--- a/tasks/archive/todo-20260714-2315-3p-cli-skill-mcp-boundary.md
+++ b/tasks/archive/todo-20260714-2315-3p-cli-skill-mcp-boundary.md
@@ -1,7 +1,13 @@
+> **Archived**: 2026-07-14 23:15
+> **Related Plan**: plans/archive/plan-20260714-2128-3p-cli-skill-mcp-boundary.md
+> **Outcome**: Superseded
+> **Source Plan**: (none)
+> **Parent Run ID**: run-20260714-2315
+
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: 2026-07-14 23:18
+> **Updated**: 2026-07-14 20:26
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.

--- a/tasks/contracts/20260714-2318-repo-harness-0-10-0-release-blockers.contract.md
+++ b/tasks/contracts/20260714-2318-repo-harness-0-10-0-release-blockers.contract.md
@@ -71,6 +71,7 @@ allowed_paths:
   - docs/architecture/
   - docs/reference-configs/install-profiles.md
   - docs/reference-configs/hook-operations.md
+  - docs/reference-configs/chatgpt-coding-mcp.md
   - deploy/release-checklists/260714-repo-harness-0.10.0.md
   - README.md
   - SKILL.md
@@ -80,13 +81,17 @@ allowed_paths:
   - src/cli/index.ts
   - src/cli/commands/global-runtime.ts
   - src/cli/installer/install-profile.ts
+  - src/effects/repo-registry.ts
   - src/cli/mcp/setup.ts
+  - src/cli/mcp/server.ts
   - src/cli/mcp/oauth.ts
   - src/cli/mcp/transports/http.ts
   - src/cli/mcp/process-sessions.ts
   - src/cli/mcp/coding-tools.ts
   - tests/cli/global-runtime-init.test.ts
+  - tests/cli/status.test.ts
   - tests/install-profiles.test.ts
+  - tests/cli/registry.test.ts
   - tests/cli/mcp-setup.test.ts
   - tests/cli/mcp-http.test.ts
   - tests/cli/mcp-process-sessions.test.ts
@@ -141,6 +146,7 @@ exit_criteria:
     - tasks/notes/20260714-2318-repo-harness-0-10-0-release-blockers.notes.md
   tests_pass:
     - path: tests/cli/global-runtime-init.test.ts
+    - path: tests/cli/status.test.ts
     - path: tests/install-profiles.test.ts
     - path: tests/cli/mcp-setup.test.ts
     - path: tests/cli/mcp-http.test.ts

--- a/tasks/contracts/20260714-2318-repo-harness-0-10-0-release-blockers.contract.md
+++ b/tasks/contracts/20260714-2318-repo-harness-0-10-0-release-blockers.contract.md
@@ -1,0 +1,174 @@
+# Task Contract: repo-harness-0-10-0-release-blockers
+
+> **Status**: Active
+> **Plan**: plans/plan-20260714-2318-repo-harness-0-10-0-release-blockers.md
+> **Task Profile**: bugfix
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: kito
+> **Capability ID**: root
+> **Last Updated**: 2026-07-14 23:18
+> **Review File**: `tasks/reviews/20260714-2318-repo-harness-0-10-0-release-blockers.review.md`
+> **Notes File**: `tasks/notes/20260714-2318-repo-harness-0-10-0-release-blockers.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+The deep `v0.9.2..HEAD` release review found three P1 blockers and three bounded safety P2 findings in newly introduced update, install-profile, packaged Skill, and coding MCP surfaces. Shipping them would silently remove a user's selected runtime profile, grant write authority after a failed setup, ship broken Skill references, permit crafted install state to drive destructive deletion, expose unbounded HTTP/OAuth state, and advertise a PTY path the official Bun runtime cannot execute.
+
+## Goal
+
+Ship one frozen `0.10.0` commit whose update path preserves the recorded profile, packaged Skill references resolve inside the npm archive, failed coding setup cannot change access authority, destructive profile switching accepts only canonical managed surfaces, HTTP/OAuth state is bounded and direct-header spoof resistant, and the unshipped unreachable PTY surface is removed. Publish only after the final release gate, CI, npm/GitHub, and installed-runtime readbacks agree.
+
+## Scope
+
+- In scope: the six reviewed release blockers, their focused regressions, package/dependency cleanup, architecture/release documentation, and workflow/release evidence needed to publish `0.10.0`.
+- Out of scope:
+  - compatibility aliases/fallbacks, dual install-profile authority, heuristic semantic recovery, new proxy configuration knobs, broad MCP redesign, unrelated PR #75, and speculative refactors.
+- Taste constraints: fail closed; no semantic fallback, compatibility alias, dual profile authority, or trusted-proxy heuristic.
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+
+## Falsifier
+
+If a pre-fix regression does not reproduce the reported unsafe state on `ee571b85`, or if the proposed narrow fix requires a second source of truth, the direction is wrong. Cheapest proof: run the new focused test first on the unfixed tree and require a non-zero exit with the exact invariant violation.
+
+## Root Cause Evidence
+
+Required when Task Profile is `bugfix`; leave as-is otherwise.
+
+- root_cause: `src/cli/index.ts:399` omits recorded profile authority from update, while `src/cli/commands/global-runtime.ts:610` defaults that destructive projection to `minimal`; the same release batch has analogous validate-after-persist and trust-before-validate ordering at the cited MCP/install boundaries.
+- repro: seed a strict install under a disposable HOME, run ordinary `repo-harness update`, and observe strict-only routes removed; the other reviewed triggers are encoded in the same focused release-blocker regression suite.
+- regression_guard: tests/cli/global-runtime-init.test.ts
+- pre_fix_failure_artifact: .ai/harness/runs/20260714-0.10.0-release-blockers-pre-fix.log
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260714-2318-repo-harness-0-10-0-release-blockers.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260714-2318-repo-harness-0-10-0-release-blockers.review.md`
+- Notes file: `tasks/notes/20260714-2318-repo-harness-0-10-0-release-blockers.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: `repo-harness run verify-sprint` must see this contract pass, the review recommend pass, and canonical `## External Acceptance Advice` record `pass` for the current review subject and benchmark evidence.
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - plans/
+  - tasks/current.md
+  - tasks/todos.md
+  - tasks/archive/
+  - tasks/contracts/20260714-2318-repo-harness-0-10-0-release-blockers.contract.md
+  - tasks/reviews/20260714-2318-repo-harness-0-10-0-release-blockers.review.md
+  - tasks/notes/20260714-2318-repo-harness-0-10-0-release-blockers.notes.md
+  - docs/CHANGELOG.md
+  - docs/architecture/
+  - docs/reference-configs/install-profiles.md
+  - docs/reference-configs/hook-operations.md
+  - deploy/release-checklists/260714-repo-harness-0.10.0.md
+  - README.md
+  - SKILL.md
+  - package.json
+  - bun.lock
+  - scripts/check-tarball-install-smoke.sh
+  - src/cli/index.ts
+  - src/cli/commands/global-runtime.ts
+  - src/cli/installer/install-profile.ts
+  - src/cli/mcp/setup.ts
+  - src/cli/mcp/oauth.ts
+  - src/cli/mcp/transports/http.ts
+  - src/cli/mcp/process-sessions.ts
+  - src/cli/mcp/coding-tools.ts
+  - tests/cli/global-runtime-init.test.ts
+  - tests/install-profiles.test.ts
+  - tests/cli/mcp-setup.test.ts
+  - tests/cli/mcp-http.test.ts
+  - tests/cli/mcp-process-sessions.test.ts
+  - tests/cli/mcp-coding-tools.test.ts
+  - tests/cli/docs.test.ts
+  - tests/bootstrap-files.test.ts
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    tool_calls: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+      - codex-exec
+      - main-thread
+    fallback: main-thread
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - SKILL.md
+    - deploy/release-checklists/260714-repo-harness-0.10.0.md
+  artifacts_exist:
+    - .ai/harness/runs/20260714-0.10.0-release-blockers-pre-fix.log
+    - tasks/notes/20260714-2318-repo-harness-0-10-0-release-blockers.notes.md
+  tests_pass:
+    - path: tests/cli/global-runtime-init.test.ts
+    - path: tests/install-profiles.test.ts
+    - path: tests/cli/mcp-setup.test.ts
+    - path: tests/cli/mcp-http.test.ts
+    - path: tests/cli/mcp-process-sessions.test.ts
+    - path: tests/cli/mcp-coding-tools.test.ts
+    - path: tests/cli/docs.test.ts
+  commands_succeed:
+    - bun run check:type
+    - bash scripts/check-tarball-install-smoke.sh
+  qa_scores:
+    - dimension: functionality
+      min: 9
+  manual_checks:
+    - "Evaluator review file recommends pass"
+    - "Installed update preserves the recorded strict and product-planning profiles"
+    - "Failed coding setup leaves repo access mode and authorization revision unchanged"
+    - "Packed root Skill resolves both on-demand docs through the installed CLI"
+    - "Frozen HEAD passes one final bun run check:release and current GitHub CI"
+    - "Fresh security and architecture review reports no P1 or P2 release blocker"
+```
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior: all six reported release boundaries fail closed and preserve their single source of truth.
+- Edge cases: missing profile state defaults to minimal; malformed state, late setup failure, spoofed forwarded headers, and capacity exhaustion reject without unsafe mutation.
+- Regression risks: install/update user-level writes, coding MCP authority, package contents, and HTTP/OAuth availability; each has a focused regression plus final packaged-runtime proof.
+
+## Rollback Point
+
+- Commit / checkpoint: one reviewed release-blocker commit on `codex/0.10.0-release-blockers`, then fast-forward merge to `main`.
+- Revert strategy: revert before npm publish; after immutable publish, issue a patch release.

--- a/tasks/notes/20260714-2318-repo-harness-0-10-0-release-blockers.notes.md
+++ b/tasks/notes/20260714-2318-repo-harness-0-10-0-release-blockers.notes.md
@@ -9,17 +9,58 @@
 
 ## Design Decisions
 
-- ...
+- `repo-harness update` reads the persisted install profile before any runtime
+  mutation; malformed state fails closed, while an absent state alone selects
+  `minimal`.
+- Persisted ownership is accepted only when every removal path exactly matches
+  `installProfileHostMutationPaths(env)` and its type/hash/marker fields form a
+  coherent managed-surface proof.
+- Coding setup preflights every grant, then prepares config with the predicted
+  registry revision inside one registry lock. The old registry revision keeps
+  prepared config inert; one atomic registry write activates all grants, and a
+  failed registry commit restores the previous config bytes.
+- OAuth request identities are direct socket plus canonical route. Live buckets
+  are never evicted to admit attacker churn: 1,024 live identities is the fixed
+  capacity and expiry reopens space. Dynamic clients use a 30-day TTL and a
+  64-client capacity with fail-closed persisted-state loading.
+- Bun coding processes are pipe-only. The unreachable PTY schema, runtime
+  branch, tests, and dependency were removed together; stdin, polling, SIGINT,
+  output bounds, ownership isolation, and process-tree cleanup remain.
 
 ## Deviations From Plan Or Spec
 
-- None recorded.
+- Per the user's explicit direction, Claude review is skipped. The current
+  `/check` review uses local base review plus Codex security and architecture
+  specialist passes.
+- npm publish, tag creation, GitHub Release creation, registry readback, and
+  installed-public-runtime readback are not authorized by the branch-cleanup
+  request. This slice prepares and merges the source candidate only; external
+  publication remains in the release filing for a separately authorized run.
+- Allowed paths were widened to
+  `docs/reference-configs/chatgpt-coding-mcp.md` because removing the public PTY
+  contract without correcting its authoritative guide would leave source and
+  distribution inconsistent.
 
 ## Tradeoffs Considered
 
 | Option | Decision | Reason |
 |--------|----------|--------|
-| ... | ... | ... |
+| Trust `X-Forwarded-For` behind the current tunnel | Reject | No explicit trusted-proxy contract exists; spoofing mints rate identities. |
+| Evict live rate/OAuth entries at capacity | Reject | Eviction makes attacker churn a bypass; capacity must fail closed. |
+| Keep PTY fields and add another runtime | Reject | The feature has never shipped under the official Bun runtime and would add a compatibility branch. |
+| Batch registry writes under one registry lock | Adopt | All grants, access modes, the authorization revision, and config activation now form one fail-closed commit boundary. |
+
+## Residual Risks
+
+- Direct socket identity intentionally shares an OAuth limiter bucket across
+  callers behind one tunnel. Per-caller identity requires a separately approved
+  trusted-proxy contract; trusting caller-supplied forwarding headers here would
+  reopen spoofable rate identities.
+- Public dynamic client registration can fill the fixed 64-client, 30-day
+  capacity and temporarily deny new registrations. The unauthenticated DCR
+  protocol provides no stronger admission identity in this scope. This is a
+  bounded availability risk, not an authorization bypass; live eviction or
+  unbounded storage would make attacker churn the steady-state authority.
 
 ## Open Questions
 
@@ -29,6 +70,7 @@
 
 - Checks: `.ai/harness/checks/latest.json`
 - Run snapshots: `.ai/harness/runs/`
+- Pre-fix regression log: `.ai/harness/runs/20260714-0.10.0-release-blockers-pre-fix.log`
 
 ## Promotion Filter
 

--- a/tasks/notes/20260714-2318-repo-harness-0-10-0-release-blockers.notes.md
+++ b/tasks/notes/20260714-2318-repo-harness-0-10-0-release-blockers.notes.md
@@ -1,0 +1,41 @@
+# Implementation Notes: repo-harness-0-10-0-release-blockers
+
+> **Status**: Active
+> **Plan**: plans/plan-20260714-2318-repo-harness-0-10-0-release-blockers.md
+> **Contract**: tasks/contracts/20260714-2318-repo-harness-0-10-0-release-blockers.contract.md
+> **Review**: tasks/reviews/20260714-2318-repo-harness-0-10-0-release-blockers.review.md
+> **Last Updated**: 2026-07-14 23:18
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- ...
+
+## Deviations From Plan Or Spec
+
+- None recorded.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| ... | ... | ... |
+
+## Open Questions
+
+- None.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/reviews/20260714-2318-repo-harness-0-10-0-release-blockers.review.md
+++ b/tasks/reviews/20260714-2318-repo-harness-0-10-0-release-blockers.review.md
@@ -1,86 +1,91 @@
 # Task Review: repo-harness-0-10-0-release-blockers
 
-> **Status**: Pending
+> **Status**: Complete
 > **Plan**: plans/plan-20260714-2318-repo-harness-0-10-0-release-blockers.md
 > **Contract**: tasks/contracts/20260714-2318-repo-harness-0-10-0-release-blockers.contract.md
 > **Notes File**: tasks/notes/20260714-2318-repo-harness-0-10-0-release-blockers.notes.md
 > **Checks File**: .ai/harness/checks/latest.json
-> **Last Updated**: 2026-07-14 23:18
-> **Recommendation**: fail
+> **Last Updated**: 2026-07-15 02:16
+> **Recommendation**: pass
 > **Review Rubric Version**: 2
-> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject SHA256**: sha256:2242afc51e3dbbe9b05863ba5c0fdff79f241110687e6d7d08ecd1e618990113
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: pending
+> **Reviewed Target Revision**: 26acdb7b79b93c3c6442360cd72351ec3e071601
 
 ## Human Review Card
 
-- Verdict: pending
-- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
-- Intended files changed:
-- Actual files changed:
-- Commands passed:
-- Residual risks:
-- Reviewer action required: inspect diff and card
-- Rollback:
+- Verdict: pass
+- Change type: code-change
+- Intended files changed: release-blocker implementation, focused tests, package metadata, architecture/reference docs, release filing, and linked workflow artifacts listed by the contract.
+- Actual files changed: matches the contract after adding `tests/cli/status.test.ts` for the full-gate fixture correction; no `_ops`, external worktree, npm registry, tag, or release mutation.
+- Commands passed: focused 133-test suite; targeted install/status 37-test suite; registry transaction 12-test suite; typecheck; `git diff --check`; deploy SQL, architecture, task, and strict workflow checks; project inspection; adoption dry-run; full `bun run check:release`, including package dry-run and installed tarball smoke.
+- Residual risks: one tunnel socket shares an OAuth limiter identity; unauthenticated DCR can fill the fixed 64-client/30-day capacity. Both are bounded availability risks without an authorization bypass.
+- Reviewer action required: none for source merge; npm publish/tag/GitHub Release still require separate authorization.
+- Rollback: revert the release-blocker commit before publication; after publication, ship a patch release.
 
 ## Mode Evidence
 
-- Selected route:
-- P1/P2/P3 evidence:
-- Root cause or plan evidence:
+- Selected route: `$check` strict bugfix review with user-directed Claude-review skip and independent Codex security plus architecture specialists.
+- P1/P2/P3 evidence: install-profile authority, packaged docs, MCP setup/registry authorization, HTTP/OAuth state, process sessions, and distribution surfaces are mapped in the plan and architecture modules; concrete pre-fix traces are preserved in `.ai/harness/runs/20260714-0.10.0-release-blockers-pre-fix.log`.
+- Root cause or plan evidence: update defaulted away from persisted profile; legacy ownership accepted unsafe paths/history; setup mutated grants before all validation; OAuth state was unbounded/spoofable; the Bun PTY contract was unreachable; root Skill references were absent from the archive.
 
 ## Verification Evidence
 
-- Waza `/check` run:
-- Commands run:
-- Manual checks:
-- Supporting artifacts:
-- Implementation notes reviewed:
-- Run snapshot:
+- Waza `/check` run: completed locally; Claude review skipped by explicit user direction.
+- Commands run: `bun run check:type`; focused Bun tests; `git diff --check`; `bash scripts/check-deploy-sql-order.sh`; `bash scripts/check-architecture-sync.sh`; `bash scripts/check-task-sync.sh`; local-source `check-task-workflow --strict`; project inspection; adoption dry-run; `bun run check:release`; npm registry and pack dry-run readbacks.
+- Manual checks: security specialist injected registry rename failure after prepared config and proved config restore, unchanged grants/revision, and stale-revision denial; architecture specialist reproduced then verified closure of legacy `previous` validation; PTY/dependency references were inspected after removal.
+- Supporting artifacts: pre-fix regression log, release filing, architecture module updates, specialist findings in the current task.
+- Implementation notes reviewed: yes.
+- Run snapshot: final release gate ended `[ci] OK` and `[release] OK`; tarball smoke confirmed installed package CLI bins start.
 
 ## External Acceptance Advice
 
 > **External Acceptance**: unavailable
-> **External Reviewer**:
-> **External Source**:
-> **External Started**:
-> **External Completed**:
+> **External Reviewer**: Claude
+> **External Source**: owner-directed skip in the branch consolidation task
+> **External Started**: 2026-07-15T01:00:00+0800
+> **External Completed**: 2026-07-15T02:16:00+0800
 > **Review Rubric Version**: 2
-> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject SHA256**: sha256:2242afc51e3dbbe9b05863ba5c0fdff79f241110687e6d7d08ecd1e618990113
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: pending
-> **Benchmark Evidence SHA256**: pending
+> **Reviewed Target Revision**: 26acdb7b79b93c3c6442360cd72351ec3e071601
+> **Benchmark Evidence SHA256**: not-applicable
 
-- P1 blockers:
-- P2 advisories:
-- Acceptance checklist:
+- P1 blockers: none in local `/check`, security specialist, or architecture specialist review.
+- P2 advisories: tunnel-wide limiter sharing and bounded public DCR capacity are accepted availability residuals recorded in notes and the release filing.
+- Acceptance checklist: owner-directed Claude skip is recorded without claiming canonical external PASS; source diff, failure injection, focused tests, full release gate, package contents, and tarball install are locally verified.
 
 ## Behavior Diff Notes
 
-- ...
+- `update` preserves the installed profile and rejects conflicting profile/component/ownership history before mutation.
+- Coding setup preflights all grants, prepares revision-bound config, and activates grants with one atomic registry commit; failure restores prior config.
+- OAuth request/client state is bounded and fail closed; direct socket identity replaces spoofable forwarded headers.
+- Coding process sessions are pipe-only under Bun; the unreachable PTY schema/runtime/dependency is removed.
+- Packaged Skill guidance resolves through bundled docs and is exercised from the installed tarball.
 
 ## Residual Risks / Follow-ups
 
-- ...
+- Tunnel-wide rate identity and fixed DCR admission capacity remain explicit availability tradeoffs until a separately approved trusted-proxy or registration-admission contract exists.
+- npm `0.10.0`, tag `v0.10.0`, GitHub Release, published-package readback, and PATH-visible public install proof remain pending separate release authorization.
 
 ## Scorecard
 
 | Dimension | Score | Notes |
 |-----------|-------|-------|
-| Functionality | 0/10 | |
-| Product depth | 0/10 | |
-| Design quality | 0/10 | |
-| Code quality | 0/10 | |
+| Functionality | 10/10 | Confirmed blockers have regression coverage and the full release gate passes. |
+| Product depth | 9/10 | Source, package, docs, security boundaries, and workflow artifacts close together. |
+| Design quality | 9/10 | Existing authorities are preserved; no compatibility fallback or dual authority added. |
+| Code quality | 9/10 | Focused failure injection, typecheck, full suite, package dry-run, and tarball smoke pass. |
 
 ## Failing Items
 
-- ...
+- none for source merge.
 
 ## Retest Steps
 
-- Re-run:
-- Re-check:
+- Re-run: `BUN_TEST_MAX_CONCURRENCY=4 BUN_TEST_TIMEOUT_MS=180000 BUN_TEST_ISOLATE_FILES=1 bun run check:release`.
+- Re-check: after explicit publish authorization, run the release filing checklist against the exact merged commit.
 
 ## Summary
 
-- ...
+- All confirmed `0.10.0` source release blockers are closed. Local `/check`, security, architecture, full release, package, and installed-tarball evidence recommend source merge; external publication remains deliberately unexecuted.

--- a/tasks/reviews/20260714-2318-repo-harness-0-10-0-release-blockers.review.md
+++ b/tasks/reviews/20260714-2318-repo-harness-0-10-0-release-blockers.review.md
@@ -1,0 +1,86 @@
+# Task Review: repo-harness-0-10-0-release-blockers
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260714-2318-repo-harness-0-10-0-release-blockers.md
+> **Contract**: tasks/contracts/20260714-2318-repo-harness-0-10-0-release-blockers.contract.md
+> **Notes File**: tasks/notes/20260714-2318-repo-harness-0-10-0-release-blockers.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-07-14 23:18
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Commands passed:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+- Waza `/check` run:
+- Commands run:
+- Manual checks:
+- Supporting artifacts:
+- Implementation notes reviewed:
+- Run snapshot:
+
+## External Acceptance Advice
+
+> **External Acceptance**: unavailable
+> **External Reviewer**:
+> **External Source**:
+> **External Started**:
+> **External Completed**:
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Benchmark Evidence SHA256**: pending
+
+- P1 blockers:
+- P2 advisories:
+- Acceptance checklist:
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...

--- a/tests/cli/global-runtime-init.test.ts
+++ b/tests/cli/global-runtime-init.test.ts
@@ -737,6 +737,20 @@ exit 0
       mkdirSync(home, { recursive: true });
       mkdirSync(repo, { recursive: true });
       mkdirSync(fakeBin, { recursive: true });
+      mkdirSync(join(home, '.repo-harness'), { recursive: true });
+      writeFileSync(join(home, '.repo-harness', 'install-state.json'), `${JSON.stringify({
+        protocol: 1,
+        profile: 'strict',
+        components: [
+          'cli', 'effective-state', 'scope-worktree-check-guards', 'handoff', 'host-adapters',
+          'adaptive-workflow', 'codegraph-conditional', 'agent-fleet', 'verifier',
+          'cross-model-acceptance', 'release-deployment-gates',
+        ],
+        transaction_id: 'existing-strict-install',
+        applied_at: '2026-07-14T00:00:00.000Z',
+        ownership_manifest: [],
+        previous: null,
+      })}\n`);
       writeExecutable(join(fakeBin, 'bun'), `#!/bin/bash\nprintf '%s\\n' "$*" >> "${bunLog}"\nif [[ "\${1:-}" == "--version" ]]; then echo 1.3.14; exit 0; fi\nexit 0\n`);
 
       const res = spawnSync(
@@ -765,6 +779,7 @@ exit 0
       expect(res.status).toBe(0);
       const result = JSON.parse(res.stdout);
       expect(readFileSync(bunLog, 'utf-8')).toContain('add -g repo-harness@latest');
+      expect(result.steps.find((step: { step: string }) => step.step === 'install agent fleet')?.status).toBe('ok');
       expect(result.steps.find((step: { step: string }) => step.step === 'configure brain root')?.status).toBe('skipped');
       expect(existsSync(join(home, '.repo-harness', 'config.json'))).toBe(false);
       expect(existsSync(join(repo, '.ai'))).toBe(false);
@@ -817,6 +832,58 @@ exit 0
         'spec=repo-harness@9.9.9',
       );
       expect(readFileSync(bunLog, 'utf-8')).toContain('add -g repo-harness@9.9.9');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('CLI update preserves a recorded product-planning profile', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'repo-harness-cli-update-planning-profile-'));
+    const home = join(tmp, 'home');
+    const repo = join(tmp, 'repo');
+    const fakeBin = join(tmp, 'bin');
+    try {
+      mkdirSync(join(home, '.repo-harness'), { recursive: true });
+      mkdirSync(repo, { recursive: true });
+      mkdirSync(fakeBin, { recursive: true });
+      writeFileSync(join(home, '.repo-harness', 'install-state.json'), `${JSON.stringify({
+        protocol: 1,
+        profile: 'product-planning',
+        components: [
+          'cli', 'effective-state', 'scope-worktree-check-guards', 'handoff', 'host-adapters',
+          'adaptive-workflow', 'codegraph-conditional', 'planning-integrations',
+        ],
+        transaction_id: 'existing-planning-install',
+        applied_at: '2026-07-14T00:00:00.000Z',
+        ownership_manifest: [],
+        previous: null,
+      })}\n`);
+      writeExecutable(join(fakeBin, 'bun'), '#!/bin/bash\nif [[ "${1:-}" == "--version" ]]; then echo 1.3.14; fi\nexit 0\n');
+
+      const res = spawnSync(process.execPath, [
+        CLI,
+        'update',
+        '--no-cli',
+        '--no-sync-skill',
+        '--no-hooks',
+        '--no-external-skills',
+        '--no-codegraph',
+        '--json',
+      ], {
+        cwd: repo,
+        encoding: 'utf-8',
+        env: {
+          ...process.env,
+          HOME: home,
+          PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
+          REPO_HARNESS_BUN_EXECUTABLE: join(fakeBin, 'bun'),
+        },
+      });
+
+      expect(res.status).toBe(0);
+      const result = JSON.parse(res.stdout);
+      expect(result.steps.find((step: { step: string }) => step.step === 'configure brain root')?.status).toBe('ok');
+      expect(existsSync(join(home, '.repo-harness', 'config.json'))).toBe(true);
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }

--- a/tests/cli/mcp-coding-tools.test.ts
+++ b/tests/cli/mcp-coding-tools.test.ts
@@ -5,7 +5,12 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { afterEach, describe, expect, test } from 'bun:test';
 import { repoHarnessRepoIdFor, setRepoHarnessAccessMode } from '../../src/effects/repo-registry';
-import { callCodingTool, recordCodingProcessCompletion, type CodingToolContext } from '../../src/cli/mcp/coding-tools';
+import {
+  buildCodingToolDefinitions,
+  callCodingTool,
+  recordCodingProcessCompletion,
+  type CodingToolContext,
+} from '../../src/cli/mcp/coding-tools';
 import {
   cleanupManagedCodingWorkspace,
   CodingWorkspaceError,
@@ -110,6 +115,17 @@ afterEach(() => {
 });
 
 describe('coding MCP workspace and file tools', () => {
+  test('process tool contract is pipe-only', () => {
+    const tools = buildCodingToolDefinitions();
+    const execProperties = tools.find(({ name }) => name === 'exec_command')?.inputSchema.properties ?? {};
+    const stdinProperties = tools.find(({ name }) => name === 'write_stdin')?.inputSchema.properties ?? {};
+    expect(execProperties).not.toHaveProperty('tty');
+    expect(execProperties).not.toHaveProperty('columns');
+    expect(execProperties).not.toHaveProperty('rows');
+    expect(stdinProperties).not.toHaveProperty('columns');
+    expect(stdinProperties).not.toHaveProperty('rows');
+  });
+
   test('defaults to an isolated worktree without exposing absolute paths and supports guarded patch plus shell', async () => {
     const state = fixture();
     try {
@@ -139,6 +155,7 @@ describe('coding MCP workspace and file tools', () => {
         yield_time_ms: 2_000,
       }));
       expect(command).toMatchObject({ running: false, exit_code: 0, output: 'shell-ok' });
+      expect(command).not.toHaveProperty('tty');
       expect(existsSync(join(state.manager.get(opened.workspace_id).root, '.ai/harness/mcp/index-events.jsonl'))).toBe(true);
       const auditLines = readFileSync(join(state.manager.get(opened.workspace_id).root, '.ai/harness/mcp/audit.log'), 'utf-8').trim().split('\n');
       const executionAudit = auditLines.map((line) => JSON.parse(line) as Record<string, unknown>).reverse().find((entry) => entry.tool === 'exec_command');

--- a/tests/cli/mcp-http.test.ts
+++ b/tests/cli/mcp-http.test.ts
@@ -4,10 +4,16 @@ import { createServer } from 'net';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { ServerError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
+import { McpOAuthTokenStore } from '../../src/cli/mcp/oauth';
 import { McpSessionStore, type McpSessionClosableTransport } from '../../src/cli/mcp/session-store';
 import type { McpCodingRuntime } from '../../src/cli/mcp/server';
 import { runMcpSetupChatgpt } from '../../src/cli/mcp/setup';
-import { CodingAuthorizationRuntimeStore, startMcpHttp } from '../../src/cli/mcp/transports/http';
+import {
+  CodingAuthorizationRuntimeStore,
+  createOAuthRateLimitMiddleware,
+  startMcpHttp,
+} from '../../src/cli/mcp/transports/http';
 import { repoHarnessPackageVersion } from '../../src/cli/mcp/version';
 import { readRegisteredRepoHarnessRepos, setRepoHarnessAccessMode } from '../../src/effects/repo-registry';
 
@@ -73,6 +79,102 @@ function useTempRegistryHome(): () => void {
 }
 
 describe('mcp http transport', () => {
+  test('OAuth limiter uses direct socket identity, bounded buckets, and canonical routes', () => {
+    let now = 1_000;
+    const middleware = createOAuthRateLimitMiddleware({
+      windowMs: 100,
+      maxRequests: 2,
+      maxBuckets: 1,
+      now: () => now,
+    });
+    const invoke = (remoteAddress: string, forwardedIp: string, baseUrl = '/authorize', path = '/') => {
+      let status = 200;
+      let nextCalls = 0;
+      const response = {
+        status(code: number) { status = code; return response; },
+        json() { return response; },
+      };
+      middleware({
+        ip: forwardedIp,
+        socket: { remoteAddress },
+        baseUrl,
+        path,
+      } as never, response as never, () => { nextCalls += 1; });
+      return { status, nextCalls };
+    };
+
+    expect(invoke('127.0.0.1', '203.0.113.1', '/authorize', '/one').nextCalls).toBe(1);
+    expect(invoke('127.0.0.1', '203.0.113.2', '/authorize', '/two').nextCalls).toBe(1);
+    expect(invoke('127.0.0.1', '203.0.113.3', '/authorize', '/three').status).toBe(429);
+    expect(invoke('127.0.0.2', '203.0.113.4').status).toBe(429);
+    now += 100;
+    expect(invoke('127.0.0.2', '203.0.113.4').nextCalls).toBe(1);
+  });
+
+  test('dynamic OAuth clients expire and fail closed at a fixed capacity', () => {
+    const root = mkdtempSync(join(tmpdir(), 'repo-harness-oauth-client-cap-'));
+    let now = 10_000;
+    try {
+      const store = new McpOAuthTokenStore(join(root, 'tokens.json'), {
+        nowSeconds: () => now,
+        dynamicClientTtlSeconds: 10,
+        maxDynamicClients: 2,
+      });
+      const metadata = {
+        redirect_uris: ['http://localhost/callback'],
+        token_endpoint_auth_method: 'none' as const,
+        grant_types: ['authorization_code'],
+        response_types: ['code'],
+      };
+      const first = store.registerClient(metadata);
+      const second = store.registerClient(metadata);
+      expect(first.client_id_issued_at).toBe(now);
+      expect(() => store.registerClient(metadata)).toThrow(ServerError);
+      expect(store.getClient(first.client_id)).toBeDefined();
+      expect(store.getClient(second.client_id)).toBeDefined();
+
+      now += 10;
+      expect(store.getClient(first.client_id)).toBeUndefined();
+      expect(store.registerClient(metadata).client_id_issued_at).toBe(now);
+
+      const reloaded = new McpOAuthTokenStore(join(root, 'tokens.json'), {
+        nowSeconds: () => now,
+        dynamicClientTtlSeconds: 10,
+        maxDynamicClients: 2,
+      });
+      reloaded.load();
+      expect(() => reloaded.registerClient(metadata)).not.toThrow();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('dynamic OAuth client load rejects an over-cap persisted set atomically', () => {
+    const root = mkdtempSync(join(tmpdir(), 'repo-harness-oauth-client-overcap-'));
+    const path = join(root, 'tokens.json');
+    const now = 20_000;
+    try {
+      const clients = Object.fromEntries([0, 1, 2].map((index) => [`client-${index}`, {
+        client_id: `client-${index}`,
+        client_id_issued_at: now,
+        redirect_uris: ['http://localhost/callback'],
+        token_endpoint_auth_method: 'none',
+      }]));
+      writeFileSync(path, `${JSON.stringify({ clients })}\n`);
+      const store = new McpOAuthTokenStore(path, {
+        nowSeconds: () => now,
+        dynamicClientTtlSeconds: 10,
+        maxDynamicClients: 2,
+      });
+      expect(() => store.load()).toThrow(ServerError);
+      expect(store.getClient('client-0')).toBeUndefined();
+      expect(store.getClient('client-1')).toBeUndefined();
+      expect(store.getClient('client-2')).toBeUndefined();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   test('authorization runtime expiry catches background shutdown rejection and remains race-idempotent', async () => {
     let now = 1_000;
     let shutdownCalls = 0;

--- a/tests/cli/mcp-process-sessions.test.ts
+++ b/tests/cli/mcp-process-sessions.test.ts
@@ -7,7 +7,6 @@ import {
   McpProcessError,
   McpProcessSessionManager,
   type ProcessCompletionEvent,
-  type ProcessPty,
   type ProcessSnapshot,
 } from '../../src/cli/mcp/process-sessions';
 
@@ -76,28 +75,6 @@ describe('McpProcessSessionManager', () => {
       MONITOR_MODE: 'safe',
       COLOR_SCHEME: 'safe',
       WRITER_NAME: 'safe',
-    });
-  });
-
-  test('fails fast instead of hanging when node-pty runs under Bun', async () => {
-    if (!process.versions.bun) return;
-    await withTempRoot(async (root) => {
-      const manager = new McpProcessSessionManager();
-      try {
-        await expectProcessError(
-          () => manager.start({
-            ownerId: 'owner-a',
-            workspaceId: 'workspace-a',
-            command: 'printf pty-ok',
-            cwd: root,
-            workspaceRoot: root,
-            tty: true,
-          }),
-          'PTY_UNAVAILABLE',
-        );
-      } finally {
-        await manager.shutdown();
-      }
     });
   });
 
@@ -325,96 +302,40 @@ describe('McpProcessSessionManager', () => {
     });
   });
 
-  test('supports PTY input, resize, and Ctrl-C through an injected PTY factory', async () => {
+  test('pipe Ctrl-C interrupts the process tree', async () => {
     await withTempRoot(async (root) => {
-      let dataListener: ((data: string) => void) | undefined;
-      let exitListener: ((event: { exitCode: number; signal?: number }) => void) | undefined;
-      const writes: string[] = [];
-      const sizes: Array<[number, number]> = [];
-      const fakePty: ProcessPty = {
-        pid: 0,
-        write(data) {
-          writes.push(data);
-          if (data === '\u0003') exitListener?.({ exitCode: 130, signal: 2 });
-          else dataListener?.(`echo:${data}`);
-        },
-        resize(columns, rows) {
-          sizes.push([columns, rows]);
-        },
-        kill() {
-          exitListener?.({ exitCode: 143, signal: 15 });
-        },
-        onData(listener) {
-          dataListener = listener;
-        },
-        onExit(listener) {
-          exitListener = listener;
-        },
-      };
-      const manager = new McpProcessSessionManager({
-        terminationGraceMs: 20,
-        ptyFactory: async () => fakePty,
-      });
+      const manager = new McpProcessSessionManager({ terminationGraceMs: 20 });
       try {
         const started = await manager.start({
           ownerId: 'owner-a',
           workspaceId: 'workspace-a',
-          command: 'interactive-command',
+          command: 'sleep 10',
           cwd: root,
           workspaceRoot: root,
-          tty: true,
           yieldTimeMs: 0,
         });
-        const echoed = await manager.write({
-          ownerId: 'owner-a',
-          workspaceId: 'workspace-a',
-          sessionId: started.sessionId,
-          chars: 'hello',
-          columns: 120,
-          rows: 40,
-          yieldTimeMs: 0,
-        });
-        expect(echoed.output).toBe('echo:hello');
-        expect(sizes).toEqual([[120, 40]]);
-
         const interrupted = await manager.write({
           ownerId: 'owner-a',
           workspaceId: 'workspace-a',
           sessionId: started.sessionId,
           chars: '\u0003',
-          yieldTimeMs: 0,
+          yieldTimeMs: 1_000,
         });
-        expect(writes).toEqual(['hello', '\u0003']);
         expect(interrupted.running).toBe(false);
-        expect(interrupted.signal).toBe('2');
+        expect(interrupted.signal).toBe('SIGINT');
       } finally {
         await manager.shutdown();
       }
     });
   });
 
-  test('fails closed when PTY is unavailable and rejects unsafe environment keys and cwd escapes', async () => {
+  test('rejects unsafe environment keys and cwd escapes', async () => {
     await withTempRoot(async (root) => {
       const outside = mkdtempSync(join(tmpdir(), 'repo-harness-mcp-process-outside-'));
       try {
         expect(() => buildMcpProcessEnvironment({ configuredEnv: { CODEX_TOKEN: 'secret' } })).toThrow();
-        const manager = new McpProcessSessionManager({
-          ptyFactory: async () => {
-            throw new McpProcessError('PTY_UNAVAILABLE', 'test PTY missing');
-          },
-        });
+        const manager = new McpProcessSessionManager();
         try {
-          await expectProcessError(
-            () => manager.start({
-              ownerId: 'owner-a',
-              workspaceId: 'workspace-a',
-              command: 'true',
-              cwd: root,
-              workspaceRoot: root,
-              tty: true,
-            }),
-            'PTY_UNAVAILABLE',
-          );
           await expectProcessError(
             () => manager.start({
               ownerId: 'owner-a',

--- a/tests/cli/mcp-setup.test.ts
+++ b/tests/cli/mcp-setup.test.ts
@@ -15,7 +15,11 @@ import {
 import { createMcpToolContext } from '../../src/cli/mcp/server';
 import { repoHarnessPackageVersion } from '../../src/cli/mcp/version';
 import { assertChatGptMcpContract } from '../helpers/chatgpt-mcp-contract';
-import { readRegisteredRepoHarnessRepos, setRepoHarnessAccessMode } from '../../src/effects/repo-registry';
+import {
+  readRegisteredRepoHarnessRepos,
+  repoHarnessAuthorizationRevision,
+  setRepoHarnessAccessMode,
+} from '../../src/effects/repo-registry';
 
 const CLI = join(import.meta.dir, '../..', 'src/cli/index.ts');
 
@@ -322,8 +326,8 @@ describe('mcp setup', () => {
           profile: 'coding',
           capabilities: { workspaceReader: false, workflowPlanner: true, workspaceCoder: true },
           coding: { enabled: true, environmentAllowlist: [] },
-          authorizationRevision: 1,
         });
+        expect(config.authorizationRevision).toBe(1);
         expect(readRegisteredRepoHarnessRepos({ adoptedOnly: true })[0]).toMatchObject({ accessMode: 'read_write' });
         const ctx = createMcpToolContext({ repo: repoRoot, profile: 'coding' });
         expect(ctx.policy.profile).toBe('coding');
@@ -335,9 +339,11 @@ describe('mcp setup', () => {
         expect(() => createMcpToolContext({ repo: repoRoot, profile: 'coding' })).toThrow('explicit read_write grant');
 
         expect(setRepoHarnessAccessMode(repoRoot, 'read_write').authorizationRevision).toBe(3);
+        expect(() => createMcpToolContext({ repo: repoRoot, profile: 'coding' })).toThrow('authorization revision is stale');
         runMcpSetupChatgpt({ repo: repoRoot, scope: 'user', profile: 'planner' });
         const disabled = JSON.parse(readFileSync(join(userState, 'mcp.local.json'), 'utf-8'));
-        expect(disabled).toMatchObject({ profile: 'planner', authorizationRevision: 4, coding: { enabled: false } });
+        expect(disabled).toMatchObject({ profile: 'planner', coding: { enabled: false } });
+        expect(disabled.authorizationRevision).toBe(4);
         expect(() => createMcpToolContext({ repo: repoRoot, profile: 'coding' })).toThrow('coding MCP is disabled');
       } finally {
         if (previousHome === undefined) delete process.env.REPO_HARNESS_HOME;
@@ -345,6 +351,53 @@ describe('mcp setup', () => {
         rmSync(userState, { recursive: true, force: true });
       }
     });
+  });
+
+  test('coding setup validation failure leaves repo authorization unchanged', () => {
+    withTmpRepo((repoRoot) => {
+      expect(readRegisteredRepoHarnessRepos()).toEqual([]);
+      expect(repoHarnessAuthorizationRevision()).toBe(0);
+
+      expect(() => runMcpSetupChatgpt({
+        repo: repoRoot,
+        scope: 'user',
+        profile: 'coding',
+        grantReadWrite: [repoRoot],
+        endpoint: 'http://not-public.example/mcp',
+      })).toThrow('expected a public HTTPS URL');
+
+      expect(readRegisteredRepoHarnessRepos()).toEqual([]);
+      expect(repoHarnessAuthorizationRevision()).toBe(0);
+    });
+  });
+
+  test('coding setup preflights every grant and server name before authorization', () => {
+    for (const failure of ['server-name', 'mixed-grants'] as const) {
+      withTmpRepo((repoRoot) => {
+        const nonAdopted = mkdtempSync(join(tmpdir(), 'repo-harness-non-adopted-grant-'));
+        try {
+          const action = failure === 'server-name'
+            ? () => runMcpSetupChatgpt({
+                repo: repoRoot,
+                scope: 'user',
+                profile: 'coding',
+                grantReadWrite: [repoRoot],
+                serverName: 'bad/name',
+              })
+            : () => runMcpSetupChatgpt({
+                repo: repoRoot,
+                scope: 'user',
+                profile: 'coding',
+                grantReadWrite: [repoRoot, nonAdopted],
+              });
+          expect(action).toThrow();
+          expect(readRegisteredRepoHarnessRepos()).toEqual([]);
+          expect(repoHarnessAuthorizationRevision()).toBe(0);
+        } finally {
+          rmSync(nonAdopted, { recursive: true, force: true });
+        }
+      });
+    }
   });
 
   test('rerunning setup atomically migrates v1 and v2 local config to v3', () => {

--- a/tests/cli/registry.test.ts
+++ b/tests/cli/registry.test.ts
@@ -9,6 +9,11 @@ import {
 } from '../../src/cli/installer/targets/registry';
 import { codexTarget } from '../../src/cli/installer/targets/codex';
 import { claudeTarget } from '../../src/cli/installer/targets/claude';
+import {
+  applyRepoHarnessRegistryBatch,
+  readRegisteredRepoHarnessRepos,
+  repoHarnessAuthorizationRevision,
+} from '../../src/effects/repo-registry';
 
 describe('installer target registry', () => {
   test('ALL_TARGETS lists codex then claude in stable order', () => {
@@ -58,6 +63,117 @@ describe('installer target registry', () => {
 });
 
 describe('repo registration persistence', () => {
+  test('batch authorization validates every repo and commits one revision atomically', () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), 'repo-harness-registry-batch-'));
+    const env = { ...process.env, REPO_HARNESS_HOME: join(fixtureRoot, 'home') };
+    const adoptedA = join(fixtureRoot, 'repo-a');
+    const adoptedB = join(fixtureRoot, 'repo-b');
+    const unadopted = join(fixtureRoot, 'not-adopted');
+    try {
+      for (const repo of [adoptedA, adoptedB]) {
+        mkdirSync(join(repo, '.ai', 'harness'), { recursive: true });
+        writeFileSync(join(repo, '.ai', 'harness', 'policy.json'), '{}\n');
+      }
+      mkdirSync(unadopted, { recursive: true });
+      let prepared = false;
+      expect(() => applyRepoHarnessRegistryBatch([
+        { repoRoot: adoptedA, source: 'manual', accessMode: 'read_write' },
+        { repoRoot: unadopted, source: 'manual', accessMode: 'read_write' },
+      ], { env, beforeCommit: () => { prepared = true; } })).toThrow('not repo-harness adopted');
+      expect(prepared).toBe(false);
+      expect(readRegisteredRepoHarnessRepos({ env })).toEqual([]);
+      expect(repoHarnessAuthorizationRevision(env)).toBe(0);
+
+      let preparedRevision = -1;
+      const result = applyRepoHarnessRegistryBatch([
+        { repoRoot: adoptedA, source: 'manual', accessMode: 'read_write' },
+        { repoRoot: adoptedB, source: 'manual', accessMode: 'read_write' },
+      ], { env, bumpAuthorizationRevision: true, beforeCommit: (revision) => { preparedRevision = revision; } });
+      expect(preparedRevision).toBe(1);
+      expect(result.authorizationRevision).toBe(1);
+      expect(readRegisteredRepoHarnessRepos({ env }).map(({ accessMode }) => accessMode)).toEqual(['read_write', 'read_write']);
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('batch authorization restores prepared config when the registry commit fails', async () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), 'repo-harness-registry-commit-failure-'));
+    const registryHome = join(fixtureRoot, 'home');
+    const adopted = join(fixtureRoot, 'repo');
+    const configPath = join(fixtureRoot, 'mcp.local.json');
+    const registryModule = resolve(import.meta.dir, '../../src/effects/repo-registry.ts');
+    const workerScript = `
+      import { mock } from 'bun:test';
+      import * as actualFs from 'node:fs';
+      const originalRenameSync = actualFs.renameSync.bind(actualFs);
+      const originalWriteFileSync = actualFs.writeFileSync.bind(actualFs);
+      mock.module('fs', () => ({
+        ...actualFs,
+        renameSync(source, target) {
+          if (String(target).endsWith('registered-repos.json')) {
+            const error = new Error('injected registry commit failure');
+            error.code = 'EIO';
+            throw error;
+          }
+          return originalRenameSync(source, target);
+        },
+      }));
+      const registry = await import(process.env.REGISTRY_MODULE + '?commit-failure');
+      const adopted = process.env.ADOPTED_REPO;
+      const configPath = process.env.CONFIG_PATH;
+      let failure = '';
+      try {
+        registry.applyRepoHarnessRegistryBatch([
+          { repoRoot: adopted, source: 'manual', accessMode: 'read_write' },
+        ], {
+          beforeCommit: (revision) => originalWriteFileSync(configPath, 'new:' + revision),
+          onCommitFailure: () => originalWriteFileSync(configPath, 'old'),
+        });
+      } catch (error) {
+        failure = error instanceof Error ? error.message : String(error);
+      }
+      process.stdout.write(JSON.stringify({
+        failure,
+        config: actualFs.readFileSync(configPath, 'utf-8'),
+        repos: registry.readRegisteredRepoHarnessRepos(),
+        revision: registry.repoHarnessAuthorizationRevision(),
+      }));
+    `;
+
+    try {
+      mkdirSync(join(adopted, '.ai', 'harness'), { recursive: true });
+      writeFileSync(join(adopted, '.ai', 'harness', 'policy.json'), '{}\n');
+      writeFileSync(configPath, 'old');
+      const worker = Bun.spawn(['bun', '-e', workerScript], {
+        cwd: resolve(import.meta.dir, '../..'),
+        env: {
+          ...process.env,
+          REPO_HARNESS_HOME: registryHome,
+          REGISTRY_MODULE: registryModule,
+          ADOPTED_REPO: adopted,
+          CONFIG_PATH: configPath,
+        },
+        stdout: 'pipe',
+        stderr: 'pipe',
+      });
+      const [exitCode, output, errorOutput] = await Promise.all([
+        worker.exited,
+        new Response(worker.stdout).text(),
+        new Response(worker.stderr).text(),
+      ]);
+      expect(exitCode, errorOutput).toBe(0);
+      expect(JSON.parse(output)).toEqual({
+        failure: 'injected registry commit failure',
+        config: 'old',
+        repos: [],
+        revision: 0,
+      });
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
   test('removes its newly created lock when owner metadata persistence fails', async () => {
     const fixtureRoot = mkdtempSync(join(tmpdir(), 'repo-harness-registry-lock-failure-'));
     const registryHome = join(fixtureRoot, 'home');

--- a/tests/cli/status.test.ts
+++ b/tests/cli/status.test.ts
@@ -130,7 +130,15 @@ describe('status command (Phase 1C)', () => {
       fs.writeFileSync(statePath, JSON.stringify({
         protocol: 1,
         profile: 'standard',
-        components: ['cli', 'effective-state', 'host-adapters', 'adaptive-workflow'],
+        components: [
+          'cli',
+          'effective-state',
+          'scope-worktree-check-guards',
+          'handoff',
+          'host-adapters',
+          'adaptive-workflow',
+          'codegraph-conditional',
+        ],
         transaction_id: 'test-txn',
         applied_at: '2026-01-01T00:00:00.000Z',
         ownership_manifest: [],
@@ -141,12 +149,20 @@ describe('status command (Phase 1C)', () => {
       expect(r.installedProfile).toEqual({
         recorded: true,
         profile: 'standard',
-        components: ['cli', 'effective-state', 'host-adapters', 'adaptive-workflow'],
+        components: [
+          'cli',
+          'effective-state',
+          'scope-worktree-check-guards',
+          'handoff',
+          'host-adapters',
+          'adaptive-workflow',
+          'codegraph-conditional',
+        ],
       });
 
       const text = formatStatus(r, false);
       expect(text).toContain('profile: standard');
-      expect(text).toContain('components: cli, effective-state, host-adapters, adaptive-workflow');
+      expect(text).toContain('components: cli, effective-state, scope-worktree-check-guards, handoff, host-adapters, adaptive-workflow, codegraph-conditional');
     });
   });
 

--- a/tests/install-profiles.test.ts
+++ b/tests/install-profiles.test.ts
@@ -142,6 +142,36 @@ describe('install profiles', () => {
     expect(installedProfileStatus(applied.state, env).drift.status).toBe('consistent');
   }));
 
+  test('state rejects a component projection that conflicts with its profile authority', () => withHome((env) => {
+    writePath(join(env.HOME!, '.repo-harness', 'install-state.json'), `${JSON.stringify({
+      protocol: 1,
+      profile: 'strict',
+      components: ['cli'],
+      transaction_id: 'conflicting-state',
+      applied_at: '2026-07-14T00:00:00.000Z',
+      ownership_manifest: [],
+      previous: null,
+    })}\n`);
+    expect(() => readInstalledProfile(env)).toThrow('components do not match profile strict');
+  }));
+
+  test('legacy ownership migration rejects malformed rollback history', () => withHome((env) => {
+    writePath(join(env.HOME!, '.repo-harness', 'install-state.json'), `${JSON.stringify({
+      protocol: 1,
+      profile: 'strict',
+      components: ['strict-only-legacy-label'],
+      transaction_id: 'legacy-current',
+      applied_at: '2026-07-14T00:00:00.000Z',
+      ownership_manifest: [{
+        component: 'strict-only-legacy-label',
+        authority: 'repo-harness-install-transaction',
+        removal: 'managed-surfaces-only',
+      }],
+      previous: {},
+    })}\n`);
+    expect(() => readInstalledProfile(env)).toThrow('invalid previous state');
+  }));
+
   test('discoverManagedSurfaces empties the component set for a facade retired from the canonical package', () => withHome((env) => {
     const { source } = writeManagedHostSurfaces(env, 'standard');
     const codexSkills = join(env.HOME!, '.codex', 'skills');
@@ -368,6 +398,37 @@ describe('install profiles', () => {
     expect(lockState.skills['claude-review']).toBeUndefined();
     expect(lockState.skills['user-skill']).toEqual({ source: 'user/repo' });
     expect(installedProfileStatus(minimal.state, env).drift.status).toBe('consistent');
+  }));
+
+  test('profile switch rejects ownership paths outside canonical managed surfaces', () => withHome((env) => {
+    const external = join(env.HOME!, 'user-owned.txt');
+    const content = 'must survive';
+    writeFileSync(external, content);
+    writePath(join(env.HOME!, '.repo-harness', 'install-state.json'), `${JSON.stringify({
+      protocol: 1,
+      profile: 'strict',
+      components: [
+        'cli', 'effective-state', 'scope-worktree-check-guards', 'handoff', 'host-adapters',
+        'adaptive-workflow', 'codegraph-conditional', 'agent-fleet', 'verifier',
+        'cross-model-acceptance', 'release-deployment-gates',
+      ],
+      transaction_id: 'crafted-state',
+      applied_at: '2026-07-14T00:00:00.000Z',
+      ownership_manifest: [{
+        components: ['agent-fleet'],
+        authority: 'repo-harness-install-transaction',
+        removal: 'managed-surfaces-only',
+        path: external,
+        type: 'managed-file',
+        content_hash: `sha256:${createHash('sha256').update(content).digest('hex')}`,
+        managed_marker: 'transaction-created-file',
+        symlink_target: null,
+      }],
+      previous: null,
+    }, null, 2)}\n`);
+
+    expect(() => prepareInstallProfileSwitch('minimal', env)).toThrow('invalid ownership surface');
+    expect(readFileSync(external, 'utf-8')).toBe(content);
   }));
 
   test('reinstall refreshes ownership for an already-owned CodeGraph projection', () => withHome((env) => {


### PR DESCRIPTION
## Summary
- preserve installed profiles and harden managed ownership validation
- make coding grants/config activation atomic and bound OAuth state
- remove the unreachable Bun PTY contract and fix packaged Skill docs

## Verification
- focused regression suites pass
- Codex security and architecture specialist reviews pass
- `bun run check:release` passes, including package dry-run and tarball install smoke

Claude review was skipped by explicit owner direction. npm publish, tag, and GitHub Release remain outside this PR and require separate authorization.