### PR TITLE
feat(workflow): establish pure ArtifactRequirementPolicy matrix (LSC-02)

### DIFF
--- a/plans/plan-20260718-1405-lsc-02-artifact-requirement-policy.md
+++ b/plans/plan-20260718-1405-lsc-02-artifact-requirement-policy.md
@@ -1,0 +1,149 @@
+# Plan: Sprint task: lsc-02-artifact-requirement-policy
+
+> **Status**: Executing
+> **Created**: 20260718-1405
+> **Slug**: lsc-02-artifact-requirement-policy
+> **Planning Source**: repo-harness-sprint
+> **Orchestration Kind**: sprint-task
+> **Source Ref**: sprint:plans/sprints/20260716-0101-loop-semantics-convergence.sprint.md#lsc-02-artifact-requirement-policy
+> **Artifact Level**: work-package
+> **Promotion Reason**: worktree_boundary
+> **Post-ESA Program Baseline**: `origin/main@3b33cea2422b1aa1e5be9080be54f731c4f2015d` (PR #79)
+> **LSC-02 Execution Base**: `origin/main@64673ee2c1148c2edfcea0afa097375898323841` (post-LSC-01 merge, PR #82)
+> **Verification Boundary**: Commands named in the captured planning output plus `repo-harness run verify-contract --contract tasks/contracts/20260718-1405-lsc-02-artifact-requirement-policy.contract.md --strict`.
+> **Rollback Surface**: Before execution remove `plans/plan-20260718-1405-lsc-02-artifact-requirement-policy.md`; after execution revert branch `codex/lsc-02-artifact-requirement-policy` or the explicitly reviewed diff.
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260718-1405-lsc-02-artifact-requirement-policy.contract.md`
+> **Task Review**: `tasks/reviews/20260718-1405-lsc-02-artifact-requirement-policy.review.md`
+> **Implementation Notes**: `tasks/notes/20260718-1405-lsc-02-artifact-requirement-policy.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from repo-harness-sprint planning output.
+- Source ref: sprint:plans/sprints/20260716-0101-loop-semantics-convergence.sprint.md#lsc-02-artifact-requirement-policy
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260718-1405-lsc-02-artifact-requirement-policy.md`
+- Sprint contract: `tasks/contracts/20260718-1405-lsc-02-artifact-requirement-policy.contract.md`
+- Sprint review: `tasks/reviews/20260718-1405-lsc-02-artifact-requirement-policy.review.md`
+- Implementation notes: `tasks/notes/20260718-1405-lsc-02-artifact-requirement-policy.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260718-1405-lsc-02-artifact-requirement-policy.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260718-1405-lsc-02-artifact-requirement-policy.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260718-1405-lsc-02-artifact-requirement-policy.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| `src/core/workflow/artifact-requirement-policy.ts` | Create | Pure requirement matrix + `resolve({ profile, operation, risk, policy })`; module-owned edit/stop/ship operation type |
+| `tests/state/fixtures/loop-semantics/artifact-requirement-policy.json` | Create | Positive cases for all nine cells; negative cases for raise semantics and invalid inputs |
+| `tests/state/artifact-requirement-policy.test.ts` | Create | Fixture-driven test pinning matrix output; totality over 9 cells |
+| `plans/sprints/20260716-0101-loop-semantics-convergence.sprint.md` | Edit | Pin LSC-02 Execution Base per successor rule |
+| Contract/review/notes for this slug | Edit | Workflow envelope |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260718-1405-lsc-02-artifact-requirement-policy.contract.md`
+- Review file: `tasks/reviews/20260718-1405-lsc-02-artifact-requirement-policy.review.md`
+- Implementation notes file: `tasks/notes/20260718-1405-lsc-02-artifact-requirement-policy.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260718-1405-lsc-02-artifact-requirement-policy.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260718-1405-lsc-02-artifact-requirement-policy.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: Before execution remove `plans/plan-20260718-1405-lsc-02-artifact-requirement-policy.md`; after execution revert branch `codex/lsc-02-artifact-requirement-policy` or the explicitly reviewed diff.
+- **Verification boundary**: Commands named in the captured planning output plus `repo-harness run verify-contract --contract tasks/contracts/20260718-1405-lsc-02-artifact-requirement-policy.contract.md --strict`.
+- **Review/acceptance boundary**: `tasks/reviews/20260718-1405-lsc-02-artifact-requirement-policy.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: worktree_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260718-1405-lsc-02-artifact-requirement-policy.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260718-1405-lsc-02-artifact-requirement-policy.contract.md`, `tasks/reviews/20260718-1405-lsc-02-artifact-requirement-policy.review.md`, and `tasks/notes/20260718-1405-lsc-02-artifact-requirement-policy.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260718-1405-lsc-02-artifact-requirement-policy.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: Before execution remove `plans/plan-20260718-1405-lsc-02-artifact-requirement-policy.md`; after execution revert branch `codex/lsc-02-artifact-requirement-policy` or the explicitly reviewed diff.
+
+## Captured Planning Output
+
+# Sprint Task: lsc-02-artifact-requirement-policy
+
+## Context
+
+- Sprint: `plans/sprints/20260716-0101-loop-semantics-convergence.sprint.md`
+- Backlog row: 2
+- Mode: contract
+- Read the sprint Source PRD and Architecture Notes before implementation.
+- The sprint row is a long-task waypoint, not a detailed implementation plan.
+
+## Goal
+
+Deliver backlog task `lsc-02-artifact-requirement-policy` so that the acceptance line holds: In an independent PR, establish one pure `ArtifactRequirementPolicy` matrix for Lite/Standard/Strict with positive/negative fixtures; do not switch consumers or implement readiness in this package
+
+## Planning Expansion (resolved 2026-07-18)
+
+The sprint row is expanded in place; the calibrated contract
+`tasks/contracts/20260718-1405-lsc-02-artifact-requirement-policy.contract.md`
+is the execution authority. Decision-complete inputs:
+
+- Delta authority: the nine `target_delta` records frozen by LSC-01 in
+  `tests/state/fixtures/loop-semantics/characterization.json`. The matrix
+  encodes exactly these approved targets, not LSC-01's current-behavior cells.
+- Module signature: `ArtifactRequirementPolicy.resolve({ profile, operation,
+  risk, taskKind, policy })` per the audit
+  (`plans/sprints/20260715-harness-loop-audit-and-optimization.md:224-242`).
+- The edit/stop/ship operation axis is a new module-owned type; it is not
+  `WorkflowOperationKind` (risk-signal axis in `src/core/workflow/profile.ts`,
+  which has no stop/ship member).
+- Placement: `src/core/workflow/artifact-requirement-policy.ts`, pure, sibling
+  to the profile authority; consumers are not switched (that starts in LSC-03).
+- Fixtures nest under `tests/state/fixtures/loop-semantics/` so they are not
+  swept into ESA adapter-parity enumeration (LSC-01 notes deviation record).
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [x] Derive requirement keys and all nine cell values from the frozen `target_delta` records and the audit matrix; record the derivation in the notes file (no invented semantics)
+- [x] Implement pure module `src/core/workflow/artifact-requirement-policy.ts` (literal matrix + `resolve` with risk/policy raise; module-owned edit/stop/ship type; exhaustiveness enforced)
+- [x] Add fixture `tests/state/fixtures/loop-semantics/artifact-requirement-policy.json` and test `tests/state/artifact-requirement-policy.test.ts` (positive: all nine cells; negative: raise semantics, invalid profile/operation)
+- [x] Pin `LSC-02 Execution Base: origin/main@64673ee2c1148c2edfcea0afa097375898323841` in the sprint header per successor rule
+- [x] Run the full Exit Criteria command surface in this worktree and record evidence
+- [x] Author the task review, obtain independent external acceptance, and ship as an independent PR against base `64673ee2`

--- a/plans/sprints/20260716-0101-loop-semantics-convergence.sprint.md
+++ b/plans/sprints/20260716-0101-loop-semantics-convergence.sprint.md
@@ -10,6 +10,7 @@
 > **Post-ESA Program Baseline**: `origin/main@3b33cea2422b1aa1e5be9080be54f731c4f2015d`
 > **Program Planning Base**: `origin/main@be3e93ce72c812a33045a15c4d97452c59fa3fbb` (PR #80)
 > **LSC-01 Execution Base**: `origin/main@d8e5f221053b8bf20f105933376c7524a0f05063` (post-CRG-01 merge, PR #83; fetched and pinned per this sprint's own successor rule now that CRG-01 has merged)
+> **LSC-02 Execution Base**: `origin/main@64673ee2c1148c2edfcea0afa097375898323841` (post-LSC-01 merge, PR #82)
 > **Predecessor**: Closeout Runner Guardrails (CRG-01), merged by PR #83 at `d8e5f221053b8bf20f105933376c7524a0f05063`; Effective State Authority Convergence (PR #79, `3b33cea2422b1aa1e5be9080be54f731c4f2015d`) remains the semantic baseline
 > **Successor Order**: Hook Runtime Diet -> Evidence & Projection Convergence -> Skill Surface & Discovery Convergence
 > **Goal Mode**: incremental

--- a/src/core/workflow/artifact-requirement-policy.ts
+++ b/src/core/workflow/artifact-requirement-policy.ts
@@ -1,0 +1,215 @@
+/**
+ * Pure artifact-requirement policy matrix for Lite/Standard/Strict x
+ * edit/stop/ship.
+ *
+ * This module is the single source of truth for which ceremony artifacts
+ * (contract, worktree, review, evidence, ...) each workflow profile
+ * requires for each operation. Every requirement key and per-cell value
+ * derives 1:1 from the nine approved `target_delta` records frozen by
+ * LSC-01 in `tests/state/fixtures/loop-semantics/characterization.json`;
+ * see `tasks/notes/20260718-1405-lsc-02-artifact-requirement-policy.notes.md`
+ * for the record -> key derivation.
+ *
+ * No consumer imports this module yet -- LSC-03..08 cut PreEdit, Stop,
+ * ship, and adapter consumers over one package at a time. This module
+ * performs no fs/process/env/network access and imports only the
+ * `WorkflowProfile` type from `./profile`. It does not reuse or extend
+ * `WorkflowOperationKind`, which is a different (risk-signal) axis with no
+ * `stop`/`ship` member.
+ */
+import type { WorkflowProfile } from './profile';
+
+/**
+ * Module-owned operation axis for artifact requirement policy. Deliberately
+ * NOT `WorkflowOperationKind` (the risk-signal axis in `./profile`, which
+ * has no `stop`/`ship` member).
+ */
+export type ArtifactRequirementOperation = 'edit' | 'stop' | 'ship';
+
+/**
+ * Every requirement key referenced by the nine frozen `target_delta`
+ * records. See the notes file for the record -> key derivation.
+ */
+export type ArtifactRequirementKey =
+  | 'safe_path'
+  | 'worktree_boundary'
+  | 'destructive_action_boundary'
+  | 'complete_approved_work_package'
+  | 'separate_contract'
+  | 'isolated_contract_worktree'
+  | 'durable_recovery_state'
+  | 'fresh_review'
+  | 'external_acceptance'
+  | 'fresh_checks'
+  | 'subject_bound_targeted_evidence'
+  | 'candidate_revision_precondition';
+
+export type ArtifactRequirementStatus = 'required' | 'not_required';
+
+/** One literal matrix cell entry: a requirement key and its policy default. */
+export interface ArtifactRequirementEntry {
+  readonly key: ArtifactRequirementKey;
+  readonly defaultStatus: ArtifactRequirementStatus;
+}
+
+/**
+ * Exhaustive Lite/Standard/Strict x edit/stop/ship matrix. The mapped type
+ * over `WorkflowProfile` and `ArtifactRequirementOperation` forces all nine
+ * cells to be present at compile time -- totality is enforced by types, not
+ * by a runtime default.
+ */
+export type ArtifactRequirementMatrix = {
+  readonly [profile in WorkflowProfile]: {
+    readonly [operation in ArtifactRequirementOperation]: readonly ArtifactRequirementEntry[];
+  };
+};
+
+/**
+ * The literal policy matrix. Derivation (per cell, per key) is recorded in
+ * `tasks/notes/20260718-1405-lsc-02-artifact-requirement-policy.notes.md`.
+ *
+ * Lite carries only baseline safety/evidence keys (no ceremony artifacts).
+ * Standard requires a complete approved work package; its `separate_contract`
+ * (and, for ship, `external_acceptance`) default to not_required but may be
+ * raised by risk or explicit policy. Strict is the maximal fail-closed
+ * envelope: every key it names is unconditionally required.
+ */
+export const ARTIFACT_REQUIREMENT_MATRIX: ArtifactRequirementMatrix = {
+  lite: {
+    edit: [
+      { key: 'safe_path', defaultStatus: 'required' },
+      { key: 'worktree_boundary', defaultStatus: 'required' },
+      { key: 'destructive_action_boundary', defaultStatus: 'required' },
+    ],
+    stop: [
+      { key: 'durable_recovery_state', defaultStatus: 'required' },
+    ],
+    ship: [
+      { key: 'subject_bound_targeted_evidence', defaultStatus: 'required' },
+    ],
+  },
+  standard: {
+    edit: [
+      { key: 'complete_approved_work_package', defaultStatus: 'required' },
+      { key: 'separate_contract', defaultStatus: 'not_required' },
+    ],
+    stop: [
+      { key: 'durable_recovery_state', defaultStatus: 'required' },
+    ],
+    ship: [
+      { key: 'complete_approved_work_package', defaultStatus: 'required' },
+      { key: 'subject_bound_targeted_evidence', defaultStatus: 'required' },
+      { key: 'separate_contract', defaultStatus: 'not_required' },
+      { key: 'external_acceptance', defaultStatus: 'not_required' },
+    ],
+  },
+  strict: {
+    edit: [
+      { key: 'separate_contract', defaultStatus: 'required' },
+      { key: 'isolated_contract_worktree', defaultStatus: 'required' },
+    ],
+    stop: [
+      { key: 'durable_recovery_state', defaultStatus: 'required' },
+    ],
+    ship: [
+      { key: 'separate_contract', defaultStatus: 'required' },
+      { key: 'isolated_contract_worktree', defaultStatus: 'required' },
+      { key: 'fresh_review', defaultStatus: 'required' },
+      { key: 'external_acceptance', defaultStatus: 'required' },
+      { key: 'fresh_checks', defaultStatus: 'required' },
+      { key: 'candidate_revision_precondition', defaultStatus: 'required' },
+    ],
+  },
+};
+
+const KNOWN_PROFILES: ReadonlySet<string> = new Set(Object.keys(ARTIFACT_REQUIREMENT_MATRIX));
+const KNOWN_OPERATIONS: ReadonlySet<string> = new Set(Object.keys(ARTIFACT_REQUIREMENT_MATRIX.lite));
+const PROFILE_RANK: Readonly<Record<WorkflowProfile, number>> = { lite: 0, standard: 1, strict: 2 };
+
+/** Explicit policy override: names requirement keys to force to `required`. */
+export interface ArtifactRequirementPolicyOverride {
+  readonly require?: readonly ArtifactRequirementKey[];
+}
+
+export interface ArtifactRequirementResolveInput {
+  readonly profile: WorkflowProfile;
+  readonly operation: ArtifactRequirementOperation;
+  /**
+   * An independently computed risk signal, ranked on the same
+   * lite < standard < strict scale as `profile`. When `risk` outranks
+   * `profile`, every not_required entry in the resolved cell is raised to
+   * required. Omit when no distinct risk signal is available.
+   */
+  readonly risk?: WorkflowProfile;
+  /** Explicit policy override; raises named not_required entries. */
+  readonly policy?: ArtifactRequirementPolicyOverride;
+}
+
+export type ArtifactRequirementRaiseSource = 'risk' | 'policy';
+
+export interface ArtifactRequirementDecision {
+  readonly key: ArtifactRequirementKey;
+  readonly defaultStatus: ArtifactRequirementStatus;
+  /** `defaultStatus` after applying the risk/policy raise rule. */
+  readonly status: ArtifactRequirementStatus;
+  /** Empty unless a not_required entry was raised to required. */
+  readonly raisedBy: readonly ArtifactRequirementRaiseSource[];
+}
+
+export interface ArtifactRequirementResolution {
+  readonly ok: true;
+  readonly profile: WorkflowProfile;
+  readonly operation: ArtifactRequirementOperation;
+  readonly requirements: readonly ArtifactRequirementDecision[];
+}
+
+export type ArtifactRequirementResolveErrorCode = 'INVALID_PROFILE' | 'INVALID_OPERATION';
+
+export interface ArtifactRequirementResolveError {
+  readonly ok: false;
+  readonly code: ArtifactRequirementResolveErrorCode;
+  readonly message: string;
+}
+
+export type ArtifactRequirementResolveResult =
+  | ArtifactRequirementResolution
+  | ArtifactRequirementResolveError;
+
+/**
+ * Resolve the artifact-requirement decision for one profile x operation
+ * cell, applying the risk/policy raise rule to any not_required entry.
+ * Unknown profile/operation values are rejected, never defaulted.
+ */
+export function resolve(input: ArtifactRequirementResolveInput): ArtifactRequirementResolveResult {
+  if (!KNOWN_PROFILES.has(input.profile)) {
+    return { ok: false, code: 'INVALID_PROFILE', message: `unknown workflow profile: ${input.profile}` };
+  }
+  if (!KNOWN_OPERATIONS.has(input.operation)) {
+    return {
+      ok: false,
+      code: 'INVALID_OPERATION',
+      message: `unknown artifact requirement operation: ${input.operation}`,
+    };
+  }
+
+  const cell = ARTIFACT_REQUIREMENT_MATRIX[input.profile][input.operation];
+  const riskRaises = input.risk !== undefined && PROFILE_RANK[input.risk] > PROFILE_RANK[input.profile];
+  const policyRequires = new Set(input.policy?.require ?? []);
+
+  const requirements = cell.map((entry): ArtifactRequirementDecision => {
+    if (entry.defaultStatus === 'required') {
+      return { key: entry.key, defaultStatus: entry.defaultStatus, status: 'required', raisedBy: [] };
+    }
+    const raisedBy: ArtifactRequirementRaiseSource[] = [];
+    if (riskRaises) raisedBy.push('risk');
+    if (policyRequires.has(entry.key)) raisedBy.push('policy');
+    return {
+      key: entry.key,
+      defaultStatus: entry.defaultStatus,
+      status: raisedBy.length > 0 ? 'required' : 'not_required',
+      raisedBy,
+    };
+  });
+
+  return { ok: true, profile: input.profile, operation: input.operation, requirements };
+}

--- a/tasks/contracts/20260718-1405-lsc-02-artifact-requirement-policy.contract.md
+++ b/tasks/contracts/20260718-1405-lsc-02-artifact-requirement-policy.contract.md
@@ -1,0 +1,244 @@
+# Task Contract: lsc-02-artifact-requirement-policy
+
+> **Status**: Active
+> **Plan**: plans/plan-20260718-1405-lsc-02-artifact-requirement-policy.md
+> **Task Profile**: code-change
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: kito
+> **Capability ID**: root
+> **Last Updated**: 2026-07-18 14:05
+> **Post-ESA Program Baseline**: `origin/main@3b33cea2422b1aa1e5be9080be54f731c4f2015d` (PR #79)
+> **LSC-02 Execution Base**: `origin/main@64673ee2c1148c2edfcea0afa097375898323841` (post-LSC-01 merge, PR #82)
+> **Review File**: `tasks/reviews/20260718-1405-lsc-02-artifact-requirement-policy.review.md`
+> **Notes File**: `tasks/notes/20260718-1405-lsc-02-artifact-requirement-policy.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+LSC-03..08 will cut PreEdit, Stop, ship, and adapter consumers over to a single
+artifact-requirement authority one package at a time. Without one pure matrix
+established first, each cutover would re-derive requirements ad hoc, mixing
+policy definition with consumer switching, and the current-behavior baseline
+frozen by LSC-01 would have no explicit target authority to converge on. If
+this package ships wrong, every later semantic cutover inherits a wrong or
+ambiguous requirement source.
+
+## Goal
+
+Deliver one pure `ArtifactRequirementPolicy` module whose matrix covers
+Lite/Standard/Strict x edit/stop/ship, whose content is exactly the nine
+approved target-delta records frozen in
+`tests/state/fixtures/loop-semantics/characterization.json`, with
+positive/negative fixture-driven tests. No consumer is switched, no readiness
+evaluator is implemented, and no production behavior changes anywhere.
+
+## Scope
+
+- In scope:
+  - New pure module `src/core/workflow/artifact-requirement-policy.ts`: the
+    machine-readable requirement matrix plus a `resolve({ profile, operation,
+    risk, policy })`-shaped accessor per the audit signature
+    (`plans/sprints/20260715-harness-loop-audit-and-optimization.md:224-242`).
+    No I/O, no environment access, imports only types from
+    `src/core/workflow/profile.ts`.
+  - The edit/stop/ship operation axis is a NEW type owned by this module. It
+    is not `WorkflowOperationKind` (that is the risk-signal input axis:
+    inspect/edit/bugfix/feature/...; it has no stop or ship member). Do not
+    conflate or extend `WorkflowOperationKind`.
+  - Requirement keys and per-cell values derive 1:1 from the nine
+    `target_delta` records in
+    `tests/state/fixtures/loop-semantics/characterization.json` (e.g.
+    `separate_contract` not_required by default for standard.edit and
+    standard.ship with risk/policy raise; strict.ship full envelope:
+    `separate_contract`, `isolated_contract_worktree`, `fresh_review`,
+    `external_acceptance`, `fresh_checks`, `candidate_revision_precondition`).
+    Cells or keys not supported by a frozen target delta or the audit matrix
+    (audit lines 238-242) must not be invented.
+  - New test `tests/state/artifact-requirement-policy.test.ts` and fixture
+    `tests/state/fixtures/loop-semantics/artifact-requirement-policy.json`
+    (nested under `loop-semantics/` because a top-level JSON in
+    `tests/state/fixtures/` is swept into ESA adapter-parity enumeration; see
+    `tasks/notes/20260716-0150-lsc-01-profile-operation-characterization.notes.md:54-58`).
+    Positive cases pin all nine cells; negative cases pin raise semantics
+    (risk/policy raising a not_required requirement) and invalid
+    profile/operation rejection.
+  - Pin the LSC-02 execution base in the sprint header of
+    `plans/sprints/20260716-0101-loop-semantics-convergence.sprint.md`
+    following the LSC-01 successor-pin precedent.
+- Out of scope:
+  - Switching any consumer: `src/core/state/project-effective-state.ts`,
+    `src/effects/state/resolve-effective-state.ts`, `.ai/hooks/pre-edit-guard.sh`,
+    `.ai/hooks/stop-orchestrator.sh`, `scripts/verify-sprint.sh`,
+    `scripts/ship-worktrees.sh`, CLI/MCP/Skill surfaces. No production file
+    imports the new module in this package.
+  - Readiness evaluator or allowedToEdit/allowedToStop/readyToShip fields
+    (LSC-06), Stop semantics cleanup (LSC-07), revision partition (LSC-04),
+    state-version allocation (LSC-05), adapter parity (LSC-08).
+  - Every path outside Allowed Paths, including `.ai/hooks/`, `assets/`,
+    `scripts/`, installer, and Skill surfaces.
+  - Compatibility code, dual authority, semantic fallback, or any second
+    representation of the matrix.
+- Taste constraints: The matrix is explicit policy data, not derived logic.
+  Prefer one literal, exhaustively typed matrix over clever generation;
+  totality over the 9 cells must be enforced by types or an exhaustiveness
+  check, not by runtime defaults.
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path
+  outside Allowed Paths.
+- Stop if a required cell or requirement key is not explicitly supported by a
+  frozen `target_delta` record or the audit matrix; do not invent semantics.
+- Stop if expressing a cell requires consulting or changing consumer behavior.
+- Stop if any existing test or golden changes value; this package must be
+  behavior-inert outside its new files.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop after three fail -> fix -> reverify rounds for the same issue.
+
+## Falsifier
+
+The single-matrix direction is falsified if the nine approved target deltas
+cannot be expressed as one pure total matrix plus a raise rule, without
+consumer-specific branches. Cheapest proof point: encode `standard.edit` and
+`standard.ship` first (the two "not_required by default, risk/policy may
+raise" cells); if raise semantics need consumer context there, stop.
+
+## Root Cause Evidence
+
+Not applicable: this is a `code-change` policy-module package, not a bugfix.
+
+- root_cause: (not applicable)
+- repro: (not applicable)
+- regression_guard: (not applicable)
+- pre_fix_failure_artifact: (not applicable)
+
+## Workflow Inventory
+
+- Source audit: `plans/sprints/20260715-harness-loop-audit-and-optimization.md`
+- Source sprint: `plans/sprints/20260716-0101-loop-semantics-convergence.sprint.md`
+- Delta authority: `tests/state/fixtures/loop-semantics/characterization.json`
+- Active plan: `plans/plan-20260718-1405-lsc-02-artifact-requirement-policy.md`
+- Review file: `tasks/reviews/20260718-1405-lsc-02-artifact-requirement-policy.review.md`
+- Notes file: `tasks/notes/20260718-1405-lsc-02-artifact-requirement-policy.notes.md`
+- Checks file: `.ai/harness/checks/latest.json` (ignored runtime evidence)
+- Run snapshots: `.ai/harness/runs/` (ignored runtime evidence)
+- Base/branch/WT: `64673ee2c1148c2edfcea0afa097375898323841` /
+  `codex/lsc-02-artifact-requirement-policy` /
+  `/Users/kito/Projects/repo-harness-loop-control-wt-lsc-02-artifact-requirement-policy`
+- Scope gate: edit only paths listed under `allowed_paths`; update this
+  contract before widening scope.
+- Completion gate: `repo-harness run verify-sprint` must see this contract
+  pass, the review recommend pass, and canonical `## External Acceptance
+  Advice` record `pass` for the current review subject and benchmark evidence.
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - plans/plan-20260718-1405-lsc-02-artifact-requirement-policy.md
+  - plans/sprints/20260716-0101-loop-semantics-convergence.sprint.md
+  - tasks/current.md
+  - tasks/todos.md
+  - tasks/contracts/20260718-1405-lsc-02-artifact-requirement-policy.contract.md
+  - tasks/reviews/20260718-1405-lsc-02-artifact-requirement-policy.review.md
+  - tasks/notes/20260718-1405-lsc-02-artifact-requirement-policy.notes.md
+  - src/core/workflow/artifact-requirement-policy.ts
+  - tests/state/artifact-requirement-policy.test.ts
+  - tests/state/fixtures/loop-semantics/artifact-requirement-policy.json
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    tool_calls: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: scope_and_acceptance_owner
+    explorer:
+      mode: read_only
+      purpose: target_delta_and_audit_archaeology
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: pure_policy_module_and_fixtures
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_and_scope_review
+  runner:
+    preferred:
+      - subagent
+      - main-thread
+    fallback: main-thread
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - plans/plan-20260718-1405-lsc-02-artifact-requirement-policy.md
+    - plans/sprints/20260716-0101-loop-semantics-convergence.sprint.md
+    - tasks/contracts/20260718-1405-lsc-02-artifact-requirement-policy.contract.md
+    - tasks/reviews/20260718-1405-lsc-02-artifact-requirement-policy.review.md
+    - tasks/notes/20260718-1405-lsc-02-artifact-requirement-policy.notes.md
+    - src/core/workflow/artifact-requirement-policy.ts
+    - tests/state/artifact-requirement-policy.test.ts
+    - tests/state/fixtures/loop-semantics/artifact-requirement-policy.json
+  artifacts_exist:
+    - tasks/reviews/20260718-1405-lsc-02-artifact-requirement-policy.review.md
+    - tasks/notes/20260718-1405-lsc-02-artifact-requirement-policy.notes.md
+  tests_pass:
+    - path: tests/state/artifact-requirement-policy.test.ts
+  commands_succeed:
+    - bun test tests/state/artifact-requirement-policy.test.ts
+    - bun run check:type
+    - bun test
+    - bash scripts/check-deploy-sql-order.sh
+    - bash scripts/check-task-sync.sh
+    - bash scripts/check-architecture-sync.sh
+    - repo-harness run check-task-workflow --strict
+    - repo-harness state resolve --json
+    - bun scripts/inspect-project-state.ts --repo . --format text
+    - bun src/cli/index.ts adopt --repo . --dry-run
+    - git diff --check
+  qa_scores:
+    - dimension: functionality
+      min: 8
+    - dimension: code_quality
+      min: 8
+  manual_checks:
+    - "Module is pure: no fs/process/env/network access; imports only types from src/core/workflow/profile.ts"
+    - "No production file imports the new module (grep -r artifact-requirement-policy src/ shows only the module itself)"
+    - "Matrix content matches the nine frozen target_delta records 1:1; no invented requirement key, cell, or semantics"
+    - "Operation axis is a module-owned edit/stop/ship type, not WorkflowOperationKind"
+    - "Negative fixtures cover risk/policy raise semantics and invalid profile/operation rejection"
+    - "Full bun test passes with no change to any existing test or golden"
+    - "Final diff contains only Allowed Paths"
+    - "Fresh task review and independent external acceptance both pass for the frozen subject"
+```
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior: additive only; the new module exists with total 9-cell
+  coverage, and zero behavior changes anywhere else in the repo.
+- Edge cases: standard.edit and standard.ship raisable requirements; strict
+  fail-closed full envelope; lite zero-ceremony rows; unknown profile or
+  operation rejected, not defaulted.
+- Regression risks: accidentally importing the module from a consumer;
+  encoding LSC-01's current-behavior cells instead of the approved target
+  deltas; widening `WorkflowOperationKind`.
+
+## Rollback Point
+
+- Commit / checkpoint: `64673ee2c1148c2edfcea0afa097375898323841`.
+- Revert strategy: revert the independent LSC-02 PR; no consumer depends on
+  the module, so the revert is behavior-inert and needs no compatibility path.

--- a/tasks/notes/20260718-1405-lsc-02-artifact-requirement-policy.notes.md
+++ b/tasks/notes/20260718-1405-lsc-02-artifact-requirement-policy.notes.md
@@ -1,0 +1,128 @@
+# Implementation Notes: lsc-02-artifact-requirement-policy
+
+> **Status**: Active
+> **Plan**: plans/plan-20260718-1405-lsc-02-artifact-requirement-policy.md
+> **Contract**: tasks/contracts/20260718-1405-lsc-02-artifact-requirement-policy.contract.md
+> **Review**: tasks/reviews/20260718-1405-lsc-02-artifact-requirement-policy.review.md
+> **Last Updated**: 2026-07-18 14:05
+> **Lifecycle**: notes
+
+## Design Decisions
+
+### Cell -> target_delta derivation
+
+Each matrix cell's requirement-entry set is exactly the frozen
+`target_delta.requirements` array for that cell (the field that names what
+is positively required), never `missing_requirements` (a per-captured-
+scenario observation of what happened to be unmet, owned by the future
+LSC-06 readiness evaluator, not by this policy module). Every entry starts
+`defaultStatus: 'required'` unless the cell's `behavior_changes` text names
+it as becoming not_required by default (see raise-key table below).
+
+| Matrix cell | Source `target_delta` record (`characterization.json`) | `requirements` -> entries |
+|---|---|---|
+| `lite.edit` | `lite.edit.no-plan-contract-allows` | `safe_path`, `worktree_boundary`, `destructive_action_boundary` -> all `required` |
+| `lite.stop` | `lite.stop.handoff-only-allows` | `durable_recovery_state` -> `required` |
+| `lite.ship` | `lite.ship.no-profile-readiness` | `subject_bound_targeted_evidence` -> `required` |
+| `standard.edit` | `standard.edit.complete-work-package-no-contract-blocks` | `complete_approved_work_package` -> `required`; `behavior_changes` ("separate_contract becomes not_required by default") adds `separate_contract` -> `not_required` |
+| `standard.stop` | `standard.stop.stale-review-warns-allows` | `durable_recovery_state` -> `required` |
+| `standard.ship` | `standard.ship.full-strict-envelope-required` | `complete_approved_work_package`, `subject_bound_targeted_evidence` -> `required`; `behavior_changes` ("separate_contract and external_acceptance become not_required by default") adds `separate_contract`, `external_acceptance` -> `not_required` |
+| `strict.edit` | `strict.edit.missing-contract-blocks` | `separate_contract`, `isolated_contract_worktree` -> both `required` |
+| `strict.stop` | `strict.stop.not-ready-to-ship-still-allows` | `durable_recovery_state` -> `required` |
+| `strict.ship` | `strict.ship.full-envelope-fragmented` | `separate_contract`, `isolated_contract_worktree`, `fresh_review`, `external_acceptance`, `fresh_checks`, `candidate_revision_precondition` -> all `required` (the fail-closed full envelope; strict rows carry no raise concept because they are already maximal) |
+
+The 12-member `ArtifactRequirementKey` union is the exact union of every key
+appearing in any of the nine `requirements` arrays above; no key was added
+that is absent from all nine records.
+
+### Raise-key derivation (risk/policy can promote a not_required entry)
+
+Only two cells carry a `not_required` entry, and both are named explicitly
+by the contract's "Key facts" and by the corresponding `behavior_changes`
+text -- no other cell's `behavior_changes` was read as implying a raisable
+key:
+
+| Cell | Key | `behavior_changes` source text |
+|---|---|---|
+| `standard.edit` | `separate_contract` | "separate_contract becomes not_required by default" |
+| `standard.ship` | `separate_contract` | "separate_contract and external_acceptance become not_required by default" |
+| `standard.ship` | `external_acceptance` | "separate_contract and external_acceptance become not_required by default" |
+
+The raise rule itself (risk outranking profile on the lite<standard<strict
+scale, or an explicit `policy.require` naming the key) is generic and
+consumer-free, satisfying the contract's falsifier: encoding
+`standard.edit`/`standard.ship` needed no consumer context, so the
+single-matrix-plus-one-raise-rule direction is not falsified.
+
+### Scope decisions not literally spelled out by a single sentence
+
+- **`resolve()` signature has 4 named params, not 5.** The audit's raw
+  pseudocode (`plans/sprints/20260715-harness-loop-audit-and-optimization.md:227-233`)
+  and the plan's un-calibrated "Captured Planning Output" section both show
+  `{ profile, operation, risk, taskKind, policy }`. The calibrated contract's
+  own Scope bullet and the plan's calibrated Detailed Design/File Changes
+  table both instead write `resolve({ profile, operation, risk, policy })`
+  -- `taskKind` is absent from both authoritative (calibrated) sources, and
+  no target_delta record varies by task kind. Implemented the 4-param form
+  per the calibrated contract; adding an unused `taskKind` parameter not
+  backed by any frozen delta would have been exactly the kind of invented,
+  unrequested surface the contract's EXECUTION_BOUNDARY forbids.
+- **No `isolated_contract_worktree` entry added for Standard.** The audit's
+  own pre-freeze recommendation table (lines 238-242) lists Standard's
+  Worktree column as "按风险/策略" (risk/policy-dependent), which could be
+  read as implying a raisable worktree key at Standard. Neither
+  `standard.edit` nor `standard.ship`'s frozen `target_delta` record
+  mentions `isolated_contract_worktree` anywhere (not in `requirements`,
+  `missing_requirements`, or `behavior_changes`) -- LSC-01's freeze evidently
+  did not carry that audit gesture into a concrete per-cell delta. Contract
+  language treats the nine frozen deltas as the primary "derive 1:1 from"
+  authority and the audit matrix as a secondary permitted-vocabulary check,
+  not a mandate to backfill every pre-freeze recommendation; left out to
+  avoid inventing a cell/key the frozen data does not instantiate.
+- **No `ArtifactRequirementPolicy.resolve(...)` namespace export.** The
+  audit's pseudocode shows a namespace-qualified call, but the contract's
+  own Scope bullet writes the accessor as plain `resolve({...})`. Exported a
+  single top-level `resolve` function (plus the matrix constant and its
+  supporting types); did not add a second `ArtifactRequirementPolicy`
+  wrapper object, since EXECUTION_BOUNDARY names "exports" explicitly among
+  forbidden unrequested extras and a namespace re-export would be exactly
+  that with no behavior it adds.
+- **`risk` is typed `WorkflowProfile`, not a new enum.** Reuses the imported
+  type directly (satisfies "imports only types from `./profile`" with zero
+  new risk vocabulary) and gives a generic, rank-based raise rule
+  (`risk` outranks `profile`) with no consumer-specific branching.
+
+## Deviations From Plan Or Spec
+
+- None recorded.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| Model each cell's entries from `target_delta.requirements` only | Use | `requirements` is the field naming what is positively required by policy; `missing_requirements` is a per-scenario observation that belongs to the future LSC-06 readiness evaluator, not this pure policy matrix |
+| Add `isolated_contract_worktree` as a not_required/raisable entry for Standard (per the audit's pre-freeze "按风险/策略" worktree gesture) | Reject | No frozen `target_delta` record for `standard.edit`/`standard.ship` names it in any field; adding it would invent a key value the LSC-01 freeze did not instantiate |
+| 5-param `resolve({ profile, operation, risk, taskKind, policy })` matching the audit's raw pseudocode | Reject | The calibrated contract's Scope bullet and the plan's calibrated Detailed Design table both omit `taskKind`; no target_delta varies by task kind, so an unused parameter would be invented surface |
+| Export both `resolve(...)` and an `ArtifactRequirementPolicy` namespace wrapper | Reject | EXECUTION_BOUNDARY names "exports" explicitly among forbidden unrequested extras; the wrapper adds no behavior over the plain function |
+
+## Open Questions
+
+- None. The two scope narrowings above (4-param signature, no Standard
+  worktree key) are resolved by the calibrated contract's own literal text
+  and the absence of supporting frozen data, respectively; flagged here for
+  the review pass rather than left as unresolved ambiguity.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/reviews/20260718-1405-lsc-02-artifact-requirement-policy.review.md
+++ b/tasks/reviews/20260718-1405-lsc-02-artifact-requirement-policy.review.md
@@ -1,0 +1,132 @@
+# Task Review: lsc-02-artifact-requirement-policy
+
+> **Status**: Complete
+> **Plan**: plans/plan-20260718-1405-lsc-02-artifact-requirement-policy.md
+> **Contract**: tasks/contracts/20260718-1405-lsc-02-artifact-requirement-policy.contract.md
+> **Notes File**: tasks/notes/20260718-1405-lsc-02-artifact-requirement-policy.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-07-18 (Round 1, Claude gatekeeper substitution for external acceptance)
+> **Recommendation**: pass
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: sha256:11865fb71c59b597406b8fce071cf299a2909da2fbedb19ddc6456a0d5f7762d
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: 64673ee2c1148c2edfcea0afa097375898323841
+
+## Human Review Card
+
+- Verdict: pass
+- Change type: code-change
+- Intended files changed: one pure policy module, one fixture-driven test, one
+  nested JSON fixture, the LSC-02 plan/contract/notes/review envelope, one
+  sprint-header base pin, and the tooling-written `tasks/todos.md` timestamp.
+- Actual files changed: exactly those nine allowed paths; no consumer, Hook,
+  installer, script, Skill, or other production path changed, and no existing
+  test or golden was edited.
+- Commands passed: targeted `bun test tests/state/artifact-requirement-policy.test.ts`
+  (17 pass); `bun run check:type`; full `bun test` (1632 pass / 1 skip / 0 fail,
+  516s); `check-deploy-sql-order`; `check-task-sync`; `check-architecture-sync`
+  (advisory, 0 blocking); `repo-harness run check-task-workflow --strict`;
+  `repo-harness state resolve --json` (no blockers); `inspect-project-state`;
+  `adopt --dry-run` (0 operations); `git diff --check`; consumer-import grep
+  (module only); independent Claude gatekeeper acceptance (PASS).
+- Residual risks: `resolve()` runtime-validates `profile`/`operation` but not
+  the `risk`/`policy.require` raise inputs (unknown values fail open by
+  silently not raising) — in-contract as delivered, must be closed at the
+  first untyped consumer boundary (LSC-06 dispatch); no fixture exercises
+  risk and policy raising the same key together (`raisedBy` ordering
+  untested). The pre-existing base-gate defects tracked in `tasks/todos.md`
+  (mechanical `guards.external_acceptance` fail-closed via empty benchmark
+  fingerprint; 120s CLI verify wrapper watchdog; `qa_scores.code_quality`
+  key mismatch) remain open and are not part of this subject.
+- Reviewer action required: none for the reviewed subject; ship as the
+  independent LSC-02 PR against `main` from base `64673ee2`.
+- Rollback: revert the independent LSC-02 PR to restore
+  `64673ee2c1148c2edfcea0afa097375898323841`; no consumer imports the module,
+  so the revert is behavior-inert and needs no compatibility path.
+
+## Mode Evidence
+
+- Selected route: `Task Profile=code-change`, `Workflow Profile=lite`
+  (deterministic risk floor, no strict-category signals), independent contract
+  worktree `codex/lsc-02-artifact-requirement-policy` from exact execution
+  base `64673ee2c1148c2edfcea0afa097375898323841`.
+- P1/P2/P3 evidence: the calibrated contract maps the profile authority
+  (`src/core/workflow/profile.ts`), the delta authority
+  (`tests/state/fixtures/loop-semantics/characterization.json`), and the
+  untouched consumers; traces one `resolve()` call per cell against the
+  fixture; and chooses one literal matrix plus one raise rule because the
+  falsifier (raise semantics needing consumer context) did not trigger.
+- Root cause or plan evidence: not a bugfix; this package establishes the
+  single artifact-requirement authority that LSC-03..08 cut consumers over to.
+
+## Verification Evidence
+
+- Waza `/check` run: superseded by the read-only Claude gatekeeper pass
+  recorded under External Acceptance Advice (fresh context, evidence-only
+  packet, PASS).
+- Commands run: full Exit Criteria surface listed on the Human Review Card,
+  all exit 0 in this worktree at the reviewed subject.
+- Manual checks: matrix-to-delta 1:1 derivation re-derived independently from
+  `tests/state/fixtures/loop-semantics/characterization.json`; module purity
+  (sole `import type { WorkflowProfile }`); module-owned edit/stop/ship axis;
+  zero consumer imports (`grep -rn artifact-requirement-policy src/`); zero
+  readiness fields; `tests/state/adapter-parity.test.ts` fixture enumeration
+  confirmed to exclude the `loop-semantics/` subdirectory.
+- Supporting artifacts: derivation tables in the notes file; fixture with 9
+  positive and 7 negative cases.
+- Implementation notes reviewed: yes (cell -> record derivation, raise-key
+  derivation, 4-parameter `resolve` narrowing rationale).
+- Run snapshot: full-suite output retained in session task log (1632 pass /
+  1 skip / 0 fail, 516.62s).
+
+## External Acceptance Advice
+
+> **External Acceptance**: pass (Round 1, Claude gatekeeper substitution — mechanical `workflow_external_acceptance_pass` still fails closed regardless, per the pre-existing base-gate defect)
+> **External Reviewer**: Claude
+> **External Source**: claude-gatekeeper (continuation of the documented 2026-07-18 exception: the repo's normal host-aware Codex requirement cannot be met because the Codex CLI is quota-limited until 2026-08-16 — probed this session with `codex exec`, which returned only the usage-limit error; see the `tasks/todos.md` solo-operator row)
+> **External Started**: 2026-07-18
+> **External Completed**: 2026-07-18
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: sha256:11865fb71c59b597406b8fce071cf299a2909da2fbedb19ddc6456a0d5f7762d
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: 64673ee2c1148c2edfcea0afa097375898323841
+> **Benchmark Evidence SHA256**: unavailable-by-defect (the fingerprint lookup returns empty even when `evals/harness/reports/profile-comparison.*` evidence exists; pre-existing base-gate defect tracked in `tasks/todos.md`, unrelated to this subject)
+
+- P1 blockers: none. The gatekeeper reviewed the exact subject
+  `sha256:11865fb7...` at target revision `64673ee2` with a fresh context and
+  no executor self-argument in its packet, re-deriving all nine matrix cells
+  from the frozen fixture rather than trusting the notes' claim.
+- P2 advisories: 2.
+  - `src/core/workflow/artifact-requirement-policy.ts:196,205` — `risk` and
+    `policy.require` are fail-open for unknown values (no runtime rejection);
+    close at the first untyped consumer boundary in LSC-06.
+  - `tests/state/fixtures/loop-semantics/artifact-requirement-policy.json` —
+    no case covers risk and policy raising the same key together; add the
+    combined-raise fixture in a later package.
+- Acceptance checklist: subject re-derived, purity verified, consumer
+  isolation verified, behavior-inertness verified, allowed-paths containment
+  verified, verification commands re-run (targeted test, typecheck, root
+  checks, strict workflow check, `git diff --check`).
+
+## Behavior Diff Notes
+
+- Additive only: the module exists with total 9-cell coverage and no caller.
+  No observable behavior of any CLI, Hook, MCP, Skill, or test changes; full
+  `bun test` passes with zero edits to existing tests or goldens.
+
+## Residual Risks / Follow-ups
+
+- Carry both P2 advisories into the LSC-06 dispatch packet (raise-input
+  validation at the first untyped boundary; combined risk+policy fixture).
+- The three base-gate infra defects and the solo-operator external-acceptance
+  gap remain tracked in `tasks/todos.md`; they gate the mechanical
+  `verify-sprint` surface, not this subject.
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 9/10 | All nine cells resolve exactly per the frozen target deltas; raise rule covers risk outrank and selective policy raise; invalid inputs rejected, not defaulted. |
+| Product depth | 8/10 | Establishes the single requirement authority the LSC cutover sequence consumes; deliberately ships zero consumer value on its own, per the one-package-per-boundary program design. |
+| Design quality | 9/10 | Literal mapped-type matrix makes totality compile-time checked; module-owned operation axis avoids the WorkflowOperationKind trap; no helper abstraction or shadow evaluator. |
+| Code quality | 9/10 | Pure module, fixture-driven test with duplicate-cell guard and axis-confusion probe, full derivation notes, typecheck and full suite green. |

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -1,7 +1,7 @@
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: 2026-07-16 03:38
+> **Updated**: 2026-07-18 14:05
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.

--- a/tests/state/artifact-requirement-policy.test.ts
+++ b/tests/state/artifact-requirement-policy.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import {
+  resolve,
+  type ArtifactRequirementKey,
+  type ArtifactRequirementOperation,
+  type ArtifactRequirementResolveInput,
+  type ArtifactRequirementResolveResult,
+} from '../../src/core/workflow/artifact-requirement-policy';
+import type { WorkflowProfile } from '../../src/core/workflow/profile';
+
+const FIXTURE_PATH = join(import.meta.dir, 'fixtures/loop-semantics/artifact-requirement-policy.json');
+
+interface RawCaseInput {
+  readonly profile: string;
+  readonly operation: string;
+  readonly risk?: string;
+  readonly policy?: { readonly require?: readonly string[] };
+}
+
+interface RawCase {
+  readonly name: string;
+  readonly input: RawCaseInput;
+  readonly expected: ArtifactRequirementResolveResult;
+}
+
+interface Fixture {
+  readonly schema: string;
+  readonly positive_cases: readonly RawCase[];
+  readonly negative_cases: readonly RawCase[];
+}
+
+const fixture = JSON.parse(readFileSync(FIXTURE_PATH, 'utf-8')) as Fixture;
+
+// The fixture stores plain strings (JSON has no notion of the module's
+// literal-union types); this boundary is the one place those strings become
+// the typed resolve() input, exactly like a real caller would construct it.
+function toResolveInput(raw: RawCaseInput): ArtifactRequirementResolveInput {
+  const input: {
+    profile: WorkflowProfile;
+    operation: ArtifactRequirementOperation;
+    risk?: WorkflowProfile;
+    policy?: { require?: readonly ArtifactRequirementKey[] };
+  } = {
+    profile: raw.profile as WorkflowProfile,
+    operation: raw.operation as ArtifactRequirementOperation,
+  };
+  if (raw.risk !== undefined) input.risk = raw.risk as WorkflowProfile;
+  if (raw.policy !== undefined) {
+    input.policy = { require: raw.policy.require as readonly ArtifactRequirementKey[] | undefined };
+  }
+  return input;
+}
+
+describe('ArtifactRequirementPolicy.resolve fixture-driven matrix', () => {
+  test('fixture declares exactly nine positive cells with no duplicates', () => {
+    expect(fixture.positive_cases).toHaveLength(9);
+    const cellKeys = new Set(
+      fixture.positive_cases.map((testCase) => `${testCase.input.profile}.${testCase.input.operation}`),
+    );
+    expect(cellKeys.size).toBe(9);
+  });
+
+  describe('positive cases (all nine profile x operation cells)', () => {
+    for (const testCase of fixture.positive_cases) {
+      test(testCase.name, () => {
+        expect(resolve(toResolveInput(testCase.input))).toEqual(testCase.expected);
+      });
+    }
+  });
+
+  describe('negative cases (risk/policy raise semantics and invalid input rejection)', () => {
+    for (const testCase of fixture.negative_cases) {
+      test(testCase.name, () => {
+        expect(resolve(toResolveInput(testCase.input))).toEqual(testCase.expected);
+      });
+    }
+  });
+});

--- a/tests/state/fixtures/loop-semantics/artifact-requirement-policy.json
+++ b/tests/state/fixtures/loop-semantics/artifact-requirement-policy.json
@@ -1,0 +1,214 @@
+{
+  "schema": "repo-harness-artifact-requirement-policy.v1",
+  "positive_cases": [
+    {
+      "name": "lite.edit default matrix",
+      "input": { "profile": "lite", "operation": "edit" },
+      "expected": {
+        "ok": true,
+        "profile": "lite",
+        "operation": "edit",
+        "requirements": [
+          { "key": "safe_path", "defaultStatus": "required", "status": "required", "raisedBy": [] },
+          { "key": "worktree_boundary", "defaultStatus": "required", "status": "required", "raisedBy": [] },
+          { "key": "destructive_action_boundary", "defaultStatus": "required", "status": "required", "raisedBy": [] }
+        ]
+      }
+    },
+    {
+      "name": "lite.stop default matrix",
+      "input": { "profile": "lite", "operation": "stop" },
+      "expected": {
+        "ok": true,
+        "profile": "lite",
+        "operation": "stop",
+        "requirements": [
+          { "key": "durable_recovery_state", "defaultStatus": "required", "status": "required", "raisedBy": [] }
+        ]
+      }
+    },
+    {
+      "name": "lite.ship default matrix",
+      "input": { "profile": "lite", "operation": "ship" },
+      "expected": {
+        "ok": true,
+        "profile": "lite",
+        "operation": "ship",
+        "requirements": [
+          { "key": "subject_bound_targeted_evidence", "defaultStatus": "required", "status": "required", "raisedBy": [] }
+        ]
+      }
+    },
+    {
+      "name": "standard.edit default matrix",
+      "input": { "profile": "standard", "operation": "edit" },
+      "expected": {
+        "ok": true,
+        "profile": "standard",
+        "operation": "edit",
+        "requirements": [
+          { "key": "complete_approved_work_package", "defaultStatus": "required", "status": "required", "raisedBy": [] },
+          { "key": "separate_contract", "defaultStatus": "not_required", "status": "not_required", "raisedBy": [] }
+        ]
+      }
+    },
+    {
+      "name": "standard.stop default matrix",
+      "input": { "profile": "standard", "operation": "stop" },
+      "expected": {
+        "ok": true,
+        "profile": "standard",
+        "operation": "stop",
+        "requirements": [
+          { "key": "durable_recovery_state", "defaultStatus": "required", "status": "required", "raisedBy": [] }
+        ]
+      }
+    },
+    {
+      "name": "standard.ship default matrix",
+      "input": { "profile": "standard", "operation": "ship" },
+      "expected": {
+        "ok": true,
+        "profile": "standard",
+        "operation": "ship",
+        "requirements": [
+          { "key": "complete_approved_work_package", "defaultStatus": "required", "status": "required", "raisedBy": [] },
+          { "key": "subject_bound_targeted_evidence", "defaultStatus": "required", "status": "required", "raisedBy": [] },
+          { "key": "separate_contract", "defaultStatus": "not_required", "status": "not_required", "raisedBy": [] },
+          { "key": "external_acceptance", "defaultStatus": "not_required", "status": "not_required", "raisedBy": [] }
+        ]
+      }
+    },
+    {
+      "name": "strict.edit default matrix",
+      "input": { "profile": "strict", "operation": "edit" },
+      "expected": {
+        "ok": true,
+        "profile": "strict",
+        "operation": "edit",
+        "requirements": [
+          { "key": "separate_contract", "defaultStatus": "required", "status": "required", "raisedBy": [] },
+          { "key": "isolated_contract_worktree", "defaultStatus": "required", "status": "required", "raisedBy": [] }
+        ]
+      }
+    },
+    {
+      "name": "strict.stop default matrix",
+      "input": { "profile": "strict", "operation": "stop" },
+      "expected": {
+        "ok": true,
+        "profile": "strict",
+        "operation": "stop",
+        "requirements": [
+          { "key": "durable_recovery_state", "defaultStatus": "required", "status": "required", "raisedBy": [] }
+        ]
+      }
+    },
+    {
+      "name": "strict.ship default matrix (full fail-closed envelope)",
+      "input": { "profile": "strict", "operation": "ship" },
+      "expected": {
+        "ok": true,
+        "profile": "strict",
+        "operation": "ship",
+        "requirements": [
+          { "key": "separate_contract", "defaultStatus": "required", "status": "required", "raisedBy": [] },
+          { "key": "isolated_contract_worktree", "defaultStatus": "required", "status": "required", "raisedBy": [] },
+          { "key": "fresh_review", "defaultStatus": "required", "status": "required", "raisedBy": [] },
+          { "key": "external_acceptance", "defaultStatus": "required", "status": "required", "raisedBy": [] },
+          { "key": "fresh_checks", "defaultStatus": "required", "status": "required", "raisedBy": [] },
+          { "key": "candidate_revision_precondition", "defaultStatus": "required", "status": "required", "raisedBy": [] }
+        ]
+      }
+    }
+  ],
+  "negative_cases": [
+    {
+      "name": "standard.edit: risk outranking profile raises separate_contract",
+      "input": { "profile": "standard", "operation": "edit", "risk": "strict" },
+      "expected": {
+        "ok": true,
+        "profile": "standard",
+        "operation": "edit",
+        "requirements": [
+          { "key": "complete_approved_work_package", "defaultStatus": "required", "status": "required", "raisedBy": [] },
+          { "key": "separate_contract", "defaultStatus": "not_required", "status": "required", "raisedBy": ["risk"] }
+        ]
+      }
+    },
+    {
+      "name": "standard.edit: explicit policy raises separate_contract",
+      "input": { "profile": "standard", "operation": "edit", "policy": { "require": ["separate_contract"] } },
+      "expected": {
+        "ok": true,
+        "profile": "standard",
+        "operation": "edit",
+        "requirements": [
+          { "key": "complete_approved_work_package", "defaultStatus": "required", "status": "required", "raisedBy": [] },
+          { "key": "separate_contract", "defaultStatus": "not_required", "status": "required", "raisedBy": ["policy"] }
+        ]
+      }
+    },
+    {
+      "name": "standard.edit: risk equal to profile does not raise (strict outranking only)",
+      "input": { "profile": "standard", "operation": "edit", "risk": "standard" },
+      "expected": {
+        "ok": true,
+        "profile": "standard",
+        "operation": "edit",
+        "requirements": [
+          { "key": "complete_approved_work_package", "defaultStatus": "required", "status": "required", "raisedBy": [] },
+          { "key": "separate_contract", "defaultStatus": "not_required", "status": "not_required", "raisedBy": [] }
+        ]
+      }
+    },
+    {
+      "name": "standard.ship: risk outranking profile raises both not_required entries",
+      "input": { "profile": "standard", "operation": "ship", "risk": "strict" },
+      "expected": {
+        "ok": true,
+        "profile": "standard",
+        "operation": "ship",
+        "requirements": [
+          { "key": "complete_approved_work_package", "defaultStatus": "required", "status": "required", "raisedBy": [] },
+          { "key": "subject_bound_targeted_evidence", "defaultStatus": "required", "status": "required", "raisedBy": [] },
+          { "key": "separate_contract", "defaultStatus": "not_required", "status": "required", "raisedBy": ["risk"] },
+          { "key": "external_acceptance", "defaultStatus": "not_required", "status": "required", "raisedBy": ["risk"] }
+        ]
+      }
+    },
+    {
+      "name": "standard.ship: explicit policy selectively raises only external_acceptance",
+      "input": { "profile": "standard", "operation": "ship", "policy": { "require": ["external_acceptance"] } },
+      "expected": {
+        "ok": true,
+        "profile": "standard",
+        "operation": "ship",
+        "requirements": [
+          { "key": "complete_approved_work_package", "defaultStatus": "required", "status": "required", "raisedBy": [] },
+          { "key": "subject_bound_targeted_evidence", "defaultStatus": "required", "status": "required", "raisedBy": [] },
+          { "key": "separate_contract", "defaultStatus": "not_required", "status": "not_required", "raisedBy": [] },
+          { "key": "external_acceptance", "defaultStatus": "not_required", "status": "required", "raisedBy": ["policy"] }
+        ]
+      }
+    },
+    {
+      "name": "invalid profile is rejected, not defaulted",
+      "input": { "profile": "nonexistent", "operation": "edit" },
+      "expected": {
+        "ok": false,
+        "code": "INVALID_PROFILE",
+        "message": "unknown workflow profile: nonexistent"
+      }
+    },
+    {
+      "name": "invalid operation is rejected, not defaulted",
+      "input": { "profile": "lite", "operation": "deploy" },
+      "expected": {
+        "ok": false,
+        "code": "INVALID_OPERATION",
+        "message": "unknown artifact requirement operation: deploy"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

LSC-02 of the Loop Semantics Convergence sprint (`plans/sprints/20260716-0101-loop-semantics-convergence.sprint.md`, backlog row 2). Acceptance line: establish one pure `ArtifactRequirementPolicy` matrix for Lite/Standard/Strict with positive/negative fixtures; do not switch consumers or implement readiness in this package.

- `src/core/workflow/artifact-requirement-policy.ts`: pure module owning the Lite/Standard/Strict x edit/stop/ship requirement matrix plus `resolve({ profile, operation, risk, policy })` with the risk/policy raise rule. The edit/stop/ship axis is module-owned (deliberately not `WorkflowOperationKind`). Totality over the 9 cells is enforced by a mapped type; unknown profile/operation is rejected, not defaulted.
- Matrix content derives 1:1 from the nine `approved_target_delta` records frozen by LSC-01 in `tests/state/fixtures/loop-semantics/characterization.json`; the derivation table is in the notes file. No invented key, cell, or semantics.
- Fixture-driven tests: 9 positive cells (duplicate-cell guard) + 7 negative cases (risk raise, policy raise, equal-rank no-raise, selective raise, invalid profile/operation).
- No consumer switched, no readiness implemented (both start in LSC-03..08); zero production files import the module.
- Execution base pinned: `origin/main@64673ee2` (post-LSC-01, PR #82), one sprint-header pin line per successor rule.

## Verification

- `bun test tests/state/artifact-requirement-policy.test.ts`: 17 pass
- Full `bun test`: 1632 pass / 1 skip / 0 fail (516s) — zero edits to existing tests/goldens
- `bun run check:type`, `git diff --check`, deploy-sql/task-sync/architecture-sync checks, `repo-harness run check-task-workflow --strict`, `state resolve` (no blockers), `adopt --dry-run` (0 operations): all green
- Independent read-only gatekeeper review: PASS — re-derived all nine cells from the frozen fixture; verdict and two non-blocking advisories recorded in `tasks/reviews/20260718-1405-lsc-02-artifact-requirement-policy.review.md`

## Notes for review

- External acceptance is recorded as a Claude gatekeeper substitution (Codex CLI quota-limited until 2026-08-16), continuing the documented LSC-01 closeout exception; the review file states this explicitly rather than claiming a clean Codex pass.
- Two advisory findings (raise-input fail-open validation; combined risk+policy raise fixture) are routed to the LSC-06 dispatch, not fixed here.

## Rollback

Revert this PR to restore `64673ee2`; the module has no consumers, so the revert is behavior-inert.