### PR TITLE
Close HRD lifecycle ledger

### DIFF
--- a/plans/plan-20260721-2104-hrd-sprint-closeout.md
+++ b/plans/plan-20260721-2104-hrd-sprint-closeout.md
@@ -1,0 +1,260 @@
+# Plan: HRD Sprint Closeout
+
+> **Status**: Executing
+> **Created**: 20260721-2104
+> **Slug**: hrd-sprint-closeout
+> **Planning Source**: repo-harness-plan
+> **Orchestration Kind**: host-plan
+> **Source Ref**: (none)
+> **Artifact Level**: work-package
+> **Promotion Reason**: verification_boundary
+> **Verification Boundary**: Close the nine-row HRD sprint and preserve historical review bytes before pinning the post-closeout merge SHA for VGBR.
+> **Rollback Surface**: Revert only the closeout PR; runtime, tests, benchmark evidence, and archived HRD reviews remain unchanged.
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260721-2104-hrd-sprint-closeout.contract.md`
+> **Task Review**: `tasks/reviews/20260721-2104-hrd-sprint-closeout.review.md`
+> **Implementation Notes**: `tasks/notes/20260721-2104-hrd-sprint-closeout.notes.md`
+
+## Agentic Routing
+- Selected route: execution
+- Routing reason: Captured from repo-harness-plan planning output.
+- Source ref: (none)
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260721-2104-hrd-sprint-closeout.md`
+- Sprint contract: `tasks/contracts/20260721-2104-hrd-sprint-closeout.contract.md`
+- Sprint review: `tasks/reviews/20260721-2104-hrd-sprint-closeout.review.md`
+- Implementation notes: `tasks/notes/20260721-2104-hrd-sprint-closeout.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260721-2104-hrd-sprint-closeout.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260721-2104-hrd-sprint-closeout.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260721-2104-hrd-sprint-closeout.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260721-2104-hrd-sprint-closeout.contract.md`
+- Review file: `tasks/reviews/20260721-2104-hrd-sprint-closeout.review.md`
+- Implementation notes file: `tasks/notes/20260721-2104-hrd-sprint-closeout.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260721-2104-hrd-sprint-closeout.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260721-2104-hrd-sprint-closeout.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: Revert only the closeout PR; runtime, tests, benchmark evidence, and archived HRD reviews remain unchanged.
+- **Verification boundary**: Close the nine-row HRD sprint and preserve historical review bytes before pinning the post-closeout merge SHA for VGBR.
+- **Review/acceptance boundary**: `tasks/reviews/20260721-2104-hrd-sprint-closeout.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: verification_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260721-2104-hrd-sprint-closeout.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260721-2104-hrd-sprint-closeout.contract.md`, `tasks/reviews/20260721-2104-hrd-sprint-closeout.review.md`, and `tasks/notes/20260721-2104-hrd-sprint-closeout.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260721-2104-hrd-sprint-closeout.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: Revert only the closeout PR; runtime, tests, benchmark evidence, and archived HRD reviews remain unchanged.
+
+## Captured Planning Output
+
+> **Task Profile**: ledger-closeout
+
+## Decision Summary
+
+Close the already-merged Hook Runtime Diet sprint without changing runtime,
+tests, benchmark data, or historical review text. The current implementation
+merge is `b5a98c903d3728002d2f663ba7a1b421913e368f` (PR #106), named
+`HRD_RUNTIME_SHA`. This package does not predict or write its own merge SHA.
+After the HRD-CLOSEOUT PR merges, the VGBR successor must fresh-fetch
+`origin/main`, pin that exact merge commit as `POST_HRD_SHA`, and keep `main`
+frozen through VGBR benchmark acceptance, including against docs-only merges.
+
+## Why
+
+HRD-01 through HRD-09 are merged and every backlog row is checked, but the
+canonical sprint header still says `Approved`. HRD-08 and HRD-09 archived
+reviews also retain historically accurate pre-merge pending language. Leaving
+the sprint open makes EPC activation ambiguous; rewriting the archived reviews
+would falsify history. This package closes only the lifecycle ledger and adds
+an append-only supersession annotation outside the archived reviews.
+
+## Goal
+
+- Set the canonical Hook Runtime Diet sprint status to `Done`.
+- Record `HRD_RUNTIME_SHA` as PR #106's immutable merge commit.
+- Freeze the successor-pinned SHA rule: a package records the exact base it
+  consumes and never predicts its own merge SHA; VGBR fresh-fetches and pins
+  the HRD-CLOSEOUT merge commit as `POST_HRD_SHA`.
+- Add one append-only historical-review supersession annotation in this
+  package's notes; do not edit either archived review.
+- Establish the strict serial dependency:
+  `HRD-CLOSEOUT merge -> POST_HRD_SHA pin/freeze -> VGBR-R -> EPC-00 -> EPC-01`.
+
+## P1: Architecture Map
+
+- Effective State and Loop Semantics are fixed predecessor authorities.
+- Hook Runtime Diet is an already-landed runtime implementation surface.
+- This package owns only the HRD sprint lifecycle projection and its own
+  workflow artifacts.
+- VGBR owns the next authoritative benchmark; EPC and SSD remain no-touch.
+- The parallel BDD2 package is a separate Program slice. Its plan, contract,
+  review, notes, todos, source, tests, and generated projections are forbidden.
+- BDD2 may continue development in its own worktree. Once HRD-CLOSEOUT merges,
+  benchmark subject quiescence forbids merging BDD2 or any other change into
+  `main` until VGBR acceptance.
+
+## P2: Concrete Trace
+
+`origin/main@b5a98c90` proves PR #106 merged -> the HRD sprint shows 9/9 rows
+complete -> this closeout changes the sprint lifecycle to `Done` -> its notes
+append a supersession annotation that points at, but does not mutate, the two
+archived reviews -> closeout PR merges -> the merge commit becomes
+the candidate post-HRD baseline -> VGBR fresh-fetches `origin/main`, pins that
+exact commit as `POST_HRD_SHA`, and consumes it under a frozen main.
+
+## P3: Design Decision
+
+- Preserve archived review bytes as historical evidence.
+- Add a new deterministic annotation rather than rewriting old conclusions.
+- Use one docs/workflow-only PR because sprint status is an independent
+  lifecycle and rollback boundary.
+- Do not reproduce full-suite, semantic, provider, or benchmark evidence for an
+  unchanged runtime subject.
+- Apply the Program-wide successor-pinned SHA rule; this package cannot and
+  does not backfill its own merge SHA.
+- No compatibility, fallback, alias, dual authority, or shadow projection.
+
+## Scope
+
+In scope:
+
+- `plans/sprints/20260719-1531-hook-runtime-diet.sprint.md`
+- This package's plan, contract, review, and notes.
+- Provider-free workflow/contract/merge-seal evidence for this exact docs
+  subject.
+
+Out of scope:
+
+- Existing HRD-08/HRD-09 archived review, contract, plan, and notes bytes.
+- `tasks/current.md`, `tasks/todos.md`, and every BDD2 artifact.
+- `src/`, `tests/`, `assets/`, `.ai/hooks/`, benchmark reports or runner.
+- VGBR execution, EPC canonicalization/implementation, SSD activation.
+- Full `bun test`, provider review, authoritative benchmark, publish or deploy.
+
+## Falsifier
+
+The direction is wrong if closing the sprint requires changing runtime behavior,
+historical review bytes, benchmark evidence, or any path outside the exact
+allowlist. Cheapest proof: hash both archived reviews before editing and prove
+the hashes are unchanged in the final diff.
+
+## Cheapest Sufficient Proof
+
+- Assert worktree `HEAD == captured base == origin/main@b5a98c90` at start.
+- Contract preflight and strict workflow gate pass.
+- `git diff --check` passes and every changed path is in the exact allowlist.
+- Both archived review hashes remain unchanged.
+- Sprint status is `Done`, all nine rows remain checked, and the closeout notes
+  contain the ordered supersession annotation.
+- Provider-free merge-gate seal passes after docs freeze.
+
+## Concurrency and Ownership
+
+- User explicitly authorizes this package to run in parallel with BDD2 because
+  actual file ownership is disjoint.
+- Do not edit BDD2's plan, contract, review, notes, todos, code, tests, assets,
+  or external Skill surface.
+- Stop if either writer requires any file owned by the other package.
+- Stop on `origin/main` drift before closeout evidence is frozen.
+- After closeout merge, BDD2 development may continue only off-main; any merge
+  is blocked until VGBR accepts the frozen subject.
+
+## Stop Conditions
+
+- Any required edit outside the exact contract `allowed_paths`.
+- Any mutation to the archived HRD-08 or HRD-09 review files.
+- Any runtime/test/benchmark change or request to rerun expensive evidence.
+- Any BDD2 path overlap.
+- Any base drift, subject drift after acceptance, or merge-gate mismatch.
+- More than three fail-fix-reverify rounds for one issue.
+
+## Verification and Acceptance
+
+- Task profile: `ledger-closeout`.
+- Evidence requirement: `benchmark: not_applicable`.
+- One semantic reviewer is frozen in the contract; review Markdown remains a
+  projection, not authority.
+- Verification is limited to contract/workflow checks, hash preservation,
+  diff scope, architecture/task consistency as applicable, and merge gate.
+- Merge authorization is separate from semantic acceptance.
+
+## Rollback
+
+Revert the HRD-CLOSEOUT PR. This restores only the prior sprint lifecycle
+projection and removes the new annotation; runtime, tests, receipts, and
+historical archived reviews remain unchanged.
+
+## Approved Execution Checklist
+
+- [ ] Capture the approved ledger-closeout plan in an isolated worktree rooted
+      at exact `origin/main@b5a98c90`.
+- [ ] Calibrate and preflight the generated contract before lifecycle edits.
+- [ ] Set HRD sprint `Status` to `Done` and add closeout dependency metadata.
+- [ ] Add the append-only historical-review supersession annotation to the new
+      closeout notes without mutating historical review bytes.
+- [ ] Run the cheapest sufficient workflow, scope, hash, and merge-gate checks.
+- [ ] Commit, push, open and merge an independent PR.
+- [ ] After merge, require VGBR to fresh-fetch and pin the actual closeout
+      merge as `POST_HRD_SHA`; freeze main until VGBR acceptance.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [x] Capture the approved ledger-closeout plan in an isolated worktree rooted at exact `origin/main@b5a98c90`.
+- [x] Calibrate and preflight the generated contract before lifecycle edits.
+- [x] Set HRD sprint `Status` to `Done` and add closeout dependency metadata.
+- [x] Add the append-only historical-review supersession annotation to the new closeout notes without mutating historical review bytes.
+- [ ] Run the cheapest sufficient workflow, scope, hash, and merge-gate checks.
+- [ ] Commit, push, open and merge an independent PR.
+- [ ] After merge, require VGBR to fresh-fetch and pin the actual closeout merge as `POST_HRD_SHA`; freeze main until VGBR acceptance.

--- a/plans/sprints/20260719-1531-hook-runtime-diet.sprint.md
+++ b/plans/sprints/20260719-1531-hook-runtime-diet.sprint.md
@@ -1,9 +1,9 @@
 # Sprint: Hook Runtime Diet
 
-> **Status**: Approved
+> **Status**: Done
 > **Slug**: hook-runtime-diet
 > **Created**: 2026-07-19 15:31
-> **Updated**: 2026-07-21 20:35
+> **Updated**: 2026-07-21 21:07
 > **Source PRD**: (none; source authority is the Harness Loop audit)
 > **Source Audit**: `plans/sprints/20260715-harness-loop-audit-and-optimization.md`
 > **Source Spec**: `docs/spec.md`
@@ -13,6 +13,9 @@
 > **Sprint Planning Base**: `origin/main@2c39c4a46c83c604fc9ce2fe2752a79d93edbddc` (live at drafting time; includes post-LSC mainline packages #91-#93 and 0.10.1 release prep, which HRD builds on)
 > **HRD-01 Execution Base**: `origin/main@4f4666efd3810ed50dd1d5da17e44fd721d84689` (post-sprint-planning push)
 > **HRD-02 Execution Base**: origin/main@b57d6323fb8ba6a0edb55117abaf9953913d9ddf (post-HRD-01 merge plus backfill)
+> **HRD_RUNTIME_SHA**: `origin/main@b5a98c903d3728002d2f663ba7a1b421913e368f` (PR #106; HRD-01 through HRD-09 merged)
+> **Closeout Package**: `plans/plan-20260721-2104-hrd-sprint-closeout.md`
+> **POST_HRD_SHA Owner**: the VGBR successor fresh-fetches after HRD-CLOSEOUT merges and pins that exact `origin/main`; this package never predicts its own merge SHA
 > **Predecessor**: Loop Semantics Convergence (Sprint A). Its semantic modules — `ArtifactRequirementPolicy`, `evaluateReadiness`, the authority/subject/evidence/projection revision partition, the progress token, stable state-version allocation, and the Stop readiness cutover — are fixed inputs to this sprint, not change surfaces
 > **Successor Order**: Evidence & Projection Convergence -> Skill Surface & Discovery Convergence
 > **Goal Mode**: incremental
@@ -298,3 +301,16 @@ flow and lands through an independent PR.
 | 2026-07-21 05:33 | hrd-07-circuit-oscillation-and-shared-lock | `plans/plan-20260721-0218-hrd-07-circuit-oscillation-and-shared-lock.md` | done |
 | 2026-07-21 17:46 | hrd-08-event-telemetry-and-benchmark | `plans/archive/plan-20260721-1621-hrd-08-event-telemetry-and-benchmark.md` | done |
 | 2026-07-21 20:35 | hrd-09-legacy-retirement-and-adopted-migration | `plans/archive/plan-20260721-1801-hrd-09-legacy-retirement-and-adopted-migration.md` | done |
+
+## Sprint Closeout
+
+- lifecycle_status: Done
+- hrd_runtime_sha: `b5a98c903d3728002d2f663ba7a1b421913e368f`
+- implementation_merge_pr: `#106`
+- backlog_result: `9/9`
+- historical_review_supersession_annotation: `tasks/notes/20260721-2104-hrd-sprint-closeout.notes.md#historical-closeout-annotation`
+- historical_review_text_mutation: none
+- successor_pinned_sha_rule: package records the base it consumes and never predicts its own merge SHA
+- post_hrd_sha_owner: VGBR successor after fresh fetch of merged `origin/main`
+- serial_successor: `POST_HRD_SHA pin and main freeze -> VGBR-R -> EPC-00 -> EPC-01`
+- freeze_rule: no merge, including docs-only, from HRD-CLOSEOUT merge through VGBR benchmark acceptance

--- a/tasks/contracts/20260721-2104-hrd-sprint-closeout.contract.md
+++ b/tasks/contracts/20260721-2104-hrd-sprint-closeout.contract.md
@@ -1,0 +1,192 @@
+# Task Contract: hrd-sprint-closeout
+
+> **Status**: Fulfilled
+> **Plan**: plans/plan-20260721-2104-hrd-sprint-closeout.md
+> **Task Profile**: ledger-closeout
+> **Workflow Profile**: strict
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: kito
+> **Capability ID**: root
+> **Last Updated**: 2026-07-21 21:04
+> **Review File**: `tasks/reviews/20260721-2104-hrd-sprint-closeout.review.md`
+> **Notes File**: `tasks/notes/20260721-2104-hrd-sprint-closeout.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+HRD-01 through HRD-09 are merged and the canonical backlog is 9/9 complete,
+but the Hook Runtime Diet sprint header remains `Approved`. That leaves the
+Program transition into VGBR/EPC ambiguous. The HRD-08 and HRD-09 archived
+reviews also retain historically accurate pre-merge pending language; changing
+those archived bytes would falsify history. This package closes only the
+lifecycle ledger and records the later superseding merge fact in a new
+append-only annotation.
+
+## Goal
+
+Set the canonical Hook Runtime Diet sprint to `Done`, record PR #106's immutable
+implementation merge as `HRD_RUNTIME_SHA`, and preserve both archived review
+files byte-for-byte. This package must not predict or write its own merge SHA.
+After merge, the next VGBR contract must fresh-fetch `origin/main`, pin the
+actual HRD-CLOSEOUT merge commit as `POST_HRD_SHA`, and consume that exact SHA
+while `main` remains frozen through benchmark acceptance.
+
+## Scope
+
+- In scope:
+  - `plans/sprints/20260719-1531-hook-runtime-diet.sprint.md`: status and
+    append-only closeout metadata only.
+  - This package's plan, contract, notes, and review.
+  - Provider-free contract/workflow/scope/hash/merge-seal evidence.
+- Out of scope:
+  - Any edit to the archived HRD-08 or HRD-09 review, plan, contract, or notes.
+  - `tasks/current.md`, `tasks/todos.md`, and every BDD2 artifact.
+  - Runtime `src/`, tests, hooks, assets, benchmark runner/reports, VGBR
+    execution, EPC canonicalization/implementation, and SSD activation.
+  - Full `bun test`, provider review, authoritative benchmark, publish, deploy,
+    or any compatibility/fallback path.
+- Taste constraints: preserve historical evidence; add the smallest explicit
+  lifecycle projection and fixed-order annotation needed to close HRD.
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+- Stop if either archived review hash changes from the frozen values below.
+- Stop on any BDD2 path overlap, runtime/test/benchmark edit, or compatibility
+  request.
+- Stop if `origin/main` moves before the closeout subject and local merge seal
+  are frozen.
+- After closeout merge, fail closed on any `main` merge until VGBR acceptance;
+  BDD2 may continue development only in its independent worktree.
+- Stop after three fail-fix-reverify rounds for one issue.
+
+## Falsifier
+
+The direction is wrong if sprint closeout requires changing runtime behavior,
+benchmark evidence, historical review bytes, or any path outside the exact
+allowlist. Cheapest proof: hash the two archived reviews before lifecycle edits
+and require the same hashes at final verification.
+
+## Root Cause Evidence
+
+Not applicable: this is a `ledger-closeout`, not a bugfix.
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260721-2104-hrd-sprint-closeout.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260721-2104-hrd-sprint-closeout.review.md`
+- Notes file: `tasks/notes/20260721-2104-hrd-sprint-closeout.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Acceptance Policy
+
+```json
+{"protocol":1,"reviewer":"Codex","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - plans/plan-20260721-2104-hrd-sprint-closeout.md
+  - plans/sprints/20260719-1531-hook-runtime-diet.sprint.md
+  - tasks/contracts/20260721-2104-hrd-sprint-closeout.contract.md
+  - tasks/reviews/20260721-2104-hrd-sprint-closeout.review.md
+  - tasks/notes/20260721-2104-hrd-sprint-closeout.notes.md
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: 1
+    wall_time_minutes: 30
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+      - codex-exec
+      - main-thread
+    fallback: main-thread
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - plans/plan-20260721-2104-hrd-sprint-closeout.md
+    - plans/sprints/20260719-1531-hook-runtime-diet.sprint.md
+    - tasks/contracts/20260721-2104-hrd-sprint-closeout.contract.md
+    - tasks/reviews/20260721-2104-hrd-sprint-closeout.review.md
+    - tasks/notes/20260721-2104-hrd-sprint-closeout.notes.md
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260721-2104-hrd-sprint-closeout.notes.md
+  tests_pass:
+  commands_succeed:
+    - repo-harness run check-task-workflow --strict
+    - git diff --check
+    - test "$(shasum -a 256 tasks/archive/review-20260721-1746-hrd-08-event-telemetry-and-benchmark.md | awk '{print $1}')" = "5b4a91d186fd02b38dac4618a48a38fc016840a961e1a057918e8e8dcf8c25f9"
+    - test "$(shasum -a 256 tasks/archive/review-20260721-2035-hrd-09-legacy-retirement-and-adopted-migration.md | awk '{print $1}')" = "54e2d4ddf9c4c3b2b1538d0d7b5259f02c6d60322975a3de533d4feb0b0917ed"
+  qa_scores:
+    - dimension: functionality
+      min: 9
+    - dimension: code quality
+      min: 9
+  manual_checks:
+    - "HRD sprint Status is Done and all nine backlog rows remain checked"
+    - "Historical Closeout Annotation records PR #106 without rewriting archived review text"
+    - "Changed paths are exactly the sprint plus this package's four workflow artifacts"
+    - "HRD_RUNTIME_SHA is b5a98c90, this package does not predict its merge SHA, and VGBR must successor-pin POST_HRD_SHA after fresh fetch"
+```
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior: no runtime behavior changes; HRD lifecycle becomes Done.
+- Edge cases: archived pending prose remains historical and is superseded only
+  through the new annotation.
+- Regression risks: `origin/main` movement after closeout merge invalidates the
+  VGBR start gate; main must freeze until VGBR benchmark acceptance. BDD2 may
+  continue off-main but cannot merge during that quiescence window.
+
+## Rollback Point
+
+- Commit / checkpoint: implementation merge
+  `b5a98c903d3728002d2f663ba7a1b421913e368f`; closeout merge SHA is assigned
+  only after the PR merges.
+- Revert strategy: revert only the HRD-CLOSEOUT PR. Runtime, tests, benchmark
+  evidence, receipts, and archived HRD reviews remain unchanged.

--- a/tasks/notes/20260721-2104-hrd-sprint-closeout.notes.md
+++ b/tasks/notes/20260721-2104-hrd-sprint-closeout.notes.md
@@ -1,0 +1,74 @@
+# Implementation Notes: hrd-sprint-closeout
+
+> **Status**: Active
+> **Plan**: plans/plan-20260721-2104-hrd-sprint-closeout.md
+> **Contract**: tasks/contracts/20260721-2104-hrd-sprint-closeout.contract.md
+> **Review**: tasks/reviews/20260721-2104-hrd-sprint-closeout.review.md
+> **Last Updated**: 2026-07-21 21:04
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- Close the sprint through a separate `ledger-closeout` package because the
+  lifecycle projection is an independent verification and rollback boundary.
+- Preserve both archived review files byte-for-byte. Their pre-merge pending
+  language is historical evidence, not text to normalize after the fact.
+- Name PR #106's implementation merge `HRD_RUNTIME_SHA`. Do not predict or
+  backfill this package's own merge SHA; the VGBR successor fresh-fetches
+  `origin/main` and pins the actual HRD-CLOSEOUT merge as `POST_HRD_SHA`.
+- Freeze `main` after the closeout merge until VGBR benchmark acceptance.
+- BDD2 may continue in its independent worktree during that window, but no
+  BDD2 or other merge may change the frozen VGBR subject.
+
+## Historical Closeout Annotation
+
+- annotation_kind: historical_review_supersession
+- target_artifacts:
+  - `tasks/archive/review-20260721-1746-hrd-08-event-telemetry-and-benchmark.md`
+  - `tasks/archive/review-20260721-2035-hrd-09-legacy-retirement-and-adopted-migration.md`
+- frozen_artifact_sha256:
+  - `5b4a91d186fd02b38dac4618a48a38fc016840a961e1a057918e8e8dcf8c25f9`
+  - `54e2d4ddf9c4c3b2b1538d0d7b5259f02c6d60322975a3de533d4feb0b0917ed`
+- historical_text_mutation: none
+- superseding_fact: PR #106 merged to `origin/main`
+- superseding_merge_sha: `b5a98c903d3728002d2f663ba7a1b421913e368f`
+- effective_base: `origin/main@b5a98c903d3728002d2f663ba7a1b421913e368f`
+- hrd_runtime_sha: `b5a98c903d3728002d2f663ba7a1b421913e368f`
+- successor_pinned_sha_rule: package records consumed base and never predicts its own merge SHA
+- post_hrd_sha_owner: VGBR successor after fresh fetch of merged `origin/main`
+- serial_successor: `POST_HRD_SHA pin and main freeze -> VGBR-R -> EPC-00 -> EPC-01`
+- supersession_statement: The archived review lifecycle and pending wording remain historical; current HRD implementation delivery is superseded by the PR #106 merge fact, while Program closeout becomes authoritative only when the HRD-CLOSEOUT PR merges.
+
+## Deviations From Plan Or Spec
+
+- None recorded.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| Rewrite archived review status/receipt prose | Rejected | It would overwrite the historical lifecycle view and make the archive narrate facts unavailable at review time. |
+| Append annotation inside each archived review | Rejected | It would still mutate frozen historical evidence. |
+| Add one closeout-owned annotation and point to it from the sprint | Selected | It preserves archive bytes and gives the current Program an explicit superseding fact. |
+| Predict or backfill this package's merge SHA | Rejected | A package cannot know its own merge commit; the first successor pins the exact merged base. |
+
+## Open Questions
+
+- None.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- HRD implementation merge: `b5a98c903d3728002d2f663ba7a1b421913e368f`
+- Frozen review hashes: recorded under `## Historical Closeout Annotation`.
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/reviews/20260721-2104-hrd-sprint-closeout.review.md
+++ b/tasks/reviews/20260721-2104-hrd-sprint-closeout.review.md
@@ -1,0 +1,136 @@
+# Task Review: hrd-sprint-closeout
+
+> **Status**: Reviewed
+> **Plan**: plans/plan-20260721-2104-hrd-sprint-closeout.md
+> **Contract**: tasks/contracts/20260721-2104-hrd-sprint-closeout.contract.md
+> **Notes File**: tasks/notes/20260721-2104-hrd-sprint-closeout.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-07-21 21:16 +0800
+> **Recommendation**: pass
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pass; typed AcceptanceReceipt remains the final local gate.
+- Change type: ledger-closeout.
+- Intended files changed: the canonical HRD sprint plus this package's plan,
+  contract, review, and notes.
+- Actual files changed: exactly those five allowed paths; no BDD2,
+  `tasks/current.md`, `tasks/todos.md`, runtime, test, hook, asset, benchmark, or
+  archived-review path changed.
+- Commands passed: contract preflight, `check-task-workflow --strict`,
+  `git diff --check`, frozen archive-review hash checks, and exact 9/9 backlog
+  inspection.
+- Residual risks: `main` drift after closeout merge would invalidate VGBR's
+  baseline; BDD2 can continue off-main but cannot merge during subject
+  quiescence.
+- Reviewer action required: record one subject-bound Codex AcceptanceReceipt,
+  then run the provider-free final verification and merge seal.
+- Rollback: revert only the HRD-CLOSEOUT PR; runtime and archived evidence are
+  unchanged.
+
+## Mode Evidence
+
+- Selected route: independent `ledger-closeout` work-package in the isolated
+  `codex/hrd-sprint-closeout` worktree.
+- P1/P2/P3 evidence: the plan maps the already-landed HRD runtime authority,
+  traces PR #106 through sprint reconciliation into the successor-pinned VGBR
+  gate, and selects append-only annotation over historical rewrite.
+- Root cause or plan evidence: all nine HRD rows and their execution log are
+  complete, while the canonical sprint header remained `Approved`.
+
+## Verification Evidence
+
+- Waza `/check` run: equivalent independent read-only gate completed twice; the
+  final gate found no subject defect and identified only the then-pending review
+  projection as a gated-auto blocker.
+- Commands run: `repo-harness run contract-run preflight --contract
+  tasks/contracts/20260721-2104-hrd-sprint-closeout.contract.md --repo .
+  --json`; `repo-harness run check-task-workflow --strict`; `git diff --check`;
+  both contract-frozen `shasum -a 256` assertions.
+- Manual checks: all four exact contract criteria are checked below.
+- Supporting artifacts: the canonical HRD sprint closeout section and
+  `tasks/notes/20260721-2104-hrd-sprint-closeout.notes.md`.
+- Implementation notes reviewed: yes.
+- Run snapshot: provider-free docs/workflow evidence only; full `bun test` and
+  the authoritative benchmark were correctly not run for this unchanged
+  runtime subject.
+
+## Manual Check Evidence
+
+- [x] HRD sprint Status is Done and all nine backlog rows remain checked
+  - Evidence: sprint header is `Done`; backlog contains exactly nine checked
+    rows and the execution log retains nine done entries.
+- [x] Historical Closeout Annotation records PR #106 without rewriting archived review text
+  - Evidence: the annotation lives only in this package's notes; frozen HRD-08
+    and HRD-09 SHA-256 values remain respectively `5b4a91d1...` and
+    `54e2d4dd...`, with no diff in either archive file.
+- [x] Changed paths are exactly the sprint plus this package's four workflow artifacts
+  - Evidence: `git status --short` lists only the sprint and the package plan,
+    contract, review, and notes, matching `allowed_paths` exactly.
+- [x] HRD_RUNTIME_SHA is b5a98c90, this package does not predict its merge SHA, and VGBR must successor-pin POST_HRD_SHA after fresh fetch
+  - Evidence: plan, contract, sprint, and notes consistently name
+    `b5a98c903d3728002d2f663ba7a1b421913e368f` as `HRD_RUNTIME_SHA`; the VGBR
+    successor owns the fresh-fetch pin after closeout merge.
+
+## Acceptance Receipt Projection
+
+> **Disposition**: external_pass
+> **Reviewer**: Codex
+> **Source**: codex-review
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: sha256:8a48a87d4183098e73ae4f89c74fed8f1767410bd1f5272e245d4ec977b74183
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: b5a98c903d3728002d2f663ba7a1b421913e368f
+> **Verification Evidence SHA256**: sha256:b2793e0ae1e5bd8466500528aa83b1eb676e8dd56fb3706f3ff720966c4a7682
+> **Issued At**: 2026-07-21T13:24:49.091Z
+
+- Summary: Independent read-only gate accepted the fulfilled HRD ledger-only closeout; exact scope, archive hashes, successor-pinned SHA rule, and BDD2 quiescence boundary pass.
+- Findings: none
+
+## Behavior Diff Notes
+
+- HRD runtime behavior and benchmark evidence do not change.
+- The canonical sprint lifecycle moves from `Approved` to `Done` after all nine
+  already-complete work-packages.
+- A new closeout-owned annotation supersedes stale lifecycle narration without
+  editing archived review bytes.
+- SHA ownership is explicit: this package records `HRD_RUNTIME_SHA`; VGBR pins
+  `POST_HRD_SHA` only after fresh-fetching the merged closeout base.
+
+## Residual Risks / Follow-ups
+
+- No other PR, including docs-only or BDD2, may merge after HRD-CLOSEOUT until
+  VGBR acceptance; otherwise the pinned benchmark subject drifts.
+- VGBR must use an orchestration worktree plus a clean detached subject
+  checkout and the canonical `no-harness / adaptive-lite / strict-harness`
+  3x9 matrix; this is successor scope, not a closeout change.
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 9/10 | Canonical HRD lifecycle and successor SHA ownership are reconciled without runtime change. |
+| Product depth | 9/10 | The closeout distinguishes runtime merge fact, historical review evidence, and successor-pinned Program baseline. |
+| Design quality | 9/10 | One new annotation preserves archive immutability and avoids self-referential SHA backfill. |
+| Code quality | 9/10 | Exact allowlist, strict workflow, diff hygiene, and frozen artifact hashes pass. |
+
+## Failing Items
+
+- None in the reviewed subject. Typed receipt, merge gate, hosted PR checks,
+  and merge are the remaining closeout operations.
+
+## Retest Steps
+
+- Re-run: contract/workflow/hash/diff checks only if a closeout artifact changes.
+- Re-check: do not run product tests or the authoritative benchmark unless a
+  runtime or benchmark subject path changes.
+
+## Summary
+
+- Pass for HRD-CLOSEOUT. The five-file ledger-only subject truthfully closes
+  the completed HRD sprint, preserves historical bytes, and establishes the
+  successor-pinned VGBR boundary without compatibility or duplicate authority.


### PR DESCRIPTION
## Summary
- mark Hook Runtime Diet Done after HRD-01..09 landed in PR #106
- preserve HRD-08/09 archived reviews byte-for-byte and append a closeout-owned supersession annotation
- separate HRD_RUNTIME_SHA from successor-pinned POST_HRD_SHA
- freeze main after merge until VGBR acceptance; BDD2 may continue off-main but cannot merge during quiescence

## Verification
- contract preflight PASS
- verify-contract 19/19 PASS (Fulfilled)
- typed Codex external_pass receipt recorded
- check-task-workflow --strict PASS
- git diff --check PASS
- archived HRD-08/09 hashes unchanged
- full bun test and authoritative benchmark intentionally not run for this ledger-only subject

## Current gate
Draft until workflow finish can archive lifecycle artifacts without overlapping the active BDD2 writer on tasks/todos.md. No merge to main is authorized before that ownership is released and the merge seal passes.