### PR TITLE
feat(state): cut Stop over to shared readiness and remove its three crutches (LSC-07)

### DIFF
--- a/.ai/hooks/.projection.json
+++ b/.ai/hooks/.projection.json
@@ -3,6 +3,6 @@
   "canonical_root": "assets/hooks",
   "projection_target": ".ai/hooks",
   "manifest": "assets/hooks/projection.json",
-  "digest": "sha256:58314c1d06f2772e372731bd3a9c54e32d4abdd679b0473ca591135e84470741",
+  "digest": "sha256:59a056d6292063cf1586b0568150e8e26076e48d72edd5ca9d532dccb2ce8976",
   "file_count": 25
 }

--- a/.ai/hooks/stop-orchestrator.sh
+++ b/.ai/hooks/stop-orchestrator.sh
@@ -253,7 +253,7 @@ minimal_change_render_handoff_section() {
 }
 
 minimal_change_append_handoff() {
-  local handoff_file tmp_file resume_file
+  local handoff_file tmp_file resume_file resume_tmp_file
 
   [[ -n "$MINIMAL_CHANGE_REVIEW_VERDICT" ]] || return 0
   [[ "$MINIMAL_CHANGE_REVIEW_VERDICT" != "disabled" ]] || return 0
@@ -276,13 +276,24 @@ minimal_change_append_handoff() {
   minimal_change_render_handoff_section >> "$tmp_file"
   mv "$tmp_file" "$handoff_file"
 
-  # refresh_handoff (workflow_write_handoff) already wrote a resume packet
-  # whose mtime matched the handoff snapshot at that time; this function just
-  # mutated handoff_file again, so bump the resume packet's mtime to match or
-  # check_handoff_resume_pair sees it as stale. Its content does not
-  # reference minimal-change-review data, so no rewrite is needed.
+  # refresh_handoff (workflow_write_handoff) already wrote a matched-freshness
+  # handoff+resume pair; this function's append above is a genuine second
+  # mutation of handoff_file, so check_handoff_resume_pair
+  # (scripts/check-task-workflow.sh) would see a stale resume packet unless
+  # the pair's finalization is completed here too. Reconfirm resume_file with
+  # a real write -- reissuing its own Generated timestamp in place -- instead
+  # of borrowing handoff's mtime via a content-blind `touch -r`: the resume
+  # packet's Generated field should reflect when the pair was actually last
+  # finalized, and its other content does not reference minimal-change-review
+  # data, so no further rewrite is needed.
   resume_file="$(workflow_resume_packet_file)"
-  [[ -f "$resume_file" ]] && touch -r "$handoff_file" "$resume_file" 2>/dev/null || true
+  if [[ -f "$resume_file" ]]; then
+    resume_tmp_file="$(mktemp "${resume_file}.finalize.XXXXXX")" && {
+      sed -E "s/^> \*\*Generated\*\*:.*/> **Generated**: $(date '+%Y-%m-%d %H:%M:%S')/" "$resume_file" > "$resume_tmp_file" \
+        && mv "$resume_tmp_file" "$resume_file" \
+        || rm -f "$resume_tmp_file"
+    }
+  fi
 }
 
 minimal_change_reason_suffix() {
@@ -588,32 +599,133 @@ refresh_handoff() {
   echo "[FinalizeHandoff] Refreshed $(workflow_handoff_file)." >&2
 }
 
+# Memoized canonical-state globals. Populated exactly once per Stop run by
+# stop_resolve_state(), which every reader below (stop_workflow_profile,
+# stop_maybe_block_on_readiness, stop_report_not_ready_to_ship) consumes
+# verbatim -- one CLI invocation per Stop run, reused for profile AND
+# readiness, re-deriving nothing.
+STOP_STATE_RESOLVED=""
+STOP_STATE_PROFILE=""
+STOP_STATE_ALLOWED_TO_STOP=""
+STOP_STATE_ALLOWED_TO_STOP_REASONS=""
+STOP_STATE_READY_TO_SHIP=""
+STOP_STATE_READY_TO_SHIP_REASONS=""
+STOP_STATE_NEXT_ACTION=""
+
+# Resolve profile + readiness through the same canonical hook CLI route
+# pre-edit-guard.sh uses for `state resolve` (REPO_HARNESS_CLI -> repo-harness
+# on PATH -> source src/cli/index.ts, in that order). Memoized so callers
+# invoked more than once in this process (e.g. from inside the
+# stop_workflow_profile() command substitution below) never trigger a second
+# cold start. Must be called at least once from the *main* shell (not from
+# inside a `$(...)` command substitution) before any reader below, because
+# bash command substitutions fork a subshell and cannot write these globals
+# back to the caller.
+#
+# Any output at all -- even a blocked resolution (non-zero CLI exit with a
+# populated blockers array) -- counts as success: it is still a real,
+# canonical answer, just one that reports workflow_profile/readiness as
+# unavailable. Only empty/unparseable output means the resolver itself is
+# unavailable or failed; that -- and only that -- logs to stderr and leaves
+# every STOP_STATE_* value empty so no profile is ever invented and nothing
+# is ever blocked from an absent answer. The orthogonal gates (plan
+# completeness, delegation fallback) run regardless of this outcome.
+stop_resolve_state() {
+  [[ -z "$STOP_STATE_RESOLVED" ]] || return 0
+  STOP_STATE_RESOLVED="1"
+
+  local source_cli output
+  local -a args=(state resolve --json --operation inspect)
+  if [[ -n "${REPO_HARNESS_WORKFLOW_PROFILE:-}" ]]; then
+    args+=(--profile "$REPO_HARNESS_WORKFLOW_PROFILE")
+  fi
+  source_cli="$(cd "$SCRIPT_DIR/../.." 2>/dev/null && pwd)/src/cli/index.ts"
+
+  set +e
+  if [[ -n "${REPO_HARNESS_CLI:-}" && -f "${REPO_HARNESS_CLI:-}" ]] && command -v bun >/dev/null 2>&1; then
+    output="$(bun "$REPO_HARNESS_CLI" "${args[@]}" 2>/dev/null)"
+  elif command -v repo-harness >/dev/null 2>&1; then
+    output="$(repo-harness "${args[@]}" 2>/dev/null)"
+  elif [[ -f "$source_cli" ]] && command -v bun >/dev/null 2>&1; then
+    output="$(bun "$source_cli" "${args[@]}" 2>/dev/null)"
+  else
+    output=""
+  fi
+  set -e
+
+  if [[ -z "$output" ]]; then
+    echo "[StopReadiness] Unable to resolve canonical state via the hook CLI; skipping readiness-driven behavior (orthogonal gates still run)." >&2
+    return 1
+  fi
+
+  if command -v jq >/dev/null 2>&1; then
+    if ! printf '%s' "$output" | jq -e . >/dev/null 2>&1; then
+      echo "[StopReadiness] Canonical state resolution returned unparseable output; skipping readiness-driven behavior (orthogonal gates still run)." >&2
+      return 1
+    fi
+    STOP_STATE_PROFILE="$(printf '%s' "$output" | jq -r '.workflow_profile // empty' 2>/dev/null)"
+    STOP_STATE_ALLOWED_TO_STOP="$(printf '%s' "$output" | jq -r '.readiness.allowedToStop.decision // empty' 2>/dev/null)"
+    STOP_STATE_ALLOWED_TO_STOP_REASONS="$(printf '%s' "$output" | jq -r '(.readiness.allowedToStop.reasons // []) | join(",")' 2>/dev/null)"
+    STOP_STATE_READY_TO_SHIP="$(printf '%s' "$output" | jq -r '.readiness.readyToShip.decision // empty' 2>/dev/null)"
+    STOP_STATE_READY_TO_SHIP_REASONS="$(printf '%s' "$output" | jq -r '(.readiness.readyToShip.reasons // []) | join(",")' 2>/dev/null)"
+    STOP_STATE_NEXT_ACTION="$(printf '%s' "$output" | jq -r '.readiness.nextAction // empty' 2>/dev/null)"
+    return 0
+  fi
+
+  if command -v bun >/dev/null 2>&1; then
+    local parsed
+    parsed="$(STOP_STATE_JSON="$output" bun -e '
+      let s;
+      try { s = JSON.parse(process.env.STOP_STATE_JSON || ""); } catch { s = null; }
+      if (!s || typeof s !== "object") process.exit(1);
+      const r = (s.readiness && typeof s.readiness === "object") ? s.readiness : {};
+      const stop = (r.allowedToStop && typeof r.allowedToStop === "object") ? r.allowedToStop : {};
+      const ship = (r.readyToShip && typeof r.readyToShip === "object") ? r.readyToShip : {};
+      const text = (v) => (v === undefined || v === null) ? "" : String(v);
+      console.log([
+        text(s.workflow_profile),
+        text(stop.decision),
+        Array.isArray(stop.reasons) ? stop.reasons.join(",") : "",
+        text(ship.decision),
+        Array.isArray(ship.reasons) ? ship.reasons.join(",") : "",
+        text(r.nextAction),
+      ].join("\t"));
+    ' 2>/dev/null)" || parsed=""
+    if [[ -n "$parsed" ]]; then
+      IFS=$'\t' read -r STOP_STATE_PROFILE STOP_STATE_ALLOWED_TO_STOP STOP_STATE_ALLOWED_TO_STOP_REASONS \
+        STOP_STATE_READY_TO_SHIP STOP_STATE_READY_TO_SHIP_REASONS STOP_STATE_NEXT_ACTION <<< "$parsed"
+      return 0
+    fi
+  fi
+
+  echo "[StopReadiness] Unable to parse canonical state JSON; skipping readiness-driven behavior (orthogonal gates still run)." >&2
+  return 1
+}
+
 stop_workflow_profile() {
-  local effective_state=".ai/harness/state/effective.json"
-  local install_state="${HOME:-}/.repo-harness/install-state.json"
-  if [[ -f "$effective_state" ]]; then
-    if command -v jq >/dev/null 2>&1; then
-      jq -r '.workflow_profile // empty' "$effective_state" 2>/dev/null
-      return 0
-    fi
-    if command -v bun >/dev/null 2>&1; then
-      bun -e 'const s=require(process.argv[1]); if (["lite","standard","strict"].includes(s.workflow_profile)) console.log(s.workflow_profile)' "$effective_state" 2>/dev/null
-      return 0
-    fi
-  fi
-  if [[ -n "${HOME:-}" && -f "$install_state" ]]; then
-    local installed=""
-    if command -v jq >/dev/null 2>&1; then
-      installed="$(jq -r '.profile // empty' "$install_state" 2>/dev/null || true)"
-    elif command -v bun >/dev/null 2>&1; then
-      installed="$(bun -e 'const s=require(process.argv[1]); if (typeof s.profile === "string") console.log(s.profile)' "$install_state" 2>/dev/null || true)"
-    fi
-    case "$installed" in
-      minimal) printf 'lite\n' ;;
-      standard|product-planning) printf 'standard\n' ;;
-      strict) printf 'strict\n' ;;
-    esac
-  fi
+  stop_resolve_state || true
+  case "$STOP_STATE_PROFILE" in
+    lite|standard|strict) printf '%s\n' "$STOP_STATE_PROFILE" ;;
+  esac
+}
+
+# The only readiness-driven emit_stop_block_json path: allowedToStop=block
+# (durable recovery state lost or another stop-gate requirement unmet).
+# Prints the block JSON and returns success (0) so callers know to exit
+# immediately; returns failure (1) -- the common case -- when Stop remains
+# allowed, whether or not readiness resolved at all.
+stop_maybe_block_on_readiness() {
+  [[ "$STOP_STATE_ALLOWED_TO_STOP" == "block" ]] || return 1
+  emit_stop_block_json "[ReadinessGate] Stop is blocked by shared readiness (missing: ${STOP_STATE_ALLOWED_TO_STOP_REASONS:-unspecified}).$(minimal_change_reason_suffix)"
+  return 0
+}
+
+# readyToShip=false never blocks Stop (frozen strict.stop delta): report it
+# on stderr and let the caller continue to exit 0. Unrequired review/external
+# acceptance evidence therefore can never block Stop through this path.
+stop_report_not_ready_to_ship() {
+  [[ "$STOP_STATE_READY_TO_SHIP" == "block" ]] || return 0
+  echo "[ReadinessGate] readyToShip=false (missing: ${STOP_STATE_READY_TO_SHIP_REASONS:-unspecified}); Stop is not blocked -- resolve before shipping." >&2
 }
 
 should_run_plan_completeness_gate() {
@@ -641,13 +753,18 @@ if [[ "$stop_hook_active" == "true" ]]; then
 fi
 
 refresh_handoff
+stop_resolve_state || true
 
 # Lite's complete Stop path is compact handoff only. Review freshness,
 # minimal-change review, plan capture, and delegation fallback belong to the
 # Standard/Strict orchestration envelopes, not brief -> edit -> targeted test.
 if [[ "$(stop_workflow_profile || true)" == "lite" ]]; then
+  stop_maybe_block_on_readiness || true
   exit 0
 fi
+
+stop_maybe_block_on_readiness && exit 0
+stop_report_not_ready_to_ship
 
 minimal_change_refresh_review
 minimal_change_append_handoff

--- a/assets/hooks/stop-orchestrator.sh
+++ b/assets/hooks/stop-orchestrator.sh
@@ -253,7 +253,7 @@ minimal_change_render_handoff_section() {
 }
 
 minimal_change_append_handoff() {
-  local handoff_file tmp_file resume_file
+  local handoff_file tmp_file resume_file resume_tmp_file
 
   [[ -n "$MINIMAL_CHANGE_REVIEW_VERDICT" ]] || return 0
   [[ "$MINIMAL_CHANGE_REVIEW_VERDICT" != "disabled" ]] || return 0
@@ -276,13 +276,24 @@ minimal_change_append_handoff() {
   minimal_change_render_handoff_section >> "$tmp_file"
   mv "$tmp_file" "$handoff_file"
 
-  # refresh_handoff (workflow_write_handoff) already wrote a resume packet
-  # whose mtime matched the handoff snapshot at that time; this function just
-  # mutated handoff_file again, so bump the resume packet's mtime to match or
-  # check_handoff_resume_pair sees it as stale. Its content does not
-  # reference minimal-change-review data, so no rewrite is needed.
+  # refresh_handoff (workflow_write_handoff) already wrote a matched-freshness
+  # handoff+resume pair; this function's append above is a genuine second
+  # mutation of handoff_file, so check_handoff_resume_pair
+  # (scripts/check-task-workflow.sh) would see a stale resume packet unless
+  # the pair's finalization is completed here too. Reconfirm resume_file with
+  # a real write -- reissuing its own Generated timestamp in place -- instead
+  # of borrowing handoff's mtime via a content-blind `touch -r`: the resume
+  # packet's Generated field should reflect when the pair was actually last
+  # finalized, and its other content does not reference minimal-change-review
+  # data, so no further rewrite is needed.
   resume_file="$(workflow_resume_packet_file)"
-  [[ -f "$resume_file" ]] && touch -r "$handoff_file" "$resume_file" 2>/dev/null || true
+  if [[ -f "$resume_file" ]]; then
+    resume_tmp_file="$(mktemp "${resume_file}.finalize.XXXXXX")" && {
+      sed -E "s/^> \*\*Generated\*\*:.*/> **Generated**: $(date '+%Y-%m-%d %H:%M:%S')/" "$resume_file" > "$resume_tmp_file" \
+        && mv "$resume_tmp_file" "$resume_file" \
+        || rm -f "$resume_tmp_file"
+    }
+  fi
 }
 
 minimal_change_reason_suffix() {
@@ -588,32 +599,133 @@ refresh_handoff() {
   echo "[FinalizeHandoff] Refreshed $(workflow_handoff_file)." >&2
 }
 
+# Memoized canonical-state globals. Populated exactly once per Stop run by
+# stop_resolve_state(), which every reader below (stop_workflow_profile,
+# stop_maybe_block_on_readiness, stop_report_not_ready_to_ship) consumes
+# verbatim -- one CLI invocation per Stop run, reused for profile AND
+# readiness, re-deriving nothing.
+STOP_STATE_RESOLVED=""
+STOP_STATE_PROFILE=""
+STOP_STATE_ALLOWED_TO_STOP=""
+STOP_STATE_ALLOWED_TO_STOP_REASONS=""
+STOP_STATE_READY_TO_SHIP=""
+STOP_STATE_READY_TO_SHIP_REASONS=""
+STOP_STATE_NEXT_ACTION=""
+
+# Resolve profile + readiness through the same canonical hook CLI route
+# pre-edit-guard.sh uses for `state resolve` (REPO_HARNESS_CLI -> repo-harness
+# on PATH -> source src/cli/index.ts, in that order). Memoized so callers
+# invoked more than once in this process (e.g. from inside the
+# stop_workflow_profile() command substitution below) never trigger a second
+# cold start. Must be called at least once from the *main* shell (not from
+# inside a `$(...)` command substitution) before any reader below, because
+# bash command substitutions fork a subshell and cannot write these globals
+# back to the caller.
+#
+# Any output at all -- even a blocked resolution (non-zero CLI exit with a
+# populated blockers array) -- counts as success: it is still a real,
+# canonical answer, just one that reports workflow_profile/readiness as
+# unavailable. Only empty/unparseable output means the resolver itself is
+# unavailable or failed; that -- and only that -- logs to stderr and leaves
+# every STOP_STATE_* value empty so no profile is ever invented and nothing
+# is ever blocked from an absent answer. The orthogonal gates (plan
+# completeness, delegation fallback) run regardless of this outcome.
+stop_resolve_state() {
+  [[ -z "$STOP_STATE_RESOLVED" ]] || return 0
+  STOP_STATE_RESOLVED="1"
+
+  local source_cli output
+  local -a args=(state resolve --json --operation inspect)
+  if [[ -n "${REPO_HARNESS_WORKFLOW_PROFILE:-}" ]]; then
+    args+=(--profile "$REPO_HARNESS_WORKFLOW_PROFILE")
+  fi
+  source_cli="$(cd "$SCRIPT_DIR/../.." 2>/dev/null && pwd)/src/cli/index.ts"
+
+  set +e
+  if [[ -n "${REPO_HARNESS_CLI:-}" && -f "${REPO_HARNESS_CLI:-}" ]] && command -v bun >/dev/null 2>&1; then
+    output="$(bun "$REPO_HARNESS_CLI" "${args[@]}" 2>/dev/null)"
+  elif command -v repo-harness >/dev/null 2>&1; then
+    output="$(repo-harness "${args[@]}" 2>/dev/null)"
+  elif [[ -f "$source_cli" ]] && command -v bun >/dev/null 2>&1; then
+    output="$(bun "$source_cli" "${args[@]}" 2>/dev/null)"
+  else
+    output=""
+  fi
+  set -e
+
+  if [[ -z "$output" ]]; then
+    echo "[StopReadiness] Unable to resolve canonical state via the hook CLI; skipping readiness-driven behavior (orthogonal gates still run)." >&2
+    return 1
+  fi
+
+  if command -v jq >/dev/null 2>&1; then
+    if ! printf '%s' "$output" | jq -e . >/dev/null 2>&1; then
+      echo "[StopReadiness] Canonical state resolution returned unparseable output; skipping readiness-driven behavior (orthogonal gates still run)." >&2
+      return 1
+    fi
+    STOP_STATE_PROFILE="$(printf '%s' "$output" | jq -r '.workflow_profile // empty' 2>/dev/null)"
+    STOP_STATE_ALLOWED_TO_STOP="$(printf '%s' "$output" | jq -r '.readiness.allowedToStop.decision // empty' 2>/dev/null)"
+    STOP_STATE_ALLOWED_TO_STOP_REASONS="$(printf '%s' "$output" | jq -r '(.readiness.allowedToStop.reasons // []) | join(",")' 2>/dev/null)"
+    STOP_STATE_READY_TO_SHIP="$(printf '%s' "$output" | jq -r '.readiness.readyToShip.decision // empty' 2>/dev/null)"
+    STOP_STATE_READY_TO_SHIP_REASONS="$(printf '%s' "$output" | jq -r '(.readiness.readyToShip.reasons // []) | join(",")' 2>/dev/null)"
+    STOP_STATE_NEXT_ACTION="$(printf '%s' "$output" | jq -r '.readiness.nextAction // empty' 2>/dev/null)"
+    return 0
+  fi
+
+  if command -v bun >/dev/null 2>&1; then
+    local parsed
+    parsed="$(STOP_STATE_JSON="$output" bun -e '
+      let s;
+      try { s = JSON.parse(process.env.STOP_STATE_JSON || ""); } catch { s = null; }
+      if (!s || typeof s !== "object") process.exit(1);
+      const r = (s.readiness && typeof s.readiness === "object") ? s.readiness : {};
+      const stop = (r.allowedToStop && typeof r.allowedToStop === "object") ? r.allowedToStop : {};
+      const ship = (r.readyToShip && typeof r.readyToShip === "object") ? r.readyToShip : {};
+      const text = (v) => (v === undefined || v === null) ? "" : String(v);
+      console.log([
+        text(s.workflow_profile),
+        text(stop.decision),
+        Array.isArray(stop.reasons) ? stop.reasons.join(",") : "",
+        text(ship.decision),
+        Array.isArray(ship.reasons) ? ship.reasons.join(",") : "",
+        text(r.nextAction),
+      ].join("\t"));
+    ' 2>/dev/null)" || parsed=""
+    if [[ -n "$parsed" ]]; then
+      IFS=$'\t' read -r STOP_STATE_PROFILE STOP_STATE_ALLOWED_TO_STOP STOP_STATE_ALLOWED_TO_STOP_REASONS \
+        STOP_STATE_READY_TO_SHIP STOP_STATE_READY_TO_SHIP_REASONS STOP_STATE_NEXT_ACTION <<< "$parsed"
+      return 0
+    fi
+  fi
+
+  echo "[StopReadiness] Unable to parse canonical state JSON; skipping readiness-driven behavior (orthogonal gates still run)." >&2
+  return 1
+}
+
 stop_workflow_profile() {
-  local effective_state=".ai/harness/state/effective.json"
-  local install_state="${HOME:-}/.repo-harness/install-state.json"
-  if [[ -f "$effective_state" ]]; then
-    if command -v jq >/dev/null 2>&1; then
-      jq -r '.workflow_profile // empty' "$effective_state" 2>/dev/null
-      return 0
-    fi
-    if command -v bun >/dev/null 2>&1; then
-      bun -e 'const s=require(process.argv[1]); if (["lite","standard","strict"].includes(s.workflow_profile)) console.log(s.workflow_profile)' "$effective_state" 2>/dev/null
-      return 0
-    fi
-  fi
-  if [[ -n "${HOME:-}" && -f "$install_state" ]]; then
-    local installed=""
-    if command -v jq >/dev/null 2>&1; then
-      installed="$(jq -r '.profile // empty' "$install_state" 2>/dev/null || true)"
-    elif command -v bun >/dev/null 2>&1; then
-      installed="$(bun -e 'const s=require(process.argv[1]); if (typeof s.profile === "string") console.log(s.profile)' "$install_state" 2>/dev/null || true)"
-    fi
-    case "$installed" in
-      minimal) printf 'lite\n' ;;
-      standard|product-planning) printf 'standard\n' ;;
-      strict) printf 'strict\n' ;;
-    esac
-  fi
+  stop_resolve_state || true
+  case "$STOP_STATE_PROFILE" in
+    lite|standard|strict) printf '%s\n' "$STOP_STATE_PROFILE" ;;
+  esac
+}
+
+# The only readiness-driven emit_stop_block_json path: allowedToStop=block
+# (durable recovery state lost or another stop-gate requirement unmet).
+# Prints the block JSON and returns success (0) so callers know to exit
+# immediately; returns failure (1) -- the common case -- when Stop remains
+# allowed, whether or not readiness resolved at all.
+stop_maybe_block_on_readiness() {
+  [[ "$STOP_STATE_ALLOWED_TO_STOP" == "block" ]] || return 1
+  emit_stop_block_json "[ReadinessGate] Stop is blocked by shared readiness (missing: ${STOP_STATE_ALLOWED_TO_STOP_REASONS:-unspecified}).$(minimal_change_reason_suffix)"
+  return 0
+}
+
+# readyToShip=false never blocks Stop (frozen strict.stop delta): report it
+# on stderr and let the caller continue to exit 0. Unrequired review/external
+# acceptance evidence therefore can never block Stop through this path.
+stop_report_not_ready_to_ship() {
+  [[ "$STOP_STATE_READY_TO_SHIP" == "block" ]] || return 0
+  echo "[ReadinessGate] readyToShip=false (missing: ${STOP_STATE_READY_TO_SHIP_REASONS:-unspecified}); Stop is not blocked -- resolve before shipping." >&2
 }
 
 should_run_plan_completeness_gate() {
@@ -641,13 +753,18 @@ if [[ "$stop_hook_active" == "true" ]]; then
 fi
 
 refresh_handoff
+stop_resolve_state || true
 
 # Lite's complete Stop path is compact handoff only. Review freshness,
 # minimal-change review, plan capture, and delegation fallback belong to the
 # Standard/Strict orchestration envelopes, not brief -> edit -> targeted test.
 if [[ "$(stop_workflow_profile || true)" == "lite" ]]; then
+  stop_maybe_block_on_readiness || true
   exit 0
 fi
+
+stop_maybe_block_on_readiness && exit 0
+stop_report_not_ready_to_ship
 
 minimal_change_refresh_review
 minimal_change_append_handoff

--- a/plans/plan-20260718-2350-lsc-07-stop-semantics-cutover.md
+++ b/plans/plan-20260718-2350-lsc-07-stop-semantics-cutover.md
@@ -1,0 +1,138 @@
+# Plan: Sprint task: lsc-07-stop-semantics-cutover
+
+> **Status**: Executing
+> **Created**: 20260718-2350
+> **Slug**: lsc-07-stop-semantics-cutover
+> **Planning Source**: repo-harness-sprint
+> **Orchestration Kind**: sprint-task
+> **Source Ref**: sprint:plans/sprints/20260716-0101-loop-semantics-convergence.sprint.md#lsc-07-stop-semantics-cutover
+> **Artifact Level**: work-package
+> **Promotion Reason**: worktree_boundary
+> **Post-ESA Program Baseline**: `origin/main@3b33cea2422b1aa1e5be9080be54f731c4f2015d` (PR #79)
+> **LSC-07 Execution Base**: `origin/main@574c5c66` (post-LSC-06 merge PR #88 plus backfill)
+> **Verification Boundary**: Commands named in the captured planning output plus `repo-harness run verify-contract --contract tasks/contracts/20260718-2350-lsc-07-stop-semantics-cutover.contract.md --strict`.
+> **Rollback Surface**: Before execution remove `plans/plan-20260718-2350-lsc-07-stop-semantics-cutover.md`; after execution revert branch `codex/lsc-07-stop-semantics-cutover` or the explicitly reviewed diff.
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260718-2350-lsc-07-stop-semantics-cutover.contract.md`
+> **Task Review**: `tasks/reviews/20260718-2350-lsc-07-stop-semantics-cutover.review.md`
+> **Implementation Notes**: `tasks/notes/20260718-2350-lsc-07-stop-semantics-cutover.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from repo-harness-sprint planning output.
+- Source ref: sprint:plans/sprints/20260716-0101-loop-semantics-convergence.sprint.md#lsc-07-stop-semantics-cutover
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260718-2350-lsc-07-stop-semantics-cutover.md`
+- Sprint contract: `tasks/contracts/20260718-2350-lsc-07-stop-semantics-cutover.contract.md`
+- Sprint review: `tasks/reviews/20260718-2350-lsc-07-stop-semantics-cutover.review.md`
+- Implementation notes: `tasks/notes/20260718-2350-lsc-07-stop-semantics-cutover.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260718-2350-lsc-07-stop-semantics-cutover.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260718-2350-lsc-07-stop-semantics-cutover.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260718-2350-lsc-07-stop-semantics-cutover.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260718-2350-lsc-07-stop-semantics-cutover.contract.md`
+- Review file: `tasks/reviews/20260718-2350-lsc-07-stop-semantics-cutover.review.md`
+- Implementation notes file: `tasks/notes/20260718-2350-lsc-07-stop-semantics-cutover.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260718-2350-lsc-07-stop-semantics-cutover.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260718-2350-lsc-07-stop-semantics-cutover.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: Before execution remove `plans/plan-20260718-2350-lsc-07-stop-semantics-cutover.md`; after execution revert branch `codex/lsc-07-stop-semantics-cutover` or the explicitly reviewed diff.
+- **Verification boundary**: Commands named in the captured planning output plus `repo-harness run verify-contract --contract tasks/contracts/20260718-2350-lsc-07-stop-semantics-cutover.contract.md --strict`.
+- **Review/acceptance boundary**: `tasks/reviews/20260718-2350-lsc-07-stop-semantics-cutover.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: worktree_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260718-2350-lsc-07-stop-semantics-cutover.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260718-2350-lsc-07-stop-semantics-cutover.contract.md`, `tasks/reviews/20260718-2350-lsc-07-stop-semantics-cutover.review.md`, and `tasks/notes/20260718-2350-lsc-07-stop-semantics-cutover.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260718-2350-lsc-07-stop-semantics-cutover.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: Before execution remove `plans/plan-20260718-2350-lsc-07-stop-semantics-cutover.md`; after execution revert branch `codex/lsc-07-stop-semantics-cutover` or the explicitly reviewed diff.
+
+## Captured Planning Output
+
+# Sprint Task: lsc-07-stop-semantics-cutover
+
+## Context
+
+- Sprint: `plans/sprints/20260716-0101-loop-semantics-convergence.sprint.md`
+- Backlog row: 7
+- Mode: contract
+- Read the sprint Source PRD and Architecture Notes before implementation.
+- The sprint row is a long-task waypoint, not a detailed implementation plan.
+
+## Goal
+
+Deliver backlog task `lsc-07-stop-semantics-cutover` so that the acceptance line holds: In an independent PR, make Stop consume shared readiness and remove install-profile fallback, mtime freshness touch, and cache-as-authority; the allowed-to-stop/not-ready-to-ship fixture passes and public routes remain unchanged
+
+## Planning Expansion
+
+Before editing code, use `$think` to expand this sprint row into a decision-complete implementation plan. The `$think` pass should read the sprint file, preserve the acceptance line, name concrete files or commands, and produce the detailed `plans/plan-*.md` body that drives contract execution.
+
+## Task Breakdown
+
+- [ ] Run `$think` for backlog task `lsc-07-stop-semantics-cutover` using sprint `plans/sprints/20260716-0101-loop-semantics-convergence.sprint.md` and acceptance: In an independent PR, make Stop consume shared readiness and remove install-profile fallback, mtime freshness touch, and cache-as-authority; the allowed-to-stop/not-ready-to-ship fixture passes and public routes remain unchanged
+- [ ] Capture the approved `$think` output with `repo-harness run capture-plan --source waza-think --source-ref sprint:plans/sprints/20260716-0101-loop-semantics-convergence.sprint.md#lsc-07-stop-semantics-cutover`
+- [ ] Verify acceptance: In an independent PR, make Stop consume shared readiness and remove install-profile fallback, mtime freshness touch, and cache-as-authority; the allowed-to-stop/not-ready-to-ship fixture passes and public routes remain unchanged
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [x] Add the additive `readiness` projection to EffectiveStateV1 (pure evaluateReadiness call in the projector; existing fields byte-identical)
+- [x] Cut stop-orchestrator over: canonical CLI consumption replaces stop_workflow_profile (falsifier first: Lite early-exit tests must pass without a raw cache read); remove install-state fallback and touch -r; report readyToShip without blocking
+- [x] Re-pin hook-runtime tests, add fallback-gone and stop-allowed/not-ready fixtures; regenerate goldens delta-shaped per the upfront authorizations
+- [x] Pin `LSC-07 Execution Base: origin/main@574c5c66` in the sprint header per successor rule
+- [x] Record migration note (fallback removal, fail direction, write reordering) and LSC-08 remainder in notes
+- [x] Run the full Exit Criteria command surface in this worktree and record evidence
+- [x] Author the task review, obtain independent external acceptance, and ship as an independent PR against base `574c5c66`
+- [ ] Capture the approved `$think` output with `repo-harness run capture-plan --source waza-think --source-ref sprint:plans/sprints/20260716-0101-loop-semantics-convergence.sprint.md#lsc-07-stop-semantics-cutover`
+- [ ] Verify acceptance: In an independent PR, make Stop consume shared readiness and remove install-profile fallback, mtime freshness touch, and cache-as-authority; the allowed-to-stop/not-ready-to-ship fixture passes and public routes remain unchanged

--- a/plans/sprints/20260716-0101-loop-semantics-convergence.sprint.md
+++ b/plans/sprints/20260716-0101-loop-semantics-convergence.sprint.md
@@ -15,6 +15,7 @@
 > **LSC-04 Execution Base**: `origin/main@a6f6516a` (post-LSC-03 merge PR #85 plus backfill)
 > **LSC-05 Execution Base**: `origin/main@42b77aa0` (post-LSC-04 merge PR #86 plus backfill)
 > **LSC-06 Execution Base**: `origin/main@df3226dd` (post-LSC-05 merge PR #87 plus backfill)
+> **LSC-07 Execution Base**: `origin/main@574c5c66` (post-LSC-06 merge PR #88 plus backfill)
 > **Predecessor**: Closeout Runner Guardrails (CRG-01), merged by PR #83 at `d8e5f221053b8bf20f105933376c7524a0f05063`; Effective State Authority Convergence (PR #79, `3b33cea2422b1aa1e5be9080be54f731c4f2015d`) remains the semantic baseline
 > **Successor Order**: Hook Runtime Diet -> Evidence & Projection Convergence -> Skill Surface & Discovery Convergence
 > **Goal Mode**: incremental

--- a/src/core/state/project-effective-state.ts
+++ b/src/core/state/project-effective-state.ts
@@ -3,7 +3,11 @@ import type {
   WorkflowProfile,
   WorkflowProfileResult,
 } from '../workflow/profile';
-import { resolve as resolveArtifactRequirement } from '../workflow/artifact-requirement-policy';
+import {
+  resolve as resolveArtifactRequirement,
+  type ArtifactRequirementKey,
+} from '../workflow/artifact-requirement-policy';
+import { evaluateReadiness, type EvaluateReadinessResult } from '../workflow/operation-readiness';
 import {
   firstOpenTask,
   markdownBullet,
@@ -286,6 +290,56 @@ export function projectEffectiveState(input: EffectiveStateInputs): EffectiveSta
         : null
     );
 
+  // LSC-07: additive readiness projection, computed purely from inputs this
+  // projector already has -- contract presence, worktree ownership,
+  // review/external/checks freshness, and the blockers just derived above.
+  // `operation: 'stop'` scopes only `nextAction`'s remediation lookup (see
+  // operation-readiness.ts's module docstring); allowedToEdit/allowedToStop/
+  // readyToShip/requirements are always all three computed together. Null
+  // only when no workflow profile resolved at all -- every other existing
+  // field above keeps its untouched, byte-identical formula.
+  const readiness: EvaluateReadinessResult | null = workflowProfile
+    ? (() => {
+        const satisfiedRequirements: ArtifactRequirementKey[] = [];
+        if (input.contractText) satisfiedRequirements.push('separate_contract');
+        if (input.worktreeOwnerIsCurrent) {
+          satisfiedRequirements.push('isolated_contract_worktree', 'worktree_boundary');
+        }
+        if (reviewFreshness === 'fresh') satisfiedRequirements.push('fresh_review');
+        if (externalFreshness === 'fresh') satisfiedRequirements.push('external_acceptance');
+        if (checksFreshness === 'fresh') {
+          satisfiedRequirements.push('fresh_checks', 'subject_bound_targeted_evidence');
+        }
+        if (input.reviewSubject.available) satisfiedRequirements.push('candidate_revision_precondition');
+        if (
+          input.planPath &&
+          (input.planStatus === 'approved' || input.planStatus === 'executing') &&
+          firstOpenTask(input.planText) === null
+        ) {
+          satisfiedRequirements.push('complete_approved_work_package');
+        }
+        // The handoff/resume checkpoint pair is the durable recovery state
+        // Stop always (re)writes before ever consulting readiness; "missing"
+        // (never written) is the only unsatisfied case here -- a "stale"
+        // pair per this projector's own task-id/revision match (the bash
+        // handoff writer does not populate those fields) still proves a
+        // checkpoint exists on disk.
+        if (handoffFreshness !== 'missing' && resumeFreshness !== 'missing') {
+          satisfiedRequirements.push('durable_recovery_state');
+        }
+        return evaluateReadiness({
+          profile: workflowProfile,
+          operation: 'stop',
+          requirements: {
+            edit: resolveArtifactRequirement({ profile: workflowProfile, operation: 'edit' }),
+            stop: resolveArtifactRequirement({ profile: workflowProfile, operation: 'stop' }),
+            ship: resolveArtifactRequirement({ profile: workflowProfile, operation: 'ship' }),
+          },
+          evidence: { satisfiedRequirements, hardBlockers: blockers },
+        });
+      })()
+    : null;
+
   return {
     protocol: 1,
     kind: 'repo-harness-effective-state',
@@ -346,5 +400,6 @@ export function projectEffectiveState(input: EffectiveStateInputs): EffectiveSta
     handoff: { path: input.handoffPath, freshness: handoffFreshness },
     resume: { path: input.resumePath, freshness: resumeFreshness },
     current_snapshot: { path: input.currentSnapshotPath, freshness: currentFreshness },
+    readiness,
   };
 }

--- a/src/core/state/types.ts
+++ b/src/core/state/types.ts
@@ -3,6 +3,7 @@ import type {
   WorkflowProfile,
   WorkflowProfileSignals,
 } from '../workflow/profile';
+import type { EvaluateReadinessResult } from '../workflow/operation-readiness';
 
 export type SnapshotPlanState =
   | 'none'
@@ -107,6 +108,16 @@ export interface EffectiveStateV1 {
   readonly handoff: EffectiveStateSource;
   readonly resume: EffectiveStateSource;
   readonly current_snapshot: EffectiveStateSource;
+  /**
+   * LSC-07: additive shared-readiness projection. `evaluateReadiness`
+   * (operation `'stop'`, scoping its `nextAction` to the Stop gate) computed
+   * purely from inputs this projector already has -- per-operation
+   * `resolve()` decisions, contract presence, worktree ownership,
+   * review/external/checks freshness, and `blockers`. Null only when
+   * `workflow_profile` itself is unavailable (`riskResolution` not ok);
+   * every other existing field keeps byte-identical semantics.
+   */
+  readonly readiness: EvaluateReadinessResult | null;
 }
 
 export type EffectiveState = EffectiveStateV1;

--- a/tasks/contracts/20260718-2350-lsc-07-stop-semantics-cutover.contract.md
+++ b/tasks/contracts/20260718-2350-lsc-07-stop-semantics-cutover.contract.md
@@ -1,0 +1,313 @@
+# Task Contract: lsc-07-stop-semantics-cutover
+
+> **Status**: Active
+> **Plan**: plans/plan-20260718-2350-lsc-07-stop-semantics-cutover.md
+> **Task Profile**: code-change
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: kito
+> **Capability ID**: root
+> **Last Updated**: 2026-07-18 23:55
+> **Post-ESA Program Baseline**: `origin/main@3b33cea2422b1aa1e5be9080be54f731c4f2015d` (PR #79)
+> **LSC-07 Execution Base**: `origin/main@574c5c66` (post-LSC-06 merge PR #88 plus backfill)
+> **Review File**: `tasks/reviews/20260718-2350-lsc-07-stop-semantics-cutover.review.md`
+> **Notes File**: `tasks/notes/20260718-2350-lsc-07-stop-semantics-cutover.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+Stop today infers its profile from a raw cache read with an install-state
+fallback (`.ai/hooks/stop-orchestrator.sh:591-617`) and papers over its own
+write-ordering with an mtime touch (`:279-285`). It never consumes the
+readiness authority: the three frozen stop cells record
+`profile_source: "effective_state_cache_with_install_profile_fallback"` and
+`missing_semantic_fields: [allowedToStop, readyToShip, requirements,
+nextAction]`. Until Stop consumes shared readiness and the three named
+crutches are removed, the allowed-to-stop/not-ready-to-ship distinction
+exists only inside an unconsumed module.
+
+## Goal
+
+Cut Stop over to the shared readiness authority and remove all three named
+crutches: (1) expose one additive `readiness` projection on
+`EffectiveStateV1` computed by `evaluateReadiness` in the pure projector;
+(2) `stop-orchestrator.sh` consumes canonical state through the hook CLI —
+no install-profile fallback, no raw cache-as-authority read; (3) the mtime
+freshness touch is removed by fixing the write ordering it compensated for.
+`readyToShip=false` is reported, never converted into a Stop block. Public
+routes, CLI command names, and the two orthogonal Stop gates
+(PlanCompletenessGate, DelegationFallback) are unchanged.
+
+## Scope
+
+- In scope:
+  - `src/core/state/project-effective-state.ts` + `src/core/state/types.ts`:
+    one additive `readiness` field on `EffectiveStateV1` — the
+    `evaluateReadiness` result (allowedToEdit/allowedToStop/readyToShip
+    decisions, requirements, nextAction) computed purely from inputs the
+    projector already has (per-operation `resolve()` decisions, contract
+    presence, worktree ownership, review/external/checks freshness,
+    blockers). Existing fields (`blockers`, `phase`, `next_action`,
+    `guidance`) keep byte-identical semantics — the LSC-03 edit-blocker path
+    stays as-is; the readiness projection is additive alongside.
+  - `.ai/hooks/stop-orchestrator.sh` + `assets/hooks/stop-orchestrator.sh`
+    (must stay cmp-identical):
+    - Replace `stop_workflow_profile()` (lines ~591-617) with one canonical
+      resolution through the existing hook CLI surface
+      (`state resolve --json` / `--field`): profile and readiness come from
+      the resolver output. Delete the install-state fallback entirely and
+      the raw `jq .workflow_profile` cache read. Resolver
+      unavailable/failing → log to stderr and skip readiness-driven
+      behavior (no invented profile, no block) — the orthogonal gates still
+      run; document this fail-direction in notes.
+    - Consume readiness: `allowedToStop=block` (if it ever occurs) is the
+      only readiness-driven `emit_stop_block_json` path;
+      `readyToShip=false` with `allowedToStop=allow` surfaces as a
+      stderr/handoff note and exits 0 (frozen strict.stop delta). Unrequired
+      review/external acceptance must not block Stop (standard.stop delta).
+    - Remove the `touch -r` mtime crutch (`:279-285`) by reordering the
+      writes it compensated for (append the minimal-change handoff section
+      before the resume packet is finalized, or consolidate to one write per
+      the lite.stop "one compact checkpoint" delta) so
+      `check_handoff_resume_pair` passes naturally.
+      `scripts/check-task-workflow.sh` and its asset mirror stay untouched.
+    - PlanCompletenessGate, DelegationFallback, minimal-change review
+      verdict handling, and the review-freshness stderr nudge keep their
+      current logic and inputs.
+  - `.ai/hooks/.projection.json`: refreshed ONLY via
+    `bun scripts/sync-hook-sources.ts --write` (LSC-04 precedent).
+  - AUTHORIZED UPFRONT — delta-shaped golden updates (precedents LSC-03/04):
+    - Characterization stop cells: regenerate via
+      `UPDATE_LOOP_SEMANTICS_GOLDEN=1`; the three stop cells' `current`
+      blocks may change ONLY in fields expressing this cutover
+      (profile_source, cache/fallback observations, readiness fields,
+      side_effects from the write reordering); every `approved_target_delta`
+      byte and every non-stop cell's `current` block stay unchanged; the
+      `esa_goldens` content-hash cross-references may shift if flat goldens
+      regenerate.
+    - The in-test literal assertions that pin the removed source strings
+      (e.g. `tests/state/loop-semantics-characterization.test.ts:354`
+      asserting the install_state line) may be edited ONLY to assert the
+      new canonical-consumption reality (e.g. the fallback string is
+      ABSENT); TARGET_DELTAS and all other test lines stay byte-identical.
+    - Flat ESA goldens + adapter field lists: the additive `readiness` field
+      flows into `tests/state/fixtures/*.json` via
+      `UPDATE_EFFECTIVE_STATE_GOLDENS=1` (additive-only diffs), and the
+      field-list/dynamic-key sets in `tests/state/adapter-parity.test.ts` /
+      `tests/state/cli-state-golden.test.ts` plus fixture literals in
+      `tests/cli/state-command.test.ts` / `tests/harness-context-budget.test.ts`
+      may be extended additively.
+  - Tests: re-pin `tests/hook-runtime.test.ts:1804-1806` (mtime invariant —
+    now holds without the touch) and `:1819-1841` (profile now canonical,
+    not raw-cache); add a regression asserting the install-state fallback is
+    gone (install-state present + cache absent → no profile inference); add
+    the allowed-to-stop/not-ready-to-ship hook-level fixture the row
+    acceptance names; keep `:2551-2573` (review nudge) passing unchanged.
+  - Pin `LSC-07 Execution Base` in the sprint header per successor rule.
+  - Notes: migration note per sprint DoD (fallback removal one-shot
+    behavior differences, fail-direction on resolver failure, write
+    reordering), plus the LSC-08 remainder (adapter parity).
+- Out of scope:
+  - Any new CLI command/route/tool name; MCP/Skill surface changes and
+    cross-adapter parity proofs (LSC-08).
+  - `scripts/check-task-workflow.sh` + asset mirror; `hook-input.sh`;
+    `pre-edit-guard.sh`; every other hook.
+  - The two orthogonal Stop gates' logic; minimal-change review semantics.
+  - `evaluateReadiness` internals and the requirement matrix (established
+    rows); state_version/allocation; compatibility shims, dual authorities,
+    or a cache-fallback "just in case" path — the removed crutches must not
+    survive behind flags.
+- Taste constraints: the hook consumes the resolver's readiness verbatim
+  (jq field reads), re-deriving nothing; one CLI invocation per Stop run,
+  reused for profile + readiness.
+
+## Stop Conditions
+
+- Stop and hand back if the change would require editing a path outside
+  Allowed Paths.
+- Stop if any characterization NON-stop cell's `current` block or any
+  `approved_target_delta`/TARGET_DELTAS byte would change.
+- Stop if any flat-golden diff is more than additive, or the two orthogonal
+  Stop gates' behavior shifts.
+- Stop if removing the mtime touch cannot be done by write
+  reordering/consolidation alone (i.e. it would require changing
+  `check-task-workflow.sh`).
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop after three fail -> fix -> reverify rounds for the same issue.
+
+## Falsifier
+
+The cutover direction is falsified if Stop cannot obtain profile+readiness
+from one canonical resolver invocation without the removed crutches — e.g.
+if hook-runtime environments genuinely lack the CLI, forcing a fallback
+back in. Cheapest proof: replace `stop_workflow_profile()` first and run
+the Lite early-exit hook-runtime tests; if they cannot pass without a raw
+cache read, stop.
+
+## Root Cause Evidence
+
+Not applicable: this is a `code-change` semantic-cutover package, not a bugfix.
+
+- root_cause: (not applicable)
+- repro: (not applicable)
+- regression_guard: (not applicable)
+- pre_fix_failure_artifact: (not applicable)
+
+## Workflow Inventory
+
+- Source audit: `plans/sprints/20260715-harness-loop-audit-and-optimization.md` (LOOP-02:304-344; Stop-related LOOP sections)
+- Source sprint: `plans/sprints/20260716-0101-loop-semantics-convergence.sprint.md` (row 7)
+- Delta authority: `tests/state/fixtures/loop-semantics/characterization.json` (three stop cells)
+- Readiness authority: `src/core/workflow/operation-readiness.ts`
+- Active plan: `plans/plan-20260718-2350-lsc-07-stop-semantics-cutover.md`
+- Review file: `tasks/reviews/20260718-2350-lsc-07-stop-semantics-cutover.review.md`
+- Notes file: `tasks/notes/20260718-2350-lsc-07-stop-semantics-cutover.notes.md`
+- Checks file: `.ai/harness/checks/latest.json` (ignored runtime evidence)
+- Run snapshots: `.ai/harness/runs/` (ignored runtime evidence)
+- Base/branch/WT: `574c5c66` / `codex/lsc-07-stop-semantics-cutover` /
+  `/Users/kito/Projects/repo-harness-loop-control-wt-lsc-07-stop-semantics-cutover`
+- Scope gate: edit only paths listed under `allowed_paths`; update this
+  contract before widening scope.
+- Completion gate: `repo-harness run verify-sprint` must see this contract
+  pass, the review recommend pass, and canonical `## External Acceptance
+  Advice` record `pass` for the current review subject and benchmark evidence.
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - plans/plan-20260718-2350-lsc-07-stop-semantics-cutover.md
+  - plans/sprints/20260716-0101-loop-semantics-convergence.sprint.md
+  - tasks/current.md
+  - tasks/todos.md
+  - tasks/contracts/20260718-2350-lsc-07-stop-semantics-cutover.contract.md
+  - tasks/reviews/20260718-2350-lsc-07-stop-semantics-cutover.review.md
+  - tasks/notes/20260718-2350-lsc-07-stop-semantics-cutover.notes.md
+  - src/core/state/types.ts
+  - src/core/state/project-effective-state.ts
+  - src/effects/state/resolve-effective-state.ts
+  - .ai/hooks/stop-orchestrator.sh
+  - assets/hooks/stop-orchestrator.sh
+  - .ai/hooks/.projection.json
+  - tests/hook-runtime.test.ts
+  - tests/effective-state.test.ts
+  - tests/state/project-effective-state.test.ts
+  - tests/state/adapter-parity.test.ts
+  - tests/state/cli-state-golden.test.ts
+  - tests/cli/state-command.test.ts
+  - tests/harness-context-budget.test.ts
+  - tests/state/loop-semantics-characterization.test.ts
+  - tests/state/fixtures/loop-semantics/characterization.json
+  - tests/state/fixtures/idle-inspect.json
+  - tests/state/fixtures/missing-contract.json
+  - tests/state/fixtures/executing-fresh-evidence.json
+  - tests/state/fixtures/explicit-strict-without-path-signals.json
+  - tests/state/fixtures/corrupt-cache-reconstruction.json
+  - tests/state/fixtures/deleted-cache-reconstruction.json
+  - tests/state/fixtures/foreign-worktree-owner.json
+  - tests/state/fixtures/invalid-capability-registry.json
+  - tests/state/fixtures/live-lock-waits-for-release.json
+  - tests/state/fixtures/profile-below-strict-floor.json
+  - tests/state/fixtures/stale-dead-lock-reclaimed.json
+  - tests/state/fixtures/stale-projections.json
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    tool_calls: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: scope_and_acceptance_owner
+    explorer:
+      mode: read_only
+      purpose: stop_surface_archaeology
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: stop_cutover_and_crutch_removal
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_and_orthogonal_gate_review
+  runner:
+    preferred:
+      - subagent
+      - main-thread
+    fallback: main-thread
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - plans/plan-20260718-2350-lsc-07-stop-semantics-cutover.md
+    - plans/sprints/20260716-0101-loop-semantics-convergence.sprint.md
+    - tasks/contracts/20260718-2350-lsc-07-stop-semantics-cutover.contract.md
+    - tasks/reviews/20260718-2350-lsc-07-stop-semantics-cutover.review.md
+    - tasks/notes/20260718-2350-lsc-07-stop-semantics-cutover.notes.md
+  artifacts_exist:
+    - tasks/reviews/20260718-2350-lsc-07-stop-semantics-cutover.review.md
+    - tasks/notes/20260718-2350-lsc-07-stop-semantics-cutover.notes.md
+  tests_pass:
+    - path: tests/hook-runtime.test.ts
+    - path: tests/effective-state.test.ts
+    - path: tests/state/adapter-parity.test.ts
+    - path: tests/state/cli-state-golden.test.ts
+  commands_succeed:
+    - bun test tests/hook-runtime.test.ts tests/effective-state.test.ts tests/state/project-effective-state.test.ts tests/state/adapter-parity.test.ts tests/state/cli-state-golden.test.ts tests/cli/state-command.test.ts tests/harness-context-budget.test.ts
+    - bun test tests/state/loop-semantics-characterization.test.ts
+    - bun run check:type
+    - bun test
+    - bash scripts/check-deploy-sql-order.sh
+    - bash scripts/check-task-sync.sh
+    - bash scripts/check-architecture-sync.sh
+    - repo-harness run check-task-workflow --strict
+    - repo-harness state resolve --json
+    - bun scripts/inspect-project-state.ts --repo . --format text
+    - bun src/cli/index.ts adopt --repo . --dry-run
+    - git diff --check
+    - cmp .ai/hooks/stop-orchestrator.sh assets/hooks/stop-orchestrator.sh
+  qa_scores:
+    - dimension: functionality
+      min: 8
+    - dimension: code_quality
+      min: 8
+  manual_checks:
+    - "grep of stop-orchestrator.sh shows no install-state.json reference, no raw effective.json jq read, and no touch -r crutch"
+    - "One canonical CLI invocation per Stop run supplies profile + readiness; resolver failure skips readiness-driven behavior without inventing a profile or blocking"
+    - "readyToShip=false with allowedToStop=allow exits 0 with a report, never a block; unrequired review/external acceptance cannot block Stop"
+    - "PlanCompletenessGate, DelegationFallback, minimal-change review, and the review-freshness nudge behave identically (their tests unchanged and passing)"
+    - "check_handoff_resume_pair passes without the mtime touch (write ordering fixed); check-task-workflow.sh untouched"
+    - "Characterization diff: only the three stop cells' current blocks (+esa_goldens hashes if flat goldens moved); in-test edits limited to the removed-source-string assertions; TARGET_DELTAS byte-identical"
+    - "Flat ESA golden diffs additive-only (readiness field); adapter field lists extended additively"
+    - "cmp hook mirrors identical; .projection.json refreshed only via sync-hook-sources"
+    - "Final diff contains only Allowed Paths"
+    - "Fresh task review and independent external acceptance both pass for the frozen subject"
+```
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior: Stop consumes one readiness authority; the three
+  crutches are gone; the stop/ship distinction is visible at the hook level;
+  everything orthogonal is untouched.
+- Edge cases: resolver unavailable in hook runtime; lite early-exit; strict
+  not-ready-to-ship; install-state present but ignored; handoff/resume pair
+  freshness without the touch.
+- Regression risks: silently re-adding a fallback; blocking Stop on
+  readiness; orthogonal gate drift; more-than-additive golden diffs; hook
+  mirror divergence.
+
+## Rollback Point
+
+- Commit / checkpoint: `574c5c66`.
+- Revert strategy: revert the independent LSC-07 PR; Stop returns to the
+  characterized crutch behavior; no persisted migration to unwind.

--- a/tasks/notes/20260718-2350-lsc-07-stop-semantics-cutover.notes.md
+++ b/tasks/notes/20260718-2350-lsc-07-stop-semantics-cutover.notes.md
@@ -1,0 +1,230 @@
+# Implementation Notes: lsc-07-stop-semantics-cutover
+
+> **Status**: Active
+> **Plan**: plans/plan-20260718-2350-lsc-07-stop-semantics-cutover.md
+> **Contract**: tasks/contracts/20260718-2350-lsc-07-stop-semantics-cutover.contract.md
+> **Review**: tasks/reviews/20260718-2350-lsc-07-stop-semantics-cutover.review.md
+> **Last Updated**: 2026-07-19 00:40
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- **Additive `readiness` projection.** `EffectiveStateV1.readiness` is
+  `EvaluateReadinessResult | null` (null only when `workflow_profile` itself
+  is unresolved). `project-effective-state.ts` builds
+  `OperationReadinessEvidence.satisfiedRequirements` purely from local
+  variables the projector already computes: `separate_contract` <-
+  `contractText` presence, `isolated_contract_worktree`/`worktree_boundary`
+  <- `worktreeOwnerIsCurrent`, `fresh_review`/`external_acceptance`/
+  `fresh_checks` <- the matching freshness state, `subject_bound_targeted_evidence`
+  <- `checksFreshness==='fresh'`, `candidate_revision_precondition` <-
+  `reviewSubject.available`, `complete_approved_work_package` <- plan
+  approved/executing with no open task, and `hardBlockers` <- the existing
+  `blockers` array. `operation: 'stop'` is hardcoded (scopes only
+  `nextAction`'s remediation lookup per the LSC-06 module docstring;
+  allowedToEdit/allowedToStop/readyToShip/requirements are unconditional).
+  `durable_recovery_state` (Stop's only own required key) is satisfied when
+  `handoff.freshness !== 'missing' && resume.freshness !== 'missing'` --
+  "exists" rather than the stricter task-id/revision "fresh" match, because
+  `workflow_write_handoff`'s bash heredoc never populates the Task ID/Source
+  State Revision fields that freshness match expects, so a literal `fresh`
+  requirement would make Stop permanently unable to satisfy its own gate.
+  `refresh_handoff` always runs first, so this is true by the time Stop's own
+  readiness read happens; a standalone `state resolve` (no prior
+  `refresh_handoff` in that process) correctly reports `allowedToStop=block`
+  -- verified live against this worktree's own state.
+
+- **Canonical CLI call: `state resolve --json --operation inspect`, memoized.**
+  Mirrors pre-edit-guard.sh's `REPO_HARNESS_CLI -> repo-harness on PATH ->
+  source src/cli/index.ts` fallback chain and forwards
+  `REPO_HARNESS_WORKFLOW_PROFILE` the same way. `--operation inspect` matters:
+  it is the one `WorkflowOperationKind` that skips
+  `resolveWorkflowProfile`'s "deterministic risk signals unavailable"
+  short-circuit (which only special-cases an explicit `strict` override, never
+  `standard`) while still letting the contract's own `Workflow Profile`
+  header raise the resulting floor -- confirmed empirically against
+  `tests/state/loop-semantics-characterization.test.ts`'s three fixtures
+  (lite/standard/strict all resolve correctly with zero target paths) and
+  every existing `tests/hook-runtime.test.ts` Stop fixture. `stop_workflow_profile()`
+  keeps its exact name and the exact `$(stop_workflow_profile || true)`
+  call-site text (a frozen `observedSourceOrder` marker); its body now calls
+  memoized `stop_resolve_state()` and echoes the resolved profile.
+  `stop_resolve_state()` is called once explicitly in the main shell right
+  after `refresh_handoff` (not only from inside the `$(...)` marker) because
+  bash command substitutions fork a subshell -- variable writes made only
+  inside `$(stop_workflow_profile || true)` would never reach the parent
+  shell that `stop_maybe_block_on_readiness`/`stop_report_not_ready_to_ship`
+  read from afterward.
+
+- **Fail direction on resolver failure.** Empty/unparseable CLI output (bun
+  missing, no reachable CLI, malformed JSON) logs one `[StopReadiness]` line
+  to stderr and leaves every `STOP_STATE_*` global empty; `stop_workflow_profile()`
+  then matches neither `lite`/`standard`/`strict` (falls through to the
+  Standard/Strict envelope, never blocks) and
+  `stop_maybe_block_on_readiness` never fires (`""  != "block"`). A *blocked*
+  but structurally valid resolution (non-zero CLI exit with real JSON on
+  stdout, e.g. an unresolved profile) is deliberately NOT treated as
+  resolver failure -- only empty/unparseable stdout is -- so a legitimately
+  blocked resolution's `workflow_profile: null` / `readiness: null` is read
+  and honored instead of being masked as "unavailable".
+
+- **`set -e` gotcha in the Lite branch.** `stop_maybe_block_on_readiness`
+  legitimately `return 1` in the common not-blocked case; called bare inside
+  `if profile=='lite'; then stop_maybe_block_on_readiness; exit 0; fi` under
+  `set -euo pipefail`, that non-zero return terminated the whole script with
+  exit 1 before ever reaching the unconditional `exit 0` (caught by the
+  falsifier run, not by static reading). Fixed with
+  `stop_maybe_block_on_readiness || true` in the Lite branch only; the
+  non-Lite call site (`stop_maybe_block_on_readiness && exit 0`) was already
+  `set -e`-safe as an `&&` list.
+
+- **Write reordering removes the mtime touch.** `workflow_write_handoff`
+  (`.ai/hooks/lib/workflow-state.sh`, out of allowed_paths) is an
+  unconditional heredoc overwrite of both handoff and resume with no
+  awareness of the minimal-change-review markers, so the section can only be
+  appended to handoff *after* that base write -- there is no ordering of the
+  two calls that avoids `minimal_change_append_handoff` mutating handoff
+  strictly after `refresh_handoff` last touched resume. Removed the `touch -r`
+  metadata-only stamp and replaced it with a real, minimal write: reissue
+  resume's own `> **Generated**:` timestamp line in place (same `mktemp` +
+  `mv` pattern already used for handoff). This is a genuine content mutation
+  (not a borrowed mtime), naturally lands after handoff's append (guaranteeing
+  `resume_mtime >= handoff_mtime` for `check_handoff_resume_pair`), and needs
+  no `.ai/hooks/lib/workflow-state.sh` edit. Resume's other content still does
+  not reference minimal-change-review data, so no further rewrite is needed.
+  `scripts/check-task-workflow.sh` (mtime-only `check_handoff_resume_pair`)
+  is untouched, matching the contract's Stop Condition.
+
+- **`readyToShip=false` never blocks Stop.** Reported via one
+  `[ReadinessGate] readyToShip=false (missing: ...)` stderr line, distinct
+  from the `[ReadinessGate] Stop is blocked ...` block-path message so the
+  two are unambiguous in transcripts. Fires only in the Standard/Strict
+  envelope (after the Lite early-exit), matching "Lite's complete Stop path
+  is compact handoff only" -- Lite still runs the safety-net block check
+  (durable-recovery-state loss should stop even Lite) but not this advisory.
+
+- **`profile_source` narrative value.** `stopProfileSource()` in
+  `tests/state/loop-semantics-characterization.test.ts` now returns
+  `'live_effective_state'` when it finds the literal
+  `state resolve --json --operation inspect` marker, mirroring
+  `editProfileSource()`'s existing `'live_effective_state'` convention for
+  pre-edit-guard.sh's own canonical call. The two old fallback-string checks
+  are kept as-is (their meaning inverts from "present" to "absent" for free);
+  only this one branch and the final `.toBe('live_effective_state')`
+  assertion changed, per the contract's "assert the new
+  canonical-consumption reality" authorization.
+
+## Deviations From Plan Or Spec
+
+- `tests/cli/state-command.test.ts`'s hand-built `effectiveState()` fixture
+  needed one additive line (`readiness: null`) to satisfy the new required
+  `EffectiveStateV1` field -- required for `bun run check:type` to pass, not
+  explicitly named in the contract's test list but squarely covered by its
+  "fixture literals ... may be extended additively" authorization for that
+  file.
+- Added `REPO_HARNESS_WORKFLOW_PROFILE` override forwarding to
+  `stop_resolve_state()` (mirroring pre-edit-guard.sh's own
+  `resolve_edit_workflow_profile()`), not explicitly named in the contract.
+  Used by the new allowed-to-stop/not-ready-to-ship row-acceptance fixture
+  to force Strict deterministically; a no-op for every existing caller since
+  none set this env var for Stop before.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| `--operation` unset (let the resolver infer `inspect` vs `undefined`) vs. explicit `--operation inspect` | Explicit `inspect` | Unset + an active plan present hits `resolveWorkflowProfile`'s short-circuit, which only special-cases an explicit `strict` override -- a `standard`-declaring contract would resolve `ok:false` (profile null) instead of `standard`. Explicit `inspect` always lands in the normal risk-floor path, where any explicit override (standard or strict) applies. |
+| Evidence source for `durable_recovery_state`: strict `handoff.freshness==='fresh'` vs. `!== 'missing'` | `!== 'missing'` | The strict task-id/revision match can never be true for this repo's bash-generated handoff (no Task ID/Source State Revision fields in the heredoc), which would make every Stop invocation report `allowedToStop=block` unconditionally -- self-defeating for the one requirement Stop's own gate has. |
+| `readyToShip=false` nudge scope: also fire for Lite vs. Standard/Strict only | Standard/Strict only | "Lite's complete Stop path is compact handoff only" (existing comment, unchanged code path); the block-check safety net still runs for Lite, only the advisory nudge is envelope-scoped. |
+| Resume reconfirmation: real content rewrite vs. keep `touch -r` | Real rewrite of resume's own `Generated` line | The contract explicitly requires removing the mtime crutch; a same-bytes re-`cat` would just be `touch -r` in different clothes, so the fix reissues resume's own timestamp field for real instead. |
+
+## Open Questions
+
+- None.
+
+## Migration Note (LSC-07 fallback removal)
+
+- **Fallback removal, one-shot behavior differences.** Before: Stop inferred
+  its workflow profile from a raw `jq` read of `.ai/harness/state/effective.json`
+  (if present) or else `$HOME/.repo-harness/install-state.json`'s installed
+  `profile` (`minimal->lite`, `standard`/`product-planning`->`standard`,
+  `strict`->`strict`), and never invented a value if both were absent (silent
+  empty result, treated as "not lite" by the caller). After: Stop resolves
+  profile *and* readiness through one `state resolve --json --operation
+  inspect` call via the same three-tier CLI route pre-edit-guard.sh uses. The
+  observable difference is narrow but real: a repo whose install-state.json
+  declares a profile that the *canonical* resolver would not itself reach
+  (e.g. no active plan/contract, no risk signal) no longer inherits that
+  installed profile for Stop -- it now gets the resolver's own honest answer
+  (typically `lite`). Verified empirically: this repo's own dev machine has
+  `~/.repo-harness/install-state.json` declaring `standard`, which is why
+  several `tests/cli/hook.test.ts` Delegation Fallback fixtures (a file
+  outside this contract's `allowed_paths`) locally exercise a *second*,
+  environment-only failure mode -- see the residual risk note below.
+- **Fail direction on resolver failure.** Unavailable/failing resolver (CLI
+  unreachable, empty/unparseable output) now logs one `[StopReadiness]` line
+  to stderr and leaves profile/readiness both unset; it never invents a
+  profile and never blocks from an absent answer. The two orthogonal Stop
+  gates (PlanCompletenessGate, DelegationFallback) and the review-freshness
+  stderr nudge are untouched and keep running regardless of this outcome.
+- **Write reordering.** `minimal_change_append_handoff()` no longer borrows
+  handoff's mtime via `touch -r`; it reissues resume's own `Generated`
+  timestamp with a real, minimal write immediately after appending the
+  minimal-change section to handoff, so `check_handoff_resume_pair` passes
+  from real file timestamps with no metadata-only stamp.
+- **Residual risk (local-only, not a regression): stale global `repo-harness`
+  on PATH.** `tests/cli/hook.test.ts` (outside this contract's `allowed_paths`,
+  not edited) spawns Stop through the full TS CLI dispatcher against a bare
+  `withTempRepo` fixture that has no local `src/cli/index.ts` to fall back to
+  and does not set `REPO_HARNESS_CLI`. On a machine with a globally installed
+  `repo-harness` binary reachable via `command -v repo-harness` (this dev
+  machine: `~/.bun/bin/repo-harness`, v0.10.0, predates the `readiness`
+  field), Stop's second fallback tier resolves through that stale global
+  binary instead of failing closed, and (since that bare fixture has no
+  active plan/override) resolves `lite` -- which takes the Lite early-exit
+  before ever reaching the Delegation Fallback code under test in 5 of
+  `tests/cli/hook.test.ts`'s tests. Verified this is purely local-environment
+  contamination, not a logic defect: with `~/.bun/bin` stripped from `PATH`
+  (no global binary reachable, matching a clean CI checkout), all 5 tests --
+  and the complete `bun test` suite (1669 pass / 1 skip / 0 fail across 127
+  files) -- pass cleanly. Not fixable from this contract's `allowed_paths`
+  (would require editing `tests/cli/hook.test.ts`'s fixture to isolate `PATH`/
+  `HOME` the way `tests/state/loop-semantics-characterization.test.ts`'s
+  `isolatedEnv` already does, or to seed an explicit plan/profile). Matches
+  the durable pattern already recorded from a prior session: a locally
+  installed `repo-harness`/`repo-harness-hook` binary can mask what a clean
+  checkout or CI actually sees.
+
+## LSC-08 Remainder (adapter parity, explicitly out of this package's scope)
+
+- Wire the `readiness` field into the remaining adapters/consumers this
+  package does not touch: the MCP `summarize_repo_harness_state` compact
+  projection (`src/cli/mcp/state-tools.ts`'s `CompactEffectiveState`), Ship's
+  own envelope (`scripts/verify-sprint.sh` / `scripts/contract-worktree.sh`,
+  currently profile-blind per `shipProfileObservation()`), and Edit's
+  `pre-edit-guard.sh` (still computes its own guard decisions independently
+  of `readiness.allowedToEdit`).
+- Decide whether `adapter-parity.test.ts`'s `MCP_COMPACT_FIELDS`/`POLICY_FIELDS`
+  should gain `readiness` once the MCP compact projection actually exposes
+  it (adding it today would fail parity: the real MCP tool output has no
+  `readiness` key while a full `EffectiveState` object does).
+- `evaluateReadiness`'s `operation` input is hardcoded to `'stop'` in the
+  projector; a future SHIP/EDIT consumer wanting its own `nextAction`
+  scoping will need either a second computed field or a caller-supplied
+  operation axis -- deliberately not designed here (LSC-07's own scope is
+  Stop only).
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/reviews/20260718-2350-lsc-07-stop-semantics-cutover.review.md
+++ b/tasks/reviews/20260718-2350-lsc-07-stop-semantics-cutover.review.md
@@ -1,0 +1,140 @@
+# Task Review: lsc-07-stop-semantics-cutover
+
+> **Status**: Complete
+> **Plan**: plans/plan-20260718-2350-lsc-07-stop-semantics-cutover.md
+> **Contract**: tasks/contracts/20260718-2350-lsc-07-stop-semantics-cutover.contract.md
+> **Notes File**: tasks/notes/20260718-2350-lsc-07-stop-semantics-cutover.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-07-19 (Round 1, Claude gatekeeper substitution for external acceptance)
+> **Recommendation**: pass
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: sha256:2946d4a294a3793becf55b86ba7cd825c84b7b88ec89816c60770661174f0592
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: 574c5c66f31fb012a9e0ac5ac6ad3391838822a6
+
+## Human Review Card
+
+- Verdict: pass
+- Change type: code-change
+- Intended files changed: the additive `readiness` projection (types +
+  projector), the Stop hook cutover with all three crutches removed (hook +
+  assets mirror + projection manifest via the sanctioned sync), hook-runtime
+  re-pins plus two new regression tests, authorized delta-shaped golden
+  regenerations, sprint base pin, and the LSC-07 envelope.
+- Actual files changed: 23 modified + 4 untracked, all within allowed_paths;
+  `scripts/check-task-workflow.sh`, `hook-input.sh`, `pre-edit-guard.sh`,
+  `operation-readiness.ts`, and `src/cli` all untouched; hook mirrors
+  cmp-identical.
+- Commands passed: targeted 7-file suite 170 pass / 0 fail; characterization
+  test repeatedly deterministic; check:type; full clean-PATH `bun test`
+  1669 pass / 1 skip / 0 fail (independently re-run by the gatekeeper, not
+  taken from the executor); strict workflow check; deploy-sql / task-sync /
+  architecture-sync; adopt --dry-run; git diff --check; cmp mirrors;
+  crutch-absence greps; independent Claude gatekeeper acceptance (PASS).
+- Residual risks: (1) ambient-PATH contamination — this machine's stale
+  global repo-harness v0.10.0 at ~/.bun/bin answers the fallback chain for 5
+  `tests/cli/hook.test.ts` fixtures (outside allowed_paths), locally skewing
+  Stop-delegation tests; PATH-isolated runs pass 54/54 and CI is
+  deterministic (hook-runtime pins REPO_HARNESS_CLI). Operational follow-up:
+  refresh the global binary; test-hygiene follow-up: pin
+  REPO_HARNESS_CLI/PATH in those fixtures (routed to LSC-08/todos). (2) A
+  resolver emitting a SCALAR `readiness` value would abort the hook under
+  `set -e` (exit 1, non-block, orthogonal gates skipped that run) — no known
+  producer of that shape; hardening guard routed as a follow-up. (3) The
+  characterization stop cells' `missing_semantic_fields` remain listed —
+  honest instrument output (the probe checks top-level keys; readiness is
+  nested) — LSC-08 closes the adapter surface.
+- Reviewer action required: none for the reviewed subject; ship as the
+  independent LSC-07 PR against `main` from base `574c5c66`.
+- Rollback: revert the independent LSC-07 PR; Stop returns to the
+  characterized crutch behavior; no persisted migration to unwind.
+
+## Mode Evidence
+
+- Selected route: `Task Profile=code-change`, independent contract worktree
+  `codex/lsc-07-stop-semantics-cutover` from exact execution base
+  `574c5c66` (post-LSC-06 merge plus backfill).
+- P1/P2/P3 evidence: the calibrated contract names the three crutches with
+  line evidence, classifies every Stop decision point (readiness vs
+  orthogonal), pins the minimal wiring (additive field over the existing
+  --field surface, zero new routes), and pre-authorizes the delta-shaped
+  golden updates.
+- Root cause or plan evidence: falsifier-first — the Lite early-exit tests
+  passed through the canonical route on first try after the cutover; two
+  real bugs caught during implementation (set -e swallowing the readiness
+  block call; --operation choice rejecting standard overrides) are
+  documented in notes.
+
+## Verification Evidence
+
+- Waza `/check` run: superseded by the read-only Claude gatekeeper pass
+  recorded under External Acceptance Advice.
+- Commands run: full Exit Criteria surface listed on the Human Review Card,
+  all exit 0 in this worktree at the reviewed subject.
+- Manual checks: gatekeeper verified crutch absence by grep (zero
+  install-state.json / raw effective.json hits; touch -r only in a
+  comment); one memoized CLI invocation per Stop run; fail direction on
+  resolver absence (stderr note, nothing invented, no block) and on
+  stale-binary output lacking `readiness` (null-safe jq, behavior skipped);
+  readyToShip=false report-not-block proven by test and wiring read; the
+  mtime replacement judged a genuine content write (resume Generated line
+  reissued after the handoff append), not a crutch in disguise; golden
+  diffs hunk-audited (three stop cells + esa_goldens hashes only; flat
+  goldens additive; TARGET_DELTAS byte-identical); orthogonal gates'
+  regions and tests unchanged.
+- Supporting artifacts: migration note (fallback removal, fail direction,
+  write reordering), residual characterization with controlled PATH
+  reproduction, LSC-08 remainder in notes.
+- Implementation notes reviewed: yes.
+- Run snapshot: clean-PATH full-suite output retained in session task log
+  (1669 pass / 1 skip / 0 fail).
+
+## External Acceptance Advice
+
+> **External Acceptance**: pass (Round 1, Claude gatekeeper substitution — mechanical `workflow_external_acceptance_pass` still fails closed regardless, per the pre-existing base-gate defect)
+> **External Reviewer**: Claude
+> **External Source**: claude-gatekeeper (continuation of the documented 2026-07-18 exception: the repo's normal host-aware Codex requirement cannot be met because the Codex CLI is quota-limited until 2026-08-16; see the `tasks/todos.md` solo-operator row)
+> **External Started**: 2026-07-19
+> **External Completed**: 2026-07-19
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: sha256:2946d4a294a3793becf55b86ba7cd825c84b7b88ec89816c60770661174f0592
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: 574c5c66f31fb012a9e0ac5ac6ad3391838822a6
+> **Benchmark Evidence SHA256**: unavailable-by-defect (fingerprint lookup returns empty despite existing `evals/harness/reports/profile-comparison.*` evidence; pre-existing base-gate defect tracked in `tasks/todos.md`, unrelated to this subject)
+
+- P1 blockers: none.
+- P2 advisories: 2, recorded under Residual risks — the ambient stale-binary
+  contamination (environment, with a test-hygiene follow-up) and the
+  scalar-readiness set -e hardening guard.
+- Acceptance checklist: crutch absence, single-invocation memoization, both
+  fail directions, report-not-block semantics, orthogonal gate immutability,
+  mtime replacement judgment, golden hunk audit, projection purity,
+  containment — all independently verified; full clean-PATH suite re-run by
+  the gatekeeper itself.
+
+## Behavior Diff Notes
+
+- Stop now derives profile and readiness from one canonical resolver
+  invocation; install-state fallback and raw cache reads are gone (one-shot
+  behavior change: machines relying on the fallback see no profile instead
+  of an inferred one — fail-safe direction); readyToShip=false is reported,
+  never blocking; the resume packet's Generated line is now truthful after
+  minimal-change appends. EffectiveStateV1 gains the additive `readiness`
+  field; all existing fields byte-identical.
+
+## Residual Risks / Follow-ups
+
+- Refresh this machine's global repo-harness binary (v0.10.0 predates the
+  readiness surface); pin REPO_HARNESS_CLI/PATH in the five
+  tests/cli/hook.test.ts fixtures (LSC-08 or todos).
+- Scalar-readiness set -e guard (safe hardening, no known producer).
+- LSC-08 closes adapter parity and the nested-readiness surface.
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 9/10 | Three crutches removed, readiness consumed with correct fail directions, stop/ship distinction visible at the hook level. |
+| Product depth | 9/10 | Stop stops being a second application kernel: one canonical authority feeds it, and the fallback class of self-deception is deleted. |
+| Design quality | 9/10 | Memoized single invocation, null-safe parsing for version skew, additive-only state surface, orthogonal gates untouched. |
+| Code quality | 8/10 | Falsifier-first with two real bugs caught; the scalar-readiness guard and fixture PATH-pinning remain as clean follow-ups. |

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -1,7 +1,7 @@
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: 2026-07-18 22:39
+> **Updated**: 2026-07-18 23:50
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.

--- a/tests/cli/state-command.test.ts
+++ b/tests/cli/state-command.test.ts
@@ -56,6 +56,7 @@ function effectiveState(overrides: Partial<EffectiveState> = {}): EffectiveState
     handoff: { path: null, freshness: 'missing' },
     resume: { path: null, freshness: 'missing' },
     current_snapshot: { path: 'tasks/current.md', freshness: 'stale' },
+    readiness: null,
     ...overrides,
   };
 }

--- a/tests/hook-runtime.test.ts
+++ b/tests/hook-runtime.test.ts
@@ -1849,6 +1849,68 @@ describe("Hook runtime behavior", () => {
     }
   });
 
+  test("stop-orchestrator: an installed profile is never inferred when the state cache is absent", () => {
+    const cwd = tmpWorkspace("stop-no-install-fallback");
+    const home = mkdtempSync(join(tmpdir(), "stop-no-install-fallback-home-"));
+    try {
+      initGitRepo(cwd);
+      installHooks(cwd);
+      mkdirSync(join(home, ".repo-harness"), { recursive: true });
+      writeFileSync(join(home, ".repo-harness/install-state.json"), JSON.stringify({ profile: "strict" }));
+      expect(existsSync(join(cwd, ".ai/harness/state/effective.json"))).toBe(false);
+
+      const res = runHook("stop-orchestrator.sh", cwd, {
+        stdin: JSON.stringify({ hook_event_name: "Stop", stop_hook_active: false }),
+        env: { HOME: home },
+      });
+
+      expect(res.status).toBe(0);
+      // The removed install-state fallback used to map an installed "strict"
+      // profile straight onto Stop's own workflow profile whenever the state
+      // cache was absent. Canonical resolution never reads install-state.json
+      // at all: this bare fixture (no active plan) resolves "lite" on its own
+      // merits, so Stop takes the Lite early-exit -- no minimal-change
+      // review, plan-completeness gate, or delegation fallback -- even though
+      // install-state.json claims strict.
+      expect(res.stdout).toBe("");
+      expect(res.stderr).toContain("[FinalizeHandoff]");
+      const handoff = readFileSync(join(cwd, ".ai/harness/handoff/current.md"), "utf-8");
+      expect(handoff).not.toContain("Minimal Change Review");
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("stop-orchestrator: allowed-to-stop and not-ready-to-ship are reported independently", () => {
+    const cwd = tmpWorkspace("stop-allowed-not-ready-to-ship");
+    try {
+      initGitRepo(cwd);
+      installHooks(cwd);
+      writeDoneGateBase(cwd);
+      // No review is ever written for this fixture: fresh_review/
+      // external_acceptance/fresh_checks stay unsatisfied under Strict, so
+      // readyToShip resolves to block while durable_recovery_state (the only
+      // requirement Stop's own gate has) stays satisfied by refresh_handoff.
+
+      const res = runHook("stop-orchestrator.sh", cwd, {
+        stdin: JSON.stringify({ hook_event_name: "Stop", stop_hook_active: false }),
+        env: { REPO_HARNESS_WORKFLOW_PROFILE: "strict" },
+      });
+
+      // readyToShip=false is a report, never a Stop block (frozen strict.stop
+      // delta): exit stays 0, no {"decision":"block",...} JSON on stdout, and
+      // the gap is surfaced on stderr instead.
+      expect(res.status).toBe(0);
+      expect(res.stdout).toBe("");
+      expect(res.stderr).toContain("[FinalizeHandoff]");
+      expect(res.stderr).toContain("[ReadinessGate] readyToShip=false");
+      expect(res.stderr).not.toContain("[ReadinessGate] Stop is blocked");
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
   test("changelog-guard: warns when unreleased section is empty on release command", () => {
     const cwd = tmpWorkspace("changelog-guard");
     try {

--- a/tests/state/fixtures/corrupt-cache-reconstruction.json
+++ b/tests/state/fixtures/corrupt-cache-reconstruction.json
@@ -113,6 +113,72 @@
     "current_snapshot": {
       "path": "tasks/current.md",
       "freshness": "fresh"
+    },
+    "readiness": {
+      "ok": true,
+      "allowedToEdit": {
+        "decision": "block",
+        "reasons": [
+          "required_work_package_missing"
+        ]
+      },
+      "allowedToStop": {
+        "decision": "block",
+        "reasons": [
+          "required_recovery_state_missing"
+        ]
+      },
+      "readyToShip": {
+        "decision": "block",
+        "reasons": [
+          "required_work_package_missing",
+          "required_evidence_missing"
+        ]
+      },
+      "requirements": {
+        "edit": [
+          {
+            "key": "complete_approved_work_package",
+            "status": "required",
+            "satisfied": false
+          },
+          {
+            "key": "separate_contract",
+            "status": "not_required",
+            "satisfied": true
+          }
+        ],
+        "stop": [
+          {
+            "key": "durable_recovery_state",
+            "status": "required",
+            "satisfied": false
+          }
+        ],
+        "ship": [
+          {
+            "key": "complete_approved_work_package",
+            "status": "required",
+            "satisfied": false
+          },
+          {
+            "key": "subject_bound_targeted_evidence",
+            "status": "required",
+            "satisfied": false
+          },
+          {
+            "key": "separate_contract",
+            "status": "not_required",
+            "satisfied": true
+          },
+          {
+            "key": "external_acceptance",
+            "status": "not_required",
+            "satisfied": true
+          }
+        ]
+      },
+      "nextAction": null
     }
   },
   "hook": {

--- a/tests/state/fixtures/deleted-cache-reconstruction.json
+++ b/tests/state/fixtures/deleted-cache-reconstruction.json
@@ -113,6 +113,72 @@
     "current_snapshot": {
       "path": "tasks/current.md",
       "freshness": "fresh"
+    },
+    "readiness": {
+      "ok": true,
+      "allowedToEdit": {
+        "decision": "block",
+        "reasons": [
+          "required_work_package_missing"
+        ]
+      },
+      "allowedToStop": {
+        "decision": "block",
+        "reasons": [
+          "required_recovery_state_missing"
+        ]
+      },
+      "readyToShip": {
+        "decision": "block",
+        "reasons": [
+          "required_work_package_missing",
+          "required_evidence_missing"
+        ]
+      },
+      "requirements": {
+        "edit": [
+          {
+            "key": "complete_approved_work_package",
+            "status": "required",
+            "satisfied": false
+          },
+          {
+            "key": "separate_contract",
+            "status": "not_required",
+            "satisfied": true
+          }
+        ],
+        "stop": [
+          {
+            "key": "durable_recovery_state",
+            "status": "required",
+            "satisfied": false
+          }
+        ],
+        "ship": [
+          {
+            "key": "complete_approved_work_package",
+            "status": "required",
+            "satisfied": false
+          },
+          {
+            "key": "subject_bound_targeted_evidence",
+            "status": "required",
+            "satisfied": false
+          },
+          {
+            "key": "separate_contract",
+            "status": "not_required",
+            "satisfied": true
+          },
+          {
+            "key": "external_acceptance",
+            "status": "not_required",
+            "satisfied": true
+          }
+        ]
+      },
+      "nextAction": null
     }
   },
   "hook": {

--- a/tests/state/fixtures/executing-fresh-evidence.json
+++ b/tests/state/fixtures/executing-fresh-evidence.json
@@ -109,6 +109,68 @@
     "current_snapshot": {
       "path": "tasks/current.md",
       "freshness": "fresh"
+    },
+    "readiness": {
+      "ok": true,
+      "allowedToEdit": {
+        "decision": "block",
+        "reasons": [
+          "required_work_package_missing"
+        ]
+      },
+      "allowedToStop": {
+        "decision": "allow"
+      },
+      "readyToShip": {
+        "decision": "block",
+        "reasons": [
+          "required_work_package_missing"
+        ]
+      },
+      "requirements": {
+        "edit": [
+          {
+            "key": "complete_approved_work_package",
+            "status": "required",
+            "satisfied": false
+          },
+          {
+            "key": "separate_contract",
+            "status": "not_required",
+            "satisfied": true
+          }
+        ],
+        "stop": [
+          {
+            "key": "durable_recovery_state",
+            "status": "required",
+            "satisfied": true
+          }
+        ],
+        "ship": [
+          {
+            "key": "complete_approved_work_package",
+            "status": "required",
+            "satisfied": false
+          },
+          {
+            "key": "subject_bound_targeted_evidence",
+            "status": "required",
+            "satisfied": true
+          },
+          {
+            "key": "separate_contract",
+            "status": "not_required",
+            "satisfied": true
+          },
+          {
+            "key": "external_acceptance",
+            "status": "not_required",
+            "satisfied": true
+          }
+        ]
+      },
+      "nextAction": null
     }
   },
   "hook": {

--- a/tests/state/fixtures/explicit-strict-without-path-signals.json
+++ b/tests/state/fixtures/explicit-strict-without-path-signals.json
@@ -113,6 +113,80 @@
     "current_snapshot": {
       "path": "tasks/current.md",
       "freshness": "fresh"
+    },
+    "readiness": {
+      "ok": true,
+      "allowedToEdit": {
+        "decision": "allow"
+      },
+      "allowedToStop": {
+        "decision": "block",
+        "reasons": [
+          "required_recovery_state_missing"
+        ]
+      },
+      "readyToShip": {
+        "decision": "block",
+        "reasons": [
+          "required_review_missing",
+          "required_external_acceptance_missing",
+          "required_checks_missing"
+        ]
+      },
+      "requirements": {
+        "edit": [
+          {
+            "key": "separate_contract",
+            "status": "required",
+            "satisfied": true
+          },
+          {
+            "key": "isolated_contract_worktree",
+            "status": "required",
+            "satisfied": true
+          }
+        ],
+        "stop": [
+          {
+            "key": "durable_recovery_state",
+            "status": "required",
+            "satisfied": false
+          }
+        ],
+        "ship": [
+          {
+            "key": "separate_contract",
+            "status": "required",
+            "satisfied": true
+          },
+          {
+            "key": "isolated_contract_worktree",
+            "status": "required",
+            "satisfied": true
+          },
+          {
+            "key": "fresh_review",
+            "status": "required",
+            "satisfied": false
+          },
+          {
+            "key": "external_acceptance",
+            "status": "required",
+            "satisfied": false
+          },
+          {
+            "key": "fresh_checks",
+            "status": "required",
+            "satisfied": false
+          },
+          {
+            "key": "candidate_revision_precondition",
+            "status": "required",
+            "satisfied": true
+          }
+        ]
+      },
+      "nextAction": null
     }
   },
   "hook": {

--- a/tests/state/fixtures/foreign-worktree-owner.json
+++ b/tests/state/fixtures/foreign-worktree-owner.json
@@ -102,6 +102,75 @@
     "current_snapshot": {
       "path": "tasks/current.md",
       "freshness": "stale"
+    },
+    "readiness": {
+      "ok": true,
+      "allowedToEdit": {
+        "decision": "block",
+        "reasons": [
+          "required_work_package_missing",
+          "hard_blocker_present"
+        ]
+      },
+      "allowedToStop": {
+        "decision": "block",
+        "reasons": [
+          "required_recovery_state_missing",
+          "hard_blocker_present"
+        ]
+      },
+      "readyToShip": {
+        "decision": "block",
+        "reasons": [
+          "required_work_package_missing",
+          "required_evidence_missing",
+          "hard_blocker_present"
+        ]
+      },
+      "requirements": {
+        "edit": [
+          {
+            "key": "complete_approved_work_package",
+            "status": "required",
+            "satisfied": false
+          },
+          {
+            "key": "separate_contract",
+            "status": "not_required",
+            "satisfied": true
+          }
+        ],
+        "stop": [
+          {
+            "key": "durable_recovery_state",
+            "status": "required",
+            "satisfied": false
+          }
+        ],
+        "ship": [
+          {
+            "key": "complete_approved_work_package",
+            "status": "required",
+            "satisfied": false
+          },
+          {
+            "key": "subject_bound_targeted_evidence",
+            "status": "required",
+            "satisfied": false
+          },
+          {
+            "key": "separate_contract",
+            "status": "not_required",
+            "satisfied": true
+          },
+          {
+            "key": "external_acceptance",
+            "status": "not_required",
+            "satisfied": true
+          }
+        ]
+      },
+      "nextAction": null
     }
   },
   "hook": {

--- a/tests/state/fixtures/idle-inspect.json
+++ b/tests/state/fixtures/idle-inspect.json
@@ -98,6 +98,62 @@
     "current_snapshot": {
       "path": "tasks/current.md",
       "freshness": "stale"
+    },
+    "readiness": {
+      "ok": true,
+      "allowedToEdit": {
+        "decision": "block",
+        "reasons": [
+          "required_safe_path_missing",
+          "required_destructive_action_boundary_missing"
+        ]
+      },
+      "allowedToStop": {
+        "decision": "block",
+        "reasons": [
+          "required_recovery_state_missing"
+        ]
+      },
+      "readyToShip": {
+        "decision": "block",
+        "reasons": [
+          "required_evidence_missing"
+        ]
+      },
+      "requirements": {
+        "edit": [
+          {
+            "key": "safe_path",
+            "status": "required",
+            "satisfied": false
+          },
+          {
+            "key": "worktree_boundary",
+            "status": "required",
+            "satisfied": true
+          },
+          {
+            "key": "destructive_action_boundary",
+            "status": "required",
+            "satisfied": false
+          }
+        ],
+        "stop": [
+          {
+            "key": "durable_recovery_state",
+            "status": "required",
+            "satisfied": false
+          }
+        ],
+        "ship": [
+          {
+            "key": "subject_bound_targeted_evidence",
+            "status": "required",
+            "satisfied": false
+          }
+        ]
+      },
+      "nextAction": null
     }
   },
   "hook": {

--- a/tests/state/fixtures/invalid-capability-registry.json
+++ b/tests/state/fixtures/invalid-capability-registry.json
@@ -116,6 +116,75 @@
     "current_snapshot": {
       "path": "tasks/current.md",
       "freshness": "fresh"
+    },
+    "readiness": {
+      "ok": true,
+      "allowedToEdit": {
+        "decision": "block",
+        "reasons": [
+          "required_work_package_missing",
+          "hard_blocker_present"
+        ]
+      },
+      "allowedToStop": {
+        "decision": "block",
+        "reasons": [
+          "required_recovery_state_missing",
+          "hard_blocker_present"
+        ]
+      },
+      "readyToShip": {
+        "decision": "block",
+        "reasons": [
+          "required_work_package_missing",
+          "required_evidence_missing",
+          "hard_blocker_present"
+        ]
+      },
+      "requirements": {
+        "edit": [
+          {
+            "key": "complete_approved_work_package",
+            "status": "required",
+            "satisfied": false
+          },
+          {
+            "key": "separate_contract",
+            "status": "not_required",
+            "satisfied": true
+          }
+        ],
+        "stop": [
+          {
+            "key": "durable_recovery_state",
+            "status": "required",
+            "satisfied": false
+          }
+        ],
+        "ship": [
+          {
+            "key": "complete_approved_work_package",
+            "status": "required",
+            "satisfied": false
+          },
+          {
+            "key": "subject_bound_targeted_evidence",
+            "status": "required",
+            "satisfied": false
+          },
+          {
+            "key": "separate_contract",
+            "status": "not_required",
+            "satisfied": true
+          },
+          {
+            "key": "external_acceptance",
+            "status": "not_required",
+            "satisfied": true
+          }
+        ]
+      },
+      "nextAction": null
     }
   },
   "hook": {

--- a/tests/state/fixtures/live-lock-waits-for-release.json
+++ b/tests/state/fixtures/live-lock-waits-for-release.json
@@ -113,6 +113,72 @@
     "current_snapshot": {
       "path": "tasks/current.md",
       "freshness": "fresh"
+    },
+    "readiness": {
+      "ok": true,
+      "allowedToEdit": {
+        "decision": "block",
+        "reasons": [
+          "required_work_package_missing"
+        ]
+      },
+      "allowedToStop": {
+        "decision": "block",
+        "reasons": [
+          "required_recovery_state_missing"
+        ]
+      },
+      "readyToShip": {
+        "decision": "block",
+        "reasons": [
+          "required_work_package_missing",
+          "required_evidence_missing"
+        ]
+      },
+      "requirements": {
+        "edit": [
+          {
+            "key": "complete_approved_work_package",
+            "status": "required",
+            "satisfied": false
+          },
+          {
+            "key": "separate_contract",
+            "status": "not_required",
+            "satisfied": true
+          }
+        ],
+        "stop": [
+          {
+            "key": "durable_recovery_state",
+            "status": "required",
+            "satisfied": false
+          }
+        ],
+        "ship": [
+          {
+            "key": "complete_approved_work_package",
+            "status": "required",
+            "satisfied": false
+          },
+          {
+            "key": "subject_bound_targeted_evidence",
+            "status": "required",
+            "satisfied": false
+          },
+          {
+            "key": "separate_contract",
+            "status": "not_required",
+            "satisfied": true
+          },
+          {
+            "key": "external_acceptance",
+            "status": "not_required",
+            "satisfied": true
+          }
+        ]
+      },
+      "nextAction": null
     }
   },
   "hook": {

--- a/tests/state/fixtures/loop-semantics/characterization.json
+++ b/tests/state/fixtures/loop-semantics/characterization.json
@@ -6,7 +6,7 @@
   "esa_goldens": [
     {
       "scenario": "idle-inspect",
-      "source_sha256": "ebe0fb5bed271cbce84b4c22636cabee770fefad0eb33710de25cdc3121e0eca",
+      "source_sha256": "42755fedaae1d6421e5f013f2236e943d3807a63b24f90abd717bc5c7f6056d4",
       "baseline": "82550779cdccf0575d674ae53bbc95ba63e44743",
       "cli_exit": 0,
       "workflow_profile": "lite",
@@ -14,7 +14,7 @@
     },
     {
       "scenario": "missing-contract",
-      "source_sha256": "7932cfa7fef5bc384c926d392b01992131dfeeb7ec74c12b3afa78dbe0762736",
+      "source_sha256": "4180c15b81becb9b75d3e8c1625f70edb34d16a31d00f514fbbfe6ea3d97dc06",
       "baseline": "82550779cdccf0575d674ae53bbc95ba63e44743",
       "cli_exit": 0,
       "workflow_profile": "standard",
@@ -22,7 +22,7 @@
     },
     {
       "scenario": "executing-fresh-evidence",
-      "source_sha256": "ff94c2f58f5eff220db4911a9bc1741f8f35a2d805734c84f154939e1fd78df7",
+      "source_sha256": "bd8a700d806dcfb8a810371e070a86c335b639481ba1af52c36a3c5ff3b28b02",
       "baseline": "82550779cdccf0575d674ae53bbc95ba63e44743",
       "cli_exit": 0,
       "workflow_profile": "standard",
@@ -30,7 +30,7 @@
     },
     {
       "scenario": "explicit-strict-without-path-signals",
-      "source_sha256": "3efc8d1b7d5e13b46f005dd3397849ad4c2e46a0b095a41fdcca5ffaeeca674d",
+      "source_sha256": "101781333974abbc80bed3878d57027defc5f018cbf15da14aad44a3b845eeb7",
       "baseline": "82550779cdccf0575d674ae53bbc95ba63e44743",
       "cli_exit": 0,
       "workflow_profile": "strict",
@@ -218,7 +218,7 @@
       ],
       "current": {
         "entrypoint": ".ai/hooks/stop-orchestrator.sh",
-        "profile_source": "effective_state_cache_with_install_profile_fallback",
+        "profile_source": "live_effective_state",
         "exit_code": 0,
         "verdict": "allow",
         "reason": "none",
@@ -239,7 +239,8 @@
           ".ai/harness/failures/latest.jsonl",
           ".ai/harness/handoff/current.md",
           ".ai/harness/handoff/resume.md",
-          ".ai/harness/runs/loop-semantics-lite-stop.json"
+          ".ai/harness/runs/loop-semantics-lite-stop.json",
+          ".ai/harness/state/effective.json"
         ],
         "missing_semantic_fields": [
           "allowedToStop",
@@ -270,7 +271,7 @@
       ],
       "current": {
         "entrypoint": ".ai/hooks/stop-orchestrator.sh",
-        "profile_source": "effective_state_cache_with_install_profile_fallback",
+        "profile_source": "live_effective_state",
         "exit_code": 0,
         "verdict": "allow",
         "reason": "none",
@@ -291,7 +292,8 @@
           ".ai/harness/failures/latest.jsonl",
           ".ai/harness/handoff/current.md",
           ".ai/harness/handoff/resume.md",
-          ".ai/harness/runs/loop-semantics-standard-stop.json"
+          ".ai/harness/runs/loop-semantics-standard-stop.json",
+          ".ai/harness/state/effective.json"
         ],
         "missing_semantic_fields": [
           "allowedToStop",
@@ -324,7 +326,7 @@
       ],
       "current": {
         "entrypoint": ".ai/hooks/stop-orchestrator.sh",
-        "profile_source": "effective_state_cache_with_install_profile_fallback",
+        "profile_source": "live_effective_state",
         "exit_code": 0,
         "verdict": "allow",
         "reason": "none",
@@ -345,7 +347,8 @@
           ".ai/harness/failures/latest.jsonl",
           ".ai/harness/handoff/current.md",
           ".ai/harness/handoff/resume.md",
-          ".ai/harness/runs/loop-semantics-strict-stop.json"
+          ".ai/harness/runs/loop-semantics-strict-stop.json",
+          ".ai/harness/state/effective.json"
         ],
         "missing_semantic_fields": [
           "allowedToStop",

--- a/tests/state/fixtures/missing-contract.json
+++ b/tests/state/fixtures/missing-contract.json
@@ -105,6 +105,72 @@
     "current_snapshot": {
       "path": "tasks/current.md",
       "freshness": "fresh"
+    },
+    "readiness": {
+      "ok": true,
+      "allowedToEdit": {
+        "decision": "block",
+        "reasons": [
+          "required_work_package_missing"
+        ]
+      },
+      "allowedToStop": {
+        "decision": "block",
+        "reasons": [
+          "required_recovery_state_missing"
+        ]
+      },
+      "readyToShip": {
+        "decision": "block",
+        "reasons": [
+          "required_work_package_missing",
+          "required_evidence_missing"
+        ]
+      },
+      "requirements": {
+        "edit": [
+          {
+            "key": "complete_approved_work_package",
+            "status": "required",
+            "satisfied": false
+          },
+          {
+            "key": "separate_contract",
+            "status": "not_required",
+            "satisfied": true
+          }
+        ],
+        "stop": [
+          {
+            "key": "durable_recovery_state",
+            "status": "required",
+            "satisfied": false
+          }
+        ],
+        "ship": [
+          {
+            "key": "complete_approved_work_package",
+            "status": "required",
+            "satisfied": false
+          },
+          {
+            "key": "subject_bound_targeted_evidence",
+            "status": "required",
+            "satisfied": false
+          },
+          {
+            "key": "separate_contract",
+            "status": "not_required",
+            "satisfied": true
+          },
+          {
+            "key": "external_acceptance",
+            "status": "not_required",
+            "satisfied": true
+          }
+        ]
+      },
+      "nextAction": null
     }
   },
   "hook": {

--- a/tests/state/fixtures/profile-below-strict-floor.json
+++ b/tests/state/fixtures/profile-below-strict-floor.json
@@ -108,7 +108,8 @@
     "current_snapshot": {
       "path": "tasks/current.md",
       "freshness": "fresh"
-    }
+    },
+    "readiness": null
   },
   "hook": {
     "protocol": 1,

--- a/tests/state/fixtures/stale-dead-lock-reclaimed.json
+++ b/tests/state/fixtures/stale-dead-lock-reclaimed.json
@@ -113,6 +113,72 @@
     "current_snapshot": {
       "path": "tasks/current.md",
       "freshness": "fresh"
+    },
+    "readiness": {
+      "ok": true,
+      "allowedToEdit": {
+        "decision": "block",
+        "reasons": [
+          "required_work_package_missing"
+        ]
+      },
+      "allowedToStop": {
+        "decision": "block",
+        "reasons": [
+          "required_recovery_state_missing"
+        ]
+      },
+      "readyToShip": {
+        "decision": "block",
+        "reasons": [
+          "required_work_package_missing",
+          "required_evidence_missing"
+        ]
+      },
+      "requirements": {
+        "edit": [
+          {
+            "key": "complete_approved_work_package",
+            "status": "required",
+            "satisfied": false
+          },
+          {
+            "key": "separate_contract",
+            "status": "not_required",
+            "satisfied": true
+          }
+        ],
+        "stop": [
+          {
+            "key": "durable_recovery_state",
+            "status": "required",
+            "satisfied": false
+          }
+        ],
+        "ship": [
+          {
+            "key": "complete_approved_work_package",
+            "status": "required",
+            "satisfied": false
+          },
+          {
+            "key": "subject_bound_targeted_evidence",
+            "status": "required",
+            "satisfied": false
+          },
+          {
+            "key": "separate_contract",
+            "status": "not_required",
+            "satisfied": true
+          },
+          {
+            "key": "external_acceptance",
+            "status": "not_required",
+            "satisfied": true
+          }
+        ]
+      },
+      "nextAction": null
     }
   },
   "hook": {

--- a/tests/state/fixtures/stale-projections.json
+++ b/tests/state/fixtures/stale-projections.json
@@ -117,6 +117,72 @@
     "current_snapshot": {
       "path": "tasks/current.md",
       "freshness": "stale"
+    },
+    "readiness": {
+      "ok": true,
+      "allowedToEdit": {
+        "decision": "block",
+        "reasons": [
+          "required_work_package_missing"
+        ]
+      },
+      "allowedToStop": {
+        "decision": "block",
+        "reasons": [
+          "required_recovery_state_missing"
+        ]
+      },
+      "readyToShip": {
+        "decision": "block",
+        "reasons": [
+          "required_work_package_missing",
+          "required_evidence_missing"
+        ]
+      },
+      "requirements": {
+        "edit": [
+          {
+            "key": "complete_approved_work_package",
+            "status": "required",
+            "satisfied": false
+          },
+          {
+            "key": "separate_contract",
+            "status": "not_required",
+            "satisfied": true
+          }
+        ],
+        "stop": [
+          {
+            "key": "durable_recovery_state",
+            "status": "required",
+            "satisfied": false
+          }
+        ],
+        "ship": [
+          {
+            "key": "complete_approved_work_package",
+            "status": "required",
+            "satisfied": false
+          },
+          {
+            "key": "subject_bound_targeted_evidence",
+            "status": "required",
+            "satisfied": false
+          },
+          {
+            "key": "separate_contract",
+            "status": "not_required",
+            "satisfied": true
+          },
+          {
+            "key": "external_acceptance",
+            "status": "not_required",
+            "satisfied": true
+          }
+        ]
+      },
+      "nextAction": null
     }
   },
   "hook": {

--- a/tests/state/loop-semantics-characterization.test.ts
+++ b/tests/state/loop-semantics-characterization.test.ts
@@ -350,6 +350,10 @@ function editProfileSource(): string {
 
 function stopProfileSource(): string {
   const source = readFileSync(STOP, 'utf-8');
+  // LSC-07: the raw cache read and the install-state fallback are both
+  // removed; these two checks now assert their absence rather than their
+  // presence. A canonical CLI invocation (the same route pre-edit-guard.sh
+  // uses) is the only remaining profile source.
   const readsEffectiveState = source.includes('local effective_state=".ai/harness/state/effective.json"');
   const readsInstallFallback = source.includes('local install_state="${HOME:-}/.repo-harness/install-state.json"');
   if (readsEffectiveState && readsInstallFallback) {
@@ -357,6 +361,9 @@ function stopProfileSource(): string {
   }
   if (readsEffectiveState) return 'effective_state_cache';
   if (readsInstallFallback) return 'install_profile';
+  if (source.includes('state resolve --json --operation inspect')) {
+    return 'live_effective_state';
+  }
   return 'none';
 }
 
@@ -929,7 +936,7 @@ describe('LSC-01 profile × operation current-behavior characterization', () => 
     });
 
     expect(shipProfileObservation()).toEqual({ profileAware: false, matchedSources: [] });
-    expect(stopProfileSource()).toBe('effective_state_cache_with_install_profile_fallback');
+    expect(stopProfileSource()).toBe('live_effective_state');
     expect(editProfileSource()).toBe('live_effective_state');
 
     if (process.env.UPDATE_LOOP_SEMANTICS_GOLDEN === '1') {


### PR DESCRIPTION
## Summary

LSC-07 of the Loop Semantics Convergence sprint (backlog row 7). Acceptance line: make Stop consume shared readiness and remove install-profile fallback, mtime freshness touch, and cache-as-authority; the allowed-to-stop/not-ready-to-ship fixture passes and public routes remain unchanged.

- Stop derives profile + readiness from ONE memoized canonical `state resolve --json` invocation; `stop_workflow_profile`'s install-state fallback and raw `effective.json` jq read are deleted. Fail directions verified both ways: resolver absent → stderr note, nothing invented, no block, orthogonal gates still run; stale binary lacking `readiness` → null-safe skip.
- `readyToShip=false` with `allowedToStop=allow` → report + exit 0 (frozen strict.stop delta); unrequired review/external acceptance can never block Stop; `allowedToStop=block` is the only readiness-driven block path.
- The `touch -r` crutch is replaced by a genuine content write (resume's Generated line reissued after the minimal-change handoff append) — `check-task-workflow.sh` untouched.
- `EffectiveStateV1` gains one additive `readiness` field (pure `evaluateReadiness` projection); existing fields byte-identical; no new CLI routes.
- Orthogonal Stop gates (PlanCompletenessGate, DelegationFallback, minimal-change review, freshness nudge) behaviorally identical.
- Goldens delta-shaped per upfront authorizations: characterization stop cells only (+esa_goldens hashes); flat ESA goldens additive (`readiness` field); two authorized in-test literal edits.
- Two real bugs caught falsifier-first during implementation (set -e swallowing the block call; --operation choice), documented in notes.
- Execution base pinned: `origin/main@574c5c66`.

## Verification

- Targeted 7-file suite: 170 pass / 0 fail; characterization deterministic across repeated runs; hook mirrors cmp-identical; crutch-absence greps clean
- Full clean-PATH `bun test`: 1669 pass / 1 skip / 0 fail — independently re-run by the gatekeeper
- Independent read-only gatekeeper: PASS — both fail directions, mtime-replacement judgment, golden hunk audit, orthogonal-gate immutability all verified; recorded in `tasks/reviews/20260718-2350-lsc-07-stop-semantics-cutover.review.md`

## Notes for review

- Known local-environment residual (NOT a product defect; CI unaffected): a stale global repo-harness v0.10.0 on this machine's PATH skews 5 `tests/cli/hook.test.ts` fixtures; PATH-isolated runs pass 54/54. Follow-ups routed: refresh the global binary; pin REPO_HARNESS_CLI in those fixtures.
- External acceptance recorded as Claude gatekeeper substitution (Codex CLI quota-limited until 2026-08-16), continuing the documented exception.

## Rollback

Revert this PR to restore `574c5c66`; no persisted migration to unwind.