### PR TITLE
EPC-03: PostBash observed importer

### DIFF
--- a/plans/plan-20260722-1810-epc-03-postbash-observed-importer.md
+++ b/plans/plan-20260722-1810-epc-03-postbash-observed-importer.md
@@ -1,0 +1,248 @@
+# Plan: EPC-03: PostBash Observed Importer
+
+> **Status**: Executing
+> **Created**: 20260722-1810
+> **Slug**: epc-03-postbash-observed-importer
+> **Planning Source**: repo-harness-sprint
+> **Orchestration Kind**: host-plan
+> **Source Ref**: sprint:plans/sprints/20260722-0001-evidence-projection-convergence.sprint.md#epc-03
+> **Artifact Level**: work-package
+> **Promotion Reason**: verification_boundary
+> **Verification Boundary**: Red-first fixtures prove: observed trust class only, observed-only ledger leaves machine gates unsatisfied (authoritative filter empty), malformed input fails closed, idempotent re-import, unbound vs bound contract fields; full bun test and root required checks green
+> **Rollback Surface**: Revert the single PR: new importer module + test suite plus one wiring edit in src/cli/hook/command-observed.ts; post-bash-latest.json writer and all other surfaces unchanged
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260722-1810-epc-03-postbash-observed-importer.contract.md`
+> **Task Review**: `tasks/reviews/20260722-1810-epc-03-postbash-observed-importer.review.md`
+> **Implementation Notes**: `tasks/notes/20260722-1810-epc-03-postbash-observed-importer.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from repo-harness-sprint planning output.
+- Source ref: sprint:plans/sprints/20260722-0001-evidence-projection-convergence.sprint.md#epc-03
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260722-1810-epc-03-postbash-observed-importer.md`
+- Sprint contract: `tasks/contracts/20260722-1810-epc-03-postbash-observed-importer.contract.md`
+- Sprint review: `tasks/reviews/20260722-1810-epc-03-postbash-observed-importer.review.md`
+- Implementation notes: `tasks/notes/20260722-1810-epc-03-postbash-observed-importer.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260722-1810-epc-03-postbash-observed-importer.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260722-1810-epc-03-postbash-observed-importer.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260722-1810-epc-03-postbash-observed-importer.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260722-1810-epc-03-postbash-observed-importer.contract.md`
+- Review file: `tasks/reviews/20260722-1810-epc-03-postbash-observed-importer.review.md`
+- Implementation notes file: `tasks/notes/20260722-1810-epc-03-postbash-observed-importer.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260722-1810-epc-03-postbash-observed-importer.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260722-1810-epc-03-postbash-observed-importer.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: Revert the single PR: new importer module + test suite plus one wiring edit in src/cli/hook/command-observed.ts; post-bash-latest.json writer and all other surfaces unchanged
+- **Verification boundary**: Red-first fixtures prove: observed trust class only, observed-only ledger leaves machine gates unsatisfied (authoritative filter empty), malformed input fails closed, idempotent re-import, unbound vs bound contract fields; full bun test and root required checks green
+- **Review/acceptance boundary**: `tasks/reviews/20260722-1810-epc-03-postbash-observed-importer.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: verification_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260722-1810-epc-03-postbash-observed-importer.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260722-1810-epc-03-postbash-observed-importer.contract.md`, `tasks/reviews/20260722-1810-epc-03-postbash-observed-importer.review.md`, and `tasks/notes/20260722-1810-epc-03-postbash-observed-importer.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260722-1810-epc-03-postbash-observed-importer.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: Revert the single PR: new importer module + test suite plus one wiring edit in src/cli/hook/command-observed.ts; post-bash-latest.json writer and all other surfaces unchanged
+
+## Captured Planning Output
+
+> **Task Profile**: code-change
+
+## Decision Summary
+
+EPC-03 implements Sprint C backlog row 7: the PostBash observed importer.
+PostBash command observations are imported into the EPC-01 ledger as
+`observed` trust-class events only; an observed-only ledger provably leaves
+machine gates unsatisfied (D4). Emission is additive: the existing
+`checks/post-bash-latest.json` write is untouched (pre-epoch legacy surface
+per D2; no cutover assigned to this row). This package runs as a two-package
+parallel wave with EPC-04 under R4: their contracts jointly prove frozen
+schema/trust/idempotency (EPC-00 freeze + merged EPC-01/02), exactly
+disjoint `allowed_paths`, disjoint test fixtures, no shared barrel, no
+shared store writer, no shared projection writer. Base SHA pinned per R1 at
+fresh fetch: `8861b40dd85c0f7faabe8eecd217baf5528a7f3c` (post-EPC-02 merge).
+
+## Why
+
+The trust matrix (D4) is only meaningful if the `observed` class exists in
+practice: rows 9–12 must demonstrate that ubiquitous low-trust telemetry
+(every Bash command) flows into the same ledger yet can never satisfy a
+gate. Importing PostBash observations now — while gates still read
+`checks/latest` — proves the trust boundary with fixtures before any
+cutover depends on it.
+
+## Goal
+
+1. `src/effects/evidence/post-bash-importer.ts`: imports one PostBash
+   observation as ONE `observed` event via the EPC-01 writer, genesis via
+   `LEDGER_EPOCH_START_SHA` (EPC-02's epoch constant, imported read-only).
+   - Trust class is hard-coded `observed`; the module exposes no way to
+     emit any other class.
+   - Subject identity: computed from repo state where available
+     (`base_commit`, `target_commit`); contract-derived fields
+     (`authority_commit`, `scope_hash`, `contract_hash`) use the active
+     contract when one exists and is committed-clean, else the literal
+     sentinel `unbound`. The sentinel is legal ONLY for `observed` events
+     (importer-level restriction documented in the module); `observed`
+     never satisfies gates, so unbound identity is safe by construction.
+   - Payload: structured summary only (command hash, exit code, duration,
+     repo-relative raw-output path reference) — no raw output bytes
+     inline (EPC-01 redaction/cap discipline).
+2. Wire `src/cli/hook/command-observed.ts`: after the existing
+   `post-bash-latest.json` write, import the same observation into the
+   ledger. Failure semantics MATCH the existing post-bash write path's
+   failure behavior exactly (no new fallback, no new severity) — document
+   the observed existing behavior in notes.
+3. `tests/evidence-post-bash-importer.test.ts` fixtures prove: import
+   yields `observed` trust class with the D3 field set (sentinel rules
+   honored); an observed-only ledger leaves machine gates unsatisfied —
+   filtering the accepted fold for `authoritative_machine` returns empty;
+   malformed observation input fails closed (nothing appended); repeat
+   import of the identical observation dedups via idempotency key;
+   unclean/absent contract produces `unbound` contract fields while a
+   clean committed contract produces bound ones.
+4. All root required checks green; one independent PR on
+   `codex/epc-03-postbash-observed-importer`.
+
+## P1: Architecture Map
+
+- Design authority: frozen D2–D6; EPC-01 store API and EPC-02 epoch
+  constant are read-only imports; no EPC-01/EPC-02 file may be modified.
+- Wiring surface: `src/cli/hook/command-observed.ts` only — disjoint from
+  EPC-04's `scripts/acceptance-receipt.ts` (R4 wave layer-1 proof).
+- `checks/post-bash-latest.json` writer stays: it is pre-epoch legacy
+  (D2), not a projection this row retires; the EPC-09 residue scan
+  targets only EPC-05/07/08 deletions.
+
+## P2: Concrete Trace
+
+EPC-02 merges -> `main` advances (row-6 flip) -> EPC-03 fresh-fetches,
+pins `8861b40dd85c0f7faabe8eecd217baf5528a7f3c` (R1) -> worktree opens on
+`codex/epc-03-postbash-observed-importer` in parallel with EPC-04's
+disjoint worktree -> importer + wiring + tests land -> fixtures prove the
+observed-only-gates-unsatisfied property -> required checks green ->
+receipt -> one PR merges (wave PRs merge serially in backlog order) ->
+EPC-05 pins its base per R1 after both wave rows merge.
+
+## P3: Design Decision
+
+- `unbound` sentinel instead of refusing emission when no clean contract
+  exists: PostBash telemetry must not vanish outside contract execution;
+  refusing would silently drop the observation (a availability fallback in
+  disguise). The sentinel is honest labeling, restricted to `observed`,
+  and gates can never accept it (D4). The verify producer (EPC-02) keeps
+  its stricter committed-authority rule — the two rules are per-trust-
+  class by design, not a contradiction.
+- Failure semantics mirror the existing post-bash write path rather than
+  inventing stricter ones: this hook runs in every session; a new
+  hard-fail would couple session stability to a telemetry surface without
+  a row mandating it.
+- One event per observation (no batching): append-position ordering is
+  the total order; batching would create artificial ordering ties.
+
+## Task Breakdown
+
+- [ ] Verify fresh fetch equals pinned base; fill contract (with R4 wave
+      disjointness proof section shared verbatim with EPC-04).
+- [ ] `post-bash-importer.ts` (observed-only, sentinel rules).
+- [ ] Wire `command-observed.ts` (matching failure semantics).
+- [ ] Tests red-first for every Goal-3 fixture.
+- [ ] Required checks; commit; receipt; PR.
+
+## Scope
+
+- In scope: `src/effects/evidence/post-bash-importer.ts`,
+  `src/cli/hook/command-observed.ts` (wiring edit only),
+  `tests/evidence-post-bash-importer.test.ts`, this package's
+  plan/contract/review/notes, `tasks/todos.md` projection,
+  `.ai/harness/worktrees/epc-03-postbash-observed-importer.json`.
+- Out of scope: every EPC-01/EPC-02 file, `scripts/acceptance-receipt.ts`
+  (EPC-04's surface), `checks/latest` or `post-bash-latest` composition,
+  any gate logic, handoff writers, `tasks/current.md`, the sprint
+  document, any new npm dependency.
+- Non-goals: retiring `post-bash-latest.json`; subject-strict binding for
+  observed events; gate cutover.
+
+## Stop Conditions
+
+- Stop if `origin/main` moves past the pinned base before worktree
+  creation.
+- Stop if wiring would require modifying an EPC-01/02 module or touching
+  EPC-04's surface — report, never widen.
+- Stop after three fail-fix-reverify rounds on one issue.
+
+## Falsifier
+
+The direction is wrong if observed import cannot reuse the EPC-01 writer
+without schema changes, or if the observed-only-unsatisfied fixture
+cannot be expressed with the existing fold primitives. Cheapest proof:
+the fixture filtering accepted events for `authoritative_machine` over an
+observed-only ledger returns empty, and the full suite stays green.
+
+## Cheapest Sufficient Proof
+
+- Fresh fetch equals pinned base at pin time; contract records it.
+- New suite green red-first; full `bun test` green; root checks green.
+- `git diff --name-only <base>..HEAD` ⊆ `allowed_paths`; zero overlap
+  with EPC-04's `allowed_paths`.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [ ] Verify fresh fetch equals pinned base; fill contract (with R4 wave
+- [ ] `post-bash-importer.ts` (observed-only, sentinel rules).
+- [ ] Wire `command-observed.ts` (matching failure semantics).
+- [ ] Tests red-first for every Goal-3 fixture.
+- [ ] Required checks; commit; receipt; PR.

--- a/src/cli/hook/command-observed.ts
+++ b/src/cli/hook/command-observed.ts
@@ -11,6 +11,7 @@ import { createHash } from 'crypto';
 import { join, dirname } from 'path';
 import { recordCircuitAttempt, type CircuitDecision } from './circuit-breaker';
 import { parseHookInput, type HookInputFs } from './hook-input';
+import { importPostBashObservation } from '../../effects/evidence/post-bash-importer';
 
 export interface CommandObservedFs extends HookInputFs {
   mkdirSync(path: string, options?: { readonly recursive?: boolean }): void;
@@ -231,6 +232,25 @@ export function runCommandObserved(opts: CommandObservedInput): CommandObservedR
     } else {
       stdout += `[ChecksFile] Updated ${postBashRelative}; ${checksRelative} remains reserved for repo-harness-run-trace.v1.\n`;
     }
+
+    // Additive ledger import (EPC-03): one `observed` EvidenceEvent per
+    // observation, after the post-bash-latest.json write above. Failure
+    // semantics match this function's existing catch-all exactly -- a
+    // thrown message is caught by the same `catch` below and produces the
+    // same exitCode 1 / reason 'write-failed' envelope as any other
+    // failure in this try block; no new fallback, no new severity.
+    const durationMs = numberValue(parsed.get('.duration_ms', parsed.get('.tool_response.duration_ms', env.HOOK_DURATION_MS ?? '0')), 0);
+    const importResult = importPostBashObservation({
+      repoRoot: opts.repoRoot,
+      command,
+      exitCode,
+      durationMs,
+      rawOutputPath: rawPath,
+    });
+    if (!importResult.ok) {
+      throw new Error(`ledger import failed (${importResult.reason}): ${importResult.message}`);
+    }
+
     return { exitCode: 0, stdout, stderr: warnings(), reason: 'ok' };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/src/effects/evidence/post-bash-importer.ts
+++ b/src/effects/evidence/post-bash-importer.ts
@@ -1,0 +1,345 @@
+/**
+ * PostBash observed importer (EPC-03).
+ *
+ * Imports one PostBash command observation into the EPC-01 ledger as
+ * exactly one `observed` trust-class event. Trust class is hard-coded --
+ * there is no parameter, override, or code path in this module that can
+ * emit any other `TrustClass`. `observed` never satisfies a machine gate
+ * (D4), so the `UNBOUND_SENTINEL` used below for contract- and repo-state-
+ * derived identity fields is safe by construction: legal ONLY here,
+ * illegal for every other trust class (frozen D3/D4,
+ * `### Frozen decisions (EPC-00, 2026-07-22)`).
+ *
+ * `src/effects/evidence/verify-producer.ts` (EPC-02) is a pattern
+ * reference only -- this module does not import from it and keeps its own
+ * private git/contract helpers. Per the sprint's R4 wave-qualification
+ * rule, parallel evidence producers share no store writer, projection
+ * writer, or barrel/export file.
+ */
+import { createHash } from "crypto";
+import { execFileSync } from "child_process";
+import { existsSync, readFileSync, statSync } from "fs";
+import { dirname, join, resolve } from "path";
+import { fileURLToPath } from "url";
+
+import type { EvidenceEventRecord, GenesisRecord, SubjectIdentity } from "../../core/evidence/types";
+import { appendEvidenceEvent, appendGenesisRecord } from "./event-log";
+import { LEDGER_EPOCH_START_SHA } from "./epoch";
+import { ensureRepoRelativePath } from "../path-safety";
+import { uniqueSorted } from "../review/diff-fingerprint";
+
+const PRODUCER_ID = "post-bash-importer";
+const EVENT_TYPE = "post_bash.command_observed";
+
+/** Legal ONLY for `observed` events (see module doc); never used by any other trust class. */
+export const UNBOUND_SENTINEL = "unbound";
+
+/**
+ * Length of the display-only command-hash prefix carried in the payload.
+ * EPC-01's D6 redaction replaces any 32+ char run of `[A-Za-z0-9+/_-]` (no
+ * dot or colon breaks it) with a freshly computed `sha256:<hash>` -- a
+ * full 64-char hex digest is exactly such a run, so storing it verbatim in
+ * the payload would come back double-hashed and useless. 16 hex chars
+ * stays well under the 32-char threshold and stays legible; the full,
+ * collision-safe hash lives in `subject_identity.command_hash`.
+ */
+const PAYLOAD_HASH_PREFIX_LENGTH = 16;
+
+/**
+ * Length of the payload's raw-output reference. `/` is inside the D6
+ * redaction charset (`[A-Za-z0-9+/_-]`), so a realistic repo-relative raw-
+ * output path (e.g. this repo's own
+ * `.ai/harness/runs/bash-output/post-bash-<ts>-<pid>-<hash12>.log`
+ * convention) is one long dot-free run once its directory separators are
+ * counted -- storing it verbatim trips the same D6 over-redaction as an
+ * unshortened hash. A fixed-length suffix keeps the most distinguishing
+ * tail (timestamp/pid/hash fragment) while staying unconditionally under
+ * the 32-char threshold regardless of caller.
+ */
+const RAW_OUTPUT_REF_LENGTH = 24;
+
+const MODULE_DIR = dirname(fileURLToPath(import.meta.url));
+const PACKAGE_ROOT = resolve(MODULE_DIR, "../../..");
+
+export type PostBashImportFailureReason = "malformed_input" | "genesis_epoch_conflict";
+
+export interface PostBashImportFailure {
+  readonly ok: false;
+  readonly reason: PostBashImportFailureReason;
+  readonly message: string;
+}
+
+export interface PostBashImportSuccess {
+  readonly ok: true;
+  readonly event: EvidenceEventRecord;
+  readonly genesis: GenesisRecord;
+}
+
+export type PostBashImportResult = PostBashImportSuccess | PostBashImportFailure;
+
+export interface PostBashObservationInput {
+  /** Repo root the observation was captured in. */
+  readonly repoRoot: string;
+  /** The exact observed command line; hashed, never interpreted or executed. */
+  readonly command: string;
+  readonly exitCode: number;
+  readonly durationMs: number;
+  /**
+   * Repo-relative path to the captured raw-output log, or null/undefined
+   * when no raw output was captured for this observation. Never the raw
+   * output bytes themselves (D6: structured summary only).
+   */
+  readonly rawOutputPath?: string | null;
+  readonly correlationRunId?: string;
+  /**
+   * Repo-relative path to the contract already resolved by the caller.
+   * Falls back to `.ai/harness/active-plan` resolution when omitted (same
+   * convention as `src/effects/evidence/verify-producer.ts`).
+   */
+  readonly contractPath?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function sha256Hex(content: Buffer | string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+function gitOutput(repoRoot: string, args: readonly string[]): { readonly ok: boolean; readonly text: string } {
+  try {
+    const text = execFileSync("git", ["-C", repoRoot, "--literal-pathspecs", ...args], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return { ok: true, text };
+  } catch {
+    return { ok: false, text: "" };
+  }
+}
+
+/** Full 40-char commit sha for `ref`, or null when it cannot be resolved (e.g. not a git repo, bad ref). */
+function gitRevParseCommit(repoRoot: string, ref: string): string | null {
+  const result = gitOutput(repoRoot, ["rev-parse", "--verify", `${ref}^{commit}`]);
+  if (!result.ok) return null;
+  const sha = result.text.trim();
+  return /^[0-9a-f]{40}$/.test(sha) ? sha : null;
+}
+
+/** `.ai/harness/active-plan` -> `plans/plan-<slug>.md` -> `tasks/contracts/<slug>.contract.md` (fallback only). */
+function resolveActiveContractPathFromMarker(repoRoot: string): string | null {
+  const markerPath = join(repoRoot, ".ai/harness/active-plan");
+  if (!existsSync(markerPath)) return null;
+  let marker: string;
+  try {
+    marker = readFileSync(markerPath, "utf-8").trim();
+  } catch {
+    return null;
+  }
+  const match = /^plans\/plan-([A-Za-z0-9][A-Za-z0-9._-]*)\.md$/.exec(marker);
+  if (!match) return null;
+  const contractRelative = `tasks/contracts/${match[1]}.contract.md`;
+  return existsSync(join(repoRoot, contractRelative)) ? contractRelative : null;
+}
+
+function resolveContractPath(repoRoot: string, explicit: string | undefined): string | null {
+  if (explicit !== undefined) {
+    const absolute = join(repoRoot, explicit);
+    if (!existsSync(absolute) || !statSync(absolute).isFile()) return null;
+    return explicit;
+  }
+  return resolveActiveContractPathFromMarker(repoRoot);
+}
+
+/** Non-empty `git status --porcelain` for the path means dirty (modified/staged) or untracked ("??"), or not a git repo at all. */
+function isContractCommittedClean(repoRoot: string, contractRelative: string): boolean {
+  const result = gitOutput(repoRoot, ["status", "--porcelain", "--", contractRelative]);
+  return result.ok && result.text.trim().length === 0;
+}
+
+function lastCommitTouching(repoRoot: string, relativePath: string): string | null {
+  const result = gitOutput(repoRoot, ["log", "-1", "--format=%H", "--", relativePath]);
+  if (!result.ok) return null;
+  const sha = result.text.trim();
+  return sha.length > 0 ? sha : null;
+}
+
+/** `.ai/harness/policy.json#worktree_strategy.review_base` (pattern reference: `verify-producer.ts`'s `resolveReviewBaseRef`). Defaults to `HEAD` so a fixture/standalone repo without a policy file still resolves. */
+function resolveReviewBaseRef(repoRoot: string): string {
+  const policyPath = join(repoRoot, ".ai/harness/policy.json");
+  if (!existsSync(policyPath)) return "HEAD";
+  try {
+    const policy = JSON.parse(readFileSync(policyPath, "utf-8")) as unknown;
+    const value = isRecord(policy) && isRecord(policy.worktree_strategy) ? policy.worktree_strategy.review_base : undefined;
+    return typeof value === "string" && value.trim() !== "" ? value : "HEAD";
+  } catch {
+    return "HEAD";
+  }
+}
+
+/** This module's own `package.json` version -- the repo-harness tool's version, independent of whichever `repoRoot` the observation came from. */
+function providerCliVersion(): string {
+  try {
+    const pkg = JSON.parse(readFileSync(join(PACKAGE_ROOT, "package.json"), "utf-8")) as { readonly version?: unknown };
+    return typeof pkg.version === "string" && pkg.version.length > 0 ? pkg.version : "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+}
+
+/**
+ * Isolated workspace/home id: a short hash of the target repo root's real
+ * path (or its plain resolved path when git is unavailable). Doubles as
+ * the genesis `worktree_id` fallback: deterministic per repo root, so two
+ * producers racing to write the first genesis record in the same worktree
+ * agree on the same value without coordinating.
+ */
+function workspaceId(repoRoot: string): string {
+  const result = gitOutput(repoRoot, ["rev-parse", "--show-toplevel"]);
+  const real = result.ok && result.text.trim() ? result.text.trim() : resolve(repoRoot);
+  return `ws-${sha256Hex(real).slice(0, 12)}`;
+}
+
+/** Extract the `allowed_paths:` list from the contract's fenced ```yaml block (pattern reference: `verify-producer.ts`'s `parseContractAllowedPaths`). */
+function parseContractAllowedPaths(contractText: string): readonly string[] {
+  const yamlBlockPattern = /```yaml\r?\n([\s\S]*?)\r?\n```/g;
+  let match: RegExpExecArray | null;
+  while ((match = yamlBlockPattern.exec(contractText)) !== null) {
+    const block = match[1] ?? "";
+    if (!/(^|\s)allowed_paths:/m.test(block)) continue;
+    const lines = block.split(/\r?\n/);
+    const startIndex = lines.findIndex((line) => /^\s*allowed_paths:\s*$/.test(line));
+    if (startIndex === -1) continue;
+    const paths: string[] = [];
+    for (let i = startIndex + 1; i < lines.length; i++) {
+      const line = lines[i] ?? "";
+      if (/^\S/.test(line)) break;
+      const itemMatch = line.match(/^\s*-\s*(.+?)\s*$/);
+      if (!itemMatch) continue;
+      const value = (itemMatch[1] ?? "").replace(/^["'`]+|["'`]+$/g, "");
+      if (value.length > 0) paths.push(value);
+    }
+    return paths;
+  }
+  return [];
+}
+
+function validationError(input: PostBashObservationInput): string | null {
+  if (typeof input.command !== "string") {
+    return "command must be a string";
+  }
+  if (!Number.isInteger(input.exitCode)) {
+    return "exitCode must be an integer";
+  }
+  if (!Number.isFinite(input.durationMs) || input.durationMs < 0) {
+    return "durationMs must be a non-negative finite number";
+  }
+  if (input.rawOutputPath !== undefined && input.rawOutputPath !== null) {
+    const check = ensureRepoRelativePath(input.rawOutputPath);
+    if (!check.ok) {
+      return `rawOutputPath failed repo-relative validation: ${check.error}`;
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolves contract-derived identity: `authority_commit`/`scope_hash`/
+ * `contract_hash` bound to the active contract when one exists and is
+ * committed-clean, else `UNBOUND_SENTINEL` for all three (P3: PostBash
+ * telemetry must not vanish outside contract execution -- refusing would
+ * silently drop the observation; the sentinel is honest labeling,
+ * restricted to `observed`, which never satisfies a gate).
+ */
+function resolveContractIdentity(
+  repoRoot: string,
+  explicitContractPath: string | undefined,
+): { readonly authorityCommit: string; readonly scopeHash: string; readonly contractHash: string } {
+  const unbound = { authorityCommit: UNBOUND_SENTINEL, scopeHash: UNBOUND_SENTINEL, contractHash: UNBOUND_SENTINEL };
+
+  const contractRelative = resolveContractPath(repoRoot, explicitContractPath);
+  if (!contractRelative || !isContractCommittedClean(repoRoot, contractRelative)) return unbound;
+
+  const authorityCommit = lastCommitTouching(repoRoot, contractRelative);
+  if (!authorityCommit) return unbound;
+
+  const contractBytes = readFileSync(join(repoRoot, contractRelative));
+  const contractHash = `sha256:${sha256Hex(contractBytes)}`;
+  const allowedPaths = parseContractAllowedPaths(contractBytes.toString("utf-8"));
+  const scopeHash = `sha256:${sha256Hex(JSON.stringify(uniqueSorted(allowedPaths)))}`;
+  return { authorityCommit, scopeHash, contractHash };
+}
+
+/**
+ * Single entry point: imports one PostBash command observation as exactly
+ * one `observed` EvidenceEvent. Fails closed (no emission, nothing
+ * appended) only on malformed input or a genesis epoch conflict; never
+ * refuses for a missing/dirty contract or unresolvable repo state (P3) --
+ * those degrade to `UNBOUND_SENTINEL` identity fields instead, because an
+ * `observed` event can never satisfy a machine gate regardless of its
+ * identity fields (D4).
+ */
+export function importPostBashObservation(input: PostBashObservationInput): PostBashImportResult {
+  const badInput = validationError(input);
+  if (badInput) {
+    return { ok: false, reason: "malformed_input", message: badInput };
+  }
+
+  const { repoRoot } = input;
+  const reviewBaseRef = resolveReviewBaseRef(repoRoot);
+  const baseCommit = gitRevParseCommit(repoRoot, reviewBaseRef) ?? UNBOUND_SENTINEL;
+  const targetCommit = gitRevParseCommit(repoRoot, "HEAD") ?? UNBOUND_SENTINEL;
+
+  const { authorityCommit, scopeHash, contractHash } = resolveContractIdentity(repoRoot, input.contractPath);
+  const commandHashHex = sha256Hex(input.command);
+  const commandHash = `sha256:${commandHashHex}`;
+  const envProviderId = `repo-harness/${providerCliVersion()}/${workspaceId(repoRoot)}`;
+
+  const subjectIdentity: SubjectIdentity = {
+    authority_commit: authorityCommit,
+    base_commit: baseCommit,
+    target_commit: targetCommit,
+    scope_hash: scopeHash,
+    // No independent verification subject exists for an observed command;
+    // the subject being observed IS the command itself. D3's field list is
+    // frozen and shared across every producer -- each supplies its own
+    // meaning for `subject_hash`; the value has no functional consequence
+    // for gate satisfaction since `observed` never satisfies one (D4).
+    subject_hash: commandHash,
+    contract_hash: contractHash,
+    command_hash: commandHash,
+    env_provider_id: envProviderId,
+  };
+
+  let genesis: GenesisRecord;
+  try {
+    genesis = appendGenesisRecord(repoRoot, LEDGER_EPOCH_START_SHA, { worktreeId: workspaceId(repoRoot) });
+  } catch (error) {
+    return {
+      ok: false,
+      reason: "genesis_epoch_conflict",
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  const event = appendEvidenceEvent(repoRoot, {
+    worktreeId: genesis.worktree_id,
+    eventType: EVENT_TYPE,
+    trustClass: "observed",
+    producer: PRODUCER_ID,
+    correlationRunId: input.correlationRunId ?? `run-${Date.now()}`,
+    subjectIdentity,
+    payload: {
+      kind: "json",
+      value: {
+        command_hash: commandHashHex.slice(0, PAYLOAD_HASH_PREFIX_LENGTH),
+        exit_code: input.exitCode,
+        duration_ms: input.durationMs,
+        raw_output_ref: input.rawOutputPath == null ? null : input.rawOutputPath.slice(-RAW_OUTPUT_REF_LENGTH),
+      },
+    },
+  });
+
+  return { ok: true, event, genesis };
+}

--- a/tasks/contracts/20260722-1810-epc-03-postbash-observed-importer.contract.md
+++ b/tasks/contracts/20260722-1810-epc-03-postbash-observed-importer.contract.md
@@ -1,0 +1,308 @@
+# Task Contract: epc-03-postbash-observed-importer
+
+> **Status**: Active
+> **Plan**: plans/plan-20260722-1810-epc-03-postbash-observed-importer.md
+> **Task Profile**: code-change
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: kito
+> **Reviewer**: Claude
+> **Waiver Policy**: user_waiver allowed, owner kito only, per Acceptance Policy below
+> **Base SHA**: `8861b40dd85c0f7faabe8eecd217baf5528a7f3c` (pinned per R1 post-EPC-02: fresh fetch after PR #118 merged, plus its row-flip commit `docs(program): mark epc-02 done via PR #118; EPC-03/04 wave unblocked`; verified equal to this worktree's HEAD at task start)
+> **Target Branch**: main (via one independent PR)
+> **Working Branch**: `codex/epc-03-postbash-observed-importer`
+> **PR Unit**: one PR carrying the importer module, the `command-observed.ts` wiring edit, the test suite, and this package's workflow artifacts
+> **Capability ID**: root
+> **Last Updated**: 2026-07-22 18:10
+> **Review File**: `tasks/reviews/20260722-1810-epc-03-postbash-observed-importer.review.md`
+> **Notes File**: `tasks/notes/20260722-1810-epc-03-postbash-observed-importer.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+EPC-03 implements Sprint C backlog row 7: the PostBash observed importer.
+PostBash command observations are imported into the EPC-01 ledger as
+`observed` trust-class events only; an observed-only ledger provably leaves
+machine gates unsatisfied (D4). Emission is additive: the existing
+`checks/post-bash-latest.json` write is untouched (pre-epoch legacy surface
+per D2; no cutover assigned to this row). The trust matrix (D4) is only
+meaningful if the `observed` class exists in practice: rows 9-12 must
+demonstrate that ubiquitous low-trust telemetry (every Bash command) flows
+into the same ledger yet can never satisfy a gate.
+
+## Goal
+
+1. `src/effects/evidence/post-bash-importer.ts`: imports one PostBash
+   observation as ONE `observed` event via the EPC-01 writer
+   (`appendEvidenceEvent`/`appendGenesisRecord`), genesis via
+   `LEDGER_EPOCH_START_SHA` (EPC-02's epoch constant, imported read-only).
+   Trust class is hard-coded `observed`; the module's public input type
+   carries no trust-class field at all, so no code path can emit any other
+   class. Subject identity: `base_commit`/`target_commit` computed from
+   repo state (git rev-parse against the resolved review-base ref and
+   `HEAD`); `authority_commit`/`scope_hash`/`contract_hash` bound to the
+   active contract when one exists and is committed-clean, else the
+   literal sentinel `unbound` -- legal ONLY for `observed` (enforced by
+   this module never accepting a caller-supplied trust class). Repo-state
+   fields also degrade to `unbound` when git cannot resolve them (e.g. a
+   non-git fixture directory), for the same reason: an `observed` event
+   can never satisfy a gate regardless of its identity fields (D4), so
+   there is no safety reason to refuse. `env_provider_id` follows the
+   existing `provider/provider_cli_version/workspace_id` construction
+   (pattern reference: `verify-producer.ts`). Payload is a small
+   structured summary only: a short (16-hex-char) command-hash prefix,
+   `exit_code`, `duration_ms`, and a short (24-char) raw-output reference
+   -- never the raw output bytes, and never a full hash or full path
+   verbatim, both of which are 32+ char dot-free runs that EPC-01's D6
+   redaction over-redacts into a useless double-hash (`/` is inside the
+   redaction charset, so a realistic repo-relative path does not survive
+   unmangled either).
+2. Wire `src/cli/hook/command-observed.ts`: after the existing
+   `post-bash-latest.json` write, import the same observation into the
+   ledger. Failure semantics MATCH the existing write path's behavior
+   exactly: the import call sits inside the same `try` block, and a
+   failure result is turned into a thrown `Error`, caught by the same
+   pre-existing `catch` that already handles every other failure in this
+   function -- same exit code (`1`), same `reason` (`write-failed`), same
+   `[PostBash] <message>` stderr convention. No new fallback, no new
+   severity, no new stdout messaging on success.
+3. `tests/evidence-post-bash-importer.test.ts`, red-first (confirmed: the
+   suite fails with "Cannot find module" before the implementation
+   existed): observed trust class with the complete D3 field set;
+   unclean/absent/untracked contract produces `unbound` identity fields,
+   a clean committed contract produces bound ones; an observed-only
+   ledger's accepted fold filtered for `authoritative_machine` is empty;
+   malformed input (non-integer `exitCode`, negative `durationMs`, an
+   absolute or path-traversal `rawOutputPath`) fails closed with nothing
+   appended; identical re-import dedups to one accepted event via the
+   idempotency key; genesis is written once with `LEDGER_EPOCH_START_SHA`.
+4. All root required checks green; one independent PR on
+   `codex/epc-03-postbash-observed-importer`.
+
+## Scope
+
+- In scope: `src/effects/evidence/post-bash-importer.ts`,
+  `src/cli/hook/command-observed.ts` (wiring edit only),
+  `tests/evidence-post-bash-importer.test.ts`, this package's
+  plan/contract/review/notes, `tasks/todos.md` projection,
+  `.ai/harness/worktrees/epc-03-postbash-observed-importer.json`.
+- Out of scope: every EPC-01/EPC-02 file (`src/core/evidence/*`,
+  `src/effects/evidence/*` existing files including `epoch.ts` and
+  `verify-producer.ts` -- read-only imports/pattern reference only),
+  `scripts/acceptance-receipt.ts` and every other EPC-04 surface
+  (`assets/templates/helpers/acceptance-receipt.ts`,
+  `src/effects/evidence/attested-import.ts`,
+  `tests/evidence-attested-import.test.ts`), `checks/latest` or
+  `post-bash-latest` composition, any gate logic, handoff writers,
+  `tasks/current.md`, the sprint document, any new npm dependency.
+- Non-goals: retiring `post-bash-latest.json`; subject-strict binding for
+  observed events; gate cutover.
+- Taste constraints: match the existing `core`/`effects` idiom (readonly
+  interfaces, `{ ok, ... }`/discriminated-union result shapes, plain
+  exported functions, no classes, no barrel `index.ts`); smallest diff
+  that satisfies the frozen D2-D6 decisions; private per-producer
+  git/contract helpers, not shared with `verify-producer.ts` (R4).
+
+## Stop Conditions
+
+- Stop and hand back to the parent if `origin/main` has moved past
+  `8861b40dd85c0f7faabe8eecd217baf5528a7f3c` before this package's
+  worktree was created -- re-fetch and re-audit, never silently re-pin.
+- Stop and hand back to the parent if correct emission would require
+  modifying an EPC-01/EPC-02 module or touching any EPC-04 surface --
+  report instead of widening scope silently.
+- Stop if `check-architecture-sync` BLOCKS (not merely advises) on the
+  changed capability surfaces -- report rather than editing
+  `.ai/context/` or architecture files.
+- Stop after three fail-fix-reverify rounds on one issue.
+
+## Falsifier
+
+The direction is wrong if observed import cannot reuse the EPC-01 writer
+without schema changes, or if the observed-only-unsatisfied fixture cannot
+be expressed with the existing fold primitives. Cheapest proof: the
+fixture filtering accepted events for `authoritative_machine` over an
+observed-only ledger returns empty, and the full suite stays green.
+
+## Root Cause Evidence
+
+Not applicable: Task Profile is `code-change`, not `bugfix`.
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260722-1810-epc-03-postbash-observed-importer.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260722-1810-epc-03-postbash-observed-importer.review.md`
+- Notes file: `tasks/notes/20260722-1810-epc-03-postbash-observed-importer.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Acceptance Policy
+
+```json
+{"protocol":1,"reviewer":"Claude","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - plans/plan-20260722-1810-epc-03-postbash-observed-importer.md
+  - tasks/contracts/20260722-1810-epc-03-postbash-observed-importer.contract.md
+  - tasks/reviews/20260722-1810-epc-03-postbash-observed-importer.review.md
+  - tasks/notes/20260722-1810-epc-03-postbash-observed-importer.notes.md
+  - src/effects/evidence/post-bash-importer.ts
+  - src/cli/hook/command-observed.ts
+  - tests/evidence-post-bash-importer.test.ts
+  - .ai/harness/worktrees/epc-03-postbash-observed-importer.json
+  - tasks/todos.md
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # New producer; no benchmark-subject-touching change in this package.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+      - codex-exec
+      - main-thread
+    fallback: main-thread
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - src/effects/evidence/post-bash-importer.ts
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260722-1810-epc-03-postbash-observed-importer.notes.md
+  tests_pass:
+    - path: tests/evidence-post-bash-importer.test.ts
+  commands_succeed:
+    - bash scripts/check-task-workflow.sh --strict
+  manual_checks:
+    - "PR diff confined to allowed_paths; no EPC-01/EPC-02 file modified; zero overlap with EPC-04 allowed_paths"
+    - "Observed-only ledger leaves authoritative filter empty (fixture)"
+    - "tasks/current.md untouched"
+```
+
+## Concurrency and Ownership
+
+- **R4 wave qualification proof** (EPC-02/03/04 parallel wave, evaluated
+  after EPC-01/EPC-02 merged): schema, trust matrix, and idempotency are
+  frozen by the EPC-00 design freeze and already merged via EPC-01
+  (`src/core/evidence/types.ts`, `fold.ts`) and EPC-02
+  (`src/effects/evidence/epoch.ts`, `verify-producer.ts` as pattern
+  reference) -- this package does not re-decide or modify any of them.
+- **Exact `allowed_paths` disjointness**: this package's `allowed_paths`
+  (above) has zero overlap with EPC-04's. EPC-04 owns
+  `scripts/acceptance-receipt.ts`,
+  `assets/templates/helpers/acceptance-receipt.ts`,
+  `src/effects/evidence/attested-import.ts`,
+  `tests/evidence-attested-import.test.ts`, and its own
+  plan/contract/review/notes/worktree-registration files. This package
+  owns `src/effects/evidence/post-bash-importer.ts`,
+  `src/cli/hook/command-observed.ts` (wiring edit only),
+  `tests/evidence-post-bash-importer.test.ts`, and its own
+  plan/contract/review/notes/worktree-registration files. Neither package
+  touches the other's file.
+- **Disjoint test fixtures**: this package's fixtures use tmp roots
+  prefixed `post-bash-importer-*` (`tests/evidence-post-bash-importer.test.ts`),
+  distinct from EPC-04's `tests/evidence-attested-import.test.ts` fixture
+  names.
+- **No shared barrel/export file**: there is no `index.ts` anywhere under
+  `src/effects/evidence/` (confirmed at task start and unchanged by this
+  package); each producer is imported directly by its own path.
+- **No shared store writer**: this package calls the existing EPC-01
+  writer (`appendEvidenceEvent`/`appendGenesisRecord` in
+  `src/effects/evidence/event-log.ts`) exactly as EPC-02 already does;
+  it adds no new writer and edits no existing writer.
+- **No shared projection writer**: this package produces no
+  `checks/latest`-style projection; `checks/post-bash-latest.json`
+  authoring is untouched pre-epoch legacy (D2), not a projection this
+  row retires or rewrites.
+- This package's own private git/contract helpers
+  (`resolveContractPath`, `isContractCommittedClean`,
+  `lastCommitTouching`, `parseContractAllowedPaths`, `workspaceId`, etc.)
+  are a separate, non-exported copy from `verify-producer.ts`'s
+  equivalents -- read as a pattern reference only, never imported from,
+  per R4's "no shared" wave-qualification requirement.
+- If an out-of-band merge lands on `main` touching this package's
+  `allowed_paths` before this package's PR merges, stop, re-fetch, and
+  re-derive against the new state; never force-push over it.
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior: adds a new `observed`-only importer
+  (`importPostBashObservation`) and wires it additively into
+  `command-observed.ts` after the existing `post-bash-latest.json` write.
+  No existing EPC-01/EPC-02 file, and no EPC-04 file, is modified.
+- Edge cases: no active contract resolves; a dirty (uncommitted) active
+  contract; an untracked (never committed) active contract; a non-git
+  fixture directory (repo-state fields degrade to `unbound` rather than
+  refusing, since `observed` never satisfies a gate); malformed input
+  (non-integer exit code, negative duration, unsafe raw-output path);
+  re-import with identical inputs (idempotency dedup at fold time, not at
+  append time); genesis-before-append semantics reused unmodified from
+  EPC-01; realistic raw-output paths and full hashes are 32+ char
+  dot-free runs that would trip EPC-01's D6 redaction if stored verbatim
+  -- both are stored as short, fixed-length references instead.
+- Regression risks: none to existing runtime surfaces -- the only
+  existing file touched is `command-observed.ts`, and only additively
+  (a new call after its existing checks-file write, with failure folded
+  into the same pre-existing catch-all). The full existing
+  `tests/command-observed.test.ts`,
+  `tests/harness-circuit-breakers.test.ts`, `tests/hook-runtime.test.ts`,
+  and `tests/cli/hook.test.ts` suites (which invoke `runCommandObserved`
+  against bare, non-git tmp directories) were re-run after this wiring
+  change and stayed green, confirming the additive import degrades
+  gracefully rather than newly failing those fixtures. The residual risk
+  surface is a later EPC-0N package mis-citing the frozen epoch constant
+  or bypassing `importPostBashObservation`'s single entry point, guarded
+  by this package's Falsifier and the trust-class-hardcoded design.
+
+## Rollback Point
+
+- Commit / checkpoint: the single commit on
+  `codex/epc-03-postbash-observed-importer` before it merges.
+- Revert strategy: revert the single PR -- every change is a new module
+  (`post-bash-importer.ts`), a new test suite, and one additive wiring
+  edit in `command-observed.ts` (a new call after the existing
+  `post-bash-latest.json` write, no existing line altered); this
+  package's workflow artifacts revert with it. `checks/post-bash-latest`
+  authoring and every other surface are unchanged, so reverting cannot
+  regress any existing consumer.

--- a/tasks/notes/20260722-1810-epc-03-postbash-observed-importer.notes.md
+++ b/tasks/notes/20260722-1810-epc-03-postbash-observed-importer.notes.md
@@ -1,0 +1,168 @@
+# Implementation Notes: epc-03-postbash-observed-importer
+
+> **Status**: Active
+> **Plan**: plans/plan-20260722-1810-epc-03-postbash-observed-importer.md
+> **Contract**: tasks/contracts/20260722-1810-epc-03-postbash-observed-importer.contract.md
+> **Review**: tasks/reviews/20260722-1810-epc-03-postbash-observed-importer.review.md
+> **Last Updated**: 2026-07-22 18:10
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- **Existing `post-bash-latest.json` write path failure semantics
+  (observed, not assumed)**: `runCommandObserved`
+  (`src/cli/hook/command-observed.ts`) wraps essentially its entire body
+  -- from input parsing through the `post-bash-latest.json` write -- in
+  one `try` block. Any thrown error anywhere in that block is caught by
+  one `catch` that returns `{ exitCode: 1, stdout: '', stderr:
+  '${warnings()}[PostBash] ${message}\n', reason: 'write-failed' }`, with
+  no differentiation by which statement threw. A separate, earlier
+  early-return path (repair-circuit-tripped) returns `exitCode: 2` before
+  ever reaching the `post-bash-latest.json` write; that branch is
+  untouched, so the ledger import correctly never runs there either,
+  mirroring how the checks-file write itself doesn't run there. The
+  ledger import call was placed as a plain statement inside the same
+  `try` block, immediately after the existing write and before the final
+  success `return`. On failure it throws `new Error(\`ledger import
+  failed (${reason}): ${message}\`)`, caught by the *same* pre-existing
+  `catch` -- identical `exitCode`/`reason`/stderr-prefix envelope as any
+  other failure in this function, no new fallback, no new severity. No
+  new stdout messaging was added on the success path (not asked for by
+  the Goal).
+
+- **Repo-state identity fields (`base_commit`/`target_commit`) degrade to
+  `unbound`, not just the contract-derived fields**: the Goal's "computed
+  from repo state where available" qualifier turned out load-bearing.
+  Every existing call site of `runCommandObserved` was read before
+  wiring: `tests/command-observed.test.ts`,
+  `tests/harness-circuit-breakers.test.ts`, and one path in
+  `tests/cli/hook.test.ts` all invoke it against a bare `mkdtempSync`
+  directory with no `git init`. Treating unresolvable repo state as a
+  hard failure (mirroring EPC-02's stricter refusal style) would have
+  turned essentially every existing `command-observed.ts` test red the
+  moment this package's wiring landed. Decision: `base_commit`/
+  `target_commit` independently fall back to `UNBOUND_SENTINEL` when
+  `git rev-parse --verify <ref>^{commit}` fails, the same sentinel
+  already used for the contract-derived fields and for the same
+  underlying reason -- `observed` never satisfies a gate (D4), so there
+  is no correctness reason to refuse just because git state is
+  unavailable. Verified empirically: the full existing
+  `command-observed.test.ts` (11 tests), `harness-circuit-breakers.test.ts`,
+  `hook-runtime.test.ts`, `cli/hook.test.ts`, and `hook-contracts.test.ts`
+  suites were re-run after the wiring change and stayed green with no
+  edits to any of those files.
+
+- **"Malformed input" does not require a non-empty `command`**: the
+  existing "keeps malformed host input observable..." test in
+  `command-observed.test.ts` deliberately feeds non-JSON stdin, which
+  resolves `command` to `''` via the existing fallback chain, and expects
+  `exitCode: 0`. Rejecting an empty command as malformed would have
+  turned that pre-existing green test red. `command` is still
+  type-checked (must be a string); only `exitCode` (must be an integer),
+  `durationMs` (must be finite and >= 0), and `rawOutputPath` (must be
+  repo-relative when present) are validated as possibly malformed.
+
+- **D6 redaction over-triggers on realistic hashes AND realistic paths**
+  (caught red-handed during the first real test run, not just inferred
+  from the plan's warning): a payload string carrying a full sha256 hex
+  digest, or a realistic repo-relative raw-output path such as
+  `.ai/harness/runs/bash-output/post-bash-<ts>-<pid>-<hash12>.log`, is a
+  single 32+ char run of `[A-Za-z0-9+/_-]` with no dot to break it --
+  `/` is *inside* the redaction charset, so directory separators do not
+  help. Observed failure: the literal path
+  `.ai/harness/runs/bash-output/post-bash-example.log` came back as
+  `.sha256:<64-hex>.log` in the emitted event's payload. Resolution:
+  neither the payload's `command_hash` nor its raw-output reference
+  stores the full string. `command_hash` is a 16-hex-char prefix of the
+  real hash; the raw-output reference (renamed `raw_output_ref`, not
+  `raw_output_path`, to avoid implying it is directly openable) is a
+  fixed 24-char suffix of the real path. Both lengths are unconditionally
+  under the 32-char threshold regardless of caller input -- a fixed-length
+  slice is robust to any reasonably formed input without coupling this
+  module to `command-observed.ts`'s specific filename shape. The
+  full-fidelity hash lives only in `subject_identity.command_hash` (and
+  `subject_hash`), which is not payload and is not redacted.
+
+- **`subject_hash` equals `command_hash` for an observed command**: D3's
+  frozen field list is shared across every evidence producer, but its
+  semantic meaning is supplied per-producer. There is no code-diff
+  "verification subject" for a PostBash observation (unlike EPC-02's
+  `buildReviewSubject` use), so `subject_hash` is set equal to
+  `command_hash` (`sha256:<hex(command)>`) -- the thing actually being
+  observed is the command itself. Zero functional consequence for gate
+  satisfaction, since `observed` events can never satisfy a machine gate
+  regardless of `subject_hash`'s value (D4); the field only needs to be a
+  non-empty string to satisfy the frozen schema.
+
+- **`worktree_id` fallback and the genesis race**: `appendGenesisRecord`
+  (EPC-01, read-only) returns the *existing* genesis record unmodified --
+  including its `worktree_id` -- whenever one already exists with a
+  matching epoch, silently ignoring whatever `worktreeId` the caller
+  passed. So this module's own `worktreeId` argument only matters if it
+  happens to write genesis first in a fresh worktree. `verify-producer.ts`
+  derives its `worktreeId` from its own contract's filename stem, which
+  assumes a contract always exists (true for verify-producer, since it
+  fails closed otherwise). This module must also work when no contract is
+  bound at all, so it uses `workspaceId(repoRoot)` (a hash of the git
+  toplevel real path, already needed for `env_provider_id`)
+  unconditionally as its `worktreeId` argument -- deterministic per repo
+  root regardless of contract state, reusing a helper already needed
+  rather than adding a second contract-stem-based code path. Every real
+  event's own `worktree_id` field still uses `genesis.worktree_id` (the
+  returned record), matching `verify-producer.ts`'s pattern, so whichever
+  producer wrote genesis first is always authoritative.
+
+- **Private per-producer helpers, not shared with `verify-producer.ts`**:
+  `resolveContractPath`, `isContractCommittedClean`, `lastCommitTouching`,
+  `parseContractAllowedPaths`, `gitOutput`, `workspaceId`,
+  `providerCliVersion`, and `resolveReviewBaseRef` are structurally
+  similar to (but a separate, non-exported copy from)
+  `verify-producer.ts`'s equivalents. Deliberate, not accidental
+  duplication: the sprint's R4 wave-qualification rule requires the
+  EPC-02/03/04 parallel wave to share no store writer, projection writer,
+  or barrel/export file, and `verify-producer.ts` was explicitly named a
+  "pattern reference (read-only)" rather than an import target for this
+  package. `ensureRepoRelativePath` (`src/effects/path-safety.ts`) and
+  `uniqueSorted` (`src/effects/review/diff-fingerprint.ts`) *are* imported
+  directly -- both are pre-existing, general (non-evidence-domain)
+  utilities that EPC-02 itself already imports the same way, so reusing
+  them is precedented and outside R4's "no shared store/projection
+  writer" scope.
+
+## Deviations From Plan Or Spec
+
+- None. The Goal's "computed from repo state where available" and the
+  redaction guidance were both explicit in the plan; the two design
+  decisions above are applications of that guidance, not departures
+  from it.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| Hard-fail when git state is unresolvable (mirror EPC-02) vs. degrade to `UNBOUND_SENTINEL` | Degrade | EPC-02's stricter rule protects an `authoritative_machine` gate; `observed` can never satisfy a gate (D4), and hard-failing would break every existing non-git `command-observed.ts` test fixture |
+| Store the full raw-output path / full hash in the payload vs. a short fixed-length reference | Short reference | The full forms trip D6's 32+ char dot-free redaction and come back double-hashed and useless; a fixed-length slice is unconditionally safe |
+| Derive `worktree_id` from a contract filename stem (like `verify-producer.ts`) vs. a repo-root hash | Repo-root hash | This module must work with no contract bound at all; the hash is always available and is already needed for `env_provider_id` |
+
+## Open Questions
+
+- None.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Red-first: `bun test tests/evidence-post-bash-importer.test.ts` failed
+  with "Cannot find module '../src/effects/evidence/post-bash-importer'"
+  (0 pass / 1 fail / 1 error) before `src/effects/evidence/post-bash-importer.ts`
+  existed; 12/12 pass after implementation.
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/reviews/20260722-1810-epc-03-postbash-observed-importer.review.md
+++ b/tasks/reviews/20260722-1810-epc-03-postbash-observed-importer.review.md
@@ -1,12 +1,12 @@
 # Task Review: epc-03-postbash-observed-importer
 
-> **Status**: Pending
+> **Status**: Reviewed
 > **Plan**: plans/plan-20260722-1810-epc-03-postbash-observed-importer.md
 > **Contract**: tasks/contracts/20260722-1810-epc-03-postbash-observed-importer.contract.md
 > **Notes File**: tasks/notes/20260722-1810-epc-03-postbash-observed-importer.notes.md
 > **Checks File**: .ai/harness/checks/latest.json
-> **Last Updated**: 2026-07-22 18:10
-> **Recommendation**: fail
+> **Last Updated**: 2026-07-22 19:35
+> **Recommendation**: pass
 > **Review Rubric Version**: 2
 > **Reviewed Subject SHA256**: pending
 > **Reviewed Subject Scope**: normalized-final-content
@@ -14,29 +14,38 @@
 
 ## Human Review Card
 
-- Verdict: pending
-- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
-- Intended files changed:
-- Actual files changed:
-- Commands passed:
-- Residual risks:
-- Reviewer action required: inspect diff and card
-- Rollback:
+- Verdict: pass
+- Change type: code-change
+- Intended files changed: new `src/effects/evidence/post-bash-importer.ts`, additive wiring in `src/cli/hook/command-observed.ts`, new `tests/evidence-post-bash-importer.test.ts`, package plan/contract/review/notes, `tasks/todos.md` projection
+- Actual files changed: exactly that set — 8 paths, single commit `a56cc93b` on base `8861b40d`; no EPC-01/EPC-02 file touched; zero overlap with EPC-04's parallel-wave surface; `command-observed.ts` diff is pure addition (no existing line modified)
+- Commands passed: `bun test tests/evidence-post-bash-importer.test.ts` (12 pass, red-first), `bun test tests/command-observed.test.ts` (11 pass), full `bun test` (1734 pass / 1 skip / 0 fail — worker + gatekeeper independent runs), `check:type` clean, `check-task-workflow --strict` OK, `contract-run preflight` preflight_pass, deploy-sql/task-sync/architecture-sync (advisory blocking=0) green, `inspect-project-state` no drift, `adopt --dry-run` 0 operations
+- Residual risks: `UNBOUND_SENTINEL` degradation covers unresolvable repo-state fields as well as contract fields (accepted ruling; legal only for `observed`, which no gate can accept per D4); payload strings deliberately truncated below the 32-char redaction threshold — full hashes live in identity fields
+- Reviewer action required: none further — gatekeeper acceptance review (fresh context, read-only) verdict PASS with all six gates verified
+- Rollback: revert the single PR; one new module + additive wiring + tests; `post-bash-latest.json` writer byte-identical to base
 
 ## Mode Evidence
 
-- Selected route:
-- P1/P2/P3 evidence:
-- Root cause or plan evidence:
+- Selected route: planning (captured work-package plan, code-change profile)
+- P1/P2/P3 evidence: plan Captured Planning Output; design authority frozen D2–D6; EPC-01 store API and EPC-02 epoch constant consumed read-only
+- Root cause or plan evidence: not a bugfix; second producer package of the frozen EPC design (parallel wave with EPC-04 under R4)
 
 ## Verification Evidence
 
-- Waza `/check` run:
-- Commands run:
-- Manual checks:
-- Supporting artifacts:
-- Implementation notes reviewed:
-- Run snapshot:
+- Waza `/check` run: gatekeeper acceptance review (fresh context, read-only) — verdict PASS
+- Commands run: see Human Review Card; executed in the contract worktree at `a56cc93b`
+- Manual checks: see Manual Check Evidence below
+- Supporting artifacts: `.ai/harness/checks/latest.json`
+- Implementation notes reviewed: yes — failure-semantics matching, unbound degradation, redaction-driven payload truncation, private-helper duplication per R4
+- Run snapshot: `.ai/harness/runs/`
+
+## Manual Check Evidence
+
+- [x] PR diff confined to allowed_paths; no EPC-01/EPC-02 file modified; zero overlap with EPC-04 allowed_paths
+  - Evidence: gatekeeper verified `git diff --name-only 8861b40d..HEAD` = 8 files all within `allowed_paths`; `src/core/evidence/*`, `epoch.ts`, `verify-producer.ts`, `event-log.ts` absent from the diff; `scripts/acceptance-receipt.ts`, `assets/templates/helpers/acceptance-receipt.ts`, `src/effects/evidence/attested-import.ts` untouched.
+- [x] Observed-only ledger leaves authoritative filter empty (fixture)
+  - Evidence: `tests/evidence-post-bash-importer.test.ts` observed-only fixture asserts accepted events are non-empty, all `observed`, and `filter(trust_class === "authoritative_machine")` returns `[]`; suite green (12/12), re-run independently by gatekeeper.
+- [x] tasks/current.md untouched
+  - Evidence: `git diff 8861b40d..HEAD -- tasks/current.md` is empty; `git status --porcelain` shows no entry for `tasks/current.md`.
 
 ## Acceptance Receipt Projection
 
@@ -55,30 +64,31 @@
 
 ## Behavior Diff Notes
 
-- ...
+- PostBash observations now import into the evidence ledger as `observed` events after the existing `post-bash-latest.json` write (unchanged, byte-identical). Import failure surfaces through the pre-existing catch-all with identical severity. Observed events can never satisfy a machine gate (D4); the row-7 fixture proves an observed-only ledger leaves the authoritative filter empty.
 
 ## Residual Risks / Follow-ups
 
-- ...
+- Sentinel-degraded identity fields on observed events are by-design unverifiable; EPC-05's selection predicate must (and per D7 does) exclude `observed` from gate satisfaction regardless.
+- EPC-04 merges after this package; wave surfaces are disjoint so no rebase conflict is expected.
 
 ## Scorecard
 
 | Dimension | Score | Notes |
 |-----------|-------|-------|
-| Functionality | 0/10 | |
-| Product depth | 0/10 | |
-| Design quality | 0/10 | |
-| Code quality | 0/10 | |
+| Functionality | 9/10 | Row-7 acceptance satisfied; trust boundary proven by fixture |
+| Product depth | 9/10 | Failure semantics matched exactly; no new severity |
+| Design quality | 9/10 | R4 private-helper duplication keeps wave disjoint |
+| Code quality | 9/10 | Full suite green twice independently; red-first tests |
 
 ## Failing Items
 
-- ...
+- none
 
 ## Retest Steps
 
-- Re-run:
-- Re-check:
+- Re-run: `bun test tests/evidence-post-bash-importer.test.ts`; `bun test tests/command-observed.test.ts`
+- Re-check: `post-bash-latest.json` construction byte-identical to base; observed-only fixture assertion
 
 ## Summary
 
-- ...
+- EPC-03 imports PostBash observations as `observed` trust-class events with unbound-sentinel identity degradation, matching failure semantics of the existing write path, and proves with fixtures that an observed-only ledger leaves machine gates unsatisfied. Gatekeeper verdict: PASS. Ready to ship as one PR (merges before EPC-04 per backlog order).

--- a/tasks/reviews/20260722-1810-epc-03-postbash-observed-importer.review.md
+++ b/tasks/reviews/20260722-1810-epc-03-postbash-observed-importer.review.md
@@ -1,0 +1,84 @@
+# Task Review: epc-03-postbash-observed-importer
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260722-1810-epc-03-postbash-observed-importer.md
+> **Contract**: tasks/contracts/20260722-1810-epc-03-postbash-observed-importer.contract.md
+> **Notes File**: tasks/notes/20260722-1810-epc-03-postbash-observed-importer.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-07-22 18:10
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Commands passed:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+- Waza `/check` run:
+- Commands run:
+- Manual checks:
+- Supporting artifacts:
+- Implementation notes reviewed:
+- Run snapshot:
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...

--- a/tasks/reviews/20260722-1810-epc-03-postbash-observed-importer.review.md
+++ b/tasks/reviews/20260722-1810-epc-03-postbash-observed-importer.review.md
@@ -49,17 +49,17 @@
 
 ## Acceptance Receipt Projection
 
-> **Disposition**: unavailable
-> **Reviewer**: unavailable
-> **Source**: unavailable
+> **Disposition**: external_pass
+> **Reviewer**: Claude
+> **Source**: claude-review
 > **Actor**: not-applicable
-> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject SHA256**: sha256:602a91853e4df979a8d59632210a119eb3559b1adb9f82101143ebe8e4192a33
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: pending
-> **Verification Evidence SHA256**: pending
-> **Issued At**: pending
+> **Reviewed Target Revision**: 8861b40dd85c0f7faabe8eecd217baf5528a7f3c
+> **Verification Evidence SHA256**: sha256:d769df85e918e16fd02eebfb06ac4794769604851643061a0e49c1ff13c966e1
+> **Issued At**: 2026-07-22T11:01:44.641Z
 
-- Summary: No AcceptanceReceipt has been recorded.
+- Summary: EPC-03 accepted: PostBash observed importer, trust boundary proven (observed-only ledger leaves authoritative filter empty), failure semantics matched, wave disjointness held; gatekeeper PASS
 - Findings: none
 
 ## Behavior Diff Notes

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -1,7 +1,7 @@
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: 2026-07-22 16:34
+> **Updated**: 2026-07-22 18:10
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.

--- a/tests/evidence-post-bash-importer.test.ts
+++ b/tests/evidence-post-bash-importer.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, test } from "bun:test";
+import { createHash } from "crypto";
+import { execFileSync } from "child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { LEDGER_EPOCH_START_SHA } from "../src/effects/evidence/epoch";
+import {
+  importPostBashObservation,
+  UNBOUND_SENTINEL,
+  type PostBashObservationInput,
+} from "../src/effects/evidence/post-bash-importer";
+import { readAcceptedEvents, readGenesisRecord } from "../src/effects/evidence/event-log";
+
+function git(repoRoot: string, args: readonly string[]): void {
+  execFileSync("git", ["-C", repoRoot, ...args], { encoding: "utf-8" });
+}
+
+function withTempRepo(prefix: string, fn: (repoRoot: string) => void): void {
+  const repoRoot = mkdtempSync(join(tmpdir(), `${prefix}-`));
+  try {
+    fn(repoRoot);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+}
+
+/**
+ * A minimal real git fixture repo, own to this producer's test suite (tmp
+ * prefix `post-bash-importer-*`, disjoint from EPC-04's fixture names per
+ * R4). One base commit plus, optionally, a committed contract declaring
+ * `allowed_paths`.
+ */
+function setupFixtureRepo(
+  repoRoot: string,
+  opts: { readonly commitContract?: boolean; readonly allowedPaths?: readonly string[] } = {},
+): { readonly contractRelative: string } {
+  mkdirSync(repoRoot, { recursive: true });
+  git(repoRoot, ["init", "-q", "-b", "main"]);
+  git(repoRoot, ["config", "user.email", "post-bash-importer-test@example.com"]);
+  git(repoRoot, ["config", "user.name", "post-bash-importer-test"]);
+
+  writeFileSync(join(repoRoot, ".gitignore"), ".ai/harness/evidence/\n");
+  writeFileSync(join(repoRoot, "README.md"), "base\n");
+  git(repoRoot, ["add", ".gitignore", "README.md"]);
+  git(repoRoot, ["commit", "-q", "-m", "base"]);
+
+  const allowedPaths = opts.allowedPaths ?? [
+    "src/effects/evidence/post-bash-importer.ts",
+    "tests/evidence-post-bash-importer.test.ts",
+  ];
+  const contractRelative = "tasks/contracts/fixture.contract.md";
+  mkdirSync(join(repoRoot, "tasks", "contracts"), { recursive: true });
+  const contractBody = [
+    "# Task Contract: fixture",
+    "",
+    "## Allowed Paths",
+    "",
+    "```yaml",
+    "allowed_paths:",
+    ...allowedPaths.map((path) => `  - ${path}`),
+    "```",
+    "",
+  ].join("\n");
+  writeFileSync(join(repoRoot, contractRelative), contractBody);
+
+  if (opts.commitContract ?? true) {
+    git(repoRoot, ["add", contractRelative]);
+    git(repoRoot, ["commit", "-q", "-m", "contract"]);
+  }
+
+  return { contractRelative };
+}
+
+function baseInput(repoRoot: string, overrides: Partial<PostBashObservationInput> = {}): PostBashObservationInput {
+  return {
+    repoRoot,
+    command: "bun test tests/evidence-post-bash-importer.test.ts",
+    exitCode: 0,
+    durationMs: 1234,
+    rawOutputPath: null,
+    ...overrides,
+  };
+}
+
+describe("importPostBashObservation: trust class and D3 field set", () => {
+  test("emits exactly one observed event with the D3 field set and the small structured payload", () => {
+    withTempRepo("post-bash-importer-basic", (repoRoot) => {
+      setupFixtureRepo(repoRoot, { commitContract: false });
+      const result = importPostBashObservation(
+        baseInput(repoRoot, { rawOutputPath: ".ai/harness/runs/bash-output/post-bash-example.log" }),
+      );
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.event.trust_class).toBe("observed");
+      expect(result.event.event_id).toMatch(/^evt-/);
+      expect(result.event.producer).toBe("post-bash-importer");
+
+      const identity = result.event.subject_identity;
+      expect(identity.base_commit).toMatch(/^[0-9a-f]{40}$/);
+      expect(identity.target_commit).toMatch(/^[0-9a-f]{40}$/);
+      expect(identity.subject_hash).toMatch(/^sha256:[0-9a-f]{64}$/);
+      expect(identity.command_hash).toMatch(/^sha256:[0-9a-f]{64}$/);
+      expect(identity.subject_hash).toBe(identity.command_hash);
+      expect(identity.env_provider_id.length).toBeGreaterThan(0);
+
+      const rawOutputPathValue = ".ai/harness/runs/bash-output/post-bash-example.log";
+      expect(result.event.payload).toEqual({
+        command_hash: expect.stringMatching(/^[0-9a-f]{16}$/),
+        exit_code: 0,
+        duration_ms: 1234,
+        raw_output_ref: rawOutputPathValue.slice(-24),
+      });
+      // The reference is a short, always-safe-length suffix, not the
+      // literal path -- verify it fits under the D6 redaction threshold
+      // and is a genuine suffix of the real repo-relative path.
+      const payloadValue = result.event.payload as { raw_output_ref: string };
+      expect(payloadValue.raw_output_ref.length).toBeLessThan(32);
+      expect(rawOutputPathValue.endsWith(payloadValue.raw_output_ref)).toBe(true);
+
+      const { accepted } = readAcceptedEvents(repoRoot);
+      expect(accepted.length).toBe(1);
+    });
+  });
+});
+
+describe("importPostBashObservation: unbound vs bound contract identity (sentinel rules)", () => {
+  test("no active contract resolves -> unbound authority/scope/contract identity", () => {
+    withTempRepo("post-bash-importer-no-contract", (repoRoot) => {
+      setupFixtureRepo(repoRoot, { commitContract: false });
+      const result = importPostBashObservation(baseInput(repoRoot));
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const identity = result.event.subject_identity;
+      expect(identity.authority_commit).toBe(UNBOUND_SENTINEL);
+      expect(identity.scope_hash).toBe(UNBOUND_SENTINEL);
+      expect(identity.contract_hash).toBe(UNBOUND_SENTINEL);
+      expect(identity.base_commit).toMatch(/^[0-9a-f]{40}$/);
+      expect(identity.target_commit).toMatch(/^[0-9a-f]{40}$/);
+    });
+  });
+
+  test("a dirty (uncommitted) contract -> unbound authority/scope/contract identity", () => {
+    withTempRepo("post-bash-importer-dirty-contract", (repoRoot) => {
+      const { contractRelative } = setupFixtureRepo(repoRoot);
+      writeFileSync(
+        join(repoRoot, contractRelative),
+        readFileSync(join(repoRoot, contractRelative), "utf-8") + "\n<!-- dirty -->\n",
+      );
+
+      const result = importPostBashObservation(baseInput(repoRoot, { contractPath: contractRelative }));
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const identity = result.event.subject_identity;
+      expect(identity.authority_commit).toBe(UNBOUND_SENTINEL);
+      expect(identity.scope_hash).toBe(UNBOUND_SENTINEL);
+      expect(identity.contract_hash).toBe(UNBOUND_SENTINEL);
+    });
+  });
+
+  test("an untracked (never committed) contract -> unbound authority/scope/contract identity", () => {
+    withTempRepo("post-bash-importer-untracked-contract", (repoRoot) => {
+      const { contractRelative } = setupFixtureRepo(repoRoot, { commitContract: false });
+      const result = importPostBashObservation(baseInput(repoRoot, { contractPath: contractRelative }));
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const identity = result.event.subject_identity;
+      expect(identity.authority_commit).toBe(UNBOUND_SENTINEL);
+      expect(identity.scope_hash).toBe(UNBOUND_SENTINEL);
+      expect(identity.contract_hash).toBe(UNBOUND_SENTINEL);
+    });
+  });
+
+  test("a clean, committed contract -> bound authority/scope/contract identity", () => {
+    withTempRepo("post-bash-importer-bound-contract", (repoRoot) => {
+      const { contractRelative } = setupFixtureRepo(repoRoot, { allowedPaths: ["src/a.ts", "src/b.ts"] });
+      const result = importPostBashObservation(baseInput(repoRoot, { contractPath: contractRelative }));
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const identity = result.event.subject_identity;
+      expect(identity.authority_commit).toMatch(/^[0-9a-f]{40}$/);
+      expect(identity.authority_commit).not.toBe(UNBOUND_SENTINEL);
+      expect(identity.contract_hash).toMatch(/^sha256:[0-9a-f]{64}$/);
+      const expectedScopeHash = `sha256:${createHash("sha256").update(JSON.stringify(["src/a.ts", "src/b.ts"])).digest("hex")}`;
+      expect(identity.scope_hash).toBe(expectedScopeHash);
+    });
+  });
+});
+
+describe("importPostBashObservation: observed-only ledger leaves authoritative gates unsatisfied", () => {
+  test("filtering the accepted fold for authoritative_machine returns empty over an observed-only ledger", () => {
+    withTempRepo("post-bash-importer-gate-unsatisfied", (repoRoot) => {
+      setupFixtureRepo(repoRoot, { commitContract: false });
+      importPostBashObservation(baseInput(repoRoot, { command: "bun test" }));
+      importPostBashObservation(baseInput(repoRoot, { command: "git status" }));
+      importPostBashObservation(baseInput(repoRoot, { command: "bun run check:type" }));
+
+      const { accepted } = readAcceptedEvents(repoRoot);
+      expect(accepted.length).toBeGreaterThan(0);
+      expect(accepted.every((event) => event.trust_class === "observed")).toBe(true);
+      expect(accepted.filter((event) => event.trust_class === "authoritative_machine")).toEqual([]);
+    });
+  });
+});
+
+describe("importPostBashObservation: fail-closed on malformed input", () => {
+  test("a non-integer exitCode fails closed and appends nothing", () => {
+    withTempRepo("post-bash-importer-malformed-exit-code", (repoRoot) => {
+      setupFixtureRepo(repoRoot, { commitContract: false });
+      const result = importPostBashObservation(baseInput(repoRoot, { exitCode: 1.5 }));
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.reason).toBe("malformed_input");
+
+      expect(readGenesisRecord(repoRoot)).toBeNull();
+      const { accepted } = readAcceptedEvents(repoRoot);
+      expect(accepted.length).toBe(0);
+    });
+  });
+
+  test("a negative durationMs fails closed and appends nothing", () => {
+    withTempRepo("post-bash-importer-malformed-duration", (repoRoot) => {
+      setupFixtureRepo(repoRoot, { commitContract: false });
+      const result = importPostBashObservation(baseInput(repoRoot, { durationMs: -1 }));
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.reason).toBe("malformed_input");
+      const { accepted } = readAcceptedEvents(repoRoot);
+      expect(accepted.length).toBe(0);
+    });
+  });
+
+  test("an absolute rawOutputPath fails closed and appends nothing", () => {
+    withTempRepo("post-bash-importer-malformed-path", (repoRoot) => {
+      setupFixtureRepo(repoRoot, { commitContract: false });
+      const result = importPostBashObservation(baseInput(repoRoot, { rawOutputPath: "/etc/passwd" }));
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.reason).toBe("malformed_input");
+      const { accepted } = readAcceptedEvents(repoRoot);
+      expect(accepted.length).toBe(0);
+    });
+  });
+
+  test("a path-traversal rawOutputPath fails closed and appends nothing", () => {
+    withTempRepo("post-bash-importer-malformed-traversal", (repoRoot) => {
+      setupFixtureRepo(repoRoot, { commitContract: false });
+      const result = importPostBashObservation(baseInput(repoRoot, { rawOutputPath: "../escape.log" }));
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.reason).toBe("malformed_input");
+      const { accepted } = readAcceptedEvents(repoRoot);
+      expect(accepted.length).toBe(0);
+    });
+  });
+});
+
+describe("importPostBashObservation: idempotent re-import", () => {
+  test("re-importing the identical observation dedups to one accepted event", () => {
+    withTempRepo("post-bash-importer-idempotent", (repoRoot) => {
+      setupFixtureRepo(repoRoot, { commitContract: false });
+      const input = baseInput(repoRoot, { command: "bun test", correlationRunId: "run-a" });
+
+      const first = importPostBashObservation(input);
+      const second = importPostBashObservation({ ...input, correlationRunId: "run-b" });
+      expect(first.ok).toBe(true);
+      expect(second.ok).toBe(true);
+      if (!first.ok || !second.ok) return;
+
+      expect(first.event.idempotency_key).toBe(second.event.idempotency_key);
+
+      const logPath = join(repoRoot, ".ai", "harness", "evidence", "events", "log.jsonl");
+      const eventLines = readFileSync(logPath, "utf-8")
+        .split("\n")
+        .filter((line) => line.length > 0)
+        .filter((line) => JSON.parse(line).kind === "evidence_event");
+      expect(eventLines.length).toBe(2);
+
+      const { accepted } = readAcceptedEvents(repoRoot);
+      expect(accepted.length).toBe(1);
+      expect(accepted[0]!.event_id).toBe(first.event.event_id);
+    });
+  });
+
+  test("genesis is written once with LEDGER_EPOCH_START_SHA across repeated imports", () => {
+    withTempRepo("post-bash-importer-genesis-once", (repoRoot) => {
+      setupFixtureRepo(repoRoot, { commitContract: false });
+      expect(readGenesisRecord(repoRoot)).toBeNull();
+
+      const first = importPostBashObservation(baseInput(repoRoot));
+      expect(first.ok).toBe(true);
+      if (!first.ok) return;
+      expect(first.genesis.ledger_epoch_start_sha).toBe(LEDGER_EPOCH_START_SHA);
+
+      const second = importPostBashObservation(baseInput(repoRoot, { command: "a different command" }));
+      expect(second.ok).toBe(true);
+
+      const logPath = join(repoRoot, ".ai", "harness", "evidence", "events", "log.jsonl");
+      const lines = readFileSync(logPath, "utf-8").split("\n").filter((line) => line.length > 0);
+      const genesisLines = lines.filter((line) => JSON.parse(line).kind === "evidence_genesis");
+      expect(genesisLines.length).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
Sprint C backlog row 7. Second producer for the EPC-01 evidence ledger, per frozen decisions D2–D6 (parallel wave with EPC-04 under R4; disjoint surfaces, merges first per backlog order).

- `src/effects/evidence/post-bash-importer.ts`: one `observed` event per PostBash observation; trust class hard-coded, no other class emittable; contract-derived identity fields bind when a committed-clean active contract exists, else the `unbound` sentinel (legal only for `observed` — gates can never accept it per D4); genesis via the single-sourced epoch constant; payload structured and redaction-safe.
- `src/cli/hook/command-observed.ts`: additive wiring after the existing `post-bash-latest.json` write (byte-identical construction retained); import failure surfaces through the pre-existing catch-all with identical severity.
- 12 red-first tests including the row-7 fixture: an observed-only ledger leaves the `authoritative_machine` filter empty.

Verification: full `bun test` 1734 pass / 0 fail / 1 skip (worker + gatekeeper independent runs); type-check clean; preflight pass; strict workflow OK. Acceptance: gatekeeper PASS (all six gates); external_pass receipt subject-bound at target revision 8861b40d.