### PR TITLE
fix(workflow): align acceptance recorder subject target with review_base

### DIFF
--- a/.ai/hooks/.projection.json
+++ b/.ai/hooks/.projection.json
@@ -3,6 +3,6 @@
   "canonical_root": "assets/hooks",
   "projection_target": ".ai/hooks",
   "manifest": "assets/hooks/projection.json",
-  "digest": "sha256:983ccd089547270123bde74ff0578b04e773b4f96efdc25047c40e55f68bdba1",
+  "digest": "sha256:efd7870eb4c60034a40606df306501bf8490b8d2c4db20a49f40a6ef3faf1ac9",
   "file_count": 3
 }

--- a/.ai/hooks/lib/workflow-state.sh
+++ b/.ai/hooks/lib/workflow-state.sh
@@ -1318,8 +1318,21 @@ workflow_current_review_subject_json() {
   # The target ref selects the implementation path set and supplies overlap
   # metadata. The subject hash itself is normalized final content and therefore
   # does not churn when the target advances on unrelated paths.
+  #
+  # Must resolve worktree_strategy.review_base -- the same key
+  # scripts/acceptance-receipt.ts's reviewBase() diffs against -- never
+  # worktree_strategy.merge_back.target (where finished work lands after
+  # merge). Those are different refs; recording the subject against the
+  # merge-back target instead of the review base is exactly why every
+  # AcceptanceReceipt failed "verification evidence is stale for the current
+  # subject" whenever local main lagged origin/main (the standard
+  # control-clone worktree pattern). Fail closed with no output when
+  # review_base is unset or empty: never fall back to base_branch/main, so a
+  # misconfigured policy can never silently record a subject against a ref
+  # the validator was never going to check.
   local target
-  target="$(workflow_target_branch)"
+  target="$(workflow_policy_get '.worktree_strategy.review_base' '')"
+  [[ -n "$target" ]] || return 0
   workflow_hook_cli_json review-subject --target "$target" --format json 2>/dev/null || true
 }
 

--- a/assets/hooks/lib/workflow-state.sh
+++ b/assets/hooks/lib/workflow-state.sh
@@ -1318,8 +1318,21 @@ workflow_current_review_subject_json() {
   # The target ref selects the implementation path set and supplies overlap
   # metadata. The subject hash itself is normalized final content and therefore
   # does not churn when the target advances on unrelated paths.
+  #
+  # Must resolve worktree_strategy.review_base -- the same key
+  # scripts/acceptance-receipt.ts's reviewBase() diffs against -- never
+  # worktree_strategy.merge_back.target (where finished work lands after
+  # merge). Those are different refs; recording the subject against the
+  # merge-back target instead of the review base is exactly why every
+  # AcceptanceReceipt failed "verification evidence is stale for the current
+  # subject" whenever local main lagged origin/main (the standard
+  # control-clone worktree pattern). Fail closed with no output when
+  # review_base is unset or empty: never fall back to base_branch/main, so a
+  # misconfigured policy can never silently record a subject against a ref
+  # the validator was never going to check.
   local target
-  target="$(workflow_target_branch)"
+  target="$(workflow_policy_get '.worktree_strategy.review_base' '')"
+  [[ -n "$target" ]] || return 0
   workflow_hook_cli_json review-subject --target "$target" --format json 2>/dev/null || true
 }
 

--- a/plans/plan-20260722-0538-receipt-subject-target-split.md
+++ b/plans/plan-20260722-0538-receipt-subject-target-split.md
@@ -1,0 +1,128 @@
+# Plan: Fix acceptance-receipt recorder/validator policy-key split (review_base vs merge_back.target)
+
+> **Program**: unblocks acceptance-receipt recording for all control-clone worktrees (Sprint C acceptance machinery)
+> **Status**: Approved
+> **Created**: 20260722-0538
+> **Slug**: receipt-subject-target-split
+> **Artifact Level**: work-package
+> **Promotion Reason**: verification_boundary
+> **Verification Boundary**: `tests/workflow-state-lib.test.ts` and `tests/prompt-handler.test.ts` (both red-then-green) + full `bun test` + `bun run check:type` + `bun run check:hooks` + `bun run check:helpers` + `repo-harness run check-task-workflow --strict` + `contract-run preflight --json` + `repo-harness run verify-sprint --prepare-acceptance`
+> **Rollback Surface**: Revert branch `codex/receipt-subject-target-split`; no data migration, no schema change, no `policy.json` key renamed or added.
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260722-0538-receipt-subject-target-split.contract.md`
+> **Task Review**: `tasks/reviews/20260722-0538-receipt-subject-target-split.review.md`
+> **Implementation Notes**: `tasks/notes/20260722-0538-receipt-subject-target-split.notes.md`
+
+## Agentic Routing
+- Selected route: orchestrator-dispatched bugfix (decision-complete on arrival)
+- Routing reason: root cause already proven by a prior diagnosis pass; orchestrator decided the fix direction (resolve the recorder from `review_base`, fail-closed) and dispatched implementation directly.
+- Due diligence:
+  - P1 map: see Root Cause Evidence below and the full callsite sweep in Detailed Design.
+  - P2 trace: `workflow_current_review_subject_json` -> `workflow_current_review_subject_value` -> `scripts/verify-sprint.sh:550` embeds `review_subject_sha256` into verification evidence -> `scripts/acceptance-receipt.ts:212` compares it against its own `currentSubject(root, reviewBase(root))`.
+  - P3 decision rationale: both policy keys are legitimate but mean different things (`merge_back.target` = where finished work lands; `review_base` = what review/acceptance subjects diff against); the defect is the recorder reading the wrong one, not the existence of two keys.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260722-0538-receipt-subject-target-split.md`
+- Sprint contract: `tasks/contracts/20260722-0538-receipt-subject-target-split.contract.md`
+- Sprint review: `tasks/reviews/20260722-0538-receipt-subject-target-split.review.md`
+- Implementation notes: `tasks/notes/20260722-0538-receipt-subject-target-split.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260722-0538-receipt-subject-target-split.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree.
+- Execution isolation: this is a control-clone worktree (`/Users/kito/Projects/repo-harness-wt-receipt-subject-target-split`, branch `codex/receipt-subject-target-split`, forked from fresh `origin/main`), isolated from the primary checkout.
+
+## Approach
+### Strategy
+Fix the one wrong-key callsite that actually causes the reported failure (`assets/hooks/lib/workflow-state.sh`'s `workflow_current_review_subject_json`), sweep every other `workflow_target_branch`/`merge_back.target`/`review-subject --target` callsite for the same shape, fix the one sibling that shares it (`src/cli/hook/prompt-handler.ts`'s review-subject advisory hint), and leave every genuine merge-back-mechanics callsite untouched. No compatibility fallback, no dual-read, no alias key.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Fix the recorder to read `review_base` (fail-closed) | Matches the validator exactly; single source of truth for "what ref does acceptance diff against" | None identified | **Chosen** |
+| Make the validator read `merge_back.target` instead | Also unifies the two sides | Wrong semantics: acceptance must diff against the review base (e.g. `origin/main`), not the eventual merge destination; would silently misreport the implementation surface whenever a worktree branches from a fresher ref than its own merge target | Rejected |
+| Add a compatibility key that reads either | Never breaks existing callers | Explicit dual authority; violates the repo's no-compat-code principle and hides the real defect | Rejected |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| `assets/hooks/lib/workflow-state.sh` | edit | `workflow_current_review_subject_json` resolves target from `.worktree_strategy.review_base` via `workflow_policy_get`, fail-closed (no output) when unset/empty; no more call to `workflow_target_branch()` |
+| `.ai/hooks/lib/workflow-state.sh` | generated | `bun run sync:hooks` projection of the above |
+| `src/cli/hook/prompt-handler.ts` | edit | `currentTargetBranch` renamed `currentReviewBaseRef`, resolves `.worktree_strategy.review_base` fail-closed (throws; sole caller already wraps in try/catch); `emitReviewHints`'s `[AcceptanceSubject]` hint now binds to the same ref the real acceptance-receipt validator will check |
+| `tests/workflow-state-lib.test.ts` | edit | new regression test: control-clone fixture (local `main` one commit behind `origin/main`), asserts recorder (`workflow_current_review_subject_value`) equals validator (`review-subject --target origin/main`); red pre-fix, green post-fix |
+| `tests/prompt-handler.test.ts` | edit | sibling regression test for the `prompt-handler.ts` hint, same divergent-ref shape; red pre-fix, green post-fix |
+
+### Root Cause Evidence (bugfix profile)
+- root_cause: `assets/hooks/lib/workflow-state.sh:1317` (`.ai/hooks/lib/workflow-state.sh:1317` generated twin) `workflow_current_review_subject_json` resolved its diff target via `workflow_target_branch()` (`:438`, reads `.worktree_strategy.merge_back.target`) instead of `.worktree_strategy.review_base` -- the key `scripts/acceptance-receipt.ts:178` `reviewBase()` diffs against. `scripts/verify-sprint.sh:550` embeds the recorder's (wrong-key) subject into verification evidence as `review_subject_sha256`; `scripts/acceptance-receipt.ts:212` then compares it against its own (`review_base`-scoped) recomputation and fails "verification evidence is stale for the current subject" on any mismatch.
+- repro: `repo-harness-hook review-subject --target main --format json` vs `--target origin/main --format json` return different `review_subject_sha256` whenever local `main` lags `origin/main` by even one commit -- the standard control-clone worktree pattern (task branch cut from fresh `origin/main`, local `main` in the same clone left behind).
+- regression_guard: `tests/workflow-state-lib.test.ts` ("recorder path resolves the review target from worktree_strategy.review_base, matching the acceptance-receipt validator, even when local main lags origin/main")
+- pre_fix_failure_artifact: `.ai/harness/runs/receipt-subject-target-split-pre-fix.log`
+
+### Callsite Sweep (grep `workflow_target_branch`, `merge_back.target`, `review-subject --target`)
+| Callsite | Resolves | Disposition |
+|---|---|---|
+| `workflow-state.sh` `workflow_current_review_subject_json` (recorder) | was `merge_back.target` | **Fixed** -> `review_base`, fail-closed |
+| `src/cli/hook/prompt-handler.ts` `emitReviewHints` `[AcceptanceSubject]` hint | was `merge_back.target` via `currentTargetBranch` | **Fixed** -> `review_base` via `currentReviewBaseRef`, fail-closed (throws, caught by existing advisory try/catch) |
+| `workflow-state.sh` `workflow_cleanup_candidate` (:540) | `merge_back.target` | Kept -- decides whether a worktree branch is merged into the merge destination, for cleanup |
+| `workflow-state.sh` `workflow_next_action` (:629, :639) | `merge_back.target` | Kept -- "finish"/"cleanup" guidance compares current branch to the merge destination |
+| `scripts/refresh-current-status.sh` `target_branch()` (:70-82, used :360) | `merge_back.target` | Kept -- pure status-dashboard display of branch vs. merge destination |
+| `scripts/archive-workflow.sh` `predict_archive_manifest` (:190-221) | `merge_back.target` | Kept -- checks out the merge destination in a scratch clone to predict post-merge archive file hashes; never computes a review subject |
+| `scripts/check-architecture-sync.sh` `target_branch` (:19,:204, used :158-159) | `merge_back.target` | Kept -- architecture-drift gate diffs against the merge destination for a different purpose (doc staleness), not an acceptance/review subject |
+| `scripts/ship-worktrees.sh` (:691), `scripts/contract-worktree.sh` (several) | `merge_back.target` | Kept -- genuine merge-back mechanics (shipping/finishing a worktree) |
+| `src/cli/hook/session-context.ts` `workflowTargetBranch` (used :829, "Target branch snapshot") | `merge_back.target` | Kept -- informational display of the merge destination's `tasks/current.md`, not a subject computation |
+| `src/effects/state/resolve-effective-state.ts` (:349-358) | `review_base` first, falls back to `merge_back.target` then `base_branch` then `main` | **Already correct** -- prioritizes `review_base`; no change |
+| `scripts/merge-gate.ts` | neither -- `--base <ref>` is an explicit CLI argument from the caller; only reads `merge_gate.enabled` from the policy at that base SHA | **Not affected** -- no recorder/validator split exists here; unchanged |
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Fail-closed recorder silently produces no subject when `review_base` is missing on an older/adopted repo's policy.json | Low | Medium | `scripts/lib/project-init-lib.sh`/`src/core/adoption/standard-plan.ts` scaffolds already default `review_base`; verified present in this repo's own `.ai/harness/policy.json` |
+| `currentReviewBaseRef` throwing changes `prompt-handler.ts` behavior when `review_base` absent | Low | Low | Sole call site already wraps in try/catch (`/* advisory only */`); falls back to the existing `unknown`/`unknown` hint text, never a crash |
+| Renaming `currentTargetBranch` breaks an external caller | Low | Low | Private, non-exported function; grep confirmed the definition and its one call site are the only references in the repo |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260722-0538-receipt-subject-target-split.contract.md`
+- Review file: `tasks/reviews/20260722-0538-receipt-subject-target-split.review.md`
+- Implementation notes file: `tasks/notes/20260722-0538-receipt-subject-target-split.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260722-0538-receipt-subject-target-split.contract.md --strict`
+- Active plan rule: this plan is written to `.ai/harness/active-plan` and the owning worktree to `.ai/harness/active-worktree`. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: branch `codex/receipt-subject-target-split`, one PR.
+- **Rollback surface**: revert the branch; no data migration, no schema, no policy key changes.
+- **Verification boundary**: see header.
+- **Review/acceptance boundary**: `tasks/reviews/20260722-0538-receipt-subject-target-split.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: none -- one bash function, one small TS helper rename/refactor, both covered by new red-then-green tests; no gate semantics changed.
+- **Why not checklist row**: independent verification boundary (own red-then-green regression evidence), own rollback surface, and a completed root-cause diagnosis distinct from any other in-flight package.
+
+## Evidence Contract
+
+- **State/progress path**: this plan's Task Breakdown; `tasks/contracts/20260722-0538-receipt-subject-target-split.contract.md`; `tasks/reviews/20260722-0538-receipt-subject-target-split.review.md`; `tasks/notes/20260722-0538-receipt-subject-target-split.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/receipt-subject-target-split-pre-fix.log`, full `bun test` output
+- **Evaluator rubric**: `tasks/reviews/20260722-0538-receipt-subject-target-split.review.md` must record a passing Waza `/check`-style recommendation
+- **Stop condition**: all task breakdown items complete, sprint verification passes, review recommends pass
+- **Rollback surface**: revert branch `codex/receipt-subject-target-split`; no data migration, no schema.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [x] T1 verify the reported root cause directly (re-read `workflow-state.sh:1322`, `acceptance-receipt.ts:178/212`) before changing anything
+- [x] T2 sweep every `workflow_target_branch`/`merge_back.target`/`review-subject --target` callsite in `.ai/hooks/`, `assets/hooks/`, `scripts/`, `assets/templates/helpers/`, `src/`; classify each as recorder-fix vs. genuine-merge-back-keep
+- [x] T3 add the regression guard to `tests/workflow-state-lib.test.ts` (control-clone fixture, local `main` behind `origin/main`); capture pre-fix red evidence to `.ai/harness/runs/receipt-subject-target-split-pre-fix.log`
+- [x] T4 fix `assets/hooks/lib/workflow-state.sh`'s `workflow_current_review_subject_json` to resolve `review_base`, fail-closed; regenerate `.ai/hooks/` via `bun run sync:hooks`
+- [x] T5 fix the sibling `src/cli/hook/prompt-handler.ts` `[AcceptanceSubject]` hint (rename `currentTargetBranch` -> `currentReviewBaseRef`, resolve `review_base` fail-closed); add its own red-then-green regression test in `tests/prompt-handler.test.ts`
+- [x] T6 full verification: named suites green, full `bun test` green, `check:type`, `check:hooks`, `check:helpers`, `check-task-workflow --strict`, `contract-run preflight --json`, `verify-sprint --prepare-acceptance`
+- [x] T7 lifecycle docs (this plan, contract, review, notes) and local commit

--- a/src/cli/hook/prompt-handler.ts
+++ b/src/cli/hook/prompt-handler.ts
@@ -406,16 +406,27 @@ function strictWorkflow(repoRoot: string, state: PromptGuardRuntimeState, fsApi:
   return /^> \*\*Workflow Profile\*\*:\s*strict\s*$/mu.test(contract);
 }
 
-function currentTargetBranch(repoRoot: string, fsApi: HookInputFs): string {
+// Resolves worktree_strategy.review_base -- the same key
+// scripts/acceptance-receipt.ts's reviewBase() diffs against -- never
+// merge_back.target (where finished work lands after merge). This is the
+// only caller (the [AcceptanceSubject] advisory hint), so it must name the
+// exact ref the real acceptance-receipt validator will require; showing a
+// hint computed against merge_back.target would silently disagree with the
+// receipt the user is about to record. Mirrors reviewBase()'s fail-closed
+// behavior: missing/empty review_base throws (the caller is advisory-only
+// and already wraps this in try/catch), never falls back to base_branch or
+// 'main'.
+function currentReviewBaseRef(repoRoot: string, fsApi: HookInputFs): string {
   const raw = text(fsApi, repoRoot, '.ai/harness/policy.json');
   if (raw) {
     try {
-      const parsed = JSON.parse(raw) as { worktree_strategy?: { merge_back?: { target?: unknown }; base_branch?: unknown } };
-      if (typeof parsed.worktree_strategy?.merge_back?.target === 'string' && parsed.worktree_strategy.merge_back.target) return parsed.worktree_strategy.merge_back.target;
-      if (typeof parsed.worktree_strategy?.base_branch === 'string' && parsed.worktree_strategy.base_branch) return parsed.worktree_strategy.base_branch;
-    } catch { /* default */ }
+      const parsed = JSON.parse(raw) as { worktree_strategy?: { review_base?: unknown } };
+      if (typeof parsed.worktree_strategy?.review_base === 'string' && parsed.worktree_strategy.review_base.trim()) {
+        return parsed.worktree_strategy.review_base;
+      }
+    } catch { /* fall through to the hard error below */ }
   }
-  return 'main';
+  throw new Error('worktree_strategy.review_base is missing');
 }
 
 function promptCircuitState(repoRoot: string, state: PromptGuardRuntimeState, fsApi: HookInputFs): {
@@ -477,7 +488,7 @@ function emitReviewHints(
   let subject = 'unknown';
   let target = 'unknown';
   try {
-    const result = buildReviewSubject(repoRoot, { targetRef: currentTargetBranch(repoRoot, fsApi) });
+    const result = buildReviewSubject(repoRoot, { targetRef: currentReviewBaseRef(repoRoot, fsApi) });
     if (result.status === 'ok') {
       subject = result.review_subject_sha256;
       target = result.target_rev;

--- a/tasks/contracts/20260722-0538-receipt-subject-target-split.contract.md
+++ b/tasks/contracts/20260722-0538-receipt-subject-target-split.contract.md
@@ -1,0 +1,152 @@
+# Task Contract: receipt-subject-target-split
+
+> **Status**: Active
+> **Plan**: plans/plan-20260722-0538-receipt-subject-target-split.md
+> **Task Profile**: bugfix
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: kito
+> **Capability ID**: runtime-harness-hook-adapters
+> **Last Updated**: 2026-07-22 05:38
+> **Review File**: `tasks/reviews/20260722-0538-receipt-subject-target-split.review.md`
+> **Notes File**: `tasks/notes/20260722-0538-receipt-subject-target-split.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+The acceptance-evidence recorder and the acceptance-receipt validator resolved the review subject against DIFFERENT `.ai/harness/policy.json` keys. `scripts/verify-sprint.sh` embeds `review_subject_sha256` into verification evidence by calling `workflow_current_review_subject_value` (`assets/hooks/lib/workflow-state.sh`), which resolved its diff target via `workflow_target_branch()` (`.worktree_strategy.merge_back.target`). `scripts/acceptance-receipt.ts`'s validator always recomputes the same subject via `reviewBase()` (`.worktree_strategy.review_base`). Whenever local `main` lagged `origin/main` -- the standard control-clone worktree pattern this repo's own workflow uses -- the two refs diverged, so the two sides silently diffed against different content and every receipt failed "verification evidence is stale for the current subject", even on genuinely correct work. Left unfixed, every control-clone worktree whose local `main` is not kept fast-forwarded to `origin/main` cannot record a passing AcceptanceReceipt.
+
+## Goal
+
+1. Fix the recorder (`assets/hooks/lib/workflow-state.sh`'s `workflow_current_review_subject_json`) to resolve its diff target from `.worktree_strategy.review_base`, fail-closed (no output, no fallback to `base_branch`/`main`) when unset or empty -- mirroring `reviewBase()`'s own fail-closed behavior. Regenerate `.ai/hooks/lib/workflow-state.sh` via `bun run sync:hooks`.
+2. Sweep every other `workflow_target_branch`/`.worktree_strategy.merge_back.target`/`review-subject --target` callsite across `.ai/hooks/`, `assets/hooks/`, `scripts/`, `assets/templates/helpers/`, and `src/` for the same wrong-key shape. Fix the one sibling that shares it (`src/cli/hook/prompt-handler.ts`'s `[AcceptanceSubject]` advisory hint, via `currentTargetBranch` -> renamed `currentReviewBaseRef`, resolving `review_base` fail-closed). Leave every genuine merge-back-mechanics callsite (`workflow_cleanup_candidate`, `workflow_next_action`, `refresh-current-status.sh`, `archive-workflow.sh`'s `predict_archive_manifest`, `check-architecture-sync.sh`, `ship-worktrees.sh`, `contract-worktree.sh`, `session-context.ts`'s "Target branch snapshot" display) untouched -- they genuinely need the merge destination, not the review base. Confirm `src/effects/state/resolve-effective-state.ts` already resolves `review_base` first (no change needed) and that `scripts/merge-gate.ts` takes `--base` as an explicit CLI argument with no policy-key resolution of its own (no change needed, no split exists).
+3. No compatibility fallback, no dual-read, no alias key.
+
+## Scope
+
+- In scope: `assets/hooks/lib/workflow-state.sh` (+ `.ai/hooks/` generated projection via `bun run sync:hooks`), `src/cli/hook/prompt-handler.ts`, `tests/workflow-state-lib.test.ts`, `tests/prompt-handler.test.ts`, this plan/contract/review/notes.
+- Out of scope: any change to `scripts/acceptance-receipt.ts` (the validator is already correct), `scripts/verify-sprint.sh` (calls the now-fixed recorder function unchanged), `scripts/merge-gate.ts` (no split exists), `src/effects/state/resolve-effective-state.ts` (already resolves `review_base` first), any genuine merge-back-mechanics callsite named in the sweep, any `.ai/harness/policy.json` key rename/addition, pushing, opening/merging a PR, benchmark runs, `--force` of any kind.
+- Taste constraints: match surrounding bash/TS style; keep the fail-closed shape identical to `reviewBase()`'s (no default, no silent fallback).
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+- Stop if any PreToolUse guard blocks an edit -- do not retry more than the documented fallback; return BLOCKED with the guard JSON if the Bash read-modify-write fallback also fails.
+
+## Falsifier
+
+If the recorder's subject (via `workflow_current_review_subject_value`) still differs from the validator's own recomputation (`buildReviewSubject(root, { targetRef: reviewBase(root) })`) after the fix, in a fixture where local `main` lags `origin/main`, the fix is wrong. Cheapest proof point: `tests/workflow-state-lib.test.ts`'s new regression test.
+
+## Root Cause Evidence
+
+Required when Task Profile is `bugfix`.
+
+- root_cause: `assets/hooks/lib/workflow-state.sh:1317` (`.ai/hooks/lib/workflow-state.sh:1317` generated twin) `workflow_current_review_subject_json` resolved its diff target via `workflow_target_branch()` (`:438`, reads `.worktree_strategy.merge_back.target`) instead of `.worktree_strategy.review_base` -- the key `scripts/acceptance-receipt.ts:178` `reviewBase()` diffs against. `scripts/verify-sprint.sh:550` embeds the recorder's (wrong-key) subject into verification evidence as `review_subject_sha256`; `scripts/acceptance-receipt.ts:212` compares it against its own (`review_base`-scoped) recomputation and fails "verification evidence is stale for the current subject" on any mismatch.
+- repro: `repo-harness-hook review-subject --target main --format json` vs `--target origin/main --format json` return different `review_subject_sha256` whenever local `main` lags `origin/main` by even one commit -- the standard control-clone worktree pattern (task branch cut from fresh `origin/main`, local `main` in the same clone left behind).
+- regression_guard: tests/workflow-state-lib.test.ts
+- pre_fix_failure_artifact: .ai/harness/runs/receipt-subject-target-split-pre-fix.log
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260722-0538-receipt-subject-target-split.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260722-0538-receipt-subject-target-split.review.md`
+- Notes file: `tasks/notes/20260722-0538-receipt-subject-target-split.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Acceptance Policy
+
+```json
+{"protocol":1,"reviewer":"Claude","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - plans/
+  - tasks/
+  - assets/hooks/
+  - .ai/hooks/
+  - src/cli/hook/
+  - tests/
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+      - codex-exec
+      - main-thread
+    fallback: main-thread
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - assets/hooks/lib/workflow-state.sh
+    - .ai/hooks/lib/workflow-state.sh
+    - src/cli/hook/prompt-handler.ts
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - .ai/harness/runs/receipt-subject-target-split-pre-fix.log
+    - tasks/notes/20260722-0538-receipt-subject-target-split.notes.md
+  tests_pass:
+    - path: tests/workflow-state-lib.test.ts
+    - path: tests/prompt-handler.test.ts
+  commands_succeed:
+    - bun run check:type
+    - bun run check:hooks
+    - bun run check:helpers
+    - repo-harness run check-task-workflow --strict
+```
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior: recorder and validator now bind to the same ref (`review_base`); an AcceptanceReceipt no longer fails "stale" purely because local `main` lagged `origin/main` in a control-clone worktree.
+- Edge cases: `review_base` missing/empty (fails closed, no silent default); `prompt-handler.ts`'s hint when `review_base` is absent (falls back to the existing `unknown`/`unknown` advisory text via its pre-existing try/catch, never crashes).
+- Regression risks: any other callsite reading `merge_back.target` for genuine merge-back mechanics must stay unchanged -- verified by the full callsite sweep recorded in the plan and this contract's Why/Goal sections.
+
+## Rollback Point
+
+- Commit / checkpoint: branch `codex/receipt-subject-target-split` forked from `61b5ec5960bd5bd763a0c02ebadbe37cba5a2c5f` (fresh `origin/main`).
+- Revert strategy: revert/delete the branch; no data migration, no schema, no policy key changes.

--- a/tasks/notes/20260722-0538-receipt-subject-target-split.notes.md
+++ b/tasks/notes/20260722-0538-receipt-subject-target-split.notes.md
@@ -1,0 +1,46 @@
+# Implementation Notes: receipt-subject-target-split
+
+> **Status**: Active
+> **Plan**: plans/plan-20260722-0538-receipt-subject-target-split.md
+> **Contract**: tasks/contracts/20260722-0538-receipt-subject-target-split.contract.md
+> **Review**: tasks/reviews/20260722-0538-receipt-subject-target-split.review.md
+> **Last Updated**: 2026-07-22 05:38
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- Kept both `worktree_strategy.review_base` and `worktree_strategy.merge_back.target` as distinct, legitimate keys (per the dispatch's decided fix) rather than merging them into one: `merge_back.target` is genuinely a different concept (where finished work lands after merge) from `review_base` (what a review/acceptance subject diffs against). The defect was one function reading the wrong one, not the existence of two keys.
+- `workflow_current_review_subject_json`'s fail-closed shape returns success with empty stdout (not a nonzero exit) when `review_base` is missing, matching the function's pre-existing contract (every caller already treats it as `2>/dev/null || true` / JSON-status-checked, never checks its raw exit code) -- this avoids introducing a new failure mode under `set -e` callers while still refusing to silently fall back to `base_branch`/`main`.
+- `src/cli/hook/prompt-handler.ts`'s `currentTargetBranch` was renamed to `currentReviewBaseRef` rather than keeping the old name with new behavior: it has exactly one caller (the `[AcceptanceSubject]` advisory hint), so the old name was actively misleading once its resolution target changed from the merge destination to the review base. Fail-closed here means throwing (caught by the caller's pre-existing `/* advisory only */` try/catch), matching `reviewBase()`'s hard-error shape rather than a silent default.
+- Full callsite sweep (grep `workflow_target_branch`, `.worktree_strategy.merge_back.target`, `review-subject --target`) is recorded in the plan's Callsite Sweep table; `src/effects/state/resolve-effective-state.ts` was found already correct (prioritizes `review_base`, falls back to `merge_back.target` then `base_branch` then `main`) and `scripts/merge-gate.ts` was found unaffected (takes `--base` as an explicit CLI argument, no policy-key resolution of its own for base-ref selection).
+- Added one regression test per site: `tests/workflow-state-lib.test.ts` (the contract's formal `regression_guard`, a control-clone fixture with local `main` one commit behind `origin/main`) and `tests/prompt-handler.test.ts` (the `prompt-handler.ts` sibling, a two-diverged-local-branches fixture). Both captured red pre-fix, green post-fix.
+
+## Deviations From Plan Or Spec
+
+- PreToolUse Edit/Write-tool guard trap (as anticipated by the dispatch): every Edit-tool and Write-tool call in this worktree failed with `[WorkflowProfileGuard] Deterministic workflow profile resolution failed for <path>` / `No stderr output`, even for a Write targeting a path completely outside any git repository (the session scratchpad). Running the equivalent `repo-harness state resolve --json --target-path <path> --operation edit` directly in a plain shell succeeded cleanly (profile `lite`, no blockers), so the failure is specific to the wrapped hook invocation context, not the underlying state resolution -- consistent with the dispatch's documented "repoRoot resolution defect" in sibling worktrees. Worked around exactly as instructed: all file creation and editing in this worktree went through Bash (heredocs for new files; a small exact-match `apply-patch.ts` script, modeled on the Edit tool's own old_string/new_string contract, for modifying existing files). Did not attempt to fix the guard itself -- out of scope for this defect.
+- No other deviations from the dispatched plan.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| Also harden `resolve-effective-state.ts`'s `review_base` resolution to fail-closed (matching the recorder's new fail-closed shape) instead of its existing default-chain fallback | Rejected | It is not exhibiting the reported bug (already prioritizes `review_base` correctly); changing its fallback semantics would be an unrequested design change outside this defect's scope |
+| Add a dedicated regression test for `prompt-handler.ts`'s fix vs. relying only on the mandated `workflow-state-lib.test.ts` guard | Added the extra test | The sibling fix would otherwise ship with zero coverage; a small, self-contained, additive test (own fixture, no shared-helper edits) proportionate to the fix, not scope creep |
+
+## Open Questions
+
+- None.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Pre-fix red evidence: `.ai/harness/runs/receipt-subject-target-split-pre-fix.log`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- The PreToolUse Edit/Write-tool guard trap in sibling worktrees is already a documented, known issue (per the dispatch); not promoted here as a new finding, only recorded as encountered-and-worked-around for this package.

--- a/tasks/reviews/20260722-0538-receipt-subject-target-split.review.md
+++ b/tasks/reviews/20260722-0538-receipt-subject-target-split.review.md
@@ -40,17 +40,17 @@
 
 ## Acceptance Receipt Projection
 
-> **Disposition**: unavailable
-> **Reviewer**: unavailable
-> **Source**: unavailable
+> **Disposition**: external_pass
+> **Reviewer**: Claude
+> **Source**: claude-review
 > **Actor**: not-applicable
-> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject SHA256**: sha256:3a09d8b17395047d341b461a4d5fdba5f2af103b76b17c4d35e8d45ed7b46048
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: pending
-> **Verification Evidence SHA256**: pending
-> **Issued At**: pending
+> **Reviewed Target Revision**: 61b5ec5960bd5bd763a0c02ebadbe37cba5a2c5f
+> **Verification Evidence SHA256**: sha256:f0476340034abbeff1537a4a429b81788c61e8d75abe9b0b58a60318218933a1
+> **Issued At**: 2026-07-21T21:53:15.453Z
 
-- Summary: No AcceptanceReceipt has been recorded. Implementation, regression guards, and full verification are complete from the executor's side; external acceptance review is the orchestrator's next step.
+- Summary: Recorder now resolves the same review_base policy key the validator diffs against, fail-closed with no fallback; full callsite sweep keeps genuine merge-back mechanics on merge_back.target; red-then-green fixture with local main one commit behind origin/main proves recorder==validator; 22/22 exit criteria Fulfilled.
 - Findings: none
 
 ## Behavior Diff Notes

--- a/tasks/reviews/20260722-0538-receipt-subject-target-split.review.md
+++ b/tasks/reviews/20260722-0538-receipt-subject-target-split.review.md
@@ -1,0 +1,86 @@
+# Task Review: receipt-subject-target-split
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260722-0538-receipt-subject-target-split.md
+> **Contract**: tasks/contracts/20260722-0538-receipt-subject-target-split.contract.md
+> **Notes File**: tasks/notes/20260722-0538-receipt-subject-target-split.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-07-22 05:38
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: bugfix
+- Intended files changed: assets/hooks/lib/workflow-state.sh, .ai/hooks/lib/workflow-state.sh, src/cli/hook/prompt-handler.ts, tests/workflow-state-lib.test.ts, tests/prompt-handler.test.ts, plus lifecycle docs
+- Actual files changed: assets/hooks/lib/workflow-state.sh, .ai/hooks/lib/workflow-state.sh, src/cli/hook/prompt-handler.ts, tests/workflow-state-lib.test.ts, tests/prompt-handler.test.ts, plans/plan-20260722-0538-receipt-subject-target-split.md, tasks/contracts/20260722-0538-receipt-subject-target-split.contract.md, tasks/reviews/20260722-0538-receipt-subject-target-split.review.md, tasks/notes/20260722-0538-receipt-subject-target-split.notes.md
+- Commands passed: see Verification Evidence below
+- Residual risks: none identified beyond those recorded in the plan's Risk Assessment
+- Reviewer action required: inspect diff and card; no external acceptance review has run yet
+- Rollback: revert branch codex/receipt-subject-target-split
+
+## Mode Evidence
+
+- Selected route: orchestrator-dispatched bugfix, decision-complete on arrival (root cause pre-proven by a prior diagnosis pass)
+- P1/P2/P3 evidence: see plan Agentic Routing section
+- Root cause or plan evidence: see this contract's Root Cause Evidence section and the plan's Callsite Sweep table
+
+## Verification Evidence
+
+- Waza `/check` run: not run (orchestrator will route acceptance separately)
+- Commands run: `bun test tests/workflow-state-lib.test.ts` (red pre-fix, green post-fix), `bun test tests/prompt-handler.test.ts` (red pre-fix, green post-fix), full `bun test`, `bun run check:type`, `bun run check:hooks`, `bun run check:helpers`, `repo-harness run check-task-workflow --strict`, `contract-run preflight --json`, `repo-harness run verify-sprint --prepare-acceptance`
+- Manual checks: re-verified the reported root cause directly against source before changing anything; swept every `workflow_target_branch`/`merge_back.target`/`review-subject --target` callsite in the repo
+- Supporting artifacts: `.ai/harness/runs/receipt-subject-target-split-pre-fix.log`
+- Implementation notes reviewed: tasks/notes/20260722-0538-receipt-subject-target-split.notes.md
+- Run snapshot: .ai/harness/runs/
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded. Implementation, regression guards, and full verification are complete from the executor's side; external acceptance review is the orchestrator's next step.
+- Findings: none
+
+## Behavior Diff Notes
+
+- Recorder (`workflow_current_review_subject_json`) now resolves `.worktree_strategy.review_base` instead of `.worktree_strategy.merge_back.target`, fail-closed (no output) when unset/empty.
+- `prompt-handler.ts`'s `[AcceptanceSubject]` advisory hint now names the same subject the real acceptance-receipt validator will require.
+- No other callsite's behavior changed; the sweep confirmed every other `merge_back.target` read is genuine merge-back mechanics.
+
+## Residual Risks / Follow-ups
+
+- None identified. The one behavioral change (fail-closed instead of defaulting) only fires when `review_base` is missing/empty, which this repo's own policy.json and the adoption scaffolds already populate by default.
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | Pending external review |
+| Product depth | 0/10 | Pending external review |
+| Design quality | 0/10 | Pending external review |
+| Code quality | 0/10 | Pending external review |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run: `bun test tests/workflow-state-lib.test.ts tests/prompt-handler.test.ts`, full `bun test`
+- Re-check: `repo-harness run verify-sprint --prepare-acceptance`
+
+## Summary
+
+- Implementation complete and fully verified from the executor's side (red-then-green regression guards, full suite green, all named checks green); awaiting external acceptance review and AcceptanceReceipt recording, which is out of this task's scope.

--- a/tests/prompt-handler.test.ts
+++ b/tests/prompt-handler.test.ts
@@ -5,6 +5,7 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import { parseHookInput } from '../src/cli/hook/hook-input';
 import { runPromptHandler, type PromptCommandResult } from '../src/cli/hook/prompt-handler';
+import { buildReviewSubject } from '../src/effects/review/diff-fingerprint';
 
 const PLAN = 'plans/plan-20260721-0000-demo.md';
 const CONTRACT = 'tasks/contracts/20260721-0000-demo.contract.md';
@@ -357,6 +358,87 @@ describe('typed UserPromptSubmit.default handler', () => {
       expect(result.stderr).toContain('[HookInput] WARN');
     } finally {
       repo.cleanup();
+    }
+  });
+
+  // Sibling of the workflow-state.sh recorder/validator policy-key split
+  // (tests/workflow-state-lib.test.ts): emitReviewHints's [AcceptanceSubject]
+  // advisory called buildReviewSubject with a targetRef resolved from
+  // worktree_strategy.merge_back.target instead of review_base, so the hint
+  // shown to the user could name a different subject hash than what the real
+  // acceptance-receipt validator (which always reads review_base) requires.
+  test('the [AcceptanceSubject] hint binds to worktree_strategy.review_base, not merge_back.target, when the two refs diverge', () => {
+    const root = mkdtempSync(join(tmpdir(), 'repo-harness-prompt-handler-subject-split-'));
+    const git = (...args: string[]) => execFileSync('git', args, { cwd: root, stdio: 'ignore' });
+    try {
+      for (const dir of ['.ai/harness/checks', 'plans', 'docs', 'tasks/contracts', 'tasks/reviews']) {
+        mkdirSync(join(root, dir), { recursive: true });
+      }
+      writeFileSync(join(root, 'docs/spec.md'), '# Spec\n');
+      writeFileSync(join(root, PLAN), [
+        '# Plan: demo',
+        '',
+        '> **Status**: Approved',
+        `> **Task Contract**: ${CONTRACT}`,
+        '',
+      ].join('\n'));
+      writeFileSync(join(root, '.ai/harness/active-plan'), `${PLAN}\n`);
+      writeFileSync(join(root, '.ai/harness/active-worktree'), `${root}\n`);
+      writeFileSync(join(root, CONTRACT), [
+        '# Task Contract: demo',
+        '',
+        '> **Status**: Pending',
+        `> **Plan**: ${PLAN}`,
+        '> **Owner**: kito',
+        '',
+        '## Acceptance Policy',
+        '',
+        '```json',
+        '{"protocol":1,"reviewer":"Claude","user_waiver":"allowed"}',
+        '```',
+        '',
+      ].join('\n'));
+      // merge-target and review-base resolve to genuinely different refs:
+      // merge-target sits one commit BEHIND review-base, mirroring the
+      // local-main-lags-origin/main shape this package fixes.
+      writeFileSync(join(root, '.ai/harness/policy.json'), `${JSON.stringify({
+        worktree_strategy: { review_base: 'review-base', merge_back: { target: 'merge-target' } },
+      }, null, 2)}\n`);
+
+      git('init', '-q', '-b', 'merge-target');
+      git('config', 'user.name', 'Prompt Handler Fixture');
+      git('config', 'user.email', 'prompt-handler-fixture@example.test');
+      git('add', '.');
+      git('commit', '-q', '-m', 'base');
+
+      // review-base advances beyond merge-target with its own change (the
+      // "other work landed upstream" commit).
+      git('checkout', '-q', '-b', 'review-base');
+      writeFileSync(join(root, 'upstream-change.txt'), 'landed after merge-target\n');
+      git('add', '.');
+      git('commit', '-q', '-m', 'upstream change');
+
+      // The actual task branch off review-base with the real new work; this
+      // is HEAD when the hint is computed.
+      git('checkout', '-q', '-b', 'work');
+      writeFileSync(join(root, 'feature.txt'), 'new work\n');
+      git('add', '.');
+      git('commit', '-q', '-m', 'feature work');
+
+      const { result } = invoke(root, '/check');
+      expect(result.exitCode).toBe(0);
+
+      const correct = buildReviewSubject(root, { targetRef: 'review-base' });
+      const wrong = buildReviewSubject(root, { targetRef: 'merge-target' });
+      expect(correct.status).toBe('ok');
+      expect(wrong.status).toBe('ok');
+      expect(correct.review_subject_sha256).not.toBe(wrong.review_subject_sha256);
+      expect(result.stdout).toContain(
+        `[AcceptanceSubject] The typed AcceptanceReceipt will bind normalized subject ${correct.review_subject_sha256} at target ${correct.target_rev}.`,
+      );
+      expect(result.stdout).not.toContain(wrong.review_subject_sha256);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
     }
   });
 });

--- a/tests/workflow-state-lib.test.ts
+++ b/tests/workflow-state-lib.test.ts
@@ -32,6 +32,12 @@ function fixtureEnv(): NodeJS.ProcessEnv {
   return env;
 }
 
+function git(cwd: string, ...args: string[]): string {
+  const result = spawnSync("git", args, { cwd, encoding: "utf-8" });
+  expect(result.status, result.stderr).toBe(0);
+  return result.stdout.trim();
+}
+
 // Minimal git fixture so workflow_current_review_subject_json (via the real
 // review-subject CLI) can resolve a genuine "ok" subject/target pair. Only the
 // contract-scoped benchmark-evidence regressions need a real subject binding;
@@ -526,6 +532,93 @@ describe("workflow-state shared library", () => {
       expect(checksMatch.status).toBe(0);
       expect(existsSync(invokedMarker)).toBe(false);
     } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  // Regression guard for the recorder/validator policy-key split: the
+  // recorder (workflow_current_review_subject_json, via
+  // workflow_current_review_subject_value -- what scripts/verify-sprint.sh
+  // embeds as review_subject_sha256 into verification evidence) must resolve
+  // its diff target from worktree_strategy.review_base, exactly like the
+  // acceptance-receipt.ts validator's reviewBase(). Before the fix the
+  // recorder read worktree_strategy.merge_back.target instead, so the two
+  // sides silently diffed against different refs and every receipt failed
+  // "verification evidence is stale for the current subject" whenever local
+  // main lagged origin/main -- the standard control-clone worktree pattern.
+  test("recorder path resolves the review target from worktree_strategy.review_base, matching the acceptance-receipt validator, even when local main lags origin/main", () => {
+    const upstream = realpathSync(mkdtempSync(join(tmpdir(), "workflow-subject-split-upstream-")));
+    const cwd = realpathSync(mkdtempSync(join(tmpdir(), "workflow-subject-split-work-")));
+    try {
+      // Upstream C0: the commit both the clone's local main and origin/main
+      // start at.
+      git(upstream, "init", "-q");
+      git(upstream, "config", "user.name", "Workflow Test");
+      git(upstream, "config", "user.email", "workflow-test@example.com");
+      writeFileSync(join(upstream, "base.txt"), "base\n");
+      git(upstream, "add", "-A");
+      git(upstream, "commit", "-q", "-m", "init");
+      git(upstream, "branch", "-M", "main");
+
+      // Clone: local main and origin/main both start at C0.
+      git(tmpdir(), "clone", "-q", upstream, cwd);
+      git(cwd, "config", "user.name", "Workflow Test");
+      git(cwd, "config", "user.email", "workflow-test@example.com");
+
+      // Upstream advances by C1 -- simulates another PR merging after the
+      // clone was made, before this task branched off origin/main.
+      writeFileSync(join(upstream, "upstream-change.txt"), "upstream only\n");
+      git(upstream, "add", "-A");
+      git(upstream, "commit", "-q", "-m", "upstream catches up");
+
+      // Fetch updates origin/main to C1, but the clone's local main branch
+      // pointer is intentionally left behind at C0 -- the standard
+      // control-clone worktree pattern this bug report describes.
+      git(cwd, "fetch", "-q", "origin");
+      expect(git(cwd, "rev-parse", "origin/main")).not.toBe(git(cwd, "rev-parse", "main"));
+
+      // The task branch is cut from origin/main (fresh), exactly like this
+      // repo's own codex/<slug> worktree-start convention -- NOT from the
+      // clone's stale local main. Diffing against stale main would sweep in
+      // C1's unrelated upstream-only file; diffing against origin/main
+      // correctly scopes to just this commit's own new work.
+      git(cwd, "checkout", "-q", "-b", "codex/demo", "origin/main");
+      writeFileSync(join(cwd, "feature.txt"), "new work\n");
+      mkdirSync(join(cwd, ".ai", "harness"), { recursive: true });
+      writeFileSync(
+        join(cwd, ".ai", "harness", "policy.json"),
+        `${JSON.stringify({
+          worktree_strategy: { review_base: "origin/main", merge_back: { target: "main" } },
+        }, null, 2)}\n`,
+      );
+      git(cwd, "add", "-A");
+      git(cwd, "commit", "-q", "-m", "feature work");
+
+      const recorded = spawnSync(
+        "bash",
+        ["-lc", 'source "$WORKFLOW_STATE"; workflow_current_review_subject_value'],
+        { cwd, encoding: "utf-8", env: evidenceAcceptanceEnv() },
+      );
+      expect(recorded.status).toBe(0);
+
+      const validator = spawnSync(
+        "bun",
+        [join(ROOT, "src/cli/hook-entry.ts"), "review-subject", "--target", "origin/main", "--format", "json"],
+        { cwd, encoding: "utf-8" },
+      );
+      expect(validator.status).toBe(0);
+      const validatorParsed = JSON.parse(validator.stdout);
+      expect(validatorParsed.status).toBe("ok");
+      expect(validatorParsed.review_subject_sha256).toMatch(/^sha256:[0-9a-f]{64}$/);
+
+      // The recorder must bind to the SAME ref the acceptance-receipt
+      // validator diffs against (review_base = origin/main here), never
+      // merge_back.target (main, stale by one commit here) -- otherwise the
+      // receipt fails purely because the two sides scoped their diff against
+      // different refs.
+      expect(recorded.stdout.trim()).toBe(validatorParsed.review_subject_sha256);
+    } finally {
+      rmSync(upstream, { recursive: true, force: true });
       rmSync(cwd, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
## Summary
- The acceptance-evidence recorder (`workflow_current_review_subject_json`) computed the review subject against `worktree_strategy.merge_back.target` (local `main`) while the validator (`acceptance-receipt.ts` `reviewBase()`) uses `worktree_strategy.review_base` (`origin/main`). Whenever local `main` lagged `origin/main` — the standard control-clone worktree pattern — every receipt failed "verification evidence is stale for the current subject".
- Recorder (and the advisory review hint in `prompt-handler.ts`) now resolve `review_base`, fail-closed with no fallback. Full callsite sweep: genuine merge-back mechanics (cleanup, finish guidance, ship/contract worktrees, archive prediction) legitimately keep `merge_back.target`; display-only sites unchanged; `resolve-effective-state.ts` already correct; `merge-gate.ts` takes an explicit `--base` and has no such split.
- Regression guards: fixture with local `main` one commit behind `origin/main` asserts recorder == validator subject hash (red pre-fix, `PRE_FIX_EXIT=1` captured; green post-fix), plus a sibling guard for the prompt-handler hint.

## Verification
- `bun test` full: 1675 pass / 1 skip / 0 fail (run twice, identical)
- `check:hooks` projection OK; `check:helpers` 50 helpers parity; `check:type` clean
- `check-task-workflow --strict` OK; preflight pass
- `verify-sprint --prepare-acceptance`: 22/22 PASS, status=Fulfilled; external_pass receipt recorded