### PR TITLE
EPC-02: Authoritative verify producer

### DIFF
--- a/assets/templates/helpers/verify-sprint.sh
+++ b/assets/templates/helpers/verify-sprint.sh
@@ -406,6 +406,61 @@ allowed_paths_check_json() {
   fi
 }
 
+# EPC-02: after a successful verification (both the --prepare-acceptance
+# freeze path and the finalize path), append one authoritative_machine
+# EvidenceEvent bound to the frozen review subject (D3/D4). Reads the subject,
+# run snapshot, and guard counts back out of $checks_file rather than any
+# in-scope bash variable, so the emitted evidence is always bound to exactly
+# what that file already asserts passed -- never a second, possibly-stale
+# notion of "the subject" computed independently in this script. Additive
+# only.
+#
+# Exit code contract (matches emit-verify-evidence.ts): 0 = emitted; 3 =
+# cannot-bind refusal (no active contract, dirty/untracked contract, or --
+# the case handled here -- the TS entry itself unresolvable in this
+# deployed-helper context); any other non-zero = a real failure (subject
+# mismatch, store/genesis error) and must fail the caller's verify run. A
+# cannot-bind refusal is refusal-to-fabricate, not a fallback: no gate reads
+# the ledger yet, so skipping emission here satisfies nothing and changes no
+# verify-run semantics.
+#
+# Companion-script resolution mirrors the existing $helper_dir/acceptance-receipt.ts
+# sibling lookup (both are deployed side-by-side by the same helper-sync
+# mechanism); REPO_HARNESS_SOURCE_ROOT is the same source-authority fallback
+# workflow_source_authority_call already uses below for hook-CLI resolution,
+# reused here rather than inventing a second mechanism. A deployed-helper
+# context (e.g. an adopted repo, or these fixture-based helper tests) has no
+# src/ tree at all, so when neither resolves this is indistinguishable from
+# "cannot bind" -- treated the same way (skip, do not fail).
+emit_verify_evidence() {
+  local command_line="$1"
+  local emit_script="$helper_dir/emit-verify-evidence.ts"
+  if [[ ! -f "$emit_script" ]]; then
+    if [[ -n "${REPO_HARNESS_SOURCE_ROOT:-}" && -f "${REPO_HARNESS_SOURCE_ROOT}/scripts/emit-verify-evidence.ts" ]]; then
+      emit_script="${REPO_HARNESS_SOURCE_ROOT}/scripts/emit-verify-evidence.ts"
+    else
+      echo "verify-sprint: evidence emission cannot bind: no $helper_dir/emit-verify-evidence.ts and no usable REPO_HARNESS_SOURCE_ROOT fallback in this deployed-helper context; skipping emission, verify result unchanged" >&2
+      return 3
+    fi
+  fi
+  [[ -n "$BUN_BIN" && -x "$BUN_BIN" ]] || { echo "verify-sprint: trusted Bun runtime is unavailable for evidence emission" >&2; return 1; }
+  command -v jq >/dev/null 2>&1 || { echo "verify-sprint: jq is required for evidence emission" >&2; return 1; }
+  local subject_sha256 run_snapshot counts_json
+  subject_sha256="$(jq -r '.review_subject_sha256 // empty' "$checks_file" 2>/dev/null)"
+  run_snapshot="$(jq -r '.lifecycle.snapshot // empty' "$checks_file" 2>/dev/null)"
+  counts_json="$(jq -c '{guards_total: (.guards | length), guards_passed: ([.guards[] | select(.status=="pass")] | length)}' "$checks_file" 2>/dev/null)"
+  [[ -n "$subject_sha256" && -n "$run_snapshot" ]] || { echo "verify-sprint: prepared evidence is missing subject or run snapshot; evidence emission needs a frozen --prepare-acceptance run" >&2; return 1; }
+  "$BUN_BIN" "$emit_script" \
+    --repo-root "$(pwd -P)" \
+    --contract "$contract_file" \
+    --subject-sha256 "$subject_sha256" \
+    --command "$command_line" \
+    --status pass \
+    --run-snapshot "$run_snapshot" \
+    --counts-json "$counts_json"
+  return $?
+}
+
 if [[ -f "$WORKFLOW_STATE_LIB" ]]; then
   # shellcheck source=/dev/null
   . "$WORKFLOW_STATE_LIB"
@@ -505,6 +560,15 @@ finalize_prepared_acceptance() {
   rm -f "$finalized_checks"
   echo "Sprint acceptance finalized without rerunning verification"
   echo "Prepared evidence: $checks_file"
+  set +e
+  emit_verify_evidence "repo-harness run verify-sprint"
+  local emit_exit=$?
+  set -e
+  case "$emit_exit" in
+    0) : ;;
+    3) : ;;
+    *) echo "verify-sprint: evidence emission failed" >&2; return 1 ;;
+  esac
 }
 
 if [[ "$prepare_acceptance" -eq 0 ]]; then
@@ -889,6 +953,15 @@ print_maintenance_advisories "$notes_file" || true
 if [[ "$exit_code" -eq 0 ]]; then
   echo "Sprint verification passed"
   echo "Run snapshot: $run_file"
+  set +e
+  emit_verify_evidence "repo-harness run verify-sprint --prepare-acceptance"
+  emit_exit=$?
+  set -e
+  case "$emit_exit" in
+    0) : ;;
+    3) : ;;
+    *) echo "verify-sprint: evidence emission failed" >&2; exit 1 ;;
+  esac
 else
   echo "Sprint verification failed" >&2
   echo "Run snapshot: $run_file" >&2

--- a/plans/plan-20260722-1634-epc-02-authoritative-verify-producer.md
+++ b/plans/plan-20260722-1634-epc-02-authoritative-verify-producer.md
@@ -1,0 +1,280 @@
+# Plan: EPC-02: Authoritative Verify Producer
+
+> **Status**: Executing
+> **Created**: 20260722-1634
+> **Slug**: epc-02-authoritative-verify-producer
+> **Planning Source**: repo-harness-sprint
+> **Orchestration Kind**: host-plan
+> **Source Ref**: sprint:plans/sprints/20260722-0001-evidence-projection-convergence.sprint.md#epc-02
+> **Artifact Level**: work-package
+> **Promotion Reason**: verification_boundary
+> **Verification Boundary**: Red-first fixtures prove: subject mismatch fails closed, dirty/untracked contract fails closed, emitted event is authoritative_machine with complete D3 subject identity and accepted by the EPC-01 fold, idempotent re-emission dedups, genesis written once with the epoch constant; the package's own verify-sprint acceptance run exercises the live emission path; full bun test and root required checks green
+> **Rollback Surface**: Revert the single PR: new files (epoch constant, producer, CLI wrapper, test suite) plus one wiring edit in scripts/verify-sprint.sh; checks/latest authoring and all other surfaces unchanged
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260722-1634-epc-02-authoritative-verify-producer.contract.md`
+> **Task Review**: `tasks/reviews/20260722-1634-epc-02-authoritative-verify-producer.review.md`
+> **Implementation Notes**: `tasks/notes/20260722-1634-epc-02-authoritative-verify-producer.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from repo-harness-sprint planning output.
+- Source ref: sprint:plans/sprints/20260722-0001-evidence-projection-convergence.sprint.md#epc-02
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260722-1634-epc-02-authoritative-verify-producer.md`
+- Sprint contract: `tasks/contracts/20260722-1634-epc-02-authoritative-verify-producer.contract.md`
+- Sprint review: `tasks/reviews/20260722-1634-epc-02-authoritative-verify-producer.review.md`
+- Implementation notes: `tasks/notes/20260722-1634-epc-02-authoritative-verify-producer.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260722-1634-epc-02-authoritative-verify-producer.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260722-1634-epc-02-authoritative-verify-producer.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260722-1634-epc-02-authoritative-verify-producer.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260722-1634-epc-02-authoritative-verify-producer.contract.md`
+- Review file: `tasks/reviews/20260722-1634-epc-02-authoritative-verify-producer.review.md`
+- Implementation notes file: `tasks/notes/20260722-1634-epc-02-authoritative-verify-producer.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260722-1634-epc-02-authoritative-verify-producer.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260722-1634-epc-02-authoritative-verify-producer.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: Revert the single PR: new files (epoch constant, producer, CLI wrapper, test suite) plus one wiring edit in scripts/verify-sprint.sh; checks/latest authoring and all other surfaces unchanged
+- **Verification boundary**: Red-first fixtures prove: subject mismatch fails closed, dirty/untracked contract fails closed, emitted event is authoritative_machine with complete D3 subject identity and accepted by the EPC-01 fold, idempotent re-emission dedups, genesis written once with the epoch constant; the package's own verify-sprint acceptance run exercises the live emission path; full bun test and root required checks green
+- **Review/acceptance boundary**: `tasks/reviews/20260722-1634-epc-02-authoritative-verify-producer.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: verification_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260722-1634-epc-02-authoritative-verify-producer.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260722-1634-epc-02-authoritative-verify-producer.contract.md`, `tasks/reviews/20260722-1634-epc-02-authoritative-verify-producer.review.md`, and `tasks/notes/20260722-1634-epc-02-authoritative-verify-producer.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260722-1634-epc-02-authoritative-verify-producer.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: Revert the single PR: new files (epoch constant, producer, CLI wrapper, test suite) plus one wiring edit in scripts/verify-sprint.sh; checks/latest authoring and all other surfaces unchanged
+
+## Captured Planning Output
+
+> **Task Profile**: code-change
+
+## Decision Summary
+
+EPC-02 implements Sprint C backlog row 6: the authoritative verify producer.
+The verify runner (`verify-sprint` chain) emits subject-bound
+`authoritative_machine` EvidenceEvents into the EPC-01 ledger, with
+non-subject-bound emission impossible by construction. This package also
+introduces the Program's single epoch constant
+(`LEDGER_EPOCH_START_SHA = 5228d4ea0d7987cf6fb73be216d5b9cc638817c3`, the
+base SHA the EPC-01 contract consumed per frozen D2) so later producers
+(EPC-03/04) import one authority instead of duplicating literals. No
+consumer cutover: `checks/latest` authoring is untouched (EPC-05 owns that
+cutover); emission runs alongside the existing checks write. Base SHA pinned
+per R1 at fresh fetch: `a8cae4d78f1a4451f3a5335b9fc345740c3c61db` (EPC-01
+PR #117 merge plus row-flip commit).
+
+## Why
+
+Rows 9–12 (materializers, checkpoints, Context Packet) select accepted
+events by trust class and exact subject; without a producer there is
+nothing authoritative to select. The verify chain is the only surface
+entitled to emit `authoritative_machine` (D4), and D3 requires emission
+bound to a full subject identity, not a bare HEAD SHA. Emitting from the
+runner itself — rather than from a side script a caller could skip —
+matches D6's construction-invariant discipline and the audit's
+"required gate 绑定 subject revision" acceptance.
+
+## Goal
+
+1. `src/effects/evidence/epoch.ts`: export the frozen epoch constant
+   `LEDGER_EPOCH_START_SHA` (D2; value `5228d4ea...`), the single source
+   for genesis initialization across all producers.
+2. `src/effects/evidence/verify-producer.ts`: builds the full D3 subject
+   identity from repo state and emits one `authoritative_machine` event
+   via the EPC-01 writer. Construction rules:
+   - `subject_hash` = the review-subject sha256 recomputed via the
+     existing review-subject builder (`src/effects/review/diff-fingerprint.ts`,
+     read-only import); if the caller supplies an expected subject hash
+     and it differs from the recomputed value, emission fails closed.
+   - `base_commit` = resolved `review_base` (policy `origin/main`) commit;
+     `target_commit` = worktree HEAD; `scope_hash` = sha256 over the
+     active contract's ordered `allowed_paths`; `contract_hash` = sha256
+     of the active contract file; `command_hash` = sha256 of the exact
+     verify command line; `env_provider_id` = host runner identity;
+     `authority_commit` = last commit touching the active contract file.
+   - Fail closed (no emission, non-zero exit) when: no active contract;
+     contract file dirty or untracked (authority must be committed);
+     subject mismatch; genesis/epoch violation from the EPC-01 store.
+   - There is no API path that emits with a partial subject: the producer
+     exposes a single entry that computes the identity itself.
+3. `scripts/emit-verify-evidence.ts`: thin bun CLI wrapper so the bash
+   verify chain can invoke the producer; no logic beyond arg parsing.
+4. Wire `scripts/verify-sprint.sh`: after successful verification (both
+   the `--prepare-acceptance` freeze path and the finalize path), invoke
+   the producer with the verification result and the frozen
+   `review_subject_sha256`; producer failure fails the verify run (no
+   silent fallback, per the Program's no-fallback rule). Emission is
+   additive: the existing `checks/latest.json` write is unchanged in this
+   package.
+5. Genesis: the producer initializes the per-worktree store on first
+   emission with `LEDGER_EPOCH_START_SHA` (D1 fresh-store + D2 rule).
+6. `tests/evidence-verify-producer.test.ts` fixtures prove: subject
+   mismatch fails closed (no event appended); dirty/untracked contract
+   fails closed; successful emission is `authoritative_machine` with the
+   complete D3 field set; emitted event is accepted by the EPC-01 fold;
+   a second identical emission dedups via idempotency key (no duplicate
+   accepted event); genesis is written once with the epoch constant.
+7. All root required checks green; one independent PR on
+   `codex/epc-02-authoritative-verify-producer`.
+
+## P1: Architecture Map
+
+- Design authority: frozen D2/D3/D4/D5/D6 (sprint Frozen decisions) and
+  EPC-01's shipped API (`src/core/evidence/`, `src/effects/evidence/` —
+  read-only imports; no EPC-01 file may be modified).
+- Wiring surface: `scripts/verify-sprint.sh` only. `verify-contract.sh`,
+  `checks/latest` composition, acceptance-receipt, PostBash, handoff
+  writers: untouched (owned by rows 7–11).
+- EPC-01 residual notes apply: high-entropy redaction may over-redact
+  long dot-free strings in payloads — keep event payloads structured and
+  small (verdict, counts, run snapshot path) rather than embedding raw
+  logs; large content belongs to blobs.
+
+## P2: Concrete Trace
+
+EPC-01 merges via PR #117 -> `main` advances to `a8cae4d7` (row-5 flip) ->
+EPC-02 fresh-fetches, verifies `origin/main == a8cae4d7`, pins it (R1) ->
+worktree opens on `codex/epc-02-authoritative-verify-producer` ->
+epoch constant + producer + CLI wrapper + verify-sprint wiring + tests
+land -> in this package's own acceptance run, `verify-sprint
+--prepare-acceptance` itself exercises the new emission path (dogfood):
+genesis written with the epoch constant, one `authoritative_machine`
+event appended and accepted -> required checks green -> receipt recorded
+immediately after evidence -> one PR merges -> EPC-03/04 pin their own
+base per R1 and import the epoch constant.
+
+## P3: Design Decision
+
+- The epoch constant lives in this package, not EPC-01 (which shipped a
+  parameterized API) and not duplicated per-producer: one authority, no
+  literal drift — this is also why EPC-02 runs serially before an
+  EPC-03/04 wave (the constant would otherwise be a shared surface
+  violating R4's wave qualification).
+- Producer failure fails the verify run: emission is part of the runner's
+  contract now; swallowing emission errors would be a semantic fallback
+  the Program forbids. The blast radius is acceptable because the
+  emission path is exercised by this package's own acceptance before
+  merge.
+- Authority must be committed (dirty contract fails closed): a
+  subject-bound event that points at uncommitted authority text would be
+  unverifiable after the fact, defeating D3's purpose.
+- CLI wrapper in `scripts/` (not a `src/cli` subcommand): the verify
+  chain is bash and already invokes bun scripts; a full CLI subcommand
+  would widen the public surface for no consumer benefit (rows 9+ import
+  the module directly).
+
+## Task Breakdown
+
+- [ ] Verify fresh fetch equals pinned base `a8cae4d7`; fill contract.
+- [ ] `epoch.ts` + `verify-producer.ts` (construction-invariant subject
+      binding, fail-closed paths).
+- [ ] `scripts/emit-verify-evidence.ts` wrapper; wire
+      `scripts/verify-sprint.sh` (additive emission, fail-closed).
+- [ ] Tests red-first for every Goal-6 fixture.
+- [ ] Required checks; commit; receipt; PR.
+
+## Scope
+
+- In scope: `src/effects/evidence/epoch.ts`,
+  `src/effects/evidence/verify-producer.ts`,
+  `scripts/emit-verify-evidence.ts`, `scripts/verify-sprint.sh` (wiring
+  edit only), `tests/evidence-verify-producer.test.ts`, this package's
+  plan/contract/review/notes, `tasks/todos.md` projection,
+  `.ai/harness/worktrees/epc-02-authoritative-verify-producer.json`.
+- Out of scope: every EPC-01 file (read-only), `checks/latest`
+  composition or any direct-authoring deletion (EPC-05), PostBash
+  (EPC-03), acceptance-receipt (EPC-04), handoff/resume/current writers
+  (EPC-07), `verify-contract.sh`, `tasks/current.md`, the sprint
+  document, any new npm dependency.
+- Non-goals: gate cutover (gates still read `checks/latest`); event
+  consumption by any existing surface; supersedes emission (nothing to
+  supersede yet).
+
+## Stop Conditions
+
+- Stop if `origin/main` moves past `a8cae4d7` before worktree creation.
+- Stop if correct emission would require modifying an EPC-01 module or
+  `verify-contract.sh` — report, do not widen scope.
+- Stop after three fail-fix-reverify rounds on one issue.
+
+## Falsifier
+
+The direction is wrong if subject-bound emission cannot be built from the
+existing review-subject builder without modifying it, or if the verify
+chain cannot tolerate fail-closed emission (i.e. the dogfood acceptance
+run of this very package cannot pass with emission enabled). Cheapest
+proof: this package's own `verify-sprint --prepare-acceptance` run
+appends exactly one accepted `authoritative_machine` event to the
+worktree ledger and still passes.
+
+## Cheapest Sufficient Proof
+
+- Fresh fetch equals `a8cae4d7` at pin time; contract records it.
+- New test suite green red-first; full `bun test` green; root required
+  checks green in the worktree.
+- The package's own acceptance run wrote genesis (epoch constant) plus
+  one accepted `authoritative_machine` event in
+  `.ai/harness/evidence/events/` of the worktree.
+- `git diff --name-only a8cae4d7..HEAD` ⊆ `allowed_paths`; no EPC-01
+  file modified.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [ ] Verify fresh fetch equals pinned base `a8cae4d7`; fill contract.
+- [ ] `epoch.ts` + `verify-producer.ts` (construction-invariant subject
+- [ ] `scripts/emit-verify-evidence.ts` wrapper; wire
+- [ ] Tests red-first for every Goal-6 fixture.
+- [ ] Required checks; commit; receipt; PR.

--- a/scripts/emit-verify-evidence.ts
+++ b/scripts/emit-verify-evidence.ts
@@ -1,0 +1,109 @@
+#!/usr/bin/env bun
+/**
+ * Thin CLI wrapper (arg parsing only) so the bash `verify-sprint` chain can
+ * invoke `emitAuthoritativeVerifyEvidence` (src/effects/evidence/verify-producer.ts).
+ * No logic beyond parsing argv and mapping the producer's typed result to an
+ * exit code.
+ *
+ * Exit code contract (verify-sprint.sh's `emit_verify_evidence` reads this):
+ *   0 = emitted.
+ *   3 = cannot-bind refusal -- no active contract, or the contract is
+ *       dirty/untracked. Sprint row 6 only requires that non-subject-bound
+ *       emission be impossible and that a subject mismatch fail closed; it
+ *       does not require every verify run to emit. Cannot-bind is
+ *       refusal-to-fabricate, not a fallback -- the caller treats it as
+ *       "skip, verify result unchanged" because no gate reads the ledger
+ *       yet, so skipping satisfies nothing.
+ *   2 = CLI usage error (bad/missing arguments).
+ *   1 = a real failure: subject mismatch, or a store/genesis error. These
+ *       must fail the caller's verify run.
+ * The producer module itself is unchanged by this contract: it still
+ * returns one typed `{ ok: false, reason, message }` refusal for every
+ * fail-closed condition; only this wrapper's mapping of `reason` to an exit
+ * code distinguishes cannot-bind from real failure.
+ */
+import { emitAuthoritativeVerifyEvidence, type VerifyProducerFailureReason } from "../src/effects/evidence/verify-producer";
+
+const CANNOT_BIND_REASONS: ReadonlySet<VerifyProducerFailureReason> = new Set([
+  "no_active_contract",
+  "contract_not_committed",
+]);
+
+function usage(): string {
+  return [
+    "usage: emit-verify-evidence.ts --repo-root <path> --command <string> --status pass|fail --run-snapshot <repo-relative-path>",
+    "         [--contract <repo-relative-path>] [--subject-sha256 <sha256>] [--counts-json <json>] [--correlation-run-id <id>]",
+  ].join("\n");
+}
+
+function parseArgs(argv: readonly string[]): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === undefined || !arg.startsWith("--")) continue;
+    const key = arg.slice(2);
+    const next = argv[i + 1];
+    if (next === undefined || next.startsWith("--")) {
+      out[key] = "";
+      continue;
+    }
+    out[key] = next;
+    i++;
+  }
+  return out;
+}
+
+function main(argv: readonly string[]): number {
+  const args = parseArgs(argv);
+  const repoRoot = args["repo-root"];
+  const commandLine = args["command"];
+  const status = args["status"];
+  const runSnapshotPath = args["run-snapshot"];
+
+  if (!repoRoot || !commandLine || (status !== "pass" && status !== "fail") || !runSnapshotPath) {
+    process.stderr.write(`emit-verify-evidence: ${usage()}\n`);
+    return 2;
+  }
+
+  let counts: Record<string, number> | undefined;
+  const countsJson = args["counts-json"];
+  if (countsJson) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(countsJson);
+    } catch (error) {
+      process.stderr.write(`emit-verify-evidence: --counts-json is not valid JSON: ${(error as Error).message}\n`);
+      return 2;
+    }
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      process.stderr.write("emit-verify-evidence: --counts-json must be a flat JSON object\n");
+      return 2;
+    }
+    counts = parsed as Record<string, number>;
+  }
+
+  const result = emitAuthoritativeVerifyEvidence({
+    repoRoot,
+    commandLine,
+    status,
+    runSnapshotPath,
+    counts,
+    contractPath: args["contract"] || undefined,
+    expectedSubjectSha256: args["subject-sha256"] || undefined,
+    correlationRunId: args["correlation-run-id"] || undefined,
+  });
+
+  if (!result.ok) {
+    const exitCode = CANNOT_BIND_REASONS.has(result.reason) ? 3 : 1;
+    const kind = exitCode === 3 ? "cannot-bind" : "fail-closed";
+    process.stderr.write(`emit-verify-evidence: ${kind} (${result.reason}): ${result.message}\n`);
+    return exitCode;
+  }
+
+  process.stdout.write(`emit-verify-evidence: appended ${result.event.event_id} (contract ${result.contractPath})\n`);
+  return 0;
+}
+
+if (import.meta.main) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/scripts/verify-sprint.sh
+++ b/scripts/verify-sprint.sh
@@ -406,6 +406,61 @@ allowed_paths_check_json() {
   fi
 }
 
+# EPC-02: after a successful verification (both the --prepare-acceptance
+# freeze path and the finalize path), append one authoritative_machine
+# EvidenceEvent bound to the frozen review subject (D3/D4). Reads the subject,
+# run snapshot, and guard counts back out of $checks_file rather than any
+# in-scope bash variable, so the emitted evidence is always bound to exactly
+# what that file already asserts passed -- never a second, possibly-stale
+# notion of "the subject" computed independently in this script. Additive
+# only.
+#
+# Exit code contract (matches emit-verify-evidence.ts): 0 = emitted; 3 =
+# cannot-bind refusal (no active contract, dirty/untracked contract, or --
+# the case handled here -- the TS entry itself unresolvable in this
+# deployed-helper context); any other non-zero = a real failure (subject
+# mismatch, store/genesis error) and must fail the caller's verify run. A
+# cannot-bind refusal is refusal-to-fabricate, not a fallback: no gate reads
+# the ledger yet, so skipping emission here satisfies nothing and changes no
+# verify-run semantics.
+#
+# Companion-script resolution mirrors the existing $helper_dir/acceptance-receipt.ts
+# sibling lookup (both are deployed side-by-side by the same helper-sync
+# mechanism); REPO_HARNESS_SOURCE_ROOT is the same source-authority fallback
+# workflow_source_authority_call already uses below for hook-CLI resolution,
+# reused here rather than inventing a second mechanism. A deployed-helper
+# context (e.g. an adopted repo, or these fixture-based helper tests) has no
+# src/ tree at all, so when neither resolves this is indistinguishable from
+# "cannot bind" -- treated the same way (skip, do not fail).
+emit_verify_evidence() {
+  local command_line="$1"
+  local emit_script="$helper_dir/emit-verify-evidence.ts"
+  if [[ ! -f "$emit_script" ]]; then
+    if [[ -n "${REPO_HARNESS_SOURCE_ROOT:-}" && -f "${REPO_HARNESS_SOURCE_ROOT}/scripts/emit-verify-evidence.ts" ]]; then
+      emit_script="${REPO_HARNESS_SOURCE_ROOT}/scripts/emit-verify-evidence.ts"
+    else
+      echo "verify-sprint: evidence emission cannot bind: no $helper_dir/emit-verify-evidence.ts and no usable REPO_HARNESS_SOURCE_ROOT fallback in this deployed-helper context; skipping emission, verify result unchanged" >&2
+      return 3
+    fi
+  fi
+  [[ -n "$BUN_BIN" && -x "$BUN_BIN" ]] || { echo "verify-sprint: trusted Bun runtime is unavailable for evidence emission" >&2; return 1; }
+  command -v jq >/dev/null 2>&1 || { echo "verify-sprint: jq is required for evidence emission" >&2; return 1; }
+  local subject_sha256 run_snapshot counts_json
+  subject_sha256="$(jq -r '.review_subject_sha256 // empty' "$checks_file" 2>/dev/null)"
+  run_snapshot="$(jq -r '.lifecycle.snapshot // empty' "$checks_file" 2>/dev/null)"
+  counts_json="$(jq -c '{guards_total: (.guards | length), guards_passed: ([.guards[] | select(.status=="pass")] | length)}' "$checks_file" 2>/dev/null)"
+  [[ -n "$subject_sha256" && -n "$run_snapshot" ]] || { echo "verify-sprint: prepared evidence is missing subject or run snapshot; evidence emission needs a frozen --prepare-acceptance run" >&2; return 1; }
+  "$BUN_BIN" "$emit_script" \
+    --repo-root "$(pwd -P)" \
+    --contract "$contract_file" \
+    --subject-sha256 "$subject_sha256" \
+    --command "$command_line" \
+    --status pass \
+    --run-snapshot "$run_snapshot" \
+    --counts-json "$counts_json"
+  return $?
+}
+
 if [[ -f "$WORKFLOW_STATE_LIB" ]]; then
   # shellcheck source=/dev/null
   . "$WORKFLOW_STATE_LIB"
@@ -505,6 +560,15 @@ finalize_prepared_acceptance() {
   rm -f "$finalized_checks"
   echo "Sprint acceptance finalized without rerunning verification"
   echo "Prepared evidence: $checks_file"
+  set +e
+  emit_verify_evidence "repo-harness run verify-sprint"
+  local emit_exit=$?
+  set -e
+  case "$emit_exit" in
+    0) : ;;
+    3) : ;;
+    *) echo "verify-sprint: evidence emission failed" >&2; return 1 ;;
+  esac
 }
 
 if [[ "$prepare_acceptance" -eq 0 ]]; then
@@ -889,6 +953,15 @@ print_maintenance_advisories "$notes_file" || true
 if [[ "$exit_code" -eq 0 ]]; then
   echo "Sprint verification passed"
   echo "Run snapshot: $run_file"
+  set +e
+  emit_verify_evidence "repo-harness run verify-sprint --prepare-acceptance"
+  emit_exit=$?
+  set -e
+  case "$emit_exit" in
+    0) : ;;
+    3) : ;;
+    *) echo "verify-sprint: evidence emission failed" >&2; exit 1 ;;
+  esac
 else
   echo "Sprint verification failed" >&2
   echo "Run snapshot: $run_file" >&2

--- a/src/effects/evidence/epoch.ts
+++ b/src/effects/evidence/epoch.ts
@@ -1,0 +1,9 @@
+/**
+ * Program-wide ledger epoch constant (D2 successor-pinned rule, sprint
+ * `### Frozen decisions (EPC-00, 2026-07-22)`). `ledger_epoch_start_sha` was
+ * not knowable at EPC-00 time; the frozen rule instead pins it to the exact
+ * base SHA the EPC-01 contract consumed at its own fresh fetch (R1). Every
+ * producer across the Program imports this single constant for genesis
+ * initialization -- it is never re-pinned by a later package.
+ */
+export const LEDGER_EPOCH_START_SHA = "5228d4ea0d7987cf6fb73be216d5b9cc638817c3";

--- a/src/effects/evidence/verify-producer.ts
+++ b/src/effects/evidence/verify-producer.ts
@@ -1,0 +1,333 @@
+/**
+ * The authoritative verify producer (Sprint C backlog row 6). The
+ * `verify-sprint` chain is the only surface entitled to emit
+ * `authoritative_machine` EvidenceEvents (D4); this module is the single
+ * entry point that does so, binding emission to a complete D3 subject
+ * identity by construction -- there is no API path that emits with a
+ * partial subject. Callers cannot inject identity fields (subject_hash,
+ * scope_hash, contract_hash, command_hash, env_provider_id,
+ * authority_commit, base_commit, target_commit); this module computes every
+ * one of them from repo state. Callers may only supply raw inputs the
+ * function cannot itself observe (the exact command line string, an
+ * optional expected subject hash used for verification only, and the small
+ * structured result payload) plus an optional explicit contract path (see
+ * "Active contract resolution" below).
+ *
+ * EPC-01 read-only imports only: `../../core/evidence/types`,
+ * `./event-log`. No EPC-01 file is modified by this package.
+ *
+ * Active contract resolution: `verify-sprint.sh` already resolves "which
+ * contract is active for this run" through its own chain (`--contract`
+ * override, `workflow_active_contract`, or a sorted fallback) before this
+ * producer is ever invoked. Re-deriving that resolution independently here
+ * would be a second, potentially divergent authority for the same datum, so
+ * `contractPath` is accepted as an optional input: when the wiring in
+ * `scripts/verify-sprint.sh` supplies it, that is the single source of
+ * truth for this run. It falls back to the repo's own
+ * `.ai/harness/active-plan` convention (`plans/plan-<slug>.md` ->
+ * `tasks/contracts/<slug>.contract.md`, the same convention
+ * `src/cli/hook/subagent-handler.ts`'s `activeContractPath` uses) only for
+ * direct/standalone callers that never resolved a contract themselves.
+ */
+import { createHash } from "crypto";
+import { execFileSync } from "child_process";
+import { existsSync, readFileSync, statSync } from "fs";
+import { basename, dirname, join, resolve } from "path";
+import { fileURLToPath } from "url";
+
+import type { EvidenceEventRecord, GenesisRecord, SubjectIdentity } from "../../core/evidence/types";
+import { appendEvidenceEvent, appendGenesisRecord } from "./event-log";
+import { buildReviewSubject, uniqueSorted } from "../review/diff-fingerprint";
+import { LEDGER_EPOCH_START_SHA } from "./epoch";
+
+const PRODUCER_ID = "verify-sprint";
+const EVENT_TYPE = "verify_sprint.result";
+
+const MODULE_DIR = dirname(fileURLToPath(import.meta.url));
+const PACKAGE_ROOT = resolve(MODULE_DIR, "../../..");
+
+export type VerifyProducerFailureReason =
+  | "no_active_contract"
+  | "contract_not_committed"
+  | "subject_mismatch"
+  | "genesis_epoch_conflict";
+
+export interface VerifyProducerFailure {
+  readonly ok: false;
+  readonly reason: VerifyProducerFailureReason;
+  readonly message: string;
+}
+
+export interface VerifyProducerSuccess {
+  readonly ok: true;
+  readonly event: EvidenceEventRecord;
+  readonly genesis: GenesisRecord;
+  readonly contractPath: string;
+}
+
+export type VerifyProducerResult = VerifyProducerSuccess | VerifyProducerFailure;
+
+export interface VerifyProducerInput {
+  /** Repo root the verification ran against. */
+  readonly repoRoot: string;
+  /** The exact verification command line invoked; hashed, never interpreted. */
+  readonly commandLine: string;
+  /** Small structured verdict for the payload (D6: payloads stay small and structured). */
+  readonly status: "pass" | "fail";
+  /** Repo-relative path to the run snapshot; validated as a payload path field by the EPC-01 writer. */
+  readonly runSnapshotPath: string;
+  /** Small structured counts for the payload; kept flat and numeric so no long strings can leak into it. */
+  readonly counts?: Readonly<Record<string, number>>;
+  /** Frozen subject hash the caller expects; emission fails closed if the recomputed hash differs. */
+  readonly expectedSubjectSha256?: string;
+  readonly correlationRunId?: string;
+  /**
+   * Repo-relative path to the contract already resolved by the caller (see
+   * module doc). Falls back to `.ai/harness/active-plan` resolution when
+   * omitted.
+   */
+  readonly contractPath?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function sha256Hex(content: Buffer | string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+function gitOutput(repoRoot: string, args: readonly string[]): { readonly ok: boolean; readonly text: string } {
+  try {
+    const text = execFileSync("git", ["-C", repoRoot, "--literal-pathspecs", ...args], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return { ok: true, text };
+  } catch {
+    return { ok: false, text: "" };
+  }
+}
+
+/** `.ai/harness/active-plan` -> `plans/plan-<slug>.md` -> `tasks/contracts/<slug>.contract.md` (fallback only). */
+function resolveActiveContractPathFromMarker(repoRoot: string): string | null {
+  const markerPath = join(repoRoot, ".ai/harness/active-plan");
+  if (!existsSync(markerPath)) return null;
+  let marker: string;
+  try {
+    marker = readFileSync(markerPath, "utf-8").trim();
+  } catch {
+    return null;
+  }
+  const match = /^plans\/plan-([A-Za-z0-9][A-Za-z0-9._-]*)\.md$/.exec(marker);
+  if (!match) return null;
+  const contractRelative = `tasks/contracts/${match[1]}.contract.md`;
+  return existsSync(join(repoRoot, contractRelative)) ? contractRelative : null;
+}
+
+function resolveContractPath(repoRoot: string, explicit: string | undefined): string | null {
+  if (explicit !== undefined) {
+    const absolute = join(repoRoot, explicit);
+    if (!existsSync(absolute) || !statSync(absolute).isFile()) return null;
+    return explicit;
+  }
+  return resolveActiveContractPathFromMarker(repoRoot);
+}
+
+/** Non-empty `git status --porcelain` for the path means dirty (modified/staged) or untracked ("??"). */
+function isContractCommittedClean(repoRoot: string, contractRelative: string): boolean {
+  const result = gitOutput(repoRoot, ["status", "--porcelain", "--", contractRelative]);
+  return result.ok && result.text.trim().length === 0;
+}
+
+function lastCommitTouching(repoRoot: string, relativePath: string): string | null {
+  const result = gitOutput(repoRoot, ["log", "-1", "--format=%H", "--", relativePath]);
+  if (!result.ok) return null;
+  const sha = result.text.trim();
+  return sha.length > 0 ? sha : null;
+}
+
+/** `.ai/harness/policy.json#worktree_strategy.review_base` (pattern reference: `scripts/acceptance-receipt.ts`'s `reviewBase`). Defaults to `HEAD` so a fixture/standalone repo without a policy file still resolves. */
+function resolveReviewBaseRef(repoRoot: string): string {
+  const policyPath = join(repoRoot, ".ai/harness/policy.json");
+  if (!existsSync(policyPath)) return "HEAD";
+  try {
+    const policy = JSON.parse(readFileSync(policyPath, "utf-8")) as unknown;
+    const value = isRecord(policy) && isRecord(policy.worktree_strategy) ? policy.worktree_strategy.review_base : undefined;
+    return typeof value === "string" && value.trim() !== "" ? value : "HEAD";
+  } catch {
+    return "HEAD";
+  }
+}
+
+/** This module's own `package.json` version -- the repo-harness tool's version, independent of whichever `repoRoot` is being verified. */
+function providerCliVersion(): string {
+  try {
+    const pkg = JSON.parse(readFileSync(join(PACKAGE_ROOT, "package.json"), "utf-8")) as { readonly version?: unknown };
+    return typeof pkg.version === "string" && pkg.version.length > 0 ? pkg.version : "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+}
+
+/** Isolated workspace/home id: a short hash of the target repo root's real path, so two parallel worktrees never collide. */
+function workspaceId(repoRoot: string): string {
+  const result = gitOutput(repoRoot, ["rev-parse", "--show-toplevel"]);
+  const real = result.ok && result.text.trim() ? result.text.trim() : resolve(repoRoot);
+  return `ws-${sha256Hex(real).slice(0, 12)}`;
+}
+
+function worktreeIdFor(contractRelative: string): string {
+  const base = contractRelative.split("/").pop() ?? contractRelative;
+  return base.replace(/\.contract\.md$/, "");
+}
+
+/**
+ * EPC-01's D6 redaction replaces any 32+ char run of `[A-Za-z0-9+/_-]` (no
+ * dot breaks it) with `sha256:<hash>` -- construction-invariant, cannot be
+ * bypassed or modified here (read-only import). The real run-snapshot
+ * filename (`<run-id>-<contract-slug>.json`, `scripts/verify-sprint.sh`'s
+ * `run_file`) is always such a run for any realistic contract slug, so
+ * storing it verbatim in the payload would always come back as a useless
+ * hash. The contract-slug suffix is redundant with `worktree_id` (same
+ * string, already in the event envelope, never redacted since redaction
+ * only walks the payload) -- so only the short run-id prefix needs to be
+ * in the payload; a reader reconstructs the real path as
+ * `.ai/harness/runs/<run_snapshot_id>-<worktree_id>.json`.
+ */
+function shortRunSnapshotId(runSnapshotPath: string, worktreeId: string): string {
+  const withoutExtension = basename(runSnapshotPath).replace(/\.json$/, "");
+  const worktreeSuffix = `-${worktreeId}`;
+  return withoutExtension.endsWith(worktreeSuffix)
+    ? withoutExtension.slice(0, -worktreeSuffix.length)
+    : withoutExtension;
+}
+
+/** Extract the `allowed_paths:` list from the contract's fenced ```yaml block (pattern reference: `scripts/verify-sprint.sh`'s `contract_allowed_paths`). */
+function parseContractAllowedPaths(contractText: string): readonly string[] {
+  const yamlBlockPattern = /```yaml\r?\n([\s\S]*?)\r?\n```/g;
+  let match: RegExpExecArray | null;
+  while ((match = yamlBlockPattern.exec(contractText)) !== null) {
+    const block = match[1] ?? "";
+    if (!/(^|\s)allowed_paths:/m.test(block)) continue;
+    const lines = block.split(/\r?\n/);
+    const startIndex = lines.findIndex((line) => /^\s*allowed_paths:\s*$/.test(line));
+    if (startIndex === -1) continue;
+    const paths: string[] = [];
+    for (let i = startIndex + 1; i < lines.length; i++) {
+      const line = lines[i] ?? "";
+      if (/^\S/.test(line)) break;
+      const itemMatch = line.match(/^\s*-\s*(.+?)\s*$/);
+      if (!itemMatch) continue;
+      const value = (itemMatch[1] ?? "").replace(/^["'`]+|["'`]+$/g, "");
+      if (value.length > 0) paths.push(value);
+    }
+    return paths;
+  }
+  return [];
+}
+
+/**
+ * Single entry point: resolves the active contract, recomputes the review
+ * subject, builds the complete D3 identity, ensures genesis, and appends
+ * exactly one `authoritative_machine` event. Fails closed (no emission)
+ * without touching the store on every named condition below.
+ */
+export function emitAuthoritativeVerifyEvidence(input: VerifyProducerInput): VerifyProducerResult {
+  const { repoRoot } = input;
+
+  const contractRelative = resolveContractPath(repoRoot, input.contractPath);
+  if (!contractRelative) {
+    return {
+      ok: false,
+      reason: "no_active_contract",
+      message: "no active contract could be resolved (no explicit contractPath and .ai/harness/active-plan did not resolve to an existing contract file)",
+    };
+  }
+
+  if (!isContractCommittedClean(repoRoot, contractRelative)) {
+    return {
+      ok: false,
+      reason: "contract_not_committed",
+      message: `active contract ${contractRelative} is dirty or untracked; authority must be committed before evidence can bind to it`,
+    };
+  }
+
+  const authorityCommit = lastCommitTouching(repoRoot, contractRelative);
+  if (!authorityCommit) {
+    return {
+      ok: false,
+      reason: "contract_not_committed",
+      message: `no commit touches ${contractRelative}; authority must be committed before evidence can bind to it`,
+    };
+  }
+
+  const reviewBaseRef = resolveReviewBaseRef(repoRoot);
+  const subject = buildReviewSubject(repoRoot, { targetRef: reviewBaseRef });
+  if (subject.status !== "ok") {
+    return {
+      ok: false,
+      reason: "subject_mismatch",
+      message: `review subject could not be computed: ${subject.reason ?? "unknown"}`,
+    };
+  }
+  if (input.expectedSubjectSha256 !== undefined && input.expectedSubjectSha256 !== subject.review_subject_sha256) {
+    return {
+      ok: false,
+      reason: "subject_mismatch",
+      message: `expected subject ${input.expectedSubjectSha256} does not match the recomputed subject ${subject.review_subject_sha256}`,
+    };
+  }
+
+  const contractAbsolute = join(repoRoot, contractRelative);
+  const contractBytes = readFileSync(contractAbsolute);
+  const contractHash = `sha256:${sha256Hex(contractBytes)}`;
+  const allowedPaths = parseContractAllowedPaths(contractBytes.toString("utf-8"));
+  const scopeHash = `sha256:${sha256Hex(JSON.stringify(uniqueSorted(allowedPaths)))}`;
+  const commandHash = `sha256:${sha256Hex(input.commandLine)}`;
+  const envProviderId = `repo-harness/${providerCliVersion()}/${workspaceId(repoRoot)}`;
+
+  const subjectIdentity: SubjectIdentity = {
+    authority_commit: authorityCommit,
+    base_commit: subject.target_rev,
+    target_commit: subject.head_rev,
+    scope_hash: scopeHash,
+    subject_hash: subject.review_subject_sha256,
+    contract_hash: contractHash,
+    command_hash: commandHash,
+    env_provider_id: envProviderId,
+  };
+
+  const worktreeId = worktreeIdFor(contractRelative);
+  let genesis: GenesisRecord;
+  try {
+    genesis = appendGenesisRecord(repoRoot, LEDGER_EPOCH_START_SHA, { worktreeId });
+  } catch (error) {
+    return {
+      ok: false,
+      reason: "genesis_epoch_conflict",
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  const event = appendEvidenceEvent(repoRoot, {
+    worktreeId: genesis.worktree_id,
+    eventType: EVENT_TYPE,
+    trustClass: "authoritative_machine",
+    producer: PRODUCER_ID,
+    correlationRunId: input.correlationRunId ?? `run-${Date.now()}`,
+    subjectIdentity,
+    payload: {
+      kind: "json",
+      value: {
+        status: input.status,
+        counts: input.counts ?? {},
+        // Short id, not the full path -- see shortRunSnapshotId's doc comment.
+        // Reconstruct with: `.ai/harness/runs/${run_snapshot_id}-${worktree_id}.json`.
+        run_snapshot_id: shortRunSnapshotId(input.runSnapshotPath, worktreeId),
+      },
+    },
+  });
+
+  return { ok: true, event, genesis, contractPath: contractRelative };
+}

--- a/tasks/contracts/20260722-1634-epc-02-authoritative-verify-producer.contract.md
+++ b/tasks/contracts/20260722-1634-epc-02-authoritative-verify-producer.contract.md
@@ -1,0 +1,280 @@
+# Task Contract: epc-02-authoritative-verify-producer
+
+> **Status**: Active
+> **Plan**: plans/plan-20260722-1634-epc-02-authoritative-verify-producer.md
+> **Task Profile**: code-change
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: kito
+> **Reviewer**: Claude
+> **Waiver Policy**: user_waiver allowed, owner kito only, per Acceptance Policy below
+> **Base SHA**: `a8cae4d78f1a4451f3a5335b9fc345740c3c61db` (pinned per R1 after EPC-01 merged via PR #117 plus its row-flip commit; verified equal to this worktree's HEAD at task start)
+> **Target Branch**: main (via one independent PR)
+> **Working Branch**: `codex/epc-02-authoritative-verify-producer`
+> **PR Unit**: one PR carrying the epoch constant, the producer, the CLI wrapper, the `verify-sprint.sh` wiring edit, the test suite, and this package's workflow artifacts
+> **Capability ID**: root
+> **Last Updated**: 2026-07-22 16:34
+> **Review File**: `tasks/reviews/20260722-1634-epc-02-authoritative-verify-producer.review.md`
+> **Notes File**: `tasks/notes/20260722-1634-epc-02-authoritative-verify-producer.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+EPC-02 implements Sprint C backlog row 6: the authoritative verify producer.
+The verify runner (`verify-sprint` chain) must emit subject-bound
+`authoritative_machine` EvidenceEvents into the EPC-01 ledger, with
+non-subject-bound emission impossible by construction (D3/D4). Rows 9-12
+(materializers, checkpoints, Context Packet) select accepted events by trust
+class and exact subject; without a producer there is nothing authoritative
+to select. This package also introduces the Program's single epoch constant
+(`LEDGER_EPOCH_START_SHA`, frozen D2 to the exact base SHA the EPC-01
+contract pinned) so later producers (EPC-03/04) import one authority instead
+of duplicating the literal.
+
+## Goal
+
+1. `src/effects/evidence/epoch.ts`: export the frozen epoch constant
+   `LEDGER_EPOCH_START_SHA` (D2; value `5228d4ea0d7987cf6fb73be216d5b9cc638817c3`,
+   the base SHA the EPC-01 contract consumed at its own fresh fetch).
+2. `src/effects/evidence/verify-producer.ts`: a single entry function,
+   `emitAuthoritativeVerifyEvidence`, that resolves the active contract,
+   recomputes the review-subject sha256 via the existing builder
+   (`src/effects/review/diff-fingerprint.ts`, read-only import), builds the
+   complete D3 subject identity from repo state, ensures genesis with
+   `LEDGER_EPOCH_START_SHA`, then appends exactly one `authoritative_machine`
+   event with a small structured payload (status, counts, run-snapshot
+   repo-relative path). Fails closed (typed result, no emission) when: no
+   active contract resolves; the contract file is dirty or untracked
+   (authority must be committed); the recomputed subject hash differs from
+   an expected hash the caller supplied; or the EPC-01 store rejects the
+   epoch. No API path emits with a partial subject -- the function computes
+   every identity field itself; callers supply only raw material it cannot
+   observe on its own (the exact command line, an optional expected subject
+   hash for verification, and the small payload fields).
+3. `scripts/emit-verify-evidence.ts`: a thin bun CLI wrapper (arg parsing
+   only) so `verify-sprint.sh` can invoke the producer from bash. Distinct
+   exit codes, per ruling (orchestrator follow-up, 2026-07-22): `0` =
+   emitted; `3` = cannot-bind refusal (no active contract, dirty/untracked
+   contract, or the TS entry unresolvable in a deployed-helper context);
+   `2` = CLI usage error; any other non-zero (`1`) = a real failure
+   (subject mismatch, store/genesis error). The producer module itself is
+   unchanged by this: it still returns one typed `{ ok: false, reason,
+   message }` refusal for every fail-closed condition; only the wrapper's
+   mapping of `reason` to an exit code distinguishes cannot-bind from real
+   failure. Sprint row 6 requires only that non-subject-bound emission be
+   impossible and that a subject mismatch fail closed -- not that every
+   verify run emit -- so cannot-bind is refusal-to-fabricate, not a
+   fallback: no gate reads the ledger yet, so skipping satisfies nothing.
+4. Wire `scripts/verify-sprint.sh`: after successful verification in both
+   the `--prepare-acceptance` freeze path and the finalize path, invoke the
+   wrapper with the frozen `review_subject_sha256` and a result summary
+   read back out of `checks/latest.json`. Exit `0` continues; exit `3`
+   (cannot-bind) prints one stderr notice and continues with the verify
+   result unchanged; any other non-zero fails the verify run (no `|| true`,
+   no silent fallback for a real failure). The existing `checks/latest.json`
+   write is untouched; emission is additive. Companion-script resolution
+   for the TS entry mirrors the existing `$helper_dir/acceptance-receipt.ts`
+   sibling lookup, with the same `REPO_HARNESS_SOURCE_ROOT` fallback
+   `workflow_source_authority_call` already uses elsewhere in this script
+   for source-authority resolution -- no new resolution mechanism.
+5. `tests/evidence-verify-producer.test.ts`, red-first: subject mismatch
+   fails closed with nothing appended; a dirty or untracked contract fails
+   closed with nothing appended; a successful emission is one
+   `authoritative_machine` event with the complete D3 field set, accepted by
+   the EPC-01 fold; re-emission with identical inputs is idempotent (one
+   accepted event, two physical appends); genesis is written once with
+   `LEDGER_EPOCH_START_SHA`.
+6. All root required checks green; one independent PR on
+   `codex/epc-02-authoritative-verify-producer`.
+
+## Scope
+
+- In scope: `src/effects/evidence/epoch.ts`,
+  `src/effects/evidence/verify-producer.ts`,
+  `scripts/emit-verify-evidence.ts`, `scripts/verify-sprint.sh` (wiring edit
+  only, additive), `tests/evidence-verify-producer.test.ts`, this package's
+  plan/contract/review/notes, `tasks/todos.md` projection,
+  `.ai/harness/worktrees/epc-02-authoritative-verify-producer.json`.
+- Out of scope: every EPC-01 file (`src/core/evidence/*`,
+  `src/effects/evidence/*` existing files -- read-only imports),
+  `checks/latest` composition or any direct-authoring deletion (EPC-05),
+  `verify-contract.sh`, PostBash (EPC-03), acceptance-receipt (EPC-04),
+  handoff/resume/current writers (EPC-07), `tasks/current.md`, the sprint
+  document, any new npm dependency.
+- Taste constraints: match the existing `core`/`effects` idiom (readonly
+  interfaces, `{ ok, ... }`/discriminated-union result shapes, plain
+  exported functions, no classes, no barrel `index.ts`); smallest diff that
+  satisfies the frozen D2-D6 decisions.
+
+## Stop Conditions
+
+- Stop and hand back to the parent if `origin/main` has moved past
+  `a8cae4d78f1a4451f3a5335b9fc345740c3c61db` before this package's worktree
+  was created -- re-fetch and re-audit, never silently re-pin.
+- Stop and hand back to the parent if correct emission would require
+  modifying an EPC-01 module or `verify-contract.sh` -- report instead of
+  widening scope silently.
+- Stop if `check-architecture-sync` BLOCKS (not merely advises) on the
+  changed capability surfaces -- report rather than editing `.ai/context/`
+  or architecture files.
+- Stop after three fail-fix-reverify rounds on one issue.
+
+## Falsifier
+
+The direction is wrong if subject-bound emission cannot be built from the
+existing review-subject builder without modifying it, or if the verify
+chain cannot tolerate fail-closed emission (i.e. this package's own dogfood
+`verify-sprint --prepare-acceptance` acceptance run cannot pass with
+emission enabled). Cheapest proof: this package's own acceptance run
+appends exactly one accepted `authoritative_machine` event to the worktree
+ledger, with genesis written using `LEDGER_EPOCH_START_SHA`, and still
+passes.
+
+## Root Cause Evidence
+
+Not applicable: Task Profile is `code-change`, not `bugfix`.
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260722-1634-epc-02-authoritative-verify-producer.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260722-1634-epc-02-authoritative-verify-producer.review.md`
+- Notes file: `tasks/notes/20260722-1634-epc-02-authoritative-verify-producer.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Acceptance Policy
+
+```json
+{"protocol":1,"reviewer":"Claude","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - plans/plan-20260722-1634-epc-02-authoritative-verify-producer.md
+  - tasks/contracts/20260722-1634-epc-02-authoritative-verify-producer.contract.md
+  - tasks/reviews/20260722-1634-epc-02-authoritative-verify-producer.review.md
+  - tasks/notes/20260722-1634-epc-02-authoritative-verify-producer.notes.md
+  - src/effects/evidence/epoch.ts
+  - src/effects/evidence/verify-producer.ts
+  - scripts/emit-verify-evidence.ts
+  - scripts/verify-sprint.sh
+  - assets/templates/helpers/verify-sprint.sh
+  - tests/evidence-verify-producer.test.ts
+  - .ai/harness/worktrees/epc-02-authoritative-verify-producer.json
+  - tasks/todos.md
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # New producer; no benchmark-subject-touching change in this package.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+      - codex-exec
+      - main-thread
+    fallback: main-thread
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - src/effects/evidence/epoch.ts
+    - src/effects/evidence/verify-producer.ts
+    - scripts/emit-verify-evidence.ts
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260722-1634-epc-02-authoritative-verify-producer.notes.md
+  tests_pass:
+    - path: tests/evidence-verify-producer.test.ts
+  commands_succeed:
+    - bun run check:type
+    - bash scripts/check-task-workflow.sh --strict
+  manual_checks:
+    - "PR diff confined to allowed_paths; no EPC-01 file modified"
+    - "Package's own acceptance run appended one accepted authoritative_machine event with genesis epoch constant"
+    - "tasks/current.md untouched"
+```
+
+## Concurrency and Ownership
+
+- This package owns exactly the paths in `allowed_paths` above; it does not
+  touch any other package's plan, contract, review, notes, or code surface.
+- This package deliberately runs serial BEFORE any EPC-03/04 wave because it
+  introduces the shared epoch constant (`LEDGER_EPOCH_START_SHA` in
+  `src/effects/evidence/epoch.ts`): landing it first gives EPC-03/04 one
+  authority to import instead of each duplicating the literal, which R4's
+  wave-qualification rule would otherwise treat as a shared-surface
+  violation. R4 wave qualification for EPC-03/04 is evaluated only after
+  this package merges.
+- Per sprint R2 Layer 2, this package makes no benchmark-subject-touching
+  change, so it holds no subject freeze and does not participate in one.
+- If an out-of-band merge lands on `main` touching this package's
+  `allowed_paths` before this package's PR merges, stop, re-fetch, and
+  re-derive against the new state; never force-push over it.
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior: adds a new producer (`emitAuthoritativeVerifyEvidence`)
+  and its CLI wrapper, wires `verify-sprint.sh` to call it additively after
+  a passing verification, and adds the Program's shared epoch constant. No
+  existing EPC-01 file, `verify-contract.sh`, or `checks/latest` writer is
+  modified.
+- Edge cases: dirty/untracked active contract; recomputed subject hash
+  differing from a caller-supplied expected hash; re-emission with
+  identical inputs (idempotency dedup at fold time, not at append time);
+  genesis-before-append semantics reused unmodified from EPC-01.
+- Regression risks: none to existing runtime surfaces (no existing file is
+  modified other than the additive `verify-sprint.sh` wiring, which fails
+  the verify run on a real failure and prints one documented notice --
+  never silent -- on a cannot-bind refusal). The risk surface is a later
+  EPC-0N package mis-citing the frozen epoch constant, bypassing
+  `emitAuthoritativeVerifyEvidence`'s single entry point, or a caller
+  mistaking cannot-bind for success (the wrapper's exit code and stderr
+  notice both distinguish it), all guarded by this package's Falsifier,
+  its "no partial subject" design, and the wrapper-level exit-code tests.
+
+## Rollback Point
+
+- Commit / checkpoint: the single commit on `codex/epc-02-authoritative-verify-producer` before it merges.
+- Revert strategy: revert the single PR -- every change is new files
+  (`epoch.ts`, `verify-producer.ts`, the CLI wrapper, the test suite) plus
+  one additive wiring edit in `scripts/verify-sprint.sh` and this package's
+  workflow artifacts; `checks/latest` authoring and every other surface are
+  unchanged, so reverting cannot regress any existing consumer.

--- a/tasks/notes/20260722-1634-epc-02-authoritative-verify-producer.notes.md
+++ b/tasks/notes/20260722-1634-epc-02-authoritative-verify-producer.notes.md
@@ -1,0 +1,257 @@
+# Implementation Notes: epc-02-authoritative-verify-producer
+
+> **Status**: Active
+> **Plan**: plans/plan-20260722-1634-epc-02-authoritative-verify-producer.md
+> **Contract**: tasks/contracts/20260722-1634-epc-02-authoritative-verify-producer.contract.md
+> **Review**: tasks/reviews/20260722-1634-epc-02-authoritative-verify-producer.review.md
+> **Last Updated**: 2026-07-22 16:34
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- **Contract resolution is a hybrid, not a re-derivation of `verify-sprint.sh`'s
+  chain.** `verify-sprint.sh` already resolves "which contract is active for
+  this run" through its own logic (`--contract` override, `workflow_active_contract`,
+  or a sorted fallback). Re-implementing that whole chain in TypeScript
+  purely for this producer would be a second, potentially divergent
+  authority for the same datum -- exactly the "shadow parser" pattern the
+  repo forbids. `emitAuthoritativeVerifyEvidence` instead takes an optional
+  `contractPath` input: the `verify-sprint.sh` wiring always passes its own
+  already-resolved `$contract_file`, so production has exactly one
+  resolution. When omitted, the function falls back to the repo's own
+  `.ai/harness/active-plan` -> `plans/plan-<slug>.md` -> `tasks/contracts/<slug>.contract.md`
+  convention (the same one `src/cli/hook/subagent-handler.ts`'s private,
+  unexported `activeContractPath` uses) so direct/standalone/test callers
+  still work without needing bash. `contractPath` is a pointer, not an
+  identity field -- the function still computes `contract_hash`,
+  `scope_hash`, and `authority_commit` from it itself, so "callers cannot
+  inject identity fields" still holds.
+- **`authority_commit` resolution**: `git log -1 --format=%H -- <contract>`,
+  only reached after confirming `git status --porcelain -- <contract>` is
+  empty (tracked and clean). A non-empty porcelain status already covers
+  both "untracked" (`?? path`) and "dirty" (`M `/`A `/etc.) in one check, so
+  both fail-closed conditions share one git call.
+- **`base_commit`/`target_commit` come from the same `buildReviewSubject`
+  call already needed for `subject_hash`, not extra git calls.**
+  `buildReviewSubject(repoRoot, { targetRef: reviewBaseRef }).target_rev` is
+  `base_commit`; `.head_rev` is `target_commit`. `reviewBaseRef` is read from
+  `.ai/harness/policy.json#worktree_strategy.review_base` (pattern reference:
+  `scripts/acceptance-receipt.ts`'s private, unexported `reviewBase`/
+  `currentSubject`, reimplemented locally since they are not exported).
+  Unlike `acceptance-receipt.ts`, a missing policy file or missing
+  `review_base` value falls back to `"HEAD"` instead of failing closed --
+  the real target repo always has this file, so the fallback only matters
+  for a fixture/standalone repo that never created one, and "no active
+  contract" / "dirty contract" / "subject mismatch" already cover every
+  fail-closed condition this package was asked to prove; a fifth reason
+  for a scenario that cannot occur in production was not added.
+- **`env_provider_id` composition**: `repo-harness/<this module's own package.json version>/<ws-hash>`.
+  The version is read from `PACKAGE_ROOT/package.json` resolved from
+  `import.meta.url` (three levels up from `src/effects/evidence/`) --
+  i.e. the repo-harness tool's own version, never the target `repoRoot`'s
+  `package.json` (which does not exist in a bare test fixture and would be
+  the wrong datum anyway: this field identifies the verifying tool, not the
+  repo being verified). `ws-<12 hex chars>` is `sha256(git rev-parse --show-toplevel)`
+  truncated -- deterministic per worktree (needed for idempotent
+  re-emission: this field feeds `subject_identity`, which feeds the
+  idempotency key, so it must not vary call-to-call for the same repo).
+- **`scope_hash`**: `sha256(JSON.stringify(uniqueSorted(allowedPaths)))`,
+  reusing `diff-fingerprint.ts`'s own exported `uniqueSorted` (byte-order
+  sort + dedup) for the same "ordered set" semantics the rest of the
+  identity already uses, instead of inventing a second sort convention.
+  `allowedPaths` is extracted from the contract's fenced ` ```yaml ` block
+  by a small local parser mirroring `verify-sprint.sh`'s `contract_allowed_paths`
+  awk function (find the block containing `allowed_paths:`, read `  - item`
+  lines until dedent). No existing TS parser for this existed to import.
+- **`event_type`/`producer` naming**: `"verify_sprint.result"` /
+  `"verify-sprint"`. No existing convention or consumer to match yet (D7's
+  materializers are future rows); named for clarity. Both feed the D5
+  idempotency key, so they must stay constant across calls for the same
+  logical run -- they are fixed constants, not caller inputs.
+- **`verify-sprint.sh` wiring**: one new bash function, `emit_verify_evidence`,
+  called from both sites (rather than duplicating the invocation inline
+  twice). It reads `review_subject_sha256`, the run-snapshot path, and guard
+  counts back out of `$checks_file` -- never from an in-scope bash variable
+  -- because `$review_subject_sha256` is only set as a global in the
+  `--prepare-acceptance` branch and is not in scope inside
+  `finalize_prepared_acceptance`. Reading everything from `$checks_file`
+  also means the emitted evidence is always bound to exactly what that file
+  already asserts passed, rather than a second in-memory notion of "the
+  subject" that could drift from it. Insertion points: the freeze path's
+  existing `if [[ "$exit_code" -eq 0 ]]` success-echo block (narrowest
+  point after the success determination), and `finalize_prepared_acceptance`'s
+  tail, right after its own two success echoes and before the function
+  closes. Both are additive; no existing line was changed, moved, or
+  removed (`git diff --stat` on the file shows insertions only).
+- **Payload shape**: `{ status, counts, run_snapshot_id }`. `counts` is
+  computed by the bash wiring from `$checks_file`'s own `guards` array
+  (`guards_total`, `guards_passed`) rather than inventing new
+  instrumentation -- it is data the script already has. `run_snapshot_id`
+  is **not** the full path (see the dogfood-caught redaction bug under
+  Evidence Links below): it is the run-id prefix only, with the redundant
+  `-<worktree_id>` suffix and `.json` extension stripped by
+  `shortRunSnapshotId`. A reader reconstructs the real path as
+  `.ai/harness/runs/<run_snapshot_id>-<worktree_id>.json` (`worktree_id` is
+  already in the event envelope). The producer's public input,
+  `VerifyProducerInput.runSnapshotPath` (and the CLI's `--run-snapshot`),
+  still take the full repo-relative path unchanged -- only the internal
+  payload construction shortens it, so the wiring in `verify-sprint.sh`
+  needed no change for this fix.
+
+## Orchestrator Ruling (2026-07-22, post-implementation follow-up)
+
+Full `bun test` after the orchestrator widened `allowed_paths` to include
+`assets/templates/helpers/verify-sprint.sh` and ran `bun run sync:helpers`
+exposed 6 real failures in `tests/helper-scripts.test.ts`: those fixtures
+deploy the repo's declared `.sh`/`.ts` helpers into a bare temp dir (no
+`src/` tree, no `scripts/emit-verify-evidence.ts` -- it is not a declared
+helper) and then run `bash scripts/verify-sprint.sh`, which now hit my new
+wiring. Two rulings applied:
+
+- **Companion-script resolution.** `emit-verify-evidence.ts` is *not* made
+  a declared helper (unlike `acceptance-receipt.ts`): its entry point
+  imports `src/effects/evidence/verify-producer.ts`, which in turn needs
+  the whole EPC-01 evidence store and `diff-fingerprint.ts` -- making it
+  standalone would mean duplicating that logic inline, which is exactly
+  the kind of new resolution mechanism the ruling said not to invent.
+  Instead, `emit_verify_evidence()` in `scripts/verify-sprint.sh` resolves
+  the TS entry the same way `acceptance-receipt.ts` is resolved today
+  (`$helper_dir/acceptance-receipt.ts`, a plain sibling-file lookup -- it
+  is a declared helper deployed alongside `verify-sprint.sh` by the same
+  `copyHelpers()`/`sync:helpers` mechanism), with one addition: when
+  `$helper_dir/emit-verify-evidence.ts` does not exist locally (a
+  deployed-helper context), it falls back to
+  `${REPO_HARNESS_SOURCE_ROOT}/scripts/emit-verify-evidence.ts` if that env
+  var is set and the file exists there -- the exact same
+  `REPO_HARNESS_SOURCE_ROOT` fallback `workflow_source_authority_call`
+  already uses a few lines above in this same script for hook-CLI
+  resolution (`PR #111`, `codex/helper-source-path-env-leak`), not a new
+  mechanism. `tests/helper-scripts.test.ts`'s `sandboxEnv()` deliberately
+  strips `REPO_HARNESS_SOURCE_ROOT`, so in those specific fixtures neither
+  path resolves -- which is exactly the "indistinguishable from cannot-bind"
+  case named in the ruling, and is handled identically (return 3, one
+  stderr notice, no crash).
+- **Cannot-bind => skip, not fail.** `scripts/emit-verify-evidence.ts` now
+  maps the producer's typed refusal to exit `3` (cannot-bind:
+  `no_active_contract` / `contract_not_committed`) versus exit `1` (real
+  failure: `subject_mismatch` / `genesis_epoch_conflict`); exit `2` stays
+  CLI usage errors. `verify-sprint.sh`'s two call sites now `case` on the
+  captured exit code: `0`/`3` continue (verify result unchanged; `3` prints
+  one stderr notice), any other non-zero fails the run. The producer
+  module (`verify-producer.ts`) is untouched by this ruling -- it still
+  returns one typed `{ ok: false, reason, message }` for every fail-closed
+  condition; only the wrapper's mapping of that `reason` to an exit code
+  changed. This is refusal-to-fabricate, not a fallback: nothing reads the
+  ledger yet, so a cannot-bind skip changes no gate's outcome.
+- **Real bug found applying this**: both call sites originally wrote
+  `emit_verify_evidence "..."; case $? in ...` as two separate statements.
+  Under `set -e` (`set -euo pipefail` at the top of the script), a
+  standalone command returning non-zero (exit `3`, the very case being
+  added) aborts the *entire script* immediately -- the `case` statement
+  handling that exit code is never reached, and the whole `verify-sprint`
+  process exits with code `3` instead of continuing. Caught by re-running
+  `tests/helper-scripts.test.ts` after the first pass of this fix (still
+  6 failing, now with `Expected: 0, Received: 3` instead of `Received: 1`
+  -- a regression in the fix itself, not a pre-existing one). Fixed with
+  this script's own established idiom (already used for
+  `contract_output`/`acceptance_row` elsewhere in this file):
+  `set +e; emit_verify_evidence "..."; emit_exit=$?; set -e; case
+  "$emit_exit" in ...`. Re-ran `tests/helper-scripts.test.ts` +
+  `tests/capability-resolver.test.ts`: 127/127 pass.
+
+## Deviations From Plan Or Spec
+
+- The plan's payload description says "run snapshot repo-relative path."
+  The shipped payload field is `run_snapshot_id` (a short id, not the
+  literal path) -- see the dogfood-caught redaction bug under Evidence
+  Links. The literal path would have been silently hashed into a useless
+  `sha256:...` value on every real invocation (the plan's own P1 section
+  separately warned this redaction risk exists), so storing it verbatim
+  would not have satisfied the plan's actual intent ("run-snapshot ...
+  path" as a *useful, dereferenceable* payload element) even though it
+  matched the literal field name. The full path is still available to
+  every caller via `VerifyProducerInput.runSnapshotPath` / the CLI's
+  `--run-snapshot`; only the payload's internal representation changed.
+- Otherwise none. The plan's Goal/P1-P3 sections did not pin an
+  `event_type` string, an exact `env_provider_id` composition, or the
+  contract-resolution mechanism at the wiring boundary; all three were left
+  as implementation latitude and are recorded above rather than being
+  deviations.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| Re-derive "active contract" independently in TS vs. accept it as an optional input from `verify-sprint.sh` | Accept as optional input, fall back to `.ai/harness/active-plan` only when omitted | A second independent resolver risks silently diverging from what `verify-sprint.sh` actually verified; the repo's no-dual-authority principle argues for consuming the one resolution that already exists in production while keeping the fallback for direct/test callers |
+| Fail closed if `.ai/harness/policy.json#worktree_strategy.review_base` is missing (mirroring `acceptance-receipt.ts`) vs. default to `HEAD` | Default to `HEAD` | The real repo always has this file; a fifth fail-closed reason for an unreachable-in-production scenario was not part of the four named fail-closed conditions and was not added |
+| Shared `emit_verify_evidence` bash helper vs. duplicating the wrapper invocation inline at both call sites | Shared helper, one definition | Smaller total diff than duplicating ~10 lines twice; both call sites already differ enough (finalize has no `review_subject_sha256` in scope) that reading from `$checks_file` in one place avoids two subtly different implementations drifting apart |
+| Test fixtures as real git repos (init/commit/tag) vs. plain temp dirs like EPC-01's fixtures | Real git repos | The producer reads git state (`status`, `log`, `rev-parse`) that EPC-01's own store never touched; a plain temp dir could not exercise the dirty/untracked/subject-mismatch fail-closed paths at all |
+
+## Open Questions
+
+- None.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- **Dogfood-caught bug (real production run, not a fixture)**: after the
+  implementation and tests were green, `bun scripts/emit-verify-evidence.ts`
+  was run directly against this worktree's own (now-committed) contract --
+  exactly as `verify-sprint.sh`'s wiring would invoke it. The event appended
+  successfully (`evt-01KY4H2...`), but `payload.run_snapshot_path` came back
+  as `.sha256:a3a43bf...json` instead of the real path. Root cause: EPC-01's
+  D6 redaction (`src/core/evidence/redaction.ts`, read-only) replaces any
+  32+ char run of `[A-Za-z0-9+/_-]` (dots break a run; slashes and hyphens
+  do not) with `sha256:<hash>`; the real run-snapshot filename
+  (`run-<timestamp>-<pid>-<contract-slug>.json`, `scripts/verify-sprint.sh`'s
+  `run_file`) is always such a run for any realistic contract slug, so the
+  field would have come back hashed on every real invocation, not just this
+  one -- a payload field that is unconditionally useless in production. This
+  is exactly the risk the dispatch's "Payload discipline" note warned about
+  in advance; the first implementation still walked into it because the
+  test fixture's own `run_snapshot_path` fixture value ("fixture-run.json")
+  happened to be short enough to dodge the redaction, so the unit test
+  suite alone did not catch it. Fixed as described above
+  (`run_snapshot_id`, short-id-only payload field); the test fixture was
+  then changed to a realistic-length filename
+  (`run-20260722T170215-94226-fixture.json`) specifically so the suffix-
+  stripping path is genuinely exercised, not just accidentally passed
+  through the no-op fallback branch. Re-ran the same direct dogfood
+  invocation after the fix: `payload.run_snapshot_id` came back as
+  `"run-20260722T170215-94226"`, fully readable. `bun test`,
+  `bun run check:type`, and the full root required-checks list were all
+  re-verified green after this fix, and the single commit was amended
+  (not a second commit) since nothing had been pushed and the dispatch's
+  own instruction was to land this package as one commit.
+- Red-first: the idempotency test (`tests/evidence-verify-producer.test.ts`)
+  failed on its first real run against the completed implementation because
+  the test fixture had no `.gitignore` for `.ai/harness/evidence/` -- the
+  producer's own first-call write showed up as untracked churn in the
+  second call's review-subject scan, changing `subject_hash` and therefore
+  the idempotency key between the two calls. Fixed by giving the fixture
+  the same `.gitignore` line the real target repo already carries from
+  EPC-01 (`.ai/harness/evidence/`), committed in the fixture's base commit
+  before any evidence is written. This is a genuine, repo-general finding,
+  not a producer bug: **a repo that does not gitignore the evidence store
+  cannot get idempotent re-emission from this producer**, because the store
+  becomes part of the diff surface `buildReviewSubject` measures. Recorded
+  here rather than promoted, since it is a one-time observation about this
+  fixture, not (yet) a repeated correction.
+- "No active contract" is a required fail-closed behavior of the function
+  (goal item 2) but is not one of the five red-first fixtures enumerated by
+  the plan's own Goal-6 or by the dispatch's deliverable C; no dedicated
+  producer-level test was added for it, matching that enumeration exactly.
+  It is now covered at the wrapper level instead, by the orchestrator
+  ruling's exit-code tests ("exit 3 (cannot-bind), not 1, when no active
+  contract resolves", `tests/evidence-verify-producer.test.ts`).
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/reviews/20260722-1634-epc-02-authoritative-verify-producer.review.md
+++ b/tasks/reviews/20260722-1634-epc-02-authoritative-verify-producer.review.md
@@ -49,17 +49,17 @@
 
 ## Acceptance Receipt Projection
 
-> **Disposition**: unavailable
-> **Reviewer**: unavailable
-> **Source**: unavailable
+> **Disposition**: external_pass
+> **Reviewer**: Claude
+> **Source**: claude-review
 > **Actor**: not-applicable
-> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject SHA256**: sha256:76d38600a04e40d9fe09ddc20f0816c1ae17a0dd60cd226ec6a6fdb6a02a2158
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: pending
-> **Verification Evidence SHA256**: pending
-> **Issued At**: pending
+> **Reviewed Target Revision**: a8cae4d78f1a4451f3a5335b9fc345740c3c61db
+> **Verification Evidence SHA256**: sha256:fe973d76838891ed8a05a957f6fdd59e7feff811628ee747583419dd4e127cee
+> **Issued At**: 2026-07-22T10:09:15.808Z
 
-- Summary: No AcceptanceReceipt has been recorded.
+- Summary: EPC-02 accepted: authoritative verify producer with construction-bound D3 subject identity, epoch constant single-sourced, cannot-bind skip semantics, mismatch fail-closed; live ledger readback evidence; gatekeeper gates clean after remediation
 - Findings: none
 
 ## Behavior Diff Notes

--- a/tasks/reviews/20260722-1634-epc-02-authoritative-verify-producer.review.md
+++ b/tasks/reviews/20260722-1634-epc-02-authoritative-verify-producer.review.md
@@ -1,12 +1,12 @@
 # Task Review: epc-02-authoritative-verify-producer
 
-> **Status**: Pending
+> **Status**: Reviewed
 > **Plan**: plans/plan-20260722-1634-epc-02-authoritative-verify-producer.md
 > **Contract**: tasks/contracts/20260722-1634-epc-02-authoritative-verify-producer.contract.md
 > **Notes File**: tasks/notes/20260722-1634-epc-02-authoritative-verify-producer.notes.md
 > **Checks File**: .ai/harness/checks/latest.json
-> **Last Updated**: 2026-07-22 16:34
-> **Recommendation**: fail
+> **Last Updated**: 2026-07-22 18:20
+> **Recommendation**: pass
 > **Review Rubric Version**: 2
 > **Reviewed Subject SHA256**: pending
 > **Reviewed Subject Scope**: normalized-final-content
@@ -14,29 +14,38 @@
 
 ## Human Review Card
 
-- Verdict: pending
-- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
-- Intended files changed:
-- Actual files changed:
-- Commands passed:
-- Residual risks:
-- Reviewer action required: inspect diff and card
-- Rollback:
+- Verdict: pass
+- Change type: code-change
+- Intended files changed: new `src/effects/evidence/epoch.ts` + `verify-producer.ts`, new `scripts/emit-verify-evidence.ts`, wiring in `scripts/verify-sprint.sh` (insertions only) with its deterministic mirror `assets/templates/helpers/verify-sprint.sh` (sync:helpers projection), new `tests/evidence-verify-producer.test.ts`, package plan/contract/review/notes, `tasks/todos.md` projection
+- Actual files changed: exactly that set — 11 paths, single commit `7d4ad84e` on base `a8cae4d7`; zero EPC-01 files modified; `verify-contract.sh`, `acceptance-receipt.ts`, `command-observed.ts`, `tasks/current.md` untouched; verify-sprint.sh diff is insertions-only
+- Commands passed: `bun test tests/evidence-verify-producer.test.ts` (11 pass, red-first), `bun test tests/helper-scripts.test.ts tests/capability-resolver.test.ts` (127 pass — previously-red characterization suites), full `bun test` (1722 pass / 1 skip / 0 fail — worker + gatekeeper re-run), `check:type` clean, `check-task-workflow --strict` OK, `contract-run preflight` preflight_pass, deploy-sql/architecture-sync (advisory blocking=0)/task-sync green, `inspect-project-state` no drift, `adopt --dry-run` 0 operations
+- Residual risks: emission fires only on already-successful verify runs, and exit-3 skip (cannot-bind) changes nothing a gate reads (no ledger consumer until EPC-05); wrapper resolution in deployed-helper contexts uses the existing `REPO_HARNESS_SOURCE_ROOT` fallback — an adopted repo without that source root skips with exit 3 rather than failing (documented in notes)
+- Reviewer action required: none further — gatekeeper FAIL on missing live-ledger evidence remediated by a live wrapper run + readback (see Manual Check Evidence); all code/scope/test gates were already clean in the gatekeeper pass
+- Rollback: revert the single PR; new files plus insertions-only wiring; mirror re-syncs via `bun run sync:helpers`
 
 ## Mode Evidence
 
-- Selected route:
-- P1/P2/P3 evidence:
-- Root cause or plan evidence:
+- Selected route: planning (captured work-package plan, code-change profile)
+- P1/P2/P3 evidence: plan Captured Planning Output; design authority is frozen D2–D6; EPC-01 store API consumed read-only
+- Root cause or plan evidence: not a bugfix; second implementation package of the frozen EPC design (first producer)
 
 ## Verification Evidence
 
-- Waza `/check` run:
-- Commands run:
-- Manual checks:
-- Supporting artifacts:
-- Implementation notes reviewed:
-- Run snapshot:
+- Waza `/check` run: gatekeeper acceptance review (fresh context, read-only) — initial FAIL solely on absent live-ledger dogfood evidence; remediated same-day with a live emission + readback; all other gates verified clean by gatekeeper
+- Commands run: see Human Review Card; executed in the contract worktree at `7d4ad84e`
+- Manual checks: see Manual Check Evidence below
+- Supporting artifacts: `.ai/harness/checks/latest.json`; `.ai/harness/evidence/events/log.jsonl` (worktree ledger)
+- Implementation notes reviewed: yes — helper-source resolution choice, cannot-bind exit-code contract (orchestrator ruling), `set -e` capture idiom bug, redaction-driven `run_snapshot_id` payload shape
+- Run snapshot: `.ai/harness/runs/`
+
+## Manual Check Evidence
+
+- [x] PR diff confined to allowed_paths; no EPC-01 file modified
+  - Evidence: `git diff --name-only a8cae4d7..HEAD` lists exactly the 11 paths in the contract's `allowed_paths`; gatekeeper verified `src/effects/evidence/epoch.ts` and `verify-producer.ts` are additions and zero EPC-01 files changed; `diff scripts/verify-sprint.sh assets/templates/helpers/verify-sprint.sh` is empty (mirror in lockstep).
+- [x] Package's own acceptance run appended one accepted authoritative_machine event with genesis epoch constant
+  - Evidence: live wrapper run in this worktree at committed-clean `7d4ad84e` appended `evt-01KY4MQST9B3EKGM05MZX9AAFQ`; readback of `.ai/harness/evidence/events/log.jsonl` shows the genesis record with `ledger_epoch_start_sha = 5228d4ea0d7987cf6fb73be216d5b9cc638817c3` followed by the accepted `authoritative_machine` `verify_sprint.result` event; the `verify-sprint --prepare-acceptance` freeze run for this acceptance exercises the same wiring live.
+- [x] tasks/current.md untouched
+  - Evidence: `git diff a8cae4d7..HEAD -- tasks/current.md` is empty; `git status --porcelain` shows no entry for `tasks/current.md`.
 
 ## Acceptance Receipt Projection
 
@@ -55,30 +64,31 @@
 
 ## Behavior Diff Notes
 
-- ...
+- The verify runner now emits a subject-bound `authoritative_machine` EvidenceEvent after successful verification (prepare and finalize paths). Cannot-bind conditions (no active contract; dirty/untracked contract; unresolvable TS entry in deployed-helper contexts) skip emission with exit 3 and one stderr notice — refusal-to-fabricate, not a fallback; subject mismatch and store/genesis errors fail the run. `checks/latest` authoring is unchanged (EPC-05 owns that cutover).
 
 ## Residual Risks / Follow-ups
 
-- ...
+- Adopted repos without `REPO_HARNESS_SOURCE_ROOT` skip emission (exit 3); acceptable while no gate reads the ledger — revisit at EPC-05 selection cutover.
+- EPC-03/04 import `LEDGER_EPOCH_START_SHA` from this package; wave qualification for their parallel execution is now evaluable.
 
 ## Scorecard
 
 | Dimension | Score | Notes |
 |-----------|-------|-------|
-| Functionality | 0/10 | |
-| Product depth | 0/10 | |
-| Design quality | 0/10 | |
-| Code quality | 0/10 | |
+| Functionality | 9/10 | Row-6 acceptance satisfied; construction-invariant subject binding |
+| Product depth | 9/10 | Exit-code contract distinguishes refusal classes; dogfood-proven live |
+| Design quality | 9/10 | Epoch constant single-sourced; insertions-only wiring; mirror in sync |
+| Code quality | 9/10 | Full suite 1722 green; characterization suites restored |
 
 ## Failing Items
 
-- ...
+- none
 
 ## Retest Steps
 
-- Re-run:
-- Re-check:
+- Re-run: `bun test tests/evidence-verify-producer.test.ts`; `bun test tests/helper-scripts.test.ts`
+- Re-check: readback of `.ai/harness/evidence/events/log.jsonl` (genesis epoch + accepted authoritative_machine event); mirror diff empty
 
 ## Summary
 
-- ...
+- EPC-02 delivers the authoritative verify producer per frozen D2–D6: the verify runner emits subject-bound `authoritative_machine` events with the full D3 identity computed by construction, the Program epoch constant is single-sourced, cannot-bind refusals skip without fabricating, and subject mismatch fails closed — proven by red-first tests, restored characterization suites, and a live ledger readback. Gatekeeper's sole blocking finding (missing live evidence) is remediated with the recorded readback. Ready to ship as one PR.

--- a/tasks/reviews/20260722-1634-epc-02-authoritative-verify-producer.review.md
+++ b/tasks/reviews/20260722-1634-epc-02-authoritative-verify-producer.review.md
@@ -1,0 +1,84 @@
+# Task Review: epc-02-authoritative-verify-producer
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260722-1634-epc-02-authoritative-verify-producer.md
+> **Contract**: tasks/contracts/20260722-1634-epc-02-authoritative-verify-producer.contract.md
+> **Notes File**: tasks/notes/20260722-1634-epc-02-authoritative-verify-producer.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-07-22 16:34
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Commands passed:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+- Waza `/check` run:
+- Commands run:
+- Manual checks:
+- Supporting artifacts:
+- Implementation notes reviewed:
+- Run snapshot:
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -1,7 +1,7 @@
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: 2026-07-22 11:51
+> **Updated**: 2026-07-22 16:34
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.

--- a/tests/evidence-verify-producer.test.ts
+++ b/tests/evidence-verify-producer.test.ts
@@ -1,0 +1,348 @@
+import { describe, expect, test } from "bun:test";
+import { createHash } from "crypto";
+import { execFileSync, spawnSync } from "child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { LEDGER_EPOCH_START_SHA } from "../src/effects/evidence/epoch";
+import { emitAuthoritativeVerifyEvidence, type VerifyProducerInput } from "../src/effects/evidence/verify-producer";
+import { readAcceptedEvents, readGenesisRecord } from "../src/effects/evidence/event-log";
+import { buildReviewSubject } from "../src/effects/review/diff-fingerprint";
+
+function git(repoRoot: string, args: readonly string[]): string {
+  return execFileSync("git", ["-C", repoRoot, ...args], { encoding: "utf-8" });
+}
+
+const REPO_ROOT = join(import.meta.dir, "..");
+const WRAPPER_PATH = join(REPO_ROOT, "scripts/emit-verify-evidence.ts");
+
+function runWrapper(args: readonly string[]): { readonly status: number | null; readonly stdout: string; readonly stderr: string } {
+  const result = spawnSync("bun", [WRAPPER_PATH, ...args], { encoding: "utf-8" });
+  return { status: result.status, stdout: result.stdout, stderr: result.stderr };
+}
+
+const RUN_SNAPSHOT_ARG = ".ai/harness/runs/run-20260722T170215-94226-fixture.json";
+
+function withTempRepo(prefix: string, fn: (repoRoot: string) => void): void {
+  const repoRoot = mkdtempSync(join(tmpdir(), `${prefix}-`));
+  try {
+    fn(repoRoot);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Builds a minimal but real git fixture repo: one base commit (tagged
+ * `base-tag`, used as `review_base` since a fixture has no `origin` remote)
+ * plus one implementation commit on top, and a committed contract file
+ * declaring `allowed_paths`. Mirrors the EPC-01 evidence test fixtures
+ * (`tests/evidence-event-store.test.ts`) but adds real git history, which
+ * this producer -- unlike EPC-01's store -- actually reads.
+ */
+function setupFixtureRepo(
+  repoRoot: string,
+  opts: { readonly allowedPaths?: readonly string[]; readonly commitContract?: boolean } = {},
+): { readonly contractRelative: string } {
+  mkdirSync(repoRoot, { recursive: true });
+  git(repoRoot, ["init", "-q", "-b", "main"]);
+  git(repoRoot, ["config", "user.email", "verify-producer-test@example.com"]);
+  git(repoRoot, ["config", "user.name", "verify-producer-test"]);
+
+  // The real target repo gitignores the evidence store (D1); mirror that here
+  // so the producer's own writes never show up as untracked churn in the next
+  // call's review-subject scan -- otherwise emitting evidence would itself
+  // change the very subject surface being measured, breaking idempotency in
+  // the fixture only (production is unaffected because it is gitignored).
+  writeFileSync(join(repoRoot, ".gitignore"), ".ai/harness/evidence/\n");
+  writeFileSync(join(repoRoot, "README.md"), "base\n");
+  git(repoRoot, ["add", ".gitignore", "README.md"]);
+  git(repoRoot, ["commit", "-q", "-m", "base"]);
+  git(repoRoot, ["tag", "base-tag"]);
+
+  mkdirSync(join(repoRoot, ".ai", "harness"), { recursive: true });
+  writeFileSync(
+    join(repoRoot, ".ai", "harness", "policy.json"),
+    JSON.stringify({ worktree_strategy: { review_base: "base-tag" } }),
+  );
+
+  const allowedPaths = opts.allowedPaths ?? ["src/example.ts", "tests/example.test.ts"];
+  const contractRelative = "tasks/contracts/fixture.contract.md";
+  mkdirSync(join(repoRoot, "tasks", "contracts"), { recursive: true });
+  const contractBody = [
+    "# Task Contract: fixture",
+    "",
+    "## Allowed Paths",
+    "",
+    "```yaml",
+    "allowed_paths:",
+    ...allowedPaths.map((path) => `  - ${path}`),
+    "```",
+    "",
+  ].join("\n");
+  writeFileSync(join(repoRoot, contractRelative), contractBody);
+
+  git(repoRoot, ["add", ".ai/harness/policy.json"]);
+  if (opts.commitContract ?? true) {
+    git(repoRoot, ["add", contractRelative]);
+  }
+  git(repoRoot, ["commit", "-q", "-m", "policy" + ((opts.commitContract ?? true) ? " and contract" : "")]);
+
+  mkdirSync(join(repoRoot, "src"), { recursive: true });
+  writeFileSync(join(repoRoot, "src", "example.ts"), "export const value = 1;\n");
+  git(repoRoot, ["add", "src/example.ts"]);
+  git(repoRoot, ["commit", "-q", "-m", "implement"]);
+
+  return { contractRelative };
+}
+
+function baseInput(repoRoot: string, contractRelative: string, overrides: Partial<VerifyProducerInput> = {}): VerifyProducerInput {
+  return {
+    repoRoot,
+    contractPath: contractRelative,
+    commandLine: "repo-harness run verify-sprint --prepare-acceptance",
+    status: "pass",
+    runSnapshotPath: ".ai/harness/runs/run-20260722T170215-94226-fixture.json",
+    ...overrides,
+  };
+}
+
+function recomputeExpectedSubject(repoRoot: string): string {
+  const subject = buildReviewSubject(repoRoot, { targetRef: "base-tag" });
+  expect(subject.status).toBe("ok");
+  return subject.review_subject_sha256;
+}
+
+describe("emitAuthoritativeVerifyEvidence: fail-closed paths", () => {
+  test("subject mismatch fails closed and appends nothing", () => {
+    withTempRepo("verify-producer-subject-mismatch", (repoRoot) => {
+      const { contractRelative } = setupFixtureRepo(repoRoot);
+      const result = emitAuthoritativeVerifyEvidence(
+        baseInput(repoRoot, contractRelative, { expectedSubjectSha256: "sha256:" + "0".repeat(64) }),
+      );
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.reason).toBe("subject_mismatch");
+
+      expect(readGenesisRecord(repoRoot)).toBeNull();
+      const { accepted } = readAcceptedEvents(repoRoot);
+      expect(accepted.length).toBe(0);
+    });
+  });
+
+  test("a dirty (uncommitted) contract fails closed and appends nothing", () => {
+    withTempRepo("verify-producer-contract-dirty", (repoRoot) => {
+      const { contractRelative } = setupFixtureRepo(repoRoot);
+      // Modify the already-committed contract without committing the change.
+      writeFileSync(join(repoRoot, contractRelative), readFileSync(join(repoRoot, contractRelative), "utf-8") + "\n<!-- dirty -->\n");
+
+      const result = emitAuthoritativeVerifyEvidence(baseInput(repoRoot, contractRelative));
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.reason).toBe("contract_not_committed");
+
+      const { accepted } = readAcceptedEvents(repoRoot);
+      expect(accepted.length).toBe(0);
+    });
+  });
+
+  test("an untracked (never committed) contract fails closed and appends nothing", () => {
+    withTempRepo("verify-producer-contract-untracked", (repoRoot) => {
+      const { contractRelative } = setupFixtureRepo(repoRoot, { commitContract: false });
+
+      const result = emitAuthoritativeVerifyEvidence(baseInput(repoRoot, contractRelative));
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.reason).toBe("contract_not_committed");
+
+      const { accepted } = readAcceptedEvents(repoRoot);
+      expect(accepted.length).toBe(0);
+    });
+  });
+});
+
+describe("emitAuthoritativeVerifyEvidence: success path", () => {
+  test("emits exactly one authoritative_machine event with the complete D3 field set, accepted by the fold", () => {
+    withTempRepo("verify-producer-success", (repoRoot) => {
+      const { contractRelative } = setupFixtureRepo(repoRoot);
+      const expectedSubject = recomputeExpectedSubject(repoRoot);
+
+      const result = emitAuthoritativeVerifyEvidence(
+        baseInput(repoRoot, contractRelative, { expectedSubjectSha256: expectedSubject }),
+      );
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.event.event_type).toBe("verify_sprint.result");
+      expect(result.event.trust_class).toBe("authoritative_machine");
+      expect(result.event.event_id).toMatch(/^evt-/);
+
+      const identity = result.event.subject_identity;
+      expect(identity.subject_hash).toBe(expectedSubject);
+      expect(identity.base_commit).toMatch(/^[0-9a-f]{40}$/);
+      expect(identity.target_commit).toMatch(/^[0-9a-f]{40}$/);
+      expect(identity.scope_hash).toMatch(/^sha256:[0-9a-f]{64}$/);
+      expect(identity.contract_hash).toMatch(/^sha256:[0-9a-f]{64}$/);
+      expect(identity.command_hash).toMatch(/^sha256:[0-9a-f]{64}$/);
+      expect(identity.env_provider_id.length).toBeGreaterThan(0);
+      expect(identity.authority_commit).toMatch(/^[0-9a-f]{40}$/);
+
+      // run_snapshot_id, not the full path: EPC-01's D6 redaction replaces any
+      // 32+ char dot-free run with a hash, and the real run-snapshot filename
+      // (<run-id>-<contract-slug>.json) is always such a run for a realistic
+      // slug, so the payload carries only the short id (see
+      // shortRunSnapshotId in verify-producer.ts).
+      expect(result.event.payload).toEqual({
+        status: "pass",
+        counts: {},
+        run_snapshot_id: "run-20260722T170215-94226", // stripped the redundant "-fixture" (worktree_id) suffix
+      });
+
+      const { accepted } = readAcceptedEvents(repoRoot);
+      expect(accepted.length).toBe(1);
+      expect(accepted[0]!.event_id).toBe(result.event.event_id);
+    });
+  });
+
+  test("scope_hash reflects the contract's own allowed_paths, not the caller's", () => {
+    withTempRepo("verify-producer-scope-hash", (repoRoot) => {
+      const { contractRelative } = setupFixtureRepo(repoRoot, { allowedPaths: ["src/a.ts", "src/b.ts"] });
+      const result = emitAuthoritativeVerifyEvidence(baseInput(repoRoot, contractRelative));
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const expectedScopeHash = `sha256:${createHash("sha256").update(JSON.stringify(["src/a.ts", "src/b.ts"])).digest("hex")}`;
+      expect(result.event.subject_identity.scope_hash).toBe(expectedScopeHash);
+    });
+  });
+});
+
+describe("emitAuthoritativeVerifyEvidence: idempotency and genesis", () => {
+  test("re-emission with identical inputs dedups to one accepted event", () => {
+    withTempRepo("verify-producer-idempotent", (repoRoot) => {
+      const { contractRelative } = setupFixtureRepo(repoRoot);
+      const input = baseInput(repoRoot, contractRelative, { correlationRunId: "run-a" });
+
+      const first = emitAuthoritativeVerifyEvidence(input);
+      const second = emitAuthoritativeVerifyEvidence({ ...input, correlationRunId: "run-b" });
+      expect(first.ok).toBe(true);
+      expect(second.ok).toBe(true);
+      if (!first.ok || !second.ok) return;
+
+      expect(first.event.idempotency_key).toBe(second.event.idempotency_key);
+
+      // Both calls physically appended (dedup happens at fold time, D5/D7 --
+      // the append layer never skips a write; only the accepted projection
+      // collapses duplicates, first occurrence wins).
+      const logPath = join(repoRoot, ".ai", "harness", "evidence", "events", "log.jsonl");
+      const eventLines = readFileSync(logPath, "utf-8")
+        .split("\n")
+        .filter((line) => line.length > 0)
+        .filter((line) => JSON.parse(line).kind === "evidence_event");
+      expect(eventLines.length).toBe(2);
+
+      const { accepted } = readAcceptedEvents(repoRoot);
+      expect(accepted.length).toBe(1);
+      expect(accepted[0]!.event_id).toBe(first.event.event_id);
+    });
+  });
+
+  test("genesis is written once with LEDGER_EPOCH_START_SHA across repeated emissions", () => {
+    withTempRepo("verify-producer-genesis-once", (repoRoot) => {
+      const { contractRelative } = setupFixtureRepo(repoRoot);
+      const input = baseInput(repoRoot, contractRelative);
+
+      expect(readGenesisRecord(repoRoot)).toBeNull();
+
+      const first = emitAuthoritativeVerifyEvidence(input);
+      expect(first.ok).toBe(true);
+      if (!first.ok) return;
+      expect(first.genesis.ledger_epoch_start_sha).toBe(LEDGER_EPOCH_START_SHA);
+
+      const afterFirst = readGenesisRecord(repoRoot);
+      expect(afterFirst).not.toBeNull();
+
+      const second = emitAuthoritativeVerifyEvidence({ ...input, correlationRunId: "run-genesis-2" });
+      expect(second.ok).toBe(true);
+
+      const logPath = join(repoRoot, ".ai", "harness", "evidence", "events", "log.jsonl");
+      const lines = readFileSync(logPath, "utf-8").split("\n").filter((line) => line.length > 0);
+      const genesisLines = lines.filter((line) => JSON.parse(line).kind === "evidence_genesis");
+      expect(genesisLines.length).toBe(1);
+      expect(JSON.parse(genesisLines[0]!).ledger_epoch_start_sha).toBe(LEDGER_EPOCH_START_SHA);
+    });
+  });
+});
+
+
+// Cannot-bind => skip, not fail (ruling: sprint row 6 requires only that
+// non-subject-bound emission is impossible and subject mismatch fails
+// closed, not that every verify run emit). This wrapper is the layer that
+// carries that distinction as an exit code; the producer module itself is
+// unchanged (still one typed refusal for every fail-closed condition -- see
+// the fail-closed describe block above, still asserting nothing appended).
+describe("scripts/emit-verify-evidence.ts: exit code contract", () => {
+  test("exit 0 on successful emission", () => {
+    withTempRepo("wrapper-exit-success", (repoRoot) => {
+      const { contractRelative } = setupFixtureRepo(repoRoot);
+      const res = runWrapper([
+        "--repo-root", repoRoot,
+        "--contract", contractRelative,
+        "--command", "repo-harness run verify-sprint --prepare-acceptance",
+        "--status", "pass",
+        "--run-snapshot", RUN_SNAPSHOT_ARG,
+      ]);
+      expect(res.status, `${res.stdout}\n${res.stderr}`).toBe(0);
+      expect(res.stdout).toContain("appended evt-");
+    });
+  });
+
+  test("exit 3 (cannot-bind), not 1, when the contract is dirty", () => {
+    withTempRepo("wrapper-exit-dirty", (repoRoot) => {
+      const { contractRelative } = setupFixtureRepo(repoRoot);
+      writeFileSync(
+        join(repoRoot, contractRelative),
+        readFileSync(join(repoRoot, contractRelative), "utf-8") + "\n<!-- dirty -->\n",
+      );
+      const res = runWrapper([
+        "--repo-root", repoRoot,
+        "--contract", contractRelative,
+        "--command", "repo-harness run verify-sprint --prepare-acceptance",
+        "--status", "pass",
+        "--run-snapshot", RUN_SNAPSHOT_ARG,
+      ]);
+      expect(res.status).toBe(3);
+      expect(res.stderr).toContain("cannot-bind");
+      expect(res.stderr).toContain("contract_not_committed");
+    });
+  });
+
+  test("exit 3 (cannot-bind), not 1, when no active contract resolves", () => {
+    withTempRepo("wrapper-exit-no-contract", (repoRoot) => {
+      setupFixtureRepo(repoRoot); // a real contract exists but is never named
+      const res = runWrapper([
+        "--repo-root", repoRoot,
+        "--command", "repo-harness run verify-sprint --prepare-acceptance",
+        "--status", "pass",
+        "--run-snapshot", RUN_SNAPSHOT_ARG,
+      ]);
+      expect(res.status).toBe(3);
+      expect(res.stderr).toContain("cannot-bind");
+      expect(res.stderr).toContain("no_active_contract");
+    });
+  });
+
+  test("exit 1 (hard fail), not 3, on subject mismatch -- must not be classified as cannot-bind", () => {
+    withTempRepo("wrapper-exit-mismatch", (repoRoot) => {
+      const { contractRelative } = setupFixtureRepo(repoRoot);
+      const res = runWrapper([
+        "--repo-root", repoRoot,
+        "--contract", contractRelative,
+        "--command", "repo-harness run verify-sprint --prepare-acceptance",
+        "--status", "pass",
+        "--run-snapshot", RUN_SNAPSHOT_ARG,
+        "--subject-sha256", "sha256:" + "0".repeat(64),
+      ]);
+      expect(res.status).toBe(1);
+      expect(res.stderr).toContain("fail-closed");
+      expect(res.stderr).toContain("subject_mismatch");
+    });
+  });
+});


### PR DESCRIPTION
Sprint C backlog row 6. First producer for the EPC-01 evidence ledger, per frozen decisions D2–D6.

- `src/effects/evidence/epoch.ts`: single-sourced Program epoch constant `LEDGER_EPOCH_START_SHA = 5228d4ea` (frozen D2 rule; EPC-03/04 will import it).
- `src/effects/evidence/verify-producer.ts`: emits one subject-bound `authoritative_machine` event per successful verify run; the full D3 subject identity (authority/base/target commits, scope/subject/contract/command hashes, provider id) is computed by construction — no caller-injectable identity fields; subject mismatch and dirty/uncommitted authority fail closed.
- `scripts/emit-verify-evidence.ts`: thin CLI wrapper with a typed exit-code contract — 0 emitted, 3 cannot-bind skip (no active contract / dirty contract / unresolvable source root; refusal-to-fabricate, prints one stderr notice), other = hard failure.
- `scripts/verify-sprint.sh` wiring (insertions only, mirror `assets/templates/helpers/verify-sprint.sh` re-synced via sync:helpers): emission after successful verification in both prepare and finalize paths; hard failures fail the verify run.
- 11 red-first tests; previously-red characterization suites restored (helper-scripts, capability-resolver).
- `checks/latest` authoring unchanged (EPC-05 owns that cutover); no EPC-01 file modified; no new dependency.

Verification: full `bun test` 1722 pass / 0 fail / 1 skip (worker + gatekeeper); type-check clean; preflight pass; strict workflow OK; live dogfood: worktree ledger readback shows genesis with the epoch constant plus an accepted `authoritative_machine` event. Acceptance: gatekeeper gates clean (sole finding — missing live ledger evidence — remediated with recorded readback); external_pass receipt subject-bound at target revision a8cae4d7.