### PR TITLE
fix(workflow): predict scratch clone nests checks evidence

### DIFF
--- a/assets/templates/helpers/archive-workflow.sh
+++ b/assets/templates/helpers/archive-workflow.sh
@@ -220,8 +220,12 @@ predict_archive_manifest() {
     git -C "$scratch_repo" update-ref "refs/heads/$target_branch" "refs/remotes/origin/$target_branch"
   fi
   if [[ -d .ai/harness/checks ]]; then
-    mkdir -p "$scratch_repo/.ai/harness"
-    cp -Rp .ai/harness/checks "$scratch_repo/.ai/harness/checks"
+    # The scratch clone materializes tracked files such as
+    # .ai/harness/checks/.gitkeep, so the destination directory may already
+    # exist; copy directory contents (src/.) so cp cannot nest a second
+    # checks/ level and hide the evidence from the replay.
+    mkdir -p "$scratch_repo/.ai/harness/checks"
+    cp -Rp .ai/harness/checks/. "$scratch_repo/.ai/harness/checks"
   fi
   for path in .ai/harness/active-plan .ai/harness/active-worktree; do
     if [[ -f "$path" ]]; then

--- a/scripts/archive-workflow.sh
+++ b/scripts/archive-workflow.sh
@@ -220,8 +220,12 @@ predict_archive_manifest() {
     git -C "$scratch_repo" update-ref "refs/heads/$target_branch" "refs/remotes/origin/$target_branch"
   fi
   if [[ -d .ai/harness/checks ]]; then
-    mkdir -p "$scratch_repo/.ai/harness"
-    cp -Rp .ai/harness/checks "$scratch_repo/.ai/harness/checks"
+    # The scratch clone materializes tracked files such as
+    # .ai/harness/checks/.gitkeep, so the destination directory may already
+    # exist; copy directory contents (src/.) so cp cannot nest a second
+    # checks/ level and hide the evidence from the replay.
+    mkdir -p "$scratch_repo/.ai/harness/checks"
+    cp -Rp .ai/harness/checks/. "$scratch_repo/.ai/harness/checks"
   fi
   for path in .ai/harness/active-plan .ai/harness/active-worktree; do
     if [[ -f "$path" ]]; then


### PR DESCRIPTION
## Summary

- `archive-workflow.sh --predict-manifest` clones the candidate into a scratch repo whose checkout already materializes the tracked `.ai/harness/checks/.gitkeep`, so `cp -Rp .ai/harness/checks <dst>` nested the evidence into `checks/checks/` and the replay failed closed with "Structured checks file is missing or empty"
- deterministic since the freeze-before-archive merge gate landed in #91; it blocks every `contract-worktree finish --gate-base` run and ship-worktrees pr mode (HRD-09 shipped around it via plain `--no-merge` plus a manual installed-helper seal)
- fix: copy directory contents (`src/.`) into an ensured destination, in both the live script and the product template mirror

## Verification

- reproduced the exact failure shape (scratch clone with materialized `.gitkeep`): before the fix the copy lands in `checks/checks/latest.json`; after the fix `latest.json` is flat and readable, no nested directory
- `bash -n` on both copies; `cmp` confirms script/template parity
- `bun test tests/scaffold-parity.test.ts tests/workflow-contract.test.ts tests/bootstrap-files.test.ts`: 30 pass, 0 fail