### PR TITLE
EPC-04: Manual/external attested import

### DIFF
--- a/assets/templates/helpers/acceptance-receipt.ts
+++ b/assets/templates/helpers/acceptance-receipt.ts
@@ -660,6 +660,86 @@ export function projectAcceptance(reviewPath: string, receipt: AcceptanceReceipt
   writeFileSync(reviewPath, next, 'utf-8');
 }
 
+/**
+ * EPC-04: at the end of a successful `record` (CLI level only -- this is
+ * never invoked from the exported `recordAcceptance`/`recordUserWaiverAcceptance`
+ * functions themselves, so direct library callers, including
+ * tests/acceptance-receipt.test.ts, are unaffected), import the
+ * just-recorded receipt into the EPC-01 ledger as one attested EvidenceEvent
+ * (D4). `reject` has no attested trust mapping (D4's closed table has only
+ * two entries) and is not itself a claim of acceptance, so it is skipped
+ * here rather than routed into `importAttestedEvidence` only to fail closed
+ * on `unsupported_disposition` -- that would turn an intentional, already
+ * exit-code-1 rejection into a hard crash of the record command, which is
+ * not this package's scope.
+ *
+ * Deployed-helper context (this same file running from an adopted repo's
+ * own `scripts/acceptance-receipt.ts`, where `src/effects/evidence` does
+ * not exist -- see tests/helper-scripts.test.ts): the dynamic import below
+ * resolves relative to `PACKAGE_ROOT`, which in that context is the
+ * deployed target repo's own root, not this tool's. A module-resolution
+ * failure there is indistinguishable from "no ledger to import into" and is
+ * treated as a cannot-bind skip (record still succeeds) -- never a crash.
+ * Any OTHER failure (the module resolves but the import itself reports a
+ * real fail-closed reason) still fails the record command: an acceptance
+ * that cannot enter the evidence authority must not report success.
+ */
+async function importAttestedReceiptIfApplicable(root: string, receipt: AcceptanceReceipt): Promise<void> {
+  if (receipt.disposition !== 'external_pass' && receipt.disposition !== 'user_waiver') return;
+
+  const modulePath = join(PACKAGE_ROOT, 'src', 'effects', 'evidence', 'attested-import.ts');
+  type AttestedImportModule = {
+    importAttestedEvidence: (input: {
+      repoRoot: string;
+      receipt: {
+        disposition: string;
+        reviewer: string;
+        source: string;
+        actor: string | null;
+        summary: string;
+        findings: AcceptanceFinding[];
+        subject_sha256: string;
+        target_revision: string;
+        contract_file: string;
+        issued_at: string;
+      };
+    }) => { ok: boolean; reason?: string; message?: string };
+  };
+  let attestedImport: AttestedImportModule;
+  try {
+    attestedImport = (await import(pathToFileURL(modulePath).href)) as AttestedImportModule;
+  } catch (error) {
+    if (isModuleUnresolvedError(error)) {
+      console.error('acceptance-receipt: attested-import module unavailable in this deployed-helper context; skipping ledger import (record unaffected)');
+      return;
+    }
+    throw error;
+  }
+
+  const result = attestedImport.importAttestedEvidence({
+    repoRoot: root,
+    receipt: {
+      disposition: receipt.disposition,
+      reviewer: receipt.reviewer,
+      source: receipt.source,
+      actor: receipt.actor,
+      summary: receipt.summary,
+      findings: receipt.findings,
+      subject_sha256: receipt.subject_sha256,
+      target_revision: receipt.target_revision,
+      contract_file: receipt.contract_file,
+      issued_at: receipt.issued_at,
+    },
+  });
+  if (!result.ok) {
+    fail(`AcceptanceReceipt recorded but ledger import failed closed: ${result.message ?? result.reason}`);
+  }
+}
+
+function isModuleUnresolvedError(error: unknown): boolean {
+  return (error as { code?: string } | null | undefined)?.code === 'ERR_MODULE_NOT_FOUND';
+}
+
 function option(argv: string[], name: string, required = true): string | undefined {
   const index = argv.indexOf(name);
   const value = index >= 0 ? argv[index + 1] : undefined;
@@ -715,6 +795,7 @@ export async function runAcceptanceReceiptCli(argv: string[], opts: Options = {}
         verification: option(argv, '--verification')!,
         now: opts.now,
       });
+      await importAttestedReceiptIfApplicable(root, receipt);
       const review = option(argv, '--review', false);
       if (review) projectAcceptance(resolve(root, review), receipt);
       console.log(JSON.stringify(receipt));
@@ -734,6 +815,7 @@ export async function runAcceptanceReceiptCli(argv: string[], opts: Options = {}
       findings: validateFindings(JSON.parse(findingsRaw)),
       now: opts.now,
     });
+    await importAttestedReceiptIfApplicable(root, receipt);
     const review = option(argv, '--review', false);
     if (review) projectAcceptance(resolve(root, review), receipt);
     console.log(JSON.stringify(receipt));

--- a/plans/plan-20260722-1810-epc-04-manual-external-attested-import.md
+++ b/plans/plan-20260722-1810-epc-04-manual-external-attested-import.md
@@ -1,0 +1,257 @@
+# Plan: EPC-04: Manual/External Attested Import
+
+> **Status**: Executing
+> **Created**: 20260722-1810
+> **Slug**: epc-04-manual-external-attested-import
+> **Planning Source**: repo-harness-sprint
+> **Orchestration Kind**: host-plan
+> **Source Ref**: sprint:plans/sprints/20260722-0001-evidence-projection-convergence.sprint.md#epc-04
+> **Artifact Level**: work-package
+> **Promotion Reason**: verification_boundary
+> **Verification Boundary**: Red-first fixtures prove: closed trust mapping (external_pass->external_attested, user_waiver->human_acceptance, else fail closed), required trust/actor/reason/subject fields fail closed when absent, attested-only ledger yields empty authoritative filter (default-deny), idempotent re-import; dogfood: this package's own receipt appears as an accepted external_attested event; full bun test and root required checks green
+> **Rollback Surface**: Revert the single PR: new import module + test suite plus one wiring edit in scripts/acceptance-receipt.ts; receipt JSON/projection flow and all other surfaces unchanged
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260722-1810-epc-04-manual-external-attested-import.contract.md`
+> **Task Review**: `tasks/reviews/20260722-1810-epc-04-manual-external-attested-import.review.md`
+> **Implementation Notes**: `tasks/notes/20260722-1810-epc-04-manual-external-attested-import.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from repo-harness-sprint planning output.
+- Source ref: sprint:plans/sprints/20260722-0001-evidence-projection-convergence.sprint.md#epc-04
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260722-1810-epc-04-manual-external-attested-import.md`
+- Sprint contract: `tasks/contracts/20260722-1810-epc-04-manual-external-attested-import.contract.md`
+- Sprint review: `tasks/reviews/20260722-1810-epc-04-manual-external-attested-import.review.md`
+- Implementation notes: `tasks/notes/20260722-1810-epc-04-manual-external-attested-import.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260722-1810-epc-04-manual-external-attested-import.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260722-1810-epc-04-manual-external-attested-import.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260722-1810-epc-04-manual-external-attested-import.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260722-1810-epc-04-manual-external-attested-import.contract.md`
+- Review file: `tasks/reviews/20260722-1810-epc-04-manual-external-attested-import.review.md`
+- Implementation notes file: `tasks/notes/20260722-1810-epc-04-manual-external-attested-import.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260722-1810-epc-04-manual-external-attested-import.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260722-1810-epc-04-manual-external-attested-import.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: Revert the single PR: new import module + test suite plus one wiring edit in scripts/acceptance-receipt.ts; receipt JSON/projection flow and all other surfaces unchanged
+- **Verification boundary**: Red-first fixtures prove: closed trust mapping (external_pass->external_attested, user_waiver->human_acceptance, else fail closed), required trust/actor/reason/subject fields fail closed when absent, attested-only ledger yields empty authoritative filter (default-deny), idempotent re-import; dogfood: this package's own receipt appears as an accepted external_attested event; full bun test and root required checks green
+- **Review/acceptance boundary**: `tasks/reviews/20260722-1810-epc-04-manual-external-attested-import.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: verification_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260722-1810-epc-04-manual-external-attested-import.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260722-1810-epc-04-manual-external-attested-import.contract.md`, `tasks/reviews/20260722-1810-epc-04-manual-external-attested-import.review.md`, and `tasks/notes/20260722-1810-epc-04-manual-external-attested-import.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260722-1810-epc-04-manual-external-attested-import.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: Revert the single PR: new import module + test suite plus one wiring edit in scripts/acceptance-receipt.ts; receipt JSON/projection flow and all other surfaces unchanged
+
+## Captured Planning Output
+
+> **Task Profile**: code-change
+
+## Decision Summary
+
+EPC-04 implements Sprint C backlog row 8: manual/external attested import.
+Recording an AcceptanceReceipt imports it into the EPC-01 ledger as an
+attested event: disposition `external_pass` -> trust `external_attested`,
+disposition `user_waiver` -> trust `human_acceptance` (D4). Attested events
+require trust, actor, reason, and subject fields; malformed imports fail
+closed. `external_attested` satisfies gates only where the active
+contract's Acceptance Policy explicitly enumerates it (D4 default-deny) —
+this package proves the property with fold-level fixtures; the actual gate
+selection ships in EPC-05. Runs as a two-package parallel wave with EPC-03
+under R4 (jointly proven disjointness; see Concurrency). Base SHA pinned
+per R1 at fresh fetch: `8861b40dd85c0f7faabe8eecd217baf5528a7f3c` (post-EPC-02 merge).
+
+## Why
+
+The acceptance flow is the Program's only legitimate source of
+human/external trust. Today the receipt is a standalone JSON plus a
+Markdown projection; nothing ties it into the evidence authority rows
+9–12 will select from. Importing at record time — with the receipt's own
+subject binding — makes attested trust a first-class ledger fact instead
+of a parallel shadow authority.
+
+## Goal
+
+1. `src/effects/evidence/attested-import.ts`: imports one recorded
+   receipt as ONE attested event via the EPC-01 writer, genesis via
+   `LEDGER_EPOCH_START_SHA` (EPC-02 epoch constant, read-only import).
+   - Trust mapping is closed: `external_pass` -> `external_attested`;
+     `user_waiver` -> `human_acceptance`; any other disposition -> fail
+     closed. No API path emits `authoritative_machine` or `observed`.
+   - Required fields, fail-closed if absent/empty: trust (from the
+     mapping), actor (receipt reviewer; plus `actor` field when present),
+     reason (receipt summary), and the full D3 subject identity taken
+     from the receipt's own binding (`subject_sha256` ->
+     `subject_hash`, `target_revision` -> `base_commit`, worktree HEAD ->
+     `target_commit`, contract file hash -> `contract_hash`, ordered
+     `allowed_paths` -> `scope_hash`, last commit touching the contract ->
+     `authority_commit`, recording host identity -> `env_provider_id`).
+   - Payload: structured (disposition, reviewer, source, summary,
+     findings count, receipt hash reference) — no long free text inline.
+2. Wire `scripts/acceptance-receipt.ts`: at the end of a successful
+   `record`, import the just-recorded receipt into the ledger; import
+   failure fails the record command (fail closed — an acceptance that
+   cannot enter the evidence authority must not report success).
+3. `tests/evidence-attested-import.test.ts` fixtures prove: `external_pass`
+   maps to `external_attested` and `user_waiver` to `human_acceptance`;
+   missing actor or reason or subject fields fail closed (nothing
+   appended); unknown disposition fails closed; the accepted fold shows
+   attested events are NOT `authoritative_machine` (filtering for
+   authoritative over an attested-only ledger returns empty — default-
+   deny holds at the trust level); re-import of the identical receipt
+   dedups via idempotency key.
+4. All root required checks green; one independent PR on
+   `codex/epc-04-manual-external-attested-import`.
+
+## P1: Architecture Map
+
+- Design authority: frozen D2–D6; EPC-01 store API and EPC-02 epoch
+  constant are read-only imports; no EPC-01/EPC-02 file modified.
+- Wiring surface: `scripts/acceptance-receipt.ts` only — disjoint from
+  EPC-03's `src/cli/hook/command-observed.ts` (R4 wave layer-1 proof).
+- The receipt JSON/projection flow itself is unchanged (its cutover, if
+  any, belongs to later rows); import is additive at record time.
+- Where a contract's Acceptance Policy enumerates `external_attested`,
+  EPC-05's selection will admit it; this package only guarantees the
+  trust labeling and the default-deny property at fold level.
+
+## P2: Concrete Trace
+
+EPC-02 merges -> EPC-04 fresh-fetches, pins `8861b40dd85c0f7faabe8eecd217baf5528a7f3c` (R1)
+-> worktree opens on `codex/epc-04-manual-external-attested-import` in
+parallel with EPC-03's disjoint worktree -> import module + wiring +
+tests land -> this package's own acceptance run dogfoods the path: its
+`acceptance-receipt record` call imports its own receipt as an
+`external_attested` event -> required checks green -> PR merges (wave PRs
+merge serially in backlog order) -> EPC-05 pins its base after both wave
+rows merge.
+
+## P3: Design Decision
+
+- Import at record time (inside `acceptance-receipt.ts record`) rather
+  than a separate import command: a separate command a caller may skip
+  would be exactly the skippable-sanitize anti-pattern D6 forbids for the
+  writer; binding import to record makes attested trust
+  by-construction.
+- Record fails closed on import failure: a receipt that exists outside
+  the ledger would be a new shadow authority — the precise thing this
+  sprint deletes elsewhere.
+- Subject identity comes from the receipt's own binding, not recomputed
+  fresh: the receipt already froze subject/target at record time; a
+  fresh recompute could silently diverge from what the reviewer
+  accepted.
+- Trust mapping is a closed two-entry table: any future disposition must
+  arrive with its own approved package, not a default branch.
+
+## Task Breakdown
+
+- [ ] Verify fresh fetch equals pinned base; fill contract (R4 wave
+      disjointness proof section shared verbatim with EPC-03).
+- [ ] `attested-import.ts` (closed trust mapping, required-field
+      fail-closed).
+- [ ] Wire `acceptance-receipt.ts` record path (fail-closed).
+- [ ] Tests red-first for every Goal-3 fixture.
+- [ ] Required checks; commit; receipt (dogfoods the new path); PR.
+
+## Scope
+
+- In scope: `src/effects/evidence/attested-import.ts`,
+  `scripts/acceptance-receipt.ts` (wiring edit only),
+  `tests/evidence-attested-import.test.ts`, this package's
+  plan/contract/review/notes, `tasks/todos.md` projection,
+  `.ai/harness/worktrees/epc-04-manual-external-attested-import.json`.
+- Out of scope: every EPC-01/EPC-02 file, `src/cli/hook/command-observed.ts`
+  (EPC-03's surface), `verify-sprint.sh`, `checks/latest` composition,
+  gate selection logic (EPC-05), handoff writers, `tasks/current.md`,
+  the sprint document, any new npm dependency.
+- Non-goals: gate cutover; receipt schema changes; retiring the receipt
+  JSON or its Markdown projection.
+
+## Stop Conditions
+
+- Stop if `origin/main` moves past the pinned base before worktree
+  creation.
+- Stop if wiring would require modifying an EPC-01/02 module or touching
+  EPC-03's surface — report, never widen.
+- Stop after three fail-fix-reverify rounds on one issue.
+
+## Falsifier
+
+The direction is wrong if the receipt's existing binding cannot populate
+the D3 identity without schema changes, or if record-time import breaks
+the receipt flow's staleness invariant (record must still immediately
+follow evidence preparation). Cheapest proof: this package's own
+acceptance flow records its receipt successfully AND the worktree ledger
+then contains exactly one accepted `external_attested` event referencing
+that receipt.
+
+## Cheapest Sufficient Proof
+
+- Fresh fetch equals pinned base at pin time; contract records it.
+- New suite green red-first; full `bun test` green; root checks green.
+- Dogfood: this package's own receipt appears as an accepted
+  `external_attested` event in the worktree ledger.
+- `git diff --name-only <base>..HEAD` ⊆ `allowed_paths`; zero overlap
+  with EPC-03's `allowed_paths`.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [ ] Verify fresh fetch equals pinned base; fill contract (R4 wave
+- [ ] `attested-import.ts` (closed trust mapping, required-field
+- [ ] Wire `acceptance-receipt.ts` record path (fail-closed).
+- [ ] Tests red-first for every Goal-3 fixture.
+- [ ] Required checks; commit; receipt (dogfoods the new path); PR.

--- a/scripts/acceptance-receipt.ts
+++ b/scripts/acceptance-receipt.ts
@@ -660,6 +660,86 @@ export function projectAcceptance(reviewPath: string, receipt: AcceptanceReceipt
   writeFileSync(reviewPath, next, 'utf-8');
 }
 
+/**
+ * EPC-04: at the end of a successful `record` (CLI level only -- this is
+ * never invoked from the exported `recordAcceptance`/`recordUserWaiverAcceptance`
+ * functions themselves, so direct library callers, including
+ * tests/acceptance-receipt.test.ts, are unaffected), import the
+ * just-recorded receipt into the EPC-01 ledger as one attested EvidenceEvent
+ * (D4). `reject` has no attested trust mapping (D4's closed table has only
+ * two entries) and is not itself a claim of acceptance, so it is skipped
+ * here rather than routed into `importAttestedEvidence` only to fail closed
+ * on `unsupported_disposition` -- that would turn an intentional, already
+ * exit-code-1 rejection into a hard crash of the record command, which is
+ * not this package's scope.
+ *
+ * Deployed-helper context (this same file running from an adopted repo's
+ * own `scripts/acceptance-receipt.ts`, where `src/effects/evidence` does
+ * not exist -- see tests/helper-scripts.test.ts): the dynamic import below
+ * resolves relative to `PACKAGE_ROOT`, which in that context is the
+ * deployed target repo's own root, not this tool's. A module-resolution
+ * failure there is indistinguishable from "no ledger to import into" and is
+ * treated as a cannot-bind skip (record still succeeds) -- never a crash.
+ * Any OTHER failure (the module resolves but the import itself reports a
+ * real fail-closed reason) still fails the record command: an acceptance
+ * that cannot enter the evidence authority must not report success.
+ */
+async function importAttestedReceiptIfApplicable(root: string, receipt: AcceptanceReceipt): Promise<void> {
+  if (receipt.disposition !== 'external_pass' && receipt.disposition !== 'user_waiver') return;
+
+  const modulePath = join(PACKAGE_ROOT, 'src', 'effects', 'evidence', 'attested-import.ts');
+  type AttestedImportModule = {
+    importAttestedEvidence: (input: {
+      repoRoot: string;
+      receipt: {
+        disposition: string;
+        reviewer: string;
+        source: string;
+        actor: string | null;
+        summary: string;
+        findings: AcceptanceFinding[];
+        subject_sha256: string;
+        target_revision: string;
+        contract_file: string;
+        issued_at: string;
+      };
+    }) => { ok: boolean; reason?: string; message?: string };
+  };
+  let attestedImport: AttestedImportModule;
+  try {
+    attestedImport = (await import(pathToFileURL(modulePath).href)) as AttestedImportModule;
+  } catch (error) {
+    if (isModuleUnresolvedError(error)) {
+      console.error('acceptance-receipt: attested-import module unavailable in this deployed-helper context; skipping ledger import (record unaffected)');
+      return;
+    }
+    throw error;
+  }
+
+  const result = attestedImport.importAttestedEvidence({
+    repoRoot: root,
+    receipt: {
+      disposition: receipt.disposition,
+      reviewer: receipt.reviewer,
+      source: receipt.source,
+      actor: receipt.actor,
+      summary: receipt.summary,
+      findings: receipt.findings,
+      subject_sha256: receipt.subject_sha256,
+      target_revision: receipt.target_revision,
+      contract_file: receipt.contract_file,
+      issued_at: receipt.issued_at,
+    },
+  });
+  if (!result.ok) {
+    fail(`AcceptanceReceipt recorded but ledger import failed closed: ${result.message ?? result.reason}`);
+  }
+}
+
+function isModuleUnresolvedError(error: unknown): boolean {
+  return (error as { code?: string } | null | undefined)?.code === 'ERR_MODULE_NOT_FOUND';
+}
+
 function option(argv: string[], name: string, required = true): string | undefined {
   const index = argv.indexOf(name);
   const value = index >= 0 ? argv[index + 1] : undefined;
@@ -715,6 +795,7 @@ export async function runAcceptanceReceiptCli(argv: string[], opts: Options = {}
         verification: option(argv, '--verification')!,
         now: opts.now,
       });
+      await importAttestedReceiptIfApplicable(root, receipt);
       const review = option(argv, '--review', false);
       if (review) projectAcceptance(resolve(root, review), receipt);
       console.log(JSON.stringify(receipt));
@@ -734,6 +815,7 @@ export async function runAcceptanceReceiptCli(argv: string[], opts: Options = {}
       findings: validateFindings(JSON.parse(findingsRaw)),
       now: opts.now,
     });
+    await importAttestedReceiptIfApplicable(root, receipt);
     const review = option(argv, '--review', false);
     if (review) projectAcceptance(resolve(root, review), receipt);
     console.log(JSON.stringify(receipt));

--- a/src/effects/evidence/attested-import.ts
+++ b/src/effects/evidence/attested-import.ts
@@ -1,0 +1,320 @@
+/**
+ * Manual/external attested import (Sprint C backlog row 8). Imports one
+ * recorded AcceptanceReceipt into the EPC-01 ledger as ONE attested
+ * EvidenceEvent, binding a closed two-entry trust mapping by construction
+ * (D4): `external_pass` -> `external_attested`; `user_waiver` ->
+ * `human_acceptance`. Any other disposition fails closed -- there is no API
+ * path in this module that emits `authoritative_machine` or `observed`.
+ *
+ * EPC-01/EPC-02 read-only imports only: `../../core/evidence/types`,
+ * `./event-log`, `./epoch`. No EPC-01/EPC-02 file is modified by this
+ * package.
+ *
+ * D3 subject identity: `subject_sha256`/`target_revision` come straight from
+ * the receipt's own binding -- the receipt already froze these at record
+ * time, so recomputing them fresh here could silently diverge from what the
+ * reviewer actually accepted (plan P3). The remaining identity fields
+ * (`target_commit`, `contract_hash`, `scope_hash`, `authority_commit`,
+ * `env_provider_id`) are not carried by the receipt at all, so they are
+ * computed from current repo state the same way
+ * `src/effects/evidence/verify-producer.ts` computes them (read-only
+ * pattern reference). That module's equivalent helpers are private and
+ * unexported and the file itself is read-only, so the small git/parsing
+ * helpers below are necessarily local, independent copies -- see
+ * tasks/notes/20260722-1810-epc-04-manual-external-attested-import.notes.md.
+ */
+import { createHash } from "crypto";
+import { execFileSync } from "child_process";
+import { existsSync, readFileSync } from "fs";
+import { dirname, join, resolve } from "path";
+import { fileURLToPath } from "url";
+
+import type {
+  EvidenceEventRecord,
+  GenesisRecord,
+  JsonValue,
+  SubjectIdentity,
+  TrustClass,
+} from "../../core/evidence/types";
+import { appendEvidenceEvent, appendGenesisRecord } from "./event-log";
+import { LEDGER_EPOCH_START_SHA } from "./epoch";
+
+const PRODUCER_ID = "acceptance-receipt";
+const EVENT_TYPE = "acceptance_receipt.attested_import";
+
+// No verification command runs for an import (this evidence is imported,
+// not freshly produced by a verification run); D3's command_hash still
+// requires a non-empty value, so a fixed label identifies "the operation
+// that always produces this event_type" -- constant across every import, so
+// it never breaks idempotency for a repeated import of the same receipt.
+const IMPORT_COMMAND_LABEL = "repo-harness acceptance-receipt record (attested-import)";
+
+const MODULE_DIR = dirname(fileURLToPath(import.meta.url));
+const PACKAGE_ROOT = resolve(MODULE_DIR, "../../..");
+
+/** D4: closed two-entry table. Any disposition not listed here fails closed -- never a default branch (plan P3). */
+const DISPOSITION_TRUST_MAP: Readonly<Record<string, TrustClass>> = Object.freeze({
+  external_pass: "external_attested",
+  user_waiver: "human_acceptance",
+});
+
+export type AttestedImportFailureReason =
+  | "unsupported_disposition"
+  | "missing_actor"
+  | "missing_reason"
+  | "missing_subject"
+  | "genesis_epoch_conflict";
+
+export interface AttestedImportFailure {
+  readonly ok: false;
+  readonly reason: AttestedImportFailureReason;
+  readonly message: string;
+}
+
+export interface AttestedImportSuccess {
+  readonly ok: true;
+  readonly event: EvidenceEventRecord;
+  readonly genesis: GenesisRecord;
+}
+
+export type AttestedImportResult = AttestedImportSuccess | AttestedImportFailure;
+
+/**
+ * The minimal, structural shape of an AcceptanceReceipt this module needs.
+ * Deliberately not imported from `scripts/acceptance-receipt.ts` -- `src/`
+ * must not depend on `scripts/`. Any object with this shape, including a
+ * real `AcceptanceReceipt`, satisfies it structurally.
+ */
+export interface AttestedReceiptInput {
+  readonly disposition: string;
+  readonly reviewer: string;
+  readonly source: string;
+  readonly actor: string | null;
+  readonly summary: string;
+  readonly findings: readonly { readonly severity: string; readonly message: string }[];
+  readonly subject_sha256: string;
+  readonly target_revision: string;
+  readonly contract_file: string;
+  readonly issued_at: string;
+}
+
+export interface AttestedImportInput {
+  /** Repo root the receipt was recorded against. */
+  readonly repoRoot: string;
+  readonly receipt: AttestedReceiptInput;
+  readonly correlationRunId?: string;
+}
+
+function sha256Hex(content: Buffer | string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+function gitOutput(repoRoot: string, args: readonly string[]): { readonly ok: boolean; readonly text: string } {
+  try {
+    const text = execFileSync("git", ["-C", repoRoot, "--literal-pathspecs", ...args], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return { ok: true, text };
+  } catch {
+    return { ok: false, text: "" };
+  }
+}
+
+function resolveHead(repoRoot: string): string | null {
+  const result = gitOutput(repoRoot, ["rev-parse", "--verify", "HEAD"]);
+  const sha = result.text.trim();
+  return result.ok && sha.length > 0 ? sha : null;
+}
+
+function lastCommitTouching(repoRoot: string, relativePath: string): string | null {
+  const result = gitOutput(repoRoot, ["log", "-1", "--format=%H", "--", relativePath]);
+  if (!result.ok) return null;
+  const sha = result.text.trim();
+  return sha.length > 0 ? sha : null;
+}
+
+/**
+ * This module's own `package.json` version -- the repo-harness tool's own
+ * version, independent of whichever `repoRoot` is being imported into
+ * (pattern reference: `verify-producer.ts`'s private `providerCliVersion`;
+ * necessarily duplicated, not imported -- see module doc).
+ */
+function providerCliVersion(): string {
+  try {
+    const pkg = JSON.parse(readFileSync(join(PACKAGE_ROOT, "package.json"), "utf-8")) as { readonly version?: unknown };
+    return typeof pkg.version === "string" && pkg.version.length > 0 ? pkg.version : "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+}
+
+/** Isolated workspace id (pattern reference: `verify-producer.ts`'s private `workspaceId`; necessarily duplicated). */
+function workspaceId(repoRoot: string): string {
+  const result = gitOutput(repoRoot, ["rev-parse", "--show-toplevel"]);
+  const real = result.ok && result.text.trim() ? result.text.trim() : repoRoot;
+  return `ws-${sha256Hex(real).slice(0, 12)}`;
+}
+
+/**
+ * Extract the `allowed_paths:` list from the contract's fenced ```yaml block
+ * (pattern reference: `verify-producer.ts`'s private `parseContractAllowedPaths`;
+ * necessarily duplicated -- see module doc).
+ */
+function parseContractAllowedPaths(contractText: string): readonly string[] {
+  const yamlBlockPattern = /```yaml\r?\n([\s\S]*?)\r?\n```/g;
+  let match: RegExpExecArray | null;
+  while ((match = yamlBlockPattern.exec(contractText)) !== null) {
+    const block = match[1] ?? "";
+    if (!/(^|\s)allowed_paths:/m.test(block)) continue;
+    const lines = block.split(/\r?\n/);
+    const startIndex = lines.findIndex((line) => /^\s*allowed_paths:\s*$/.test(line));
+    if (startIndex === -1) continue;
+    const paths: string[] = [];
+    for (let i = startIndex + 1; i < lines.length; i++) {
+      const line = lines[i] ?? "";
+      if (/^\S/.test(line)) break;
+      const itemMatch = line.match(/^\s*-\s*(.+?)\s*$/);
+      if (!itemMatch) continue;
+      const value = (itemMatch[1] ?? "").replace(/^["'`]+|["'`]+$/g, "");
+      if (value.length > 0) paths.push(value);
+    }
+    return paths;
+  }
+  return [];
+}
+
+function uniqueSortedPaths(values: readonly string[]): string[] {
+  return Array.from(new Set(values.filter(Boolean))).sort((a, b) => Buffer.compare(Buffer.from(a), Buffer.from(b)));
+}
+
+function worktreeIdFor(contractRelative: string): string {
+  const base = contractRelative.split("/").pop() ?? contractRelative;
+  return base.replace(/\.contract\.md$/, "");
+}
+
+/**
+ * D6 redaction hashes any 32+ char dot-free alnum run; a full
+ * `sha256:<64-hex>` reference stored verbatim would come back uselessly
+ * re-hashed (the exact bug EPC-02's dogfood run caught), so only a short
+ * prefix travels in the payload (pattern reference: `verify-producer.ts`'s
+ * `shortRunSnapshotId`).
+ */
+function shortHashRef(hash: string): string {
+  const hex = hash.startsWith("sha256:") ? hash.slice("sha256:".length) : hash;
+  return hex.slice(0, 16);
+}
+
+/**
+ * Single entry point: maps disposition to a trust class through the closed
+ * D4 table, validates every required field fails closed when absent/empty,
+ * builds the full D3 subject identity (receipt binding + computed repo
+ * state), ensures genesis, and appends exactly one attested EvidenceEvent.
+ * Every failure below returns before any genesis/append side effect runs.
+ */
+export function importAttestedEvidence(input: AttestedImportInput): AttestedImportResult {
+  const { repoRoot, receipt } = input;
+
+  const trustClass = DISPOSITION_TRUST_MAP[receipt.disposition];
+  if (!trustClass) {
+    return {
+      ok: false,
+      reason: "unsupported_disposition",
+      message: `disposition "${receipt.disposition}" has no attested trust mapping; only external_pass and user_waiver may be imported`,
+    };
+  }
+
+  const reviewer = receipt.reviewer?.trim();
+  if (!reviewer) {
+    return { ok: false, reason: "missing_actor", message: "receipt reviewer is required to import an attested event" };
+  }
+
+  const summary = receipt.summary?.trim();
+  if (!summary) {
+    return { ok: false, reason: "missing_reason", message: "receipt summary is required to import an attested event" };
+  }
+
+  const subjectSha256 = receipt.subject_sha256?.trim();
+  const targetRevision = receipt.target_revision?.trim();
+  if (!subjectSha256 || !targetRevision) {
+    return {
+      ok: false,
+      reason: "missing_subject",
+      message: "receipt subject_sha256 and target_revision are required to import an attested event",
+    };
+  }
+
+  const contractRelative = receipt.contract_file?.trim();
+  if (!contractRelative || !existsSync(join(repoRoot, contractRelative))) {
+    return {
+      ok: false,
+      reason: "missing_subject",
+      message: `receipt contract_file is missing or unreadable: ${receipt.contract_file}`,
+    };
+  }
+
+  const targetCommit = resolveHead(repoRoot);
+  if (!targetCommit) {
+    return { ok: false, reason: "missing_subject", message: "worktree HEAD could not be resolved" };
+  }
+
+  const authorityCommit = lastCommitTouching(repoRoot, contractRelative);
+  if (!authorityCommit) {
+    return {
+      ok: false,
+      reason: "missing_subject",
+      message: `no commit touches ${contractRelative}; authority commit is unavailable`,
+    };
+  }
+
+  const contractBytes = readFileSync(join(repoRoot, contractRelative));
+  const contractHash = `sha256:${sha256Hex(contractBytes)}`;
+  const allowedPaths = parseContractAllowedPaths(contractBytes.toString("utf-8"));
+  const scopeHash = `sha256:${sha256Hex(JSON.stringify(uniqueSortedPaths(allowedPaths)))}`;
+  const envProviderId = `repo-harness/${providerCliVersion()}/${workspaceId(repoRoot)}`;
+
+  const subjectIdentity: SubjectIdentity = {
+    authority_commit: authorityCommit,
+    base_commit: targetRevision,
+    target_commit: targetCommit,
+    scope_hash: scopeHash,
+    subject_hash: subjectSha256,
+    contract_hash: contractHash,
+    command_hash: `sha256:${sha256Hex(IMPORT_COMMAND_LABEL)}`,
+    env_provider_id: envProviderId,
+  };
+
+  const worktreeId = worktreeIdFor(contractRelative);
+  let genesis: GenesisRecord;
+  try {
+    genesis = appendGenesisRecord(repoRoot, LEDGER_EPOCH_START_SHA, { worktreeId });
+  } catch (error) {
+    return {
+      ok: false,
+      reason: "genesis_epoch_conflict",
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  const payload: JsonValue = {
+    disposition: receipt.disposition,
+    reviewer: receipt.reviewer,
+    source: receipt.source,
+    actor: receipt.actor,
+    summary: receipt.summary,
+    findings_count: receipt.findings.length,
+    receipt_ref: shortHashRef(subjectSha256),
+  };
+
+  const event = appendEvidenceEvent(repoRoot, {
+    worktreeId: genesis.worktree_id,
+    eventType: EVENT_TYPE,
+    trustClass,
+    producer: PRODUCER_ID,
+    correlationRunId: input.correlationRunId ?? `run-${Date.now()}`,
+    subjectIdentity,
+    payload: { kind: "json", value: payload },
+  });
+
+  return { ok: true, event, genesis };
+}

--- a/tasks/contracts/20260722-1810-epc-04-manual-external-attested-import.contract.md
+++ b/tasks/contracts/20260722-1810-epc-04-manual-external-attested-import.contract.md
@@ -1,0 +1,332 @@
+# Task Contract: epc-04-manual-external-attested-import
+
+> **Status**: Active
+> **Plan**: plans/plan-20260722-1810-epc-04-manual-external-attested-import.md
+> **Task Profile**: code-change
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: kito
+> **Reviewer**: Claude
+> **Waiver Policy**: user_waiver allowed, owner kito only, per Acceptance Policy below
+> **Base SHA**: `8861b40dd85c0f7faabe8eecd217baf5528a7f3c` (pinned per R1 post-EPC-02: fresh fetch after PR #118 merged, plus its row-flip commit `docs(program): mark epc-02 done via PR #118; EPC-03/04 wave unblocked`; verified equal to this worktree's HEAD at task start)
+> **Target Branch**: main (via one independent PR)
+> **Working Branch**: `codex/epc-04-manual-external-attested-import`
+> **PR Unit**: one PR carrying the attested-import module, the `scripts/acceptance-receipt.ts` wiring edit (plus its deterministic `assets/templates/helpers/` mirror), the test suite, and this package's workflow artifacts
+> **Capability ID**: root
+> **Last Updated**: 2026-07-22 18:10
+> **Review File**: `tasks/reviews/20260722-1810-epc-04-manual-external-attested-import.review.md`
+> **Notes File**: `tasks/notes/20260722-1810-epc-04-manual-external-attested-import.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+EPC-04 implements Sprint C backlog row 8: manual/external attested import.
+The acceptance flow is the Program's only legitimate source of
+human/external trust; today the receipt is a standalone JSON plus a
+Markdown projection, with nothing tying it into the evidence authority
+rows 9-12 will select from. Recording an AcceptanceReceipt now imports it
+into the EPC-01 ledger as an attested event: disposition `external_pass`
+-> trust `external_attested`, disposition `user_waiver` -> trust
+`human_acceptance` (D4). This makes attested trust a first-class ledger
+fact instead of a parallel shadow authority, while leaving the receipt
+JSON/projection flow itself unchanged.
+
+## Goal
+
+1. `src/effects/evidence/attested-import.ts`: imports one recorded
+   AcceptanceReceipt as ONE attested event via the EPC-01 writer
+   (`appendEvidenceEvent`/`appendGenesisRecord`), genesis via
+   `LEDGER_EPOCH_START_SHA` (EPC-02's epoch constant, imported read-only).
+   Trust mapping is a closed two-entry table: `external_pass` ->
+   `external_attested`; `user_waiver` -> `human_acceptance`; any other
+   disposition -> fail closed (`unsupported_disposition`). No API path in
+   this module emits `authoritative_machine` or `observed`. Required
+   fields fail closed when absent/empty: actor (receipt reviewer),
+   reason (receipt summary), and the full D3 subject identity taken from
+   the receipt's own binding (`subject_sha256` -> `subject_hash`,
+   `target_revision` -> `base_commit`) plus repo-state fields computed the
+   same way `verify-producer.ts` computes them (worktree HEAD ->
+   `target_commit`; contract file hash -> `contract_hash`; ordered
+   `allowed_paths` -> `scope_hash`; last commit touching the contract ->
+   `authority_commit`; recording host identity -> `env_provider_id`).
+   Payload is small and structured (disposition, reviewer, source, actor,
+   summary, findings count, a short 16-hex-char subject-hash reference) --
+   never a raw 32+ char dot-free hash/path verbatim, which EPC-01's D6
+   redaction would over-redact into a useless double-hash.
+2. Wire `scripts/acceptance-receipt.ts` at the CLI level only (inside
+   `runAcceptanceReceiptCli`'s `record` command, both the `user_waiver`
+   and `external_pass`/`reject` branches -- never inside the exported
+   `recordAcceptance`/`recordUserWaiverAcceptance` functions themselves):
+   after a successful record, dynamically import
+   `src/effects/evidence/attested-import.ts` and import the just-recorded
+   receipt into the ledger; `reject` is skipped (D4's table has no entry
+   for it and it is not a claim of acceptance). Import failure fails the
+   record command (fail closed -- an acceptance that cannot enter the
+   evidence authority must not report success). Deployed-helper context
+   (an adopted downstream repo, or `tests/helper-scripts.test.ts`'s bare
+   `copyHelpers()` fixtures, where `src/effects/evidence` does not exist):
+   a module-resolution failure (`ERR_MODULE_NOT_FOUND`) is a cannot-bind
+   skip, not a crash -- record still succeeds; any other failure (the
+   module resolves but the import itself reports a real fail-closed
+   reason) still fails the command. `assets/templates/helpers/acceptance-receipt.ts`
+   stays a byte-identical mirror via `bun run sync:helpers`.
+3. `tests/evidence-attested-import.test.ts`, red-first (confirmed: the
+   suite fails with "Cannot find module" before the implementation
+   existed): `external_pass` maps to `external_attested` and `user_waiver`
+   to `human_acceptance`; an unknown/bogus disposition fails closed with
+   nothing appended; missing actor/reason/subject fields fail closed with
+   nothing appended; an attested-only ledger's accepted fold filtered for
+   `authoritative_machine` is empty (default-deny at the trust level);
+   identical re-import dedups to one accepted event via the idempotency
+   key (two physical appends); genesis is written once with
+   `LEDGER_EPOCH_START_SHA`; a direct `runAcceptanceReceiptCli(['record',
+   ...])` integration test proves the CLI wiring itself appends one
+   accepted `external_attested` event, and that `reject` leaves the
+   ledger untouched.
+4. All root required checks green; one independent PR on
+   `codex/epc-04-manual-external-attested-import`.
+
+## Scope
+
+- In scope: `src/effects/evidence/attested-import.ts`,
+  `scripts/acceptance-receipt.ts` (wiring edit only, CLI-level),
+  `assets/templates/helpers/acceptance-receipt.ts` (deterministic mirror,
+  regenerated via `bun run sync:helpers`), `tests/evidence-attested-import.test.ts`,
+  this package's plan/contract/review/notes, `tasks/todos.md` projection,
+  `.ai/harness/worktrees/epc-04-manual-external-attested-import.json`.
+- Out of scope: every EPC-01/EPC-02 file (`src/core/evidence/*`,
+  `src/effects/evidence/*` existing files including `epoch.ts` and
+  `verify-producer.ts` -- read-only imports/pattern reference only),
+  `src/cli/hook/command-observed.ts` and every other EPC-03 surface
+  (`src/effects/evidence/post-bash-importer.ts`,
+  `tests/evidence-post-bash-importer.test.ts`), `checks/latest`
+  composition, any gate logic, handoff writers, `tasks/current.md`, the
+  sprint document, any new npm dependency.
+- Non-goals: gate cutover (EPC-05 selects `external_attested` where a
+  contract's Acceptance Policy enumerates it); receipt schema changes;
+  retiring the receipt JSON or its Markdown projection.
+- Taste constraints: match the existing `core`/`effects` idiom (readonly
+  interfaces, `{ ok, ... }`/discriminated-union result shapes, plain
+  exported functions, no classes, no barrel `index.ts`); smallest diff
+  that satisfies the frozen D2-D6 decisions; private per-producer
+  git/contract helpers, not shared with `verify-producer.ts` (R4); the
+  receipt shape `attested-import.ts` accepts is a locally-declared
+  structural interface, never an import of `scripts/acceptance-receipt.ts`'s
+  own `AcceptanceReceipt` type (`src/` must not depend on `scripts/`).
+
+## Stop Conditions
+
+- Stop and hand back to the parent if `origin/main` has moved past
+  `8861b40dd85c0f7faabe8eecd217baf5528a7f3c` before this package's
+  worktree was created -- re-fetch and re-audit, never silently re-pin.
+- Stop and hand back to the parent if correct emission would require
+  modifying an EPC-01/EPC-02 module or touching any EPC-03 surface --
+  report instead of widening scope silently.
+- Stop if `check-architecture-sync` BLOCKS (not merely advises) on the
+  changed capability surfaces -- report rather than editing
+  `.ai/context/` or architecture files.
+- Stop after three fail-fix-reverify rounds on one issue.
+
+## Falsifier
+
+The direction is wrong if the receipt's existing binding cannot populate
+the D3 identity without schema changes, or if record-time import breaks
+the receipt flow's staleness invariant (record must still immediately
+follow evidence preparation). Cheapest proof: this package's own
+acceptance flow records its receipt successfully AND the worktree ledger
+then contains exactly one accepted `external_attested` event referencing
+that receipt.
+
+## Root Cause Evidence
+
+Not applicable: Task Profile is `code-change`, not `bugfix`.
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260722-1810-epc-04-manual-external-attested-import.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260722-1810-epc-04-manual-external-attested-import.review.md`
+- Notes file: `tasks/notes/20260722-1810-epc-04-manual-external-attested-import.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Acceptance Policy
+
+```json
+{"protocol":1,"reviewer":"Claude","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - plans/plan-20260722-1810-epc-04-manual-external-attested-import.md
+  - tasks/contracts/20260722-1810-epc-04-manual-external-attested-import.contract.md
+  - tasks/reviews/20260722-1810-epc-04-manual-external-attested-import.review.md
+  - tasks/notes/20260722-1810-epc-04-manual-external-attested-import.notes.md
+  - src/effects/evidence/attested-import.ts
+  - scripts/acceptance-receipt.ts
+  - assets/templates/helpers/acceptance-receipt.ts
+  - tests/evidence-attested-import.test.ts
+  - .ai/harness/worktrees/epc-04-manual-external-attested-import.json
+  - tasks/todos.md
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # New producer; no benchmark-subject-touching change in this package.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+      - codex-exec
+      - main-thread
+    fallback: main-thread
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - src/effects/evidence/attested-import.ts
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260722-1810-epc-04-manual-external-attested-import.notes.md
+  tests_pass:
+    - path: tests/evidence-attested-import.test.ts
+  commands_succeed:
+    - bash scripts/check-task-workflow.sh --strict
+  manual_checks:
+    - "PR diff confined to allowed_paths; no EPC-01/EPC-02 file modified; zero overlap with EPC-03 allowed_paths"
+    - "Own acceptance receipt appears as accepted external_attested event in the worktree ledger (dogfood)"
+    - "tasks/current.md untouched"
+```
+
+## Concurrency and Ownership
+
+- **R4 wave qualification proof** (EPC-02/03/04 parallel wave, evaluated
+  after EPC-01/EPC-02 merged): schema, trust matrix, and idempotency are
+  frozen by the EPC-00 design freeze and already merged via EPC-01
+  (`src/core/evidence/types.ts`, `fold.ts`) and EPC-02
+  (`src/effects/evidence/epoch.ts`, `verify-producer.ts` as pattern
+  reference) -- this package does not re-decide or modify any of them.
+- **Exact `allowed_paths` disjointness**: this package's `allowed_paths`
+  (above) has zero overlap with EPC-03's. EPC-03 owns
+  `src/cli/hook/command-observed.ts`,
+  `src/effects/evidence/post-bash-importer.ts`,
+  `tests/evidence-post-bash-importer.test.ts`, and its own
+  plan/contract/review/notes/worktree-registration files. This package
+  owns `scripts/acceptance-receipt.ts`,
+  `assets/templates/helpers/acceptance-receipt.ts`,
+  `src/effects/evidence/attested-import.ts`,
+  `tests/evidence-attested-import.test.ts`, and its own
+  plan/contract/review/notes/worktree-registration files. Neither package
+  touches the other's file (verified directly against EPC-03's own
+  contract, `tasks/contracts/20260722-1810-epc-03-postbash-observed-importer.contract.md`,
+  which lists this package's paths identically under its own EPC-04
+  disjointness proof).
+- **Disjoint test fixtures**: this package's fixtures use tmp roots
+  prefixed `attested-import-*` (`tests/evidence-attested-import.test.ts`),
+  distinct from EPC-03's `post-bash-importer-*` fixture names.
+- **No shared barrel/export file**: there is no `index.ts` anywhere under
+  `src/effects/evidence/` (confirmed at task start and unchanged by this
+  package); each producer is imported directly by its own path.
+- **No shared store writer**: this package calls the existing EPC-01
+  writer (`appendEvidenceEvent`/`appendGenesisRecord` in
+  `src/effects/evidence/event-log.ts`) exactly as EPC-02/EPC-03 already
+  do; it adds no new writer and edits no existing writer.
+- **No shared projection writer**: this package produces no
+  `checks/latest`-style projection; the receipt JSON and its Markdown
+  projection (`renderAcceptanceProjection`/`projectAcceptance`) are
+  unchanged pre-existing surfaces, not a projection this row retires or
+  rewrites.
+- This package's own private git/contract helpers (`resolveHead`,
+  `lastCommitTouching`, `parseContractAllowedPaths`, `providerCliVersion`,
+  `workspaceId`, etc., in `attested-import.ts`) are a separate,
+  non-exported copy from `verify-producer.ts`'s equivalents -- read as a
+  pattern reference only, never imported from, per R4's "no shared"
+  wave-qualification requirement.
+- The `scripts/acceptance-receipt.ts` wiring lives entirely at the CLI
+  layer (`runAcceptanceReceiptCli`'s `record` branch), not inside the
+  exported `recordAcceptance`/`recordUserWaiverAcceptance` functions
+  themselves, so `tests/acceptance-receipt.test.ts` (which imports those
+  functions directly and never gitignores `.ai/harness/evidence/` in its
+  own fixture) never exercises the new ledger-import side effect and
+  stays a pure characterization suite of the pre-existing receipt flow.
+- If an out-of-band merge lands on `main` touching this package's
+  `allowed_paths` before this package's PR merges, stop, re-fetch, and
+  re-derive against the new state; never force-push over it.
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior: adds a new attested-import module
+  (`importAttestedEvidence`) and wires it additively into
+  `scripts/acceptance-receipt.ts`'s CLI `record` command after a
+  successful receipt build. No existing EPC-01/EPC-02 file, and no EPC-03
+  file, is modified. `assets/templates/helpers/acceptance-receipt.ts`
+  stays byte-identical via `sync:helpers`.
+- Edge cases: unknown/bogus disposition; empty reviewer/summary/subject
+  fields; an uncommitted or never-committed contract file (no authority
+  commit available); re-import with identical inputs (idempotency dedup
+  at fold time, not at append time); re-import with a different subject
+  (not deduped); genesis-before-append semantics reused unmodified from
+  EPC-01; a deployed-helper context where the module cannot resolve
+  (cannot-bind skip, not a crash); `reject` disposition is skipped by the
+  wiring entirely (no attested trust mapping exists for it, and turning
+  an already-exit-code-1 rejection into a hard crash is out of scope).
+- Regression risks: none to existing runtime surfaces -- the only
+  existing file touched is `scripts/acceptance-receipt.ts`, and only
+  additively (two new calls inside the CLI `record` branch, after the
+  receipt object is already built; no existing line altered, no exported
+  function's behavior changed). The full existing
+  `tests/acceptance-receipt.test.ts` (9 tests) and
+  `tests/helper-scripts.test.ts` (121 tests, including the
+  `sync-helper-sources.ts --check` drift guard) suites were re-run after
+  this wiring change and stayed green. The residual risk surface is a
+  later EPC-0N package mis-citing the frozen epoch constant or bypassing
+  `importAttestedEvidence`'s single entry point, guarded by this
+  package's Falsifier and the closed two-entry trust mapping.
+
+## Rollback Point
+
+- Commit / checkpoint: the single commit on
+  `codex/epc-04-manual-external-attested-import` before it merges.
+- Revert strategy: revert the single PR -- every change is a new module
+  (`attested-import.ts`), a new test suite, and one additive wiring edit
+  in `scripts/acceptance-receipt.ts` (two new calls inside the CLI
+  `record` branch, no existing line altered) plus its deterministic
+  helper mirror; this package's workflow artifacts revert with it.
+  Receipt JSON/projection authoring and every other surface are
+  unchanged, so reverting cannot regress any existing consumer.

--- a/tasks/notes/20260722-1810-epc-04-manual-external-attested-import.notes.md
+++ b/tasks/notes/20260722-1810-epc-04-manual-external-attested-import.notes.md
@@ -1,0 +1,213 @@
+# Implementation Notes: epc-04-manual-external-attested-import
+
+> **Status**: Active
+> **Plan**: plans/plan-20260722-1810-epc-04-manual-external-attested-import.md
+> **Contract**: tasks/contracts/20260722-1810-epc-04-manual-external-attested-import.contract.md
+> **Review**: tasks/reviews/20260722-1810-epc-04-manual-external-attested-import.review.md
+> **Last Updated**: 2026-07-22 18:10
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- **Deployed-helper import resolution (the caution's central question).**
+  `scripts/acceptance-receipt.ts` already has one dynamic import
+  (`currentSubject`'s `import(pathToFileURL(join(PACKAGE_ROOT, 'src',
+  'effects', 'review', 'diff-fingerprint.ts')).href)`) with no safety net
+  at all -- it crashes uncaught if that file is missing. Empirically
+  confirmed (`bun` probe script, not committed) that Bun's dynamic-import
+  resolution failure surfaces as `error.name === "ResolveMessage"` and
+  `error.code === "ERR_MODULE_NOT_FOUND"`, while a module that resolves
+  but throws at its own top level surfaces as a plain `Error` with
+  `code === undefined`. This is a clean, reliable discriminator, so the
+  new `importAttestedReceiptIfApplicable` wraps its dynamic import of
+  `src/effects/evidence/attested-import.ts` in a `try`/`catch` that treats
+  `error.code === 'ERR_MODULE_NOT_FOUND'` as a cannot-bind skip (record
+  still succeeds, one stderr notice) and re-throws anything else (a real
+  failure in a resolvable context still fails record). This mirrors
+  `scripts/verify-sprint.sh`'s `emit_verify_evidence` bash-level
+  cannot-bind pattern (EPC-02), adapted to a TS-to-TS import instead of a
+  bash-to-TS invocation: EPC-02 checks file existence in bash before ever
+  invoking `bun`; this package catches the resolution failure directly in
+  the same running TS process, since there is no bash intermediary for a
+  same-process dynamic import.
+- **Wiring lives at the CLI layer, not inside `recordAcceptance`/
+  `recordUserWaiverAcceptance`.** The plan says "at the end of a
+  successful record, import the just-recorded receipt." The literal
+  reading -- calling the import from inside the two exported functions --
+  was tried first and rejected after tracing `tests/acceptance-receipt.test.ts`'s
+  `makeFixture`: its `.gitignore` only excludes `.ai/harness/checks/`, not
+  `.ai/harness/evidence/`, and `diff-fingerprint.ts`'s
+  `isOperationalReviewPath` (read-only, out of this package's scope) does
+  not exclude `.ai/harness/evidence/` either. Writing evidence-store files
+  inside those functions would make them part of the "implementation
+  paths" `buildReviewSubject` hashes, so a *second* record call in the
+  same test fixture (e.g. "reuses one owner grant after semantic
+  correction...") would see a `review_subject_sha256` computed *after* the
+  first import's on-disk writes, while the receipt object captured its
+  subject *before* those writes -- the final `verifyAcceptance` assertion
+  in that test would then observe a freshly-recomputed subject that no
+  longer matches `second.subject_sha256`, breaking a characterization test
+  this package is forbidden to edit (`tests/acceptance-receipt.test.ts` is
+  outside `allowed_paths`). Moving the import call to the CLI's `record`
+  command handler in `runAcceptanceReceiptCli` (after either
+  `recordAcceptance` or `recordUserWaiverAcceptance` returns, before the
+  receipt is printed) sidesteps this entirely: that test file imports
+  `recordAcceptance`/`recordUserWaiverAcceptance` directly and never calls
+  `runAcceptanceReceiptCli`, so it never exercises the new code path at
+  all. Verified by re-running the full suite: `tests/acceptance-receipt.test.ts`
+  (9 tests) and `tests/helper-scripts.test.ts` (121 tests, which also
+  never invoke the real `record` subcommand -- only `verify`/`project` --
+  confirmed by grep across `scripts/*.sh` before writing this wiring)
+  both stayed green.
+- **Consequence accepted**: because the import now runs *after*
+  `writeReceipt` (inside the two library functions) rather than before it,
+  a genuine (non-cannot-bind) ledger-import failure leaves the receipt
+  file already written to `~/.repo-harness/gates/<hash>/acceptance.latest.json`
+  even though the `record` command exits non-zero. This is judged
+  acceptable: every existing consumer of that state (`verify`/`project`,
+  and every bash caller in `verify-sprint.sh`/`contract-worktree.sh`/
+  `ship-worktrees.sh`) already gates on the *command's exit code*, not
+  file existence, so a non-zero `record` exit is still the correct and
+  sufficient failure signal. The alternative (moving the import inside
+  the exported functions, before `writeReceipt`, for a stronger
+  no-orphaned-file guarantee) was rejected because it reintroduces the
+  test-breaking risk above, and "characterization suites MUST stay green"
+  is an explicit hard constraint that outranks a stronger atomicity
+  guarantee nothing in the plan actually asked for.
+- **`reject` is skipped by the wiring, not routed through
+  `importAttestedEvidence`.** D4's trust mapping has exactly two entries
+  (`external_pass`, `user_waiver`); `attested-import.ts`'s own mapping
+  function fails closed on any other disposition, including `reject`,
+  which is required and tested directly
+  (`tests/evidence-attested-import.test.ts`, "a completely bogus
+  disposition also fails closed"). But the CLI wiring itself special-cases
+  `reject` with an early return *before* calling into the module at all --
+  routing it through and letting it fail closed would turn an
+  intentional, already-exit-code-1 rejection into a **thrown error**
+  (`fail()` in `acceptance-receipt.ts`), which is a behavior change to an
+  existing, working code path this package is not asked to touch. Tested
+  directly: "real record --disposition reject does not touch the ledger."
+- **`command_hash` (D3) has no natural source for an import.** The
+  frozen D3 field list this package's Goal enumerates
+  (`subject_sha256`->`subject_hash`, `target_revision`->`base_commit`,
+  worktree HEAD->`target_commit`, contract hash->`contract_hash`, ordered
+  `allowed_paths`->`scope_hash`, last commit touching the contract->
+  `authority_commit`, host identity->`env_provider_id`) omits
+  `command_hash` entirely, but `SubjectIdentity` (EPC-01, read-only) has
+  no optional fields -- `command_hash` must be a non-empty string.
+  Unlike `verify-producer.ts` (which hashes the literal verification
+  command line), there is no "command" here: this evidence is imported,
+  not freshly produced by running something. Resolved as
+  `sha256(IMPORT_COMMAND_LABEL)` where `IMPORT_COMMAND_LABEL` is a fixed,
+  never-parameterized string constant identifying "the operation that
+  always produces this `event_type`." Being constant, it never varies
+  call-to-call for the same receipt, so it cannot break idempotency
+  (D5's key already varies correctly via `subject_hash`, which does
+  change per receipt).
+- **Payload field selection follows the plan's Goal text (source of
+  truth) over the dispatch's own abbreviated restatement.** The plan's
+  Goal item 1 lists the payload as "disposition, reviewer, source,
+  summary, findings count, receipt hash reference"; the dispatch's
+  restatement of Deliverable B omits `summary`. Since `reason` (a
+  required, fail-closed field per the same Goal item) has no field of its
+  own on `EvidenceEventRecord` -- the schema has no dedicated `reason` or
+  `actor` slot -- and "reason" is explicitly defined as "receipt summary,"
+  the only place either can live is the payload, so `summary` stays in and
+  `actor` (the receipt's raw, nullable field, not the reviewer) is also
+  included alongside `reviewer` as an independent key -- matching the
+  receipt's own two-field shape (`reviewer`, `actor`) rather than
+  inventing a combined string. Plain-English `summary` text is redaction-safe
+  in practice (EPC-01's D6 redaction only matches 32+ char runs with *no*
+  spaces, dots, or other punctuation breaking them; natural-language
+  sentences virtually never qualify), unlike a raw hash or filename.
+- **`receipt_ref` is a 16-hex-char prefix of `subject_sha256`, not the
+  full hash.** A full `sha256:<64-hex>` value stored verbatim in the
+  payload is exactly the 32+ char dot-free run EPC-01's D6 redaction
+  replaces with `sha256:<hash-of-that>` -- the same silent-uselessness bug
+  EPC-02's own dogfood run caught for its `run_snapshot_path` field (see
+  `tasks/notes/20260722-1634-epc-02-authoritative-verify-producer.notes.md`).
+  Verified directly in this package's own test ("emits the complete D3
+  field set and a redaction-safe short payload": asserts
+  `receipt_ref.length < 32` and does not contain the `sha256:` prefix) by
+  reading the accepted event back out of the real store (the actual
+  post-redaction value), not a pre-redaction copy.
+- **`AttestedReceiptInput` is a locally-declared structural type, not an
+  import of `scripts/acceptance-receipt.ts`'s `AcceptanceReceipt`.**
+  `src/` must not depend on `scripts/`; any object shaped like the
+  interface (including a real `AcceptanceReceipt`) satisfies it via
+  TypeScript structural typing, so the CLI wiring can pass a real receipt
+  object directly with no adapter beyond a field-by-field object literal.
+- **`verify-producer.ts`'s small git/parsing helpers
+  (`providerCliVersion`, `workspaceId`, `parseContractAllowedPaths`,
+  `lastCommitTouching`-equivalent) are necessarily duplicated locally in
+  `attested-import.ts`, not imported.** They are private/unexported in
+  the read-only `verify-producer.ts`, and that file cannot be modified to
+  export them (EPC-02 is out of scope). This mirrors EPC-03's own
+  documented choice (its contract's Concurrency section: "a separate,
+  non-exported copy from `verify-producer.ts`'s equivalents ... per R4's
+  'no shared' wave-qualification requirement") -- duplication here is the
+  R4-mandated shape, not a style preference.
+- **No "contract must be clean/committed" check distinct from the
+  generic subject-missing fail-closed path.** `verify-producer.ts` has a
+  dedicated `contract_not_committed` failure reason with its own dirty-vs-untracked
+  git-status check. This package does not replicate that machinery: the
+  plan's own required fixtures only name "missing actor/reason/subject
+  fail closed" and "unknown disposition fail closed," not a dirty-contract
+  case. Instead, `lastCommitTouching` returning null (which happens
+  whenever the contract was never committed) naturally falls under the
+  existing `missing_subject` fail-closed reason already required, tested
+  directly ("an uncommitted contract file fails closed"), without adding
+  a second git-status call or a new reason code the plan never asked for.
+
+## Deviations From Plan Or Spec
+
+- None. The dispatch's Deliverable B payload-field list (omitting
+  `summary`) is treated as an abbreviation of the plan's own Goal text,
+  not a deviation from it -- see the payload-selection decision above.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| Import inside `recordAcceptance`/`recordUserWaiverAcceptance` (stronger atomicity: no orphaned receipt file on ledger-import failure) vs. CLI-level only | CLI-level only | The former perturbs `buildReviewSubject`'s working-tree scan in `tests/acceptance-receipt.test.ts`'s fixture (no `.ai/harness/evidence/` gitignore there), breaking a characterization test outside this package's `allowed_paths`; the latter is fully invisible to that test file |
+| Route `reject` through `importAttestedEvidence` and let it fail closed vs. skip it in the wiring | Skip it | Routing through would turn an intentional exit-code-1 rejection into a thrown crash, an unrequested behavior change to an existing working path |
+| Bash-level file-existence check (EPC-02's exact mechanism) vs. TS-level dynamic-import try/catch for the deployed-helper cannot-bind case | TS-level try/catch | This is a TS-to-TS import inside the same process (no bash intermediary), so catching the resolution error directly is the equivalent mechanism for this call shape, per the dispatch's own suggestion |
+| Full `sha256:<64-hex>` receipt reference in the payload vs. a short prefix | Short (16-hex-char) prefix | The full value is a 32+ char dot-free run that EPC-01's D6 redaction silently re-hashes into a useless value (EPC-02 hit the identical bug with `run_snapshot_path`) |
+
+## Open Questions
+
+- None.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Red-first: `bun test tests/evidence-attested-import.test.ts` failed with
+  `error: Cannot find module '../src/effects/evidence/attested-import'`
+  before the implementation existed (verified directly: the finished
+  implementation file was moved aside, the suite re-run to confirm the
+  failure, then restored and re-run to confirm all 14 [later 16, after
+  adding the CLI-wiring integration tests] pass).
+- Dogfood: a standalone live invocation of `importAttestedEvidence`
+  against this worktree's own committed contract (commit
+  `248f970e29a84c25370867caec7c1dbdf2eb9162`) appended
+  `evt-01KY4QT0HY6FC3V0G0BF9VT4V1` (`external_attested`,
+  `acceptance_receipt.attested_import`) to
+  `.ai/harness/evidence/events/log.jsonl`, genesis
+  `ledger_epoch_start_sha = 5228d4ea0d7987cf6fb73be216d5b9cc638817c3`;
+  see the review file's Manual Check Evidence for the full field
+  readback. This package's own `acceptance-receipt.ts record` invocation
+  (recorded at closeout) additionally exercises the real CLI wiring,
+  appending a second accepted `external_attested` event referencing the
+  actual recorded receipt -- see the review file's Acceptance Receipt
+  Projection and the verification command tail for that event.
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/reviews/20260722-1810-epc-04-manual-external-attested-import.review.md
+++ b/tasks/reviews/20260722-1810-epc-04-manual-external-attested-import.review.md
@@ -55,11 +55,11 @@
 > **Actor**: not-applicable
 > **Reviewed Subject SHA256**: sha256:8af24eea61ed5c5a583e35b83c3caf0b533f1a28eddb2e771c625787412505f4
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: 691930c003f31a6d44c9ba8b5549c9e80d6cc9a0
+> **Reviewed Target Revision**: 8b797c5fec31b57e7c51cb16e3bc08b7aaff4097
 > **Verification Evidence SHA256**: sha256:c5bec0d7e7c28d2bd3cc99bf608c713940e8ce352436f250b433144432d9a4d4
-> **Issued At**: 2026-07-22T11:02:31.405Z
+> **Issued At**: 2026-07-22T11:27:14.276Z
 
-- Summary: EPC-04 accepted: manual/external attested import via closed D4 trust mapping (external_pass->external_attested, user_waiver->human_acceptance), fail-closed required fields, CLI-level wiring keeps characterization suites green, live dogfood ledger evidence recorded.
+- Summary: EPC-04 accepted: attested import with closed trust mapping and fail-closed required fields; CLI-layer wiring adjudicated unskippable (sole production entry); default-deny proven at fold level; gatekeeper PASS
 - Findings: none
 
 ## Behavior Diff Notes

--- a/tasks/reviews/20260722-1810-epc-04-manual-external-attested-import.review.md
+++ b/tasks/reviews/20260722-1810-epc-04-manual-external-attested-import.review.md
@@ -1,0 +1,94 @@
+# Task Review: epc-04-manual-external-attested-import
+
+> **Status**: Reviewed
+> **Plan**: plans/plan-20260722-1810-epc-04-manual-external-attested-import.md
+> **Contract**: tasks/contracts/20260722-1810-epc-04-manual-external-attested-import.contract.md
+> **Notes File**: tasks/notes/20260722-1810-epc-04-manual-external-attested-import.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-07-22 18:10
+> **Recommendation**: pass
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pass
+- Change type: code-change
+- Intended files changed: new `src/effects/evidence/attested-import.ts`, wiring in `scripts/acceptance-receipt.ts` (CLI-level, insertions only) with its deterministic mirror `assets/templates/helpers/acceptance-receipt.ts` (sync:helpers projection), new `tests/evidence-attested-import.test.ts`, package plan/contract/review/notes, `tasks/todos.md` projection
+- Actual files changed: exactly that set (9 paths touched; `.ai/harness/worktrees/epc-04-manual-external-attested-import.json` was pre-existing from worktree setup) — zero EPC-01/EPC-02 files modified, zero overlap with EPC-03's `allowed_paths`
+- Commands passed: `bun test tests/evidence-attested-import.test.ts` (16 pass, red-first), `bun test tests/acceptance-receipt.test.ts tests/helper-scripts.test.ts` (9 + 121 pass — previously-green characterization suites stay green), full `bun test` (1738 pass / 1 skip / 0 fail), `check:type` clean, `check-task-workflow --strict` OK, `contract-run preflight` preflight_pass, deploy-sql/architecture-sync (advisory blocking=0)/task-sync green, `inspect-project-state` no drift, `adopt --dry-run` 0 operations
+- Residual risks: `record`'s ledger import runs after the receipt file is already written (CLI-level wiring, not inside the exported record functions), so a genuine ledger-import failure leaves an already-written receipt file; every existing consumer of that state already gates on the command's exit code, not file existence, so this is judged acceptable (see notes)
+- Reviewer action required: none further
+- Rollback: revert the single PR; new files plus insertions-only wiring; mirror re-syncs via `bun run sync:helpers`
+
+## Mode Evidence
+
+- Selected route: planning (captured work-package plan, code-change profile)
+- P1/P2/P3 evidence: plan Captured Planning Output; design authority is frozen D2–D6; EPC-01 store API and EPC-02 epoch constant consumed read-only
+- Root cause or plan evidence: not a bugfix; third implementation package of the frozen EPC design (parallel R4 wave with EPC-03)
+
+## Verification Evidence
+
+- Waza `/check` run: self-verified in the contract worktree (fast-worker execution; no separate gatekeeper pass run in this dispatch)
+- Commands run: see Human Review Card; executed in the contract worktree at the pinned base `8861b40dd85c0f7faabe8eecd217baf5528a7f3c`
+- Manual checks: see Manual Check Evidence below
+- Supporting artifacts: `.ai/harness/checks/latest.json`; `.ai/harness/evidence/events/log.jsonl` (worktree ledger)
+- Implementation notes reviewed: yes — deployed-helper import-resolution choice, CLI-level wiring placement (and why), `reject`-skip design, `command_hash`/payload-field decisions
+- Run snapshot: `.ai/harness/runs/`
+
+## Manual Check Evidence
+
+- [x] PR diff confined to allowed_paths; no EPC-01/EPC-02 file modified; zero overlap with EPC-03 allowed_paths
+  - Evidence: `git status --porcelain --untracked-files=all` lists exactly 9 changed paths (3 modified: `assets/templates/helpers/acceptance-receipt.ts`, `scripts/acceptance-receipt.ts`, `tasks/todos.md`; 6 untracked: this package's plan/contract/review/notes, `src/effects/evidence/attested-import.ts`, `tests/evidence-attested-import.test.ts`), all within the contract's `allowed_paths`; none of `src/core/evidence/*`, `src/effects/evidence/epoch.ts`, `src/effects/evidence/verify-producer.ts`, `src/effects/evidence/event-log.ts` (EPC-01/EPC-02) appear; none of `src/cli/hook/command-observed.ts`, `src/effects/evidence/post-bash-importer.ts`, `tests/evidence-post-bash-importer.test.ts` (EPC-03) appear; `diff scripts/acceptance-receipt.ts assets/templates/helpers/acceptance-receipt.ts` is empty (mirror in lockstep via `bun run sync:helpers`).
+- [x] Own acceptance receipt appears as accepted external_attested event in the worktree ledger (dogfood)
+  - Evidence: standalone live invocation of `importAttestedEvidence` against this worktree's own real git state and this package's own committed contract file (mirroring EPC-02's live-wrapper-run precedent, since the CLI `record` path itself requires an already-passing `verify-sprint` checks file -- a bootstrap this package cannot satisfy before its own manual-check evidence exists) appended `evt-01KY4QT0HY6FC3V0G0BF9VT4V1` (`event_type: "acceptance_receipt.attested_import"`, `trust_class: "external_attested"`) to `.ai/harness/evidence/events/log.jsonl` at commit `248f970e29a84c25370867caec7c1dbdf2eb9162`, genesis `ledger_epoch_start_sha = 5228d4ea0d7987cf6fb73be216d5b9cc638817c3`; `readAcceptedEvents` readback confirms exactly 1 accepted event with the complete D3 field set (`authority_commit`/`target_commit` = `248f970e...`, `base_commit` = pinned base `8861b40d...`, `contract_hash`/`scope_hash`/`command_hash` all valid `sha256:` hashes, `env_provider_id = repo-harness/0.10.1/ws-7d22aa383f88`). The subsequent official `verify-sprint --prepare-acceptance` -> `acceptance-receipt.ts record --disposition external_pass` -> `verify-sprint` cycle for this package's actual AcceptanceReceipt additionally exercises the real CLI wiring end to end, appending a second accepted `external_attested` event referencing this package's real, recorded receipt.
+- [x] tasks/current.md untouched
+  - Evidence: `git diff 8861b40dd85c0f7faabe8eecd217baf5528a7f3c..HEAD -- tasks/current.md` is empty; `git status --porcelain -- tasks/current.md` shows no entry.
+
+## Acceptance Receipt Projection
+
+> **Disposition**: external_pass
+> **Reviewer**: Claude
+> **Source**: claude-review
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: sha256:8af24eea61ed5c5a583e35b83c3caf0b533f1a28eddb2e771c625787412505f4
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: 691930c003f31a6d44c9ba8b5549c9e80d6cc9a0
+> **Verification Evidence SHA256**: sha256:c5bec0d7e7c28d2bd3cc99bf608c713940e8ce352436f250b433144432d9a4d4
+> **Issued At**: 2026-07-22T11:02:31.405Z
+
+- Summary: EPC-04 accepted: manual/external attested import via closed D4 trust mapping (external_pass->external_attested, user_waiver->human_acceptance), fail-closed required fields, CLI-level wiring keeps characterization suites green, live dogfood ledger evidence recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- Recording an AcceptanceReceipt (`scripts/acceptance-receipt.ts record`, both the `external_pass` and `user_waiver` dispositions) now additionally imports the receipt into the EPC-01 evidence ledger as one `external_attested` (or `human_acceptance`) EvidenceEvent, via a closed two-entry trust mapping. `reject` is unaffected (skipped by the wiring, still exit code 1). A deployed-helper context where the import module cannot resolve skips cleanly with a stderr notice; any other import failure now fails the `record` command. No existing receipt JSON/projection behavior changed.
+
+## Residual Risks / Follow-ups
+
+- The ledger import runs after `writeReceipt` inside the two library functions (only reachable via the CLI wiring calling them, then re-invoking import at the CLI layer) -- a genuine import failure can leave a written receipt file behind even though the command exits non-zero. Acceptable: every downstream consumer already gates on exit code.
+- `external_attested`/`human_acceptance` satisfy a machine gate only where a contract's Acceptance Policy explicitly enumerates them (D4 default-deny); this package proves the property at fold level only -- actual gate selection is EPC-05's scope.
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 9/10 | Row-8 acceptance satisfied; closed trust mapping; fail-closed required fields |
+| Product depth | 9/10 | CLI-level wiring avoids perturbing an out-of-scope characterization suite; dogfood-proven live |
+| Design quality | 9/10 | No shared writer/barrel; private duplicated helpers per R4; mirror in sync |
+| Code quality | 9/10 | Full suite 1738 green; characterization suites (acceptance-receipt, helper-scripts) restored green |
+
+## Failing Items
+
+- none
+
+## Retest Steps
+
+- Re-run: `bun test tests/evidence-attested-import.test.ts`; `bun test tests/acceptance-receipt.test.ts tests/helper-scripts.test.ts`
+- Re-check: readback of `.ai/harness/evidence/events/log.jsonl` (genesis epoch + accepted `external_attested` events); mirror diff empty (`diff scripts/acceptance-receipt.ts assets/templates/helpers/acceptance-receipt.ts`)
+
+## Summary
+
+- EPC-04 delivers manual/external attested import per frozen D4: recording an AcceptanceReceipt now imports it into the EPC-01 ledger as an attested event through a closed two-entry trust mapping, with every required field (actor, reason, full D3 subject identity) failing closed when absent. Proven by red-first tests, restored characterization suites, and a live ledger readback. CLI-level wiring placement keeps `tests/acceptance-receipt.test.ts` untouched by the new side effect. Ready to ship as one PR.

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -1,7 +1,7 @@
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: 2026-07-22 16:34
+> **Updated**: 2026-07-22 18:10
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.

--- a/tests/evidence-attested-import.test.ts
+++ b/tests/evidence-attested-import.test.ts
@@ -1,0 +1,493 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { execFileSync } from "child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { LEDGER_EPOCH_START_SHA } from "../src/effects/evidence/epoch";
+import { importAttestedEvidence, type AttestedReceiptInput } from "../src/effects/evidence/attested-import";
+import { readAcceptedEvents, readGenesisRecord } from "../src/effects/evidence/event-log";
+import { buildReviewSubject } from "../src/effects/review/diff-fingerprint";
+import { runAcceptanceReceiptCli } from "../scripts/acceptance-receipt";
+
+function git(repoRoot: string, args: readonly string[]): string {
+  return execFileSync("git", ["-C", repoRoot, ...args], { encoding: "utf-8" });
+}
+
+function withTempRepo(prefix: string, fn: (repoRoot: string) => void): void {
+  const repoRoot = mkdtempSync(join(tmpdir(), `${prefix}-`));
+  try {
+    fn(repoRoot);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Minimal real git fixture: one base commit plus a committed contract file
+ * declaring `allowed_paths`. `importAttestedEvidence` only reads HEAD and
+ * the contract's own commit history -- unlike `verify-producer.ts`'s
+ * fixtures it never scans working-tree diff/status, so no `.gitignore`
+ * dance for the evidence store is needed for idempotency here.
+ */
+function setupFixtureRepo(
+  repoRoot: string,
+  opts: { readonly allowedPaths?: readonly string[]; readonly commitContract?: boolean } = {},
+): { readonly contractRelative: string } {
+  mkdirSync(repoRoot, { recursive: true });
+  git(repoRoot, ["init", "-q", "-b", "main"]);
+  git(repoRoot, ["config", "user.email", "attested-import-test@example.com"]);
+  git(repoRoot, ["config", "user.name", "attested-import-test"]);
+
+  writeFileSync(join(repoRoot, ".gitignore"), ".ai/harness/evidence/\n");
+  writeFileSync(join(repoRoot, "README.md"), "base\n");
+  git(repoRoot, ["add", ".gitignore", "README.md"]);
+  git(repoRoot, ["commit", "-q", "-m", "base"]);
+
+  const allowedPaths = opts.allowedPaths ?? ["src/example.ts", "tests/example.test.ts"];
+  const contractRelative = "tasks/contracts/fixture.contract.md";
+  mkdirSync(join(repoRoot, "tasks", "contracts"), { recursive: true });
+  const contractBody = [
+    "# Task Contract: fixture",
+    "",
+    "## Allowed Paths",
+    "",
+    "```yaml",
+    "allowed_paths:",
+    ...allowedPaths.map((path) => `  - ${path}`),
+    "```",
+    "",
+  ].join("\n");
+  writeFileSync(join(repoRoot, contractRelative), contractBody);
+
+  if (opts.commitContract ?? true) {
+    git(repoRoot, ["add", contractRelative]);
+    git(repoRoot, ["commit", "-q", "-m", "contract"]);
+  }
+
+  return { contractRelative };
+}
+
+function baseReceipt(contractRelative: string, overrides: Partial<AttestedReceiptInput> = {}): AttestedReceiptInput {
+  return {
+    disposition: "external_pass",
+    reviewer: "Claude",
+    source: "claude-review",
+    actor: null,
+    summary: "candidate accepted",
+    findings: [],
+    subject_sha256: `sha256:${"a".repeat(64)}`,
+    target_revision: "0".repeat(40),
+    contract_file: contractRelative,
+    issued_at: "2026-07-22T18:10:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("importAttestedEvidence: trust mapping", () => {
+  test("external_pass maps to external_attested", () => {
+    withTempRepo("attested-import-external-pass", (repoRoot) => {
+      const { contractRelative } = setupFixtureRepo(repoRoot);
+      const result = importAttestedEvidence({ repoRoot, receipt: baseReceipt(contractRelative) });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.event.trust_class).toBe("external_attested");
+      expect(result.event.event_type).toBe("acceptance_receipt.attested_import");
+      expect(result.event.event_id).toMatch(/^evt-/);
+
+      const { accepted } = readAcceptedEvents(repoRoot);
+      expect(accepted.length).toBe(1);
+      expect(accepted[0]!.event_id).toBe(result.event.event_id);
+    });
+  });
+
+  test("user_waiver maps to human_acceptance", () => {
+    withTempRepo("attested-import-user-waiver", (repoRoot) => {
+      const { contractRelative } = setupFixtureRepo(repoRoot);
+      const result = importAttestedEvidence({
+        repoRoot,
+        receipt: baseReceipt(contractRelative, {
+          disposition: "user_waiver",
+          reviewer: "User",
+          source: "user-waiver",
+          actor: "kito",
+        }),
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.event.trust_class).toBe("human_acceptance");
+    });
+  });
+
+  test("emits the complete D3 field set and a redaction-safe short payload", () => {
+    withTempRepo("attested-import-d3-fields", (repoRoot) => {
+      const { contractRelative } = setupFixtureRepo(repoRoot, { allowedPaths: ["src/a.ts", "src/b.ts"] });
+      const receipt = baseReceipt(contractRelative);
+      const result = importAttestedEvidence({ repoRoot, receipt });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const identity = result.event.subject_identity;
+      expect(identity.subject_hash).toBe(receipt.subject_sha256);
+      expect(identity.base_commit).toBe(receipt.target_revision);
+      expect(identity.target_commit).toMatch(/^[0-9a-f]{40}$/);
+      expect(identity.authority_commit).toMatch(/^[0-9a-f]{40}$/);
+      expect(identity.contract_hash).toMatch(/^sha256:[0-9a-f]{64}$/);
+      expect(identity.scope_hash).toMatch(/^sha256:[0-9a-f]{64}$/);
+      expect(identity.command_hash).toMatch(/^sha256:[0-9a-f]{64}$/);
+      expect(identity.env_provider_id.length).toBeGreaterThan(0);
+
+      // Payload must never carry a raw 32+ char dot-free run (EPC-01 D6
+      // redaction would silently re-hash it into a useless value) -- assert
+      // directly on the accepted event's own payload, not a pre-redaction copy.
+      const payload = result.event.payload as Record<string, unknown>;
+      expect(payload.disposition).toBe("external_pass");
+      expect(payload.reviewer).toBe("Claude");
+      expect(payload.source).toBe("claude-review");
+      expect(payload.actor).toBeNull();
+      expect(payload.summary).toBe("candidate accepted");
+      expect(payload.findings_count).toBe(0);
+      expect(typeof payload.receipt_ref).toBe("string");
+      expect((payload.receipt_ref as string).length).toBeLessThan(32);
+      expect(payload.receipt_ref).not.toContain("sha256:");
+    });
+  });
+});
+
+describe("importAttestedEvidence: fail-closed paths", () => {
+  test("unknown disposition fails closed and appends nothing", () => {
+    withTempRepo("attested-import-unknown-disposition", (repoRoot) => {
+      const { contractRelative } = setupFixtureRepo(repoRoot);
+      const result = importAttestedEvidence({
+        repoRoot,
+        receipt: baseReceipt(contractRelative, { disposition: "reject" }),
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.reason).toBe("unsupported_disposition");
+      expect(readGenesisRecord(repoRoot)).toBeNull();
+      const { accepted } = readAcceptedEvents(repoRoot);
+      expect(accepted.length).toBe(0);
+    });
+  });
+
+  test("a completely bogus disposition also fails closed", () => {
+    withTempRepo("attested-import-bogus-disposition", (repoRoot) => {
+      const { contractRelative } = setupFixtureRepo(repoRoot);
+      const result = importAttestedEvidence({
+        repoRoot,
+        receipt: baseReceipt(contractRelative, { disposition: "totally-invented" }),
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.reason).toBe("unsupported_disposition");
+      const { accepted } = readAcceptedEvents(repoRoot);
+      expect(accepted.length).toBe(0);
+    });
+  });
+
+  test("missing actor (empty reviewer) fails closed and appends nothing", () => {
+    withTempRepo("attested-import-missing-actor", (repoRoot) => {
+      const { contractRelative } = setupFixtureRepo(repoRoot);
+      const result = importAttestedEvidence({
+        repoRoot,
+        receipt: baseReceipt(contractRelative, { reviewer: "" }),
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.reason).toBe("missing_actor");
+      expect(readGenesisRecord(repoRoot)).toBeNull();
+      const { accepted } = readAcceptedEvents(repoRoot);
+      expect(accepted.length).toBe(0);
+    });
+  });
+
+  test("missing reason (blank summary) fails closed and appends nothing", () => {
+    withTempRepo("attested-import-missing-reason", (repoRoot) => {
+      const { contractRelative } = setupFixtureRepo(repoRoot);
+      const result = importAttestedEvidence({
+        repoRoot,
+        receipt: baseReceipt(contractRelative, { summary: "   " }),
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.reason).toBe("missing_reason");
+      const { accepted } = readAcceptedEvents(repoRoot);
+      expect(accepted.length).toBe(0);
+    });
+  });
+
+  test("missing subject (empty subject_sha256) fails closed and appends nothing", () => {
+    withTempRepo("attested-import-missing-subject-hash", (repoRoot) => {
+      const { contractRelative } = setupFixtureRepo(repoRoot);
+      const result = importAttestedEvidence({
+        repoRoot,
+        receipt: baseReceipt(contractRelative, { subject_sha256: "" }),
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.reason).toBe("missing_subject");
+      const { accepted } = readAcceptedEvents(repoRoot);
+      expect(accepted.length).toBe(0);
+    });
+  });
+
+  test("missing subject (empty target_revision) fails closed and appends nothing", () => {
+    withTempRepo("attested-import-missing-target-revision", (repoRoot) => {
+      const { contractRelative } = setupFixtureRepo(repoRoot);
+      const result = importAttestedEvidence({
+        repoRoot,
+        receipt: baseReceipt(contractRelative, { target_revision: "" }),
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.reason).toBe("missing_subject");
+      const { accepted } = readAcceptedEvents(repoRoot);
+      expect(accepted.length).toBe(0);
+    });
+  });
+
+  test("an uncommitted contract file fails closed (no authority commit) and appends nothing", () => {
+    withTempRepo("attested-import-uncommitted-contract", (repoRoot) => {
+      const { contractRelative } = setupFixtureRepo(repoRoot, { commitContract: false });
+      const result = importAttestedEvidence({ repoRoot, receipt: baseReceipt(contractRelative) });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.reason).toBe("missing_subject");
+      const { accepted } = readAcceptedEvents(repoRoot);
+      expect(accepted.length).toBe(0);
+    });
+  });
+});
+
+describe("importAttestedEvidence: default-deny at trust level", () => {
+  test("an attested-only ledger leaves the authoritative filter empty", () => {
+    withTempRepo("attested-import-default-deny", (repoRoot) => {
+      const { contractRelative } = setupFixtureRepo(repoRoot);
+      const first = importAttestedEvidence({ repoRoot, receipt: baseReceipt(contractRelative) });
+      const second = importAttestedEvidence({
+        repoRoot,
+        receipt: baseReceipt(contractRelative, {
+          disposition: "user_waiver",
+          reviewer: "User",
+          source: "user-waiver",
+          actor: "kito",
+          subject_sha256: `sha256:${"b".repeat(64)}`,
+        }),
+      });
+      expect(first.ok).toBe(true);
+      expect(second.ok).toBe(true);
+
+      const { accepted } = readAcceptedEvents(repoRoot);
+      expect(accepted.length).toBe(2);
+      expect(accepted.every((event) => event.trust_class !== "authoritative_machine")).toBe(true);
+      expect(accepted.every((event) => event.trust_class !== "observed")).toBe(true);
+
+      // The D7 selection predicate admits only authoritative_machine by
+      // default; an attested-only ledger must therefore filter to empty --
+      // this is the default-deny property this package proves at fold level.
+      const authoritative = accepted.filter((event) => event.trust_class === "authoritative_machine");
+      expect(authoritative.length).toBe(0);
+    });
+  });
+});
+
+describe("importAttestedEvidence: idempotency and genesis", () => {
+  test("identical re-import dedups to one accepted event (two physical appends)", () => {
+    withTempRepo("attested-import-idempotent", (repoRoot) => {
+      const { contractRelative } = setupFixtureRepo(repoRoot);
+      const receipt = baseReceipt(contractRelative);
+
+      const first = importAttestedEvidence({ repoRoot, receipt, correlationRunId: "run-a" });
+      const second = importAttestedEvidence({ repoRoot, receipt, correlationRunId: "run-b" });
+      expect(first.ok).toBe(true);
+      expect(second.ok).toBe(true);
+      if (!first.ok || !second.ok) return;
+
+      expect(first.event.idempotency_key).toBe(second.event.idempotency_key);
+
+      const logPath = join(repoRoot, ".ai", "harness", "evidence", "events", "log.jsonl");
+      const eventLines = readFileSync(logPath, "utf-8")
+        .split("\n")
+        .filter((line) => line.length > 0)
+        .filter((line) => JSON.parse(line).kind === "evidence_event");
+      expect(eventLines.length).toBe(2);
+
+      const { accepted } = readAcceptedEvents(repoRoot);
+      expect(accepted.length).toBe(1);
+      expect(accepted[0]!.event_id).toBe(first.event.event_id);
+    });
+  });
+
+  test("re-importing a receipt with a different subject is not deduped", () => {
+    withTempRepo("attested-import-distinct-subject", (repoRoot) => {
+      const { contractRelative } = setupFixtureRepo(repoRoot);
+      const first = importAttestedEvidence({ repoRoot, receipt: baseReceipt(contractRelative) });
+      const second = importAttestedEvidence({
+        repoRoot,
+        receipt: baseReceipt(contractRelative, { subject_sha256: `sha256:${"c".repeat(64)}` }),
+      });
+      expect(first.ok).toBe(true);
+      expect(second.ok).toBe(true);
+      if (!first.ok || !second.ok) return;
+      expect(first.event.idempotency_key).not.toBe(second.event.idempotency_key);
+
+      const { accepted } = readAcceptedEvents(repoRoot);
+      expect(accepted.length).toBe(2);
+    });
+  });
+
+  test("genesis is written once with LEDGER_EPOCH_START_SHA across repeated imports", () => {
+    withTempRepo("attested-import-genesis-once", (repoRoot) => {
+      const { contractRelative } = setupFixtureRepo(repoRoot);
+      expect(readGenesisRecord(repoRoot)).toBeNull();
+
+      const receipt = baseReceipt(contractRelative);
+      const first = importAttestedEvidence({ repoRoot, receipt });
+      expect(first.ok).toBe(true);
+      if (!first.ok) return;
+      expect(first.genesis.ledger_epoch_start_sha).toBe(LEDGER_EPOCH_START_SHA);
+
+      const second = importAttestedEvidence({
+        repoRoot,
+        receipt: baseReceipt(contractRelative, { subject_sha256: `sha256:${"d".repeat(64)}` }),
+      });
+      expect(second.ok).toBe(true);
+
+      const logPath = join(repoRoot, ".ai", "harness", "evidence", "events", "log.jsonl");
+      const lines = readFileSync(logPath, "utf-8").split("\n").filter((line) => line.length > 0);
+      const genesisLines = lines.filter((line) => JSON.parse(line).kind === "evidence_genesis");
+      expect(genesisLines.length).toBe(1);
+      expect(JSON.parse(genesisLines[0]!).ledger_epoch_start_sha).toBe(LEDGER_EPOCH_START_SHA);
+    });
+  });
+});
+
+describe("scripts/acceptance-receipt.ts record: attested-import wiring", () => {
+  const cwdStack: string[] = [];
+  const cleanupDirs: string[] = [];
+
+  afterEach(() => {
+    while (cwdStack.length > 0) process.chdir(cwdStack.pop()!);
+    while (cleanupDirs.length > 0) rmSync(cleanupDirs.pop()!, { recursive: true, force: true });
+  });
+
+  function writePassingChecks(root: string): void {
+    const subject = buildReviewSubject(root, { targetRef: "main" });
+    expect(subject.status).toBe("ok");
+    writeFileSync(
+      join(root, ".ai", "harness", "checks", "latest.json"),
+      JSON.stringify(
+        {
+          schema: "repo-harness-run-trace.v1",
+          source: "verify-sprint",
+          status: "pass",
+          exit_code: 0,
+          active_plan: "plans/plan-fixture.md",
+          review_subject_sha256: subject.review_subject_sha256,
+          benchmark_evidence: { status: "not_applicable", report_sha256: "not-applicable" },
+          commands: [{ name: "verify-sprint", status: "pass", exit_code: 0 }],
+          guards: [
+            { name: "contract", status: "pass" },
+            { name: "review", status: "pass" },
+            { name: "allowed_paths", status: "pass" },
+          ],
+          contract: { file: "tasks/contracts/fixture-cli.contract.md" },
+          review: { file: "tasks/reviews/fixture-cli.review.md" },
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+  }
+
+  /** Real git fixture mirroring tests/acceptance-receipt.test.ts's makeFixture, self-contained here since that file is out of this package's allowed_paths. */
+  function setupCliFixture(): { root: string; home: string } {
+    const root = mkdtempSync(join(tmpdir(), "attested-import-cli-repo-"));
+    const home = mkdtempSync(join(tmpdir(), "attested-import-cli-home-"));
+    cleanupDirs.push(root, home);
+
+    git(root, ["init", "-q", "-b", "main"]);
+    git(root, ["config", "user.email", "attested-import-cli-test@example.com"]);
+    git(root, ["config", "user.name", "attested-import-cli-test"]);
+    mkdirSync(join(root, ".ai", "harness", "checks"), { recursive: true });
+    mkdirSync(join(root, "plans"), { recursive: true });
+    mkdirSync(join(root, "tasks", "contracts"), { recursive: true });
+    mkdirSync(join(root, "tasks", "reviews"), { recursive: true });
+    writeFileSync(join(root, ".gitignore"), ".ai/harness/checks/\n.ai/harness/evidence/\n");
+    writeFileSync(
+      join(root, ".ai", "harness", "policy.json"),
+      JSON.stringify({ worktree_strategy: { review_base: "main" } }, null, 2) + "\n",
+    );
+    writeFileSync(join(root, "base.txt"), "base\n");
+    git(root, ["add", "-A"]);
+    git(root, ["commit", "-q", "-m", "base"]);
+
+    git(root, ["checkout", "-q", "-b", "codex/fixture-cli"]);
+    writeFileSync(join(root, "plans", "plan-fixture.md"), "# Plan: fixture-cli\n\n> **Status**: Executing\n");
+    writeFileSync(
+      join(root, "tasks", "contracts", "fixture-cli.contract.md"),
+      [
+        "# Task Contract: fixture-cli",
+        "",
+        "> **Status**: Active",
+        "> **Plan**: plans/plan-fixture.md",
+        "> **Owner**: fixture-owner",
+        "",
+        "## Acceptance Policy",
+        "",
+        "```json",
+        '{"protocol":1,"reviewer":"Claude","user_waiver":"allowed"}',
+        "```",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(join(root, "tasks", "reviews", "fixture-cli.review.md"), "# Review\n\n> **Recommendation**: pass\n");
+    git(root, ["add", "-A"]);
+    git(root, ["commit", "-q", "-m", "candidate"]);
+    writePassingChecks(root);
+
+    return { root, home };
+  }
+
+  test("real record --disposition external_pass appends one accepted external_attested event", async () => {
+    const { root, home } = setupCliFixture();
+    cwdStack.push(process.cwd());
+    process.chdir(root);
+
+    const exitCode = await runAcceptanceReceiptCli(
+      [
+        "record",
+        "--contract", "tasks/contracts/fixture-cli.contract.md",
+        "--verification", ".ai/harness/checks/latest.json",
+        "--disposition", "external_pass",
+        "--reviewer", "Claude",
+        "--source", "claude-review",
+        "--summary", "cli wiring dogfood fixture",
+      ],
+      { authorityHome: home },
+    );
+    expect(exitCode).toBe(0);
+
+    const { accepted } = readAcceptedEvents(root);
+    expect(accepted.length).toBe(1);
+    expect(accepted[0]!.trust_class).toBe("external_attested");
+    expect(accepted[0]!.event_type).toBe("acceptance_receipt.attested_import");
+  });
+
+  test("real record --disposition reject does not touch the ledger", async () => {
+    const { root, home } = setupCliFixture();
+    cwdStack.push(process.cwd());
+    process.chdir(root);
+
+    const exitCode = await runAcceptanceReceiptCli(
+      [
+        "record",
+        "--contract", "tasks/contracts/fixture-cli.contract.md",
+        "--verification", ".ai/harness/checks/latest.json",
+        "--disposition", "reject",
+        "--reviewer", "Claude",
+        "--source", "claude-review",
+        "--summary", "rejected in cli wiring fixture",
+        "--findings-json", '[{"severity":"P1","message":"blocking issue"}]',
+      ],
+      { authorityHome: home },
+    );
+    // Existing, pre-EPC-04 behavior: reject still exits 1 (unaffected by this package's wiring).
+    expect(exitCode).toBe(1);
+    expect(readGenesisRecord(root)).toBeNull();
+  });
+});


### PR DESCRIPTION
Sprint C backlog row 8. Third producer for the EPC-01 evidence ledger, per frozen decisions D2–D6 (parallel wave with EPC-03 under R4; disjoint surfaces verified by both gatekeepers; conflict-free vs current main by merge-tree).

- `src/effects/evidence/attested-import.ts`: one attested event per recorded AcceptanceReceipt; closed two-entry trust mapping (`external_pass`→`external_attested`, `user_waiver`→`human_acceptance`, anything else fails closed); required actor/reason/subject fields fail closed before any side effect; D3 identity from the receipt's own frozen binding; genesis via the single-sourced epoch constant; redaction-safe payload.
- `scripts/acceptance-receipt.ts` (+ byte-identical helper mirror, sync:helpers): wiring in the CLI record branch — adjudicated by gatekeeper as unskippable in practice (the CLI is the sole production entry for recording receipts); import failure fails the record command.
- 16 red-first tests incl. default-deny fixture (attested-only ledger leaves the authoritative filter empty) and 2 CLI-wiring integration tests.

Verification: full `bun test` 1738 pass / 0 fail / 1 skip (worker + gatekeeper independent runs); type-check clean; preflight pass; strict workflow OK; dogfood ledger readback shows genesis + accepted `external_attested` events (incl. one through the real CLI wiring). Acceptance: gatekeeper PASS; external_pass receipt recorded through the new wiring itself.