### PR TITLE
fix(guard): fail-closed plan-status authority and truthful runner constraints

### DIFF
--- a/.ai/harness/policy.json
+++ b/.ai/harness/policy.json
@@ -6,7 +6,22 @@
     "archive_directory": "plans/archive",
     "glob": "plan-*.md",
     "active_worktree_marker_file": ".ai/harness/active-worktree",
-    "source_of_truth": "per-worktree explicit marker with active-worktree owner"
+    "source_of_truth": "per-worktree explicit marker with active-worktree owner",
+    "statuses": [
+      "Draft",
+      "Annotating",
+      "Approved",
+      "Executing",
+      "Blocked",
+      "Review",
+      "Complete",
+      "Completed",
+      "Done",
+      "Fulfilled",
+      "Archived",
+      "Abandoned",
+      "Superseded"
+    ]
   },
   "tasks": {
     "todo_file": "tasks/todos.md",

--- a/.ai/hooks/.projection.json
+++ b/.ai/hooks/.projection.json
@@ -3,6 +3,6 @@
   "canonical_root": "assets/hooks",
   "projection_target": ".ai/hooks",
   "manifest": "assets/hooks/projection.json",
-  "digest": "sha256:98540230d4e268f5a7ea71f02da2b0c0b476c190d741032f1c793ad5ab9920bb",
+  "digest": "sha256:dec02d0deb04c586e5e12de7a7dfed81ffd1e6e16539943b5301e423f5a8b61f",
   "file_count": 25
 }

--- a/.ai/hooks/pre-edit-guard.sh
+++ b/.ai/hooks/pre-edit-guard.sh
@@ -190,13 +190,39 @@ edit_plan_gate_mode() {
   printf '%s' "$mode"
 }
 
+# Single authority for the known-good plan-status vocabulary: reads
+# .ai/harness/policy.json's active_plan.statuses array (owner-decided,
+# 2026-07-20 falsifier resolution) rather than hardcoding a second list in
+# this guard. Prints one known status per line. Empty output covers every
+# "authority unavailable" case alike (missing policy.json, missing jq,
+# missing active_plan.statuses key, or an empty array) -- the caller must
+# treat empty output as fail-closed, not as "nothing to check against".
+plan_status_known_values() {
+  local policy_file=".ai/harness/policy.json"
+  [[ -f "$policy_file" ]] || return 0
+  command -v jq >/dev/null 2>&1 || return 0
+  jq -r '.active_plan.statuses[]? // empty' "$policy_file" 2>/dev/null
+}
+
+# True (0) when $1 exactly matches one line of the newline-separated known
+# statuses in $2. Byte-equal comparison: no case-folding, no trimming.
+plan_status_is_known() {
+  local status="$1"
+  local known_values="$2"
+  local candidate
+  while IFS= read -r candidate; do
+    [[ "$candidate" == "$status" ]] && return 0
+  done <<< "$known_values"
+  return 1
+}
+
 # Edit-layer plan gate: the deterministic enforcement point for "no
 # implementation edits without an approved plan". The prompt layer only
 # advises (natural-language intent guessing is unreliable); this gate keys
 # off path + plan state. Modes: enforce (default) | advice | off, via
 # REPO_HARNESS_EDIT_PLAN_GATE or policy .guards.edit_plan_gate.
 run_edit_plan_gate() {
-  local mode gate_plan gate_status
+  local mode gate_plan gate_status known_statuses
   mode="$(edit_plan_gate_mode)"
   [[ "$mode" == "off" ]] && return 0
   is_repo_scoped_path "$FILE_PATH" || return 0
@@ -246,6 +272,34 @@ run_edit_plan_gate() {
           "Complete the annotation cycle and move the plan to Approved before implementation." \
           "state_violation"
         exit 2
+      fi
+      ;;
+    *)
+      known_statuses="$(plan_status_known_values)"
+      if [[ -z "$known_statuses" ]]; then
+        echo "[PlanStatusGuard] Plan-status authority unavailable (.ai/harness/policy.json active_plan.statuses is missing, empty, or unreadable); implementation edit: $FILE_PATH"
+        if [[ "$mode" == "advice" ]]; then
+          echo "[PlanStatusGuard] Advisory: restore active_plan.statuses in .ai/harness/policy.json (the single known-status authority) before implementation."
+        else
+          hook_structured_error \
+            "PlanStatusGuard" \
+            "Implementation edit to $FILE_PATH could not be checked against plan-status authority: .ai/harness/policy.json is missing, unreadable, or has no active_plan.statuses array." \
+            "Restore active_plan.statuses in .ai/harness/policy.json (the single known-status authority) before implementation." \
+            "missing_artifact"
+          exit 2
+        fi
+      elif ! plan_status_is_known "$gate_status" "$known_statuses"; then
+        echo "[PlanStatusGuard] Plan status '$gate_status' in $gate_plan is not in the known-status authority; implementation edit: $FILE_PATH"
+        if [[ "$mode" == "advice" ]]; then
+          echo "[PlanStatusGuard] Advisory: fix the plan Status header in $gate_plan to a known value, or add '$gate_status' to active_plan.statuses in .ai/harness/policy.json if it is a legitimate new status."
+        else
+          hook_structured_error \
+            "PlanStatusGuard" \
+            "Implementation edit to $FILE_PATH while plan status '$gate_status' in $gate_plan is not in the known-status authority (.ai/harness/policy.json active_plan.statuses)." \
+            "Fix the plan Status header in $gate_plan to a known value, or add '$gate_status' to active_plan.statuses in .ai/harness/policy.json if it is a legitimate new status." \
+            "state_violation"
+          exit 2
+        fi
       fi
       ;;
   esac

--- a/.claude/templates/contract.template.md
+++ b/.claude/templates/contract.template.md
@@ -85,7 +85,7 @@ evidence_requirements:
 delegation:
   budget:
     tokens: null
-    tool_calls: null
+    runner_invocations: null
     wall_time_minutes: null
   permission_scope:
     mode: inherit_allowed_paths

--- a/assets/hooks/pre-edit-guard.sh
+++ b/assets/hooks/pre-edit-guard.sh
@@ -190,13 +190,39 @@ edit_plan_gate_mode() {
   printf '%s' "$mode"
 }
 
+# Single authority for the known-good plan-status vocabulary: reads
+# .ai/harness/policy.json's active_plan.statuses array (owner-decided,
+# 2026-07-20 falsifier resolution) rather than hardcoding a second list in
+# this guard. Prints one known status per line. Empty output covers every
+# "authority unavailable" case alike (missing policy.json, missing jq,
+# missing active_plan.statuses key, or an empty array) -- the caller must
+# treat empty output as fail-closed, not as "nothing to check against".
+plan_status_known_values() {
+  local policy_file=".ai/harness/policy.json"
+  [[ -f "$policy_file" ]] || return 0
+  command -v jq >/dev/null 2>&1 || return 0
+  jq -r '.active_plan.statuses[]? // empty' "$policy_file" 2>/dev/null
+}
+
+# True (0) when $1 exactly matches one line of the newline-separated known
+# statuses in $2. Byte-equal comparison: no case-folding, no trimming.
+plan_status_is_known() {
+  local status="$1"
+  local known_values="$2"
+  local candidate
+  while IFS= read -r candidate; do
+    [[ "$candidate" == "$status" ]] && return 0
+  done <<< "$known_values"
+  return 1
+}
+
 # Edit-layer plan gate: the deterministic enforcement point for "no
 # implementation edits without an approved plan". The prompt layer only
 # advises (natural-language intent guessing is unreliable); this gate keys
 # off path + plan state. Modes: enforce (default) | advice | off, via
 # REPO_HARNESS_EDIT_PLAN_GATE or policy .guards.edit_plan_gate.
 run_edit_plan_gate() {
-  local mode gate_plan gate_status
+  local mode gate_plan gate_status known_statuses
   mode="$(edit_plan_gate_mode)"
   [[ "$mode" == "off" ]] && return 0
   is_repo_scoped_path "$FILE_PATH" || return 0
@@ -246,6 +272,34 @@ run_edit_plan_gate() {
           "Complete the annotation cycle and move the plan to Approved before implementation." \
           "state_violation"
         exit 2
+      fi
+      ;;
+    *)
+      known_statuses="$(plan_status_known_values)"
+      if [[ -z "$known_statuses" ]]; then
+        echo "[PlanStatusGuard] Plan-status authority unavailable (.ai/harness/policy.json active_plan.statuses is missing, empty, or unreadable); implementation edit: $FILE_PATH"
+        if [[ "$mode" == "advice" ]]; then
+          echo "[PlanStatusGuard] Advisory: restore active_plan.statuses in .ai/harness/policy.json (the single known-status authority) before implementation."
+        else
+          hook_structured_error \
+            "PlanStatusGuard" \
+            "Implementation edit to $FILE_PATH could not be checked against plan-status authority: .ai/harness/policy.json is missing, unreadable, or has no active_plan.statuses array." \
+            "Restore active_plan.statuses in .ai/harness/policy.json (the single known-status authority) before implementation." \
+            "missing_artifact"
+          exit 2
+        fi
+      elif ! plan_status_is_known "$gate_status" "$known_statuses"; then
+        echo "[PlanStatusGuard] Plan status '$gate_status' in $gate_plan is not in the known-status authority; implementation edit: $FILE_PATH"
+        if [[ "$mode" == "advice" ]]; then
+          echo "[PlanStatusGuard] Advisory: fix the plan Status header in $gate_plan to a known value, or add '$gate_status' to active_plan.statuses in .ai/harness/policy.json if it is a legitimate new status."
+        else
+          hook_structured_error \
+            "PlanStatusGuard" \
+            "Implementation edit to $FILE_PATH while plan status '$gate_status' in $gate_plan is not in the known-status authority (.ai/harness/policy.json active_plan.statuses)." \
+            "Fix the plan Status header in $gate_plan to a known value, or add '$gate_status' to active_plan.statuses in .ai/harness/policy.json if it is a legitimate new status." \
+            "state_violation"
+          exit 2
+        fi
       fi
       ;;
   esac

--- a/assets/reference-configs/sprint-contracts.md
+++ b/assets/reference-configs/sprint-contracts.md
@@ -61,7 +61,7 @@ new generated contracts should include the field.
 
 New contracts include a `## Delegation Contract` YAML block between allowed paths and exit criteria. This block is the forward-compatible contract-kappa surface for future delegated execution; it is metadata unless a runner such as `contract-run` consumes it.
 
-- `budget`: optional limits for `tokens`, `tool_calls`, and `wall_time_minutes`. `null` means the current session/default command limits apply; explicit numbers are hard limits only where the runner can enforce them and otherwise advisory in the run manifest.
+- `budget`: optional limits for `tokens`, `runner_invocations`, and `wall_time_minutes`. `null` means the current session/default command limits apply. `wall_time_minutes` is a hard limit mechanically enforced via the bounded process runner deadline; a non-null `tokens` is REJECTED at preflight (contract-run has no token-budget enforcement mechanism, so it refuses to run with an unenforced constraint instead of silently treating it as advisory).
 - `permission_scope`: the execution permission model. The default `mode: inherit_allowed_paths` means worker edits are limited by the contract `allowed_paths`; `writable_paths: []` means no narrower override; `network: inherited` means no new network permission is granted by the contract itself.
 - `roles`: named responsibilities for `parent`, `explorer`, `worker`, and `verifier`. The parent remains the approval/checkpoint owner; explorer and verifier are read-only; worker may edit only within `allowed_paths` or a narrower `writable_paths` list. The verifier rubric is exactly the contract `exit_criteria`.
 

--- a/assets/templates/contract.template.md
+++ b/assets/templates/contract.template.md
@@ -85,7 +85,7 @@ evidence_requirements:
 delegation:
   budget:
     tokens: null
-    tool_calls: null
+    runner_invocations: null
     wall_time_minutes: null
   permission_scope:
     mode: inherit_allowed_paths

--- a/assets/templates/helpers/contract-run.ts
+++ b/assets/templates/helpers/contract-run.ts
@@ -2,6 +2,12 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { dirname, isAbsolute, join, relative, resolve } from "path";
 import { spawnSync } from "child_process";
+import { fileURLToPath } from "url";
+
+// Sibling of the existing bounded process runner (scripts/run-bounded-verifier-command.ts,
+// mirrored to assets/templates/helpers/run-bounded-verifier-command.ts): both live next to
+// whichever copy of this file is executing, canonical or projected.
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 
 type Mode = "dry-run" | "run" | "preflight";
 
@@ -13,14 +19,14 @@ interface Options {
   verifierCommand?: string;
   out?: string;
   json: boolean;
-  maxToolCalls?: number;
+  maxRunnerInvocations?: number;
   runner?: string;
   effort?: string;
 }
 
 interface DelegationBudget {
   tokens: number | null;
-  tool_calls: number | null;
+  runner_invocations: number | null;
   wall_time_minutes: number | null;
 }
 
@@ -44,7 +50,12 @@ interface DelegationContract {
 interface BriefPreflight {
   ok: boolean;
   issues: string[];
-  failure_class: "incomplete_brief" | "incomplete_root_cause" | null;
+  failure_class:
+    | "incomplete_brief"
+    | "incomplete_root_cause"
+    | "legacy_delegation_field"
+    | "unenforceable_delegation_constraint"
+    | null;
 }
 
 interface DelegationRole {
@@ -59,6 +70,7 @@ interface ChildResult {
   stdout_path: string;
   stderr_path: string;
   skipped?: boolean;
+  timed_out?: boolean;
 }
 
 // Canonical anti-extras clause injected into every runner-reachable surface (worker
@@ -80,11 +92,18 @@ function usage(): string {
     "Usage:",
     "  bun scripts/contract-run.ts preflight --contract <contract-file> [--repo <path>] [--json]",
     "  bun scripts/contract-run.ts dry-run --contract <contract-file> [--repo <path>] [--out <dir>] [--runner <label>] [--effort <tier>] [--json]",
-    "  bun scripts/contract-run.ts run --contract <contract-file> --worker-command <cmd> --verifier-command <cmd> [--repo <path>] [--out <dir>] [--max-tool-calls <n>] [--runner <label>] [--effort <tier>] [--json]",
+    "  bun scripts/contract-run.ts run --contract <contract-file> --worker-command <cmd> --verifier-command <cmd> [--repo <path>] [--out <dir>] [--max-runner-invocations <n>] [--runner <label>] [--effort <tier>] [--json]",
     "",
     "preflight asserts the contract is a self-sufficient execution brief (Goal, Scope,",
     "Allowed Paths, Exit Criteria are filled in, not template placeholders) and exits",
     "non-zero otherwise. run enforces the same gate before dispatching the worker.",
+    "",
+    "preflight also enforce-or-rejects the Delegation Contract budget: wall_time_minutes",
+    "rides the existing bounded process runner deadline (scripts/run-bounded-verifier-command.ts);",
+    "a non-null tokens, a non-'inherited' network, or a non-empty writable_paths narrowing",
+    "is REJECTED (contract-run cannot yet enforce those dimensions, so it refuses to run with",
+    "a false safety claim instead of silently ignoring them); the retired tool_calls budget",
+    "field name is rejected in favor of runner_invocations, with no alias.",
     "",
     "--runner records which runner label actually ran this contract (manifest.runner_usage);",
     "it defaults to the contract's own delegation.runner.preferred[0] and does not itself",
@@ -137,8 +156,8 @@ function parseArgs(argv: string[]): Options {
         opts.out = requireValue(argv, ++index, arg);
         index++;
         break;
-      case "--max-tool-calls":
-        opts.maxToolCalls = parsePositiveInt(requireValue(argv, ++index, arg), arg);
+      case "--max-runner-invocations":
+        opts.maxRunnerInvocations = parsePositiveInt(requireValue(argv, ++index, arg), arg);
         index++;
         break;
       case "--runner":
@@ -329,7 +348,7 @@ function parseDelegation(markdown: string): DelegationContract {
   return {
     budget: {
       tokens: parseNullableNumber(block, "tokens"),
-      tool_calls: parseNullableNumber(block, "tool_calls"),
+      runner_invocations: parseNullableNumber(block, "runner_invocations"),
       wall_time_minutes: parseNullableNumber(block, "wall_time_minutes"),
     },
     permission_scope: {
@@ -346,6 +365,42 @@ function parseDelegation(markdown: string): DelegationContract {
     },
     runner: parseRunner(block),
   };
+}
+
+// The budget field was renamed tool_calls -> runner_invocations (the old name counted
+// worker/verifier process launches, not model tool calls, and never had an enforcement
+// story attached to the name it claimed). No alias: a contract that still declares
+// tool_calls must fail closed instead of silently parsing as an unset runner_invocations
+// budget, which would drop the author's intended limit without any signal.
+function hasLegacyToolCallsField(markdown: string): boolean {
+  const block = fencedYamlBlock(markdown, "delegation");
+  return /^\s*tool_calls\s*:/m.test(block);
+}
+
+// Enforce-or-reject for every delegation constraint contract-run cannot yet make true:
+// wall_time_minutes rides the existing bounded process runner deadline (see runChild), so
+// it is mechanically enforced rather than checked here. tokens, a non-'inherited' network,
+// and a writable_paths narrowing have no enforcement mechanism in this runner, so a non-null
+// declaration is rejected at preflight instead of silently parsing to a no-op -- a declared
+// constraint the runner cannot honor is a false safety claim.
+function checkUnenforceableDelegationConstraints(delegation: DelegationContract): string[] {
+  const issues: string[] = [];
+  if (delegation.budget.tokens !== null) {
+    issues.push(
+      `Delegation budget.tokens is set to ${delegation.budget.tokens}, but contract-run has no token-budget enforcement mechanism; set it to null instead of declaring a limit that will not be checked.`,
+    );
+  }
+  if (delegation.permission_scope.network !== "inherited") {
+    issues.push(
+      `Delegation permission_scope.network is '${delegation.permission_scope.network}', but contract-run cannot restrict network access beyond the inherited environment; set it to 'inherited' instead of declaring a restriction that will not be enforced.`,
+    );
+  }
+  if (delegation.permission_scope.writable_paths.length > 0) {
+    issues.push(
+      `Delegation permission_scope.writable_paths narrows to [${delegation.permission_scope.writable_paths.join(", ")}], but contract-run does not enforce a writable-path boundary narrower than allowed_paths; leave it empty instead of declaring a narrowing that will not be enforced.`,
+    );
+  }
+  return issues;
 }
 
 function parseRunner(block: string): RunnerContract {
@@ -532,12 +587,33 @@ function runBriefPreflight(markdown: string, repo: string): BriefPreflight {
   const rootCauseIssues =
     readHeader(markdown, "Task Profile") === "bugfix" ? checkRootCauseEvidence(markdown, repo) : [];
 
-  const issues = [...baseIssues, ...rootCauseIssues];
+  const legacyFieldIssues = hasLegacyToolCallsField(markdown)
+    ? [
+        "Delegation budget uses the retired field name 'tool_calls'; rename it to 'runner_invocations'. No alias is supported, so the old name is rejected rather than silently ignored.",
+      ]
+    : [];
+
+  const delegationConstraintIssues = checkUnenforceableDelegationConstraints(parseDelegation(markdown));
+
+  const issues = [...baseIssues, ...rootCauseIssues, ...legacyFieldIssues, ...delegationConstraintIssues];
   const failureClass: BriefPreflight["failure_class"] =
-    baseIssues.length > 0 ? "incomplete_brief" : rootCauseIssues.length > 0 ? "incomplete_root_cause" : null;
+    baseIssues.length > 0
+      ? "incomplete_brief"
+      : rootCauseIssues.length > 0
+        ? "incomplete_root_cause"
+        : legacyFieldIssues.length > 0
+          ? "legacy_delegation_field"
+          : delegationConstraintIssues.length > 0
+            ? "unenforceable_delegation_constraint"
+            : null;
 
   return { ok: issues.length === 0, issues, failure_class: failureClass };
 }
+
+// Sentinel exit code the bounded runner writes when the deadline fires (see
+// scripts/run-bounded-verifier-command.ts). Surfaced separately so a timeout reads as
+// "wall_time_minutes exceeded" in the manifest instead of a generic child failure.
+const BOUNDED_RUNNER_TIMEOUT_EXIT_CODE = 124;
 
 function runChild(
   role: "worker" | "verifier",
@@ -545,18 +621,67 @@ function runChild(
   repo: string,
   runDir: string,
   env: NodeJS.ProcessEnv,
+  deadlineMs: number | null,
 ): ChildResult {
   const stdoutPath = join(runDir, `${role}.stdout.log`);
   const stderrPath = join(runDir, `${role}.stderr.log`);
+  const childEnv = { ...process.env, ...env, CONTRACT_RUN_ROLE: role };
+
+  if (deadlineMs !== null) {
+    // wall_time_minutes is non-null: ride the existing bounded process runner instead of
+    // reimplementing deadline/process-group termination here. It writes combined
+    // stdout+stderr to one log (its own process-group-aware kill logic needs a single
+    // stream), so stderr_path stays present but empty in this branch.
+    const boundedResultPath = join(runDir, `${role}.bounded-result.json`);
+    const boundedRunner = join(SCRIPT_DIR, "run-bounded-verifier-command.ts");
+    const wrapper = spawnSync(
+      process.execPath,
+      [
+        boundedRunner,
+        "--deadline-ms",
+        String(deadlineMs),
+        "--log",
+        stdoutPath,
+        "--result",
+        boundedResultPath,
+        "--",
+        "/bin/sh",
+        "-c",
+        command,
+      ],
+      { cwd: repo, encoding: "utf-8", env: childEnv },
+    );
+    if (!existsSync(stdoutPath)) writeFileSync(stdoutPath, "");
+    writeFileSync(stderrPath, "");
+    let exitCode: number | null = wrapper.status;
+    let timedOut = false;
+    if (existsSync(boundedResultPath)) {
+      try {
+        const bounded = JSON.parse(readFileSync(boundedResultPath, "utf-8")) as {
+          exit_code: number;
+          timed_out: boolean;
+        };
+        exitCode = bounded.exit_code;
+        timedOut = bounded.timed_out === true;
+      } catch {
+        // Keep the wrapper's own exit status if the result artifact is unreadable.
+      }
+    }
+    return {
+      role,
+      command,
+      exit_code: exitCode,
+      stdout_path: repoRelative(repo, stdoutPath),
+      stderr_path: repoRelative(repo, stderrPath),
+      timed_out: timedOut || exitCode === BOUNDED_RUNNER_TIMEOUT_EXIT_CODE,
+    };
+  }
+
   const result = spawnSync(command, {
     cwd: repo,
     shell: true,
     encoding: "utf-8",
-    env: {
-      ...process.env,
-      ...env,
-      CONTRACT_RUN_ROLE: role,
-    },
+    env: childEnv,
   });
   writeFileSync(stdoutPath, result.stdout ?? "");
   writeFileSync(stderrPath, result.stderr ?? "");
@@ -566,6 +691,7 @@ function runChild(
     exit_code: result.status,
     stdout_path: repoRelative(repo, stdoutPath),
     stderr_path: repoRelative(repo, stderrPath),
+    timed_out: false,
   };
 }
 
@@ -607,7 +733,12 @@ function buildRun(opts: Options) {
     return { manifest, manifestPath: "" };
   }
 
-  const toolLimit = opts.maxToolCalls ?? delegation.budget.tool_calls;
+  const runnerInvocationLimit = opts.maxRunnerInvocations ?? delegation.budget.runner_invocations;
+  // wall_time_minutes rides the existing bounded process runner deadline (runChild),
+  // shared across worker and verifier so it bounds the whole delegated task's wall clock,
+  // matching how verify-contract.sh computes one verification_deadline_ms for its run.
+  const wallTimeDeadlineMs =
+    delegation.budget.wall_time_minutes !== null ? Date.now() + delegation.budget.wall_time_minutes * 60_000 : null;
   const slug = contractPath
     .split("/")
     .pop()!
@@ -683,7 +814,7 @@ function buildRun(opts: Options) {
   ]);
 
   const children: ChildResult[] = [];
-  let toolCalls = 0;
+  let runnerInvocations = 0;
   let status: "dry_run" | "pass" | "fail" = opts.mode === "dry-run" ? "dry_run" : "pass";
   let failureClass = "";
 
@@ -701,7 +832,7 @@ function buildRun(opts: Options) {
   };
 
   const consume = (role: "worker" | "verifier") => {
-    if (toolLimit !== null && toolCalls + 1 > toolLimit) {
+    if (runnerInvocationLimit !== null && runnerInvocations + 1 > runnerInvocationLimit) {
       status = "fail";
       failureClass = "budget_exceeded";
       children.push({
@@ -714,7 +845,7 @@ function buildRun(opts: Options) {
       });
       return false;
     }
-    toolCalls++;
+    runnerInvocations++;
     return true;
   };
 
@@ -725,25 +856,33 @@ function buildRun(opts: Options) {
 
   if (opts.mode === "run" && briefPreflight.ok) {
     if (consume("worker")) {
-      const worker = runChild("worker", opts.workerCommand!, repo, runDir, {
-        ...baseEnv,
-        CONTRACT_RUN_PROMPT: baseEnv.CONTRACT_RUN_WORKER_PROMPT,
-      });
+      const worker = runChild(
+        "worker",
+        opts.workerCommand!,
+        repo,
+        runDir,
+        { ...baseEnv, CONTRACT_RUN_PROMPT: baseEnv.CONTRACT_RUN_WORKER_PROMPT },
+        wallTimeDeadlineMs,
+      );
       children.push(worker);
       if (worker.exit_code !== 0) {
         status = "fail";
-        failureClass = "worker_failed";
+        failureClass = worker.timed_out ? "wall_time_exceeded" : "worker_failed";
       }
     }
     if (status === "pass" && consume("verifier")) {
-      const verifier = runChild("verifier", opts.verifierCommand!, repo, runDir, {
-        ...baseEnv,
-        CONTRACT_RUN_PROMPT: baseEnv.CONTRACT_RUN_VERIFIER_PROMPT,
-      });
+      const verifier = runChild(
+        "verifier",
+        opts.verifierCommand!,
+        repo,
+        runDir,
+        { ...baseEnv, CONTRACT_RUN_PROMPT: baseEnv.CONTRACT_RUN_VERIFIER_PROMPT },
+        wallTimeDeadlineMs,
+      );
       children.push(verifier);
       if (verifier.exit_code !== 0) {
         status = "fail";
-        failureClass = "verifier_failed";
+        failureClass = verifier.timed_out ? "wall_time_exceeded" : "verifier_failed";
       } else if (reviewFile && !existsSync(repoPath(repo, reviewFile))) {
         status = "fail";
         failureClass = "missing_review";
@@ -789,7 +928,7 @@ function buildRun(opts: Options) {
       verifier: delegation.roles.verifier,
       allowed_paths: allowedPaths,
       verifier_rubric: "contract exit_criteria",
-      budget_semantics: "null uses session default; explicit numbers are enforced where the runner supports that dimension",
+      budget_semantics: "null uses session default; wall_time_minutes is mechanically enforced via the bounded process runner deadline; a non-null tokens, a non-'inherited' network, or a non-empty writable_paths narrowing fails preflight instead of parsing to a silent no-op",
       permission_semantics: "explorer and verifier are read-only; worker is constrained to allowed_paths or narrower writable_paths",
       role_profiles: {
         parent: "orchestrator",
@@ -799,8 +938,8 @@ function buildRun(opts: Options) {
       },
     },
     budget_usage: {
-      tool_calls: toolCalls,
-      tool_call_limit: toolLimit,
+      runner_invocations: runnerInvocations,
+      runner_invocation_limit: runnerInvocationLimit,
     },
     children,
   };

--- a/assets/templates/helpers/ensure-task-workflow.sh
+++ b/assets/templates/helpers/ensure-task-workflow.sh
@@ -468,7 +468,7 @@ evidence_requirements:
 delegation:
   budget:
     tokens: null
-    tool_calls: null
+    runner_invocations: null
     wall_time_minutes: null
   permission_scope:
     mode: inherit_allowed_paths

--- a/assets/templates/helpers/plan-to-todo.sh
+++ b/assets/templates/helpers/plan-to-todo.sh
@@ -510,7 +510,7 @@ evidence_requirements:
 delegation:
   budget:
     tokens: null
-    tool_calls: null
+    runner_invocations: null
     wall_time_minutes: null
   permission_scope:
     mode: inherit_allowed_paths

--- a/docs/reference-configs/contract-brief-example-bugfix.md
+++ b/docs/reference-configs/contract-brief-example-bugfix.md
@@ -75,7 +75,7 @@ evidence_requirements:
 delegation:
   budget:
     tokens: null
-    tool_calls: null
+    runner_invocations: null
     wall_time_minutes: null
   permission_scope:
     mode: inherit_allowed_paths

--- a/docs/reference-configs/contract-brief-example.md
+++ b/docs/reference-configs/contract-brief-example.md
@@ -62,12 +62,12 @@ evidence_requirements:
 delegation:
   budget:
     tokens: null
-    tool_calls: 4
+    runner_invocations: 4
     wall_time_minutes: 20
   permission_scope:
     mode: inherit_allowed_paths
     writable_paths: []
-    network: off
+    network: inherited
   roles:
     parent:
       mode: narrate_and_gatekeep

--- a/docs/reference-configs/sprint-contracts.md
+++ b/docs/reference-configs/sprint-contracts.md
@@ -61,7 +61,7 @@ new generated contracts should include the field.
 
 New contracts include a `## Delegation Contract` YAML block between allowed paths and exit criteria. This block is the forward-compatible contract-kappa surface for future delegated execution; it is metadata unless a runner such as `contract-run` consumes it.
 
-- `budget`: optional limits for `tokens`, `tool_calls`, and `wall_time_minutes`. `null` means the current session/default command limits apply; explicit numbers are hard limits only where the runner can enforce them and otherwise advisory in the run manifest.
+- `budget`: optional limits for `tokens`, `runner_invocations`, and `wall_time_minutes`. `null` means the current session/default command limits apply. `wall_time_minutes` is a hard limit mechanically enforced via the bounded process runner deadline; a non-null `tokens` is REJECTED at preflight (contract-run has no token-budget enforcement mechanism, so it refuses to run with an unenforced constraint instead of silently treating it as advisory).
 - `permission_scope`: the execution permission model. The default `mode: inherit_allowed_paths` means worker edits are limited by the contract `allowed_paths`; `writable_paths: []` means no narrower override; `network: inherited` means no new network permission is granted by the contract itself.
 - `roles`: named responsibilities for `parent`, `explorer`, `worker`, and `verifier`. The parent remains the approval/checkpoint owner; explorer and verifier are read-only; worker may edit only within `allowed_paths` or a narrower `writable_paths` list. The verifier rubric is exactly the contract `exit_criteria`.
 

--- a/plans/plan-20260720-0033-plan-status-fail-closed-and-runner-truth.md
+++ b/plans/plan-20260720-0033-plan-status-fail-closed-and-runner-truth.md
@@ -1,6 +1,6 @@
 # Plan: Fail-closed plan-status authority and truthful runner constraints
 
-> **Status**: Approved
+> **Status**: Executing
 > **Created**: 20260720-0033
 > **Slug**: plan-status-fail-closed-and-runner-truth
 > **Planning Source**: repo-harness-plan

--- a/scripts/contract-run.ts
+++ b/scripts/contract-run.ts
@@ -2,6 +2,12 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { dirname, isAbsolute, join, relative, resolve } from "path";
 import { spawnSync } from "child_process";
+import { fileURLToPath } from "url";
+
+// Sibling of the existing bounded process runner (scripts/run-bounded-verifier-command.ts,
+// mirrored to assets/templates/helpers/run-bounded-verifier-command.ts): both live next to
+// whichever copy of this file is executing, canonical or projected.
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 
 type Mode = "dry-run" | "run" | "preflight";
 
@@ -13,14 +19,14 @@ interface Options {
   verifierCommand?: string;
   out?: string;
   json: boolean;
-  maxToolCalls?: number;
+  maxRunnerInvocations?: number;
   runner?: string;
   effort?: string;
 }
 
 interface DelegationBudget {
   tokens: number | null;
-  tool_calls: number | null;
+  runner_invocations: number | null;
   wall_time_minutes: number | null;
 }
 
@@ -44,7 +50,12 @@ interface DelegationContract {
 interface BriefPreflight {
   ok: boolean;
   issues: string[];
-  failure_class: "incomplete_brief" | "incomplete_root_cause" | null;
+  failure_class:
+    | "incomplete_brief"
+    | "incomplete_root_cause"
+    | "legacy_delegation_field"
+    | "unenforceable_delegation_constraint"
+    | null;
 }
 
 interface DelegationRole {
@@ -59,6 +70,7 @@ interface ChildResult {
   stdout_path: string;
   stderr_path: string;
   skipped?: boolean;
+  timed_out?: boolean;
 }
 
 // Canonical anti-extras clause injected into every runner-reachable surface (worker
@@ -80,11 +92,18 @@ function usage(): string {
     "Usage:",
     "  bun scripts/contract-run.ts preflight --contract <contract-file> [--repo <path>] [--json]",
     "  bun scripts/contract-run.ts dry-run --contract <contract-file> [--repo <path>] [--out <dir>] [--runner <label>] [--effort <tier>] [--json]",
-    "  bun scripts/contract-run.ts run --contract <contract-file> --worker-command <cmd> --verifier-command <cmd> [--repo <path>] [--out <dir>] [--max-tool-calls <n>] [--runner <label>] [--effort <tier>] [--json]",
+    "  bun scripts/contract-run.ts run --contract <contract-file> --worker-command <cmd> --verifier-command <cmd> [--repo <path>] [--out <dir>] [--max-runner-invocations <n>] [--runner <label>] [--effort <tier>] [--json]",
     "",
     "preflight asserts the contract is a self-sufficient execution brief (Goal, Scope,",
     "Allowed Paths, Exit Criteria are filled in, not template placeholders) and exits",
     "non-zero otherwise. run enforces the same gate before dispatching the worker.",
+    "",
+    "preflight also enforce-or-rejects the Delegation Contract budget: wall_time_minutes",
+    "rides the existing bounded process runner deadline (scripts/run-bounded-verifier-command.ts);",
+    "a non-null tokens, a non-'inherited' network, or a non-empty writable_paths narrowing",
+    "is REJECTED (contract-run cannot yet enforce those dimensions, so it refuses to run with",
+    "a false safety claim instead of silently ignoring them); the retired tool_calls budget",
+    "field name is rejected in favor of runner_invocations, with no alias.",
     "",
     "--runner records which runner label actually ran this contract (manifest.runner_usage);",
     "it defaults to the contract's own delegation.runner.preferred[0] and does not itself",
@@ -137,8 +156,8 @@ function parseArgs(argv: string[]): Options {
         opts.out = requireValue(argv, ++index, arg);
         index++;
         break;
-      case "--max-tool-calls":
-        opts.maxToolCalls = parsePositiveInt(requireValue(argv, ++index, arg), arg);
+      case "--max-runner-invocations":
+        opts.maxRunnerInvocations = parsePositiveInt(requireValue(argv, ++index, arg), arg);
         index++;
         break;
       case "--runner":
@@ -329,7 +348,7 @@ function parseDelegation(markdown: string): DelegationContract {
   return {
     budget: {
       tokens: parseNullableNumber(block, "tokens"),
-      tool_calls: parseNullableNumber(block, "tool_calls"),
+      runner_invocations: parseNullableNumber(block, "runner_invocations"),
       wall_time_minutes: parseNullableNumber(block, "wall_time_minutes"),
     },
     permission_scope: {
@@ -346,6 +365,42 @@ function parseDelegation(markdown: string): DelegationContract {
     },
     runner: parseRunner(block),
   };
+}
+
+// The budget field was renamed tool_calls -> runner_invocations (the old name counted
+// worker/verifier process launches, not model tool calls, and never had an enforcement
+// story attached to the name it claimed). No alias: a contract that still declares
+// tool_calls must fail closed instead of silently parsing as an unset runner_invocations
+// budget, which would drop the author's intended limit without any signal.
+function hasLegacyToolCallsField(markdown: string): boolean {
+  const block = fencedYamlBlock(markdown, "delegation");
+  return /^\s*tool_calls\s*:/m.test(block);
+}
+
+// Enforce-or-reject for every delegation constraint contract-run cannot yet make true:
+// wall_time_minutes rides the existing bounded process runner deadline (see runChild), so
+// it is mechanically enforced rather than checked here. tokens, a non-'inherited' network,
+// and a writable_paths narrowing have no enforcement mechanism in this runner, so a non-null
+// declaration is rejected at preflight instead of silently parsing to a no-op -- a declared
+// constraint the runner cannot honor is a false safety claim.
+function checkUnenforceableDelegationConstraints(delegation: DelegationContract): string[] {
+  const issues: string[] = [];
+  if (delegation.budget.tokens !== null) {
+    issues.push(
+      `Delegation budget.tokens is set to ${delegation.budget.tokens}, but contract-run has no token-budget enforcement mechanism; set it to null instead of declaring a limit that will not be checked.`,
+    );
+  }
+  if (delegation.permission_scope.network !== "inherited") {
+    issues.push(
+      `Delegation permission_scope.network is '${delegation.permission_scope.network}', but contract-run cannot restrict network access beyond the inherited environment; set it to 'inherited' instead of declaring a restriction that will not be enforced.`,
+    );
+  }
+  if (delegation.permission_scope.writable_paths.length > 0) {
+    issues.push(
+      `Delegation permission_scope.writable_paths narrows to [${delegation.permission_scope.writable_paths.join(", ")}], but contract-run does not enforce a writable-path boundary narrower than allowed_paths; leave it empty instead of declaring a narrowing that will not be enforced.`,
+    );
+  }
+  return issues;
 }
 
 function parseRunner(block: string): RunnerContract {
@@ -532,12 +587,33 @@ function runBriefPreflight(markdown: string, repo: string): BriefPreflight {
   const rootCauseIssues =
     readHeader(markdown, "Task Profile") === "bugfix" ? checkRootCauseEvidence(markdown, repo) : [];
 
-  const issues = [...baseIssues, ...rootCauseIssues];
+  const legacyFieldIssues = hasLegacyToolCallsField(markdown)
+    ? [
+        "Delegation budget uses the retired field name 'tool_calls'; rename it to 'runner_invocations'. No alias is supported, so the old name is rejected rather than silently ignored.",
+      ]
+    : [];
+
+  const delegationConstraintIssues = checkUnenforceableDelegationConstraints(parseDelegation(markdown));
+
+  const issues = [...baseIssues, ...rootCauseIssues, ...legacyFieldIssues, ...delegationConstraintIssues];
   const failureClass: BriefPreflight["failure_class"] =
-    baseIssues.length > 0 ? "incomplete_brief" : rootCauseIssues.length > 0 ? "incomplete_root_cause" : null;
+    baseIssues.length > 0
+      ? "incomplete_brief"
+      : rootCauseIssues.length > 0
+        ? "incomplete_root_cause"
+        : legacyFieldIssues.length > 0
+          ? "legacy_delegation_field"
+          : delegationConstraintIssues.length > 0
+            ? "unenforceable_delegation_constraint"
+            : null;
 
   return { ok: issues.length === 0, issues, failure_class: failureClass };
 }
+
+// Sentinel exit code the bounded runner writes when the deadline fires (see
+// scripts/run-bounded-verifier-command.ts). Surfaced separately so a timeout reads as
+// "wall_time_minutes exceeded" in the manifest instead of a generic child failure.
+const BOUNDED_RUNNER_TIMEOUT_EXIT_CODE = 124;
 
 function runChild(
   role: "worker" | "verifier",
@@ -545,18 +621,67 @@ function runChild(
   repo: string,
   runDir: string,
   env: NodeJS.ProcessEnv,
+  deadlineMs: number | null,
 ): ChildResult {
   const stdoutPath = join(runDir, `${role}.stdout.log`);
   const stderrPath = join(runDir, `${role}.stderr.log`);
+  const childEnv = { ...process.env, ...env, CONTRACT_RUN_ROLE: role };
+
+  if (deadlineMs !== null) {
+    // wall_time_minutes is non-null: ride the existing bounded process runner instead of
+    // reimplementing deadline/process-group termination here. It writes combined
+    // stdout+stderr to one log (its own process-group-aware kill logic needs a single
+    // stream), so stderr_path stays present but empty in this branch.
+    const boundedResultPath = join(runDir, `${role}.bounded-result.json`);
+    const boundedRunner = join(SCRIPT_DIR, "run-bounded-verifier-command.ts");
+    const wrapper = spawnSync(
+      process.execPath,
+      [
+        boundedRunner,
+        "--deadline-ms",
+        String(deadlineMs),
+        "--log",
+        stdoutPath,
+        "--result",
+        boundedResultPath,
+        "--",
+        "/bin/sh",
+        "-c",
+        command,
+      ],
+      { cwd: repo, encoding: "utf-8", env: childEnv },
+    );
+    if (!existsSync(stdoutPath)) writeFileSync(stdoutPath, "");
+    writeFileSync(stderrPath, "");
+    let exitCode: number | null = wrapper.status;
+    let timedOut = false;
+    if (existsSync(boundedResultPath)) {
+      try {
+        const bounded = JSON.parse(readFileSync(boundedResultPath, "utf-8")) as {
+          exit_code: number;
+          timed_out: boolean;
+        };
+        exitCode = bounded.exit_code;
+        timedOut = bounded.timed_out === true;
+      } catch {
+        // Keep the wrapper's own exit status if the result artifact is unreadable.
+      }
+    }
+    return {
+      role,
+      command,
+      exit_code: exitCode,
+      stdout_path: repoRelative(repo, stdoutPath),
+      stderr_path: repoRelative(repo, stderrPath),
+      timed_out: timedOut || exitCode === BOUNDED_RUNNER_TIMEOUT_EXIT_CODE,
+    };
+  }
+
   const result = spawnSync(command, {
     cwd: repo,
     shell: true,
     encoding: "utf-8",
-    env: {
-      ...process.env,
-      ...env,
-      CONTRACT_RUN_ROLE: role,
-    },
+    env: childEnv,
   });
   writeFileSync(stdoutPath, result.stdout ?? "");
   writeFileSync(stderrPath, result.stderr ?? "");
@@ -566,6 +691,7 @@ function runChild(
     exit_code: result.status,
     stdout_path: repoRelative(repo, stdoutPath),
     stderr_path: repoRelative(repo, stderrPath),
+    timed_out: false,
   };
 }
 
@@ -607,7 +733,12 @@ function buildRun(opts: Options) {
     return { manifest, manifestPath: "" };
   }
 
-  const toolLimit = opts.maxToolCalls ?? delegation.budget.tool_calls;
+  const runnerInvocationLimit = opts.maxRunnerInvocations ?? delegation.budget.runner_invocations;
+  // wall_time_minutes rides the existing bounded process runner deadline (runChild),
+  // shared across worker and verifier so it bounds the whole delegated task's wall clock,
+  // matching how verify-contract.sh computes one verification_deadline_ms for its run.
+  const wallTimeDeadlineMs =
+    delegation.budget.wall_time_minutes !== null ? Date.now() + delegation.budget.wall_time_minutes * 60_000 : null;
   const slug = contractPath
     .split("/")
     .pop()!
@@ -683,7 +814,7 @@ function buildRun(opts: Options) {
   ]);
 
   const children: ChildResult[] = [];
-  let toolCalls = 0;
+  let runnerInvocations = 0;
   let status: "dry_run" | "pass" | "fail" = opts.mode === "dry-run" ? "dry_run" : "pass";
   let failureClass = "";
 
@@ -701,7 +832,7 @@ function buildRun(opts: Options) {
   };
 
   const consume = (role: "worker" | "verifier") => {
-    if (toolLimit !== null && toolCalls + 1 > toolLimit) {
+    if (runnerInvocationLimit !== null && runnerInvocations + 1 > runnerInvocationLimit) {
       status = "fail";
       failureClass = "budget_exceeded";
       children.push({
@@ -714,7 +845,7 @@ function buildRun(opts: Options) {
       });
       return false;
     }
-    toolCalls++;
+    runnerInvocations++;
     return true;
   };
 
@@ -725,25 +856,33 @@ function buildRun(opts: Options) {
 
   if (opts.mode === "run" && briefPreflight.ok) {
     if (consume("worker")) {
-      const worker = runChild("worker", opts.workerCommand!, repo, runDir, {
-        ...baseEnv,
-        CONTRACT_RUN_PROMPT: baseEnv.CONTRACT_RUN_WORKER_PROMPT,
-      });
+      const worker = runChild(
+        "worker",
+        opts.workerCommand!,
+        repo,
+        runDir,
+        { ...baseEnv, CONTRACT_RUN_PROMPT: baseEnv.CONTRACT_RUN_WORKER_PROMPT },
+        wallTimeDeadlineMs,
+      );
       children.push(worker);
       if (worker.exit_code !== 0) {
         status = "fail";
-        failureClass = "worker_failed";
+        failureClass = worker.timed_out ? "wall_time_exceeded" : "worker_failed";
       }
     }
     if (status === "pass" && consume("verifier")) {
-      const verifier = runChild("verifier", opts.verifierCommand!, repo, runDir, {
-        ...baseEnv,
-        CONTRACT_RUN_PROMPT: baseEnv.CONTRACT_RUN_VERIFIER_PROMPT,
-      });
+      const verifier = runChild(
+        "verifier",
+        opts.verifierCommand!,
+        repo,
+        runDir,
+        { ...baseEnv, CONTRACT_RUN_PROMPT: baseEnv.CONTRACT_RUN_VERIFIER_PROMPT },
+        wallTimeDeadlineMs,
+      );
       children.push(verifier);
       if (verifier.exit_code !== 0) {
         status = "fail";
-        failureClass = "verifier_failed";
+        failureClass = verifier.timed_out ? "wall_time_exceeded" : "verifier_failed";
       } else if (reviewFile && !existsSync(repoPath(repo, reviewFile))) {
         status = "fail";
         failureClass = "missing_review";
@@ -789,7 +928,7 @@ function buildRun(opts: Options) {
       verifier: delegation.roles.verifier,
       allowed_paths: allowedPaths,
       verifier_rubric: "contract exit_criteria",
-      budget_semantics: "null uses session default; explicit numbers are enforced where the runner supports that dimension",
+      budget_semantics: "null uses session default; wall_time_minutes is mechanically enforced via the bounded process runner deadline; a non-null tokens, a non-'inherited' network, or a non-empty writable_paths narrowing fails preflight instead of parsing to a silent no-op",
       permission_semantics: "explorer and verifier are read-only; worker is constrained to allowed_paths or narrower writable_paths",
       role_profiles: {
         parent: "orchestrator",
@@ -799,8 +938,8 @@ function buildRun(opts: Options) {
       },
     },
     budget_usage: {
-      tool_calls: toolCalls,
-      tool_call_limit: toolLimit,
+      runner_invocations: runnerInvocations,
+      runner_invocation_limit: runnerInvocationLimit,
     },
     children,
   };

--- a/scripts/ensure-task-workflow.sh
+++ b/scripts/ensure-task-workflow.sh
@@ -468,7 +468,7 @@ evidence_requirements:
 delegation:
   budget:
     tokens: null
-    tool_calls: null
+    runner_invocations: null
     wall_time_minutes: null
   permission_scope:
     mode: inherit_allowed_paths

--- a/scripts/lib/project-init-lib.sh
+++ b/scripts/lib/project-init-lib.sh
@@ -324,7 +324,7 @@ evidence_requirements:
 delegation:
   budget:
     tokens: null
-    tool_calls: null
+    runner_invocations: null
     wall_time_minutes: null
   permission_scope:
     mode: inherit_allowed_paths
@@ -1834,7 +1834,8 @@ pi_write_harness_policy() {
     "archive_directory": "plans/archive",
     "glob": "plan-*.md",
     "active_worktree_marker_file": ".ai/harness/active-worktree",
-    "source_of_truth": "per-worktree explicit marker with active-worktree owner"
+    "source_of_truth": "per-worktree explicit marker with active-worktree owner",
+    "statuses": ["Draft", "Annotating", "Approved", "Executing", "Blocked", "Review", "Complete", "Completed", "Done", "Fulfilled", "Archived", "Abandoned", "Superseded"]
   },
   "tasks": {
     "todo_file": "tasks/todos.md",

--- a/scripts/plan-to-todo.sh
+++ b/scripts/plan-to-todo.sh
@@ -510,7 +510,7 @@ evidence_requirements:
 delegation:
   budget:
     tokens: null
-    tool_calls: null
+    runner_invocations: null
     wall_time_minutes: null
   permission_scope:
     mode: inherit_allowed_paths

--- a/src/cli/hook/prompt-guard-decision.ts
+++ b/src/cli/hook/prompt-guard-decision.ts
@@ -205,11 +205,20 @@ export const PROMPT_GUARD_EXECUTION_TABLE: Readonly<
       decideApprovedPlanAction('plan_execution_projection', state),
     general_execution: (state: PromptGuardState) => decideApprovedPlanAction('general_execution', state),
   }),
+  // A plan status that classifies as 'unknown' (empty, malformed, or any
+  // string outside the known lifecycle values) gets the same conservative
+  // advisory treatment as 'draft'/'annotating': steer the session toward
+  // repairing plan authority instead of silently allowing execution. This
+  // layer stays advisory only (see render_prompt_guard_action in
+  // prompt-guard.sh, which exits 0 for every branch) — the hard fail-closed
+  // block for unrecognized plan status lives at the edit boundary
+  // (pre-edit-guard.sh), not here.
   unknown: Object.freeze({
-    embedded_approved_plan: () => 'allow',
-    bug_fix_execution: () => 'allow',
-    plan_execution_projection: () => 'allow',
-    general_execution: () => 'allow',
+    embedded_approved_plan: () => decideDraftPlanAction('embedded_approved_plan'),
+    bug_fix_execution: () => decideDraftPlanAction('bug_fix_execution'),
+    plan_execution_projection: () =>
+      decideDraftPlanAction('plan_execution_projection'),
+    general_execution: () => decideDraftPlanAction('general_execution'),
   }),
 });
 

--- a/tasks/contracts/20260720-0033-plan-status-fail-closed-and-runner-truth.contract.md
+++ b/tasks/contracts/20260720-0033-plan-status-fail-closed-and-runner-truth.contract.md
@@ -1,6 +1,6 @@
 # Task Contract: plan-status-fail-closed-and-runner-truth
 
-> **Status**: Partial
+> **Status**: Fulfilled
 > **Plan**: plans/plan-20260720-0033-plan-status-fail-closed-and-runner-truth.md
 > **Task Profile**: code-change
 > <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->

--- a/tasks/contracts/20260720-0033-plan-status-fail-closed-and-runner-truth.contract.md
+++ b/tasks/contracts/20260720-0033-plan-status-fail-closed-and-runner-truth.contract.md
@@ -1,0 +1,304 @@
+# Task Contract: plan-status-fail-closed-and-runner-truth
+
+> **Status**: Partial
+> **Plan**: plans/plan-20260720-0033-plan-status-fail-closed-and-runner-truth.md
+> **Task Profile**: code-change
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: kito
+> **Capability ID**: root
+> **Last Updated**: 2026-07-20 01:20
+> **Source Audit**: `docs/researches/20260716-gpt-5-6-prompt-guidance-harness-audit.md` (P0 items 1-2; slice 1)
+> **Execution Base**: `origin/main@8254b2398ec8ad97bb5afd3e3655862b9f96a81d` (post-HRD-02 merge plus backfill and P0 promotion; this branch's fork point)
+> **Sequencing**: between HRD rows — HRD-02 closed; HRD-03 must not start until this package merges and pins the post-fix SHA
+> **Review File**: `tasks/reviews/20260720-0033-plan-status-fail-closed-and-runner-truth.review.md`
+> **Notes File**: `tasks/notes/20260720-0033-plan-status-fail-closed-and-runner-truth.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+Two audited P0 correctness defects make declared authority weaker than it
+claims: a malformed or unrecognized plan status falls through both the
+prompt decision table and the edit guard (fail open), and `contract-run`
+parses delegation constraints it silently never enforces while its
+`tool_calls` counter counts process launches under a false name. Every HRD
+cutover row is parity-bound to the HRD-01 baseline, so no sprint row can fix
+these; they persist until this package lands. Shipping wrong here weakens
+the harness's central promise — that declared gates are real.
+
+## Goal
+
+Malformed/unknown plan status deterministically blocks implementation edits
+at the edit boundary while the prompt layer stays advisory; every non-null
+delegation constraint is either mechanically enforced or rejected at
+preflight; the runner counter carries the honest name
+`runner_invocations` with no alias; and the whole change is delivered with
+positive/negative fixtures and a documented characterization-golden outcome.
+
+## Scope
+
+- In scope:
+  - `src/cli/hook/prompt-guard-decision.ts`: the `unknown` plan-status
+    branch (lines ~208-213) moves from silent `allow` to the conservative
+    advisory/orientation action for all four execution actions — the prompt
+    layer steers repair, it does not gain hard authority (audit LOOP-09
+    boundary). Extend `tests/cli/prompt-guard-decision.test.ts` with
+    positive/negative cases.
+  - `assets/hooks/pre-edit-guard.sh` (canonical) + `bun run sync:hooks`
+    projection to `.ai/hooks/pre-edit-guard.sh`: the plan-status `case`
+    gains a fail-closed default branch — any status outside the known set
+    produces a structured block naming the offending status and plan file.
+    Known-good statuses behave exactly as today. Fixtures: malformed,
+    empty, unrecognized, and each known-good status.
+  - AMENDMENT (owner decision 2026-07-20, falsifier resolution): the known
+    set's single authority is a new `statuses` array for plans in
+    `.ai/harness/policy.json`, mirroring the existing prds/sprints shape,
+    carrying the full observed legitimate vocabulary (the 11-value code
+    union plus `Blocked` and `Review`, which live on three current real
+    plans). The guard's default branch reads membership from that array;
+    the default emission for newly initialized repos is added where
+    prds/sprints statuses are already emitted
+    (`scripts/lib/project-init-lib.sh` + helper mirror). The three legacy
+    scattered lists (`pre-edit-guard` case arms, `validate_plan_transition`,
+    `plan_terminal_status`) keep their current semantics untouched in this
+    package; converging them into projections of the policy array is
+    follow-up work, not this slice.
+  - AMENDMENT (Stop-2 resolution): `docs/reference-configs/sprint-contracts.md`
+    and its byte-parity mirror `assets/reference-configs/sprint-contracts.md`
+    are renamed together in this package (the parity test
+    `tests/sprint-backlog.test.ts` stays untouched and must stay green).
+  - AMENDMENT (round-2 blocker resolution): `tests/runtime-profile-enforcement.test.ts`
+    joins the named test surfaces — its shared `initRepo()` policy fixture
+    gains the `active_plan.statuses` array, and its two fixtures that
+    deliberately used `InProgress` to exploit the pre-fix fail-open switch
+    to `Blocked` (now legitimate per the policy authority). Test intent is
+    preserved; only the fixture adapts to the closed authority.
+  - `scripts/contract-run.ts` + canonical mirror
+    `assets/templates/helpers/contract-run.ts` (+ `bun run sync:helpers`):
+    enforce-or-reject for every delegation constraint — `wall_time_minutes`
+    enforced via the existing bounded process runner deadline;
+    `tokens`, `network` (any value other than `inherited`), and
+    `writable_paths` narrowing REJECTED at preflight with a clear message
+    while unenforceable (no silent parse-to-noop); `tool_calls` →
+    `runner_invocations` one-shot rename across parser, enforcement,
+    report output, and messages, failing closed (clear error) when the old
+    field name is present.
+  - Rename ripple, same package, no alias: `.claude/templates/contract.template.md`
+    + `assets/templates/contract.template.md`, scaffold emitters
+    `scripts/plan-to-todo.sh`, `scripts/ensure-task-workflow.sh`,
+    `scripts/lib/project-init-lib.sh` (+ their `assets/templates/helpers/`
+    mirrors where they exist), docs
+    `docs/reference-configs/sprint-contracts.md`,
+    `docs/reference-configs/contract-brief-example.md`,
+    `docs/reference-configs/contract-brief-example-bugfix.md`, and THIS
+    package's own contract file's Delegation Contract block (bootstrap:
+    the new parser must accept this very contract). Historical/archived
+    contracts and the research audit text are records — do not rewrite.
+  - Tests: extend `tests/contract-run.test.ts` (+
+    `tests/helper-scripts.test.ts` where it pins the old name) with
+    preflight-rejection and rename coverage; new
+    `tests/plan-status-gate.test.ts` for the edit-guard fixtures if the
+    existing hook test files are not the natural home.
+  - Characterization outcome: run `tests/hook-runtime-characterization.test.ts`;
+    if the frozen golden legitimately shifts (the fixture repo's
+    PreToolUse.edit path), regenerate ONCE via
+    `UPDATE_HOOK_RUNTIME_CHARACTERIZATION_GOLDEN=1` and record the exact
+    before/after cell delta in the notes and PR body; if it does not shift,
+    record that instead. Either outcome is acceptable; an undocumented one
+    is not.
+- Out of scope:
+  - Any HRD row content; `src/effects/loop/`, `src/core/loop/`,
+    `src/cli/hook/runtime.ts`, `route-registry.ts` untouched.
+  - The `verify-contract` qa_scores dimension mismatch (separate todos row);
+    the solo-operator external-acceptance policy decision (separate todos
+    row); prompt slimming (audit slices ≥2).
+  - Enforcing `tokens`/`network`/`writable_paths` mechanically in this
+    package — the honest deliverable is reject-while-unenforceable; real
+    enforcement arrives with the runner surfaces that can measure them.
+  - Every path outside Allowed Paths; compatibility alias, dual field,
+    fallback window, or silent migration.
+- Taste constraints: the fail-closed default must name what it saw, not
+  just "invalid"; rejection messages must say which constraint and why;
+  the known-status list must have one authority, not a second copy in the
+  guard.
+
+## Stop Conditions
+
+- Stop and hand back if the change would require editing a path outside
+  Allowed Paths.
+- Stop if the known-good plan-status set cannot be derived from one
+  existing authority without inventing a second list.
+- Stop if `wall_time_minutes` cannot ride the existing bounded runner
+  without new process machinery.
+- Stop if any existing test outside the named surfaces changes value
+  (the characterization golden's documented one-shot is the sole
+  exception).
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop after three fail -> fix -> reverify rounds for the same issue.
+
+## Falsifier
+
+The fail-closed direction is falsified if legitimate workflows routinely
+carry plan statuses outside the known set (the block would fire on healthy
+repos). Cheapest proof point: before implementing, grep the repo's own
+plans/ (active + archive) and the LSC/HRD envelope history for every
+`> **Status**:` value ever used; if statuses appear that the status
+authority does not know, stop and report — the authority list, not the
+guard, needs the decision first.
+
+## Root Cause Evidence
+
+Not applicable: `code-change` correctness package delivering fail-closed
+behavior with fixtures; the audit + 2026-07-20 source re-verification are
+the defect record (see plan Problem section for file:line).
+
+- root_cause: (not applicable)
+- repro: (not applicable)
+- regression_guard: (not applicable)
+- pre_fix_failure_artifact: (not applicable)
+
+## Workflow Inventory
+
+- Source audit: `docs/researches/20260716-gpt-5-6-prompt-guidance-harness-audit.md`
+- Source plan: `plans/plan-20260720-0033-plan-status-fail-closed-and-runner-truth.md`
+- Active plan: `plans/plan-20260720-0033-plan-status-fail-closed-and-runner-truth.md`
+- Review file: `tasks/reviews/20260720-0033-plan-status-fail-closed-and-runner-truth.review.md`
+- Notes file: `tasks/notes/20260720-0033-plan-status-fail-closed-and-runner-truth.notes.md`
+- Checks file: `.ai/harness/checks/latest.json` (ignored runtime evidence)
+- Run snapshots: `.ai/harness/runs/` (ignored runtime evidence)
+- Base/branch/WT: `8254b2398ec8ad97bb5afd3e3655862b9f96a81d` /
+  `codex/plan-status-fail-closed-and-runner-truth` /
+  `/Users/kito/Projects/repo-harness-wt-plan-status-fail-closed-and-runner-truth`
+- Scope gate: edit only paths listed under `allowed_paths`; update this
+  contract before widening scope.
+- Completion gate: `repo-harness run verify-sprint` must see this contract
+  pass, the review recommend pass, and canonical `## External Acceptance
+  Advice` record `pass` for the current review subject and benchmark evidence.
+- CLI note: the global `repo-harness` binary is the packaged copy; run
+  in-worktree verification through `bun src/cli/index.ts` / `bun test` so
+  the renamed parser under test is this branch's code, not the installed
+  package's.
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - plans/plan-20260720-0033-plan-status-fail-closed-and-runner-truth.md
+  - tasks/current.md
+  - tasks/todos.md
+  - tasks/contracts/20260720-0033-plan-status-fail-closed-and-runner-truth.contract.md
+  - tasks/reviews/20260720-0033-plan-status-fail-closed-and-runner-truth.review.md
+  - tasks/notes/20260720-0033-plan-status-fail-closed-and-runner-truth.notes.md
+  - src/cli/hook/prompt-guard-decision.ts
+  - assets/hooks/pre-edit-guard.sh
+  - .ai/hooks/pre-edit-guard.sh
+  - .ai/hooks/.projection.json
+  - scripts/contract-run.ts
+  - assets/templates/helpers/contract-run.ts
+  - scripts/plan-to-todo.sh
+  - assets/templates/helpers/plan-to-todo.sh
+  - scripts/ensure-task-workflow.sh
+  - assets/templates/helpers/ensure-task-workflow.sh
+  - scripts/lib/project-init-lib.sh
+  - assets/templates/helpers/lib/project-init-lib.sh
+  - .claude/templates/contract.template.md
+  - assets/templates/contract.template.md
+  - docs/reference-configs/sprint-contracts.md
+  - assets/reference-configs/sprint-contracts.md
+  - .ai/harness/policy.json
+  - docs/reference-configs/contract-brief-example.md
+  - docs/reference-configs/contract-brief-example-bugfix.md
+  - tests/cli/prompt-guard-decision.test.ts
+  - tests/contract-run.test.ts
+  - tests/helper-scripts.test.ts
+  - tests/plan-status-gate.test.ts
+  - tests/runtime-profile-enforcement.test.ts
+  - tests/hook-runtime-characterization.test.ts
+  - tests/fixtures/loop-runtime/characterization.json
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+      - codex-exec
+      - main-thread
+    fallback: main-thread
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - src/cli/hook/prompt-guard-decision.ts
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260720-0033-plan-status-fail-closed-and-runner-truth.notes.md
+  tests_pass:
+    - path: tests/cli/prompt-guard-decision.test.ts
+    - path: tests/contract-run.test.ts
+    - path: tests/hook-runtime-characterization.test.ts
+  commands_succeed:
+    - bun run check:type
+    - bun run check:hooks
+    - bun run check:helpers
+    - bun run check:state-boundaries
+  qa_scores:
+    - dimension: functionality
+      min: 7
+  manual_checks:
+    - "Evaluator review file recommends pass"
+    - "Every non-null delegation constraint is enforced or rejected at preflight"
+    - "Characterization golden outcome is documented as unchanged or one-shot regenerated with the exact cell delta"
+```
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior: unknown/malformed status blocks at the edit guard
+  with a structured reason; known statuses unchanged; preflight rejects
+  unenforceable non-null constraints; `runner_invocations` is the only
+  live name.
+- Edge cases: empty status, whitespace status, casing variants, missing
+  plan file (existing missing_artifact path unchanged); old `tool_calls`
+  field in a contract fails closed with a clear message.
+- Regression risks: over-broad blocking on healthy statuses (Falsifier
+  covers), scaffold emitters drifting from the template, projection/mirror
+  desync (check:hooks/check:helpers gate it).
+
+## Rollback Point
+
+- Commit / checkpoint: branch fork point `8254b2398ec8ad97bb5afd3e3655862b9f96a81d`
+- Revert strategy: revert the single PR; guard, parser, templates, docs, and (if regenerated) the characterization golden revert as one unit.

--- a/tasks/contracts/20260720-0033-plan-status-fail-closed-and-runner-truth.contract.md
+++ b/tasks/contracts/20260720-0033-plan-status-fail-closed-and-runner-truth.contract.md
@@ -66,6 +66,16 @@ positive/negative fixtures and a documented characterization-golden outcome.
     and its byte-parity mirror `assets/reference-configs/sprint-contracts.md`
     are renamed together in this package (the parity test
     `tests/sprint-backlog.test.ts` stays untouched and must stay green).
+  - AMENDMENT (ship-boundary CI fix): `tests/state/loop-semantics-characterization.test.ts`
+    joins the named test surfaces — its `prepare()` fixture repos carry no
+    `.ai/harness/policy.json`, so the new authority-unavailable branch
+    blocked the `standard.edit` cell in full-suite CI (a coverage gap: the
+    dispatch-scoped groups never ran `tests/state/`). The fixture gains a
+    minimal policy carrying only `active_plan.statuses` (the 13-value
+    authority), restoring the frozen cells' intent — a properly adopted
+    repo always has the policy file; the omission was fixture minimalism,
+    not frozen semantics. The frozen characterization JSON must come back
+    byte-identical; any other cell shifting fails this amendment.
   - AMENDMENT (round-2 blocker resolution): `tests/runtime-profile-enforcement.test.ts`
     joins the named test surfaces — its shared `initRepo()` policy fixture
     gains the `active_plan.statuses` array, and its two fixtures that
@@ -212,6 +222,7 @@ allowed_paths:
   - tests/helper-scripts.test.ts
   - tests/plan-status-gate.test.ts
   - tests/runtime-profile-enforcement.test.ts
+  - tests/state/loop-semantics-characterization.test.ts
   - tests/hook-runtime-characterization.test.ts
   - tests/fixtures/loop-runtime/characterization.json
 ```

--- a/tasks/notes/20260720-0033-plan-status-fail-closed-and-runner-truth.notes.md
+++ b/tasks/notes/20260720-0033-plan-status-fail-closed-and-runner-truth.notes.md
@@ -398,3 +398,19 @@ Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset 
 - Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
 - Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
 - Promote to harness asset files only after verification across more than one task or fixture.
+
+## Ship-Boundary CI Fix (round 4)
+
+Full-suite CI failed on `tests/state/loop-semantics-characterization.test.ts`
+(`standard.edit` cell: expected allow/exit 0, got PlanStatusGuard/exit 2) — a
+coverage gap: no dispatch round ran `tests/state/`. Root cause: `prepare()`
+fixture repos carry no `.ai/harness/policy.json`, so the new
+authority-unavailable branch fires. Guard ordering (`plan_gate` before
+`strict_contract`) means every non-lite edit cell traverses the status case.
+Fix (contract AMENDMENT, ship-boundary): fixture gains a minimal policy with
+only `active_plan.statuses` (13 values, copied from the live authority) —
+adopted repos always carry the policy file, so the omission was fixture
+minimalism, not frozen semantics. Frozen characterization JSON came back
+byte-identical (21/21 expects, no regeneration). `state-concurrency`'s single
+local ENOENT was classified as host-load flake: passes on main and on
+re-run in this worktree, and CI never failed it.

--- a/tasks/notes/20260720-0033-plan-status-fail-closed-and-runner-truth.notes.md
+++ b/tasks/notes/20260720-0033-plan-status-fail-closed-and-runner-truth.notes.md
@@ -1,0 +1,400 @@
+# Implementation Notes: plan-status-fail-closed-and-runner-truth
+
+> **Status**: Active
+> **Plan**: plans/plan-20260720-0033-plan-status-fail-closed-and-runner-truth.md
+> **Contract**: tasks/contracts/20260720-0033-plan-status-fail-closed-and-runner-truth.contract.md
+> **Review**: tasks/reviews/20260720-0033-plan-status-fail-closed-and-runner-truth.review.md
+> **Last Updated**: 2026-07-20 05:20
+> **Lifecycle**: notes
+
+## Resumption: Round-2 Blocker Resolved (round 3)
+
+- **Amendment.** The contract was amended a third time: `tests/runtime-profile-enforcement.test.ts`
+  joined the named test surfaces and Allowed Paths, closing the round-2
+  open item (the `InProgress` fixture collision) rather than leaving it as
+  a permanent gap.
+- **Applied exactly the 3-site fix diagnosed in round 2, nothing else in
+  the file changed:**
+  1. `initRepo()`'s shared `policy.json` literal (~line 23) gained
+     `active_plan: { statuses: [...13-value array...] }` -- the same
+     authority `.ai/harness/policy.json` and
+     `tests/plan-status-gate.test.ts` use, duplicated here only as test
+     input data (this file cannot import policy.json's array; it
+     constructs its own scratch repo's copy, same as
+     `tests/plan-status-gate.test.ts`'s `KNOWN_STATUSES` constant does).
+  2. `'> **Status**: InProgress'` -> `'> **Status**: Blocked'` at the
+     "Strict high-risk paths..." fixture (~line 132).
+  3. `'> **Status**: InProgress'` -> `'> **Status**: Blocked'` at the
+     "batch containing one strict-category path..." fixture (~line 300).
+  Both fixtures' explanatory comments were updated in place (not left
+  stale) since their entire content is about justifying the status-value
+  choice: they now explain that `Blocked` is a real, policy-recognized
+  status (passes both the `missing_contract` avoidance and the new
+  fail-closed default branch), rather than a value that happened to fall
+  through an authority gap that no longer exists. No other line, test, or
+  assertion in the file was touched -- both tests still isolate the exact
+  same `StrictContractGuard` behavior they always did.
+- **Verified: `bun test tests/hook-runtime.test.ts tests/hook-contracts.test.ts
+  tests/runtime-profile-enforcement.test.ts` -> 113 pass, 0 fail, 1165
+  expect() calls.** The round-2 open item is closed; no open items remain
+  from this package's own scope.
+
+## Resumption: Owner Decision And Deliverable 2 Completion (round 2)
+
+- **Owner decision (Option A).** The two Falsifier/Stop Condition findings
+  from round 1 were resolved by the orchestrator with the owner: `Blocked`
+  and `Review` join the known-good set rather than being folded into the
+  existing Draft/Annotating block bucket. The contract was amended in place
+  (two AMENDMENT bullets in Scope, two new Allowed Paths:
+  `assets/reference-configs/sprint-contracts.md`, `.ai/harness/policy.json`).
+- **13-value array provenance.** `.ai/harness/policy.json`'s new
+  `active_plan.statuses` array is exactly: the round-1-derived 11-value
+  union (`Draft`, `Annotating`, `Approved`, `Executing`, `Complete`,
+  `Completed`, `Done`, `Fulfilled`, `Archived`, `Abandoned`, `Superseded`)
+  plus `Blocked` and `Review` (the two statuses observed on three real,
+  non-archived plan files with no prior authority). Placed as a new sibling
+  key inside the existing `active_plan` object (which already owns
+  `directory: "plans"` etc.) rather than a new top-level `plans` key,
+  mirroring the `statuses` *shape* used by `prds`/`sprints` (a plain array
+  living alongside the object that already describes that artifact
+  family's location) most literally. `guards.edit_plan_gate` was
+  considered and rejected as the placement: that section is about gate
+  *mode* (enforce/advice/off), a different axis from status *vocabulary*.
+- **Where the array is NOT written.** `src/core/adoption/standard-plan.ts`'s
+  `defaultPolicy()` is a third, independent default-policy generator (for
+  the `repo-harness adopt` path, distinct from `project-init-lib.sh`'s
+  brand-new-repo `pi_write_harness_policy`). It has its own `active_plan`
+  object but never emits `prds`/`sprints` `statuses` arrays at all -- so it
+  is not "where prds/sprints statuses are already emitted," the coordinator's
+  named target. It is also outside Allowed Paths. Left untouched; the only
+  parity assertion between the two default-policy sources
+  (`tests/create-project-dirs.runtime.test.ts:388-389`) covers
+  `agentic_development.routing` specifically, not `active_plan`, so no
+  regression risk from leaving it alone.
+- **Missing-array fail-closed rationale.** `plan_status_known_values()`
+  (new, in `assets/hooks/pre-edit-guard.sh`) reads
+  `.ai/harness/policy.json`'s `active_plan.statuses[]` via `jq` and prints
+  one status per line; it does not distinguish *why* the result is empty
+  (missing file, missing `jq` binary, missing key, or an empty array) --
+  every one of those collapses to "the authority is unavailable," which the
+  caller treats as fail-closed with a distinct message
+  ("Plan-status authority unavailable ... policy.json ... missing, empty,
+  or unreadable") and `failure_class: missing_artifact`, separate from the
+  "status not in the known set" message (`failure_class: state_violation`).
+  This was a deliberate simplification: distinguishing the four underlying
+  causes would need more logic in the guard for no behavioral benefit (all
+  four require the same fix: restore the array), and the guard must not
+  carry a second hardcoded list to reason about *why* jq returned nothing.
+  Verified live: both "key absent" and "policy.json file absent entirely"
+  fixtures produce the same authority-unavailable block
+  (`tests/plan-status-gate.test.ts`).
+- **One authority, no hardcoded list in the guard.** The three legacy
+  scattered lists (`pre-edit-guard`'s own `Draft|Annotating` case arm,
+  `validate_plan_transition`, `plan_terminal_status`) are untouched per the
+  amendment -- converging them is explicitly follow-up work. The NEW default
+  branch reads exclusively from `plan_status_known_values()`, which reads
+  exclusively from `policy.json`; no status string is hardcoded a second
+  time anywhere in the new code path.
+- **Stop-2 resolution.** `docs/reference-configs/sprint-contracts.md` and
+  `assets/reference-configs/sprint-contracts.md` were renamed together
+  (`tool_calls` -> `runner_invocations`) with an identical edit to both,
+  keeping them byte-identical (`tests/sprint-backlog.test.ts`'s "sprint
+  asset parity" test reverified green). Also fixed the same line's stale
+  claim that unenforceable budget dimensions are merely "advisory in the
+  run manifest" -- that described the pre-fix silent-noop behavior this
+  whole package removes; it now names the real enforce-or-reject split
+  (`wall_time_minutes` mechanically enforced, `tokens` rejected at
+  preflight).
+- **New Stop Condition instance found while implementing Deliverable 2
+  (unresolved, requires an Allowed-Paths amendment or a direct fix outside
+  this dispatch): `tests/runtime-profile-enforcement.test.ts` has two
+  fixtures (lines ~122 and ~287) that set an active plan's `Status` to the
+  literal string `InProgress`, with a code comment explaining this was
+  deliberately chosen as a status outside `{Draft, Annotating, Approved,
+  Executing}` specifically *to exploit* pre-edit-guard.sh's old fail-open
+  behavior on anything else -- isolating a `StrictContractGuard` assertion
+  from an unrelated `missing_contract` blocker tied to Approved/Executing.
+  2 of 113 tests in that file now fail
+  (`bun test tests/runtime-profile-enforcement.test.ts`: 111 pass, 2 fail).
+  This is not a defect in the new guard logic: the fixture's own status
+  word is exactly the class of "plausible-looking but unrecognized" string
+  the fix exists to catch.
+  **Precise root cause (verified against the actual failure output, not
+  assumed):** the block that actually fires is the *authority-unavailable*
+  branch, not the *unrecognized-status* branch --
+  `"...could not be checked against plan-status authority:
+  .ai/harness/policy.json is missing, unreadable, or has no
+  active_plan.statuses array."` This file's shared `initRepo()` helper
+  (line ~23) writes a minimal policy.json (`{ hook_source, worktree_strategy
+  }`) with no `active_plan.statuses` key at all, so *any* status reaching
+  the new default branch in this file -- not just `InProgress` -- would
+  currently hit "authority unavailable" first. The complete, verified-
+  sufficient fix is therefore two parts at three sites, all in this one
+  file: (1) add `active_plan: { statuses: [...13-value array...] }` to the
+  shared `initRepo()`'s policy.json literal (one edit, benefits all 26
+  tests in the file uniformly -- safe because no currently-passing test in
+  the file exercises a status reaching the new branch, so none could be
+  relying on the array's absence); (2) rename `InProgress` -> `Blocked` (or
+  any known status outside `{Draft, Annotating, Approved, Executing}`) at
+  the two specific fixture sites (~122, ~287). None of this changes either
+  test's intent -- both still isolate the exact same `StrictContractGuard`
+  assertion via a plan status that is real/current but not Draft/Annotating/
+  Approved/Executing. This file is not in this contract's Allowed Paths, so
+  the fix was not applied here; reported instead of silently editing
+  outside scope or silently weakening the (correct) new guard behavior to
+  make the old fixture pass.
+
+## Design Decisions
+
+- **Falsifier grep result (full observed `> **Status**:` inventory).** Ran the
+  falsifier before any edit: `grep -rhoE '^> \*\*Status\*\*: .*' plans/` (active
+  + `plans/archive/`) plus the equivalent for `tasks/contracts/`. Full plans/
+  inventory (archive + active combined): Archived(46), Executing(37),
+  Approved(12), Done(10), Draft(9), Complete(8), Completed(5), Superseded(4),
+  Blocked(2), Review(1), Fulfilled(1), Abandoned(1). Restricting to
+  non-archived `plans/*.md` (the population that can actually sit behind
+  `.ai/harness/active-plan`) narrows to: Approved(10), Blocked(2), Complete(7),
+  Completed(4), Draft(8), Executing(37), Fulfilled(1), Review(1).
+- **Known-set authority I derived from, and why it is fragmented.**
+  `get_plan_status` (`assets/hooks/lib/workflow-state.sh:260`) is a bare
+  awk extractor with no enum of its own. Its callers encode the "known" plan
+  statuses in three places that never share code: (1)
+  `assets/hooks/pre-edit-guard.sh:238`'s own `Draft|Annotating` case arm
+  (pre-existing, unchanged); (2) `validate_plan_transition` in the same
+  `workflow-state.sh` file, whose case arms only ever mention `Draft`,
+  `Annotating`, `Approved`, `Executing`; (3) `plan_terminal_status()` in
+  `scripts/check-task-workflow.sh:371` (`Complete|Completed|Done|Fulfilled|
+  Archived|Abandoned|Superseded`) plus that same script's inline
+  `"$plan_status" == "Approved" || "$plan_status" == "Executing"` check.
+  `.ai/harness/policy.json` has a formal `"statuses": [...]` array for `prds`
+  and `sprints` but **none for plans** -- confirming the gap is structural,
+  not an oversight in my search. Neither `workflow-state.sh` nor
+  `check-task-workflow.sh` is in this contract's Allowed Paths, so even if I
+  wanted to centralize these into one cross-file authority I could not (and
+  Scope only asked for a change inside `pre-edit-guard.sh`).
+- **Deliverable 2 (pre-edit-guard.sh fail-closed default) NOT implemented --
+  Falsifier/Stop Condition hit, reported per contract instruction.** Union of
+  the three fragments above = 11 known statuses (Draft, Annotating, Approved,
+  Executing, Complete, Completed, Done, Fulfilled, Archived, Abandoned,
+  Superseded). Real, currently non-archived `plans/*.md` files use two
+  statuses outside that union: `Blocked` (2 files:
+  `plan-20260711-0219-codex-native-role-model-override.md`,
+  `plan-20260711-1034-chatgpt-coding-mcp-live-canary.md`) and `Review` (1
+  file: `plan-20260529-0004-capability-context-cli-hook.md`). Neither string
+  appears in `validate_plan_transition`'s case arms, `plan_terminal_status`,
+  `.ai/harness/policy.json`, or any `docs/reference-configs/` lifecycle
+  description -- there is no code or doc authority that already knows them.
+  `validate_plan_transition` is a denylist of specific bad transitions, not
+  an allowlist, so nothing in the existing transition guard actually forbids
+  a human from writing `Blocked` by hand; both hits read as deliberate,
+  human-authored pause signals, not typos. Per the contract's Falsifier
+  ("if statuses appear that the status authority does not know, stop and
+  report -- the authority list, not the guard, needs the decision first")
+  and Stop Condition ("Stop if the known-good plan-status set cannot be
+  derived from one existing authority without inventing a second list"), I
+  stopped on this one deliverable rather than picking an interpretation
+  unilaterally. The two live resolutions are materially different results,
+  not just an enumeration nit: (a) add `Blocked`/`Review` to the fail-closed
+  bucket (same treatment as an unrecognized status), or (b) add them to the
+  existing `Draft|Annotating` block-with-today's-message bucket (since a
+  Blocked/Review plan arguably should not silently allow edits either, but
+  the correct *reason* to surface differs from "unrecognized/possibly
+  corrupted"). Both are defensible; neither is provably what the repo owner
+  intended, and shipping the wrong one on a P0 correctness package trades
+  one fail-open/fail-wrong-message bug for another. `tests/plan-status-gate.md`
+  fixtures were not created for the same reason.
+  Everything else in Deliverables 1/3/4/5/6 has zero dependency on this
+  question and was completed and verified.
+- **Deliverable 1 (prompt-guard-decision.ts `unknown` branch) is unrelated to
+  the blocked question above and was implemented.** `PROMPT_GUARD_PLAN_STATES`
+  is a small closed 8-value TS union (`none|stale_marker|foreign_worktree|
+  draft|annotating|approved|executing|unknown`); the bash caller
+  (`assets/hooks/prompt-guard.sh:434`) already buckets *any* status besides
+  the four literal names into `unknown` via a `case ... *) ... unknown` arm
+  -- classification was never in question, only the resulting *action*. The
+  `unknown` execution-table row moved from `() => 'allow'` (four intents) to
+  `() => decideDraftPlanAction(intent)`, exactly mirroring what `annotating`
+  already does. This was the smallest change that satisfies "conservative
+  advisory/orientation action": it reuses an existing action
+  (`plan_status_not_approved_block` / `plan_capture_draft_advice`) and
+  existing bash rendering rather than inventing a new `PromptGuardAction`
+  member, new message, or new bash case arm. Confirmed advisory-only:
+  `render_prompt_guard_action` in `assets/hooks/prompt-guard.sh` exits 0 on
+  every branch (comment at line 969-971) -- the hard block still lives only
+  at the edit boundary, which for `unknown` remains the Deliverable-2 gap
+  above (today's pre-edit-guard.sh silently allows implementation edits
+  when the active plan's status is anything other than Draft/Annotating).
+- **contract-run.ts rejection-message design.** Each of the three
+  unenforceable constraints (`tokens`, `network`, `writable_paths`) gets its
+  own issue string naming the exact field path (`budget.tokens`,
+  `permission_scope.network`, `permission_scope.writable_paths`), the
+  observed value, *why* it can't be honored ("contract-run has no
+  token-budget enforcement mechanism" / "cannot restrict network access
+  beyond the inherited environment" / "does not enforce a writable-path
+  boundary narrower than allowed_paths"), and the fix (set to
+  null/'inherited'/empty). All non-null/non-default constraints are
+  collected together (not fail-fast on the first one) so one preflight run
+  surfaces every problem in the contract at once, matching the existing
+  `baseIssues`/`rootCauseIssues` concatenation pattern. The retired
+  `tool_calls` field gets a distinct `failure_class`
+  (`legacy_delegation_field`, vs `unenforceable_delegation_constraint` for
+  the other three) because the remediation is different in kind (rename the
+  key vs. change/remove the value) and because silently parsing `tool_calls`
+  as an absent `runner_invocations` would drop the author's intended limit
+  without any signal -- worth a sharper, separately-labeled failure than a
+  generic constraint rejection.
+- **wall_time_minutes enforcement mechanism.** Rides the existing bounded
+  process runner (`scripts/run-bounded-verifier-command.ts`, invoked as a
+  sibling via `SCRIPT_DIR` so it resolves correctly from both the canonical
+  `scripts/contract-run.ts` and the projected
+  `assets/templates/helpers/contract-run.ts`) rather than adding a bare
+  `spawnSync({timeout})`: the bounded runner's SIGTERM-then-SIGKILL,
+  process-group-aware termination is what actually reaps descendants a
+  shell-spawned worker/verifier command may leave behind, which
+  `spawnSync`'s native `timeout` (kills only the immediate child, no
+  process-group semantics) does not guarantee. One shared deadline is
+  computed once per `run` (not per child) and passed to both the worker and
+  verifier `runChild` calls, bounding the whole delegated task's wall clock
+  rather than each child individually, matching how
+  `verify-contract.sh` computes one `verification_deadline_ms` for its
+  whole pass. Trade-off accepted: routing through the bounded runner merges
+  stdout+stderr into one log file (the wrapper's own process-group kill
+  logic needs a single stream) instead of the unbounded path's separate
+  stdout/stderr files; no existing test asserted on that separation, and a
+  `timed_out` field plus a distinct `wall_time_exceeded` failure_class were
+  added so a deadline miss reads as a named enforcement outcome instead of a
+  generic `worker_failed`/`verifier_failed`. Verified live (not just
+  type-checked): a worker with `sleep 10` under `wall_time_minutes: 0.03`
+  (~1.8s) was actually SIGTERM'd before it could write its output file or
+  finish sleeping (see `tests/contract-run.test.ts`'s
+  "run enforces wall_time_minutes..." test and the manual scratch probe
+  recorded in this session: `worker.bounded-result.json` showed
+  `"signal":"SIGTERM"`, empty stdout, and no leftover `sleep` process).
+- **`docs/reference-configs/sprint-contracts.md` prose left unrenamed --
+  second, narrower Stop Condition hit.** This file is one of the three docs
+  named in Scope for the rename ripple and its `budget: ... tool_calls ...`
+  sentence is genuinely stale after this change (it also still describes the
+  pre-fix "otherwise advisory" silent-noop semantics). It is NOT edited here:
+  `assets/reference-configs/sprint-contracts.md` is a byte-identical mirror
+  enforced by `tests/sprint-backlog.test.ts`'s "sprint asset parity" test
+  (`toBe()` against the two files' raw content), and that mirror path is
+  outside this contract's Allowed Paths, as is `tests/sprint-backlog.test.ts`
+  itself. There is no `sync:*` command that projects `docs/reference-configs/`
+  -> `assets/reference-configs/` (only `sync:hooks` and `sync:helpers` exist,
+  neither targets this pair). Editing only the `docs/` side would desync the
+  pair and fail that parity test -- a regression in a test outside this
+  contract's named surfaces, which Stop Conditions explicitly forbid.
+  `docs/reference-configs/contract-brief-example.md` and
+  `contract-brief-example-bugfix.md` have no such mirror (confirmed: no
+  matching filenames under `assets/reference-configs/`) and were renamed
+  normally, including fixing `contract-brief-example.md`'s
+  `network: off` -> `network: inherited` (it is exercised by contract-run.ts's
+  own "golden example contract brief passes its own preflight gate" test, so
+  `off` would have started failing preflight under the new enforce-or-reject
+  behavior).
+- **`tests/helper-scripts.test.ts:3852`'s `tool_calls: 20` left as-is.** That
+  fixture belongs to "verify-contract should ignore delegation metadata
+  before exit criteria" -- the test's own point is that `verify-contract.sh`
+  never parses the Delegation Contract block at all, so the literal field
+  name inside it is inert for that test regardless of spelling. Scope's
+  "tests/helper-scripts.test.ts (+ where it pins the old name)" qualifier
+  reads as covering only assertions that actually depend on the name; this
+  one does not, so it was left untouched rather than making an unrequested
+  edit.
+- **Golden outcome (round 1, before Deliverable 2): unchanged, not
+  regenerated.** `bun test tests/hook-runtime-characterization.test.ts`
+  passed clean (1 pass, 0 fail, 14 expect() calls) with no diff against the
+  frozen golden. Expected: Deliverable 2 was not yet implemented; the
+  `prompt-guard-decision.ts` change only touches the `unknown` bucket's
+  action mapping, which the characterization fixture repo's plan statuses
+  do not appear to exercise; `contract-run.ts` is an unrelated code path.
+- **Golden outcome (round 2, after Deliverable 2): still unchanged, not
+  regenerated.** Re-ran `bun test tests/hook-runtime-characterization.test.ts`
+  after implementing the `pre-edit-guard.sh` fail-closed default branch: 1
+  pass, 0 fail, 14 expect() calls, no diff. Confirmed by reading the
+  fixture builder (`tests/hook-runtime-characterization.test.ts:162-186`
+  `buildFixtureRepo()`), not just by the test passing: it writes only a
+  bare git repo, a copied `.ai/hooks/`, and an empty
+  `.ai/harness/workflow-contract.json` -- no `docs/spec.md`, no
+  `.ai/harness/policy.json`, no `.ai/harness/active-plan` marker, no plan
+  file at all. For the `PreToolUse.edit` route (`src/example.ts`), the
+  missing `docs/spec.md` trips the pre-existing `SpecGuard` check inside
+  `run_edit_plan_gate` before the function ever reaches the
+  `gate_status`/`case` logic my new default branch lives in, so the new
+  code path is structurally unreachable by this fixture regardless of
+  `WORKFLOW_PROFILE` resolution -- not a coincidence, a direct consequence
+  of the fixture never getting far enough to hit it. No
+  `UPDATE_HOOK_RUNTIME_CHARACTERIZATION_GOLDEN=1` regeneration was needed
+  or run in either round.
+
+## Deviations From Plan Or Spec
+
+- (round 1, resolved in round 2) Deliverable 2 was initially not
+  implemented pending an owner decision on the known-status authority --
+  see Falsifier finding above. The owner resolved it (Option A: `Blocked`/
+  `Review` join the known-good set via a new `.ai/harness/policy.json`
+  `active_plan.statuses` array) and the contract was amended with two new
+  Allowed Paths; Deliverable 2 is now fully implemented (see "Resumption"
+  section above) and no longer a deviation.
+- (round 1, resolved in round 2) `docs/reference-configs/sprint-contracts.md`
+  was initially left unedited because its byte-parity mirror
+  (`assets/reference-configs/sprint-contracts.md`) and the parity test
+  (`tests/sprint-backlog.test.ts`) were both outside Allowed Paths. The
+  contract was amended to add the mirror file to Allowed Paths; both files
+  were renamed together in round 2 and the parity test stays green. No
+  longer a deviation.
+- (round 2, resolved in round 3) `tests/runtime-profile-enforcement.test.ts`
+  had two fixtures (`InProgress` plan status, ~lines 122 and 287) plus a
+  shared `initRepo()` policy.json fixture (~line 23) with no
+  `active_plan.statuses` key; together these depended on
+  pre-edit-guard.sh's old fail-open behavior on any non-Draft/Annotating
+  status. The contract was amended to add this file to Allowed Paths; the
+  3-site fix diagnosed in round 2 (`active_plan.statuses` added to
+  `initRepo()`, both `InProgress` sites renamed to `Blocked`) was applied
+  in round 3 -- see the round-3 "Resumption" section above. `bun test
+  tests/hook-runtime.test.ts tests/hook-contracts.test.ts
+  tests/runtime-profile-enforcement.test.ts` is 113/113. No longer a
+  deviation.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| Guess a known-status resolution for `Blocked`/`Review` and ship Deliverable 2 anyway | Rejected | Falsifier and a Stop Condition both explicitly name this exact scenario as an owner decision, not an executor judgment call; the two live resolutions produce materially different user-facing behavior |
+| Route `wall_time_minutes` through bare `spawnSync({timeout})` instead of the bounded runner | Rejected | Does not reap the whole process group; the Stop Condition explicitly frames this as "ride the existing bounded runner ... [not] new process machinery" |
+| Hand-edit `assets/reference-configs/sprint-contracts.md` to keep the mirror in sync | Rejected | Outside Allowed Paths; would itself violate the "edit only Allowed Paths" hard constraint even though it would restore a *different* test's parity |
+| Add a new `PromptGuardAction` for the `unknown` branch instead of reusing `decideDraftPlanAction` | Rejected | Reusing the existing draft/annotating advisory path is the smaller diff, needs no new bash rendering, and already matches "conservative advisory/orientation action" |
+| Place the new `statuses` array under `guards` instead of `active_plan` | Rejected | `guards` configures gate *mode* (enforce/advice/off); `active_plan` already owns the plans/ location fields `prds`/`sprints` mirror with their own `statuses` arrays -- same shape, same axis |
+| Silently swap `InProgress` -> `Blocked` in `tests/runtime-profile-enforcement.test.ts` to keep it green | Rejected | File is outside this contract's Allowed Paths; editing it without authorization would violate the same hard constraint that gated the sprint-contracts.md and policy.json work until the contract was amended |
+| Weaken the new default branch (e.g. skip it under `WORKFLOW_PROFILE=strict`) to avoid preempting `StrictContractGuard` | Rejected | Not a real fix -- `InProgress` is exactly the "plausible but unrecognized" class of status the fix exists to catch; narrowing the guard's applicability to dodge one test would reintroduce a fail-open gap for that profile |
+
+## Open Questions
+
+- (Resolved in round 3: `tests/runtime-profile-enforcement.test.ts` was
+  added to Allowed Paths and the 3-site fix was applied; 113/113.)
+- Should `docs/reference-configs/sprint-contracts.md` and
+  `assets/reference-configs/sprint-contracts.md` gain a `sync:*` command (or
+  the parity test move) so this class of doc update does not keep hitting
+  the Allowed-Paths wall in future packages? (Resolved for this package by
+  the Stop-2 Allowed-Paths amendment, but the structural gap remains.)
+- Follow-up (explicitly out of scope per the amendment): converge the three
+  legacy scattered plan-status lists (`pre-edit-guard`'s own
+  `Draft|Annotating` arm, `validate_plan_transition`, `plan_terminal_status`)
+  into projections of `.ai/harness/policy.json`'s `active_plan.statuses`,
+  so there is truly one authority repo-wide instead of one authority for
+  the new fail-closed branch plus three untouched legacy copies.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/reviews/20260720-0033-plan-status-fail-closed-and-runner-truth.review.md
+++ b/tasks/reviews/20260720-0033-plan-status-fail-closed-and-runner-truth.review.md
@@ -1,0 +1,86 @@
+# Task Review: plan-status-fail-closed-and-runner-truth
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260720-0033-plan-status-fail-closed-and-runner-truth.md
+> **Contract**: tasks/contracts/20260720-0033-plan-status-fail-closed-and-runner-truth.contract.md
+> **Notes File**: tasks/notes/20260720-0033-plan-status-fail-closed-and-runner-truth.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-07-20 01:54
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Commands passed:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+- Waza `/check` run:
+- Commands run:
+- Manual checks:
+- Supporting artifacts:
+- Implementation notes reviewed:
+- Run snapshot:
+
+## External Acceptance Advice
+
+> **External Acceptance**: unavailable
+> **External Reviewer**:
+> **External Source**:
+> **External Started**:
+> **External Completed**:
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Benchmark Evidence SHA256**: pending
+
+- P1 blockers:
+- P2 advisories:
+- Acceptance checklist:
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...

--- a/tasks/reviews/20260720-0033-plan-status-fail-closed-and-runner-truth.review.md
+++ b/tasks/reviews/20260720-0033-plan-status-fail-closed-and-runner-truth.review.md
@@ -1,86 +1,168 @@
 # Task Review: plan-status-fail-closed-and-runner-truth
 
-> **Status**: Pending
+> **Status**: Complete
 > **Plan**: plans/plan-20260720-0033-plan-status-fail-closed-and-runner-truth.md
 > **Contract**: tasks/contracts/20260720-0033-plan-status-fail-closed-and-runner-truth.contract.md
 > **Notes File**: tasks/notes/20260720-0033-plan-status-fail-closed-and-runner-truth.notes.md
 > **Checks File**: .ai/harness/checks/latest.json
-> **Last Updated**: 2026-07-20 01:54
-> **Recommendation**: fail
+> **Last Updated**: 2026-07-20 (Round 1 acceptance after three implementation rounds; external slot per standing chain instruction)
+> **Recommendation**: pass
 > **Review Rubric Version**: 2
-> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject SHA256**: sha256:a774794dabca6fe5d07c378ee625ab1d6db7d0742cd4173d77466b4762bbcdd1
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: pending
+> **Reviewed Target Revision**: a1481a866ba3c1fddee73f4baf1cfebe169381bb
 
 ## Human Review Card
 
-- Verdict: pending
-- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
-- Intended files changed:
-- Actual files changed:
-- Commands passed:
-- Residual risks:
-- Reviewer action required: inspect diff and card
-- Rollback:
+- Verdict: pass
+- Change type: code-change (deliberate behavior change: fail-open → fail-closed; parity was explicitly not the criterion)
+- Intended files changed: the two audited P0 fixes — fail-closed plan-status
+  authority (policy array + guard default branch + prompt-layer advisory)
+  and truthful runner constraints (wall-time enforcement, unenforceable-
+  constraint rejection, `runner_invocations` rename) — plus the rename
+  ripple across templates/scaffolds/docs mirrors and the envelope.
+- Actual files changed: 27 files (+882 −108), every one inside Allowed
+  Paths across all three implementation rounds (two contract amendments
+  recorded in Scope). Forbidden surfaces empty-diff: `runtime.ts`,
+  `route-registry.ts`, `src/core/loop/`, `src/effects/loop/`, the HRD-01
+  characterization test and golden. Historical contracts and the research
+  audit text not rewritten.
+- Commands passed: group A 187 pass / 0 fail (prompt-guard-decision,
+  contract-run, helper-scripts, plan-status-gate ×21, characterization);
+  hook group 113 pass / 0 fail; sprint-backlog parity 23 pass; broad
+  `tests/cli/` 431 pass / 1 pre-existing win32 skip / 0 fail; `check:type`,
+  `check:hooks`, `check:helpers`, `check:state-boundaries` green — all in
+  both the worker and the independent gatekeeper session. Live probes:
+  unknown status `Bananas` → exit 2 structured block; `Blocked` → exit 0;
+  empty statuses array → exit 2 authority-unavailable; sleep-10 worker
+  SIGTERM'd under a 1.8s `wall_time_minutes` deadline (`wall_time_exceeded`).
+- Residual risks: (1) post-merge, re-running `contract-run preflight`
+  against older non-archived contracts still carrying `tool_calls` fails
+  closed — intended one-shot semantics ("records, do not rewrite"); no
+  workflow re-runs preflight on closed contracts, but operators should know.
+  (2) The three legacy status lists (`Draft|Annotating` case arms,
+  `validate_plan_transition`, `plan_terminal_status`) remain deferred
+  convergence targets — recorded follow-up, not this slice. (3) The
+  prompt-layer unknown-status advisory reuses draft wording; the edit-layer
+  message carries the exact repair path.
+- Reviewer action required: none for the reviewed subject; ship as an
+  independent PR against `main` from base `8254b239`.
+- Rollback: revert the single PR; guard, policy array, parser, templates,
+  docs mirrors, and test fixtures revert as one unit; no data migration.
 
 ## Mode Evidence
 
-- Selected route:
-- P1/P2/P3 evidence:
-- Root cause or plan evidence:
+- Selected route: `Task Profile=code-change`, independent contract worktree
+  `codex/plan-status-fail-closed-and-runner-truth` from exact execution
+  base `8254b239` (post-HRD-02 close plus P0 promotion), sequenced between
+  HRD rows per the contract header.
+- P1/P2/P3 evidence: plan Problem section carries the 2026-07-20 source
+  re-verification (file:line) of both audit P0s; contract Design Decisions
+  pin edit-layer-hard/prompt-layer-advisory, enforce-or-reject, one-shot
+  rename, and golden handling.
+- Root cause or plan evidence: falsifier-first — the pre-edit status
+  inventory found `Blocked`×2/`Review`×1 on real plans outside every code
+  authority, exactly the designed stop; the owner decision (policy.json
+  `active_plan.statuses`, 13 values) resolved it before the guard was
+  written.
 
 ## Verification Evidence
 
-- Waza `/check` run:
-- Commands run:
-- Manual checks:
-- Supporting artifacts:
-- Implementation notes reviewed:
-- Run snapshot:
+- Waza `/check` run: orchestrator session 2026-07-20; scope on target
+  across three rounds, hard stops 0, key diffs read directly (guard
+  authority functions, fail-closed branches, rejection machinery).
+- Commands run: the full battery above; independent gatekeeper re-ran all
+  suites plus live fixture probes and the isolated wall-time kill test;
+  `pi_write_harness_policy` invoked live to prove default emission.
+- Manual checks: see Manual Check Evidence below.
+- Supporting artifacts: `tests/plan-status-gate.test.ts` (21 fixtures
+  including per-status pass-through and both authority-unavailable
+  closures); mirror byte-identity proven by `cmp` on all four pairs.
+- Implementation notes reviewed: yes — falsifier inventory, authority
+  provenance, both Stop Condition write-ups and resolutions, rejection-
+  message design, bounded-runner choice, golden structural reasoning.
+- Run snapshot: `.ai/harness/checks/latest.json` (verify-contract, this
+  worktree).
+
+## Manual Check Evidence
+
+- [x] Every non-null delegation constraint is enforced or rejected at preflight
+  - Evidence: `wall_time_minutes` mechanically enforced via the bounded runner (sleep-10 worker killed in 2.35s under a 1.8s deadline, `failure_class: wall_time_exceeded`); `runner_invocations` limit enforced via `consume()`; non-null `tokens`, non-`inherited` `network`, non-empty `writable_paths` rejected with `unenforceable_delegation_constraint` naming each constraint; legacy `tool_calls` rejected with `legacy_delegation_field`. Negative probes run in-session with exit 1 and named messages.
+- [x] Characterization golden outcome is documented as unchanged or one-shot regenerated with the exact cell delta
+  - Evidence: unchanged — `git diff 8254b239..a1481a86 -- tests/fixtures/loop-runtime/characterization.json` is empty; structural reason verified twice (fixture repo writes only README.md, so SpecGuard terminates the PreToolUse.edit cell before the new branch is reachable) and recorded in the notes file.
 
 ## External Acceptance Advice
 
-> **External Acceptance**: unavailable
-> **External Reviewer**:
-> **External Source**:
-> **External Started**:
-> **External Completed**:
+> **External Acceptance**: waived (user standing instruction for the continuous chain run, 2026-07-20)
+> **External Reviewer**: none — Codex quota remains exhausted until 2026-08-16 (verified on HRD-01, `codex exec` refused by provider usage limit); no second AI host available
+> **External Source**: user waiver (actor: kito; standing in-session instruction 2026-07-20; precedent: `5b3a2693` and the HRD-01/HRD-02 waivers). Substitute internal evidence: fresh-context Claude gatekeeper PASS with live probes, plus merge-gate and CI at the ship boundary
+> **External Started**: 2026-07-20
+> **External Completed**: 2026-07-20 (waiver recorded; not a Codex review)
 > **Review Rubric Version**: 2
-> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject SHA256**: sha256:a774794dabca6fe5d07c378ee625ab1d6db7d0742cd4173d77466b4762bbcdd1
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: pending
-> **Benchmark Evidence SHA256**: pending
+> **Reviewed Target Revision**: a1481a866ba3c1fddee73f4baf1cfebe169381bb
+> **Benchmark Evidence SHA256**: not_applicable
 
-- P1 blockers:
-- P2 advisories:
-- Acceptance checklist:
+- P1 blockers: none. Gatekeeper verdict PASS — scope fit (27 files all in
+  allowed paths), full battery re-run independently, live fail-closed
+  probes, wall-time kill verified end-to-end (absolute-epoch deadline
+  convention cross-checked against `run-bounded-verifier-command.ts:111`
+  and `verify-contract.sh:633`), single-authority hard stop held (guard
+  reads only the policy array), all four mirror pairs byte-identical.
+- P2 advisories: todos timestamp churn (cosmetic); legacy-`tool_calls`
+  contracts fail preflight post-merge (intended, operational note);
+  prompt-layer advisory wording reuses draft phrasing; full `bun test`
+  deferred to the CI ship boundary.
+- Acceptance checklist: audit slice-1 clauses all hold — unknown/malformed
+  blocks ✓ (matrix + live probe), every non-null constraint enforced or
+  rejected ✓, safety tests green ✓; falsifier chain: inventory → owner
+  decision → 13-value authority; observed values ⊂ authority, so the block
+  cannot fire on this repo's healthy history ✓; fail-open survivors in the
+  plan-status gate: none ✓.
 
 ## Behavior Diff Notes
 
-- ...
+- Deliberate behavior changes, each fixture-pinned: unknown/malformed plan
+  status now blocks implementation edits (was: silent pass-through);
+  prompt-layer unknown bucket now advises conservatively (was: allow ×4);
+  `wall_time_minutes` now kills over-deadline runners (was: parsed no-op);
+  unenforceable non-null constraints now fail preflight (was: silent);
+  `tool_calls` now errors (was: the live field name). Known-good statuses,
+  Draft/Annotating gating, lite-profile scope-outs, and advice/off modes
+  unchanged.
 
 ## Residual Risks / Follow-ups
 
-- ...
+- Converge the three legacy status lists into projections of the policy
+  authority (deferred follow-up, not this slice).
+- Operational note on legacy-`tool_calls` contracts above.
 
 ## Scorecard
 
 | Dimension | Score | Notes |
 |-----------|-------|-------|
-| Functionality | 0/10 | |
-| Product depth | 0/10 | |
-| Design quality | 0/10 | |
-| Code quality | 0/10 | |
+| Functionality | 9/10 | Both audit P0s closed with live-probe evidence; falsifier chain executed as designed |
+| Product depth | 9/10 | Authority-unavailable itself fails closed; per-status matrix; end-to-end kill test |
+| Design quality | 9/10 | Single authority honored (zero hardcoded list in the guard); enforce-or-reject honesty; three-round stop discipline |
+| Code quality | 8/10 | Clean; prompt-layer advisory wording nit and deferred list convergence noted |
 
 ## Failing Items
 
-- ...
+- none
 
 ## Retest Steps
 
-- Re-run:
-- Re-check:
+- Re-run: `bun test tests/cli/prompt-guard-decision.test.ts tests/contract-run.test.ts tests/helper-scripts.test.ts tests/plan-status-gate.test.ts tests/hook-runtime-characterization.test.ts tests/hook-runtime.test.ts tests/hook-contracts.test.ts tests/runtime-profile-enforcement.test.ts && bun run check:type && bun run check:hooks && bun run check:helpers && bun run check:state-boundaries`
+- Re-check: `bun src/cli/index.ts run verify-contract --contract tasks/contracts/20260720-0033-plan-status-fail-closed-and-runner-truth.contract.md --strict`
 
 ## Summary
 
-- ...
+- The two audited P0 correctness defects are closed: plan-status authority
+  is a single 13-value policy array with fail-closed enforcement at the
+  edit boundary (authority-unavailable included), and every delegation
+  constraint is now either mechanically enforced or rejected under the
+  honest `runner_invocations` name with no alias. Three implementation
+  rounds, two contract amendments, owner decision on the status authority,
+  gatekeeper PASS with live probes. Fit to ship as an independent PR from
+  base `8254b239`; HRD-03 pins the post-merge SHA.

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -1,7 +1,7 @@
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: 2026-07-20 01:15
+> **Updated**: 2026-07-20 01:54
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.

--- a/tests/cli/prompt-guard-decision.test.ts
+++ b/tests/cli/prompt-guard-decision.test.ts
@@ -105,6 +105,30 @@ describe('prompt-guard decision engine', () => {
     ).toBe('plan_status_no_active_block');
   });
 
+  test('unknown plan status gets the same conservative advisory as draft, never silent allow', () => {
+    const unknown = state({ plan: 'unknown' });
+
+    // Positive: matches the draft/annotating advisory action, not 'allow'.
+    expect(decidePromptGuardAction('embedded_approved_plan', unknown)).toBe(
+      'plan_status_not_approved_block',
+    );
+    expect(decidePromptGuardAction('bug_fix_execution', unknown)).toBe(
+      'plan_status_not_approved_block',
+    );
+    expect(decidePromptGuardAction('general_execution', unknown)).toBe(
+      'plan_status_not_approved_block',
+    );
+    expect(decidePromptGuardAction('plan_execution_projection', unknown)).toBe(
+      'plan_capture_draft_advice',
+    );
+
+    // Negative: none of the four execution intents silently allow on an
+    // unrecognized plan status (this was the fail-open bug).
+    for (const intent of PROMPT_GUARD_EXECUTION_INTENTS) {
+      expect(decidePromptGuardAction(intent, unknown)).not.toBe('allow');
+    }
+  });
+
   test('approved plan without contract scaffolds explicit execution and blocks generic execution', () => {
     const approved = state({
       plan: 'approved',

--- a/tests/contract-run.test.ts
+++ b/tests/contract-run.test.ts
@@ -30,12 +30,12 @@ function makeRepo(prefix = "contract-run-"): string {
 
 function writePilotContract(
   repo: string,
-  toolCalls: string | number | null = 2,
+  runnerInvocations: string | number | null = 2,
   why: string = "This pilot proves the worker→verifier file-coupled loop; without it the runner ships unverified.",
   options: { exemplar?: boolean; stopConditions?: string[]; runnerFallback?: string | null } = {},
 ): string {
   const contractPath = join(repo, "tasks/contracts/pilot.contract.md");
-  const budgetValue = toolCalls === null ? "null" : String(toolCalls);
+  const budgetValue = runnerInvocations === null ? "null" : String(runnerInvocations);
   const fallbackValue = options.runnerFallback === undefined ? "main-thread" : options.runnerFallback === null ? "null" : options.runnerFallback;
   writeFileSync(
     contractPath,
@@ -86,12 +86,12 @@ function writePilotContract(
       "delegation:",
       "  budget:",
       "    tokens: null",
-      `    tool_calls: ${budgetValue}`,
+      `    runner_invocations: ${budgetValue}`,
       "    wall_time_minutes: 5",
       "  permission_scope:",
       "    mode: inherit_allowed_paths",
       "    writable_paths: []",
-      "    network: off",
+      "    network: inherited",
       "  roles:",
       "    parent:",
       "      mode: narrate_and_gatekeep",
@@ -177,12 +177,73 @@ function writeContractWithBlankOutOfScope(repo: string): string {
       "delegation:",
       "  budget:",
       "    tokens: null",
-      "    tool_calls: 2",
+      "    runner_invocations: 2",
       "    wall_time_minutes: 5",
       "  permission_scope:",
       "    mode: inherit_allowed_paths",
       "    writable_paths: []",
-      "    network: off",
+      "    network: inherited",
+      "  roles:",
+      "    worker:",
+      "      mode: edit_within_allowed_paths",
+      "      purpose: implementation",
+      "```",
+      "",
+      "## Exit Criteria (Machine Verifiable)",
+      "",
+      "```yaml",
+      "exit_criteria:",
+      "  files_exist:",
+      "    - src/pilot.txt",
+      "```",
+      "",
+    ].join("\n"),
+  );
+  return contractPath;
+}
+
+// Writes a self-sufficient brief (so base preflight issues never mask the delegation-only
+// case under test) with a caller-supplied Delegation Contract budget/permission_scope body,
+// isolating each enforce-or-reject and rename assertion to exactly the lines under test.
+function writeContractWithDelegation(repo: string, delegationBudgetAndScopeLines: string[]): string {
+  const contractPath = join(repo, "tasks/contracts/pilot.contract.md");
+  writeFileSync(
+    contractPath,
+    [
+      "# Task Contract: pilot",
+      "",
+      "> **Status**: Active",
+      "> **Plan**: plans/plan.md",
+      "> **Owner**: test",
+      "> **Review File**: `tasks/reviews/pilot.review.md`",
+      "> **Notes File**: `tasks/notes/pilot.notes.md`",
+      "",
+      "## Why",
+      "",
+      "This pilot proves the worker→verifier file-coupled loop; without it the runner ships unverified.",
+      "",
+      "## Goal",
+      "",
+      "Create src/pilot.txt containing worker-output so the verifier can confirm the exit criteria.",
+      "",
+      "## Scope",
+      "",
+      "- In scope: create src/pilot.txt with worker-output",
+      "- Out of scope: anything outside src/",
+      "",
+      "## Allowed Paths",
+      "",
+      "```yaml",
+      "allowed_paths:",
+      "  - src/",
+      "  - tasks/reviews/",
+      "```",
+      "",
+      "## Delegation Contract",
+      "",
+      "```yaml",
+      "delegation:",
+      ...delegationBudgetAndScopeLines,
       "  roles:",
       "    worker:",
       "      mode: edit_within_allowed_paths",
@@ -377,7 +438,7 @@ describe("contract-run helper", () => {
       expect(res.status).toBe(0);
       const manifest = parseJson(res.stdout);
       expect(manifest.status).toBe("pass");
-      expect((manifest.budget_usage as { tool_calls: number }).tool_calls).toBe(2);
+      expect((manifest.budget_usage as { runner_invocations: number }).runner_invocations).toBe(2);
       expect((manifest.children as unknown[])).toHaveLength(2);
       expect(readFileSync(join(repo, "src/pilot.txt"), "utf-8")).toContain("worker-output");
       expect(existsSync(join(repo, "tasks/reviews/pilot.review.md"))).toBe(true);
@@ -477,8 +538,13 @@ describe("contract-run helper", () => {
       const manifest = parseJson(res.stdout);
       expect(manifest.status).toBe("fail");
       expect(manifest.failure_class).toBe("budget_exceeded");
-      expect((manifest.budget_usage as { tool_calls: number; tool_call_limit: number }).tool_calls).toBe(1);
-      expect((manifest.budget_usage as { tool_calls: number; tool_call_limit: number }).tool_call_limit).toBe(1);
+      expect(
+        (manifest.budget_usage as { runner_invocations: number; runner_invocation_limit: number }).runner_invocations,
+      ).toBe(1);
+      expect(
+        (manifest.budget_usage as { runner_invocations: number; runner_invocation_limit: number })
+          .runner_invocation_limit,
+      ).toBe(1);
       const children = manifest.children as Array<{ role: string; skipped?: boolean }>;
       expect(children).toEqual([
         expect.objectContaining({ role: "worker" }),
@@ -696,12 +762,12 @@ describe("contract-run helper", () => {
           "delegation:",
           "  budget:",
           "    tokens: null",
-          "    tool_calls: null",
+          "    runner_invocations: null",
           "    wall_time_minutes: 5",
           "  permission_scope:",
           "    mode: inherit_allowed_paths",
           "    writable_paths: []",
-          "    network: off",
+          "    network: inherited",
           "  roles:",
           "    worker:",
           "      mode: edit_within_allowed_paths",
@@ -1085,5 +1151,262 @@ describe("contract-run helper", () => {
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }
+  });
+
+  describe("delegation budget enforce-or-reject", () => {
+    test("preflight rejects a non-null tokens budget with a named-constraint message", () => {
+      const repo = makeRepo("contract-run-tokens-reject-");
+      try {
+        writeContractWithDelegation(repo, [
+          "  budget:",
+          "    tokens: 5000",
+          "    runner_invocations: null",
+          "    wall_time_minutes: null",
+          "  permission_scope:",
+          "    mode: inherit_allowed_paths",
+          "    writable_paths: []",
+          "    network: inherited",
+        ]);
+        const res = runContractRun(repo, [
+          "preflight",
+          "--repo",
+          repo,
+          "--contract",
+          "tasks/contracts/pilot.contract.md",
+          "--json",
+        ]);
+        expect(res.status).toBe(1);
+        const manifest = parseJson(res.stdout);
+        expect(manifest.status).toBe("fail");
+        expect(manifest.failure_class).toBe("unenforceable_delegation_constraint");
+        const issues = (manifest.brief_preflight as { issues: string[] }).issues;
+        expect(issues.some((issue) => issue.includes("budget.tokens") && issue.includes("5000"))).toBe(true);
+      } finally {
+        rmSync(repo, { recursive: true, force: true });
+      }
+    });
+
+    test("preflight rejects a non-inherited network value with a named-constraint message", () => {
+      const repo = makeRepo("contract-run-network-reject-");
+      try {
+        writeContractWithDelegation(repo, [
+          "  budget:",
+          "    tokens: null",
+          "    runner_invocations: null",
+          "    wall_time_minutes: null",
+          "  permission_scope:",
+          "    mode: inherit_allowed_paths",
+          "    writable_paths: []",
+          "    network: none",
+        ]);
+        const res = runContractRun(repo, [
+          "preflight",
+          "--repo",
+          repo,
+          "--contract",
+          "tasks/contracts/pilot.contract.md",
+          "--json",
+        ]);
+        expect(res.status).toBe(1);
+        const manifest = parseJson(res.stdout);
+        expect(manifest.status).toBe("fail");
+        expect(manifest.failure_class).toBe("unenforceable_delegation_constraint");
+        const issues = (manifest.brief_preflight as { issues: string[] }).issues;
+        expect(
+          issues.some((issue) => issue.includes("permission_scope.network") && issue.includes("'none'")),
+        ).toBe(true);
+      } finally {
+        rmSync(repo, { recursive: true, force: true });
+      }
+    });
+
+    test("preflight rejects a non-empty writable_paths narrowing with a named-constraint message", () => {
+      const repo = makeRepo("contract-run-writable-paths-reject-");
+      try {
+        writeContractWithDelegation(repo, [
+          "  budget:",
+          "    tokens: null",
+          "    runner_invocations: null",
+          "    wall_time_minutes: null",
+          "  permission_scope:",
+          "    mode: inherit_allowed_paths",
+          "    writable_paths:",
+          "      - src/narrow.ts",
+          "    network: inherited",
+        ]);
+        const res = runContractRun(repo, [
+          "preflight",
+          "--repo",
+          repo,
+          "--contract",
+          "tasks/contracts/pilot.contract.md",
+          "--json",
+        ]);
+        expect(res.status).toBe(1);
+        const manifest = parseJson(res.stdout);
+        expect(manifest.status).toBe("fail");
+        expect(manifest.failure_class).toBe("unenforceable_delegation_constraint");
+        const issues = (manifest.brief_preflight as { issues: string[] }).issues;
+        expect(
+          issues.some(
+            (issue) => issue.includes("permission_scope.writable_paths") && issue.includes("src/narrow.ts"),
+          ),
+        ).toBe(true);
+      } finally {
+        rmSync(repo, { recursive: true, force: true });
+      }
+    });
+
+    test("preflight reports every unenforceable constraint together, not just the first", () => {
+      const repo = makeRepo("contract-run-multi-reject-");
+      try {
+        writeContractWithDelegation(repo, [
+          "  budget:",
+          "    tokens: 1000",
+          "    runner_invocations: null",
+          "    wall_time_minutes: null",
+          "  permission_scope:",
+          "    mode: inherit_allowed_paths",
+          "    writable_paths: []",
+          "    network: sandboxed",
+        ]);
+        const res = runContractRun(repo, [
+          "preflight",
+          "--repo",
+          repo,
+          "--contract",
+          "tasks/contracts/pilot.contract.md",
+          "--json",
+        ]);
+        expect(res.status).toBe(1);
+        const manifest = parseJson(res.stdout);
+        const issues = (manifest.brief_preflight as { issues: string[] }).issues;
+        expect(issues.some((issue) => issue.includes("budget.tokens"))).toBe(true);
+        expect(issues.some((issue) => issue.includes("permission_scope.network"))).toBe(true);
+        expect(issues.length).toBe(2);
+      } finally {
+        rmSync(repo, { recursive: true, force: true });
+      }
+    });
+
+    test("preflight passes when tokens is null, network is inherited, and writable_paths is empty", () => {
+      const repo = makeRepo("contract-run-enforceable-ok-");
+      try {
+        writeContractWithDelegation(repo, [
+          "  budget:",
+          "    tokens: null",
+          "    runner_invocations: 3",
+          "    wall_time_minutes: 5",
+          "  permission_scope:",
+          "    mode: inherit_allowed_paths",
+          "    writable_paths: []",
+          "    network: inherited",
+        ]);
+        const res = runContractRun(repo, [
+          "preflight",
+          "--repo",
+          repo,
+          "--contract",
+          "tasks/contracts/pilot.contract.md",
+          "--json",
+        ]);
+        expect(res.status).toBe(0);
+        const manifest = parseJson(res.stdout);
+        expect(manifest.status).toBe("preflight_pass");
+        expect((manifest.brief_preflight as { ok: boolean; issues: string[] }).issues).toEqual([]);
+      } finally {
+        rmSync(repo, { recursive: true, force: true });
+      }
+    });
+
+    test("preflight fails closed on the retired tool_calls field name instead of silently dropping the budget", () => {
+      const repo = makeRepo("contract-run-legacy-field-");
+      try {
+        writeContractWithDelegation(repo, [
+          "  budget:",
+          "    tokens: null",
+          "    tool_calls: 3",
+          "    wall_time_minutes: null",
+          "  permission_scope:",
+          "    mode: inherit_allowed_paths",
+          "    writable_paths: []",
+          "    network: inherited",
+        ]);
+        const res = runContractRun(repo, [
+          "preflight",
+          "--repo",
+          repo,
+          "--contract",
+          "tasks/contracts/pilot.contract.md",
+          "--json",
+        ]);
+        expect(res.status).toBe(1);
+        const manifest = parseJson(res.stdout);
+        expect(manifest.status).toBe("fail");
+        expect(manifest.failure_class).toBe("legacy_delegation_field");
+        const issues = (manifest.brief_preflight as { issues: string[] }).issues;
+        expect(
+          issues.some((issue) => issue.includes("tool_calls") && issue.includes("runner_invocations")),
+        ).toBe(true);
+      } finally {
+        rmSync(repo, { recursive: true, force: true });
+      }
+    });
+
+    test("run enforces wall_time_minutes via the bounded process runner deadline and kills an overrunning worker", () => {
+      const repo = makeRepo("contract-run-walltime-");
+      try {
+        writeContractWithDelegation(repo, [
+          "  budget:",
+          "    tokens: null",
+          "    runner_invocations: null",
+          "    wall_time_minutes: 0.03",
+          "  permission_scope:",
+          "    mode: inherit_allowed_paths",
+          "    writable_paths: []",
+          "    network: inherited",
+        ]);
+        const workerCommand = writeExecutable(
+          repo,
+          "worker-slow.sh",
+          ["#!/bin/bash", "sleep 10", "mkdir -p src", "printf 'worker-output\\n' > src/pilot.txt", ""].join("\n"),
+        );
+        const verifierCommand = writeExecutable(
+          repo,
+          "verifier.sh",
+          ["#!/bin/bash", "printf 'ran\\n' > verifier-ran.txt", ""].join("\n"),
+        );
+
+        const res = runContractRun(repo, [
+          "run",
+          "--repo",
+          repo,
+          "--contract",
+          "tasks/contracts/pilot.contract.md",
+          "--worker-command",
+          workerCommand,
+          "--verifier-command",
+          verifierCommand,
+          "--out",
+          ".ai/harness/runs/walltime",
+          "--json",
+        ]);
+
+        expect(res.status).toBe(1);
+        const manifest = parseJson(res.stdout);
+        expect(manifest.status).toBe("fail");
+        expect(manifest.failure_class).toBe("wall_time_exceeded");
+        const children = manifest.children as Array<{ role: string; exit_code: number | null; timed_out?: boolean }>;
+        expect(children[0].role).toBe("worker");
+        expect(children[0].exit_code).toBe(124);
+        expect(children[0].timed_out).toBe(true);
+        // The worker never reached its own file write: the process was actually
+        // terminated at the deadline, not merely reported as failed after completing.
+        expect(existsSync(join(repo, "src/pilot.txt"))).toBe(false);
+        expect(existsSync(join(repo, "verifier-ran.txt"))).toBe(false);
+      } finally {
+        rmSync(repo, { recursive: true, force: true });
+      }
+    });
   });
 });

--- a/tests/plan-status-gate.test.ts
+++ b/tests/plan-status-gate.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { spawnSync } from 'child_process';
+
+// Edit-guard fixtures for the pre-edit-guard.sh fail-closed default branch
+// (2026-07-20 falsifier resolution): any plan status outside the single
+// authority -- .ai/harness/policy.json's active_plan.statuses array --
+// deterministically blocks implementation edits, while every status in that
+// array (including Blocked/Review, added by owner decision) behaves exactly
+// as before. Covers: malformed, empty, unrecognized, each known-good
+// status, and the missing-authority case (policy.json lacks the array).
+
+const ROOT = join(import.meta.dir, '..');
+const HOOK = join(ROOT, 'assets/hooks/pre-edit-guard.sh');
+const CLI = join(ROOT, 'src/cli/index.ts');
+
+// Mirrors .ai/harness/policy.json's active_plan.statuses (owner-decided
+// 13-value union: the 11-value code union plus Blocked and Review, which
+// live on three current real plans). Duplicated here deliberately as test
+// input data, not as a second guard authority -- the guard itself reads
+// only the scratch repo's own policy.json at runtime.
+const KNOWN_STATUSES = [
+  'Draft',
+  'Annotating',
+  'Approved',
+  'Executing',
+  'Blocked',
+  'Review',
+  'Complete',
+  'Completed',
+  'Done',
+  'Fulfilled',
+  'Archived',
+  'Abandoned',
+  'Superseded',
+];
+
+function git(cwd: string, args: string[]): void {
+  const result = spawnSync('git', args, { cwd, encoding: 'utf-8' });
+  if (result.status !== 0) throw new Error(result.stderr);
+}
+
+function initRepo(cwd: string, options: { withStatusesArray?: boolean } = {}): void {
+  const withStatusesArray = options.withStatusesArray ?? true;
+  git(cwd, ['init', '-b', 'main']);
+  git(cwd, ['config', 'user.email', 'plan-status-gate@example.com']);
+  git(cwd, ['config', 'user.name', 'Plan Status Gate Test']);
+  mkdirSync(join(cwd, '.ai/harness'), { recursive: true });
+  mkdirSync(join(cwd, 'docs'), { recursive: true });
+  mkdirSync(join(cwd, 'plans'), { recursive: true });
+  writeFileSync(join(cwd, '.ai/harness/workflow-contract.json'), '{}\n');
+  writeFileSync(
+    join(cwd, '.ai/harness/policy.json'),
+    JSON.stringify(
+      {
+        hook_source: 'repo',
+        worktree_strategy: { review_base: 'main', base_branch: 'main' },
+        ...(withStatusesArray ? { active_plan: { statuses: KNOWN_STATUSES } } : {}),
+      },
+      null,
+      2,
+    ),
+  );
+  writeFileSync(join(cwd, 'docs/spec.md'), '# Spec\n');
+  writeFileSync(join(cwd, 'README.md'), '# fixture\n');
+  git(cwd, ['add', '.']);
+  git(cwd, ['commit', '-m', 'seed']);
+}
+
+function writeActivePlan(cwd: string, status: string): string {
+  const plan = 'plans/plan-20260720-0000-gate-fixture.md';
+  writeFileSync(
+    join(cwd, plan),
+    ['# Gate Fixture', '', `> **Status**: ${status}`, ''].join('\n'),
+  );
+  writeFileSync(join(cwd, '.ai/harness/active-plan'), `${plan}\n`);
+  writeFileSync(join(cwd, '.ai/harness/active-worktree'), `${cwd}\n`);
+  return plan;
+}
+
+function preEdit(cwd: string, path: string, extraEnv: NodeJS.ProcessEnv = {}) {
+  return spawnSync('bash', [HOOK], {
+    cwd,
+    input: JSON.stringify({ tool_input: { file_path: path } }),
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      HOOK_REPO_ROOT: cwd,
+      REPO_HARNESS_CLI: CLI,
+      REPO_HARNESS_WORKFLOW_PROFILE: 'standard',
+      ...extraEnv,
+    },
+  });
+}
+
+describe('pre-edit-guard plan-status fail-closed default (falsifier-resolved authority)', () => {
+  test('malformed status blocks with a structured reason naming the status and plan file', () => {
+    const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'plan-status-malformed-')));
+    try {
+      initRepo(cwd);
+      const plan = writeActivePlan(cwd, '!!broken!!');
+      const result = preEdit(cwd, 'src/feature.ts');
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain('PlanStatusGuard');
+      expect(result.stderr).toContain('!!broken!!');
+      expect(result.stderr).toContain(plan);
+      expect(result.stderr).toContain('not in the known-status authority');
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test('empty status blocks with a structured reason', () => {
+    const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'plan-status-empty-')));
+    try {
+      initRepo(cwd);
+      const plan = 'plans/plan-20260720-0000-gate-fixture.md';
+      // No "> **Status**:" line at all: get_plan_status returns "".
+      writeFileSync(join(cwd, plan), ['# Gate Fixture', ''].join('\n'));
+      writeFileSync(join(cwd, '.ai/harness/active-plan'), `${plan}\n`);
+      writeFileSync(join(cwd, '.ai/harness/active-worktree'), `${cwd}\n`);
+      const result = preEdit(cwd, 'src/feature.ts');
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain('PlanStatusGuard');
+      expect(result.stderr).toContain(plan);
+      expect(result.stderr).toContain('not in the known-status authority');
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test('unrecognized (but plausible-looking) status blocks -- not just literal garbage', () => {
+    const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'plan-status-unrecognized-')));
+    try {
+      initRepo(cwd);
+      const plan = writeActivePlan(cwd, 'InProgress');
+      const result = preEdit(cwd, 'src/feature.ts');
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain('PlanStatusGuard');
+      expect(result.stderr).toContain('InProgress');
+      expect(result.stderr).toContain(plan);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test('casing variant of a known status is not byte-equal and blocks', () => {
+    const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'plan-status-casing-')));
+    try {
+      initRepo(cwd);
+      writeActivePlan(cwd, 'executing');
+      const result = preEdit(cwd, 'src/feature.ts');
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain('PlanStatusGuard');
+      expect(result.stderr).toContain('executing');
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test('missing plan file keeps the existing missing_artifact path unchanged', () => {
+    const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'plan-status-missing-plan-')));
+    try {
+      initRepo(cwd);
+      // Active-plan marker points at a plan file that does not exist.
+      writeFileSync(join(cwd, '.ai/harness/active-plan'), 'plans/plan-does-not-exist.md\n');
+      writeFileSync(join(cwd, '.ai/harness/active-worktree'), `${cwd}\n`);
+      const result = preEdit(cwd, 'src/feature.ts');
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain('PlanStatusGuard');
+      expect(result.stderr).toContain('without an active plan');
+      expect(result.stderr).not.toContain('not in the known-status authority');
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  describe('each known-good status', () => {
+    for (const status of KNOWN_STATUSES) {
+      test(`'${status}' behaves exactly as today`, () => {
+        const cwd = realpathSync(mkdtempSync(join(tmpdir(), `plan-status-known-${status.toLowerCase()}-`)));
+        try {
+          initRepo(cwd);
+          writeActivePlan(cwd, status);
+          const result = preEdit(cwd, 'src/feature.ts');
+          if (status === 'Draft' || status === 'Annotating') {
+            // Unchanged pre-existing behavior: still blocks, but via the
+            // original Draft/Annotating message, never the new
+            // "not in the known-status authority" reason.
+            expect(result.status).toBe(2);
+            expect(result.stderr).toContain('PlanStatusGuard');
+            expect(result.stderr).toContain(`plan status is ${status}`);
+            expect(result.stderr).not.toContain('not in the known-status authority');
+          } else {
+            // Every other known-good status passes through silently, same
+            // as before this package: no PlanStatusGuard block at all.
+            expect(result.status).toBe(0);
+            expect(result.stdout).not.toContain('PlanStatusGuard');
+            expect(result.stderr).not.toContain('PlanStatusGuard');
+          }
+        } finally {
+          rmSync(cwd, { recursive: true, force: true });
+        }
+      });
+    }
+  });
+
+  test('missing active_plan.statuses array is itself a fail-closed authority-unavailable condition', () => {
+    const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'plan-status-no-authority-')));
+    try {
+      initRepo(cwd, { withStatusesArray: false });
+      // Even a status that would otherwise be perfectly legitimate (Executing)
+      // must still block when the authority itself cannot be read: an
+      // unavailable authority is not "nothing to check against".
+      const plan = writeActivePlan(cwd, 'Executing');
+      const result = preEdit(cwd, 'src/feature.ts');
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain('PlanStatusGuard');
+      expect(result.stderr).toContain('policy.json');
+      expect(result.stderr).toContain('active_plan.statuses');
+      expect(result.stderr).not.toContain('not in the known-status authority');
+      expect(result.stderr).not.toContain(plan);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test('missing policy.json entirely is also fail-closed', () => {
+    const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'plan-status-no-policy-file-')));
+    try {
+      initRepo(cwd, { withStatusesArray: false });
+      rmSync(join(cwd, '.ai/harness/policy.json'));
+      writeActivePlan(cwd, 'Executing');
+      const result = preEdit(cwd, 'src/feature.ts');
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain('PlanStatusGuard');
+      expect(result.stderr).toContain('policy.json');
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test('advice mode reports the same unrecognized status without hard-blocking', () => {
+    const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'plan-status-advice-')));
+    try {
+      initRepo(cwd);
+      writeActivePlan(cwd, 'InProgress');
+      const result = preEdit(cwd, 'src/feature.ts', { REPO_HARNESS_EDIT_PLAN_GATE: 'advice' });
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('PlanStatusGuard');
+      expect(result.stdout).toContain('Advisory');
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/runtime-profile-enforcement.test.ts
+++ b/tests/runtime-profile-enforcement.test.ts
@@ -22,6 +22,16 @@ function initRepo(cwd: string): void {
   writeFileSync(join(cwd, '.ai/harness/workflow-contract.json'), '{}\n');
   writeFileSync(join(cwd, '.ai/harness/policy.json'), JSON.stringify({
     hook_source: 'repo', worktree_strategy: { review_base: 'main', base_branch: 'main' },
+    // Single known-status authority the plan-status fail-closed default
+    // branch reads (pre-edit-guard.sh's plan_status_known_values()); must
+    // be present so fixtures below can use a real, non-Draft/Annotating/
+    // Approved/Executing status without tripping "authority unavailable".
+    active_plan: {
+      statuses: [
+        'Draft', 'Annotating', 'Approved', 'Executing', 'Blocked', 'Review',
+        'Complete', 'Completed', 'Done', 'Fulfilled', 'Archived', 'Abandoned', 'Superseded',
+      ],
+    },
   }, null, 2));
   writeFileSync(join(cwd, 'README.md'), '# fixture\n');
   git(cwd, ['add', '.']);
@@ -116,10 +126,13 @@ describe('risk-based runtime profile enforcement', () => {
         // approved/executing with no contract file yet), which now fails
         // pre-edit-guard.sh closed via the generic WorkflowProfileGuard
         // before ever reaching the StrictContractGuard check this test wants
-        // to isolate. A status outside {Draft, Annotating, Approved,
-        // Executing} still passes PlanStatusGuard (only Draft/Annotating
-        // block) without also tripping missing_contract.
-        '# Strict', '', '> **Status**: InProgress', `> **Task Contract**: ${contract}`, '',
+        // to isolate. "Blocked" is a real status in the policy.json
+        // active_plan.statuses authority (not Draft/Annotating, so it still
+        // passes PlanStatusGuard's own case arm; not Approved/Executing, so
+        // it avoids missing_contract) -- unlike the plan's original
+        // "InProgress" placeholder, it also passes the fail-closed default
+        // branch instead of relying on that branch not existing yet.
+        '# Strict', '', '> **Status**: Blocked', `> **Task Contract**: ${contract}`, '',
         '## Evidence Contract', '- **State/progress path**: plan', '- **Verification evidence**: test',
         '- **Evaluator rubric**: review', '- **Stop condition**: pass', '- **Rollback surface**: revert', '',
       ].join('\n'));
@@ -277,14 +290,17 @@ describe('apply_patch batch-scope resolves the full pending write scope (guard g
       writeFileSync(join(cwd, 'docs/spec.md'), '# Spec\n');
       const plan = 'plans/plan-20260713-1300-batch-strict.md';
       writeFileSync(join(cwd, plan), [
-        // Status "InProgress" (not Executing/Approved), same reasoning as the
-        // "Strict high-risk paths" fixture above: avoids the state
-        // resolver's own missing_contract blocker so this test's specific
-        // assertion (src/plain1.ts named by StrictContractGuard, proving the
-        // batch-scope strict-token leak) is reachable and unambiguous, not
-        // masked by an unrelated, coincidental blocker that would fire
-        // regardless of whether the batch-scope fix under test works at all.
-        '# Batch Strict', '', '> **Status**: InProgress', '',
+        // Status "Blocked" (not Executing/Approved/Draft/Annotating), same
+        // reasoning as the "Strict high-risk paths" fixture above: avoids
+        // the state resolver's own missing_contract blocker AND passes the
+        // plan-status fail-closed default branch (it is a real status in
+        // the policy.json active_plan.statuses authority) so this test's
+        // specific assertion (src/plain1.ts named by StrictContractGuard,
+        // proving the batch-scope strict-token leak) is reachable and
+        // unambiguous, not masked by an unrelated, coincidental blocker
+        // that would fire regardless of whether the batch-scope fix under
+        // test works at all.
+        '# Batch Strict', '', '> **Status**: Blocked', '',
         '## Evidence Contract', '- **State/progress path**: plan', '- **Verification evidence**: test',
         '- **Evaluator rubric**: review', '- **Stop condition**: pass', '- **Rollback surface**: revert', '',
       ].join('\n'));

--- a/tests/state/loop-semantics-characterization.test.ts
+++ b/tests/state/loop-semantics-characterization.test.ts
@@ -252,6 +252,27 @@ function prepare(profile: Profile): ReturnType<typeof createEffectiveStateFixtur
   const fixture = createEffectiveStateFixture();
   writeFileSync(join(fixture.cwd, '.git/info/exclude'), '.home/\n', { flag: 'a' });
   writeFixture(fixture.cwd, 'docs/spec.md', '# Loop semantics characterization fixture\n');
+  // A properly adopted repo always carries the plan-status authority
+  // (.ai/harness/policy.json active_plan.statuses); without it the
+  // fail-closed edit gate blocks on authority-unavailable, which is not
+  // the semantics these cells freeze. Minimal policy: the authority only.
+  writeFixture(
+    fixture.cwd,
+    '.ai/harness/policy.json',
+    `${JSON.stringify(
+      {
+        active_plan: {
+          statuses: [
+            'Draft', 'Annotating', 'Approved', 'Executing', 'Blocked',
+            'Review', 'Complete', 'Completed', 'Done', 'Fulfilled',
+            'Archived', 'Abandoned', 'Superseded',
+          ],
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
   if (profile === 'strict') {
     // Ship receives explicit Strict metadata so its current profile-blind
     // result is compared against a genuinely distinct Standard input.


### PR DESCRIPTION
Standalone P0 correctness package from the GPT-5.6 prompt-guidance audit (slice 1), sequenced between HRD-02 and HRD-03. Execution base `8254b239`.

## What

- **Fail-closed plan-status authority.** New `active_plan.statuses` 13-value array in `.ai/harness/policy.json` is the single vocabulary authority (owner decision after the falsifier inventory found `Blocked`×2/`Review`×1 on real plans outside every code list); default emission added for newly initialized repos. `pre-edit-guard.sh` gains a fail-closed default branch: authority-unavailable → block, unknown status → block naming status+file, known statuses byte-equal pass-through. Prompt-layer `unknown` bucket moves from silent allow to conservative advisory (edit layer stays the hard gate).
- **Truthful runner constraints.** `wall_time_minutes` mechanically enforced via the bounded process runner (verified by an actual SIGTERM kill test); non-null `tokens` / non-`inherited` `network` / non-empty `writable_paths` rejected at preflight with named-constraint messages; `tool_calls` → `runner_invocations` one-shot rename failing closed on the legacy field, rippled across parser, templates, scaffold emitters, and doc mirrors (no alias).
- 21-fixture plan-status gate suite; contract-run rejection/enforcement suite; two test fixtures that deliberately exploited the old fail-open adapted with intent preserved.

## Behavior changes (deliberate, fixture-pinned)

Unknown/malformed plan status now blocks implementation edits; unenforceable declared constraints now fail preflight instead of parsing to no-ops; legacy `tool_calls` contracts fail closed (records not rewritten). HRD-01 characterization golden unchanged (structural reason documented).

## Verification

187 + 113 + 23 targeted tests 0 fail; `tests/cli/` sweep 431 pass; `check:type`/`check:hooks`/`check:helpers`/`check:state-boundaries` green; `verify-contract --strict` 16/16 Fulfilled; independent gatekeeper PASS with live probes (unknown status blocks, `Blocked` passes, empty-array blocks, wall-time kill). Three implementation rounds, two contract amendments, one owner decision — all recorded in the notes file.