### PR TITLE
fix: protect self-host source from downstream adopt

### DIFF
--- a/plans/plan-20260715-0401-self-host-adopt-boundary.md
+++ b/plans/plan-20260715-0401-self-host-adopt-boundary.md
@@ -1,0 +1,153 @@
+# Plan: Self-host adopt boundary fix
+
+> **Status**: Executing
+> **Created**: 20260715-0401
+> **Slug**: self-host-adopt-boundary
+> **Planning Source**: codex-plan
+> **Orchestration Kind**: host-plan
+> **Source Ref**: (none)
+> **Artifact Level**: work-package
+> **Promotion Reason**: risk_boundary
+> **Verification Boundary**: Installed and source CLIs must both produce zero downstream adopt operations for the source checkout
+> **Rollback Surface**: Revert the single source-checkout boundary commit
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260715-0401-self-host-adopt-boundary.contract.md`
+> **Task Review**: `tasks/reviews/20260715-0401-self-host-adopt-boundary.review.md`
+> **Implementation Notes**: `tasks/notes/20260715-0401-self-host-adopt-boundary.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from codex-plan planning output.
+- Source ref: (none)
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260715-0401-self-host-adopt-boundary.md`
+- Sprint contract: `tasks/contracts/20260715-0401-self-host-adopt-boundary.contract.md`
+- Sprint review: `tasks/reviews/20260715-0401-self-host-adopt-boundary.review.md`
+- Implementation notes: `tasks/notes/20260715-0401-self-host-adopt-boundary.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260715-0401-self-host-adopt-boundary.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260715-0401-self-host-adopt-boundary.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260715-0401-self-host-adopt-boundary.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260715-0401-self-host-adopt-boundary.contract.md`
+- Review file: `tasks/reviews/20260715-0401-self-host-adopt-boundary.review.md`
+- Implementation notes file: `tasks/notes/20260715-0401-self-host-adopt-boundary.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260715-0401-self-host-adopt-boundary.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260715-0401-self-host-adopt-boundary.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: Revert the single source-checkout boundary commit
+- **Verification boundary**: Installed and source CLIs must both produce zero downstream adopt operations for the source checkout
+- **Review/acceptance boundary**: `tasks/reviews/20260715-0401-self-host-adopt-boundary.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: risk_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260715-0401-self-host-adopt-boundary.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260715-0401-self-host-adopt-boundary.contract.md`, `tasks/reviews/20260715-0401-self-host-adopt-boundary.review.md`, and `tasks/notes/20260715-0401-self-host-adopt-boundary.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260715-0401-self-host-adopt-boundary.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: Revert the single source-checkout boundary commit
+
+## Captured Planning Output
+
+# Self-host adopt boundary fix
+
+## Goal
+
+Make installed and source-checkout repo-harness runtimes recognize the repo-harness source checkout identically, so downstream `adopt` is never recommended or applied to source-owned workflow surfaces.
+
+## P1: Architecture Map
+
+- `src/core/adoption/plan.ts` is the common adoption planner entrypoint.
+- `src/core/adoption/standard-plan.ts` owns downstream projection and known-generated cleanup.
+- `src/cli/commands/init-hook.ts` turns pending adoption operations into the `repo.adopt-refresh` Agent action.
+- `tests/cli/adoption-plan.test.ts` and `tests/cli/init-hook.test.ts` are the focused regression surfaces.
+
+## P2: Concrete Trace
+
+An npm-installed CLI runs `setup check` in the repo-harness source checkout. The setup check invokes standard downstream planning. Existing self-host detection compares the target path with the running package root; those paths differ for a global install, so byte-identical canonical `scripts/*` files are classified as generated downstream copies and scheduled for deletion/untracking.
+
+## P3: Design Decision
+
+Introduce one structural source-checkout predicate shared by planner, cleanup, and setup check. Standard downstream adoption becomes a no-op for the source checkout; setup check reports downstream refresh as not applicable. Explicit `self-host` review mode remains fail closed. Do not add aliases, fallback parsing, or multiple authorities.
+
+## Task Breakdown
+
+- [x] Add failing regression coverage for installed-runtime/source-target separation and false-positive package names.
+- [x] Implement the shared structural source-checkout authority and route planner/setup-check through it.
+- [x] Verify direct dry-run returns zero operations, setup check emits no adopt action, focused tests/typecheck/workflow checks pass, and no source files are mutated by dry-run.
+- [ ] Commit, push, and require green GitHub CI.
+
+## Verification Boundary
+
+- `bun test tests/cli/adoption-plan.test.ts tests/cli/init-hook.test.ts`
+- `bun run check:type`
+- `bun src/cli/index.ts adopt --repo . --dry-run --json`
+- `repo-harness setup check --target codex --check-updates --json`
+- root required workflow checks and GitHub CI
+
+## Out of Scope
+
+- Applying downstream adoption to the source checkout.
+- Changing explicit self-host review mode semantics.
+- Repairing unrelated Waza, adapter, or documentation drift.
+
+## Rollback Surface
+
+Revert the single source-checkout boundary commit; no migration or persistent data mutation is introduced.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [x] Add failing regression coverage for installed-runtime/source-target separation and false-positive package names.
+- [x] Implement the shared structural source-checkout authority and route planner/setup-check through it.
+- [x] Verify direct dry-run returns zero operations, setup check emits no adopt action, focused tests/typecheck/workflow checks pass, and no source files are mutated by dry-run.
+- [ ] Commit, push, and require green GitHub CI.

--- a/plans/plan-20260715-0401-self-host-adopt-boundary.md
+++ b/plans/plan-20260715-0401-self-host-adopt-boundary.md
@@ -123,7 +123,7 @@ Introduce one structural source-checkout predicate shared by planner, cleanup, a
 - [x] Add failing regression coverage for installed-runtime/source-target separation and false-positive package names.
 - [x] Implement the shared structural source-checkout authority and route planner/setup-check through it.
 - [x] Verify direct dry-run returns zero operations, setup check emits no adopt action, focused tests/typecheck/workflow checks pass, and no source files are mutated by dry-run.
-- [ ] Commit, push, and require green GitHub CI.
+- [x] Commit, push, and require green GitHub CI.
 
 ## Verification Boundary
 
@@ -150,4 +150,4 @@ Revert the single source-checkout boundary commit; no migration or persistent da
 - [x] Add failing regression coverage for installed-runtime/source-target separation and false-positive package names.
 - [x] Implement the shared structural source-checkout authority and route planner/setup-check through it.
 - [x] Verify direct dry-run returns zero operations, setup check emits no adopt action, focused tests/typecheck/workflow checks pass, and no source files are mutated by dry-run.
-- [ ] Commit, push, and require green GitHub CI.
+- [x] Commit, push, and require green GitHub CI.

--- a/src/cli/commands/init-hook.ts
+++ b/src/cli/commands/init-hook.ts
@@ -17,6 +17,7 @@ import { runDoctor, type CheckStatus, type DoctorReport } from './doctor';
 import { runStatus, type StatusReport } from './status';
 import type { InstallTargetSpec } from './install';
 import { planAdoption } from '../../core/adoption/plan';
+import { isRepoHarnessSourceCheckout } from '../../core/adoption/source-checkout';
 
 export type InitHookTarget = InstallTargetSpec;
 export type InitHookStatus = 'ok' | 'attention' | 'blocked';
@@ -260,6 +261,16 @@ function adoptionRefreshCheck(
       status: 'na',
       source: 'status',
       detail: `repo is not repo-harness adopted (${report.repo.optInMarker} missing)`,
+    };
+  }
+
+  if (isRepoHarnessSourceCheckout(report.repo.repoRoot)) {
+    return {
+      id,
+      title,
+      status: 'na',
+      source: 'status',
+      detail: 'self-host source checkout owns its workflow surfaces; downstream adopt refresh is not applicable',
     };
   }
 

--- a/src/core/adoption/plan.ts
+++ b/src/core/adoption/plan.ts
@@ -4,6 +4,7 @@ import type { AdoptionPlan } from "./operations";
 import { summarizeOperations } from "./summary";
 import { withRollbackMetadata } from "./rollback";
 import { planStandardAdoption } from "./standard-plan";
+import { isRepoHarnessSourceCheckout } from "./source-checkout";
 
 export interface PlanAdoptionOptions {
   readonly repoRoot: string;
@@ -21,6 +22,23 @@ export interface PlanAdoptionOptions {
 export function planAdoption(opts: PlanAdoptionOptions): AdoptionPlan {
   const repoRoot = resolve(opts.repoRoot);
   const mode = opts.mode ?? "standard";
+  if (mode === "standard" && isRepoHarnessSourceCheckout(repoRoot)) {
+    const operations: AdoptionPlan["operations"] = [];
+    return {
+      protocol: 1,
+      command: "adopt",
+      repoRoot,
+      mode,
+      apply: opts.apply === true,
+      operations,
+      summary: summarizeOperations(operations),
+      warnings: [{
+        code: "self-host-source-noop",
+        message: "The repo-harness source checkout owns its workflow surfaces; downstream adopt is not applicable.",
+        risk: "low",
+      }],
+    };
+  }
   const planned = planStandardAdoption({ repoRoot, mode, env: opts.env });
   const operations = planned.operations.map(withRollbackMetadata);
 

--- a/src/core/adoption/source-checkout.ts
+++ b/src/core/adoption/source-checkout.ts
@@ -1,0 +1,43 @@
+import { existsSync, lstatSync, readFileSync } from "fs";
+import { join, resolve } from "path";
+
+const SOURCE_AUTHORITY_FILES = [
+  "assets/workflow-contract.v1.json",
+  "scripts/check-ci.sh",
+  "src/cli/index.ts",
+  "src/cli/hook-entry.ts",
+  "src/core/adoption/standard-plan.ts",
+] as const;
+
+function regularFile(repoRoot: string, path: string): boolean {
+  const target = join(repoRoot, path);
+  return existsSync(target) && lstatSync(target).isFile();
+}
+
+/**
+ * Identify the repo-harness package source by its complete canonical package
+ * shape. The target path is deliberately irrelevant: an installed CLI and the
+ * source checkout necessarily live under different roots.
+ */
+export function isRepoHarnessSourceCheckout(repoRoot: string): boolean {
+  const root = resolve(repoRoot);
+  if (!regularFile(root, "package.json")) return false;
+
+  let manifest: unknown;
+  try {
+    manifest = JSON.parse(readFileSync(join(root, "package.json"), "utf-8"));
+  } catch {
+    return false;
+  }
+  if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) return false;
+
+  const packageManifest = manifest as Record<string, unknown>;
+  const bins = packageManifest.bin;
+  if (!bins || typeof bins !== "object" || Array.isArray(bins)) return false;
+  const binMap = bins as Record<string, unknown>;
+  if (packageManifest.name !== "repo-harness") return false;
+  if (binMap["repo-harness"] !== "src/cli/index.ts") return false;
+  if (binMap["repo-harness-hook"] !== "src/cli/hook-entry.ts") return false;
+
+  return SOURCE_AUTHORITY_FILES.every((path) => regularFile(root, path));
+}

--- a/src/core/adoption/standard-plan.ts
+++ b/src/core/adoption/standard-plan.ts
@@ -1,5 +1,5 @@
 import { createHash } from "crypto";
-import { existsSync, lstatSync, readdirSync, readFileSync, realpathSync } from "fs";
+import { existsSync, lstatSync, readdirSync, readFileSync } from "fs";
 import { basename, dirname, join, relative, resolve, sep } from "path";
 import type { AdoptionMode } from "./modes";
 import type { AdoptionOperation, AdoptionWarning, WriteFileOperation } from "./operations";
@@ -8,9 +8,9 @@ import { adoptionTemplateFile } from "./manifest-templates";
 import { gitignoreManagedBlockOperation } from "./gitignore-plan";
 import { managedBlockNeedsUpdate } from "./managed-block";
 import { loadWorkflowContractAsset, readWorkflowContractAsset } from "./workflow-contract-asset";
+import { isRepoHarnessSourceCheckout } from "./source-checkout";
 
 const ASSET_ROOT = join(import.meta.dir, "..", "..", "..", "assets");
-const PACKAGE_ROOT = join(import.meta.dir, "..", "..", "..");
 const TEMPLATE_ROOT = join(ASSET_ROOT, "templates");
 const HOOK_ROOT = join(ASSET_ROOT, "hooks");
 const REFERENCE_ROOT = join(ASSET_ROOT, "reference-configs");
@@ -423,14 +423,6 @@ function knownGeneratedFile(repoRoot: string, path: string): boolean {
   return false;
 }
 
-function isSelfHostedSourceRepo(repoRoot: string): boolean {
-  try {
-    return realpathSync(repoRoot) === realpathSync(PACKAGE_ROOT);
-  } catch {
-    return resolve(repoRoot) === resolve(PACKAGE_ROOT);
-  }
-}
-
 function isCanonicalDeferredLedger(content: string): boolean {
   return /^# Deferred Goal Ledger\s*$/m.test(content) && /^> \*\*Status\*\*:\s*Backlog\s*$/m.test(content);
 }
@@ -542,7 +534,7 @@ function addKnownGeneratedCleanup(repoRoot: string, operations: AdoptionOperatio
   // The source package owns its canonical scripts. They may be byte-identical
   // to package helpers, but that is not evidence that this source repo is a
   // downstream generated runtime copy.
-  if (isSelfHostedSourceRepo(repoRoot)) return;
+  if (isRepoHarnessSourceCheckout(repoRoot)) return;
   const contract = loadWorkflowContractAsset<WorkflowContractAsset>();
   const actions = contract.migrations?.upgrade?.actions ?? [];
   for (const action of actions) {

--- a/tasks/contracts/20260715-0401-self-host-adopt-boundary.contract.md
+++ b/tasks/contracts/20260715-0401-self-host-adopt-boundary.contract.md
@@ -1,0 +1,143 @@
+# Task Contract: self-host-adopt-boundary
+
+> **Status**: Fulfilled
+> **Plan**: plans/plan-20260715-0401-self-host-adopt-boundary.md
+> **Task Profile**: bugfix
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: kito
+> **Capability ID**: root
+> **Last Updated**: 2026-07-15 04:01
+> **Review File**: `tasks/reviews/20260715-0401-self-host-adopt-boundary.review.md`
+> **Notes File**: `tasks/notes/20260715-0401-self-host-adopt-boundary.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+The installed CLI currently treats the repo-harness source checkout as a downstream adopted repository because self-host detection compares the target path with the running package root. A setup-check recommendation can therefore lead an operator toward an `adopt` plan that deletes and untracks canonical source scripts.
+
+## Goal
+
+Make self-host source-checkout recognition independent of the running package location. Standard downstream adoption must be a no-op for the source checkout, setup check must not emit `repo.adopt-refresh`, and explicit self-host review mode must remain fail closed.
+
+## Scope
+
+- In scope: one structural source-checkout predicate shared by adoption planning, generated cleanup, and setup check; focused regression coverage; workflow evidence.
+- Out of scope: applying downstream adoption to the source checkout; changing explicit self-host review mode; unrelated adapter, Waza, CodeGraph, or documentation refresh.
+- Taste constraints: fail closed; no path-location heuristic, compatibility alias, fallback parser, or second source authority.
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+
+## Falsifier
+
+If a structurally incomplete repository named `repo-harness` is classified as the source checkout, or explicit self-host review mode stops blocking apply, the predicate is too broad. Cheapest proof: focused adoption-plan tests with a false-positive fixture and the existing self-host apply assertion.
+
+## Root Cause Evidence
+
+Required when Task Profile is `bugfix`; leave as-is otherwise.
+
+- root_cause: `src/core/adoption/standard-plan.ts:isSelfHostedSourceRepo` recognizes self-host only when `repoRoot` equals the running package root, which is false for an npm-installed CLI targeting the source checkout.
+- repro: run `repo-harness adopt --repo /Users/kito/Projects/repo-harness --dry-run --json` from the Bun-global `0.10.0` install and observe 35 `remove` plus 35 `gitUntrack` source-script operations.
+- regression_guard: tests/cli/adoption-plan.test.ts
+- pre_fix_failure_artifact: .ai/harness/runs/20260715-self-host-adopt-boundary-pre-fix.log
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260715-0401-self-host-adopt-boundary.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260715-0401-self-host-adopt-boundary.review.md`
+- Notes file: `tasks/notes/20260715-0401-self-host-adopt-boundary.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: `repo-harness run verify-sprint` must see this contract pass, the review recommend pass, and canonical `## External Acceptance Advice` record `pass` for the current review subject and benchmark evidence.
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - docs/spec.md
+  - plans/
+  - tasks/todos.md
+  - tasks/contracts/20260715-0401-self-host-adopt-boundary.contract.md
+  - tasks/reviews/20260715-0401-self-host-adopt-boundary.review.md
+  - tasks/notes/20260715-0401-self-host-adopt-boundary.notes.md
+  - .ai/context/capabilities.json
+  - .claude/templates/
+  - src/
+  - tests/
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    tool_calls: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+      - codex-exec
+      - main-thread
+    fallback: main-thread
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - src/core/adoption/source-checkout.ts
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260715-0401-self-host-adopt-boundary.notes.md
+  tests_pass:
+    - path: tests/cli/adoption-plan.test.ts
+    - path: tests/cli/init-hook.test.ts
+    - path: tests/readme-dx.test.ts
+  commands_succeed:
+    - bun test tests/readme-dx.test.ts tests/cli/adoption-plan.test.ts tests/cli/init-hook.test.ts
+    - bun run check:type
+    - bash scripts/check-task-sync.sh
+    - bun src/cli/index.ts run check-task-workflow --strict
+  qa_scores:
+    - dimension: functionality
+      min: 7
+  manual_checks:
+    - "Evaluator review file recommends pass"
+    - "Source adopt dry-run planned zero operations"
+```
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior: installed and source CLIs produce no downstream adopt operations or refresh action for this source checkout.
+- Edge cases: a name-only `repo-harness` fixture is not classified as source; explicit self-host review mode remains blocked.
+- Regression risks: downstream adopted repositories must continue to receive normal standard adoption plans.
+
+## Rollback Point
+
+- Commit / checkpoint: branch `codex/self-host-adopt-boundary`.
+- Revert strategy: revert the single boundary commit; no migration or persistent data mutation is introduced.

--- a/tasks/notes/20260715-0401-self-host-adopt-boundary.notes.md
+++ b/tasks/notes/20260715-0401-self-host-adopt-boundary.notes.md
@@ -1,0 +1,53 @@
+# Implementation Notes: self-host-adopt-boundary
+
+> **Status**: Active
+> **Plan**: plans/plan-20260715-0401-self-host-adopt-boundary.md
+> **Contract**: tasks/contracts/20260715-0401-self-host-adopt-boundary.contract.md
+> **Review**: tasks/reviews/20260715-0401-self-host-adopt-boundary.review.md
+> **Last Updated**: 2026-07-15 04:01
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- Standard downstream adoption is not a valid maintenance surface for the repo-harness source checkout; source-owned workflow surfaces are maintained directly and through projection checks.
+- Source-checkout identity must be derived from the canonical package shape, not equality with the running package directory, because installed and checkout runtimes live at different paths.
+- The shared predicate will serve planner, cleanup, and setup-check consumers so they cannot drift independently.
+
+## Deviations From Plan Or Spec
+
+- None recorded.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| Compare target to running package path | Reject | Fails whenever the CLI is globally installed. |
+| Detect only `package.json#name` | Reject | A name collision would suppress legitimate downstream adoption. |
+| Require canonical package name, bin map, and source authority files | Adopt | Stable across installed/check-out runtime separation and narrow enough to avoid name-only false positives. |
+
+## Open Questions
+
+- None.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Pre-fix regression: `.ai/harness/runs/20260715-self-host-adopt-boundary-pre-fix.log` records the missing shared predicate and the setup-check false positive with `PRE_FIX_EXIT=1`.
+- Focused post-fix tests: `bun test tests/cli/adoption-plan.test.ts tests/cli/init-hook.test.ts` passed 40 tests.
+- README onboarding regression: the first full suite exposed a self-host-coupled README DX fixture; moving that assertion to a disposable downstream repository preserves its onboarding contract. The expanded focused run passed 48 tests.
+- Installed-runtime proof: a disposable global install from the branch tarball returned `plannedTotal=0` for source-checkout adopt and emitted no `repo.adopt-refresh` action.
+- Full repository test: `bun test` passed 1476 tests, skipped 1 platform-specific test, and failed 0 in 501.78 seconds.
+- Required checks: deploy SQL ordering, architecture sync, task sync, strict workflow check, project inspection, typecheck, and `git diff --check` all passed.
+- Source runtime proof: `adopt --repo . --dry-run --json` returned `plannedTotal=0`; `setup check --target codex --check-updates --json` reported `repo.adopt-refresh=na` with no adopt action.
+- CodeGraph proof: local and global CLI version `1.4.1`; the worktree index was initialized, synchronized, and read back as `up-to-date`; Codex and Claude MCP configurations were both detected.
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/notes/20260715-0401-self-host-adopt-boundary.notes.md
+++ b/tasks/notes/20260715-0401-self-host-adopt-boundary.notes.md
@@ -41,6 +41,7 @@
 - Required checks: deploy SQL ordering, architecture sync, task sync, strict workflow check, project inspection, typecheck, and `git diff --check` all passed.
 - Source runtime proof: `adopt --repo . --dry-run --json` returned `plannedTotal=0`; `setup check --target codex --check-updates --json` reported `repo.adopt-refresh=na` with no adopt action.
 - CodeGraph proof: local and global CLI version `1.4.1`; the worktree index was initialized, synchronized, and read back as `up-to-date`; Codex and Claude MCP configurations were both detected.
+- GitHub proof: PR #78 first candidate `6cac4211` passed both Test jobs and all six push/pull-request MCP matrix jobs (8/8 checks green).
 
 ## Promotion Filter
 

--- a/tasks/reviews/20260715-0401-self-host-adopt-boundary.review.md
+++ b/tasks/reviews/20260715-0401-self-host-adopt-boundary.review.md
@@ -8,7 +8,7 @@
 > **Last Updated**: 2026-07-15 04:30
 > **Recommendation**: pass
 > **Review Rubric Version**: 2
-> **Reviewed Subject SHA256**: sha256:3f7d2164daa93066ba8a634b9ae0e386c986883c6a946c9618b2a820f7a6ad2e
+> **Reviewed Subject SHA256**: sha256:1f43a81213fa0999401ebdadafdb78fd48492161c84af77f3bead77b5c7c518b
 > **Reviewed Subject Scope**: normalized-final-content
 > **Reviewed Target Revision**: 7ecb762dd0fce80bbf08866e46dd518428218d2c
 
@@ -18,7 +18,7 @@
 - Change type: bugfix
 - Intended files changed: shared source-checkout predicate, adoption planner/cleanup/setup-check consumers, regression tests, and workflow artifacts named by the contract
 - Actual files changed: intended contract scope only; review subject reports zero target-overlap paths
-- Commands passed: 48 focused tests; typecheck; full suite 1476 pass / 1 skip / 0 fail; deploy SQL, architecture, task, strict workflow, inspection, adoption dry-run, setup-check, CodeGraph, and diff checks
+- Commands passed: 48 focused tests; typecheck; full suite 1476 pass / 1 skip / 0 fail; deploy SQL, architecture, task, strict workflow, inspection, adoption dry-run, setup-check, CodeGraph, diff checks, and PR #78 GitHub CI 8/8
 - External acceptance: unavailable; maintainer instructed this workflow to skip `claude-review`, and no Claude pass is claimed
 - Residual risks: the published and PATH-visible `0.10.0` CLI remains old until a follow-up release/install refresh; the branch tarball proof validates the fixed installed-runtime shape without mutating the real global install
 - Reviewer action required: none for the maintainer-authorized merge waiver
@@ -37,12 +37,12 @@
 - Manual checks: source dry-run returned zero operations; setup check reported `repo.adopt-refresh=na`; incomplete name-only fixture was not classified as source; explicit self-host apply remains blocked
 - Supporting artifacts: `.ai/harness/runs/20260715-self-host-adopt-boundary-pre-fix.log`, plan, contract, notes, and this review
 - Implementation notes reviewed: yes
-- Run snapshot: full repository test 1476 pass / 1 skip / 0 fail in 501.78 seconds; CodeGraph 1.4.1 index up-to-date
+- Run snapshot: full repository test 1476 pass / 1 skip / 0 fail in 501.78 seconds; CodeGraph 1.4.1 index up-to-date; PR #78 first candidate CI 8/8 green
 
 ## Manual Check Evidence
 
 - [x] Evaluator review file recommends pass
-  - Evidence: Human Review Card verdict and top-level Recommendation are pass for subject `sha256:3f7d2164daa93066ba8a634b9ae0e386c986883c6a946c9618b2a820f7a6ad2e`.
+  - Evidence: Human Review Card verdict and top-level Recommendation are pass for subject `sha256:1f43a81213fa0999401ebdadafdb78fd48492161c84af77f3bead77b5c7c518b`.
 - [x] Source adopt dry-run planned zero operations
   - Evidence: `bun src/cli/index.ts adopt --repo . --dry-run --json` exited 0 with `summary.plannedTotal=0`, `operations=[]`, and warning `self-host-source-noop`.
 
@@ -54,7 +54,7 @@
 > **External Started**: not run
 > **External Completed**: not run
 > **Review Rubric Version**: 2
-> **Reviewed Subject SHA256**: sha256:3f7d2164daa93066ba8a634b9ae0e386c986883c6a946c9618b2a820f7a6ad2e
+> **Reviewed Subject SHA256**: sha256:1f43a81213fa0999401ebdadafdb78fd48492161c84af77f3bead77b5c7c518b
 > **Reviewed Subject Scope**: normalized-final-content
 > **Reviewed Target Revision**: 7ecb762dd0fce80bbf08866e46dd518428218d2c
 > **Benchmark Evidence SHA256**: unavailable

--- a/tasks/reviews/20260715-0401-self-host-adopt-boundary.review.md
+++ b/tasks/reviews/20260715-0401-self-host-adopt-boundary.review.md
@@ -1,0 +1,97 @@
+# Task Review: self-host-adopt-boundary
+
+> **Status**: Passed
+> **Plan**: plans/plan-20260715-0401-self-host-adopt-boundary.md
+> **Contract**: tasks/contracts/20260715-0401-self-host-adopt-boundary.contract.md
+> **Notes File**: tasks/notes/20260715-0401-self-host-adopt-boundary.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-07-15 04:30
+> **Recommendation**: pass
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: sha256:3f7d2164daa93066ba8a634b9ae0e386c986883c6a946c9618b2a820f7a6ad2e
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: 7ecb762dd0fce80bbf08866e46dd518428218d2c
+
+## Human Review Card
+
+- Verdict: pass
+- Change type: bugfix
+- Intended files changed: shared source-checkout predicate, adoption planner/cleanup/setup-check consumers, regression tests, and workflow artifacts named by the contract
+- Actual files changed: intended contract scope only; review subject reports zero target-overlap paths
+- Commands passed: 48 focused tests; typecheck; full suite 1476 pass / 1 skip / 0 fail; deploy SQL, architecture, task, strict workflow, inspection, adoption dry-run, setup-check, CodeGraph, and diff checks
+- External acceptance: unavailable; maintainer instructed this workflow to skip `claude-review`, and no Claude pass is claimed
+- Residual risks: the published and PATH-visible `0.10.0` CLI remains old until a follow-up release/install refresh; the branch tarball proof validates the fixed installed-runtime shape without mutating the real global install
+- Reviewer action required: none for the maintainer-authorized merge waiver
+- Rollback: revert the single boundary commit; no migration or persistent product data mutation
+
+## Mode Evidence
+
+- Selected route: isolated bugfix work-package in a contract worktree
+- P1/P2/P3 evidence: captured plan maps planner, cleanup, and setup-check ownership; implementation notes record the shared authority decision
+- Root cause or plan evidence: pre-fix artifact records installed-runtime/source-target path separation producing destructive source-script cleanup operations
+
+## Verification Evidence
+
+- Waza `/check` run: source-equivalent focused review completed in the isolated worktree; Claude review was skipped by maintainer instruction
+- Commands run: `bun test tests/readme-dx.test.ts tests/cli/adoption-plan.test.ts tests/cli/init-hook.test.ts`; `bun run check:type`; `bun test`; root required checks; source adopt/setup probes; disposable installed-runtime probe; CodeGraph init/sync/check; `git diff --check`
+- Manual checks: source dry-run returned zero operations; setup check reported `repo.adopt-refresh=na`; incomplete name-only fixture was not classified as source; explicit self-host apply remains blocked
+- Supporting artifacts: `.ai/harness/runs/20260715-self-host-adopt-boundary-pre-fix.log`, plan, contract, notes, and this review
+- Implementation notes reviewed: yes
+- Run snapshot: full repository test 1476 pass / 1 skip / 0 fail in 501.78 seconds; CodeGraph 1.4.1 index up-to-date
+
+## Manual Check Evidence
+
+- [x] Evaluator review file recommends pass
+  - Evidence: Human Review Card verdict and top-level Recommendation are pass for subject `sha256:3f7d2164daa93066ba8a634b9ae0e386c986883c6a946c9618b2a820f7a6ad2e`.
+- [x] Source adopt dry-run planned zero operations
+  - Evidence: `bun src/cli/index.ts adopt --repo . --dry-run --json` exited 0 with `summary.plannedTotal=0`, `operations=[]`, and warning `self-host-source-noop`.
+
+## External Acceptance Advice
+
+> **External Acceptance**: unavailable
+> **External Reviewer**: not run
+> **External Source**: maintainer merge waiver
+> **External Started**: not run
+> **External Completed**: not run
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: sha256:3f7d2164daa93066ba8a634b9ae0e386c986883c6a946c9618b2a820f7a6ad2e
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: 7ecb762dd0fce80bbf08866e46dd518428218d2c
+> **Benchmark Evidence SHA256**: unavailable
+
+- P1 blockers: none in the implementation review; independent external acceptance remains unavailable by maintainer instruction
+- P2 advisories: release/install refresh is still required before the PATH-visible CLI contains this fix
+- Acceptance checklist: normalized subject and target revision recorded; installed and source runtime boundaries proven; no external verdict fabricated
+
+## Behavior Diff Notes
+
+- Before: source ownership depended on target path equaling the running package path, so a global CLI could plan deletion/untracking of canonical source scripts.
+- After: canonical package/bin/source shape identifies the source checkout independent of runtime location; standard adopt returns a no-op warning and setup check reports downstream refresh as not applicable.
+- Explicit `self-host` review mode remains fail closed, and ordinary downstream repositories still receive the normal adoption plan.
+
+## Residual Risks / Follow-ups
+
+- PATH-visible `repo-harness@0.10.0` does not yet contain this source fix. A patch release and official global refresh are required to change the real installed runtime.
+- Independent external acceptance is unavailable under the maintainer waiver.
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 9/10 | Direct source and disposable installed-runtime probes prove zero adopt operations and no refresh action. |
+| Product depth | 8/10 | Corrects both destructive planning and the recommendation path from one shared boundary. |
+| Design quality | 9/10 | One structural authority, path-independent and fail closed; no compatibility behavior. |
+| Code quality | 9/10 | Narrow consumers, false-positive coverage, onboarding fixture correction, and full suite green. |
+
+## Failing Items
+
+- Canonical external acceptance remains unavailable; this does not change the local implementation recommendation.
+
+## Retest Steps
+
+- Re-run: `bun test tests/readme-dx.test.ts tests/cli/adoption-plan.test.ts tests/cli/init-hook.test.ts && bun run check:type`
+- Re-check: `bun src/cli/index.ts adopt --repo . --dry-run --json && bun src/cli/index.ts setup check --target codex --check-updates --json`
+
+## Summary
+
+- The self-host source checkout can no longer enter the downstream adoption cleanup path when the CLI runs from another installation location. Local implementation review recommends pass; external acceptance remains explicitly unavailable and is not represented as a Claude pass.

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -1,7 +1,7 @@
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: 2026-07-14 23:18
+> **Updated**: 2026-07-15 04:01
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.

--- a/tests/cli/adoption-plan.test.ts
+++ b/tests/cli/adoption-plan.test.ts
@@ -4,6 +4,7 @@ import { spawnSync } from "child_process";
 import { tmpdir } from "os";
 import { join } from "path";
 import { planAdoption } from "../../src/core/adoption/plan";
+import { isRepoHarnessSourceCheckout } from "../../src/core/adoption/source-checkout";
 import { applyAdoptionPlan, rollbackAdoptionTransaction } from "../../src/effects/fs-transaction";
 
 const ROOT = join(import.meta.dir, "..", "..");
@@ -41,9 +42,27 @@ describe("canonical adoption plan", () => {
   });
 
   test("self-host source planning never schedules its canonical scripts for generated-runtime cleanup", () => {
+    expect(isRepoHarnessSourceCheckout(ROOT)).toBe(true);
     const plan = planAdoption({ repoRoot: ROOT, mode: "standard" });
-    expect(plan.operations.some((operation) => operation.kind === "remove" && operation.path?.startsWith("scripts/"))).toBe(false);
-    expect(plan.operations.some((operation) => operation.kind === "gitUntrack" && operation.path?.startsWith("scripts/"))).toBe(false);
+    expect(plan.summary.plannedTotal).toBe(0);
+    expect(plan.operations).toEqual([]);
+    expect(plan.warnings).toEqual([
+      {
+        code: "self-host-source-noop",
+        message: "The repo-harness source checkout owns its workflow surfaces; downstream adopt is not applicable.",
+        risk: "low",
+      },
+    ]);
+  });
+
+  test("source checkout detection requires the complete canonical package shape", () => {
+    const repo = tempRepo();
+    try {
+      writeFileSync(join(repo, "package.json"), JSON.stringify({ name: "repo-harness" }));
+      expect(isRepoHarnessSourceCheckout(repo)).toBe(false);
+    } finally {
+      cleanup(repo);
+    }
   });
 
   test("standard apply installs state, hooks, templates, package scripts, and a recoverable manifest", () => {

--- a/tests/cli/init-hook.test.ts
+++ b/tests/cli/init-hook.test.ts
@@ -336,6 +336,29 @@ describe('init-hook command', () => {
     });
   });
 
+  test('does not recommend downstream adopt refresh for the repo-harness source checkout', () => {
+    withTempHome((home) => {
+      mkdirSync(join(home, '.codex'), { recursive: true });
+      writeFileSync(join(home, '.codex', 'AGENTS.md'), '# Global Working Rules\n');
+
+      const report = runInitHook({
+        cwd: ROOT,
+        sourceRoot: join(home, '.bun', 'install', 'global', 'node_modules', 'repo-harness'),
+        target: 'codex',
+        checkUpdates: true,
+        env: { ...process.env, HOME: home },
+        statusReport: statusReportForRepo(ROOT),
+        doctorReport: baseDoctorReport(),
+        toolingReport: baseToolingReport(),
+      });
+
+      const check = report.checks.find((entry) => entry.id === 'repo.adopt-refresh');
+      expect(check?.status).toBe('na');
+      expect(check?.detail).toContain('self-host source checkout');
+      expect(report.agent_actions.find((entry) => entry.id === 'repo.adopt-refresh')).toBeUndefined();
+    });
+  });
+
   test('does not ask Agents to refresh adoption for non-adopted repos', () => {
     withTempHome((home, repo) => {
       mkdirSync(join(home, '.codex'), { recursive: true });

--- a/tests/readme-dx.test.ts
+++ b/tests/readme-dx.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { spawnSync } from "child_process";
+import { tmpdir } from "os";
 import { join } from "path";
 
 const ROOT = join(import.meta.dir, "..");
@@ -206,15 +207,21 @@ describe("README DX contract", () => {
   });
 
   test("dry-run keeps the canonical adoption-plan onboarding signal", () => {
-    const res = spawnSync("bun", ["src/cli/index.ts", "adopt", "--repo", ".", "--dry-run"], {
-      cwd: ROOT,
-      encoding: "utf-8",
-    });
+    const repo = mkdtempSync(join(tmpdir(), "repo-harness-readme-dx-"));
+    try {
+      writeFileSync(join(repo, "package.json"), JSON.stringify({ name: "readme-dx-fixture", private: true }));
+      const res = spawnSync("bun", ["src/cli/index.ts", "adopt", "--repo", repo, "--dry-run"], {
+        cwd: ROOT,
+        encoding: "utf-8",
+      });
 
-    expect(res.status).toBe(0);
-    expect(res.stdout).toContain("[adopt-plan] repo:");
-    expect(res.stdout).toContain("[adopt-plan] operations:");
-    expect(res.stdout).toContain("writeFile:");
+      expect(res.status).toBe(0);
+      expect(res.stdout).toContain(`[adopt-plan] repo: ${repo}`);
+      expect(res.stdout).toContain("[adopt-plan] operations:");
+      expect(res.stdout).toContain("writeFile:");
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
   }, 15000);
 
   test("runtime red-flag scan uses an explicit allowlist for install examples and legacy aliases", () => {


### PR DESCRIPTION
## Summary
- detect the repo-harness source checkout from its canonical package shape instead of the running package path
- make standard downstream adopt a no-op for the source checkout and mark setup refresh not applicable
- preserve downstream onboarding behavior and explicit self-host fail-closed semantics

## Verification
- `bun test`: 1476 pass, 1 skip, 0 fail
- focused adoption/init/README tests: 48 pass
- typecheck and all required repository checks pass
- source and disposable installed-runtime probes both return zero adopt operations and no refresh action
- CodeGraph 1.4.1 index synchronized and up-to-date

## Review boundary
Maintainer explicitly requested skipping Claude review. Local implementation review recommends pass; canonical external acceptance is recorded as unavailable, not waived into a synthetic pass.