### PR TITLE
EPC-01: EvidenceEvent protocol and append-only event store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ tasks/.current.md.tmp.*
 .ai/harness/active-worktree
 .ai/harness/sprint/
 .ai/harness/worktrees/
+.ai/harness/evidence/
 .ai/harness/runs/
 .ai/harness/state/
 .ai/harness/chatgpt/browser-lock.json

--- a/plans/plan-20260722-1151-epc-01-evidence-event-store.md
+++ b/plans/plan-20260722-1151-epc-01-evidence-event-store.md
@@ -1,0 +1,270 @@
+# Plan: EPC-01: EvidenceEvent Protocol and Event Store
+
+> **Status**: Executing
+> **Created**: 20260722-1151
+> **Slug**: epc-01-evidence-event-store
+> **Planning Source**: repo-harness-sprint
+> **Orchestration Kind**: host-plan
+> **Source Ref**: sprint:plans/sprints/20260722-0001-evidence-projection-convergence.sprint.md#epc-01
+> **Artifact Level**: work-package
+> **Promotion Reason**: verification_boundary
+> **Verification Boundary**: New evidence test suites prove append atomicity, replay determinism, corrupt-tail truncation+quarantine, duplicate-import no-op, supersedes exclusion, genesis fail-closed, redaction-by-construction, path fail-closed, blob write-once; full bun test and root required checks green in the contract worktree
+> **Rollback Surface**: Revert the single PR: all changes are new files under src/core/evidence/, src/effects/evidence/, tests/, plus one .gitignore line and package workflow artifacts; no existing runtime surface is modified
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260722-1151-epc-01-evidence-event-store.contract.md`
+> **Task Review**: `tasks/reviews/20260722-1151-epc-01-evidence-event-store.review.md`
+> **Implementation Notes**: `tasks/notes/20260722-1151-epc-01-evidence-event-store.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from repo-harness-sprint planning output.
+- Source ref: sprint:plans/sprints/20260722-0001-evidence-projection-convergence.sprint.md#epc-01
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260722-1151-epc-01-evidence-event-store.md`
+- Sprint contract: `tasks/contracts/20260722-1151-epc-01-evidence-event-store.contract.md`
+- Sprint review: `tasks/reviews/20260722-1151-epc-01-evidence-event-store.review.md`
+- Implementation notes: `tasks/notes/20260722-1151-epc-01-evidence-event-store.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260722-1151-epc-01-evidence-event-store.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260722-1151-epc-01-evidence-event-store.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260722-1151-epc-01-evidence-event-store.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260722-1151-epc-01-evidence-event-store.contract.md`
+- Review file: `tasks/reviews/20260722-1151-epc-01-evidence-event-store.review.md`
+- Implementation notes file: `tasks/notes/20260722-1151-epc-01-evidence-event-store.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260722-1151-epc-01-evidence-event-store.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260722-1151-epc-01-evidence-event-store.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: Revert the single PR: all changes are new files under src/core/evidence/, src/effects/evidence/, tests/, plus one .gitignore line and package workflow artifacts; no existing runtime surface is modified
+- **Verification boundary**: New evidence test suites prove append atomicity, replay determinism, corrupt-tail truncation+quarantine, duplicate-import no-op, supersedes exclusion, genesis fail-closed, redaction-by-construction, path fail-closed, blob write-once; full bun test and root required checks green in the contract worktree
+- **Review/acceptance boundary**: `tasks/reviews/20260722-1151-epc-01-evidence-event-store.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: verification_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260722-1151-epc-01-evidence-event-store.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260722-1151-epc-01-evidence-event-store.contract.md`, `tasks/reviews/20260722-1151-epc-01-evidence-event-store.review.md`, and `tasks/notes/20260722-1151-epc-01-evidence-event-store.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260722-1151-epc-01-evidence-event-store.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: Revert the single PR: all changes are new files under src/core/evidence/, src/effects/evidence/, tests/, plus one .gitignore line and package workflow artifacts; no existing runtime surface is modified
+
+## Captured Planning Output
+
+> **Task Profile**: code-change
+
+## Decision Summary
+
+EPC-01 implements Sprint C backlog row 5: the single `EvidenceEvent` schema
+and the atomic append-only per-worktree event store, exactly as frozen by
+EPC-00's design decisions D1–D6 (sprint `### Frozen decisions (EPC-00,
+2026-07-22)` section — the design authority; this package re-decides
+nothing). Pure schema, fold/replay, and accepted-set logic live in
+`src/core/evidence/`; the IO store (atomic append, genesis record, blob
+store, corrupt-tail recovery, quarantine) lives in `src/effects/evidence/`.
+No existing surface is cut over: no producer, no consumer, no gate reads
+the ledger yet (rows 6–13 own those packages). `.gitignore` gains the
+`.ai/harness/evidence/` entry per D1. Base SHA is pinned per R1 at fresh
+fetch: `5228d4ea0d7987cf6fb73be216d5b9cc638817c3` (`POST_VGBR_SHA` lineage:
+EPC-00 merged via PR #116 plus its row-flip commit).
+
+## Why
+
+Rows 6–13 (producers, importers, materializers, checkpoints, recovery-view
+cutover) all depend on one evidence authority existing first. EPC-00 froze
+the design (D1 topology, D2 epoch, D3 subject identity, D4 trust classes,
+D5 event identity/replay, D6 blob and safety policy); EPC-01 is the first
+implementation package and delivers only the ledger substrate with proof
+(tests) that its invariants hold. Shipping producers or cutovers in the
+same package would violate the sprint's one-authority-per-package rule and
+R5's same-package-cutover discipline (cutovers belong to the packages that
+replace each retired writer).
+
+## Goal
+
+1. `EvidenceEvent` schema with the frozen field set: D3 subject identity
+   (`authority_commit`, `base_commit`, `target_commit`, `scope_hash`,
+   `subject_hash`, `contract_hash`, `command_hash`, `env_provider_id`,
+   envelope `schema_version` + `worktree_id`), D4 trust class enum
+   (`authoritative_machine` | `observed` | `human_acceptance` |
+   `external_attested`), D5 identity (`event_id` = `evt-<ULID>`,
+   `correlation_run_id`, idempotency key, optional `supersedes`).
+2. Append-only store under `.ai/harness/evidence/events/` (per-worktree,
+   gitignored): atomic whole-line JSONL append + fsync; genesis record
+   carrying `ledger_epoch_start_sha` as a hard precondition of the first
+   append (D2, fail closed); total order = append position (D5).
+3. Content-addressed blob store under `.ai/harness/evidence/blobs/` with
+   D6 invariants by construction: 200-line/8-KiB inline cap with overflow
+   to `blob_sha256`+`blob_bytes`, secret-denylist + high-entropy redaction
+   before write, repo-relative-path-only rule (fail closed on escape),
+   symlinks never dereferenced, binary always offloaded, sha256 only,
+   write-once immutable blobs.
+4. Pure replay/fold in `src/core/evidence/`: deterministic accepted-set
+   computation (idempotency dedup, supersedes exclusion, append-position
+   order) as a pure function; corrupt-tail recovery truncates at the last
+   valid offset and quarantines the tail to `events.corrupt-<ts>` (D5,
+   fail closed — never skip a corrupt middle record).
+5. Tests proving: append atomicity; replay determinism (identical accepted
+   set and bytes across replays); corrupt-tail truncation + quarantine;
+   duplicate-import no-op; supersedes exclusion; genesis-before-append
+   fail-closed; redaction as construction invariant; absolute/escaping
+   path fail-closed; blob write-once.
+6. `.gitignore` entry `.ai/harness/evidence/`.
+7. All root required checks green in the contract worktree; one
+   independent PR on `codex/epc-01-evidence-event-store`.
+
+## P1: Architecture Map
+
+- Design authority: sprint `### Frozen decisions (EPC-00, 2026-07-22)`
+  D1–D6; this package cites, never re-decides.
+- `src/core/` holds pure logic (existing precedent: `core/state`,
+  `core/workflow`); `src/effects/` holds IO (existing precedent:
+  `effects/fs-transaction.ts`, `effects/state`). New modules:
+  `src/core/evidence/` (schema, fold, accepted-set, corrupt-tail policy as
+  pure functions over parsed records) and `src/effects/evidence/`
+  (append/fsync, genesis, blob store, quarantine writes).
+- No existing module may import the new store in this package (no consumer
+  cutover); the new modules import only existing shared utilities (e.g.
+  path safety, fs transaction helpers) — never `src/cli` hook handlers.
+- Legacy evidence surfaces (`.ai/harness/events.jsonl`, `checks/*`,
+  `journal/`, `runs/`) are pre-epoch artifacts per D2: untouched, never
+  parsed as EvidenceEvents.
+
+## P2: Concrete Trace
+
+EPC-00 merges via PR #116 -> `main` advances to `5228d4ea` (row-4 flip) ->
+EPC-01 fresh-fetches, verifies `origin/main == 5228d4ea`, pins it as Base
+SHA (R1) -> contract worktree opens on `codex/epc-01-evidence-event-store`
+-> `src/core/evidence/` + `src/effects/evidence/` + tests land -> first
+append in a fresh store writes the genesis record with
+`ledger_epoch_start_sha` = this package's pinned base (D2 rule) -> replay
+fold produces byte-identical accepted sets across runs -> corrupt-tail
+fixture truncates + quarantines -> required checks green -> receipt
+recorded immediately after evidence -> one PR merges -> EPC-02 pins its own
+base per R1.
+
+## P3: Design Decision
+
+- Split pure/IO along the repo's existing `core`/`effects` boundary rather
+  than one module: replay determinism and accepted-set logic must be
+  testable without touching a filesystem, and EPC-05/06/07 materializers
+  will consume the pure fold without importing the writer.
+- Single JSONL log file per worktree (`events/log.jsonl`) rather than
+  file-per-event: D5's total order is append position in "the per-worktree
+  log"; a directory of files would reintroduce mtime/filename ordering,
+  which D5/D7 forbid.
+- The idempotency key and redaction run inside the writer's constructor
+  path (construction invariant), not as a separate sanitize step a caller
+  could skip — D6 explicitly requires deny-by-construction.
+- ULID implementation is vendored as a small pure function (no new
+  dependency) unless an existing dependency already provides one; adding a
+  package for 40 lines fails the smallest-change rule.
+
+## Task Breakdown
+
+- [ ] Verify fresh fetch equals pinned base `5228d4ea`; fill contract.
+- [ ] `src/core/evidence/`: schema types, ULID, idempotency key, fold /
+      accepted-set, corrupt-tail policy (pure).
+- [ ] `src/effects/evidence/`: append-only store, genesis record, blob
+      store with D6 invariants, quarantine.
+- [ ] Tests for every Goal-5 invariant (red first where feasible).
+- [ ] `.gitignore` entry; required checks; commit; receipt; PR.
+
+## Scope
+
+- In scope: `src/core/evidence/`, `src/effects/evidence/`, new test files
+  `tests/evidence-*.test.ts`, `.gitignore` (one entry), this package's
+  plan/contract/review/notes, `tasks/todos.md` if the projection rewrites
+  it.
+- Out of scope: any producer/importer/materializer (rows 6–12), any edit
+  to existing hook handlers, `verify-sprint`, `checks/*` writers,
+  handoff/resume/current writers, `tasks/current.md`, benchmark surfaces,
+  the sprint document (row flip happens post-merge on `main`, outside this
+  package), any new npm dependency.
+- Non-goals: reading or migrating pre-epoch artifacts; wiring any gate to
+  the ledger; checkpoint materialization (EPC-06); `checks/latest`
+  selection (EPC-05).
+
+## Stop Conditions
+
+- Stop if `origin/main` moves past `5228d4ea` before the worktree is
+  created — re-fetch, re-audit, re-pin with report.
+- Stop if implementing any invariant would require editing a path outside
+  `allowed_paths` (e.g. an existing shared utility needs a change) —
+  report instead of widening scope silently.
+- Stop after three fail-fix-reverify rounds on one issue.
+
+## Falsifier
+
+The direction is wrong if the store cannot satisfy a D1–D6 invariant
+without modifying existing runtime surfaces (would mean the frozen design
+conflicts with repo reality), or if any test needs a consumer wired in to
+pass. Cheapest proof: the PR diff contains only new files plus one
+`.gitignore` line and the package workflow files; `bun test` green
+including the new evidence suites.
+
+## Cheapest Sufficient Proof
+
+- Fresh fetch equals `5228d4ea` at pin time; contract records it.
+- New evidence test files pass; full `bun test` green; all root required
+  checks green in the worktree.
+- `git diff --name-only <base>..HEAD` ⊆ `allowed_paths`; no existing
+  `src/` file modified.
+- Replay determinism test asserts byte-identical accepted-set output
+  across two independent folds of the same log.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [ ] Verify fresh fetch equals pinned base `5228d4ea`; fill contract.
+- [ ] `src/core/evidence/`: schema types, ULID, idempotency key, fold /
+- [ ] `src/effects/evidence/`: append-only store, genesis record, blob
+- [ ] Tests for every Goal-5 invariant (red first where feasible).
+- [ ] `.gitignore` entry; required checks; commit; receipt; PR.

--- a/src/core/evidence/canonical-json.ts
+++ b/src/core/evidence/canonical-json.ts
@@ -1,0 +1,26 @@
+/**
+ * Deterministic JSON serialization: object keys are sorted recursively so
+ * the same logical value always serializes to the same bytes regardless of
+ * construction order. Arrays keep their given order (order is significant).
+ * Used by the idempotency key (D5) and payload-size measurement (D6).
+ */
+import type { JsonValue } from "./types";
+
+function canonicalizeValue(value: JsonValue): string {
+  if (value === null || typeof value === "number" || typeof value === "boolean") {
+    return JSON.stringify(value);
+  }
+  if (typeof value === "string") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => canonicalizeValue(entry)).join(",")}]`;
+  }
+  const keys = Object.keys(value).sort();
+  const entries = keys.map((key) => `${JSON.stringify(key)}:${canonicalizeValue((value as Record<string, JsonValue>)[key]!)}`);
+  return `{${entries.join(",")}}`;
+}
+
+export function canonicalize(value: JsonValue): string {
+  return canonicalizeValue(value);
+}

--- a/src/core/evidence/fold.ts
+++ b/src/core/evidence/fold.ts
@@ -1,0 +1,135 @@
+/**
+ * Pure fold / accepted-set / corrupt-tail-detection logic (D5). No IO: the
+ * effects layer (`src/effects/evidence/event-log.ts`) supplies raw lines
+ * read from disk and performs the quarantine write; everything here is a
+ * deterministic function of its inputs so replay is provably reproducible.
+ */
+import type { EvidenceEventRecord, EvidenceLogRecord, GenesisRecord, SubjectIdentity, TrustClass } from "./types";
+
+export type ParsedLogLine =
+  | { readonly ok: true; readonly record: EvidenceLogRecord }
+  | { readonly ok: false; readonly error: string };
+
+const TRUST_CLASSES: ReadonlySet<string> = new Set<TrustClass>([
+  "authoritative_machine",
+  "observed",
+  "human_acceptance",
+  "external_attested",
+]);
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isValidGenesis(value: unknown): value is GenesisRecord {
+  if (!isRecord(value)) return false;
+  return value.kind === "evidence_genesis"
+    && value.schema_version === 1
+    && isNonEmptyString(value.worktree_id)
+    && isNonEmptyString(value.ledger_epoch_start_sha)
+    && isNonEmptyString(value.created_at);
+}
+
+function isValidSubjectIdentity(value: unknown): value is SubjectIdentity {
+  if (!isRecord(value)) return false;
+  return isNonEmptyString(value.authority_commit)
+    && isNonEmptyString(value.base_commit)
+    && isNonEmptyString(value.target_commit)
+    && isNonEmptyString(value.scope_hash)
+    && isNonEmptyString(value.subject_hash)
+    && isNonEmptyString(value.contract_hash)
+    && isNonEmptyString(value.command_hash)
+    && isNonEmptyString(value.env_provider_id);
+}
+
+function isValidEvidenceEvent(value: unknown): value is EvidenceEventRecord {
+  if (!isRecord(value)) return false;
+  if (value.kind !== "evidence_event" || value.schema_version !== 1) return false;
+  if (!isNonEmptyString(value.worktree_id)) return false;
+  if (!isNonEmptyString(value.event_id)) return false;
+  if (!isNonEmptyString(value.correlation_run_id)) return false;
+  if (!isNonEmptyString(value.event_type)) return false;
+  if (typeof value.trust_class !== "string" || !TRUST_CLASSES.has(value.trust_class)) return false;
+  if (!isNonEmptyString(value.producer)) return false;
+  if (!isValidSubjectIdentity(value.subject_identity)) return false;
+  if (!isNonEmptyString(value.idempotency_key)) return false;
+  if (!isNonEmptyString(value.payload_hash)) return false;
+  if (!isNonEmptyString(value.created_at)) return false;
+  if (value.supersedes !== undefined && !Array.isArray(value.supersedes)) return false;
+  const hasPayload = value.payload !== undefined;
+  const hasBlob = isNonEmptyString(value.blob_sha256);
+  if (hasPayload === hasBlob) return false; // exactly one of payload/blob_sha256 must be present
+  return true;
+}
+
+/** Parse one JSONL line into a typed record, or a typed parse failure -- never throws. */
+export function parseLogLine(line: string): ParsedLogLine {
+  if (line.length === 0) {
+    return { ok: false, error: "empty line" };
+  }
+  let value: unknown;
+  try {
+    value = JSON.parse(line);
+  } catch (error) {
+    return { ok: false, error: `invalid JSON: ${error instanceof Error ? error.message : String(error)}` };
+  }
+  if (isValidGenesis(value)) return { ok: true, record: value };
+  if (isValidEvidenceEvent(value)) return { ok: true, record: value };
+  return { ok: false, error: "record does not match a known EvidenceLogRecord shape" };
+}
+
+export interface CorruptTailResult {
+  /** Count of leading lines (from index 0) that parsed as valid records. */
+  readonly validLineCount: number;
+  /** Index of the first unparseable/truncated line, or null if none found. */
+  readonly corruptStartIndex: number | null;
+}
+
+/**
+ * D5 corrupt-tail policy: the first unparseable/truncated record truncates
+ * the accepted log at the last valid offset. Never skip a corrupt middle
+ * record and resume -- everything from the first bad line onward, including
+ * any later well-formed-looking line, is corrupt tail.
+ */
+export function findCorruptTail(parsedLines: readonly ParsedLogLine[]): CorruptTailResult {
+  for (let i = 0; i < parsedLines.length; i++) {
+    if (!parsedLines[i]!.ok) {
+      return { validLineCount: i, corruptStartIndex: i };
+    }
+  }
+  return { validLineCount: parsedLines.length, corruptStartIndex: null };
+}
+
+export interface FoldResult {
+  readonly accepted: readonly EvidenceEventRecord[];
+  readonly acceptedIdempotencyKeys: readonly string[];
+}
+
+/**
+ * D5/D7-adjacent accepted-set fold: total order = append position (the
+ * array's given order, never re-sorted); dedup by idempotency key (a later
+ * duplicate is a no-op, the first occurrence wins); exclude every event_id
+ * appearing in the union of all supersedes lists. Pure: identical input
+ * always yields an identical, byte-serializable result.
+ */
+export function foldAcceptedEvents(events: readonly EvidenceEventRecord[]): FoldResult {
+  const seenIdempotencyKeys = new Set<string>();
+  const deduped: EvidenceEventRecord[] = [];
+  for (const event of events) {
+    if (seenIdempotencyKeys.has(event.idempotency_key)) continue;
+    seenIdempotencyKeys.add(event.idempotency_key);
+    deduped.push(event);
+  }
+
+  const supersededIds = new Set<string>();
+  for (const event of deduped) {
+    for (const id of event.supersedes ?? []) supersededIds.add(id);
+  }
+
+  const accepted = deduped.filter((event) => !supersededIds.has(event.event_id));
+  return { accepted, acceptedIdempotencyKeys: accepted.map((event) => event.idempotency_key) };
+}

--- a/src/core/evidence/idempotency.ts
+++ b/src/core/evidence/idempotency.ts
@@ -1,0 +1,42 @@
+/**
+ * D5 idempotency key: identical key implies no-op dedup on replay (e.g.
+ * re-importing the same external attestation twice yields exactly one
+ * accepted event).
+ */
+import { createHash } from "crypto";
+import { canonicalize } from "./canonical-json";
+import type { JsonValue, SubjectIdentity, TrustClass } from "./types";
+
+export interface IdempotencyInput {
+  readonly subjectIdentity: SubjectIdentity;
+  readonly eventType: string;
+  readonly trustClass: TrustClass;
+  readonly payloadHash: string;
+  readonly producer: string;
+}
+
+function subjectIdentityAsJson(subject: SubjectIdentity): JsonValue {
+  return {
+    authority_commit: subject.authority_commit,
+    base_commit: subject.base_commit,
+    target_commit: subject.target_commit,
+    scope_hash: subject.scope_hash,
+    subject_hash: subject.subject_hash,
+    contract_hash: subject.contract_hash,
+    command_hash: subject.command_hash,
+    env_provider_id: subject.env_provider_id,
+  };
+}
+
+/** sha256(canonical(subject_identity . event_type . trust_class . payload_hash . producer)). */
+export function computeIdempotencyKey(input: IdempotencyInput): string {
+  const composite: JsonValue = {
+    subject_identity: subjectIdentityAsJson(input.subjectIdentity),
+    event_type: input.eventType,
+    trust_class: input.trustClass,
+    payload_hash: input.payloadHash,
+    producer: input.producer,
+  };
+  const digest = createHash("sha256").update(canonicalize(composite)).digest("hex");
+  return `sha256:${digest}`;
+}

--- a/src/core/evidence/json-walk.ts
+++ b/src/core/evidence/json-walk.ts
@@ -1,0 +1,47 @@
+/**
+ * Generic, pure recursive walkers over a `JsonValue` tree. Shared by path
+ * field discovery and secret redaction so both operate the same way over
+ * arbitrary payload shapes.
+ */
+import type { JsonValue } from "./types";
+
+export interface StringLeaf {
+  readonly path: readonly string[];
+  readonly value: string;
+}
+
+export function collectStringLeaves(value: JsonValue, pathPrefix: readonly string[] = []): readonly StringLeaf[] {
+  if (typeof value === "string") {
+    return [{ path: pathPrefix, value }];
+  }
+  if (value === null || typeof value === "number" || typeof value === "boolean") {
+    return [];
+  }
+  if (Array.isArray(value)) {
+    return value.flatMap((entry, index) => collectStringLeaves(entry, [...pathPrefix, String(index)]));
+  }
+  const record = value as Record<string, JsonValue>;
+  return Object.keys(record).flatMap((key) => collectStringLeaves(record[key]!, [...pathPrefix, key]));
+}
+
+export function mapStringLeaves(
+  value: JsonValue,
+  fn: (path: readonly string[], leaf: string) => string,
+  pathPrefix: readonly string[] = [],
+): JsonValue {
+  if (typeof value === "string") {
+    return fn(pathPrefix, value);
+  }
+  if (value === null || typeof value === "number" || typeof value === "boolean") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry, index) => mapStringLeaves(entry, fn, [...pathPrefix, String(index)]));
+  }
+  const record = value as Record<string, JsonValue>;
+  const result: Record<string, JsonValue> = {};
+  for (const key of Object.keys(record)) {
+    result[key] = mapStringLeaves(record[key]!, fn, [...pathPrefix, key]);
+  }
+  return result;
+}

--- a/src/core/evidence/payload-cap.ts
+++ b/src/core/evidence/payload-cap.ts
@@ -1,0 +1,18 @@
+/**
+ * D6 inline payload cap: 200 lines or 8 KiB, whichever first. Reuses the
+ * PostBash offload precedent's dual line/byte threshold shape
+ * (`src/cli/hook/command-observed.ts`'s `longLines`/`longBytes`) with
+ * EPC-01's own frozen numbers.
+ */
+export const INLINE_MAX_LINES = 200;
+export const INLINE_MAX_BYTES = 8192;
+
+function lineCount(text: string): number {
+  if (!text) return 0;
+  const lines = text.split("\n");
+  return text.endsWith("\n") ? lines.length - 1 : lines.length;
+}
+
+export function exceedsInlineCap(serialized: string): boolean {
+  return lineCount(serialized) >= INLINE_MAX_LINES || Buffer.byteLength(serialized, "utf8") >= INLINE_MAX_BYTES;
+}

--- a/src/core/evidence/redaction.ts
+++ b/src/core/evidence/redaction.ts
@@ -1,0 +1,97 @@
+/**
+ * D6 secret redaction: deny-by-construction. A fixed denylist of secret env
+ * var NAMES plus a high-entropy token pattern; any matched substring of the
+ * ORIGINAL text is replaced with `sha256:<hash-of-the-secret>`. Pure: this
+ * module never reads `process.env` itself -- the caller (an effects module)
+ * collects the present values and passes them in as `knownSecretValues`.
+ */
+import { createHash } from "crypto";
+import type { JsonValue } from "./types";
+import { mapStringLeaves } from "./json-walk";
+
+/** Env var NAMES whose present VALUES must never appear raw in a payload. */
+export const SECRET_DENYLIST_ENV_KEYS: readonly string[] = [
+  "GH_TOKEN",
+  "GITHUB_TOKEN",
+  "ANTHROPIC_API_KEY",
+  "CLAUDE_CODE_OAUTH_TOKEN",
+  "OPENAI_API_KEY",
+  "SSH_AUTH_SOCK",
+];
+
+const HIGH_ENTROPY_TOKEN_SOURCE = "[A-Za-z0-9+/_-]{32,}";
+
+interface Span {
+  readonly start: number;
+  readonly end: number;
+}
+
+function hashSecret(secret: string): string {
+  return `sha256:${createHash("sha256").update(secret).digest("hex")}`;
+}
+
+function findKnownSecretSpans(text: string, knownSecretValues: readonly string[]): Span[] {
+  const spans: Span[] = [];
+  for (const secret of knownSecretValues) {
+    if (secret.length === 0) continue;
+    let fromIndex = 0;
+    while (fromIndex <= text.length) {
+      const index = text.indexOf(secret, fromIndex);
+      if (index === -1) break;
+      spans.push({ start: index, end: index + secret.length });
+      fromIndex = index + secret.length;
+    }
+  }
+  return spans;
+}
+
+function findHighEntropySpans(text: string): Span[] {
+  const spans: Span[] = [];
+  const pattern = new RegExp(HIGH_ENTROPY_TOKEN_SOURCE, "g");
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(text)) !== null) {
+    spans.push({ start: match.index, end: match.index + match[0].length });
+  }
+  return spans;
+}
+
+/** Sort and union overlapping/adjacent spans so no original byte is hashed twice. */
+function mergeSpans(spans: readonly Span[]): Span[] {
+  if (spans.length === 0) return [];
+  const sorted = [...spans].sort((a, b) => (a.start - b.start) || (a.end - b.end));
+  const merged: Span[] = [sorted[0]!];
+  for (const span of sorted.slice(1)) {
+    const last = merged[merged.length - 1]!;
+    if (span.start <= last.end) {
+      merged[merged.length - 1] = { start: last.start, end: Math.max(last.end, span.end) };
+    } else {
+      merged.push(span);
+    }
+  }
+  return merged;
+}
+
+/**
+ * Redact every matched span exactly once, over the ORIGINAL text only. A
+ * two-pass "denylist then regex" design would re-scan the hex output of the
+ * first pass (itself high-entropy) and double-hash it; computing spans from
+ * both sources up front and slicing the original string avoids that.
+ */
+export function redactSecretValue(text: string, knownSecretValues: readonly string[]): string {
+  const spans = mergeSpans([...findKnownSecretSpans(text, knownSecretValues), ...findHighEntropySpans(text)]);
+  if (spans.length === 0) return text;
+  let out = "";
+  let cursor = 0;
+  for (const span of spans) {
+    out += text.slice(cursor, span.start);
+    out += hashSecret(text.slice(span.start, span.end));
+    cursor = span.end;
+  }
+  out += text.slice(cursor);
+  return out;
+}
+
+/** Pure: walk a JSON payload and redact every string leaf. */
+export function redactPayloadStrings(value: JsonValue, knownSecretValues: readonly string[]): JsonValue {
+  return mapStringLeaves(value, (_path, leaf) => redactSecretValue(leaf, knownSecretValues));
+}

--- a/src/core/evidence/types.ts
+++ b/src/core/evidence/types.ts
@@ -1,0 +1,74 @@
+/**
+ * EvidenceEvent protocol types (EPC-01).
+ *
+ * Frozen by sprint `### Frozen decisions (EPC-00, 2026-07-22)` D3-D6. This
+ * module defines the shape only; it performs no IO and imports neither `fs`
+ * nor `process`.
+ */
+
+export type JsonPrimitive = string | number | boolean | null;
+
+export type JsonValue = JsonPrimitive | readonly JsonValue[] | { readonly [key: string]: JsonValue };
+
+/** D4 trust matrix. Default is deny: absent an explicit allow, `external_attested` is `observed` for a gate. */
+export type TrustClass =
+  | "authoritative_machine"
+  | "observed"
+  | "human_acceptance"
+  | "external_attested";
+
+/** D3 subject identity, exact field list frozen by EPC-00. */
+export interface SubjectIdentity {
+  readonly authority_commit: string;
+  readonly base_commit: string;
+  readonly target_commit: string;
+  readonly scope_hash: string;
+  readonly subject_hash: string;
+  readonly contract_hash: string;
+  readonly command_hash: string;
+  readonly env_provider_id: string;
+}
+
+/** First record of a fresh per-worktree store; hard precondition of the first append (D2). */
+export interface GenesisRecord {
+  readonly kind: "evidence_genesis";
+  readonly schema_version: 1;
+  readonly worktree_id: string;
+  readonly ledger_epoch_start_sha: string;
+  readonly created_at: string;
+}
+
+/**
+ * A single EvidenceEvent (D3-D6). Exactly one of `payload` or `blob_sha256`
+ * is present, never both and never neither -- enforced by the writer
+ * construction path in `src/effects/evidence/event-writer.ts`.
+ */
+export interface EvidenceEventRecord {
+  readonly kind: "evidence_event";
+  readonly schema_version: 1;
+  readonly worktree_id: string;
+  readonly event_id: string;
+  readonly correlation_run_id: string;
+  readonly event_type: string;
+  readonly trust_class: TrustClass;
+  readonly producer: string;
+  readonly subject_identity: SubjectIdentity;
+  readonly idempotency_key: string;
+  readonly supersedes?: readonly string[];
+  readonly payload_hash: string;
+  readonly payload?: JsonValue;
+  readonly blob_sha256?: string;
+  readonly blob_bytes?: number;
+  readonly content_type?: string;
+  readonly created_at: string;
+}
+
+export type EvidenceLogRecord = GenesisRecord | EvidenceEventRecord;
+
+export function isGenesisRecord(record: EvidenceLogRecord): record is GenesisRecord {
+  return record.kind === "evidence_genesis";
+}
+
+export function isEvidenceEventRecord(record: EvidenceLogRecord): record is EvidenceEventRecord {
+  return record.kind === "evidence_event";
+}

--- a/src/core/evidence/ulid.ts
+++ b/src/core/evidence/ulid.ts
@@ -1,0 +1,69 @@
+/**
+ * Vendored ULID (Universally Unique Lexicographically Sortable Identifier)
+ * implementation. No npm package: D5 requires a lexicographically sortable,
+ * time-embedding `event_id` (`evt-<ULID>`), and a dependency for ~40 lines
+ * of Crockford base32 encoding fails the smallest-change rule (see plan P3
+ * and `tasks/notes/20260722-1151-epc-01-evidence-event-store.notes.md`).
+ *
+ * `encodeUlid` is a pure function of its two explicit inputs so replay/tests
+ * never depend on wall-clock time or the system RNG. `generateUlid` /
+ * `generateEventId` are the impure convenience wrappers that real producers
+ * call; they use `crypto.randomBytes` (not `fs`, not `process`).
+ */
+import { randomBytes as nodeRandomBytes } from "crypto";
+
+const CROCKFORD_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+const TIME_CHARS = 10;
+const RANDOM_BYTES = 10; // 80 bits == 16 base32 chars with zero padding waste
+const MAX_TIME_MS = 2 ** 48 - 1;
+
+function encodeTimestamp(timeMs: number): string {
+  if (!Number.isInteger(timeMs) || timeMs < 0 || timeMs > MAX_TIME_MS) {
+    throw new Error(`ulid: timestamp must be an integer in [0, 2^48-1], got ${timeMs}`);
+  }
+  let remaining = timeMs;
+  const chars = new Array<string>(TIME_CHARS);
+  for (let i = TIME_CHARS - 1; i >= 0; i--) {
+    chars[i] = CROCKFORD_ALPHABET[remaining % 32]!;
+    remaining = Math.floor(remaining / 32);
+  }
+  return chars.join("");
+}
+
+function encodeRandomness(bytes: Uint8Array): string {
+  if (bytes.length !== RANDOM_BYTES) {
+    throw new Error(`ulid: randomness must be exactly ${RANDOM_BYTES} bytes, got ${bytes.length}`);
+  }
+  // Sliding 5-bit window over the byte stream. `bitBuffer` is masked back
+  // down to its unconsumed remainder (<8 bits) after every drain, so it
+  // never grows past ~12 bits and stays inside 32-bit bitwise-op range even
+  // though the full randomness is 80 bits.
+  let out = "";
+  let bitBuffer = 0;
+  let bitCount = 0;
+  for (const byte of bytes) {
+    bitBuffer = (bitBuffer << 8) | byte;
+    bitCount += 8;
+    while (bitCount >= 5) {
+      bitCount -= 5;
+      out += CROCKFORD_ALPHABET[(bitBuffer >>> bitCount) & 0x1f];
+    }
+    bitBuffer &= (1 << bitCount) - 1;
+  }
+  return out;
+}
+
+/** Pure: encode an exact (timeMs, randomness) pair into a 26-char ULID string. */
+export function encodeUlid(timeMs: number, randomness: Uint8Array): string {
+  return `${encodeTimestamp(timeMs)}${encodeRandomness(randomness)}`;
+}
+
+/** Impure convenience wrapper: real wall-clock time + CSPRNG randomness. */
+export function generateUlid(): string {
+  return encodeUlid(Date.now(), nodeRandomBytes(RANDOM_BYTES));
+}
+
+/** D5: `event_id` = `evt-<ULID>`. */
+export function generateEventId(): string {
+  return `evt-${generateUlid()}`;
+}

--- a/src/effects/evidence/atomic-append.ts
+++ b/src/effects/evidence/atomic-append.ts
@@ -1,0 +1,59 @@
+/**
+ * Low-level durable file primitives for the evidence store. Mirrors the
+ * open/write-loop/fsync idiom already used by `src/effects/fs-transaction.ts`
+ * (that file's own `writeFileDurably` is a private, unexported helper, so an
+ * equivalent is implemented locally here rather than modifying it -- see
+ * tasks/notes/20260722-1151-epc-01-evidence-event-store.notes.md).
+ */
+import { closeSync, constants, fsyncSync, mkdirSync, openSync, writeSync } from "fs";
+import { dirname } from "path";
+
+function writeAllSync(fd: number, data: Buffer): void {
+  let offset = 0;
+  while (offset < data.length) {
+    offset += writeSync(fd, data, offset, data.length - offset);
+  }
+}
+
+function ensureParentDir(path: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+}
+
+/** Append one line plus a trailing newline; creates the file if missing. Whole-line append + fsync (D5). */
+export function appendLineDurably(path: string, line: string, mode = 0o600): void {
+  ensureParentDir(path);
+  let fd: number | null = null;
+  try {
+    fd = openSync(path, constants.O_WRONLY | constants.O_CREAT | constants.O_APPEND, mode);
+    writeAllSync(fd, Buffer.from(`${line}\n`, "utf-8"));
+    fsyncSync(fd);
+  } finally {
+    if (fd !== null) closeSync(fd);
+  }
+}
+
+/** Create a brand-new file exclusively; throws with code EEXIST if it already exists (write-once). */
+export function createFileExclusiveDurably(path: string, content: Buffer, mode = 0o600): void {
+  ensureParentDir(path);
+  let fd: number | null = null;
+  try {
+    fd = openSync(path, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL, mode);
+    writeAllSync(fd, content);
+    fsyncSync(fd);
+  } finally {
+    if (fd !== null) closeSync(fd);
+  }
+}
+
+/** Create or fully replace a file's content (used for quarantine dumps); fsync before returning. */
+export function writeFileDurably(path: string, content: string | Buffer, mode = 0o600): void {
+  ensureParentDir(path);
+  let fd: number | null = null;
+  try {
+    fd = openSync(path, constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC, mode);
+    writeAllSync(fd, Buffer.isBuffer(content) ? content : Buffer.from(content, "utf-8"));
+    fsyncSync(fd);
+  } finally {
+    if (fd !== null) closeSync(fd);
+  }
+}

--- a/src/effects/evidence/blob-store.ts
+++ b/src/effects/evidence/blob-store.ts
@@ -1,0 +1,74 @@
+/**
+ * Content-addressed, write-once blob store (D6). Name = sha256 hex.
+ * Symlinks are never dereferenced when ingesting a path into the store --
+ * a symlink's own target string is hashed and returned as metadata; its
+ * target's content is never read.
+ */
+import { createHash } from "crypto";
+import { existsSync, lstatSync, readFileSync, readlinkSync } from "fs";
+import { join } from "path";
+import { resolveInsideRepo } from "../path-safety";
+import { resolveBlobsDir } from "./paths";
+import { createFileExclusiveDurably } from "./atomic-append";
+
+export interface BlobWriteResult {
+  readonly sha256: string;
+  readonly bytes: number;
+  readonly wasNew: boolean;
+  readonly path: string;
+}
+
+function sha256Hex(content: Buffer): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+function mismatchError(digest: string): Error {
+  return new Error(
+    `blob content mismatch for ${digest}: on-disk bytes differ from the requested write `
+    + "(refusing to overwrite a different content at the same content-addressed name)",
+  );
+}
+
+/** Write-once: identical content at the same name is a no-op; different content at the same name is an error. */
+export function writeBlob(repoRoot: string, content: Buffer): BlobWriteResult {
+  const digest = sha256Hex(content);
+  const blobsDir = resolveBlobsDir(repoRoot);
+  const blobPath = join(blobsDir, digest);
+
+  if (existsSync(blobPath)) {
+    if (!readFileSync(blobPath).equals(content)) throw mismatchError(digest);
+    return { sha256: digest, bytes: content.length, wasNew: false, path: blobPath };
+  }
+
+  try {
+    createFileExclusiveDurably(blobPath, content);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+      // Lost a create race against another writer for the same digest.
+      if (!readFileSync(blobPath).equals(content)) throw mismatchError(digest);
+      return { sha256: digest, bytes: content.length, wasNew: false, path: blobPath };
+    }
+    throw error;
+  }
+  return { sha256: digest, bytes: content.length, wasNew: true, path: blobPath };
+}
+
+export type FileBlobIngestResult =
+  | { readonly kind: "file"; readonly sha256: string; readonly bytes: number; readonly wasNew: boolean; readonly path: string }
+  | { readonly kind: "symlink"; readonly linkTarget: string; readonly sha256: string };
+
+/** Ingest a repo-relative path. A symlink is recorded as metadata (D6); its target is never dereferenced. */
+export function ingestFileAsBlob(repoRoot: string, relativePath: string): FileBlobIngestResult {
+  const target = resolveInsideRepo(repoRoot, relativePath);
+  if (!target.ok || !target.path) throw new Error(target.error ?? "invalid path");
+
+  const stat = lstatSync(target.path);
+  if (stat.isSymbolicLink()) {
+    const linkTarget = readlinkSync(target.path);
+    return { kind: "symlink", linkTarget, sha256: sha256Hex(Buffer.from(linkTarget, "utf-8")) };
+  }
+
+  const content = readFileSync(target.path);
+  const write = writeBlob(repoRoot, content);
+  return { kind: "file", sha256: write.sha256, bytes: write.bytes, wasNew: write.wasNew, path: write.path };
+}

--- a/src/effects/evidence/event-log.ts
+++ b/src/effects/evidence/event-log.ts
@@ -1,0 +1,132 @@
+/**
+ * Append-only event log IO (D1/D2/D5). Genesis-before-append is enforced
+ * fail-closed; reads apply the pure corrupt-tail policy from
+ * `src/core/evidence/fold.ts` and quarantine any discarded tail.
+ */
+import { existsSync, readFileSync, truncateSync } from "fs";
+import { join } from "path";
+import type { EvidenceEventRecord, EvidenceLogRecord, GenesisRecord } from "../../core/evidence/types";
+import { findCorruptTail, foldAcceptedEvents, parseLogLine } from "../../core/evidence/fold";
+import { buildEvidenceEvent, type EvidenceEventConstructionInput } from "./event-writer";
+import { appendLineDurably, writeFileDurably } from "./atomic-append";
+import { resolveEventsDir, resolveLogPath } from "./paths";
+
+export type EvidenceEventInput = EvidenceEventConstructionInput;
+
+function readRawLines(logPath: string): string[] {
+  if (!existsSync(logPath)) return [];
+  const raw = readFileSync(logPath, "utf-8");
+  if (raw.length === 0) return [];
+  const lines = raw.split("\n");
+  // Every complete record line ends with "\n" by construction (appendLineDurably
+  // always writes one), so a non-empty final split element means the last
+  // write was truncated mid-line; keep it so it is detected as corrupt.
+  if (lines[lines.length - 1] === "") lines.pop();
+  return lines;
+}
+
+/** Read and validate exactly the first record as a genesis record; null if the store is empty or malformed. */
+export function readGenesisRecord(repoRoot: string): GenesisRecord | null {
+  const lines = readRawLines(resolveLogPath(repoRoot));
+  if (lines.length === 0) return null;
+  const parsed = parseLogLine(lines[0]!);
+  if (!parsed.ok || parsed.record.kind !== "evidence_genesis") return null;
+  return parsed.record;
+}
+
+export interface AppendGenesisOptions {
+  readonly worktreeId: string;
+}
+
+/**
+ * D2: the store's genesis record carries `ledger_epoch_start_sha`. Writing
+ * it is idempotent for a matching epoch; fails closed if the store already
+ * has a different epoch pinned, or has non-genesis content at position 0.
+ */
+export function appendGenesisRecord(
+  repoRoot: string,
+  ledgerEpochStartSha: string,
+  opts: AppendGenesisOptions,
+): GenesisRecord {
+  const logPath = resolveLogPath(repoRoot);
+  const lines = readRawLines(logPath);
+
+  if (lines.length > 0) {
+    const parsed = parseLogLine(lines[0]!);
+    if (!parsed.ok || parsed.record.kind !== "evidence_genesis") {
+      throw new Error(`cannot write genesis record: store at ${logPath} already has non-genesis content`);
+    }
+    if (parsed.record.ledger_epoch_start_sha !== ledgerEpochStartSha) {
+      throw new Error(
+        `genesis epoch mismatch: store is pinned to ${parsed.record.ledger_epoch_start_sha}, requested ${ledgerEpochStartSha}`,
+      );
+    }
+    return parsed.record;
+  }
+
+  const record: GenesisRecord = {
+    kind: "evidence_genesis",
+    schema_version: 1,
+    worktree_id: opts.worktreeId,
+    ledger_epoch_start_sha: ledgerEpochStartSha,
+    created_at: new Date().toISOString(),
+  };
+  appendLineDurably(logPath, JSON.stringify(record));
+  return record;
+}
+
+/**
+ * Append one evidence event. Always goes through `buildEvidenceEvent`'s
+ * construction path -- there is no way to append a hand-built record that
+ * skipped D6's invariants. Fails closed if the store has no genesis record.
+ */
+export function appendEvidenceEvent(repoRoot: string, input: EvidenceEventInput): EvidenceEventRecord {
+  const logPath = resolveLogPath(repoRoot);
+  if (!readGenesisRecord(repoRoot)) {
+    throw new Error(`cannot append: store at ${logPath} has no genesis record; call appendGenesisRecord first`);
+  }
+  const record = buildEvidenceEvent(repoRoot, input);
+  appendLineDurably(logPath, JSON.stringify(record));
+  return record;
+}
+
+export interface ReadAcceptedEventsResult {
+  readonly genesis: GenesisRecord | null;
+  readonly accepted: readonly EvidenceEventRecord[];
+  readonly quarantinedPath: string | null;
+}
+
+/**
+ * Read the log, apply D5's corrupt-tail policy (truncate at the last valid
+ * offset, quarantine the discarded tail, never skip a corrupt middle
+ * record and resume), and fold the valid evidence events into the accepted
+ * set.
+ */
+export function readAcceptedEvents(repoRoot: string): ReadAcceptedEventsResult {
+  const logPath = resolveLogPath(repoRoot);
+  const rawLines = readRawLines(logPath);
+  const parsedLines = rawLines.map((line) => parseLogLine(line));
+  const corruptTail = findCorruptTail(parsedLines);
+
+  let quarantinedPath: string | null = null;
+  if (corruptTail.corruptStartIndex !== null) {
+    const corruptLines = rawLines.slice(corruptTail.corruptStartIndex);
+    quarantinedPath = join(resolveEventsDir(repoRoot), `events.corrupt-${Date.now()}`);
+    writeFileDurably(quarantinedPath, `${corruptLines.join("\n")}\n`);
+
+    const validPrefix = rawLines.slice(0, corruptTail.validLineCount).map((line) => `${line}\n`).join("");
+    truncateSync(logPath, Buffer.byteLength(validPrefix, "utf-8"));
+  }
+
+  const validRecords: EvidenceLogRecord[] = [];
+  for (let i = 0; i < corruptTail.validLineCount; i++) {
+    const parsed = parsedLines[i]!;
+    if (parsed.ok) validRecords.push(parsed.record);
+  }
+
+  const genesis = validRecords.find((record): record is GenesisRecord => record.kind === "evidence_genesis") ?? null;
+  const events = validRecords.filter((record): record is EvidenceEventRecord => record.kind === "evidence_event");
+  const fold = foldAcceptedEvents(events);
+
+  return { genesis, accepted: fold.accepted, quarantinedPath };
+}

--- a/src/effects/evidence/event-writer.ts
+++ b/src/effects/evidence/event-writer.ts
@@ -1,0 +1,124 @@
+/**
+ * The single construction path for a real `EvidenceEventRecord`. D6
+ * invariants (path-field safety, secret redaction, inline/blob decision)
+ * run unconditionally here -- there is no other way to produce a record, so
+ * there is no skippable "sanitize" step a caller could bypass.
+ */
+import { createHash } from "crypto";
+import type { EvidenceEventRecord, JsonValue, SubjectIdentity, TrustClass } from "../../core/evidence/types";
+import { canonicalize } from "../../core/evidence/canonical-json";
+import { generateEventId } from "../../core/evidence/ulid";
+import { computeIdempotencyKey } from "../../core/evidence/idempotency";
+import { redactPayloadStrings } from "../../core/evidence/redaction";
+import { collectStringLeaves } from "../../core/evidence/json-walk";
+import { exceedsInlineCap } from "../../core/evidence/payload-cap";
+import { ensureRepoRelativePath } from "../path-safety";
+import { collectDenylistSecretValues } from "./secret-env";
+import { writeBlob } from "./blob-store";
+
+export type EvidencePayloadInput =
+  | { readonly kind: "json"; readonly value: JsonValue }
+  | { readonly kind: "binary"; readonly content: Buffer; readonly contentType?: string };
+
+export interface EvidenceEventConstructionInput {
+  readonly worktreeId: string;
+  readonly eventType: string;
+  readonly trustClass: TrustClass;
+  readonly producer: string;
+  readonly correlationRunId: string;
+  readonly subjectIdentity: SubjectIdentity;
+  readonly supersedes?: readonly string[];
+  readonly payload: EvidencePayloadInput;
+}
+
+/** Path-field convention: any object key named `path`, or ending `_path`/`Path`. */
+function isPathFieldKey(key: string): boolean {
+  return key === "path" || key.endsWith("_path") || key.endsWith("Path");
+}
+
+function assertPayloadPathFieldsAreSafe(value: JsonValue): void {
+  for (const leaf of collectStringLeaves(value)) {
+    const key = leaf.path[leaf.path.length - 1];
+    if (key === undefined || !isPathFieldKey(key)) continue;
+    const result = ensureRepoRelativePath(leaf.value);
+    if (!result.ok) {
+      throw new Error(
+        `evidence payload path field "${leaf.path.join(".")}" failed repo-relative validation: ${result.error}`,
+      );
+    }
+  }
+}
+
+function sha256Hex(content: Buffer | string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+interface ConstructedPayload {
+  readonly payload?: JsonValue;
+  readonly blobSha256?: string;
+  readonly blobBytes?: number;
+  readonly contentType?: string;
+  readonly payloadHash: string;
+}
+
+function constructPayload(repoRoot: string, input: EvidencePayloadInput): ConstructedPayload {
+  if (input.kind === "binary") {
+    // D6: binary payloads are always offloaded to a blob, never inline.
+    const write = writeBlob(repoRoot, input.content);
+    return {
+      blobSha256: write.sha256,
+      blobBytes: write.bytes,
+      contentType: input.contentType,
+      payloadHash: `sha256:${write.sha256}`,
+    };
+  }
+
+  assertPayloadPathFieldsAreSafe(input.value);
+  const knownSecretValues = collectDenylistSecretValues();
+  const redacted = redactPayloadStrings(input.value, knownSecretValues);
+  const serialized = canonicalize(redacted);
+  const payloadHash = `sha256:${sha256Hex(serialized)}`;
+
+  if (!exceedsInlineCap(serialized)) {
+    return { payload: redacted, payloadHash };
+  }
+
+  const write = writeBlob(repoRoot, Buffer.from(serialized, "utf-8"));
+  return {
+    blobSha256: write.sha256,
+    blobBytes: write.bytes,
+    contentType: "application/json",
+    payloadHash,
+  };
+}
+
+export function buildEvidenceEvent(repoRoot: string, input: EvidenceEventConstructionInput): EvidenceEventRecord {
+  const constructed = constructPayload(repoRoot, input.payload);
+  const idempotencyKey = computeIdempotencyKey({
+    subjectIdentity: input.subjectIdentity,
+    eventType: input.eventType,
+    trustClass: input.trustClass,
+    payloadHash: constructed.payloadHash,
+    producer: input.producer,
+  });
+
+  return {
+    kind: "evidence_event",
+    schema_version: 1,
+    worktree_id: input.worktreeId,
+    event_id: generateEventId(),
+    correlation_run_id: input.correlationRunId,
+    event_type: input.eventType,
+    trust_class: input.trustClass,
+    producer: input.producer,
+    subject_identity: input.subjectIdentity,
+    idempotency_key: idempotencyKey,
+    ...(input.supersedes && input.supersedes.length > 0 ? { supersedes: input.supersedes } : {}),
+    payload_hash: constructed.payloadHash,
+    ...(constructed.payload !== undefined ? { payload: constructed.payload } : {}),
+    ...(constructed.blobSha256 !== undefined
+      ? { blob_sha256: constructed.blobSha256, blob_bytes: constructed.blobBytes, content_type: constructed.contentType }
+      : {}),
+    created_at: new Date().toISOString(),
+  };
+}

--- a/src/effects/evidence/paths.ts
+++ b/src/effects/evidence/paths.ts
@@ -1,0 +1,28 @@
+/**
+ * Store layout (D1): a single per-worktree append-only log plus a
+ * content-addressed blob directory, both gitignored. Resolution goes
+ * through the existing `path-safety` module (reused, not modified).
+ */
+import { resolveInsideRepo } from "../path-safety";
+
+export const EVENTS_DIR_RELATIVE = ".ai/harness/evidence/events";
+export const LOG_FILE_RELATIVE = ".ai/harness/evidence/events/log.jsonl";
+export const BLOBS_DIR_RELATIVE = ".ai/harness/evidence/blobs";
+
+function resolveOrThrow(repoRoot: string, relativePath: string): string {
+  const result = resolveInsideRepo(repoRoot, relativePath);
+  if (!result.ok || !result.path) throw new Error(result.error ?? `invalid evidence store path: ${relativePath}`);
+  return result.path;
+}
+
+export function resolveEventsDir(repoRoot: string): string {
+  return resolveOrThrow(repoRoot, EVENTS_DIR_RELATIVE);
+}
+
+export function resolveLogPath(repoRoot: string): string {
+  return resolveOrThrow(repoRoot, LOG_FILE_RELATIVE);
+}
+
+export function resolveBlobsDir(repoRoot: string): string {
+  return resolveOrThrow(repoRoot, BLOBS_DIR_RELATIVE);
+}

--- a/src/effects/evidence/secret-env.ts
+++ b/src/effects/evidence/secret-env.ts
@@ -1,0 +1,16 @@
+/**
+ * The only file in this package that reads `process.env` for redaction
+ * purposes. Collects present values for the fixed denylist (D6) and hands
+ * them to the pure `redactSecretValue` function -- the core module never
+ * touches `process.env` itself.
+ */
+import { SECRET_DENYLIST_ENV_KEYS } from "../../core/evidence/redaction";
+
+export function collectDenylistSecretValues(env: NodeJS.ProcessEnv = process.env): readonly string[] {
+  const values: string[] = [];
+  for (const key of SECRET_DENYLIST_ENV_KEYS) {
+    const value = env[key];
+    if (typeof value === "string" && value.length > 0) values.push(value);
+  }
+  return values;
+}

--- a/tasks/contracts/20260722-1151-epc-01-evidence-event-store.contract.md
+++ b/tasks/contracts/20260722-1151-epc-01-evidence-event-store.contract.md
@@ -1,0 +1,357 @@
+# Task Contract: epc-01-evidence-event-store
+
+> **Status**: Active
+> **Plan**: plans/plan-20260722-1151-epc-01-evidence-event-store.md
+> **Task Profile**: code-change
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: kito
+> **Reviewer**: Claude
+> **Waiver Policy**: user_waiver allowed, owner kito only, per Acceptance Policy below
+> **Base SHA**: `5228d4ea0d7987cf6fb73be216d5b9cc638817c3` (pinned per R1 after EPC-00 merged via PR #116 plus its row-flip commit; verified equal to this worktree's HEAD at task start)
+> **Target Branch**: main (via one independent PR)
+> **Working Branch**: `codex/epc-01-evidence-event-store`
+> **PR Unit**: one PR carrying the new evidence modules (`src/core/evidence/`, `src/effects/evidence/`) plus their tests, one `.gitignore` line, and this package's workflow artifacts
+> **Capability ID**: root
+> **Last Updated**: 2026-07-22 11:51
+> **Review File**: `tasks/reviews/20260722-1151-epc-01-evidence-event-store.review.md`
+> **Notes File**: `tasks/notes/20260722-1151-epc-01-evidence-event-store.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+EPC-01 implements Sprint C backlog row 5: the single `EvidenceEvent` schema and
+the atomic append-only per-worktree event store, exactly as frozen by EPC-00's
+design decisions D1-D6 (sprint `### Frozen decisions (EPC-00, 2026-07-22)`
+section -- the design authority; this package re-decides nothing). Rows 6-13
+(producers, importers, materializers, checkpoints, recovery-view cutover) all
+depend on one evidence authority existing first; shipping a producer or a
+cutover in this same package would violate the sprint's one-authority-per-
+package rule and R5's same-package-cutover discipline.
+
+## Goal
+
+1. `EvidenceEvent` schema with the frozen field set: D3 subject identity
+   (`authority_commit`, `base_commit`, `target_commit`, `scope_hash`,
+   `subject_hash`, `contract_hash`, `command_hash`, `env_provider_id`,
+   envelope `schema_version` + `worktree_id`), D4 trust class enum
+   (`authoritative_machine` | `observed` | `human_acceptance` |
+   `external_attested`), D5 identity (`event_id` = `evt-<ULID>`,
+   `correlation_run_id`, idempotency key, optional `supersedes`).
+2. Append-only store under `.ai/harness/evidence/events/` (per-worktree,
+   gitignored): atomic whole-line JSONL append + fsync; genesis record
+   carrying `ledger_epoch_start_sha` as a hard precondition of the first
+   append (D2, fail closed); total order = append position (D5).
+3. Content-addressed blob store under `.ai/harness/evidence/blobs/` with D6
+   invariants by construction: 200-line/8-KiB inline cap with overflow to
+   `blob_sha256`+`blob_bytes`, secret-denylist + high-entropy redaction
+   before write, repo-relative-path-only rule (fail closed on escape),
+   symlinks never dereferenced, binary always offloaded, sha256 only,
+   write-once immutable blobs.
+4. Pure replay/fold in `src/core/evidence/`: deterministic accepted-set
+   computation (idempotency dedup, supersedes exclusion, append-position
+   order) as a pure function; corrupt-tail recovery truncates at the last
+   valid offset and quarantines the tail to `events.corrupt-<ts>` (D5, fail
+   closed -- never skip a corrupt middle record).
+5. Tests proving: append atomicity; replay determinism; corrupt-tail
+   truncation + quarantine; duplicate-import no-op; supersedes exclusion;
+   genesis-before-append fail-closed; redaction as construction invariant;
+   absolute/escaping path fail-closed; blob write-once.
+6. `.gitignore` entry `.ai/harness/evidence/`.
+7. All root required checks green in the contract worktree; one independent
+   PR on `codex/epc-01-evidence-event-store`.
+
+## P1: Architecture Map
+
+- Design authority: sprint `### Frozen decisions (EPC-00, 2026-07-22)` D1-D6;
+  this package cites, never re-decides.
+- `src/core/` holds pure logic (existing precedent: `core/state`,
+  `core/workflow`); `src/effects/` holds IO (existing precedent:
+  `effects/fs-transaction.ts`, `effects/state`). New modules:
+  `src/core/evidence/` (schema types, ULID, canonical JSON, idempotency key,
+  redaction, inline-cap policy, fold/accepted-set, corrupt-tail policy -- all
+  pure, no `fs`/`process` imports) and `src/effects/evidence/` (path
+  resolution, durable append/fsync primitives, the event log, the blob
+  store, secret-env collection, and the single event-construction path).
+- No existing module imports the new store in this package (no consumer
+  cutover); the new modules import only existing shared utilities
+  (`src/effects/path-safety.ts`) -- never `src/cli` hook handlers, never
+  `src/effects/fs-transaction.ts`'s private helpers (its own
+  `writeFileDurably` is not exported, so an equivalent append/write helper is
+  implemented locally in `src/effects/evidence/atomic-append.ts`; see notes).
+- Legacy evidence surfaces (`.ai/harness/events.jsonl`, `checks/*`,
+  `journal/`, `runs/`) are pre-epoch artifacts per D2: untouched, never
+  parsed as EvidenceEvents.
+
+## P2: Concrete Trace
+
+EPC-00 merges via PR #116 -> `main` advances to `5228d4ea` (row-4 flip) ->
+EPC-01 pins that SHA as Base SHA (R1) -> contract worktree opens on
+`codex/epc-01-evidence-event-store` from that exact commit -> `bun install
+--frozen-lockfile` -> `src/core/evidence/` + `src/effects/evidence/` + tests
+land (tests written first, confirmed red on missing modules, then
+implemented to green) -> first append in a fresh store writes the genesis
+record with `ledger_epoch_start_sha` = this package's pinned base (D2 rule)
+-> replay fold produces byte-identical accepted sets across runs ->
+corrupt-tail fixtures truncate + quarantine -> full `bun test` (1711 pass, 1
+pre-existing skip, 0 fail) and root required checks pass in the worktree ->
+one commit -> one PR merges -> EPC-02 pins its own base per R1.
+
+## P3: Design Decision
+
+- Split pure/IO along the repo's existing `core`/`effects` boundary rather
+  than one module: replay determinism and accepted-set logic must be
+  testable without touching a filesystem, and later materializers will
+  consume the pure fold without importing the writer.
+- Single JSONL log file per worktree (`events/log.jsonl`) rather than
+  file-per-event: D5's total order is append position in "the per-worktree
+  log"; a directory of files would reintroduce mtime/filename ordering,
+  which D5/D7 forbid.
+- The idempotency key and redaction run inside the writer's constructor path
+  (`src/effects/evidence/event-writer.ts`'s `buildEvidenceEvent`), not as a
+  separate sanitize step a caller could skip -- `appendEvidenceEvent` only
+  accepts the raw input descriptor, never a pre-built record, so there is no
+  bypass.
+- ULID implementation is vendored as a small pure function (no new
+  dependency): `encodeUlid(timeMs, randomness)` is a pure function of its two
+  explicit inputs (replay/tests never depend on wall-clock time or the
+  system RNG); `generateUlid`/`generateEventId` are the impure convenience
+  wrappers real producers call.
+- Full design rationale for every non-obvious call within D1-D6's letter
+  (redaction single-pass merge, corrupt-tail quarantine-vs-throw, path-field
+  convention, blob mismatch handling, symlink hashing) is recorded in
+  `tasks/notes/20260722-1151-epc-01-evidence-event-store.notes.md`.
+
+## Scope
+
+- In scope: `src/core/evidence/`, `src/effects/evidence/`, the three named
+  test files, one `.gitignore` entry, this package's plan/contract/review/
+  notes, `tasks/todos.md` if the projection machinery rewrites it, and
+  `.ai/harness/worktrees/epc-01-evidence-event-store.json` (gitignored
+  worktree state marker; present for parity with the EPC-00 contract's
+  `allowed_paths` shape, expected to produce no tracked diff).
+- Out of scope: any producer/importer/materializer (rows 6-12), any edit to
+  existing hook handlers, `verify-sprint`, `checks/*` writers, handoff/
+  resume/current writers, `tasks/current.md`, benchmark surfaces, the sprint
+  document (row flip happens post-merge on `main`, outside this package),
+  any new npm dependency.
+- Non-goals: reading or migrating pre-epoch artifacts; wiring any gate to the
+  ledger; checkpoint materialization; `checks/latest` selection.
+- Taste constraints: match the existing `core`/`effects` idiom observed in
+  `src/effects/path-safety.ts`, `src/effects/fs-transaction.ts`, and
+  `src/core/adoption/managed-block.ts` (readonly interfaces, `{ ok, error }`
+  result shapes, plain exported functions, no classes, no barrel
+  `index.ts`); smallest diff that satisfies D1-D6.
+
+## Stop Conditions
+
+- Stop and hand back to the parent if `origin/main` has moved past
+  `5228d4ea0d7987cf6fb73be216d5b9cc638817c3` before this package's worktree
+  was created -- re-fetch and re-audit, never silently re-pin.
+- Stop and hand back to the parent if implementing any invariant would
+  require editing a path outside `allowed_paths` (e.g. an existing shared
+  utility needs a change) -- report instead of widening scope silently.
+- Stop if `check-architecture-sync` blocks (not merely advises) on the new
+  `src/` modules -- report the capability-registry gap rather than editing
+  `.ai/context/` or architecture files.
+- Stop after three fail-fix-reverify rounds on one issue.
+
+## Falsifier
+
+The direction is wrong if the store cannot satisfy a D1-D6 invariant without
+modifying existing runtime surfaces (would mean the frozen design conflicts
+with repo reality), or if any test needs a consumer wired in to pass.
+Cheapest proof: the PR diff contains only new files plus one `.gitignore`
+line and the package workflow files; `bun test` green including the new
+evidence suites.
+
+## Root Cause Evidence
+
+Not applicable: Task Profile is `code-change`, not `bugfix`.
+
+## Cheapest Sufficient Proof
+
+- Local worktree HEAD equals `5228d4ea0d7987cf6fb73be216d5b9cc638817c3` at
+  task start; contract records it.
+- New evidence test files pass (31 tests, 3 files); full `bun test` green
+  (1711 pass / 1 pre-existing skip / 0 fail); all root required checks green
+  in the worktree.
+- `git diff --name-only <base>..HEAD` (subject to the final commit) is a
+  subset of `allowed_paths`; no existing `src/` file modified.
+- Replay determinism test asserts byte-identical accepted-set output across
+  two independent folds/reads of the same log.
+
+## Concurrency and Ownership
+
+- This package owns exactly the paths in `allowed_paths` below; it does not
+  touch any other package's plan, contract, review, notes, or code surface.
+- Per sprint R2 Layer 2, this package makes no benchmark-subject-touching
+  change, so it holds no subject freeze and does not participate in one.
+- If an out-of-band merge lands on `main` touching this package's
+  `allowed_paths` before this package's PR merges, stop, re-fetch, and
+  re-derive against the new state; never force-push over it.
+
+## No-Compatibility Declaration
+
+This package introduces no alias, dual read/write path, semantic fallback,
+or steady-state migration shim. It retires nothing (no prior evidence
+authority exists to retire) and cuts over no existing consumer -- no
+producer, importer, materializer, or gate reads this store yet; that wiring
+belongs to later Sprint C rows, each of which retires its own predecessor
+writer in its own package (sprint R5).
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260722-1151-epc-01-evidence-event-store.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260722-1151-epc-01-evidence-event-store.review.md`
+- Notes file: `tasks/notes/20260722-1151-epc-01-evidence-event-store.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this
+  contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed
+  AcceptanceReceipt under the frozen policy below, then run `verify-sprint`;
+  review Markdown is projection only.
+
+## Acceptance Policy
+
+```json
+{"protocol":1,"reviewer":"Claude","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - plans/plan-20260722-1151-epc-01-evidence-event-store.md
+  - tasks/contracts/20260722-1151-epc-01-evidence-event-store.contract.md
+  - tasks/reviews/20260722-1151-epc-01-evidence-event-store.review.md
+  - tasks/notes/20260722-1151-epc-01-evidence-event-store.notes.md
+  - src/core/evidence/
+  - src/effects/evidence/
+  - tests/evidence-event-store.test.ts
+  - tests/evidence-blob-store.test.ts
+  - tests/evidence-replay-recovery.test.ts
+  - .gitignore
+  - .ai/harness/worktrees/epc-01-evidence-event-store.json
+  - tasks/todos.md
+```
+
+## Forbidden Paths and Actions
+
+```yaml
+forbidden:
+  paths:
+    - src/ (every path other than src/core/evidence/ and src/effects/evidence/)
+    - scripts/
+    - assets/
+    - package.json
+    - tasks/current.md
+    - plans/sprints/20260722-0001-evidence-projection-convergence.sprint.md
+    - any hook handler (.ai/hooks/, src/cli/hook/)
+    - any existing checks/handoff writer
+  flags:
+    - any git --force flag
+  actions:
+    - push in this step (local commit only; no push, no PR open, no merge)
+    - adding a new npm dependency
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # New ledger substrate; consumes no benchmark subject.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+      - codex-exec
+      - main-thread
+    fallback: main-thread
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - src/core/evidence/types.ts
+    - src/effects/evidence/event-log.ts
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260722-1151-epc-01-evidence-event-store.notes.md
+  tests_pass:
+    - path: tests/evidence-event-store.test.ts
+    - path: tests/evidence-blob-store.test.ts
+    - path: tests/evidence-replay-recovery.test.ts
+  commands_succeed:
+    - bash scripts/check-task-workflow.sh --strict
+  manual_checks:
+    - "PR diff confined to allowed_paths; no existing src/ file modified"
+    - "Genesis record precondition enforced fail-closed"
+    - "tasks/current.md untouched"
+```
+
+## Manual Acceptance
+
+- Reviewer (`Claude`, per Acceptance Policy) confirms: `src/core/evidence/`
+  and `src/effects/evidence/` implement D1-D6 exactly as frozen; the three
+  named test files cover append atomicity, genesis-before-append fail-closed,
+  replay determinism, duplicate-import no-op, supersedes exclusion,
+  corrupt-tail truncation + quarantine (including the corrupt-middle-record
+  case), redaction invariant, path fail-closed, inline-cap overflow, and
+  blob write-once; the PR diff is confined to `allowed_paths`; no existing
+  `src/` file is modified; `tasks/current.md` is untouched.
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior: adds a new, unwired evidence ledger substrate (schema,
+  append-only store, blob store, pure fold/replay). No existing runtime path
+  reads or writes it; no producer, consumer, or gate is cut over.
+- Edge cases: `origin/main` moving past the pinned base before this
+  package's PR merges (see Concurrency and Ownership); corrupt-tail recovery
+  is exercised for both an end-of-file truncated record and a corrupt middle
+  record followed by further well-formed-looking writes.
+- Regression risks: none to existing runtime surfaces (no existing file is
+  modified); the risk surface is a later EPC-0N package mis-citing a frozen
+  D-decision or bypassing `buildEvidenceEvent`'s construction path, both
+  guarded by this package's Falsifier and the "single construction path, no
+  skippable sanitize step" design.
+
+## Rollback
+
+Revert the single PR: every change is new files under `src/core/evidence/`,
+`src/effects/evidence/`, `tests/`, plus one `.gitignore` line and this
+package's workflow artifacts; no existing runtime surface is modified.
+Before any PR opens, this package's local worktree commit can also be
+discarded outright via `git worktree remove` (run from outside the
+worktree), with no effect on the root checkout or `main`.

--- a/tasks/notes/20260722-1151-epc-01-evidence-event-store.notes.md
+++ b/tasks/notes/20260722-1151-epc-01-evidence-event-store.notes.md
@@ -1,0 +1,145 @@
+# Implementation Notes: epc-01-evidence-event-store
+
+> **Status**: Active
+> **Plan**: plans/plan-20260722-1151-epc-01-evidence-event-store.md
+> **Contract**: tasks/contracts/20260722-1151-epc-01-evidence-event-store.contract.md
+> **Review**: tasks/reviews/20260722-1151-epc-01-evidence-event-store.review.md
+> **Last Updated**: 2026-07-22 11:51
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- **Vendored ULID, split pure/impure.** D5 asks for a lexicographically
+  sortable, time-embedding `event_id`. `src/core/evidence/ulid.ts` exports
+  `encodeUlid(timeMs, randomness: Uint8Array)` as a fully pure function of
+  its two explicit inputs, plus `generateUlid()`/`generateEventId()` as thin
+  impure wrappers around `Date.now()` and `crypto.randomBytes`. This keeps
+  the "no fs/process imports" constraint on `src/core/evidence/` literal
+  (only `crypto` is imported, never `fs`/`process`) while still letting
+  tests exercise the encoding deterministically (fixed timestamp + fixed
+  randomness) without needing to fake wall-clock time. The 5-bit
+  sliding-window bit-packer in `encodeRandomness` matters: a naive
+  `(bitBuffer << 8) | byte` accumulated across all 10 input bytes would
+  overflow JS's 32-bit bitwise-op range; masking `bitBuffer` down to its
+  unconsumed remainder after every drain keeps it under ~12 bits at all
+  times.
+- **Single log file, not file-per-event.** D5's total order is "append
+  position in the per-worktree log" (singular). A directory of one file per
+  event would reintroduce mtime/filename-based ordering, which D5/D7
+  explicitly forbid. `src/effects/evidence/paths.ts` fixes the layout to
+  `.ai/harness/evidence/events/log.jsonl`.
+- **Redaction is construction-invariant by removing the bypass, not by
+  convention.** `src/effects/evidence/event-log.ts`'s `appendEvidenceEvent`
+  only accepts the raw `EvidenceEventInput` descriptor and always calls
+  `buildEvidenceEvent` (the construction path in `event-writer.ts`) before
+  writing. There is no exported function that accepts a pre-built
+  `EvidenceEventRecord` and appends it directly, so a caller cannot
+  construct a record by hand and skip redaction/path-safety/inline-cap --
+  the only way to get a record onto disk is through construction.
+- **Redaction must be a single pass over the *original* text, not two
+  sequential passes.** An initial design ran the denylist substring-replace
+  first, then the high-entropy regex second. That double-redacts: the
+  denylist pass's own output (`sha256:<64-hex>`) is itself a 64-char run of
+  `[A-Za-z0-9]`, so the entropy pass re-matches and re-hashes it, producing
+  `sha256:sha256:<hash-of-a-hash>`. Fixed by computing spans from *both*
+  sources against the original string, merging overlapping/adjacent spans,
+  and slicing the original text exactly once (`src/core/evidence/redaction.ts`).
+  This was caught by reasoning through the pipeline before it ever reached a
+  test, but is exactly the kind of thing D6's "not a skippable sanitize
+  step" phrasing is protecting against -- worth flagging since it is not
+  obvious from the frozen decision's one-line description.
+- **Path-field convention.** D6 says "absolute paths in payload path fields
+  rejected fail-closed" but does not define which fields are "path fields"
+  for an arbitrary, caller-defined JSON payload. This package defines the
+  convention locally (`isPathFieldKey` in `event-writer.ts`): any object key
+  literally `path`, or ending in `_path` or `Path`, at any depth. Every
+  string value at such a key is validated via the existing
+  `ensureRepoRelativePath` (`src/effects/path-safety.ts`, imported, not
+  modified). This is a choice within D6's letter, not a re-decision of it;
+  a later row that needs a different convention should amend it explicitly
+  rather than each producer inventing its own.
+- **`payload_hash` vs `blob_sha256` naming/prefix asymmetry is deliberate.**
+  D6 states the repo-wide convention is "sha256, hex, `sha256:`-prefixed".
+  Fields whose name already encodes the algorithm (`blob_sha256`) store
+  plain 64-char hex, because that value is also used verbatim as the blob's
+  on-disk filename (portable, no colon in a filename). Generic hash fields
+  that do not name the algorithm (`payload_hash`, `idempotency_key`, and the
+  redaction replacement token) use the `sha256:` prefix. Both are "the
+  repo's hash convention" applied consistently at their respective call
+  sites.
+- **Corrupt-tail recovery is a returned result, not a thrown exception.**
+  D5 says the policy is "fail-closed -- never skip a corrupt middle record
+  and continue"; genesis-before-append is separately and explicitly
+  specified as "fails closed (throws)". Read this as: genesis absence is a
+  precondition violation on a *write* (throw is right), while corrupt-tail
+  discovery on a *read* is an expected, self-healing recovery path a future
+  materializer needs to keep functioning past (truncate the accepted view,
+  quarantine the tail, return both facts in the result). `readAcceptedEvents`
+  therefore never throws for corruption; `quarantinedPath` in its result
+  signals that recovery happened.
+- **Quarantine also truncates the live log file, not just the returned
+  view.** "Quarantine the invalid tail" is read as removing it from the live
+  location, not merely ignoring it while leaving garbage bytes on disk that
+  a future append would then be appended after. `readAcceptedEvents`
+  recomputes the exact valid byte offset from the valid lines themselves
+  (never assumes uniform line length) and calls `truncateSync` to that
+  offset after the quarantine file is durably written.
+- **Blob mismatch check runs on every write, not only when a collision is
+  "detected" some other way.** Since the blob's name *is* its content hash,
+  a real SHA-256 collision is not the realistic failure mode; on-disk
+  corruption or a partial/aborted prior write is. `writeBlob` always reads
+  and byte-compares existing content before treating an existing file as a
+  hit, so a corrupted blob fails closed on the next write attempt instead of
+  silently being treated as already-correct.
+- **Symlink safety is enforced by never calling `readFileSync` on a path
+  until after `lstatSync` confirms it is not a symlink.** `ingestFileAsBlob`
+  branches on `lstatSync(...).isSymbolicLink()` before any content read; for
+  a symlink it hashes the raw `readlinkSync` target string and returns a
+  `{ kind: 'symlink', linkTarget, sha256 }` descriptor with no blob write at
+  all -- the target file's bytes are never opened, so there is no path by
+  which they could be ingested as a side effect.
+
+## Deviations From Plan Or Spec
+
+- None. All D1-D6 invariants named in the plan's Goal section are
+  implemented as specified; the choices above are within D1-D6's letter
+  (concrete mechanics the frozen decisions left to the implementer), not
+  deviations from them.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| Use `src/effects/locking/exclusive-directory-lock.ts` for append safety | Not used | D5 asks for "atomic whole-line append + fsync", which a single bounded `O_APPEND` write already provides for this per-worktree, effectively-single-writer use case; the lock module solves cross-process mutual exclusion across crashes, a different and heavier problem than what D5 specifies. Revisit if a later row adds genuinely concurrent multi-process writers to the same store. |
+| Reuse `src/effects/fs-transaction.ts`'s internal `writeFileDurably` | Not possible | It is a private, unexported helper (only `atomicWriteFile` and the `apply*Operation` functions are exported). Implemented an equivalent open/write-loop/fsync helper locally in `src/effects/evidence/atomic-append.ts` in append (`O_APPEND`), exclusive-create (`O_EXCL`, for write-once blobs), and truncating (`O_TRUNC`, for quarantine dumps) variants. |
+| ULID as an npm dependency (e.g. `ulid`/`ulidx`) | Not used | Plan P3 explicitly calls out that adding a package for ~40 lines fails the smallest-change rule; vendored a minimal Crockford base32 encoder instead. |
+| Import `src/effects/path-safety.ts` directly into `src/core/evidence/` (it has no `fs`/`process` imports itself, so it is transitively pure) | Not done | No existing `core/*` module imports from `effects/*`, even a pure one; path-field validation lives in `src/effects/evidence/event-writer.ts` instead, preserving the repo's existing core-never-imports-effects direction. |
+
+## Open Questions
+
+- None. This package deliberately does not decide anything D1-D6 left open
+  for a later row (materializer wiring, `checks/latest` selection, recovery
+  view retirement) -- those stay with EPC-05/06/07/09 as scoped by the plan.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- New test files (red confirmed before implementation, then implemented to
+  green): `tests/evidence-event-store.test.ts`,
+  `tests/evidence-blob-store.test.ts`, `tests/evidence-replay-recovery.test.ts`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness
+asset files only when all three hold: hard to reverse, surprising without
+local context, and a real trade-off existed. If any one is missing, keep it
+in this notes file instead.
+
+## Promotion Candidates
+
+- None yet. The redaction single-pass/double-hash pitfall is a reusable
+  pattern (any "denylist then generic pattern" redaction pipeline over the
+  same string is vulnerable to re-matching its own hash output), but it has
+  only been observed once in this package; promote to `tasks/lessons.md`
+  only if a second, independent occurrence surfaces elsewhere in the repo.

--- a/tasks/reviews/20260722-1151-epc-01-evidence-event-store.review.md
+++ b/tasks/reviews/20260722-1151-epc-01-evidence-event-store.review.md
@@ -1,12 +1,12 @@
 # Task Review: epc-01-evidence-event-store
 
-> **Status**: Pending
+> **Status**: Reviewed
 > **Plan**: plans/plan-20260722-1151-epc-01-evidence-event-store.md
 > **Contract**: tasks/contracts/20260722-1151-epc-01-evidence-event-store.contract.md
 > **Notes File**: tasks/notes/20260722-1151-epc-01-evidence-event-store.notes.md
 > **Checks File**: .ai/harness/checks/latest.json
-> **Last Updated**: 2026-07-22 11:51
-> **Recommendation**: fail
+> **Last Updated**: 2026-07-22 16:35
+> **Recommendation**: pass
 > **Review Rubric Version**: 2
 > **Reviewed Subject SHA256**: pending
 > **Reviewed Subject Scope**: normalized-final-content
@@ -14,29 +14,38 @@
 
 ## Human Review Card
 
-- Verdict: pending
-- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
-- Intended files changed:
-- Actual files changed:
-- Commands passed:
-- Residual risks:
-- Reviewer action required: inspect diff and card
-- Rollback:
+- Verdict: pass
+- Change type: code-change
+- Intended files changed: new `src/core/evidence/` (8 pure modules), new `src/effects/evidence/` (6 IO modules), three new `tests/evidence-*.test.ts` suites, one `.gitignore` line, package plan/contract/review/notes, `tasks/todos.md` projection line
+- Actual files changed: exactly that set — 23 paths, single commit `5c5cab0f` on base `5228d4ea`; only pre-existing files modified are `.gitignore` (+1 line) and `tasks/todos.md` (projection); zero existing `src/`/`scripts/` modules modified; zero imports of the new modules from existing code (no consumer cutover)
+- Commands passed: `bun test tests/evidence-*.test.ts` (31 pass / 0 fail / 136 expects, red-first), full `bun test` (1711 pass / 1 skip / 0 fail — run by worker twice and re-run by gatekeeper), `check-task-workflow --strict` OK, `contract-run preflight` preflight_pass, `check-deploy-sql-order` OK, `check-architecture-sync` advisory blocking=0, `check-task-sync` OK, `inspect-project-state` no drift, `adopt --dry-run` 0 operations, `bun run check:type` clean
+- Residual risks: high-entropy redaction pattern `[A-Za-z0-9+/_-]{32,}` over-redacts long dot-free paths and 64-hex digests inside payload strings (fail-safe direction; EPC-02+ producers embedding long paths/hashes inline must account for it); inline cap uses `>=` so exactly-200-line / exactly-8192-byte payloads offload (one unit stricter than the frozen wording, safe direction); D5 supersession acyclicity is a stated property not yet enforced by the fold (nothing can violate it while zero producers exist — revisit in EPC-02..04 if a producer emits supersedes)
+- Reviewer action required: none further — gatekeeper acceptance review (fresh context, read-only) verdict PASS
+- Rollback: revert the single PR; all changes are new files plus one `.gitignore` line; no existing runtime surface modified
 
 ## Mode Evidence
 
-- Selected route:
-- P1/P2/P3 evidence:
-- Root cause or plan evidence:
+- Selected route: planning (captured work-package plan, code-change profile)
+- P1/P2/P3 evidence: plan Captured Planning Output; design authority is the sprint's `### Frozen decisions (EPC-00, 2026-07-22)` D1–D6 — implementation audited against their letter by gatekeeper
+- Root cause or plan evidence: not a bugfix; first implementation package of the frozen EPC design
 
 ## Verification Evidence
 
-- Waza `/check` run:
-- Commands run:
-- Manual checks:
-- Supporting artifacts:
-- Implementation notes reviewed:
-- Run snapshot:
+- Waza `/check` run: gatekeeper acceptance review (fresh context, read-only) — verdict PASS
+- Commands run: see Human Review Card; executed in the contract worktree at `5c5cab0f`
+- Manual checks: see Manual Check Evidence below
+- Supporting artifacts: `.ai/harness/checks/latest.json`; red-first evidence (three suites written and failing with module-not-found before implementation existed)
+- Implementation notes reviewed: yes — vendored ULID split, single-pass span-merge redaction, path-field convention, quarantine-vs-throw boundary, local `writeFileDurably` equivalent, declined lock reuse
+- Run snapshot: `.ai/harness/runs/`
+
+## Manual Check Evidence
+
+- [x] PR diff confined to allowed_paths; no existing src/ file modified
+  - Evidence: `git diff --name-status 5228d4ea..HEAD` lists 23 paths, all within the contract's `allowed_paths`; the only modified pre-existing files are `.gitignore` (one added line `.ai/harness/evidence/`) and `tasks/todos.md` (projection line); gatekeeper grep of `src/` + `scripts/` for imports of `core/evidence` / `effects/evidence` outside the new modules returned zero hits.
+- [x] Genesis record precondition enforced fail-closed
+  - Evidence: `appendEvidenceEvent` throws when the store lacks a genesis record (`src/effects/evidence/event-log.ts:85-87`); genesis is idempotent for a matching epoch and fails closed on epoch mismatch or a non-genesis first record; covered by the genesis-before-append tests in `tests/evidence-event-store.test.ts` (red-first, now green).
+- [x] tasks/current.md untouched
+  - Evidence: `git diff 5228d4ea..HEAD -- tasks/current.md` is empty; `git status --porcelain` shows no entry for `tasks/current.md`.
 
 ## Acceptance Receipt Projection
 
@@ -55,30 +64,31 @@
 
 ## Behavior Diff Notes
 
-- ...
+- Purely additive: a new evidence ledger substrate (`EvidenceEvent` schema, append-only per-worktree store with genesis/epoch enforcement, content-addressed write-once blob store, deterministic fold with corrupt-tail quarantine). No producer, consumer, or gate reads it yet; runtime behavior of every existing surface is unchanged.
 
 ## Residual Risks / Follow-ups
 
-- ...
+- Over-eager entropy redaction and `>=` cap boundary: carried into EPC-02+ producer design notes (non-blocking, fail-safe direction).
+- Supersession acyclicity enforcement: revisit when the first producer emits `supersedes` (EPC-02..04).
 
 ## Scorecard
 
 | Dimension | Score | Notes |
 |-----------|-------|-------|
-| Functionality | 0/10 | |
-| Product depth | 0/10 | |
-| Design quality | 0/10 | |
-| Code quality | 0/10 | |
+| Functionality | 9/10 | All D1–D6 invariants implemented and tested; 31 red-first tests green |
+| Product depth | 9/10 | Fail-closed semantics throughout; no bypass path for hand-built records |
+| Design quality | 9/10 | Pure/IO split along existing core/effects boundary; no new dependency |
+| Code quality | 9/10 | Full suite green; type-check clean; construction-invariant safety |
 
 ## Failing Items
 
-- ...
+- none
 
 ## Retest Steps
 
-- Re-run:
-- Re-check:
+- Re-run: `bun test tests/evidence-event-store.test.ts tests/evidence-blob-store.test.ts tests/evidence-replay-recovery.test.ts`; `repo-harness run check-task-workflow --strict`
+- Re-check: grep `src/`+`scripts/` for imports of the new modules (must remain zero until EPC-02)
 
 ## Summary
 
-- ...
+- EPC-01 delivers the EvidenceEvent protocol and atomic append-only per-worktree event store exactly per the frozen D1–D6 decisions: schema with full subject identity and trust classes, genesis/epoch fail-closed enforcement, deterministic replay, corrupt-tail quarantine, and a construction-invariant blob/safety layer — all as new files with zero consumer cutover. Gatekeeper verdict: PASS. Ready to ship as one PR.

--- a/tasks/reviews/20260722-1151-epc-01-evidence-event-store.review.md
+++ b/tasks/reviews/20260722-1151-epc-01-evidence-event-store.review.md
@@ -1,0 +1,84 @@
+# Task Review: epc-01-evidence-event-store
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260722-1151-epc-01-evidence-event-store.md
+> **Contract**: tasks/contracts/20260722-1151-epc-01-evidence-event-store.contract.md
+> **Notes File**: tasks/notes/20260722-1151-epc-01-evidence-event-store.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-07-22 11:51
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Commands passed:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+- Waza `/check` run:
+- Commands run:
+- Manual checks:
+- Supporting artifacts:
+- Implementation notes reviewed:
+- Run snapshot:
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...

--- a/tasks/reviews/20260722-1151-epc-01-evidence-event-store.review.md
+++ b/tasks/reviews/20260722-1151-epc-01-evidence-event-store.review.md
@@ -49,17 +49,17 @@
 
 ## Acceptance Receipt Projection
 
-> **Disposition**: unavailable
-> **Reviewer**: unavailable
-> **Source**: unavailable
+> **Disposition**: external_pass
+> **Reviewer**: Claude
+> **Source**: claude-review
 > **Actor**: not-applicable
-> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject SHA256**: sha256:7a6f16c776720bdb924b2580e0e9eeaca0f2d632a2de4c2de48ced80479f01c3
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: pending
-> **Verification Evidence SHA256**: pending
-> **Issued At**: pending
+> **Reviewed Target Revision**: 5228d4ea0d7987cf6fb73be216d5b9cc638817c3
+> **Verification Evidence SHA256**: sha256:d54894cac4d3f9e5838beb7681a9fd16c1bdc33f813e214c181851d18156563f
+> **Issued At**: 2026-07-22T08:30:15.688Z
 
-- Summary: No AcceptanceReceipt has been recorded.
+- Summary: EPC-01 accepted: EvidenceEvent protocol + append-only store per frozen D1-D6; 31 red-first tests green, full suite 1711 pass; no consumer cutover; gatekeeper PASS; diff confined to allowed_paths
 - Findings: none
 
 ## Behavior Diff Notes

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -1,7 +1,7 @@
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: 2026-07-22 11:07
+> **Updated**: 2026-07-22 11:51
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.

--- a/tests/evidence-blob-store.test.ts
+++ b/tests/evidence-blob-store.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "bun:test";
+import { createHash } from "crypto";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { writeBlob, ingestFileAsBlob } from "../src/effects/evidence/blob-store";
+
+function withTempRepo(prefix: string, fn: (repoRoot: string) => void): void {
+  const repoRoot = mkdtempSync(join(tmpdir(), `${prefix}-`));
+  try {
+    fn(repoRoot);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+}
+
+function sha256hex(content: Buffer | string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+describe("content-addressed blob store", () => {
+  test("writeBlob names the blob after its sha256 content hash", () => {
+    withTempRepo("evidence-blob-addressing", (repoRoot) => {
+      const content = Buffer.from("hello evidence blob store");
+      const result = writeBlob(repoRoot, content);
+      expect(result.sha256).toBe(sha256hex(content));
+      expect(result.bytes).toBe(content.length);
+      expect(result.wasNew).toBe(true);
+      const blobPath = join(repoRoot, ".ai/harness/evidence/blobs", result.sha256);
+      expect(existsSync(blobPath)).toBe(true);
+      expect(readFileSync(blobPath)).toEqual(content);
+    });
+  });
+
+  test("writing identical content twice is a write-once no-op", () => {
+    withTempRepo("evidence-blob-write-once", (repoRoot) => {
+      const content = Buffer.from("identical content");
+      const first = writeBlob(repoRoot, content);
+      const second = writeBlob(repoRoot, content);
+      expect(first.sha256).toBe(second.sha256);
+      expect(first.wasNew).toBe(true);
+      expect(second.wasNew).toBe(false);
+    });
+  });
+
+  test("a corrupted on-disk blob that no longer matches its own filename hash fails closed on rewrite", () => {
+    withTempRepo("evidence-blob-mismatch", (repoRoot) => {
+      const legitimate = Buffer.from("legitimate content for this hash");
+      const digest = sha256hex(legitimate);
+      const blobsDir = join(repoRoot, ".ai/harness/evidence/blobs");
+      mkdirSync(blobsDir, { recursive: true });
+      // Simulate on-disk corruption: a file sits at the content-addressed name
+      // but its bytes do not match that name.
+      writeFileSync(join(blobsDir, digest), "corrupted bytes, not the real content");
+
+      expect(() => writeBlob(repoRoot, legitimate)).toThrow(/mismatch|different|corrupt/i);
+    });
+  });
+
+  test("ingestFileAsBlob hashes and stores a regular file's content", () => {
+    withTempRepo("evidence-blob-ingest-file", (repoRoot) => {
+      mkdirSync(join(repoRoot, "artifacts"), { recursive: true });
+      const relativePath = "artifacts/report.txt";
+      const content = "report body content\n";
+      writeFileSync(join(repoRoot, relativePath), content);
+
+      const result = ingestFileAsBlob(repoRoot, relativePath);
+      expect(result.kind).toBe("file");
+      if (result.kind !== "file") throw new Error("expected file result");
+      expect(result.sha256).toBe(sha256hex(content));
+      expect(result.wasNew).toBe(true);
+
+      const second = ingestFileAsBlob(repoRoot, relativePath);
+      if (second.kind !== "file") throw new Error("expected file result");
+      expect(second.wasNew).toBe(false);
+      expect(second.sha256).toBe(result.sha256);
+    });
+  });
+
+  test("ingestFileAsBlob never dereferences a symlink to hash or store its target content", () => {
+    withTempRepo("evidence-blob-symlink-safety", (repoRoot) => {
+      mkdirSync(join(repoRoot, "artifacts"), { recursive: true });
+      const targetContent = "TARGET-CONTENT-that-must-never-be-read";
+      const targetRelative = "artifacts/real-target.txt";
+      const linkRelative = "artifacts/link-to-target.txt";
+      writeFileSync(join(repoRoot, targetRelative), targetContent);
+      symlinkSync(join(repoRoot, targetRelative), join(repoRoot, linkRelative));
+
+      const result = ingestFileAsBlob(repoRoot, linkRelative);
+      expect(result.kind).toBe("symlink");
+      if (result.kind !== "symlink") throw new Error("expected symlink result");
+      expect(result.linkTarget).toBe(join(repoRoot, targetRelative));
+      // The symlink's own hash must be over the link target string, not the
+      // dereferenced file content.
+      expect(result.sha256).toBe(sha256hex(result.linkTarget));
+      expect(result.sha256).not.toBe(sha256hex(targetContent));
+
+      // The blob store must never have ingested the target file's actual bytes
+      // as a side effect of resolving the symlink.
+      const targetContentBlobPath = join(
+        repoRoot,
+        ".ai/harness/evidence/blobs",
+        sha256hex(targetContent),
+      );
+      expect(existsSync(targetContentBlobPath)).toBe(false);
+    });
+  });
+
+  test("ingestFileAsBlob rejects absolute and escaping paths fail-closed", () => {
+    withTempRepo("evidence-blob-ingest-path-safety", (repoRoot) => {
+      expect(() => ingestFileAsBlob(repoRoot, "/etc/passwd")).toThrow(/absolute|repo-relative/i);
+      expect(() => ingestFileAsBlob(repoRoot, "../outside.txt")).toThrow(/traversal|escap/i);
+    });
+  });
+});

--- a/tests/evidence-event-store.test.ts
+++ b/tests/evidence-event-store.test.ts
@@ -1,0 +1,312 @@
+import { describe, expect, test, afterEach } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { generateEventId, encodeUlid } from "../src/core/evidence/ulid";
+import { canonicalize } from "../src/core/evidence/canonical-json";
+import { computeIdempotencyKey } from "../src/core/evidence/idempotency";
+import type { SubjectIdentity } from "../src/core/evidence/types";
+import {
+  appendEvidenceEvent,
+  appendGenesisRecord,
+  readAcceptedEvents,
+  type EvidenceEventInput,
+} from "../src/effects/evidence/event-log";
+
+function withTempRepo(prefix: string, fn: (repoRoot: string) => void): void {
+  const repoRoot = mkdtempSync(join(tmpdir(), `${prefix}-`));
+  try {
+    fn(repoRoot);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+}
+
+function subjectIdentity(overrides: Partial<SubjectIdentity> = {}): SubjectIdentity {
+  return {
+    authority_commit: "5228d4ea0d7987cf6fb73be216d5b9cc638817c3",
+    base_commit: "5228d4ea0d7987cf6fb73be216d5b9cc638817c3",
+    target_commit: "abcdef1234567890abcdef1234567890abcdef12",
+    scope_hash: "sha256:" + "a".repeat(64),
+    subject_hash: "sha256:" + "b".repeat(64),
+    contract_hash: "sha256:" + "c".repeat(64),
+    command_hash: "sha256:" + "d".repeat(64),
+    env_provider_id: "claude-code/1.0.0/home-abc",
+    ...overrides,
+  };
+}
+
+function baseInput(overrides: Partial<EvidenceEventInput> = {}): EvidenceEventInput {
+  return {
+    worktreeId: "epc-01-evidence-event-store",
+    eventType: "verification.command_run",
+    trustClass: "authoritative_machine",
+    producer: "test-harness",
+    correlationRunId: "run-test-0001",
+    subjectIdentity: subjectIdentity(),
+    payload: { kind: "json", value: { note: "hello world" } },
+    ...overrides,
+  };
+}
+
+function freshGenesisRepo(repoRoot: string, ledgerEpochStartSha = "5228d4ea0d7987cf6fb73be216d5b9cc638817c3") {
+  mkdirSync(repoRoot, { recursive: true });
+  appendGenesisRecord(repoRoot, ledgerEpochStartSha, { worktreeId: "epc-01-evidence-event-store" });
+}
+
+describe("evidence event schema and identity", () => {
+  test("event_id is evt-<ULID>, lexicographically sortable and time-embedding", () => {
+    const first = generateEventId();
+    expect(first).toMatch(/^evt-[0-9A-HJKMNP-TV-Z]{26}$/);
+    const earlier = encodeUlid(1_000, new Uint8Array(10));
+    const later = encodeUlid(2_000, new Uint8Array(10));
+    expect(earlier < later).toBe(true);
+    // Same millisecond, different randomness must not collide for reasonable inputs.
+    const a = encodeUlid(5_000, new Uint8Array(10).fill(1));
+    const b = encodeUlid(5_000, new Uint8Array(10).fill(2));
+    expect(a).not.toBe(b);
+    expect(a.slice(0, 10)).toBe(b.slice(0, 10));
+  });
+
+  test("encodeUlid rejects timestamps outside the 48-bit range", () => {
+    expect(() => encodeUlid(-1, new Uint8Array(10))).toThrow();
+    expect(() => encodeUlid(2 ** 48, new Uint8Array(10))).toThrow();
+  });
+
+  test("canonicalize produces identical bytes regardless of key insertion order", () => {
+    const left = canonicalize({ b: 1, a: { d: 2, c: 3 } });
+    const right = canonicalize({ a: { c: 3, d: 2 }, b: 1 });
+    expect(left).toBe(right);
+    expect(left).toBe('{"a":{"c":3,"d":2},"b":1}');
+  });
+
+  test("canonicalize preserves array order (arrays are not sorted)", () => {
+    expect(canonicalize([3, 1, 2])).toBe("[3,1,2]");
+  });
+
+  test("computeIdempotencyKey is deterministic and sensitive to every input field", () => {
+    const base = {
+      subjectIdentity: subjectIdentity(),
+      eventType: "verification.command_run",
+      trustClass: "authoritative_machine" as const,
+      payloadHash: "sha256:" + "e".repeat(64),
+      producer: "test-harness",
+    };
+    const keyA = computeIdempotencyKey(base);
+    const keyB = computeIdempotencyKey(base);
+    expect(keyA).toBe(keyB);
+    expect(keyA).toMatch(/^sha256:[0-9a-f]{64}$/);
+
+    const changedProducer = computeIdempotencyKey({ ...base, producer: "other-producer" });
+    expect(changedProducer).not.toBe(keyA);
+
+    const changedTrust = computeIdempotencyKey({ ...base, trustClass: "observed" });
+    expect(changedTrust).not.toBe(keyA);
+  });
+});
+
+describe("append-only event store", () => {
+  test("genesis-before-append is enforced fail-closed", () => {
+    withTempRepo("evidence-genesis-gate", (repoRoot) => {
+      mkdirSync(repoRoot, { recursive: true });
+      expect(() => appendEvidenceEvent(repoRoot, baseInput())).toThrow(/genesis/i);
+
+      appendGenesisRecord(repoRoot, "5228d4ea0d7987cf6fb73be216d5b9cc638817c3", {
+        worktreeId: "epc-01-evidence-event-store",
+      });
+      const record = appendEvidenceEvent(repoRoot, baseInput());
+      expect(record.event_id).toMatch(/^evt-/);
+    });
+  });
+
+  test("genesis is idempotent for the same epoch sha and fails closed on a conflicting epoch", () => {
+    withTempRepo("evidence-genesis-idempotent", (repoRoot) => {
+      mkdirSync(repoRoot, { recursive: true });
+      const first = appendGenesisRecord(repoRoot, "5228d4ea0d7987cf6fb73be216d5b9cc638817c3", {
+        worktreeId: "epc-01-evidence-event-store",
+      });
+      const second = appendGenesisRecord(repoRoot, "5228d4ea0d7987cf6fb73be216d5b9cc638817c3", {
+        worktreeId: "epc-01-evidence-event-store",
+      });
+      expect(second).toEqual(first);
+
+      expect(() =>
+        appendGenesisRecord(repoRoot, "0000000000000000000000000000000000000000", {
+          worktreeId: "epc-01-evidence-event-store",
+        }),
+      ).toThrow(/epoch/i);
+    });
+  });
+
+  test("many sequential appends land as whole, well-formed JSON lines (append atomicity)", () => {
+    withTempRepo("evidence-append-atomicity", (repoRoot) => {
+      freshGenesisRepo(repoRoot);
+      const total = 50;
+      for (let i = 0; i < total; i++) {
+        appendEvidenceEvent(
+          repoRoot,
+          baseInput({ payload: { kind: "json", value: { i, note: `event-${i}` } } }),
+        );
+      }
+      const logPath = join(repoRoot, ".ai/harness/evidence/events/log.jsonl");
+      const raw = readFileSync(logPath, "utf-8");
+      expect(raw.endsWith("\n")).toBe(true);
+      const lines = raw.split("\n").filter((line) => line.length > 0);
+      // genesis + total events
+      expect(lines.length).toBe(total + 1);
+      for (const line of lines) {
+        expect(() => JSON.parse(line)).not.toThrow();
+      }
+    });
+  });
+
+  test("duplicate-import with an identical idempotency key is a no-op", () => {
+    withTempRepo("evidence-dedup", (repoRoot) => {
+      freshGenesisRepo(repoRoot);
+      const input = baseInput({ correlationRunId: "run-dup-1" });
+      const first = appendEvidenceEvent(repoRoot, input);
+      const second = appendEvidenceEvent(repoRoot, { ...input, correlationRunId: "run-dup-2" });
+      // Same subject/event_type/trust_class/payload/producer -> identical idempotency key.
+      expect(first.idempotency_key).toBe(second.idempotency_key);
+
+      const { accepted } = readAcceptedEvents(repoRoot);
+      expect(accepted.length).toBe(1);
+      expect(accepted[0]!.event_id).toBe(first.event_id);
+    });
+  });
+
+  test("supersedes excludes the superseded event from the accepted set", () => {
+    withTempRepo("evidence-supersedes", (repoRoot) => {
+      freshGenesisRepo(repoRoot);
+      const original = appendEvidenceEvent(
+        repoRoot,
+        baseInput({ payload: { kind: "json", value: { version: 1 } } }),
+      );
+      const replacement = appendEvidenceEvent(
+        repoRoot,
+        baseInput({
+          payload: { kind: "json", value: { version: 2 } },
+          supersedes: [original.event_id],
+        }),
+      );
+
+      const { accepted } = readAcceptedEvents(repoRoot);
+      const ids = accepted.map((event) => event.event_id);
+      expect(ids).not.toContain(original.event_id);
+      expect(ids).toContain(replacement.event_id);
+      expect(accepted.length).toBe(1);
+    });
+  });
+});
+
+describe("D6 construction-invariant safety", () => {
+  const originalEnv = { ...process.env };
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  test("known secret env values are never stored raw; replaced with sha256:<hash>", () => {
+    withTempRepo("evidence-redaction-denylist", (repoRoot) => {
+      freshGenesisRepo(repoRoot);
+      const secret = "ghp_abcdefghijklmnopqrstuvwxyz0123456789AB";
+      process.env.GH_TOKEN = secret;
+      const record = appendEvidenceEvent(
+        repoRoot,
+        baseInput({ payload: { kind: "json", value: { log_excerpt: `token=${secret} end` } } }),
+      );
+
+      const logPath = join(repoRoot, ".ai/harness/evidence/events/log.jsonl");
+      const raw = readFileSync(logPath, "utf-8");
+      expect(raw.includes(secret)).toBe(false);
+      expect(raw).toContain("sha256:");
+      expect(JSON.stringify(record).includes(secret)).toBe(false);
+    });
+  });
+
+  test("high-entropy token runs are redacted even when not on the fixed denylist", () => {
+    withTempRepo("evidence-redaction-entropy", (repoRoot) => {
+      freshGenesisRepo(repoRoot);
+      const token = "Zx9Qk3mP7vRt2Nw8Ly5Ju1Hb6Fg4Ds0Ac";
+      expect(token.length).toBeGreaterThanOrEqual(32);
+      const record = appendEvidenceEvent(
+        repoRoot,
+        baseInput({ payload: { kind: "json", value: { detail: `secret=${token}` } } }),
+      );
+      const logPath = join(repoRoot, ".ai/harness/evidence/events/log.jsonl");
+      const raw = readFileSync(logPath, "utf-8");
+      expect(raw.includes(token)).toBe(false);
+      expect(JSON.stringify(record).includes(token)).toBe(false);
+    });
+  });
+
+  test("absolute paths in payload path fields are rejected fail-closed", () => {
+    withTempRepo("evidence-path-absolute", (repoRoot) => {
+      freshGenesisRepo(repoRoot);
+      expect(() =>
+        appendEvidenceEvent(
+          repoRoot,
+          baseInput({ payload: { kind: "json", value: { file_path: "/etc/passwd" } } }),
+        ),
+      ).toThrow(/absolute|repo-relative/i);
+    });
+  });
+
+  test("path escapes (..) in payload path fields are rejected fail-closed", () => {
+    withTempRepo("evidence-path-escape", (repoRoot) => {
+      freshGenesisRepo(repoRoot);
+      expect(() =>
+        appendEvidenceEvent(
+          repoRoot,
+          baseInput({ payload: { kind: "json", value: { path: "../../etc/passwd" } } }),
+        ),
+      ).toThrow(/traversal|escap/i);
+    });
+  });
+
+  test("repo-relative payload path fields are accepted", () => {
+    withTempRepo("evidence-path-ok", (repoRoot) => {
+      freshGenesisRepo(repoRoot);
+      const record = appendEvidenceEvent(
+        repoRoot,
+        baseInput({ payload: { kind: "json", value: { artifact_path: "tasks/notes/example.md" } } }),
+      );
+      expect(record.payload).toBeDefined();
+    });
+  });
+
+  test("inline payload cap overflows to a content-addressed blob", () => {
+    withTempRepo("evidence-inline-cap", (repoRoot) => {
+      freshGenesisRepo(repoRoot);
+      // Space-separated so no single run reaches the 32-char high-entropy
+      // threshold; this must overflow on size alone, not get redacted first.
+      const big = "word ".repeat(2000);
+      const record = appendEvidenceEvent(
+        repoRoot,
+        baseInput({ payload: { kind: "json", value: { blob_like: big } } }),
+      );
+      expect(record.payload).toBeUndefined();
+      expect(record.blob_sha256).toMatch(/^[0-9a-f]{64}$/);
+      expect(record.blob_bytes).toBeGreaterThan(8192 - 1);
+      const blobPath = join(repoRoot, ".ai/harness/evidence/blobs", record.blob_sha256!);
+      expect(existsSync(blobPath)).toBe(true);
+    });
+  });
+
+  test("binary payloads are always offloaded to a blob, never inline", () => {
+    withTempRepo("evidence-binary-blob", (repoRoot) => {
+      freshGenesisRepo(repoRoot);
+      const content = Buffer.from([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+      const record = appendEvidenceEvent(
+        repoRoot,
+        baseInput({ payload: { kind: "binary", content, contentType: "application/octet-stream" } }),
+      );
+      expect(record.payload).toBeUndefined();
+      expect(record.blob_sha256).toMatch(/^[0-9a-f]{64}$/);
+      expect(record.content_type).toBe("application/octet-stream");
+      const blobPath = join(repoRoot, ".ai/harness/evidence/blobs", record.blob_sha256!);
+      expect(existsSync(blobPath)).toBe(true);
+      expect(readFileSync(blobPath)).toEqual(content);
+    });
+  });
+});

--- a/tests/evidence-replay-recovery.test.ts
+++ b/tests/evidence-replay-recovery.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, test } from "bun:test";
+import { appendFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { foldAcceptedEvents, findCorruptTail, parseLogLine } from "../src/core/evidence/fold";
+import type { EvidenceEventRecord } from "../src/core/evidence/types";
+import {
+  appendEvidenceEvent,
+  appendGenesisRecord,
+  readAcceptedEvents,
+  type EvidenceEventInput,
+} from "../src/effects/evidence/event-log";
+
+function withTempRepo(prefix: string, fn: (repoRoot: string) => void): void {
+  const repoRoot = mkdtempSync(join(tmpdir(), `${prefix}-`));
+  try {
+    fn(repoRoot);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+}
+
+function baseInput(overrides: Partial<EvidenceEventInput> = {}): EvidenceEventInput {
+  return {
+    worktreeId: "epc-01-evidence-event-store",
+    eventType: "verification.command_run",
+    trustClass: "authoritative_machine",
+    producer: "test-harness",
+    correlationRunId: "run-replay-0001",
+    subjectIdentity: {
+      authority_commit: "5228d4ea0d7987cf6fb73be216d5b9cc638817c3",
+      base_commit: "5228d4ea0d7987cf6fb73be216d5b9cc638817c3",
+      target_commit: "abcdef1234567890abcdef1234567890abcdef12",
+      scope_hash: "sha256:" + "a".repeat(64),
+      subject_hash: "sha256:" + "b".repeat(64),
+      contract_hash: "sha256:" + "c".repeat(64),
+      command_hash: "sha256:" + "d".repeat(64),
+      env_provider_id: "claude-code/1.0.0/home-abc",
+    },
+    payload: { kind: "json", value: { note: "hello" } },
+    ...overrides,
+  };
+}
+
+function freshGenesisRepo(repoRoot: string) {
+  mkdirSync(repoRoot, { recursive: true });
+  appendGenesisRecord(repoRoot, "5228d4ea0d7987cf6fb73be216d5b9cc638817c3", {
+    worktreeId: "epc-01-evidence-event-store",
+  });
+}
+
+function logPathFor(repoRoot: string): string {
+  return join(repoRoot, ".ai/harness/evidence/events/log.jsonl");
+}
+
+describe("pure fold and corrupt-tail policy", () => {
+  test("foldAcceptedEvents is a deterministic pure function of its input array", () => {
+    const events: EvidenceEventRecord[] = [
+      {
+        kind: "evidence_event",
+        schema_version: 1,
+        worktree_id: "w1",
+        event_id: "evt-00000000000000000000000001",
+        correlation_run_id: "run-1",
+        event_type: "x",
+        trust_class: "authoritative_machine",
+        producer: "p",
+        subject_identity: {
+          authority_commit: "a",
+          base_commit: "a",
+          target_commit: "a",
+          scope_hash: "sha256:" + "0".repeat(64),
+          subject_hash: "sha256:" + "1".repeat(64),
+          contract_hash: "sha256:" + "2".repeat(64),
+          command_hash: "sha256:" + "3".repeat(64),
+          env_provider_id: "env",
+        },
+        idempotency_key: "sha256:" + "4".repeat(64),
+        payload_hash: "sha256:" + "5".repeat(64),
+        payload: { a: 1 },
+        created_at: "2026-07-22T00:00:00.000Z",
+      },
+      {
+        kind: "evidence_event",
+        schema_version: 1,
+        worktree_id: "w1",
+        event_id: "evt-00000000000000000000000002",
+        correlation_run_id: "run-2",
+        event_type: "x",
+        trust_class: "authoritative_machine",
+        producer: "p",
+        subject_identity: {
+          authority_commit: "a",
+          base_commit: "a",
+          target_commit: "a",
+          scope_hash: "sha256:" + "0".repeat(64),
+          subject_hash: "sha256:" + "1".repeat(64),
+          contract_hash: "sha256:" + "2".repeat(64),
+          command_hash: "sha256:" + "3".repeat(64),
+          env_provider_id: "env",
+        },
+        idempotency_key: "sha256:" + "6".repeat(64),
+        supersedes: ["evt-00000000000000000000000001"],
+        payload_hash: "sha256:" + "7".repeat(64),
+        payload: { a: 2 },
+        created_at: "2026-07-22T00:00:01.000Z",
+      },
+    ];
+
+    const first = foldAcceptedEvents(events);
+    const second = foldAcceptedEvents(events);
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second));
+    expect(first.accepted.map((e) => e.event_id)).toEqual(["evt-00000000000000000000000002"]);
+  });
+
+  test("parseLogLine rejects malformed JSON without throwing", () => {
+    const result = parseLogLine("{not valid json");
+    expect(result.ok).toBe(false);
+  });
+
+  const validGenesisLine = JSON.stringify({
+    kind: "evidence_genesis",
+    schema_version: 1,
+    worktree_id: "w1",
+    ledger_epoch_start_sha: "5228d4ea0d7987cf6fb73be216d5b9cc638817c3",
+    created_at: "2026-07-22T00:00:00.000Z",
+  });
+  const validEventLine = (eventId: string) =>
+    JSON.stringify({
+      kind: "evidence_event",
+      schema_version: 1,
+      worktree_id: "w1",
+      event_id: eventId,
+      correlation_run_id: "run-1",
+      event_type: "x",
+      trust_class: "authoritative_machine",
+      producer: "p",
+      subject_identity: {
+        authority_commit: "a",
+        base_commit: "a",
+        target_commit: "a",
+        scope_hash: "sha256:" + "0".repeat(64),
+        subject_hash: "sha256:" + "1".repeat(64),
+        contract_hash: "sha256:" + "2".repeat(64),
+        command_hash: "sha256:" + "3".repeat(64),
+        env_provider_id: "env",
+      },
+      idempotency_key: "sha256:" + "4".repeat(64),
+      payload_hash: "sha256:" + "5".repeat(64),
+      payload: { a: 1 },
+      created_at: "2026-07-22T00:00:00.000Z",
+    });
+
+  test("findCorruptTail reports no corruption for an all-valid log", () => {
+    const lines = [validGenesisLine, validEventLine("evt-1")];
+    const result = findCorruptTail(lines.map((line) => parseLogLine(line)));
+    expect(result.corruptStartIndex).toBeNull();
+    expect(result.validLineCount).toBe(2);
+  });
+
+  test("findCorruptTail stops at the first bad record and does not resume after it", () => {
+    const parsed = [
+      parseLogLine(validGenesisLine),
+      parseLogLine(validEventLine("evt-1")),
+      parseLogLine("{not valid json"),
+      parseLogLine(validEventLine("evt-3")),
+    ];
+    const result = findCorruptTail(parsed);
+    expect(result.corruptStartIndex).toBe(2);
+    expect(result.validLineCount).toBe(2);
+  });
+});
+
+describe("replay determinism across the append-only store", () => {
+  test("readAcceptedEvents yields byte-identical accepted sets across two independent reads", () => {
+    withTempRepo("evidence-replay-determinism", (repoRoot) => {
+      freshGenesisRepo(repoRoot);
+      appendEvidenceEvent(repoRoot, baseInput({ payload: { kind: "json", value: { v: 1 } } }));
+      const dup = baseInput({ payload: { kind: "json", value: { v: "dup" } } });
+      appendEvidenceEvent(repoRoot, dup);
+      appendEvidenceEvent(repoRoot, dup);
+      appendEvidenceEvent(repoRoot, baseInput({ payload: { kind: "json", value: { v: 3 } } }));
+
+      const firstRead = readAcceptedEvents(repoRoot);
+      const secondRead = readAcceptedEvents(repoRoot);
+      expect(JSON.stringify(firstRead.accepted)).toBe(JSON.stringify(secondRead.accepted));
+      expect(firstRead.accepted.length).toBe(secondRead.accepted.length);
+    });
+  });
+});
+
+describe("corrupt-tail recovery and quarantine", () => {
+  test("a truncated final record is quarantined and excluded from the accepted view", () => {
+    withTempRepo("evidence-corrupt-tail-end", (repoRoot) => {
+      freshGenesisRepo(repoRoot);
+      appendEvidenceEvent(repoRoot, baseInput({ payload: { kind: "json", value: { v: 1 } } }));
+      appendEvidenceEvent(repoRoot, baseInput({ payload: { kind: "json", value: { v: 2 } } }));
+
+      const path = logPathFor(repoRoot);
+      const before = readFileSync(path, "utf-8");
+      // Simulate a crash mid-write: append a truncated, unparseable fragment
+      // with no trailing newline.
+      appendFileSync(path, '{"kind":"evidence_event","event_id":"evt-broke');
+
+      const result = readAcceptedEvents(repoRoot);
+      expect(result.accepted.length).toBe(2);
+      expect(result.quarantinedPath).not.toBeNull();
+      expect(existsSync(result.quarantinedPath!)).toBe(true);
+      const quarantined = readFileSync(result.quarantinedPath!, "utf-8");
+      expect(quarantined).toContain("evt-broke");
+
+      // The live log is truncated back to the last valid offset so future
+      // appends continue cleanly.
+      const after = readFileSync(path, "utf-8");
+      expect(after).toBe(before);
+    });
+  });
+
+  test("a corrupt middle record fails closed: later well-formed lines are not resumed past it", () => {
+    withTempRepo("evidence-corrupt-tail-middle", (repoRoot) => {
+      freshGenesisRepo(repoRoot);
+      const first = appendEvidenceEvent(repoRoot, baseInput({ payload: { kind: "json", value: { v: 1 } } }));
+
+      const path = logPathFor(repoRoot);
+      // Inject a corrupt middle record directly (bypassing the safe writer),
+      // simulating on-disk corruption between two otherwise-valid appends.
+      appendFileSync(path, "this line is not json at all\n");
+
+      const third = appendEvidenceEvent(repoRoot, baseInput({ payload: { kind: "json", value: { v: 3 } } }));
+
+      const result = readAcceptedEvents(repoRoot);
+      const ids = result.accepted.map((e) => e.event_id);
+      expect(ids).toContain(first.event_id);
+      expect(ids).not.toContain(third.event_id);
+      expect(result.quarantinedPath).not.toBeNull();
+      const quarantined = readFileSync(result.quarantinedPath!, "utf-8");
+      expect(quarantined).toContain("this line is not json at all");
+      // The well-formed record written after the corruption must also be
+      // quarantined, not silently accepted by skipping the bad line.
+      expect(quarantined).toContain(third.event_id);
+    });
+  });
+
+  test("quarantine files are named events.corrupt-<ts> and live beside the log", () => {
+    withTempRepo("evidence-corrupt-tail-naming", (repoRoot) => {
+      freshGenesisRepo(repoRoot);
+      appendEvidenceEvent(repoRoot, baseInput());
+      const path = logPathFor(repoRoot);
+      appendFileSync(path, "garbage\n");
+
+      const result = readAcceptedEvents(repoRoot);
+      expect(result.quarantinedPath).not.toBeNull();
+      const dir = join(repoRoot, ".ai/harness/evidence/events");
+      const entries = readdirSync(dir);
+      expect(entries.some((name) => /^events\.corrupt-/.test(name))).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Sprint C (Evidence & Projection Convergence) backlog row 5. Implements the frozen EPC-00 design decisions D1–D6.

- `src/core/evidence/` (pure): EvidenceEvent schema with full D3 subject identity, D4 trust classes, D5 identity (`evt-<ULID>`, correlation_run_id, sha256 idempotency key, supersedes), deterministic fold/accepted-set, corrupt-tail policy.
- `src/effects/evidence/` (IO): atomic append-only per-worktree store (`.ai/harness/evidence/events/`, whole-line append + fsync), genesis record with `ledger_epoch_start_sha` enforced fail-closed (D2), content-addressed write-once blob store with D6 construction invariants (200-line/8-KiB inline cap, secret + high-entropy redaction, repo-relative-path-only, symlink non-dereference, binary offload, sha256 only), corrupt-tail quarantine.
- Three red-first test suites: 31 tests / 136 expects covering every invariant.
- One `.gitignore` line (`.ai/harness/evidence/`). No new dependency. No consumer cutover: zero imports from existing code; no existing runtime surface modified.

Verification: full `bun test` 1711 pass / 0 fail / 1 skip (worker twice + gatekeeper re-run); type-check clean; preflight pass; strict workflow check OK; task-sync/architecture-sync/deploy-sql-order/inspect-project-state/adopt --dry-run green. Acceptance: gatekeeper PASS; external_pass receipt, subject-bound at target revision 5228d4ea.