### PR TITLE
EPC-05: checks/latest materializer — first authority cutover

### DIFF
--- a/.ai/hooks/.projection.json
+++ b/.ai/hooks/.projection.json
@@ -3,6 +3,6 @@
   "canonical_root": "assets/hooks",
   "projection_target": ".ai/hooks",
   "manifest": "assets/hooks/projection.json",
-  "digest": "sha256:efd7870eb4c60034a40606df306501bf8490b8d2c4db20a49f40a6ef3faf1ac9",
+  "digest": "sha256:006caba4b236504c0af72dbc97fa94a9f77d493918c91c4d6d6aa6813c7063b3",
   "file_count": 3
 }

--- a/.ai/hooks/lib/workflow-state.sh
+++ b/.ai/hooks/lib/workflow-state.sh
@@ -110,7 +110,15 @@ workflow_ensure_harness_surface() {
     "$(dirname "$(workflow_pending_orchestration_file)")" \
     "$(workflow_runs_dir)"
 
-  [[ -f "$(workflow_checks_file)" ]] || printf "{}\n" > "$(workflow_checks_file)"
+  # EPC-05: no {} bootstrap for checks/latest.json here anymore -- it is now
+  # materialized exclusively from the evidence ledger
+  # (src/effects/evidence/checks-materializer.ts); a missing file is genuine
+  # absence, not a placeholder this library should paper over. Every existing
+  # consumer of workflow_checks_file's content already treats "missing or
+  # empty" as its own fail-closed branch (workflow_checks_pass,
+  # workflow_acceptance_receipt_status, workflow_next_action's `[[ ! -f
+  # "$checks_file" ]]` check above), so removing this bootstrap changes no
+  # consumer's observable pass/fail outcome -- only which message they print.
   [[ -f "$(workflow_handoff_file)" ]] || printf "# Harness Handoff\n\n> **Reason**: bootstrap\n" > "$(workflow_handoff_file)"
   [[ -f "$(workflow_resume_packet_file)" ]] || printf "# Codex Resume Packet\n\n> **Reason**: bootstrap\n" > "$(workflow_resume_packet_file)"
   [[ -f "$(workflow_failure_log_file)" ]] || : > "$(workflow_failure_log_file)"

--- a/assets/hooks/lib/workflow-state.sh
+++ b/assets/hooks/lib/workflow-state.sh
@@ -110,7 +110,15 @@ workflow_ensure_harness_surface() {
     "$(dirname "$(workflow_pending_orchestration_file)")" \
     "$(workflow_runs_dir)"
 
-  [[ -f "$(workflow_checks_file)" ]] || printf "{}\n" > "$(workflow_checks_file)"
+  # EPC-05: no {} bootstrap for checks/latest.json here anymore -- it is now
+  # materialized exclusively from the evidence ledger
+  # (src/effects/evidence/checks-materializer.ts); a missing file is genuine
+  # absence, not a placeholder this library should paper over. Every existing
+  # consumer of workflow_checks_file's content already treats "missing or
+  # empty" as its own fail-closed branch (workflow_checks_pass,
+  # workflow_acceptance_receipt_status, workflow_next_action's `[[ ! -f
+  # "$checks_file" ]]` check above), so removing this bootstrap changes no
+  # consumer's observable pass/fail outcome -- only which message they print.
   [[ -f "$(workflow_handoff_file)" ]] || printf "# Harness Handoff\n\n> **Reason**: bootstrap\n" > "$(workflow_handoff_file)"
   [[ -f "$(workflow_resume_packet_file)" ]] || printf "# Codex Resume Packet\n\n> **Reason**: bootstrap\n" > "$(workflow_resume_packet_file)"
   [[ -f "$(workflow_failure_log_file)" ]] || : > "$(workflow_failure_log_file)"

--- a/assets/templates/helpers/verify-sprint.sh
+++ b/assets/templates/helpers/verify-sprint.sh
@@ -434,6 +434,8 @@ allowed_paths_check_json() {
 # "cannot bind" -- treated the same way (skip, do not fail).
 emit_verify_evidence() {
   local command_line="$1"
+  local run_trace_file="$2"
+  local status="${3:-pass}"
   local emit_script="$helper_dir/emit-verify-evidence.ts"
   if [[ ! -f "$emit_script" ]]; then
     if [[ -n "${REPO_HARNESS_SOURCE_ROOT:-}" && -f "${REPO_HARNESS_SOURCE_ROOT}/scripts/emit-verify-evidence.ts" ]]; then
@@ -445,19 +447,22 @@ emit_verify_evidence() {
   fi
   [[ -n "$BUN_BIN" && -x "$BUN_BIN" ]] || { echo "verify-sprint: trusted Bun runtime is unavailable for evidence emission" >&2; return 1; }
   command -v jq >/dev/null 2>&1 || { echo "verify-sprint: jq is required for evidence emission" >&2; return 1; }
+  [[ -n "$run_trace_file" && -s "$run_trace_file" ]] || { echo "verify-sprint: run-trace file is missing for evidence emission: $run_trace_file" >&2; return 1; }
   local subject_sha256 run_snapshot counts_json
-  subject_sha256="$(jq -r '.review_subject_sha256 // empty' "$checks_file" 2>/dev/null)"
-  run_snapshot="$(jq -r '.lifecycle.snapshot // empty' "$checks_file" 2>/dev/null)"
-  counts_json="$(jq -c '{guards_total: (.guards | length), guards_passed: ([.guards[] | select(.status=="pass")] | length)}' "$checks_file" 2>/dev/null)"
+  subject_sha256="$(jq -r '.review_subject_sha256 // empty' "$run_trace_file" 2>/dev/null)"
+  run_snapshot="$(jq -r '.lifecycle.snapshot // empty' "$run_trace_file" 2>/dev/null)"
+  counts_json="$(jq -c '{guards_total: (.guards | length), guards_passed: ([.guards[] | select(.status=="pass")] | length)}' "$run_trace_file" 2>/dev/null)"
   [[ -n "$subject_sha256" && -n "$run_snapshot" ]] || { echo "verify-sprint: prepared evidence is missing subject or run snapshot; evidence emission needs a frozen --prepare-acceptance run" >&2; return 1; }
   "$BUN_BIN" "$emit_script" \
     --repo-root "$(pwd -P)" \
     --contract "$contract_file" \
     --subject-sha256 "$subject_sha256" \
     --command "$command_line" \
-    --status pass \
+    --status "$status" \
     --run-snapshot "$run_snapshot" \
-    --counts-json "$counts_json"
+    --counts-json "$counts_json" \
+    --run-trace-file "$run_trace_file" \
+    --checks-file "$checks_file"
   return $?
 }
 
@@ -556,14 +561,13 @@ finalize_prepared_acceptance() {
       | .guards = [.guards[] | if .name == "acceptance_receipt" then .status = "pass" else . end]
       | .next_step = "finish contract worktree or archive completed task"
     ' "$checks_file" > "$finalized_checks"
-  cp "$finalized_checks" "$checks_file"
-  rm -f "$finalized_checks"
   echo "Sprint acceptance finalized without rerunning verification"
   echo "Prepared evidence: $checks_file"
   set +e
-  emit_verify_evidence "repo-harness run verify-sprint"
+  emit_verify_evidence "repo-harness run verify-sprint" "$finalized_checks" "pass"
   local emit_exit=$?
   set -e
+  rm -f "$finalized_checks"
   case "$emit_exit" in
     0) : ;;
     3) : ;;
@@ -945,7 +949,6 @@ else
 EOF_CHECKS
 fi
 
-cp "$checks_report" "$checks_file"
 cp "$checks_report" "$run_file"
 
 print_maintenance_advisories "$notes_file" || true
@@ -953,18 +956,35 @@ print_maintenance_advisories "$notes_file" || true
 if [[ "$exit_code" -eq 0 ]]; then
   echo "Sprint verification passed"
   echo "Run snapshot: $run_file"
-  set +e
-  emit_verify_evidence "repo-harness run verify-sprint --prepare-acceptance"
-  emit_exit=$?
-  set -e
-  case "$emit_exit" in
-    0) : ;;
-    3) : ;;
-    *) echo "verify-sprint: evidence emission failed" >&2; exit 1 ;;
-  esac
 else
   echo "Sprint verification failed" >&2
   echo "Run snapshot: $run_file" >&2
 fi
+
+# EPC-05: checks/latest.json is materialized FROM the ledger by
+# emit-verify-evidence.ts's --checks-file handling (see that script's single
+# call into the checks-materializer). Emission (and, on success, this
+# materialization) is attempted for both a passing AND a failing verify
+# result -- a failing verify-sprint run is still a real, subject-bound,
+# authoritative_machine fact ("verification did not pass"), and consumers
+# read the payload's own status field, not the event's trust class, to tell
+# pass from fail (workflow_checks_pass already works this way). Cannot-bind
+# (exit 3) means checks/latest.json is simply not (re)written this run --
+# never a fabricated or stale-content fallback.
+verify_status="$([[ "$exit_code" -eq 0 ]] && printf pass || printf fail)"
+set +e
+emit_verify_evidence "repo-harness run verify-sprint --prepare-acceptance" "$checks_report" "$verify_status"
+emit_exit=$?
+set -e
+case "$emit_exit" in
+  0) : ;;
+  3) : ;;
+  *)
+    echo "verify-sprint: evidence emission failed" >&2
+    if [[ "$exit_code" -eq 0 ]]; then
+      exit 1
+    fi
+    ;;
+esac
 
 exit "$exit_code"

--- a/plans/plan-20260722-1929-epc-05-checks-latest-materializer.md
+++ b/plans/plan-20260722-1929-epc-05-checks-latest-materializer.md
@@ -1,0 +1,298 @@
+# Plan: EPC-05: checks/latest Materializer and First Authority Cutover
+
+> **Status**: Executing
+> **Created**: 20260722-1929
+> **Slug**: epc-05-checks-latest-materializer
+> **Planning Source**: repo-harness-sprint
+> **Orchestration Kind**: host-plan
+> **Source Ref**: sprint:plans/sprints/20260722-0001-evidence-projection-convergence.sprint.md#epc-05
+> **Artifact Level**: work-package
+> **Promotion Reason**: rollback_boundary
+> **Verification Boundary**: Red-first D7/D8 materializer fixtures; no-independent-authoring test proves no writer outside the materializer; hand-edited checks/latest is overwritten with provenance; the package's own acceptance flow runs end-to-end on materialized evidence; full bun test green with only deleted-mechanics characterization updates
+> **Rollback Surface**: Revert the single PR: restores the direct cp authoring and {} bootstrap, removes the materializer and payload upgrade; consumers never changed so no consumer rollback needed
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260722-1929-epc-05-checks-latest-materializer.contract.md`
+> **Task Review**: `tasks/reviews/20260722-1929-epc-05-checks-latest-materializer.review.md`
+> **Implementation Notes**: `tasks/notes/20260722-1929-epc-05-checks-latest-materializer.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from repo-harness-sprint planning output.
+- Source ref: sprint:plans/sprints/20260722-0001-evidence-projection-convergence.sprint.md#epc-05
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260722-1929-epc-05-checks-latest-materializer.md`
+- Sprint contract: `tasks/contracts/20260722-1929-epc-05-checks-latest-materializer.contract.md`
+- Sprint review: `tasks/reviews/20260722-1929-epc-05-checks-latest-materializer.review.md`
+- Implementation notes: `tasks/notes/20260722-1929-epc-05-checks-latest-materializer.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260722-1929-epc-05-checks-latest-materializer.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260722-1929-epc-05-checks-latest-materializer.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260722-1929-epc-05-checks-latest-materializer.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260722-1929-epc-05-checks-latest-materializer.contract.md`
+- Review file: `tasks/reviews/20260722-1929-epc-05-checks-latest-materializer.review.md`
+- Implementation notes file: `tasks/notes/20260722-1929-epc-05-checks-latest-materializer.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260722-1929-epc-05-checks-latest-materializer.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260722-1929-epc-05-checks-latest-materializer.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: Revert the single PR: restores the direct cp authoring and {} bootstrap, removes the materializer and payload upgrade; consumers never changed so no consumer rollback needed
+- **Verification boundary**: Red-first D7/D8 materializer fixtures; no-independent-authoring test proves no writer outside the materializer; hand-edited checks/latest is overwritten with provenance; the package's own acceptance flow runs end-to-end on materialized evidence; full bun test green with only deleted-mechanics characterization updates
+- **Review/acceptance boundary**: `tasks/reviews/20260722-1929-epc-05-checks-latest-materializer.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: rollback_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260722-1929-epc-05-checks-latest-materializer.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260722-1929-epc-05-checks-latest-materializer.contract.md`, `tasks/reviews/20260722-1929-epc-05-checks-latest-materializer.review.md`, and `tasks/notes/20260722-1929-epc-05-checks-latest-materializer.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260722-1929-epc-05-checks-latest-materializer.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: Revert the single PR: restores the direct cp authoring and {} bootstrap, removes the materializer and payload upgrade; consumers never changed so no consumer rollback needed
+
+## Captured Planning Output
+
+> **Task Profile**: code-change
+
+## Decision Summary
+
+EPC-05 implements Sprint C backlog row 9: the `checks/latest` materializer
+and the Program's first authority cutover. After this package,
+`.ai/harness/checks/latest.json` is a deterministic materialization of the
+evidence ledger via the frozen D7 selection predicate, carrying the frozen
+D8 provenance block — and every direct authoring path is deleted in this
+same package (R5): the `cp` at the end of `scripts/verify-sprint.sh`
+(formerly line ~504) and the `{}` bootstrap in
+`.ai/hooks/lib/workflow-state.sh`. A no-independent-authoring test proves
+no other writer exists. Consumers (acceptance-receipt, prompt-handler,
+merge-gate readers) keep reading the same file path and schema — the file's
+*content authority* changes, not its consumer contract. Base SHA pinned per
+R1 at fresh fetch: `822153362d008dc2f4418903711f85e9e8266207` (post-wave:
+EPC-03 PR #119 + EPC-04 PR #120 + row flips).
+
+## Why
+
+`checks/latest` is today authored by whichever writer runs last — the
+audit's core "shadow authority" finding. With EPC-01..04 merged, every
+trust class now flows into the ledger (authoritative verify events,
+observed PostBash, attested receipts), so the file can finally become what
+D4 requires: a projection carrying no independent trust. Deleting the
+direct authoring in the same package (R5) is what prevents a dual
+authority from surviving the transition.
+
+## Goal
+
+1. `src/effects/evidence/checks-materializer.ts` (new): implements the
+   frozen D7 selection predicate over the per-worktree ledger —
+   worktree_id == current, contract_id == active contract, subject_hash
+   exact equality, trust_class ∈ {authoritative_machine} plus
+   `human_acceptance`/`external_attested` only where the active
+   contract's Acceptance Policy enumerates them (D4), supersedes
+   excluded, winner = highest append position (never mtime) — and
+   renders `checks/latest.json` deterministically with the frozen D8
+   provenance block (`schema_version`, `generated_at`,
+   `materializer_version`, `source_event_ids`, `source_checkpoint_id`
+   (null), `subject_hash`, `content_hash`, `worktree_id`,
+   `contract_id`). No exact subject match ⇒ `status: "unsatisfied"`
+   (fail closed; never a stale or different-subject event).
+2. Verify-event payload upgrade (same-package, EPC-02 surface now owned
+   here): the verify producer's event must carry everything the
+   materialized checks file needs — the full finalized run-trace content
+   moves into a content-addressed blob (D6 binary/overflow discipline)
+   referenced from the event; small structured fields stay inline. The
+   producer's construction invariants (subject binding, fail-closed
+   classes, exit-code contract) are unchanged.
+3. Cutover in `scripts/verify-sprint.sh` (+ mirror via sync:helpers):
+   after emitting the authoritative event, the script invokes the
+   materializer to produce `checks/latest.json` FROM the ledger; the
+   direct `cp` authoring path is deleted in this package. The
+   `--prepare-acceptance` freeze and finalize semantics (frozen
+   review_subject binding, receipt pending→pass flow) must behave
+   identically from every consumer's point of view.
+4. Delete the `{}` bootstrap authoring of `checks/latest` in
+   `.ai/hooks/lib/workflow-state.sh`; a missing file is now represented
+   by the materializer's `unsatisfied` rendering or by genuine absence —
+   consumers' existing missing-file handling governs, no new fallback.
+5. No-independent-authoring test: a test that fails if any source file
+   outside the materializer writes `checks/latest.json` (e.g. grep-based
+   over `scripts/`, `src/`, `.ai/hooks/`, excluding the materializer
+   module and its single call site), plus a behavior test proving a
+   hand-edited `checks/latest.json` is fully overwritten by the next
+   materialization and carries provenance for drift detection.
+6. Acceptance-receipt compatibility: `acceptance-receipt record/verify`
+   must still find the verification evidence it binds to
+   (`verification_evidence_sha256` semantics preserved against the
+   materialized file); the receipt flow's staleness invariant (record
+   immediately after prepare, no commit between) is unchanged.
+7. All characterization suites green (updated only where they asserted
+   the deleted direct-authoring mechanics — the sanctioned semantic
+   change of this row); full `bun test` green; one independent PR on
+   `codex/epc-05-checks-latest-materializer`.
+
+## P1: Architecture Map
+
+- Design authority: frozen D4/D7/D8 (sprint Frozen decisions). The named
+  deletion targets come from EPC-00's rows 5–13 confirmation: the
+  verify-sprint `cp` and the workflow-state `{}` bootstrap.
+- Owned surfaces this package: new materializer module; verify-producer
+  payload upgrade; verify-sprint.sh + mirror; workflow-state.sh (the one
+  bootstrap site); tests. EPC-01 store/fold stay read-only.
+- Consumers NOT owned here (must stay green unmodified):
+  `scripts/acceptance-receipt.ts` (reads checks file),
+  `src/cli/hook/prompt-handler.ts`, `scripts/merge-gate.ts`,
+  `scripts/verify-contract.sh`. If a consumer cannot stay green without
+  modification, STOP and report (scope decision needed).
+- EPC-04 residual note applies: the ledger, not the receipt file, is the
+  authority the materializer consults for attested trust.
+
+## P2: Concrete Trace
+
+Wave merges (PR #119/#120) -> `main` at `82215336` -> EPC-05
+fresh-fetches, pins it (R1) -> worktree opens on
+`codex/epc-05-checks-latest-materializer` -> materializer + payload
+upgrade + cutover land; direct authoring deleted same-package ->
+no-independent-authoring and D7/D8 fixtures green red-first -> this
+package's own acceptance run dogfoods the full cutover: prepare emits the
+event, materializes checks/latest from the ledger, records the receipt
+against materialized evidence, finalize re-materializes -> full suite
+green -> receipt -> one PR merges -> EPC-06 pins its base per R1.
+
+## P3: Design Decision
+
+- The run-trace content rides a D6 blob rather than inflating inline
+  payload: traces exceed the 8-KiB inline cap and contain long paths the
+  redaction pass would mangle; a content-addressed blob preserves bytes
+  exactly and the event stays small.
+- The materialized file keeps the existing consumer-facing schema
+  (`repo-harness-run-trace.v1` fields) with the D8 provenance block
+  added — consumers keep working, drift becomes provable, and no
+  consumer rewrite is smuggled into this row (EPC-07/08 own their own
+  cutovers).
+- `unsatisfied` rendering vs deleting the file on no-match: rendering a
+  typed `unsatisfied` file preserves atomic-read semantics for existing
+  consumers whose missing-file branches differ; both paths are
+  fail-closed (no gate passes on `unsatisfied`).
+- Characterization updates are confined to assertions about the deleted
+  authoring mechanics; assertions about consumer-visible behavior stay
+  untouched to prove the cutover is invisible to consumers.
+
+## Task Breakdown
+
+- [ ] Verify fresh fetch equals pinned base `82215336`; fill contract.
+- [ ] Materializer module (D7 predicate + D8 provenance, red-first).
+- [ ] Verify-producer payload upgrade (blob-carried trace).
+- [ ] verify-sprint.sh cutover + mirror; workflow-state.sh bootstrap
+      deletion.
+- [ ] No-independent-authoring + hand-edit-overwrite tests.
+- [ ] Full-suite green incl. characterization updates; commit; receipt
+      (dogfoods the cutover); PR.
+
+## Scope
+
+- In scope: `src/effects/evidence/checks-materializer.ts`,
+  `src/effects/evidence/verify-producer.ts` (payload upgrade only),
+  `scripts/emit-verify-evidence.ts` (if the payload upgrade needs new
+  args), `scripts/verify-sprint.sh` + `assets/templates/helpers/verify-sprint.sh`,
+  `.ai/hooks/lib/workflow-state.sh` (the `{}` bootstrap site only),
+  `tests/evidence-checks-materializer.test.ts`, existing test files ONLY
+  where they characterize the deleted authoring mechanics
+  (`tests/helper-scripts.test.ts`, `tests/prompt-handler.test.ts`,
+  `tests/acceptance-receipt.test.ts` — minimal assertions updates), this
+  package's plan/contract/review/notes, `tasks/todos.md` projection,
+  `.ai/harness/worktrees/epc-05-checks-latest-materializer.json`.
+- Out of scope: EPC-01 store/fold modules; `post-bash-importer.ts`;
+  `attested-import.ts`; consumer logic in `acceptance-receipt.ts`,
+  `prompt-handler.ts`, `merge-gate.ts`, `verify-contract.sh`;
+  checkpoint/handoff/current writers (EPC-06/07); Context Packet
+  (EPC-08); `tasks/current.md`; the sprint document; any new npm
+  dependency.
+- Non-goals: checkpoint materialization; recovery-view cutover; retiring
+  `post-bash-latest.json`.
+
+## Stop Conditions
+
+- Stop if `origin/main` moves past `822153362d...` before worktree
+  creation.
+- Stop if a consumer (acceptance-receipt/prompt-handler/merge-gate/
+  verify-contract) cannot stay green without modifying it — that is a
+  scope decision for the orchestrator, not a silent widening.
+- Stop if the receipt staleness invariant cannot be preserved (record
+  immediately after prepare) under the materialized flow.
+- Stop after three fail-fix-reverify rounds on one issue.
+
+## Falsifier
+
+The direction is wrong if materializing from the ledger cannot reproduce
+a consumer-equivalent `checks/latest.json` (i.e. any consumer needs a
+rewrite to stay green), or if deleting the direct authoring breaks the
+frozen prepare/record/finalize acceptance flow. Cheapest proof: this
+package's own acceptance flow completes end-to-end on the materialized
+file, and the full characterization suite passes with only
+deleted-mechanics assertions updated.
+
+## Cheapest Sufficient Proof
+
+- Fresh fetch equals `82215336` at pin time; contract records it.
+- Red-first materializer suite green; no-independent-authoring test
+  green; hand-edit-overwrite test green; full `bun test` green.
+- Dogfood: the package's own acceptance evidence in
+  `checks/latest.json` carries the D8 provenance block whose
+  `source_event_ids` resolve to accepted ledger events.
+- `git diff --name-only <base>..HEAD` ⊆ `allowed_paths`; the deleted
+  `cp` and `{}` bootstrap no longer exist anywhere.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [ ] Verify fresh fetch equals pinned base `82215336`; fill contract.
+- [ ] Materializer module (D7 predicate + D8 provenance, red-first).
+- [ ] Verify-producer payload upgrade (blob-carried trace).
+- [ ] verify-sprint.sh cutover + mirror; workflow-state.sh bootstrap
+- [ ] No-independent-authoring + hand-edit-overwrite tests.
+- [ ] Full-suite green incl. characterization updates; commit; receipt

--- a/scripts/emit-verify-evidence.ts
+++ b/scripts/emit-verify-evidence.ts
@@ -1,28 +1,38 @@
 #!/usr/bin/env bun
 /**
  * Thin CLI wrapper (arg parsing only) so the bash `verify-sprint` chain can
- * invoke `emitAuthoritativeVerifyEvidence` (src/effects/evidence/verify-producer.ts).
- * No logic beyond parsing argv and mapping the producer's typed result to an
- * exit code.
+ * invoke `emitAuthoritativeVerifyEvidence` (src/effects/evidence/verify-producer.ts)
+ * and, on a successful emission, materialize `checks/latest.json` from the
+ * ledger via `src/effects/evidence/checks-materializer.ts`. This is the
+ * materializer's single call site (see that module's doc comment and
+ * tests/evidence-checks-materializer.test.ts's no-independent-authoring test).
+ * No logic beyond parsing argv, mapping the producer's typed result to an
+ * exit code, and (additively) invoking the materializer.
  *
  * Exit code contract (verify-sprint.sh's `emit_verify_evidence` reads this):
- *   0 = emitted.
+ *   0 = emitted (and, when --checks-file was given, materialized).
  *   3 = cannot-bind refusal -- no active contract, or the contract is
  *       dirty/untracked. Sprint row 6 only requires that non-subject-bound
  *       emission be impossible and that a subject mismatch fail closed; it
  *       does not require every verify run to emit. Cannot-bind is
  *       refusal-to-fabricate, not a fallback -- the caller treats it as
- *       "skip, verify result unchanged" because no gate reads the ledger
- *       yet, so skipping satisfies nothing.
+ *       "skip, verify result unchanged" because checks/latest.json is simply
+ *       not (re)written this run (EPC-05: the caller no longer authors it
+ *       directly either, so a cannot-bind run's checks/latest.json is
+ *       whatever a previous run left it, or absent).
  *   2 = CLI usage error (bad/missing arguments).
- *   1 = a real failure: subject mismatch, or a store/genesis error. These
- *       must fail the caller's verify run.
+ *   1 = a real failure: subject mismatch, a store/genesis error, or (when
+ *       --checks-file was given) a materialization error after a successful
+ *       emission. These must fail the caller's verify run.
  * The producer module itself is unchanged by this contract: it still
  * returns one typed `{ ok: false, reason, message }` refusal for every
  * fail-closed condition; only this wrapper's mapping of `reason` to an exit
  * code distinguishes cannot-bind from real failure.
  */
+import { readFileSync } from "fs";
 import { emitAuthoritativeVerifyEvidence, type VerifyProducerFailureReason } from "../src/effects/evidence/verify-producer";
+import { writeChecksLatest } from "../src/effects/evidence/checks-materializer";
+import type { JsonValue } from "../src/core/evidence/types";
 
 const CANNOT_BIND_REASONS: ReadonlySet<VerifyProducerFailureReason> = new Set([
   "no_active_contract",
@@ -33,6 +43,7 @@ function usage(): string {
   return [
     "usage: emit-verify-evidence.ts --repo-root <path> --command <string> --status pass|fail --run-snapshot <repo-relative-path>",
     "         [--contract <repo-relative-path>] [--subject-sha256 <sha256>] [--counts-json <json>] [--correlation-run-id <id>]",
+    "         [--run-trace-file <path>] [--checks-file <repo-relative-path>]",
   ].join("\n");
 }
 
@@ -82,6 +93,24 @@ function main(argv: readonly string[]): number {
     counts = parsed as Record<string, number>;
   }
 
+  let runTrace: JsonValue | undefined;
+  const runTraceFile = args["run-trace-file"];
+  if (runTraceFile) {
+    let raw: string;
+    try {
+      raw = readFileSync(runTraceFile, "utf-8");
+    } catch (error) {
+      process.stderr.write(`emit-verify-evidence: --run-trace-file could not be read: ${(error as Error).message}\n`);
+      return 2;
+    }
+    try {
+      runTrace = JSON.parse(raw) as JsonValue;
+    } catch (error) {
+      process.stderr.write(`emit-verify-evidence: --run-trace-file is not valid JSON: ${(error as Error).message}\n`);
+      return 2;
+    }
+  }
+
   const result = emitAuthoritativeVerifyEvidence({
     repoRoot,
     commandLine,
@@ -91,6 +120,7 @@ function main(argv: readonly string[]): number {
     contractPath: args["contract"] || undefined,
     expectedSubjectSha256: args["subject-sha256"] || undefined,
     correlationRunId: args["correlation-run-id"] || undefined,
+    runTrace,
   });
 
   if (!result.ok) {
@@ -101,6 +131,25 @@ function main(argv: readonly string[]): number {
   }
 
   process.stdout.write(`emit-verify-evidence: appended ${result.event.event_id} (contract ${result.contractPath})\n`);
+
+  const checksFilePath = args["checks-file"];
+  if (checksFilePath) {
+    try {
+      const projection = writeChecksLatest({
+        repoRoot,
+        contractPath: result.contractPath,
+        subjectHash: result.event.subject_identity.subject_hash,
+        checksFilePath,
+      });
+      process.stdout.write(
+        `emit-verify-evidence: materialized ${checksFilePath} (status ${String(projection.status)}, ${projection.provenance.source_event_ids.length} source event(s))\n`,
+      );
+    } catch (error) {
+      process.stderr.write(`emit-verify-evidence: materialization failed after a successful emission: ${(error as Error).message}\n`);
+      return 1;
+    }
+  }
+
   return 0;
 }
 

--- a/scripts/verify-sprint.sh
+++ b/scripts/verify-sprint.sh
@@ -434,6 +434,8 @@ allowed_paths_check_json() {
 # "cannot bind" -- treated the same way (skip, do not fail).
 emit_verify_evidence() {
   local command_line="$1"
+  local run_trace_file="$2"
+  local status="${3:-pass}"
   local emit_script="$helper_dir/emit-verify-evidence.ts"
   if [[ ! -f "$emit_script" ]]; then
     if [[ -n "${REPO_HARNESS_SOURCE_ROOT:-}" && -f "${REPO_HARNESS_SOURCE_ROOT}/scripts/emit-verify-evidence.ts" ]]; then
@@ -445,19 +447,22 @@ emit_verify_evidence() {
   fi
   [[ -n "$BUN_BIN" && -x "$BUN_BIN" ]] || { echo "verify-sprint: trusted Bun runtime is unavailable for evidence emission" >&2; return 1; }
   command -v jq >/dev/null 2>&1 || { echo "verify-sprint: jq is required for evidence emission" >&2; return 1; }
+  [[ -n "$run_trace_file" && -s "$run_trace_file" ]] || { echo "verify-sprint: run-trace file is missing for evidence emission: $run_trace_file" >&2; return 1; }
   local subject_sha256 run_snapshot counts_json
-  subject_sha256="$(jq -r '.review_subject_sha256 // empty' "$checks_file" 2>/dev/null)"
-  run_snapshot="$(jq -r '.lifecycle.snapshot // empty' "$checks_file" 2>/dev/null)"
-  counts_json="$(jq -c '{guards_total: (.guards | length), guards_passed: ([.guards[] | select(.status=="pass")] | length)}' "$checks_file" 2>/dev/null)"
+  subject_sha256="$(jq -r '.review_subject_sha256 // empty' "$run_trace_file" 2>/dev/null)"
+  run_snapshot="$(jq -r '.lifecycle.snapshot // empty' "$run_trace_file" 2>/dev/null)"
+  counts_json="$(jq -c '{guards_total: (.guards | length), guards_passed: ([.guards[] | select(.status=="pass")] | length)}' "$run_trace_file" 2>/dev/null)"
   [[ -n "$subject_sha256" && -n "$run_snapshot" ]] || { echo "verify-sprint: prepared evidence is missing subject or run snapshot; evidence emission needs a frozen --prepare-acceptance run" >&2; return 1; }
   "$BUN_BIN" "$emit_script" \
     --repo-root "$(pwd -P)" \
     --contract "$contract_file" \
     --subject-sha256 "$subject_sha256" \
     --command "$command_line" \
-    --status pass \
+    --status "$status" \
     --run-snapshot "$run_snapshot" \
-    --counts-json "$counts_json"
+    --counts-json "$counts_json" \
+    --run-trace-file "$run_trace_file" \
+    --checks-file "$checks_file"
   return $?
 }
 
@@ -556,14 +561,13 @@ finalize_prepared_acceptance() {
       | .guards = [.guards[] | if .name == "acceptance_receipt" then .status = "pass" else . end]
       | .next_step = "finish contract worktree or archive completed task"
     ' "$checks_file" > "$finalized_checks"
-  cp "$finalized_checks" "$checks_file"
-  rm -f "$finalized_checks"
   echo "Sprint acceptance finalized without rerunning verification"
   echo "Prepared evidence: $checks_file"
   set +e
-  emit_verify_evidence "repo-harness run verify-sprint"
+  emit_verify_evidence "repo-harness run verify-sprint" "$finalized_checks" "pass"
   local emit_exit=$?
   set -e
+  rm -f "$finalized_checks"
   case "$emit_exit" in
     0) : ;;
     3) : ;;
@@ -945,7 +949,6 @@ else
 EOF_CHECKS
 fi
 
-cp "$checks_report" "$checks_file"
 cp "$checks_report" "$run_file"
 
 print_maintenance_advisories "$notes_file" || true
@@ -953,18 +956,35 @@ print_maintenance_advisories "$notes_file" || true
 if [[ "$exit_code" -eq 0 ]]; then
   echo "Sprint verification passed"
   echo "Run snapshot: $run_file"
-  set +e
-  emit_verify_evidence "repo-harness run verify-sprint --prepare-acceptance"
-  emit_exit=$?
-  set -e
-  case "$emit_exit" in
-    0) : ;;
-    3) : ;;
-    *) echo "verify-sprint: evidence emission failed" >&2; exit 1 ;;
-  esac
 else
   echo "Sprint verification failed" >&2
   echo "Run snapshot: $run_file" >&2
 fi
+
+# EPC-05: checks/latest.json is materialized FROM the ledger by
+# emit-verify-evidence.ts's --checks-file handling (see that script's single
+# call into the checks-materializer). Emission (and, on success, this
+# materialization) is attempted for both a passing AND a failing verify
+# result -- a failing verify-sprint run is still a real, subject-bound,
+# authoritative_machine fact ("verification did not pass"), and consumers
+# read the payload's own status field, not the event's trust class, to tell
+# pass from fail (workflow_checks_pass already works this way). Cannot-bind
+# (exit 3) means checks/latest.json is simply not (re)written this run --
+# never a fabricated or stale-content fallback.
+verify_status="$([[ "$exit_code" -eq 0 ]] && printf pass || printf fail)"
+set +e
+emit_verify_evidence "repo-harness run verify-sprint --prepare-acceptance" "$checks_report" "$verify_status"
+emit_exit=$?
+set -e
+case "$emit_exit" in
+  0) : ;;
+  3) : ;;
+  *)
+    echo "verify-sprint: evidence emission failed" >&2
+    if [[ "$exit_code" -eq 0 ]]; then
+      exit 1
+    fi
+    ;;
+esac
 
 exit "$exit_code"

--- a/src/cli/hook/mutation-observed.ts
+++ b/src/cli/hook/mutation-observed.ts
@@ -397,6 +397,27 @@ interface ContractVerificationTarget {
   readonly checksFile: string;
 }
 
+/**
+ * EPC-05 orchestrator ruling (residual finding 2b, closed in this same
+ * package): continuous contract verification (this Stop-time cascade) is
+ * telemetry about "is the active contract still passing", not acceptance
+ * evidence -- it must never write to the policy's `harness.checks_file`
+ * (`.ai/harness/checks/latest.json`), the file
+ * `src/effects/evidence/checks-materializer.ts` now exclusively authors
+ * from the evidence ledger. Writing continuous-verification telemetry to
+ * that same path was exactly the last-writer-wins shadow authority the
+ * audit called out: a Stop-time run could silently clobber a frozen
+ * `--prepare-acceptance` evidence bundle, and the two schemas are not even
+ * compatible (`verify-contract.sh`'s own `write_report()` has no
+ * `source`/`status`/`exit_code` fields at all -- nothing downstream could
+ * even tell the two apart by content). This report gets its own,
+ * deliberately-namespaced file instead; already covered by the existing
+ * `.ai/harness/checks/*.latest.json` gitignore pattern. The policy default
+ * itself (`resolveChecksFile` below, `harness.checks_file`) is unchanged --
+ * every OTHER consumer of the acceptance-evidence checks file is unaffected.
+ */
+const CONTRACT_VERIFICATION_REPORT_RELATIVE = '.ai/harness/checks/contract-verify.latest.json';
+
 /** `run_continuous_contract_verification()`'s guard (post-edit-guard.sh:31-47), ported condition-for-condition. */
 function resolveContractVerificationTarget(
   collector: MutationObservedCollector,
@@ -409,7 +430,7 @@ function resolveContractVerificationTarget(
   if (!contractFile || !fileExists(repoRoot, contractFile)) return null;
   const contractText = readText(repoRoot, contractFile);
   if (!contractText || !contractReferencesPath(contractText, contractFile, filePath)) return null;
-  return { contractFile, checksFile: resolveChecksFile(repoRoot) };
+  return { contractFile, checksFile: CONTRACT_VERIFICATION_REPORT_RELATIVE };
 }
 
 // ---------------------------------------------------------------------------
@@ -417,6 +438,17 @@ function resolveContractVerificationTarget(
 // gate for the (retired) task-handoff regeneration.
 // ---------------------------------------------------------------------------
 
+/**
+ * EPC-05 note: deliberately NOT extended to
+ * `CONTRACT_VERIFICATION_REPORT_RELATIVE` (`.ai/harness/checks/contract-verify.latest.json`).
+ * This guard flags a hand-EDIT of a checkpoint-relevant file (the file was
+ * the subject of a tracked Write/Edit tool call); the continuous-verification
+ * report is machine-written telemetry from a Stop-time subprocess spawn, never
+ * itself the target of an edit tool call in normal operation, so adding it
+ * here would be unreachable. The existing `.ai/harness/checks/latest.json`
+ * check is unchanged: hand-editing the acceptance-evidence file is still
+ * checkpoint-worthy.
+ */
 function isCheckpointPath(filePath: string): boolean {
   if (filePath === 'tasks/todos.md') return true;
   if (/^plans\/.*\.md$/.test(filePath)) return true;

--- a/src/core/evidence/redaction.ts
+++ b/src/core/evidence/redaction.ts
@@ -4,6 +4,60 @@
  * ORIGINAL text is replaced with `sha256:<hash-of-the-secret>`. Pure: this
  * module never reads `process.env` itself -- the caller (an effects module)
  * collects the present values and passes them in as `knownSecretValues`.
+ *
+ * EPC-05 gatekeeper CRITICAL fix (typed-field exemption at the construction
+ * boundary, "Option B"; a within-letter D6 refinement -- D6's frozen text
+ * pins the invariant that secrets never appear raw, not this exact entropy
+ * pattern, per the EPC-01 acceptance record): the bare entropy pattern was
+ * mangling legitimate structured payload values that happen to be 32+ chars
+ * of `[A-Za-z0-9+/_-]` with no breaking dot -- an already-computed sha256
+ * hash value got double-hashed (`sha256:sha256:...`), and any repo-relative
+ * path whose directory+filename-stem run is 32+ chars (any realistic
+ * contract slug) had that whole run replaced with a hash, e.g.
+ * `tasks/contracts/<long-slug>.contract.md` -> `sha256:<hash>.contract.md`.
+ * Live repro: `evt-01KY4YMNNF0BFAPHV968AX04J6` in the EPC-05 worktree's own
+ * ledger (a real `verify-sprint` run against this package's own,
+ * realistic-length contract slug).
+ *
+ * Two typed exemptions from entropy redaction are applied structurally --
+ * classified BEFORE the entropy pass runs, never a post-hoc unhash:
+ *
+ *   1. Declared hash: a whole string value matching
+ *      `^(sha256:)?[0-9a-f]{40,64}$` is already a hash or a raw git commit
+ *      SHA (40 hex chars) -- entropy-redacting it a second time is exactly
+ *      the double-prefix bug. Whole-value match only; a hash or SHA
+ *      embedded inside a longer free-text string (e.g. a full command
+ *      line) is NOT exempted by this rule and keeps the entropy pattern for
+ *      that embedded span.
+ *   2. Declared or inferred path: a field whose KEY follows the existing
+ *      path-key convention (`path`/`_path`/`Path` suffix -- the same
+ *      convention `src/effects/evidence/event-writer.ts`'s `isPathFieldKey`
+ *      enforces fail-closed repo-relative validation for; duplicated here
+ *      as a one-line convention check, not imported, since this is a core
+ *      module and must not depend on the effects layer) is exempt, AND --
+ *      because several real run-trace fields carry paths without following
+ *      that key convention (`run_file`, `lifecycle.snapshot`,
+ *      `contract.file`, `active_plan`; never renamed to fit the
+ *      convention, since these are established consumer-facing field
+ *      names outside this package's authority to rewrite) -- a value that
+ *      WHOLE-VALUE parses as a safe repo-relative path is exempt too:
+ *      contains `/`, no leading `/`, no `..` path-traversal segment, and
+ *      ends with a file extension (a final dot-suffix on the string). This
+ *      is a lightweight redaction-exemption heuristic only, not a security
+ *      validator -- `src/effects/path-safety.ts`'s `ensureRepoRelativePath`
+ *      remains the actual fail-closed check for path-key-convention fields,
+ *      unchanged and still enforced by `event-writer.ts` independently of
+ *      this module.
+ *
+ * Both exemptions skip ONLY the entropy pattern. The secret-value denylist
+ * check (`findKnownSecretSpans`) still runs unconditionally over every
+ * field, exempted or not -- a literal secret value sitting in a hash-shaped
+ * or path-shaped position must still be replaced. Free-text fields (no
+ * matching exemption -- e.g. a command line embedding a path inside other
+ * words, `branch`, or any bare identifier with no path separator+extension)
+ * are unaffected by this refinement and remain subject to entropy redaction
+ * exactly as before; this is an accepted, out-of-ruling-scope residual since
+ * no consumer gates on those fields' exact value.
  */
 import { createHash } from "crypto";
 import type { JsonValue } from "./types";
@@ -20,6 +74,46 @@ export const SECRET_DENYLIST_ENV_KEYS: readonly string[] = [
 ];
 
 const HIGH_ENTROPY_TOKEN_SOURCE = "[A-Za-z0-9+/_-]{32,}";
+
+/** Rule 1: a whole value already shaped like a declared hash or a raw git
+ * commit SHA (40 hex chars) -- lowercase hex only, matching how every hash
+ * in this codebase is actually produced (`createHash(...).digest("hex")`
+ * and `sha256:`-prefixing convention). Whole-value match only. */
+const DECLARED_HASH_PATTERN = /^(sha256:)?[0-9a-f]{40,64}$/;
+
+export function isDeclaredHashValue(value: string): boolean {
+  return DECLARED_HASH_PATTERN.test(value);
+}
+
+/** Rule 2a: mirrors `event-writer.ts`'s `isPathFieldKey` convention
+ * (`path`/`_path`/`Path` key suffix). Duplicated, not imported -- see the
+ * module doc comment on why this core module must not depend on the
+ * effects layer. Kept in sync by hand; the convention itself is a stable,
+ * one-line rule unlikely to drift. */
+export function isPathConventionKey(key: string | undefined): boolean {
+  if (key === undefined) return false;
+  return key === "path" || key.endsWith("_path") || key.endsWith("Path");
+}
+
+/** Rule 2b: a lightweight heuristic (redaction-exemption only, NOT the
+ * security validator -- see the module doc comment) for "this whole value
+ * looks like a repo-relative file path": contains a `/`, no leading `/`, no
+ * `..` path-traversal segment, and ends in a file extension. */
+export function looksLikeSafeRepoRelativePath(value: string): boolean {
+  if (value.length === 0) return false;
+  if (value.startsWith("/")) return false;
+  if (!value.includes("/")) return false;
+  if (value.split("/").includes("..")) return false;
+  return /\.[^./]+$/.test(value);
+}
+
+/** Structural classification: does this leaf (key + value) qualify for
+ * either typed exemption? Computed once, up front -- see the module doc
+ * comment's "order of operations" note (classify first, then redact the
+ * rest; never a post-hoc unhash). */
+export function isEntropyExemptLeaf(key: string | undefined, value: string): boolean {
+  return isDeclaredHashValue(value) || isPathConventionKey(key) || looksLikeSafeRepoRelativePath(value);
+}
 
 interface Span {
   readonly start: number;
@@ -76,9 +170,21 @@ function mergeSpans(spans: readonly Span[]): Span[] {
  * two-pass "denylist then regex" design would re-scan the hex output of the
  * first pass (itself high-entropy) and double-hash it; computing spans from
  * both sources up front and slicing the original string avoids that.
+ *
+ * `entropyExempt` (rule 3/4): when true, the entropy pattern is skipped
+ * entirely for this value -- the denylist-secret-value check still always
+ * runs regardless. Defaults to `false` (today's unchanged behavior) for
+ * every direct caller that does not pass it.
  */
-export function redactSecretValue(text: string, knownSecretValues: readonly string[]): string {
-  const spans = mergeSpans([...findKnownSecretSpans(text, knownSecretValues), ...findHighEntropySpans(text)]);
+export function redactSecretValue(
+  text: string,
+  knownSecretValues: readonly string[],
+  opts: { readonly entropyExempt?: boolean } = {},
+): string {
+  const spans = mergeSpans([
+    ...findKnownSecretSpans(text, knownSecretValues),
+    ...(opts.entropyExempt ? [] : findHighEntropySpans(text)),
+  ]);
   if (spans.length === 0) return text;
   let out = "";
   let cursor = 0;
@@ -91,7 +197,13 @@ export function redactSecretValue(text: string, knownSecretValues: readonly stri
   return out;
 }
 
-/** Pure: walk a JSON payload and redact every string leaf. */
+/** Pure: walk a JSON payload and redact every string leaf, classifying each
+ * leaf's entropy-exemption status from its own key + value before redacting
+ * (order of operations: classify first, then redact the rest). */
 export function redactPayloadStrings(value: JsonValue, knownSecretValues: readonly string[]): JsonValue {
-  return mapStringLeaves(value, (_path, leaf) => redactSecretValue(leaf, knownSecretValues));
+  return mapStringLeaves(value, (path, leaf) => {
+    const key = path[path.length - 1];
+    const exempt = isEntropyExemptLeaf(key, leaf);
+    return redactSecretValue(leaf, knownSecretValues, { entropyExempt: exempt });
+  });
 }

--- a/src/effects/evidence/checks-materializer.ts
+++ b/src/effects/evidence/checks-materializer.ts
@@ -1,0 +1,277 @@
+/**
+ * The `checks/latest.json` materializer (Sprint C backlog row 9 / D7 + D8).
+ * This module is the sole authority that renders `checks/latest.json`; the
+ * only writer of that file anywhere in this repository is this module plus
+ * its single call site in `scripts/emit-verify-evidence.ts` (see
+ * `tests/evidence-checks-materializer.test.ts`'s no-independent-authoring
+ * test). Every previously-direct authoring path (`scripts/verify-sprint.sh`'s
+ * `cp`, `.ai/hooks/lib/workflow-state.sh`'s `{}` bootstrap) is deleted in
+ * this same package (R5).
+ *
+ * D7 selection predicate (frozen, sprint `### Frozen decisions (EPC-00,
+ * 2026-07-22)`):
+ *
+ *   accepted := events WHERE
+ *        worktree_id   == current worktree
+ *    AND contract_id   == active contract
+ *    AND subject_hash  == frozen-subject hash        (exact equality)
+ *    AND trust_class ∈ {authoritative_machine}       (human_acceptance /
+ *                       external_attested admitted only where the contract's
+ *                       Acceptance Policy enumerates them -- D4)
+ *    AND event_id NOT ∈ (union of supersedes[])
+ *   winner := last(accepted ORDER BY append_position ASC)
+ *             -- never mtime / filename recency / last-writer-wins
+ *
+ * `contract_id == active contract` and `worktree_id == current` collapse to
+ * one filter in this system's actual schema: `EvidenceEventRecord.worktree_id`
+ * is already populated with the active contract's own slug at emission time
+ * (`worktreeIdFor()` in `verify-producer.ts`, exported and reused here rather
+ * than re-implemented -- both this module and `verify-producer.ts` are owned
+ * by this SAME package, so sharing this one small pure helper does not
+ * revisit the EPC-02/03/04 wave's "no shared private helper" qualification,
+ * which was specifically about proving independence across DIFFERENT
+ * parallel packages).
+ *
+ * `readAcceptedEvents` (EPC-01, read-only) already applies D5's fold: total
+ * order by append position, idempotency-key dedup, and supersedes exclusion.
+ * This module applies exactly one more filter on top of that already-accepted
+ * set: worktree_id + subject_hash + trust-class-admission.
+ *
+ * No exact subject_hash match -> `status: "unsatisfied"` (fail-closed; never
+ * a stale or different-subject event, per D7's closing sentence).
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+import type { EvidenceEventRecord, JsonValue } from "../../core/evidence/types";
+import { canonicalize } from "../../core/evidence/canonical-json";
+import { createHash } from "crypto";
+import { readAcceptedEvents } from "./event-log";
+import { resolveBlobsDir } from "./paths";
+import { writeFileDurably } from "./atomic-append";
+import { worktreeIdFor } from "./verify-producer";
+
+/** Bumped only when this module's own rendering logic changes shape. */
+export const MATERIALIZER_VERSION = "1";
+export const CHECKS_SCHEMA_VERSION = 1;
+
+export interface AcceptancePolicySummary {
+  /** true when a syntactically valid Acceptance Policy JSON block was found. */
+  readonly present: boolean;
+  readonly userWaiverAllowed: boolean;
+}
+
+/**
+ * Local, structural re-parse of the contract's `## Acceptance Policy` fenced
+ * JSON block -- the same block `scripts/acceptance-receipt.ts`'s
+ * `parseAcceptancePolicy` reads. Duplicated here (not imported) because
+ * `src/` must not depend on `scripts/` (R4/EPC-04 precedent); this is a
+ * small, closed, read-only structural parse, not a second authority over
+ * the policy's meaning -- D4's two-entry admission table is what this
+ * module derives from the result, unchanged from EPC-04's trust mapping
+ * (`external_pass` -> `external_attested`, `user_waiver` -> `human_acceptance`).
+ */
+export function parseAcceptancePolicySummary(contractText: string): AcceptancePolicySummary {
+  const section = contractText.match(/^## Acceptance Policy[ \t]*\r?\n+```json[ \t]*\r?\n([\s\S]*?)\r?\n```[ \t]*$/m);
+  if (!section) return { present: false, userWaiverAllowed: false };
+  let value: unknown;
+  try {
+    value = JSON.parse(section[1]!);
+  } catch {
+    return { present: false, userWaiverAllowed: false };
+  }
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return { present: false, userWaiverAllowed: false };
+  }
+  const record = value as Record<string, unknown>;
+  if (record.protocol !== 1) return { present: false, userWaiverAllowed: false };
+  if (record.reviewer !== "Claude" && record.reviewer !== "Codex") return { present: false, userWaiverAllowed: false };
+  if (record.user_waiver !== "allowed" && record.user_waiver !== "forbidden") {
+    return { present: false, userWaiverAllowed: false };
+  }
+  return { present: true, userWaiverAllowed: record.user_waiver === "allowed" };
+}
+
+/**
+ * D4 admission gate: `authoritative_machine` is always admitted by the
+ * caller (this function is only consulted for the other two trust classes).
+ * Default is deny -- an absent/invalid Acceptance Policy admits neither.
+ */
+function isTrustClassAdmitted(trustClass: EvidenceEventRecord["trust_class"], policy: AcceptancePolicySummary): boolean {
+  if (trustClass === "authoritative_machine") return true;
+  if (trustClass === "observed") return false;
+  if (!policy.present) return false;
+  if (trustClass === "external_attested") return true;
+  if (trustClass === "human_acceptance") return policy.userWaiverAllowed;
+  return false;
+}
+
+export interface MaterializeChecksLatestInput {
+  readonly repoRoot: string;
+  /** Repo-relative path to the active contract, e.g. `tasks/contracts/<slug>.contract.md`. */
+  readonly contractPath: string;
+  /** Exact-equality target for D7's `subject_hash` filter. */
+  readonly subjectHash: string;
+  /** Injectable for deterministic tests; defaults to the real clock. */
+  readonly now?: () => Date;
+}
+
+export interface ChecksLatestProvenance {
+  readonly schema_version: number;
+  readonly generated_at: string;
+  readonly materializer_version: string;
+  readonly source_event_ids: readonly string[];
+  readonly source_checkpoint_id: null;
+  readonly subject_hash: string;
+  readonly content_hash: string;
+  readonly worktree_id: string;
+  readonly contract_id: string;
+}
+
+export type ChecksLatestProjection = Readonly<Record<string, JsonValue>> & {
+  readonly provenance: ChecksLatestProvenance;
+};
+
+function sha256Hex(text: string): string {
+  return createHash("sha256").update(text).digest("hex");
+}
+
+/** sha256 of the consumer-facing content only -- excludes the provenance
+ * block itself (which embeds this hash and a volatile `generated_at`), so
+ * replaying the same accepted events always reproduces the same
+ * `content_hash` (EPC-09's drift check depends on this). */
+function contentHashOf(consumerFacing: Readonly<Record<string, JsonValue>>): string {
+  return `sha256:${sha256Hex(canonicalize(consumerFacing as JsonValue))}`;
+}
+
+function readBlobJson(repoRoot: string, blobSha256: string): unknown {
+  const blobPath = join(resolveBlobsDir(repoRoot), blobSha256);
+  const raw = readFileSync(blobPath, "utf-8");
+  return JSON.parse(raw);
+}
+
+/** Extracts the full run-trace object a matching event carries, whether
+ * inline or blob-offloaded (D6 overflow discipline, transparent to readers).
+ * Returns undefined when the event carries no `run_trace` field at all (an
+ * older/smaller caller that never supplied one) -- treated the same as "no
+ * match" by the caller, since there is nothing to project from. */
+function extractRunTrace(repoRoot: string, event: EvidenceEventRecord): Record<string, JsonValue> | undefined {
+  let value: unknown;
+  if (event.payload !== undefined) {
+    value = event.payload;
+  } else if (event.blob_sha256) {
+    try {
+      value = readBlobJson(repoRoot, event.blob_sha256);
+    } catch {
+      return undefined;
+    }
+  } else {
+    return undefined;
+  }
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
+  const runTrace = (value as Record<string, unknown>).run_trace;
+  if (typeof runTrace !== "object" || runTrace === null || Array.isArray(runTrace)) return undefined;
+  return runTrace as Record<string, JsonValue>;
+}
+
+function isoNow(now: () => Date): string {
+  return now().toISOString();
+}
+
+/**
+ * Pure projection builder: no IO beyond reading already-loaded accepted
+ * events and (for a blob-backed winner) one blob file. Callers that need the
+ * write should use `writeChecksLatest` below.
+ */
+export function buildChecksLatestProjection(
+  input: MaterializeChecksLatestInput,
+  accepted: readonly EvidenceEventRecord[],
+  contractText: string,
+): ChecksLatestProjection {
+  const now = input.now ?? (() => new Date());
+  const worktreeId = worktreeIdFor(input.contractPath);
+  const policy = parseAcceptancePolicySummary(contractText);
+
+  const matching = accepted.filter(
+    (event) =>
+      event.worktree_id === worktreeId &&
+      event.subject_identity.subject_hash === input.subjectHash &&
+      isTrustClassAdmitted(event.trust_class, policy),
+  );
+
+  const sourceEventIds = matching.map((event) => event.event_id);
+
+  if (matching.length === 0) {
+    const consumerFacing: Record<string, JsonValue> = { schema: "repo-harness-run-trace.v1", status: "unsatisfied" };
+    return {
+      ...consumerFacing,
+      provenance: {
+        schema_version: CHECKS_SCHEMA_VERSION,
+        generated_at: isoNow(now),
+        materializer_version: MATERIALIZER_VERSION,
+        source_event_ids: sourceEventIds,
+        source_checkpoint_id: null,
+        subject_hash: input.subjectHash,
+        content_hash: contentHashOf(consumerFacing),
+        worktree_id: worktreeId,
+        contract_id: input.contractPath,
+      },
+    };
+  }
+
+  // D7 winner: last accepted event matching the predicate, in append order
+  // (never mtime/filename recency).
+  const winner = matching[matching.length - 1]!;
+  const runTrace = extractRunTrace(input.repoRoot, winner);
+
+  if (runTrace === undefined) {
+    const consumerFacing: Record<string, JsonValue> = { schema: "repo-harness-run-trace.v1", status: "unsatisfied" };
+    return {
+      ...consumerFacing,
+      provenance: {
+        schema_version: CHECKS_SCHEMA_VERSION,
+        generated_at: isoNow(now),
+        materializer_version: MATERIALIZER_VERSION,
+        source_event_ids: sourceEventIds,
+        source_checkpoint_id: null,
+        subject_hash: input.subjectHash,
+        content_hash: contentHashOf(consumerFacing),
+        worktree_id: worktreeId,
+        contract_id: input.contractPath,
+      },
+    };
+  }
+
+  return {
+    ...runTrace,
+    provenance: {
+      schema_version: CHECKS_SCHEMA_VERSION,
+      generated_at: isoNow(now),
+      materializer_version: MATERIALIZER_VERSION,
+      source_event_ids: sourceEventIds,
+      source_checkpoint_id: null,
+      subject_hash: input.subjectHash,
+      content_hash: contentHashOf(runTrace),
+      worktree_id: worktreeId,
+      contract_id: input.contractPath,
+    },
+  };
+}
+
+export interface WriteChecksLatestInput extends MaterializeChecksLatestInput {
+  /** Repo-relative path to write to, e.g. `.ai/harness/checks/latest.json`. */
+  readonly checksFilePath: string;
+}
+
+/**
+ * The materializer's one disk-writing entry point. `scripts/emit-verify-evidence.ts`
+ * is this function's single call site (see module doc + the
+ * no-independent-authoring test).
+ */
+export function writeChecksLatest(input: WriteChecksLatestInput): ChecksLatestProjection {
+  const contractText = readFileSync(join(input.repoRoot, input.contractPath), "utf-8");
+  const { accepted } = readAcceptedEvents(input.repoRoot);
+  const projection = buildChecksLatestProjection(input, accepted, contractText);
+  const absolutePath = join(input.repoRoot, input.checksFilePath);
+  writeFileDurably(absolutePath, `${JSON.stringify(projection, null, 2)}\n`);
+  return projection;
+}

--- a/src/effects/evidence/verify-producer.ts
+++ b/src/effects/evidence/verify-producer.ts
@@ -35,7 +35,7 @@ import { existsSync, readFileSync, statSync } from "fs";
 import { basename, dirname, join, resolve } from "path";
 import { fileURLToPath } from "url";
 
-import type { EvidenceEventRecord, GenesisRecord, SubjectIdentity } from "../../core/evidence/types";
+import type { EvidenceEventRecord, GenesisRecord, JsonValue, SubjectIdentity } from "../../core/evidence/types";
 import { appendEvidenceEvent, appendGenesisRecord } from "./event-log";
 import { buildReviewSubject, uniqueSorted } from "../review/diff-fingerprint";
 import { LEDGER_EPOCH_START_SHA } from "./epoch";
@@ -87,6 +87,19 @@ export interface VerifyProducerInput {
    * omitted.
    */
   readonly contractPath?: string;
+  /**
+   * EPC-05 payload upgrade: the full finalized run-trace object (everything
+   * `scripts/verify-sprint.sh`'s own `checks_report` already computed), so
+   * the checks/latest.json materializer can reconstruct the consumer-facing
+   * projection from the ledger alone. Optional and purely additive -- when
+   * omitted, the emitted payload is byte-identical to the pre-EPC-05 shape
+   * (this keeps every existing direct caller of this function, including
+   * tests/evidence-verify-producer.test.ts, unaffected). D6's existing
+   * "json" payload construction (path-safety + redaction, then inline-or-blob
+   * by size) applies to this field exactly as it does to every other
+   * payload value -- no new bypass of that construction invariant.
+   */
+  readonly runTrace?: JsonValue;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -177,7 +190,17 @@ function workspaceId(repoRoot: string): string {
   return `ws-${sha256Hex(real).slice(0, 12)}`;
 }
 
-function worktreeIdFor(contractRelative: string): string {
+/**
+ * `worktree_id` (the ledger's own field) is populated with the active
+ * contract's own slug -- this system's actual reduction of D7's
+ * "worktree_id == current AND contract_id == active contract" into one
+ * filterable field. Exported so `checks-materializer.ts` (owned by this
+ * same package) derives the identical value rather than re-implementing it;
+ * this is not a re-opening of the EPC-02/03/04 "no shared private helper"
+ * wave qualification, which concerned proving independence across DIFFERENT
+ * parallel packages, not sharing within one serial package's own two files.
+ */
+export function worktreeIdFor(contractRelative: string): string {
   const base = contractRelative.split("/").pop() ?? contractRelative;
   return base.replace(/\.contract\.md$/, "");
 }
@@ -325,6 +348,10 @@ export function emitAuthoritativeVerifyEvidence(input: VerifyProducerInput): Ver
         // Short id, not the full path -- see shortRunSnapshotId's doc comment.
         // Reconstruct with: `.ai/harness/runs/${run_snapshot_id}-${worktree_id}.json`.
         run_snapshot_id: shortRunSnapshotId(input.runSnapshotPath, worktreeId),
+        // EPC-05: additive only -- omitted entirely (not even as an explicit
+        // `undefined`) when the caller supplies no runTrace, so this object's
+        // own shape is byte-identical to the pre-EPC-05 payload in that case.
+        ...(input.runTrace !== undefined ? { run_trace: input.runTrace } : {}),
       },
     },
   });

--- a/tasks/contracts/20260722-1929-epc-05-checks-latest-materializer.contract.md
+++ b/tasks/contracts/20260722-1929-epc-05-checks-latest-materializer.contract.md
@@ -1,0 +1,456 @@
+# Task Contract: epc-05-checks-latest-materializer
+
+> **Status**: Active
+> **Plan**: plans/plan-20260722-1929-epc-05-checks-latest-materializer.md
+> **Task Profile**: code-change
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: kito
+> **Reviewer**: Claude
+> **Waiver Policy**: user_waiver allowed, owner kito only, per Acceptance Policy below
+> **Base SHA**: `822153362d008dc2f4418903711f85e9e8266207` (pinned per R1 post-wave: fresh fetch after EPC-04 PR #120 merged, plus its row-flip commit `docs(program): mark epc-04 done via PR #120; EPC-05 unblocked`; verified equal to this worktree's HEAD at task start)
+> **Target Branch**: main (via one independent PR)
+> **Working Branch**: `codex/epc-05-checks-latest-materializer`
+> **PR Unit**: one PR carrying the new materializer module, the verify-producer payload upgrade, the verify-sprint.sh cutover (plus its deterministic `assets/templates/helpers/` mirror), the single `workflow-state.sh` bootstrap deletion, the red-first test suite, the characterization updates it required, and this package's workflow artifacts
+> **Capability ID**: root
+> **Last Updated**: 2026-07-22 21:45
+> **Review File**: `tasks/reviews/20260722-1929-epc-05-checks-latest-materializer.review.md`
+> **Notes File**: `tasks/notes/20260722-1929-epc-05-checks-latest-materializer.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+EPC-05 implements Sprint C backlog row 9 and is the Program's first authority
+cutover: `checks/latest.json` is authored today by whichever writer ran last
+(the audit's "shadow authority" finding). With EPC-01..04 merged, every trust
+class the Program recognizes (authoritative machine verification, observed
+PostBash, human/external attestation) now flows into the EvidenceEvent
+ledger, so `checks/latest.json` can finally become what D4 requires: a
+projection carrying no independent trust of its own. This package deletes
+the two direct-authoring sites EPC-00 froze as row 9's complete enumeration
+(`scripts/verify-sprint.sh`'s `cp`, `.ai/hooks/lib/workflow-state.sh`'s `{}`
+bootstrap) in the same package that replaces them (R5) -- what prevents a
+dual authority from surviving the transition.
+
+## Goal
+
+1. `src/effects/evidence/checks-materializer.ts` (new): implements the frozen
+   D7 selection predicate over the per-worktree ledger -- `worktree_id`
+   equal to the active contract's own slug (this system's existing reduction
+   of "worktree_id == current AND contract_id == active contract" into one
+   filterable field, per `verify-producer.ts`'s `worktreeIdFor`, exported and
+   reused rather than re-implemented), `subject_hash` exact equality,
+   `trust_class` `authoritative_machine` always admitted plus
+   `human_acceptance`/`external_attested` admitted only where the active
+   contract's Acceptance Policy JSON enumerates them (D4; a local structural
+   re-parse of the same block `acceptance-receipt.ts` reads, since `src/`
+   must not depend on `scripts/`), supersedes excluded (already applied by
+   the EPC-01 fold), winner = highest append position (never mtime/filename).
+   Renders `checks/latest.json` preserving the consumer-facing
+   `repo-harness-run-trace.v1` field shape plus a nested D8 provenance block
+   (`schema_version`, `generated_at`, `materializer_version`,
+   `source_event_ids`, `source_checkpoint_id: null`, `subject_hash`,
+   `content_hash`, `worktree_id`, `contract_id`). No exact subject match (or
+   a matching event that carries no run-trace content at all) renders a
+   typed `status: "unsatisfied"` (fail closed).
+2. Verify-producer payload upgrade (`verify-producer.ts`, `emit-verify-evidence.ts`):
+   an optional, purely additive `runTrace` input carries the full finalized
+   run-trace object; when supplied, it rides inside the existing "json"
+   payload's `run_trace` field, so EPC-01's already-frozen D6 construction
+   invariant (path-safety + redaction, then inline-or-blob by the existing
+   200-line/8-KiB cap) decides inline-vs-blob exactly as it does for every
+   other payload value -- no new bypass. Omitted entirely when the caller
+   supplies nothing, so every existing direct caller of
+   `emitAuthoritativeVerifyEvidence` (including
+   `tests/evidence-verify-producer.test.ts`, out of this package's
+   `allowed_paths`) observes a byte-identical payload shape to before.
+   Producer invariants (subject binding, fail-closed classes, wrapper exit
+   codes 0/3/other) unchanged.
+3. `scripts/verify-sprint.sh` cutover (+ `assets/templates/helpers/verify-sprint.sh`
+   mirror via `bun run sync:helpers`): both direct-authoring sites named by
+   EPC-00 are deleted. `emit_verify_evidence()` now reads its subject/run-snapshot
+   binding from an explicit run-trace file argument (not from
+   `$checks_file`, which this script no longer writes directly), passes that
+   file through as the emitted event's `run_trace`, and passes
+   `--checks-file "$checks_file"` so a successful emission also materializes
+   `checks/latest.json` from the ledger (`emit-verify-evidence.ts` is this
+   materializer's single call site). Emission is now attempted for both a
+   passing AND a failing verify result (a failing run is still a real,
+   subject-bound `authoritative_machine` fact; consumers already read the
+   payload's own status field, not the event's trust class, to tell pass
+   from fail) -- this is required for `checks/latest.json` to ever reflect a
+   failing outcome once direct authoring is gone. Cannot-bind (exit 3) means
+   `checks/latest.json` is simply not (re)written this run, never a
+   fabricated or stale-content fallback. The `--prepare-acceptance` freeze
+   and `finalize_prepared_acceptance` semantics (frozen `review_subject`
+   binding, receipt pending -> pass flow, `acceptance-receipt.ts verify`
+   staleness check) are unchanged in a ledger-reachable context; the ONE
+   named residual is documented in Deliverable D below.
+4. `.ai/hooks/lib/workflow-state.sh` deletes ONLY the `{}` bootstrap line
+   inside `workflow_ensure_harness_surface`; nothing else in this file
+   changes. **Scope correction found during full-suite verification**:
+   `.ai/hooks/lib/workflow-state.sh` is not independently authoritative --
+   it is a generated projection of `assets/hooks/lib/workflow-state.sh`
+   (`scripts/sync-hook-sources.ts`, `canonical_root: assets/hooks`,
+   `projection_target: .ai/hooks`). Editing only the projected copy is not
+   durable: `tests/hook-source-projection.test.ts`'s own drift/idempotency
+   checks (part of the full `bun test` run) regenerate `.ai/hooks/` from the
+   canonical source and silently reverted the edit. The identical one-line
+   deletion is therefore applied to BOTH `assets/hooks/lib/workflow-state.sh`
+   (the canonical source -- added to `allowed_paths` below) and
+   `.ai/hooks/lib/workflow-state.sh` (regenerated from it via `bun run
+   sync:hooks`, byte-identical). Every existing consumer of
+   `workflow_checks_file`'s content (`workflow_checks_pass`,
+   `workflow_acceptance_receipt_status`, `workflow_next_action`'s own
+   `[[ ! -f "$checks_file" ]]` branch) already treats "missing or empty" as
+   its own fail-closed case, so this changes no consumer's observable
+   pass/fail outcome, only which message it prints.
+5. `tests/evidence-checks-materializer.test.ts` (new, red-first: fails with
+   "Cannot find module" before the materializer existed): the full D7
+   predicate matrix (exact-subject-only, stale-subject unsatisfied,
+   append-position winner over `created_at`, supersedes exclusion,
+   trust-class + policy gating for all four trust classes, worktree_id
+   mismatch), D8 provenance completeness and `content_hash` self-consistency
+   plus replay determinism, a hand-edited `checks/latest.json` fully
+   overwritten by the next materialization, two end-to-end
+   producer-then-materializer tests (pass and fail), and a
+   no-independent-authoring sweep over `scripts/`, `src/`, `.ai/hooks/` that
+   fails if any writer of `checks/latest.json` exists outside this
+   materializer module, its single call site, and a small named allowlist of
+   pre-existing project-initialization/adoption scaffolding that seeds a
+   brand-new downstream repo's genesis placeholder (a distinct, out-of-scope
+   lifecycle -- see Scope).
+6. All characterization suites green, updated only where they asserted the
+   deleted direct-authoring mechanics (the sanctioned semantic change of this
+   row): 8 `verify-sprint` fixtures in `tests/helper-scripts.test.ts` (every
+   deployed-helper fixture in that file cannot-binds emission today --
+   `scripts/emit-verify-evidence.ts` and the ledger/materializer modules are
+   source-repo-only tooling, never copied into `assets/templates/helpers/`,
+   mirroring the EPC-03/04 precedent for `post-bash-importer.ts`/`attested-import.ts`).
+   `tests/prompt-handler.test.ts` and `tests/acceptance-receipt.test.ts`
+   needed zero changes (verified by running them unmodified). Full `bun
+   test` green; one independent PR on
+   `codex/epc-05-checks-latest-materializer`.
+7. **Orchestrator ruling on residual finding 2b (authorized mid-package
+   widening)**: `src/cli/hook/mutation-observed.ts`'s
+   `processContractVerification` (Stop-time continuous contract
+   verification, via the post-edit-guard cascade) IS a live direct-authoring
+   path for `checks/latest.json` -- it invokes `verify-contract.sh
+   --report-file <path>` where `<path>` defaulted to the policy
+   `harness.checks_file` (`.ai/harness/checks/latest.json`), the same file
+   the materializer now exclusively authors. Row 9's acceptance line
+   ("every direct authoring path deleted in this package") requires closing
+   it here. Fix: `resolveContractVerificationTarget` now points the
+   continuous-verification report at a dedicated
+   `.ai/harness/checks/contract-verify.latest.json` instead of resolving the
+   policy checks_file; the policy default itself (`resolveChecksFile`,
+   `harness.checks_file`) is unchanged for every other consumer. Rationale:
+   continuous verification is Stop-time telemetry (a different, incompatible
+   schema -- `verify-contract.sh`'s own `write_report()` has no
+   `source`/`status`/`exit_code` fields at all), not acceptance evidence;
+   writing it to the acceptance-evidence path was exactly the last-writer-wins
+   shadow authority the audit called out (Stop-time telemetry could silently
+   clobber a frozen `--prepare-acceptance` evidence bundle). The new filename
+   is already covered by the existing `.ai/harness/checks/*.latest.json`
+   gitignore pattern. `isCheckpointPath`'s existing check for
+   `.ai/harness/checks/latest.json` is unchanged and NOT extended to the new
+   filename (documented decision: that guard flags a hand-EDIT of the
+   acceptance-evidence file as checkpoint-worthy; the new file is
+   machine-written telemetry, never edited via a tool call, so extending the
+   guard to it would be dead code). `tests/mutation-observed.test.ts`'s one
+   assertion characterizing the old target path is updated; every other
+   assertion in that file (including the `isCheckpointPath` coverage) is
+   unchanged. Full `bun test` re-verified green after this change.
+8. **Gatekeeper CRITICAL fix (orchestrator ruling, authorized mid-package
+   widening): D6 entropy redaction was mangling the run_trace payload**.
+   `src/core/evidence/redaction.ts`'s high-entropy pattern
+   (`[A-Za-z0-9+/_-]{32,}`) matched legitimate 32+ char dot-free runs in
+   structured payload values -- an already-computed `sha256:`-prefixed hash
+   got double-hashed (`sha256:sha256:...`), and any repo-relative path whose
+   directory+filename-stem run reached 32+ chars (any realistic contract
+   slug, including this package's own) had that run replaced with a hash,
+   breaking `review_subject_sha256`, `run_file`, `lifecycle.snapshot`,
+   `contract.file`, `active_plan`, `allowed_paths`/`files_changed` array
+   entries, and 40-char git SHAs in `diff_base`. Live repro:
+   `evt-01KY4YMNNF0BFAPHV968AX04J6` in this worktree's own ledger (the
+   gatekeeper's own dogfood run of this contract). Fix (Option B, a
+   within-letter D6 refinement -- D6's frozen text pins the invariant that
+   secrets never appear raw, not this exact pattern): two typed exemptions
+   applied structurally BEFORE the entropy pass runs (deny-by-construction
+   preserved, never a post-hoc unhash) -- (1) a whole string value matching
+   `^(sha256:)?[0-9a-f]{40,64}$` is a declared hash, entropy-exempt (kills
+   the double-prefix bug; whole-value match only, no partial-token
+   exemption); (2) a field whose key follows the existing path-key
+   convention (`path`/`_path`/`Path` suffix) keeps its existing fail-closed
+   repo-relative validation and is entropy-exempt, AND a value that
+   whole-value parses as a safe repo-relative path (contains `/`, no
+   leading `/`, no `..` segment, ends in a file extension) is exempt too --
+   covering the named fields above without renaming any of them. The
+   secret-value denylist check still runs unconditionally over every field,
+   exempted or not. Free-text fields (a command line embedding a path
+   inside other words, `branch`, or any bare identifier with no path
+   separator+extension) are NOT exempted and keep the entropy pattern
+   exactly as before -- an accepted, out-of-ruling-scope residual since no
+   consumer gates on those fields' exact value (documented in notes.md).
+
+## Scope
+
+- In scope: `src/effects/evidence/checks-materializer.ts`,
+  `src/effects/evidence/verify-producer.ts` (payload upgrade only),
+  `scripts/emit-verify-evidence.ts`, `scripts/verify-sprint.sh` +
+  `assets/templates/helpers/verify-sprint.sh` (deterministic mirror via `bun
+  run sync:helpers`), `.ai/hooks/lib/workflow-state.sh` +
+  `assets/hooks/lib/workflow-state.sh` (its canonical projection source,
+  discovered necessary during full-suite verification -- see Goal 4; the
+  `{}` bootstrap site only, in both, kept in sync via `bun run sync:hooks`,
+  which also mechanically updates its own tracked digest marker
+  `.ai/hooks/.projection.json`), `tests/evidence-checks-materializer.test.ts`,
+  `tests/helper-scripts.test.ts` (checks/latest.json-content assertions in
+  the 8 `verify-sprint` fixtures only -- redirected to the unchanged run
+  snapshot file, or asserting absence, per the cannot-bind reality of a
+  deployed-helper fixture; every other assertion in every other fixture is
+  untouched), `src/cli/hook/mutation-observed.ts` (the
+  `resolveContractVerificationTarget` report-path redirect only -- see Goal
+  7; authorized by orchestrator ruling after initial delivery) +
+  `tests/mutation-observed.test.ts` (one characterization assertion for the
+  same redirect), this package's plan/contract/review/notes,
+  `tasks/todos.md` projection,
+  `.ai/harness/worktrees/epc-05-checks-latest-materializer.json`.
+  `tests/prompt-handler.test.ts` and `tests/acceptance-receipt.test.ts` are
+  allowed-path but were NOT touched (verified green unmodified).
+- Out of scope: EPC-01 store/fold modules (`src/core/evidence/*`,
+  `src/effects/evidence/event-log.ts`, `blob-store.ts`, `event-writer.ts`,
+  `epoch.ts`, `paths.ts`, `atomic-append.ts` -- read-only imports/pattern
+  reference only), `post-bash-importer.ts`, `attested-import.ts`; consumer
+  logic in `scripts/acceptance-receipt.ts`, `src/cli/hook/prompt-handler.ts`,
+  `scripts/merge-gate.ts`, `scripts/verify-contract.sh` (must stay green
+  unmodified -- verified: `mutation-observed.ts`'s fix changes only the
+  ARGUMENT it passes to `verify-contract.sh --report-file`, never
+  `verify-contract.sh` itself); project-initialization/adoption scaffolding
+  (`scripts/plan-to-todo.sh`, `scripts/ensure-task-workflow.sh`,
+  `scripts/lib/project-init-lib.sh`, `src/core/adoption/standard-plan.ts`);
+  checkpoint/handoff/current writers (EPC-06/07); Context Packet (EPC-08);
+  `tasks/current.md`; the sprint document; any new npm dependency.
+- Non-goals: checkpoint materialization; recovery-view cutover; retiring
+  `post-bash-latest.json`; deploying the ledger/materializer tooling to
+  downstream adopted repos (residual 2a -- accepted by the orchestrator as a
+  known Program intermediate state for EPC-09 to document; see notes.md's
+  Open Questions).
+
+## Stop Conditions
+
+- Stop and hand back to the parent if `origin/main` has moved past
+  `822153362d008dc2f4418903711f85e9e8266207` before this package's worktree
+  was created -- re-fetch and re-audit, never silently re-pin.
+- Stop and hand back to the parent if a named consumer
+  (`acceptance-receipt.ts`/`prompt-handler.ts`/`merge-gate.ts`/`verify-contract.sh`)
+  cannot stay green without modification -- report instead of widening scope
+  silently.
+- Stop if `check-architecture-sync` BLOCKS (not merely advises) on the
+  changed capability surfaces -- report rather than editing `.ai/context/`
+  or architecture files.
+- Stop if the receipt staleness invariant (record immediately after
+  prepare, no commit between) cannot be preserved under the materialized
+  flow.
+- Stop after three fail-fix-reverify rounds on one issue.
+
+## Falsifier
+
+The direction is wrong if materializing from the ledger cannot reproduce a
+consumer-equivalent `checks/latest.json` in a ledger-reachable context
+(i.e. a named consumer needs a rewrite to stay green), or if deleting the
+two named direct-authoring sites breaks the frozen prepare/record/finalize
+acceptance flow in that same context. Cheapest proof: this package's own
+acceptance flow (a real, git-backed, source-rooted worktree -- this one)
+completes end-to-end on the materialized file, and the full characterization
+suite passes with only deleted-mechanics assertions updated.
+
+## Root Cause Evidence
+
+Not applicable: Task Profile is `code-change`, not `bugfix`.
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260722-1929-epc-05-checks-latest-materializer.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260722-1929-epc-05-checks-latest-materializer.review.md`
+- Notes file: `tasks/notes/20260722-1929-epc-05-checks-latest-materializer.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Acceptance Policy
+
+```json
+{"protocol":1,"reviewer":"Claude","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - plans/plan-20260722-1929-epc-05-checks-latest-materializer.md
+  - tasks/contracts/20260722-1929-epc-05-checks-latest-materializer.contract.md
+  - tasks/reviews/20260722-1929-epc-05-checks-latest-materializer.review.md
+  - tasks/notes/20260722-1929-epc-05-checks-latest-materializer.notes.md
+  - src/effects/evidence/checks-materializer.ts
+  - src/effects/evidence/verify-producer.ts
+  - scripts/emit-verify-evidence.ts
+  - scripts/verify-sprint.sh
+  - assets/templates/helpers/verify-sprint.sh
+  - .ai/hooks/lib/workflow-state.sh
+  - assets/hooks/lib/workflow-state.sh
+  - .ai/hooks/.projection.json
+  - src/cli/hook/mutation-observed.ts
+  - tests/mutation-observed.test.ts
+  - src/core/evidence/redaction.ts
+  - tests/evidence-event-store.test.ts
+  - tests/evidence-checks-materializer.test.ts
+  - tests/helper-scripts.test.ts
+  - tests/prompt-handler.test.ts
+  - tests/acceptance-receipt.test.ts
+  - .ai/harness/worktrees/epc-05-checks-latest-materializer.json
+  - tasks/todos.md
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Materializer/producer row; no benchmark-subject-touching change in this package.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+      - codex-exec
+      - main-thread
+    fallback: main-thread
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - src/effects/evidence/checks-materializer.ts
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260722-1929-epc-05-checks-latest-materializer.notes.md
+  tests_pass:
+    - path: tests/evidence-checks-materializer.test.ts
+  commands_succeed:
+    - bash scripts/check-task-workflow.sh --strict
+  manual_checks:
+    - "No direct authoring path for checks/latest remains (cp and {} bootstrap deleted; no-independent-authoring test green)"
+    - "Package's own acceptance evidence carries D8 provenance whose source_event_ids resolve to accepted ledger events"
+    - "tasks/current.md untouched"
+```
+
+## Concurrency and Ownership
+
+- This package runs serially (R4 default); it is not part of a parallel
+  wave, so no cross-package `allowed_paths` disjointness proof is required.
+- No shared barrel/export file: there is no `index.ts` anywhere under
+  `src/effects/evidence/` (confirmed at task start and unchanged by this
+  package).
+- One same-package shared helper is intentional and documented:
+  `checks-materializer.ts` imports `worktreeIdFor` from `verify-producer.ts`
+  (both owned by this package) rather than re-implementing it. This is not a
+  re-opening of the EPC-02/03/04 wave's "no shared private helper"
+  qualification, which concerned proving independence across DIFFERENT
+  parallel packages, not sharing within one serial package's own two files.
+- **Resolved during this package (orchestrator ruling, see Goal 7)**:
+  `src/cli/hook/mutation-observed.ts`'s `processContractVerification` was a
+  third, previously-unnamed direct-authoring path for `checks/latest.json`
+  (it invoked `scripts/verify-contract.sh --report-file <checks_file>` from
+  the post-edit-guard Stop-time cascade, writing a narrower
+  contract-verification-only schema directly over the acceptance-evidence
+  path). The orchestrator ruled this must close in this package (row 9's
+  "every direct authoring path" acceptance line). Fix: the report now
+  targets a dedicated `.ai/harness/checks/contract-verify.latest.json`;
+  `verify-contract.sh` itself (a named consumer) was never modified, only
+  the argument `mutation-observed.ts` passes it. Reader trace (full
+  results in the notes file): no reader anywhere depends on
+  `verify-contract.sh`'s own report landing at the acceptance-evidence path
+  -- `pendingPostEditJournalSection` (SessionStart) only reads event
+  count/id, never payload content; no test exercises
+  `processContractVerification`'s actual subprocess call; `isCheckpointPath`
+  is a distinct, unrelated concern (detects a hand-EDIT of the
+  acceptance-evidence file, deliberately not extended to the new
+  machine-written telemetry file). `tests/mutation-observed.test.ts`'s one
+  characterizing assertion is updated; every other assertion in that file
+  (32 tests total in the combined suite run) is unchanged and green.
+- If an out-of-band merge lands on `main` touching this package's
+  `allowed_paths` before this package's PR merges, stop, re-fetch, and
+  re-derive against the new state; never force-push over it.
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior: `checks/latest.json` is now a deterministic
+  materialization of the evidence ledger (D7 selection + D8 provenance);
+  both named direct-authoring sites are deleted in this same package.
+  Emission (and, on success, materialization) is attempted for both a
+  passing and a failing verify-sprint run.
+- Edge cases: no matching accepted event (`unsatisfied`); a matching event
+  whose payload carries no `run_trace` (`unsatisfied`, fail closed rather
+  than fabricating content); a superseded event (excluded, per the
+  already-frozen D5 fold); append-position ties broken only by append order,
+  never `created_at`/mtime; policy-gated `human_acceptance`/`external_attested`
+  admission; a cannot-bind emission (no active contract, dirty contract, or
+  the ledger/materializer tooling simply not reachable in a deployed-helper
+  context) leaves `checks/latest.json` absent rather than stale or
+  fabricated.
+- Regression risks: the one remaining accepted residual (2a) is that in any
+  context where the ledger/materializer tooling is unreachable (every
+  downstream adopted repo today, and any self-hosted worktree without
+  `REPO_HARNESS_SOURCE_ROOT` pointing at a full source checkout),
+  `checks/latest.json`'s acceptance_receipt pending -> pass transition no
+  longer becomes observable on that file (it stays at whatever a
+  ledger-reachable run last materialized, or absent) -- accepted by the
+  orchestrator as a known Program intermediate state (EPC-09 to document),
+  not this package's to resolve. Residual 2b (mutation-observed.ts's
+  Stop-time continuous-verification writer) was found and closed within
+  this same package per orchestrator ruling; see
+  `tasks/notes/20260722-1929-epc-05-checks-latest-materializer.notes.md`'s
+  Open Questions for both writeups in full.
+
+## Rollback Point
+
+- Commit / checkpoint: the single commit on
+  `codex/epc-05-checks-latest-materializer` before it merges.
+- Revert strategy: revert the single PR -- restores the direct `cp`
+  authoring, the `{}` bootstrap, and mutation-observed.ts's
+  continuous-verification report target pointed back at the acceptance
+  checks_file; removes the materializer module and the payload upgrade. No
+  named consumer (`acceptance-receipt.ts`, `prompt-handler.ts`,
+  `merge-gate.ts`, `verify-contract.sh`) was ever modified, so reverting
+  cannot regress any existing consumer; this package's workflow artifacts
+  revert with it.

--- a/tasks/notes/20260722-1929-epc-05-checks-latest-materializer.notes.md
+++ b/tasks/notes/20260722-1929-epc-05-checks-latest-materializer.notes.md
@@ -1,0 +1,480 @@
+# Implementation Notes: epc-05-checks-latest-materializer
+
+> **Status**: Active
+> **Plan**: plans/plan-20260722-1929-epc-05-checks-latest-materializer.md
+> **Contract**: tasks/contracts/20260722-1929-epc-05-checks-latest-materializer.contract.md
+> **Review**: tasks/reviews/20260722-1929-epc-05-checks-latest-materializer.review.md
+> **Last Updated**: 2026-07-22 21:45
+> **Lifecycle**: notes
+
+## Gatekeeper CRITICAL fix (2026-07-22, mid-package, orchestrator ruling)
+
+**Finding**: the gatekeeper ran this package's own dogfood
+(`bash scripts/verify-sprint.sh --prepare-acceptance` against this
+contract, now committed-clean) and found the materialized
+`checks/latest.json` was NOT consumer-equivalent:
+`review_subject_sha256` came back double-prefixed
+(`sha256:sha256:...`), and every long-slug path field
+(`run_file`, `lifecycle.snapshot`, `contract.file`, `active_plan`,
+`allowed_paths`/`files_changed` array entries, `diff_base`'s 40-char git
+SHAs) came back partially hashed. Live repro preserved as evidence:
+`evt-01KY4YMNNF0BFAPHV968AX04J6` in this worktree's own ledger
+(`.ai/harness/evidence/events/log.jsonl` + its blob).
+
+**Root cause**: `src/core/evidence/redaction.ts`'s D6 high-entropy pattern
+(`[A-Za-z0-9+/_-]{32,}`) has no notion of "this value is already a hash" or
+"this value is a path" -- it blindly matches any 32+ char run of that
+character class anywhere in any string leaf. `.` is not in the character
+class (it breaks a run), but `/` and `-` ARE, so a realistic contract slug
+like `tasks/contracts/20260722-1929-epc-05-checks-latest-materializer` (no
+dots until the final `.contract.md`) is one continuous 60+ char run and
+gets replaced wholesale. This package's OWN payload upgrade (Goal 2) was
+the first caller to ever push a large, structurally rich object (the full
+verify-sprint run-trace) through this pre-existing, previously
+low-stakes pass -- every prior caller's payloads were small structured
+summaries (`{status, counts, run_snapshot_id}`) that never happened to
+contain a long dot-free run, so the bug was latent, not new to this
+package, but this package is what first triggered it in practice.
+
+**Fix -- typed-field exemption at the construction boundary ("Option B"),
+implemented in `src/core/evidence/redaction.ts`** (see that module's own
+doc comment for the full design writeup): two typed exemptions from
+entropy redaction, applied structurally BEFORE the entropy pass runs
+(classify first, redact the rest -- never a post-hoc unhash):
+
+1. **Declared hash**: a whole string value matching
+   `^(sha256:)?[0-9a-f]{40,64}$` (a bare 40-char git SHA, a bare 64-char
+   sha256 hex digest, or a `sha256:`-prefixed one) is exempt. Whole-value
+   match only -- a hash or SHA embedded inside a longer free-text string
+   (e.g. `"contract sha256:<hash> failed"`, or a full command line
+   embedding a contract path) is NOT exempted and keeps the entropy
+   pattern for that embedded span.
+2. **Declared or inferred path**: a field whose KEY follows the existing
+   `path`/`_path`/`Path` suffix convention (mirroring
+   `event-writer.ts`'s `isPathFieldKey`, duplicated as a one-line
+   convention check rather than imported, since `redaction.ts` is a core
+   module and must not depend on the effects layer) is exempt, AND a value
+   that whole-value parses as a safe repo-relative path (contains `/`, no
+   leading `/`, no `..` segment, ends in a file extension) is exempt too --
+   covering `run_file`, `lifecycle.snapshot`, `contract.file`,
+   `active_plan`, and every path-shaped array entry in `allowed_paths`/
+   `files_changed` WITHOUT renaming any of these established
+   consumer-facing field names.
+
+The secret-value denylist check is unconditional -- it still runs over
+every field, exempted or not (a literal secret sitting in a hash-shaped or
+path-shaped position still gets replaced; two new tests prove this for
+both exemption categories). Free-text fields with no matching exemption
+(a command line embedding a path inside other words, `branch` -- a bare
+identifier with a `/` but no file extension, so it does not qualify as a
+path -- or any other bare long identifier) are UNCHANGED by this fix and
+remain subject to entropy redaction exactly as before. This is an
+accepted, out-of-ruling-scope residual: no consumer gates on `branch`'s
+(or any other free-text field's) exact value, only on the named
+consumer-facing fields the ruling scoped this fix to. Recorded here rather
+than silently expanding the exemption criteria beyond what was authorized.
+
+**D6 framing**: this is a within-letter refinement, not a re-decision of
+D6. D6's frozen text (EPC-00) pins the invariant -- deny-by-construction,
+secrets never appear raw -- not this specific character-class regex; the
+EPC-01 acceptance record for D6 did not pin the pattern either. The fix
+changes WHICH values are subject to the entropy pattern, never removes the
+denylist-secret-value check, and preserves "classify first, redact the
+rest" as a structural (not post-hoc) property.
+
+**Regression coverage**: confirmed genuine red-then-green directly --
+temporarily reverted `redaction.ts` to its pre-fix content and re-ran the
+two strengthened end-to-end tests in `tests/evidence-checks-materializer.test.ts`;
+both failed showing the exact double-prefix and path-mangling symptoms
+byte-for-byte; restored the fix and both passed again (18/18 in that file,
+28/28 in `tests/evidence-event-store.test.ts` including 11 new redaction
+unit tests: declared-hash whole-value exemption, hash-embedded-in-free-text
+non-exemption, double-prefix regression, path-key-convention exemption,
+whole-value safe-path exemption for the four named non-conventional
+fields, array-entry exemption, `..`-traversal non-exemption, denylist
+firing inside both exemption categories, free-text entropy redaction
+unchanged, and one end-to-end `appendEvidenceEvent` proof).
+
+## Finding 3 (documentation only, EPC-09 carry-forward)
+
+Two more pre-existing, non-ledger `{}`-shaped first-writers were found
+during this ruling's review, distinct from both the two EPC-00-named
+sites and the mutation-observed.ts residual (2b), and are NOT touched by
+this package (no code change authorized or needed -- fail-closed content,
+cannot clobber a real materialization):
+
+- `scripts/plan-to-todo.sh:1090` and `scripts/ensure-task-workflow.sh:899`
+  (plus their `assets/templates/helpers/` mirrors): both write
+  `echo "{}" > .ai/harness/checks/latest.json` guarded by
+  `if [[ ! -f ... ]]`, i.e. only-if-absent. These are project-genesis
+  scaffolding (already documented as out-of-scope allowlist entries in
+  `tests/evidence-checks-materializer.test.ts`'s no-independent-authoring
+  sweep), not this worktree's own live authority path -- they seed a
+  BRAND NEW repo/worktree's placeholder before any ledger exists there.
+  Carried forward for EPC-09's deprecation-residue scan to decide whether
+  these guarded seeds should eventually retire too, once every consumer of
+  a freshly-scaffolded repo can tolerate `checks/latest.json` being
+  genuinely absent instead of `{}`.
+- **The globally installed `repo-harness` binary on this machine is
+  version 0.10.1 and still carries the pre-cutover direct `cp` authoring**
+  (confirmed directly: the live repro event `evt-01KY4YMNNF0BFAPHV968AX04J6`'s
+  `env_provider_id` reads `repo-harness/0.10.1/ws-...`, and `command -v
+  repo-harness` resolves to that global install, not this worktree's
+  in-progress source). Until the next release publishes this cutover,
+  the global CLI is a live legacy writer -- any acceptance/dogfood
+  activity in THIS worktree must invoke `bash scripts/verify-sprint.sh`
+  directly (which resolves `emit-verify-evidence.ts` from the worktree's
+  own `scripts/` via `$helper_dir`, not the global install), never
+  `repo-harness run verify-sprint`, or the global binary's OWN legacy `cp`
+  would silently re-clobber the materialized file with old-schema content
+  and defeat the whole cutover being tested. This is purely an
+  operational/dogfood-discipline note for this package and does not change
+  any shipped code.
+
+## Design Decisions
+
+- **D7's "worktree_id == current AND contract_id == active contract" collapses
+  to one filter.** `EvidenceEventRecord.worktree_id` is already populated with
+  the active contract's own slug at emission time (`verify-producer.ts`'s
+  `worktreeIdFor`, unchanged, EPC-02). The materializer filters on that single
+  field (via the same helper, now exported and reused, not re-implemented) plus
+  `subject_hash` exact equality plus trust-class admission; it does not
+  introduce a second, separate `contract_id` filter, since none exists on the
+  event schema and D3/D5 are frozen/read-only.
+- **`content_hash` excludes the provenance block itself.** D8 says
+  "content_hash (sha256 of the projection payload itself)". The provenance
+  block embeds `content_hash` and a volatile `generated_at`, so hashing the
+  whole rendered file would make `content_hash` un-reproducible on replay.
+  `content_hash` is computed over the consumer-facing content only
+  (`canonicalize()`, EPC-01's own deterministic serializer), so re-materializing
+  from the identical accepted event set always reproduces the identical
+  `content_hash` (required for EPC-09's drift check to mean anything).
+- **Trust-class admission mirrors EPC-04's exact table, re-derived locally.**
+  `authoritative_machine` always admitted. `external_attested` admitted
+  whenever a syntactically valid Acceptance Policy JSON block exists (the
+  schema has no separate "external_pass forbidden" toggle -- `reviewer` is a
+  mandatory field). `human_acceptance` admitted only when
+  `user_waiver: "allowed"`. `observed` never admitted. Absent/invalid policy
+  admits neither of the gated two (default-deny, D4). This is a **local,
+  duplicated, structural re-parse** of the same `## Acceptance Policy` fenced
+  JSON block `scripts/acceptance-receipt.ts`'s `parseAcceptancePolicy` reads --
+  not an import, per the `src/` must-not-depend-on-`scripts/` precedent EPC-04
+  set for `attested-import.ts`.
+- **The payload upgrade is optional and purely additive, not a breaking
+  change to `VerifyProducerInput`.** `runTrace?: JsonValue` is threaded into
+  the existing "json" payload's `run_trace` field only when the caller
+  supplies it; when omitted, the payload object literal is byte-identical to
+  before (verified: `tests/evidence-verify-producer.test.ts`, which is **not**
+  in this package's `allowed_paths`, passes unmodified -- 11/11 green). This
+  was a deliberate design choice to resolve a real tension: any unconditional
+  shape change to the payload would have broken that test's exact
+  `toEqual({status, counts, run_snapshot_id})` assertion, and that file is a
+  characterization of a module this package legitimately extends but was not
+  listed as touchable. Making the extension additive-only resolves the
+  tension without silently widening scope or stopping the task.
+- **Emission is now attempted for both a passing and a failing verify-sprint
+  run**, not only a passing one (the pre-EPC-05 code hardcoded `--status
+  pass` and only called `emit_verify_evidence` inside the `exit_code -eq 0`
+  branch). This is a necessary, in-scope extension of Goal 3's "verify ->
+  emit -> materialize" flow, not scope creep: without it, a failing verify
+  run would leave `checks/latest.json` stale (still showing the last
+  passing run's content) once direct authoring is gone, since nothing would
+  ever emit/materialize a `status: "fail"` projection. `authoritative_machine`
+  trust already covers this correctly -- it is a real, subject-bound,
+  machine-produced fact regardless of whether the fact is "passed" or
+  "failed"; consumers (`workflow_checks_pass`) already read the payload's own
+  `status` field, not the event's trust class, to distinguish pass from fail.
+- **`checks-materializer.ts` and `emit-verify-evidence.ts` are, and remain,
+  source-repo-only tooling.** Neither is listed in
+  `assets/workflow-contract.v1.json`'s helper inventory, so `bun run
+  sync:helpers` never tries to deploy them -- confirmed identical to the
+  pre-existing precedent for `attested-import.ts`/`post-bash-importer.ts`
+  (EPC-03/04). This was not a new decision this package made; it surfaced an
+  existing, load-bearing consequence of that precedent (see Open Questions).
+
+## Deviations From Plan Or Spec
+
+- **Scope correction, discovered by the full `bun test` run, not silent**:
+  the dispatch named `.ai/hooks/lib/workflow-state.sh` as the sole file for
+  Goal 4's bootstrap deletion. That file turned out to be a generated
+  projection of `assets/hooks/lib/workflow-state.sh`
+  (`scripts/sync-hook-sources.ts`: `canonical_root: assets/hooks`,
+  `projection_target: .ai/hooks`) -- editing only the projected copy is not
+  durable, proven directly: `tests/hook-source-projection.test.ts`'s own
+  drift/idempotency checks regenerated `.ai/hooks/` from the canonical
+  source mid-run and silently reverted the deletion (caught by re-running
+  the full suite, not missed). The fix applies the identical one-line
+  deletion to `assets/hooks/lib/workflow-state.sh` as well, then runs `bun
+  run sync:hooks` to regenerate the projected copy from it (now
+  byte-identical, confirmed via `bun run check:hooks`). Both files are now
+  in the contract's `allowed_paths`. This is the same category of
+  necessary-not-discretionary widening as `verify-producer.ts`'s payload
+  upgrade needing to be additive-only for `tests/evidence-verify-producer.test.ts`
+  -- a fact discovered by running the goal's own verification, not a
+  unilateral scope decision.
+- Otherwise none: the plan's Goals 1-6, D7/D8 predicate, and Genesis note
+  were followed as written; the two design points below (fail-path
+  emission, additive-only payload) were left as open judgment calls by the
+  plan ("decide ... and document") and are recorded here rather than being
+  silent.
+
+## Touched Characterization Assertions
+
+Every existing test assertion changed by this package, with before/after
+rationale. No assertion outside this list was modified in
+`tests/helper-scripts.test.ts`, `tests/prompt-handler.test.ts`, or
+`tests/acceptance-receipt.test.ts`.
+
+`tests/prompt-handler.test.ts` and `tests/acceptance-receipt.test.ts`: **zero
+assertions touched** -- both construct their own synthetic
+`checks/latest.json` fixture content directly (never invoke
+`verify-sprint.sh` or `workflow_ensure_harness_surface`), so neither
+characterizes the deleted authoring mechanics. Verified green, unmodified.
+
+`tests/helper-scripts.test.ts` (8 `verify-sprint` fixtures; all 8 are
+non-git or, where git-backed, still never set `REPO_HARNESS_SOURCE_ROOT` nor
+have `scripts/emit-verify-evidence.ts` deployed into the fixture's `scripts/`
+-- so emission cannot-binds in every one of them, exit 3, and
+`checks/latest.json` is genuinely absent after the cutover):
+
+1. **"verify-sprint should write passing structured checks for the active
+   sprint"** -- before: read rich content from `.ai/harness/checks/latest.json`.
+   After: assert `checks/latest.json` is absent; read the identical rich
+   content from the run snapshot file instead (`.ai/harness/runs/*.json`,
+   unchanged -- still directly written by `verify-sprint.sh`, since only
+   `checks/latest.json`'s direct authoring was in scope to delete). Every
+   field-level assertion value is unchanged; only the source file moved.
+2. **"verify-sprint finalizes one AcceptanceReceipt without rerunning
+   contract tests"** -- before: asserted the jq-patched `acceptance_receipt`
+   (`status: pass, disposition: external_pass, ...`) landed in
+   `checks/latest.json` via the deleted `cp`. After: asserts
+   `checks/latest.json` retains its **pre-seeded** content
+   (`acceptance_receipt: { status: "pending" }`) unchanged, since finalize's
+   own emission also cannot-binds in this fixture (no `emit-verify-evidence.ts`
+   deployed) and nothing else rewrites the file. This is the one test whose
+   assertion *value*, not just its file source, changed -- see Open
+   Questions for the residual this documents. `rerunMarker`
+   absent/`projectionMarker` present/exit-0 assertions (the test's actual
+   named purpose) are unchanged.
+3. **"verify-sprint prints a notes promotion-candidate advisory without
+   changing exit code"** -- before: read `checks/latest.json` only to embed
+   its content in a failure message. After: same status/exit-code
+   assertions unchanged; added `expectChecksLatestAbsent` for both fixture
+   roots; dropped the (already-incidental) checks-file read from the
+   failure-message string.
+4. **"verify-sprint should fail when committed branch diff exceeds
+   allowed_paths"** -- before/after: identical pattern to #1 (absent +
+   read from run snapshot instead); all field values unchanged
+   (`status: fail`, `failure_class: allowed_paths`, `diff_base.ref`,
+   `files_changed`, `allowed_paths_check`).
+5. **"verify-sprint should scope the default branch diff from immutable
+   contract-worktree metadata"** -- three sequential `--prepare-acceptance`
+   runs in one fixture; each of the three checks-file reads redirected to
+   `latestRunSnapshot(cwd)` (a new shared helper that finds the most
+   recently generated `.ai/harness/runs/*.json` by its own `generated_at`
+   field, robust against filename timestamp collisions). All field values
+   unchanged.
+6. **"verify-sprint ignores Human Review Card semantics because Markdown is
+   projection only"** -- absent + read from run snapshot; `review.status`/
+   `review.card` assertions unchanged.
+7. **"verify-sprint does not require a Human Review Card authoring path"** --
+   identical pattern to #6.
+8. **"verify-sprint should write failing structured checks before exiting"**
+   -- absent + read from run snapshot; `status: fail`, `contract.status:
+   fail`, `acceptance_receipt.status: pending`, `run_file` naming all
+   unchanged in value.
+
+Shared test-file additions (not modifications of existing assertions):
+`latestRunSnapshot(cwd)` and `expectChecksLatestAbsent(cwd)` helpers, and the
+new `tests/evidence-checks-materializer.test.ts` suite (red-first: confirmed
+"Cannot find module" before the materializer file existed, by temporarily
+removing it and re-running; 17/17 pass after restoring it).
+
+`tests/mutation-observed.test.ts` (orchestrator ruling, residual 2b -- see
+Open Questions):
+
+9. **"contract-verification is true only when the active contract's
+   exit_criteria references the edited path"** -- before: asserted
+   `payload.contract_verification.checks_file` equals
+   `'.ai/harness/checks/latest.json'` (the old, now-redirected target).
+   After: asserts it equals `'.ai/harness/checks/contract-verify.latest.json'`.
+   Every other assertion in this test, and every other test in the file
+   (17 total, including the `isCheckpointPath` coverage at "checkpoint is
+   true for ... .ai/harness/checks/latest.json"), is unchanged -- that
+   guard's check for the acceptance-evidence path is deliberately not
+   touched (see Open Questions).
+
+## The unsatisfied-vs-absent choice
+
+Two physically distinct scenarios, resolved differently:
+
+- **Absent**: when `scripts/emit-verify-evidence.ts` cannot even be found
+  (no source-repo checkout reachable at `$helper_dir` or via
+  `REPO_HARNESS_SOURCE_ROOT`) -- there is no code path capable of invoking
+  *any* TypeScript, materializer included, so nothing can render even a typed
+  `unsatisfied` file. This is verify-sprint.sh's own reality in every
+  deployed/downstream-adopted repo today (the ledger/materializer tooling is
+  source-repo-only, mirroring the EPC-03/04 precedent) and in every fixture
+  in `tests/helper-scripts.test.ts`.
+- **Unsatisfied**: when the materializer function itself *does* run (the
+  ledger is reachable) but finds no accepted event matching the exact
+  `worktree_id + subject_hash + admitted-trust-class` predicate -- e.g. a
+  brand-new contract before its first successful emission, a subject that
+  changed since the last accepted event, or (defensively) a matching event
+  that for some reason carries no `run_trace` payload at all. Exercised
+  directly by `tests/evidence-checks-materializer.test.ts`'s D7 predicate
+  matrix; not something `verify-sprint.sh`'s own normal flow produces today
+  (a successful emission always carries the run_trace that immediately
+  satisfies its own subject), but a real, tested, fail-closed floor for any
+  other future caller of `writeChecksLatest`/`buildChecksLatestProjection`.
+
+## The finalize re-materialization decision
+
+`finalize_prepared_acceptance()` re-invokes `emit_verify_evidence` (now with
+the jq-patched `$finalized_checks` as its run-trace file and `status=pass`
+hardcoded, matching the pre-existing invariant that finalize only ever
+reaches this call after every earlier guard already required a passing
+state) and, on a successful emission, `emit-verify-evidence.ts` materializes
+`checks/latest.json` from the ledger again -- so in a ledger-reachable
+context, the acceptance_receipt pending -> pass transition is realized by a
+**second** `authoritative_machine` event (appended strictly after the
+`user_waiver`/`external_pass`-mapped `human_acceptance`/`external_attested`
+event that `acceptance-receipt.ts record`'s CLI wiring already imports,
+EPC-04) whose payload carries the patched `acceptance_receipt` block. D7's
+winner is simply "last accepted event matching the predicate" -- this second
+event wins by append position alone, regardless of trust class, which is
+why the patched content becomes visible without needing the
+`human_acceptance`/`external_attested` event to itself be D7's winner.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| Force `runTrace` required on `VerifyProducerInput` | Rejected | Breaks `tests/evidence-verify-producer.test.ts`'s exact payload assertion; that file is not in this package's `allowed_paths`. Optional/additive resolves the tension with zero consumer-test modification. |
+| Materialize unconditionally on every verify-sprint invocation, even cannot-bind | Rejected | There is no reachable code path to do so when the TS tooling itself cannot be found (the overwhelming majority of real-world invocations, per the deployed-helper precedent); "absent" is the only physically honest outcome there. |
+| Only emit on a passing verify result (pre-existing behavior) | Rejected | Leaves `checks/latest.json` permanently stale on a fail once direct authoring is deleted -- a real regression to the fail-reporting gate, not just a fixture nuance. |
+| Rewrite all 8 `tests/helper-scripts.test.ts` fixtures into full git+ledger integration tests so real materialization exercises them | Rejected (for 7 of 8) | Enormous scope/time cost for a claim ("this deployed-helper simulation should now also simulate a full source-repo checkout") that contradicts the fixtures' own established purpose (simulating a downstream adopter, which never gets the ledger). Redirecting to the unchanged run-snapshot file is the minimal, honest fix. |
+| Give `checks-materializer.ts` its own `contract_id` filter separate from `worktree_id` | Rejected | No such field exists on `EvidenceEventRecord`/`SubjectIdentity` (D3, frozen); `worktree_id` already IS the contract slug by construction. Introducing a parallel notion would be a second, redundant authority for the same datum. |
+
+## Open Questions
+
+- **Residual 2a -- accepted by the orchestrator as a known Program
+  intermediate state, no action taken here.** The ledger/materializer
+  tooling's "source-repo-only" status means `checks/latest.json` becomes
+  structurally unavailable in every downstream adopted repo, and in any
+  self-hosted worktree without `REPO_HARNESS_SOURCE_ROOT` pointing at a full
+  source checkout. Not a regression this package *introduced* --
+  `emit-verify-evidence.ts` has never been deployed (static relative import
+  of `../src/effects/evidence/verify-producer`; never in
+  `assets/workflow-contract.v1.json`'s helper inventory even at EPC-02 time)
+  -- but EPC-02..04 never mattered for this because nothing read the ledger
+  yet; this package is the first to make `checks/latest.json`'s *entire
+  content* depend on that same unreachable tooling. Orchestrator ruling
+  (2026-07-22, mid-package): accepted as a known Program intermediate state;
+  EPC-09's release closeout must document it; carried forward by the
+  orchestrator, not resolved here.
+
+- **Residual 2b -- RESOLVED in this package per orchestrator ruling
+  (2026-07-22, mid-package, authorized after initial delivery).**
+  `src/cli/hook/mutation-observed.ts`'s `processContractVerification` IS a
+  live direct-authoring path for `checks/latest.json` (Stop-time continuous
+  contract verification via `verify-contract.sh --report-file`, defaulting
+  to the policy `harness.checks_file`). Ruling: row 9's "every direct
+  authoring path deleted in this package" acceptance line requires closing
+  it here, since it is genuinely live (not dormant), even though it wasn't
+  one of EPC-00's two originally-named sites.
+
+  **Fix**: `resolveContractVerificationTarget` now returns a dedicated
+  constant, `CONTRACT_VERIFICATION_REPORT_RELATIVE =
+  '.ai/harness/checks/contract-verify.latest.json'`, instead of calling
+  `resolveChecksFile(repoRoot)`. `resolveChecksFile` itself (the general
+  `harness.checks_file` policy resolver) is UNCHANGED -- kept for its
+  documented general-purpose role even though, after this fix, nothing else
+  in this file calls it (`bun run check:type` confirmed this does not
+  produce an unused-declaration error; left in place rather than deleted, to
+  keep the diff to exactly the authorized redirect).
+
+  **Rationale recorded** (per ruling): continuous verification is Stop-time
+  telemetry ("is the active contract still passing"), not acceptance
+  evidence. Writing it to the acceptance-evidence path was exactly the
+  last-writer-wins shadow authority the audit called out -- it could
+  silently clobber a frozen `--prepare-acceptance` evidence bundle, and the
+  two schemas are not even compatible: `verify-contract.sh`'s own
+  `write_report()` produces `{contract, run_id, previous_status,
+  next_status, failure_class, quiet, strict, read_only,
+  executes_contract_commands, budget_ms, total_duration_ms, timed_out,
+  total, failed, results}` -- no `source`/`status`/`exit_code` fields at
+  all, so nothing downstream could even tell the two apart by content had
+  a clobber occurred.
+
+  **Reader trace (full results)**: grepped every reader of
+  `checks_file`/`contract_verification`/`.ai/harness/checks/` across
+  `src/`, `scripts/`, `tests/`.
+  - `pendingPostEditJournalSection` (SessionStart orientation,
+    `mutation-observed.ts:664`): reads only `events.length`,
+    `oldest.created_at`, `oldest.event_id` for a generic "N pending
+    events" message with a static `reference: 'repo-harness run
+    verify-contract'` string -- never reads `contract_verification.checks_file`'s
+    value. Unaffected.
+  - No test anywhere exercises `processContractVerification`'s actual
+    subprocess call (codegraph's own blast-radius query confirmed "no
+    covering tests found" for that function); the only covering assertion
+    was `tests/mutation-observed.test.ts`'s dirty-bit/payload-construction
+    test, which characterizes the field's *value*, not a real
+    `verify-contract.sh` invocation -- updated (see Touched Characterization
+    Assertions).
+  - `isCheckpointPath` (line ~424) and the `resolveChecksFile` resolver (line
+    ~459): different, unrelated concern -- `isCheckpointPath` flags a
+    hand-EDIT (tool-call mutation) of a checkpoint-relevant file, not "where
+    does contract-verification write its own report". Decision: do NOT
+    extend the guard to the new filename -- the new file is machine-written
+    telemetry from a Stop-time subprocess spawn, never itself the target of
+    an Edit/Write tool call in normal operation, so covering it would be
+    dead code. The existing `.ai/harness/checks/latest.json` check is
+    unchanged (hand-editing the acceptance-evidence file is still
+    checkpoint-worthy).
+  - Every OTHER match (`src/core/adoption/gitignore-plan.ts`,
+    `src/core/adoption/standard-plan.ts`, `src/cli/mcp/policy.ts`,
+    `src/cli/mcp/tools.ts`, `src/cli/chatgpt-browser/file-policy.ts`,
+    `src/effects/review/diff-fingerprint.ts`'s `isOperationalReviewPath`,
+    `scripts/check-task-workflow.sh`, `scripts/ensure-task-workflow.sh`,
+    `scripts/lib/project-init-lib.sh`, `scripts/archive-workflow.sh`,
+    `scripts/sync-codex-installed-copies.sh`) is a GENERIC glob/prefix
+    pattern over `.ai/harness/checks/*` or `.ai/harness/checks/**`
+    (gitignore entries, MCP read/write-scope allowances, cache-glob
+    exclusions, review-subject exclusions, archive-copy globs) -- the new
+    `contract-verify.latest.json` file transparently falls under every one
+    of these with zero code change required. Confirmed directly: this
+    repo's own tracked `.gitignore` already has
+    `.ai/harness/checks/*.latest.json` (line 37), matching the new filename.
+  - No reader outside this package's `allowed_paths` was found to depend on
+    the OLD target path's specific location or content -- the STOP
+    condition ("if a reader outside allowed_paths depends on it, STOP and
+    report") was not triggered.
+
+  **Changed**: `src/cli/hook/mutation-observed.ts` (redirect + documented
+  `isCheckpointPath` decision), `tests/mutation-observed.test.ts` (one
+  characterization assertion), `tests/evidence-checks-materializer.test.ts`
+  (new direct behavioral test proving the redirect, so the
+  no-independent-authoring sweep needs no exclusion for this file -- it
+  never needed one mechanically, since the grep patterns only match direct
+  `writeFileSync`/`writeFileDurably`/`Bun.write` calls, not a subprocess
+  `--report-file` argument; the new test closes that detection gap with a
+  precise behavioral proof instead of widening the regex sweep into
+  something fragile). Both allowed-path additions recorded in the contract
+  (Goal 7).
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/reviews/20260722-1929-epc-05-checks-latest-materializer.review.md
+++ b/tasks/reviews/20260722-1929-epc-05-checks-latest-materializer.review.md
@@ -1,0 +1,84 @@
+# Task Review: epc-05-checks-latest-materializer
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260722-1929-epc-05-checks-latest-materializer.md
+> **Contract**: tasks/contracts/20260722-1929-epc-05-checks-latest-materializer.contract.md
+> **Notes File**: tasks/notes/20260722-1929-epc-05-checks-latest-materializer.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-07-22 19:29
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Commands passed:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+- Waza `/check` run:
+- Commands run:
+- Manual checks:
+- Supporting artifacts:
+- Implementation notes reviewed:
+- Run snapshot:
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...

--- a/tasks/reviews/20260722-1929-epc-05-checks-latest-materializer.review.md
+++ b/tasks/reviews/20260722-1929-epc-05-checks-latest-materializer.review.md
@@ -49,17 +49,17 @@
 
 ## Acceptance Receipt Projection
 
-> **Disposition**: unavailable
-> **Reviewer**: unavailable
-> **Source**: unavailable
+> **Disposition**: external_pass
+> **Reviewer**: Claude
+> **Source**: claude-review
 > **Actor**: not-applicable
-> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject SHA256**: sha256:3f84199781b62a17c0307a2e35ad03d56e8a9075038022a624a5eca572af3069
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: pending
-> **Verification Evidence SHA256**: pending
-> **Issued At**: pending
+> **Reviewed Target Revision**: 822153362d008dc2f4418903711f85e9e8266207
+> **Verification Evidence SHA256**: sha256:ca18ffa0c3cca08270e97d3cbc3a2ed4e746b9c6b909309a09d1afb90a4a2bc7
+> **Issued At**: 2026-07-22T13:54:15.708Z
 
-- Summary: No AcceptanceReceipt has been recorded.
+- Summary: EPC-05 accepted: first authority cutover — checks/latest materialized only from the ledger (D7/D8), three direct authoring paths deleted, redaction typed-field exemption per ruling; round-2 gatekeeper PASS with live dogfood readback
 - Findings: none
 
 ## Behavior Diff Notes

--- a/tasks/reviews/20260722-1929-epc-05-checks-latest-materializer.review.md
+++ b/tasks/reviews/20260722-1929-epc-05-checks-latest-materializer.review.md
@@ -1,12 +1,12 @@
 # Task Review: epc-05-checks-latest-materializer
 
-> **Status**: Pending
+> **Status**: Reviewed
 > **Plan**: plans/plan-20260722-1929-epc-05-checks-latest-materializer.md
 > **Contract**: tasks/contracts/20260722-1929-epc-05-checks-latest-materializer.contract.md
 > **Notes File**: tasks/notes/20260722-1929-epc-05-checks-latest-materializer.notes.md
 > **Checks File**: .ai/harness/checks/latest.json
-> **Last Updated**: 2026-07-22 19:29
-> **Recommendation**: fail
+> **Last Updated**: 2026-07-22 22:20
+> **Recommendation**: pass
 > **Review Rubric Version**: 2
 > **Reviewed Subject SHA256**: pending
 > **Reviewed Subject Scope**: normalized-final-content
@@ -14,29 +14,38 @@
 
 ## Human Review Card
 
-- Verdict: pending
-- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
-- Intended files changed:
-- Actual files changed:
-- Commands passed:
-- Residual risks:
-- Reviewer action required: inspect diff and card
-- Rollback:
+- Verdict: pass
+- Change type: code-change
+- Intended files changed: new `src/effects/evidence/checks-materializer.ts`; typed-field redaction exemption in `src/core/evidence/redaction.ts`; verify-producer runTrace blob payload; emit wrapper flags; verify-sprint.sh cutover (+ helper mirror); workflow-state.sh `{}` bootstrap deletion (canonical + projection + digest); mutation-observed continuous-verification redirect; three test suites (new materializer suite; event-store redaction coverage; characterization updates); package plan/contract/review/notes; `tasks/todos.md` projection
+- Actual files changed: exactly that set — 19 paths, single amended commit `3ceca8db` on base `82215336`; consumers (`acceptance-receipt.ts`, `prompt-handler.ts`, `merge-gate.ts`, `verify-contract.sh`) absent from the diff; EPC-01 store/fold (except the authorized redaction refinement), post-bash-importer, attested-import untouched; both mirrors byte-identical
+- Commands passed: new suites 46 pass (red-first, incl. the double-prefix regression reproduced red on revert); full `bun test` 1779 pass / 1 skip / 0 fail (worker + gatekeeper independent runs); `check:type` clean; `check-task-workflow --strict` OK; `contract-run preflight` preflight_pass; deploy-sql/task-sync/architecture-sync (advisory blocking=0) green; `inspect-project-state` no drift; `adopt --dry-run` 0 operations
+- Residual risks: `branch` and absolute `worktree` fields remain entropy-redacted (verified inert — the receipt fingerprint gates on neither); guarded only-if-absent `{}` seeds in `plan-to-todo.sh`/`ensure-task-workflow.sh` remain non-ledger first-writers for fresh repos (fail-closed content, carried to EPC-09); downstream adopters lack the ledger tooling until the next release, so `checks/latest` is structurally unavailable there post-cutover (accepted Program intermediate state, EPC-09 release-notes obligation); globally installed repo-harness 0.10.1 still carries the pre-cutover `cp` on this machine — in-worktree acceptance must use `bash scripts/verify-sprint.sh` until the release ships
+- Reviewer action required: none further — round-1 gatekeeper FAIL (redaction mangling CRITICAL + fixture-blindness HIGH) remediated per orchestrator ruling (typed-field exemption at construction boundary); round-2 gatekeeper re-gate verdict PASS with live dogfood readback
+- Rollback: revert the single PR — restores direct authoring (cp + bootstrap + mutation-observed target) and removes materializer/redaction refinement; consumers never changed
 
 ## Mode Evidence
 
-- Selected route:
-- P1/P2/P3 evidence:
-- Root cause or plan evidence:
+- Selected route: planning (captured work-package plan, code-change profile)
+- P1/P2/P3 evidence: plan Captured Planning Output; design authority frozen D4/D6/D7/D8; D6 pattern refinement within letter (pattern unpinned, recorded at EPC-01 acceptance)
+- Root cause or plan evidence: cutover package; the round-1 CRITICAL root cause (entropy pattern lacking hash/path typing) live-reproduced via event `evt-01KY4YMNNF0BFAPHV968AX04J6` before the fix
 
 ## Verification Evidence
 
-- Waza `/check` run:
-- Commands run:
-- Manual checks:
-- Supporting artifacts:
-- Implementation notes reviewed:
-- Run snapshot:
+- Waza `/check` run: two gatekeeper reviews (fresh context, read-only): round-1 FAIL with findings; round-2 PASS after remediation
+- Commands run: see Human Review Card; executed in the contract worktree at `3ceca8db`
+- Manual checks: see Manual Check Evidence below
+- Supporting artifacts: `.ai/harness/checks/latest.json` (materialized, D8 provenance); `.ai/harness/evidence/events/log.jsonl`; run snapshots
+- Implementation notes reviewed: yes — full ruling history, reader trace, characterization assertion inventory, residuals
+- Run snapshot: `.ai/harness/runs/`
+
+## Manual Check Evidence
+
+- [x] No direct authoring path for checks/latest remains (cp and {} bootstrap deleted; no-independent-authoring test green)
+  - Evidence: both verify-sprint `cp` sites deleted (script + helper mirror byte-identical); `printf "{}\n"` bootstrap removed from `.ai/hooks/lib/workflow-state.sh` and canonical `assets/hooks/lib/workflow-state.sh` with projection digest regenerated; Stop-time continuous verification redirected to `.ai/harness/checks/contract-verify.latest.json`; gatekeeper's independent repo-wide writer sweep found no writer outside the materializer and its single call site; the no-independent-authoring test and the mutation-observed behavioral test are green.
+- [x] Package's own acceptance evidence carries D8 provenance whose source_event_ids resolve to accepted ledger events
+  - Evidence: round-2 gatekeeper live dogfood (`bash scripts/verify-sprint.sh --prepare-acceptance` in the worktree): materialized `checks/latest.json` has `review_subject_sha256` single-prefixed and byte-equal to `provenance.subject_hash`; `provenance.source_event_ids` resolve to `authoritative_machine` ledger events with matching `subject_hash` and `authority_commit == HEAD`; `run_file`/`contract.file`/`active_plan`/`allowed_paths` byte-intact under the 47-char slug.
+- [x] tasks/current.md untouched
+  - Evidence: `git diff 82215336..HEAD -- tasks/current.md` is empty; `git status --porcelain` shows no entry for `tasks/current.md`.
 
 ## Acceptance Receipt Projection
 
@@ -55,30 +64,31 @@
 
 ## Behavior Diff Notes
 
-- ...
+- `checks/latest.json` is now a deterministic materialization of the evidence ledger (D7 selection, D8 provenance); the three direct authoring paths are gone; continuous contract verification writes to its own telemetry file; the D6 redaction gains whole-value declared-hash and safe-repo-relative-path exemptions (denylist unconditional, free text unchanged). Consumer-facing schema preserved; prompt-handler and acceptance-receipt suites unchanged and green.
 
 ## Residual Risks / Follow-ups
 
-- ...
+- EPC-09 carry-forward: guarded `{}` seeds; downstream structural unavailability of checks/latest until release; global 0.10.1 legacy writer on this machine.
+- EPC-07/08 consume the materializer patterns; supersedes emission still unexercised by producers.
 
 ## Scorecard
 
 | Dimension | Score | Notes |
 |-----------|-------|-------|
-| Functionality | 0/10 | |
-| Product depth | 0/10 | |
-| Design quality | 0/10 | |
-| Code quality | 0/10 | |
+| Functionality | 9/10 | First authority cutover complete; three paths closed; live dogfood clean |
+| Product depth | 9/10 | Round-1 CRITICAL found by required dogfood, fixed at construction boundary |
+| Design quality | 9/10 | Typed exemption preserves deny-by-construction and denylist |
+| Code quality | 9/10 | 1779 green twice independently; genuine red-first regressions |
 
 ## Failing Items
 
-- ...
+- none
 
 ## Retest Steps
 
-- Re-run:
-- Re-check:
+- Re-run: `bun test tests/evidence-checks-materializer.test.ts tests/evidence-event-store.test.ts`; `bash scripts/verify-sprint.sh --prepare-acceptance` (worktree script)
+- Re-check: materialized provenance resolves to ledger events; writer sweep clean
 
 ## Summary
 
-- ...
+- EPC-05 completes the Program's first authority cutover: `checks/latest` is materialized only from the ledger via the frozen D7 predicate with D8 provenance, all three direct authoring paths are deleted/closed same-package, and the round-1 CRITICAL (entropy redaction mangling run traces) is fixed with a typed-field exemption at the construction boundary — proven by red-first regressions and live dogfood readback. Round-2 gatekeeper verdict: PASS. Ready to ship as one PR.

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -1,7 +1,7 @@
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: 2026-07-22 18:10
+> **Updated**: 2026-07-22 19:29
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.

--- a/tests/evidence-checks-materializer.test.ts
+++ b/tests/evidence-checks-materializer.test.ts
@@ -1,0 +1,706 @@
+import { describe, expect, test } from "bun:test";
+import { execFileSync } from "child_process";
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { dirname, join } from "path";
+
+import type { EvidenceEventRecord, SubjectIdentity, TrustClass } from "../src/core/evidence/types";
+import { appendEvidenceEvent, appendGenesisRecord, readAcceptedEvents } from "../src/effects/evidence/event-log";
+import { LEDGER_EPOCH_START_SHA } from "../src/effects/evidence/epoch";
+import { emitAuthoritativeVerifyEvidence } from "../src/effects/evidence/verify-producer";
+import { buildReviewSubject } from "../src/effects/review/diff-fingerprint";
+import {
+  buildChecksLatestProjection,
+  parseAcceptancePolicySummary,
+  writeChecksLatest,
+  type ChecksLatestProjection,
+} from "../src/effects/evidence/checks-materializer";
+import { canonicalize } from "../src/core/evidence/canonical-json";
+import { createHash } from "crypto";
+import {
+  runMutationObserved,
+  readPendingPostEditEvents,
+  type MutationObservedCollector,
+} from "../src/cli/hook/mutation-observed";
+
+const REPO_ROOT = join(import.meta.dir, "..");
+const CONTRACT_RELATIVE = "tasks/contracts/fixture.contract.md";
+const SUBJECT_A = `sha256:${"a".repeat(64)}`;
+const SUBJECT_B = `sha256:${"b".repeat(64)}`;
+// Gatekeeper CRITICAL regression fixture: a realistic-length contract slug
+// (this package's own actual slug) -- short slugs like "fixture" never
+// tripped the D6 entropy pattern's 32-char threshold, which is exactly how
+// the bug slipped past every other test in this file.
+const LONG_SLUG = "20260722-1929-epc-05-checks-latest-materializer";
+const LONG_SLUG_CONTRACT_RELATIVE = `tasks/contracts/${LONG_SLUG}.contract.md`;
+const LONG_SLUG_RUN_FILE = `.ai/harness/runs/run-20260722T210100-77777-${LONG_SLUG}.json`;
+const LONG_SLUG_ACTIVE_PLAN = `plans/plan-${LONG_SLUG}.md`;
+
+function withTempRepo(prefix: string, fn: (repoRoot: string) => void): void {
+  const repoRoot = mkdtempSync(join(tmpdir(), `${prefix}-`));
+  try {
+    fn(repoRoot);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+}
+
+function contractWithPolicy(policyJson: string | null): string {
+  const lines = ["# Task Contract: fixture", "", "## Allowed Paths", "", "```yaml", "allowed_paths:", "  - src/example.ts", "```", ""];
+  if (policyJson !== null) {
+    lines.push("## Acceptance Policy", "", "```json", policyJson, "```", "");
+  }
+  return lines.join("\n");
+}
+
+function seedGenesis(repoRoot: string): void {
+  mkdirSync(join(repoRoot, "tasks", "contracts"), { recursive: true });
+  appendGenesisRecord(repoRoot, LEDGER_EPOCH_START_SHA, { worktreeId: "fixture" });
+}
+
+function baseIdentity(overrides: Partial<SubjectIdentity> = {}): SubjectIdentity {
+  return {
+    authority_commit: "a".repeat(40),
+    base_commit: "b".repeat(40),
+    target_commit: "c".repeat(40),
+    scope_hash: `sha256:${"d".repeat(64)}`,
+    subject_hash: SUBJECT_A,
+    contract_hash: `sha256:${"f".repeat(64)}`,
+    command_hash: `sha256:${"0".repeat(64)}`,
+    env_provider_id: "repo-harness/0.0.0/ws-test",
+    ...overrides,
+  };
+}
+
+/**
+ * Directly appends a real event via the EPC-01 writer (not the verify
+ * producer) so tests can hold precise, independent control over
+ * worktree_id / trust_class / subject_hash / supersedes / run_trace --
+ * mirroring EPC-03/EPC-04's own low-level ledger fixture style
+ * (tests/evidence-post-bash-importer.test.ts, tests/evidence-attested-import.test.ts).
+ */
+function seedEvent(
+  repoRoot: string,
+  opts: {
+    readonly worktreeId?: string;
+    readonly trustClass?: TrustClass;
+    readonly subjectHash?: string;
+    readonly supersedes?: readonly string[];
+    readonly runTraceMarker?: string;
+    readonly correlationRunId?: string;
+  } = {},
+): EvidenceEventRecord {
+  return appendEvidenceEvent(repoRoot, {
+    worktreeId: opts.worktreeId ?? "fixture",
+    eventType: "verify_sprint.result",
+    trustClass: opts.trustClass ?? "authoritative_machine",
+    producer: "verify-sprint",
+    correlationRunId: opts.correlationRunId ?? `run-${Math.random().toString(36).slice(2)}`,
+    subjectIdentity: baseIdentity({ subject_hash: opts.subjectHash ?? SUBJECT_A }),
+    supersedes: opts.supersedes,
+    payload: {
+      kind: "json",
+      value: {
+        status: "pass",
+        counts: {},
+        run_snapshot_id: "run-fixture",
+        run_trace: {
+          schema: "repo-harness-run-trace.v1",
+          status: "pass",
+          marker: opts.runTraceMarker ?? "default",
+        },
+      },
+    },
+  });
+}
+
+describe("checks-materializer: D7 selection predicate", () => {
+  test("exact subject match only -- a stale/different subject never satisfies", () => {
+    withTempRepo("materializer-stale-subject", (repoRoot) => {
+      seedGenesis(repoRoot);
+      seedEvent(repoRoot, { subjectHash: SUBJECT_A, runTraceMarker: "v1" });
+      const { accepted } = readAcceptedEvents(repoRoot);
+
+      const projection = buildChecksLatestProjection(
+        { repoRoot, contractPath: "tasks/contracts/fixture.contract.md", subjectHash: SUBJECT_B },
+        accepted,
+        contractWithPolicy(null),
+      );
+
+      expect(projection.status).toBe("unsatisfied");
+      expect(projection.provenance.source_event_ids).toEqual([]);
+      expect(projection.provenance.subject_hash).toBe(SUBJECT_B);
+    });
+  });
+
+  test("append-position winner -- never mtime/created_at, never filename recency", () => {
+    withTempRepo("materializer-append-order", (repoRoot) => {
+      seedGenesis(repoRoot);
+      const first = seedEvent(repoRoot, { subjectHash: SUBJECT_A, runTraceMarker: "v1", correlationRunId: "run-1" });
+      const second = seedEvent(repoRoot, { subjectHash: SUBJECT_A, runTraceMarker: "v2", correlationRunId: "run-2" });
+      expect(first.created_at <= second.created_at).toBe(true);
+
+      const { accepted } = readAcceptedEvents(repoRoot);
+      const projection = buildChecksLatestProjection(
+        { repoRoot, contractPath: "tasks/contracts/fixture.contract.md", subjectHash: SUBJECT_A },
+        accepted,
+        contractWithPolicy(null),
+      );
+
+      expect(projection.status).toBe("pass");
+      expect((projection as Record<string, unknown>).marker).toBe("v2");
+      expect(projection.provenance.source_event_ids).toEqual([first.event_id, second.event_id]);
+    });
+  });
+
+  test("a superseded event is excluded from the winner even though it matches subject/trust", () => {
+    withTempRepo("materializer-supersedes", (repoRoot) => {
+      seedGenesis(repoRoot);
+      const superseded = seedEvent(repoRoot, { subjectHash: SUBJECT_A, runTraceMarker: "superseded" });
+      const winnerEvent = seedEvent(repoRoot, {
+        subjectHash: SUBJECT_A,
+        runTraceMarker: "superseding",
+        supersedes: [superseded.event_id],
+      });
+
+      const { accepted } = readAcceptedEvents(repoRoot);
+      // fold.ts's D5 accepted-set already excludes the superseded event.
+      expect(accepted.find((event) => event.event_id === superseded.event_id)).toBeUndefined();
+
+      const projection = buildChecksLatestProjection(
+        { repoRoot, contractPath: "tasks/contracts/fixture.contract.md", subjectHash: SUBJECT_A },
+        accepted,
+        contractWithPolicy(null),
+      );
+
+      expect(projection.status).toBe("pass");
+      expect((projection as Record<string, unknown>).marker).toBe("superseding");
+      expect(projection.provenance.source_event_ids).toEqual([winnerEvent.event_id]);
+    });
+  });
+
+  test("observed trust class never satisfies the gate, policy or not", () => {
+    withTempRepo("materializer-observed-excluded", (repoRoot) => {
+      seedGenesis(repoRoot);
+      seedEvent(repoRoot, { subjectHash: SUBJECT_A, trustClass: "observed", runTraceMarker: "observed-only" });
+      const { accepted } = readAcceptedEvents(repoRoot);
+
+      const projection = buildChecksLatestProjection(
+        { repoRoot, contractPath: "tasks/contracts/fixture.contract.md", subjectHash: SUBJECT_A },
+        accepted,
+        contractWithPolicy('{"protocol":1,"reviewer":"Claude","user_waiver":"allowed"}'),
+      );
+
+      expect(projection.status).toBe("unsatisfied");
+      expect(projection.provenance.source_event_ids).toEqual([]);
+    });
+  });
+
+  test("external_attested is admitted when the contract carries a valid Acceptance Policy block", () => {
+    withTempRepo("materializer-external-attested-admitted", (repoRoot) => {
+      seedGenesis(repoRoot);
+      seedEvent(repoRoot, { subjectHash: SUBJECT_A, trustClass: "external_attested", runTraceMarker: "attested" });
+      const { accepted } = readAcceptedEvents(repoRoot);
+
+      const projection = buildChecksLatestProjection(
+        { repoRoot, contractPath: "tasks/contracts/fixture.contract.md", subjectHash: SUBJECT_A },
+        accepted,
+        contractWithPolicy('{"protocol":1,"reviewer":"Claude","user_waiver":"allowed"}'),
+      );
+
+      expect(projection.status).toBe("pass");
+      expect((projection as Record<string, unknown>).marker).toBe("attested");
+    });
+  });
+
+  test("external_attested is excluded (default-deny) when the contract has no Acceptance Policy block at all", () => {
+    withTempRepo("materializer-external-attested-denied", (repoRoot) => {
+      seedGenesis(repoRoot);
+      seedEvent(repoRoot, { subjectHash: SUBJECT_A, trustClass: "external_attested", runTraceMarker: "attested" });
+      const { accepted } = readAcceptedEvents(repoRoot);
+
+      const projection = buildChecksLatestProjection(
+        { repoRoot, contractPath: "tasks/contracts/fixture.contract.md", subjectHash: SUBJECT_A },
+        accepted,
+        contractWithPolicy(null),
+      );
+
+      expect(projection.status).toBe("unsatisfied");
+    });
+  });
+
+  test("human_acceptance is admitted only when the policy's user_waiver is allowed, excluded when forbidden", () => {
+    withTempRepo("materializer-human-acceptance-policy-gated", (repoRoot) => {
+      seedGenesis(repoRoot);
+      seedEvent(repoRoot, { subjectHash: SUBJECT_A, trustClass: "human_acceptance", runTraceMarker: "waived" });
+      const { accepted } = readAcceptedEvents(repoRoot);
+
+      const allowed = buildChecksLatestProjection(
+        { repoRoot, contractPath: "tasks/contracts/fixture.contract.md", subjectHash: SUBJECT_A },
+        accepted,
+        contractWithPolicy('{"protocol":1,"reviewer":"Claude","user_waiver":"allowed"}'),
+      );
+      expect(allowed.status).toBe("pass");
+      expect((allowed as Record<string, unknown>).marker).toBe("waived");
+
+      const forbidden = buildChecksLatestProjection(
+        { repoRoot, contractPath: "tasks/contracts/fixture.contract.md", subjectHash: SUBJECT_A },
+        accepted,
+        contractWithPolicy('{"protocol":1,"reviewer":"Claude","user_waiver":"forbidden"}'),
+      );
+      expect(forbidden.status).toBe("unsatisfied");
+    });
+  });
+
+  test("a different worktree_id (a different contract slug) never matches, even with an identical subject_hash", () => {
+    withTempRepo("materializer-worktree-mismatch", (repoRoot) => {
+      seedGenesis(repoRoot);
+      seedEvent(repoRoot, { worktreeId: "other-contract-slug", subjectHash: SUBJECT_A, runTraceMarker: "other" });
+      const { accepted } = readAcceptedEvents(repoRoot);
+
+      const projection = buildChecksLatestProjection(
+        { repoRoot, contractPath: "tasks/contracts/fixture.contract.md", subjectHash: SUBJECT_A },
+        accepted,
+        contractWithPolicy(null),
+      );
+
+      expect(projection.status).toBe("unsatisfied");
+    });
+  });
+});
+
+describe("checks-materializer: D8 provenance", () => {
+  test("provenance block carries the complete frozen field list and a self-consistent content_hash", () => {
+    withTempRepo("materializer-provenance", (repoRoot) => {
+      seedGenesis(repoRoot);
+      const event = seedEvent(repoRoot, { subjectHash: SUBJECT_A, runTraceMarker: "provenance-check" });
+      const { accepted } = readAcceptedEvents(repoRoot);
+
+      const projection = buildChecksLatestProjection(
+        { repoRoot, contractPath: CONTRACT_RELATIVE, subjectHash: SUBJECT_A, now: () => new Date("2026-07-22T12:00:00.000Z") },
+        accepted,
+        contractWithPolicy(null),
+      );
+
+      const { provenance, ...consumerFacing } = projection as ChecksLatestProjection & Record<string, unknown>;
+      expect(provenance.schema_version).toBe(1);
+      expect(provenance.generated_at).toBe("2026-07-22T12:00:00.000Z");
+      expect(typeof provenance.materializer_version).toBe("string");
+      expect(provenance.materializer_version.length).toBeGreaterThan(0);
+      expect(provenance.source_event_ids).toEqual([event.event_id]);
+      expect(provenance.source_checkpoint_id).toBeNull();
+      expect(provenance.subject_hash).toBe(SUBJECT_A);
+      expect(provenance.worktree_id).toBe("fixture");
+      expect(provenance.contract_id).toBe(CONTRACT_RELATIVE);
+
+      const recomputed = `sha256:${createHash("sha256").update(canonicalize(consumerFacing as never)).digest("hex")}`;
+      expect(provenance.content_hash).toBe(recomputed);
+      expect(provenance.content_hash).toMatch(/^sha256:[0-9a-f]{64}$/);
+    });
+  });
+
+  test("content_hash is a pure function of the resolved event content -- identical replay reproduces identical bytes", () => {
+    withTempRepo("materializer-replay-determinism", (repoRoot) => {
+      seedGenesis(repoRoot);
+      seedEvent(repoRoot, { subjectHash: SUBJECT_A, runTraceMarker: "replay" });
+      const { accepted } = readAcceptedEvents(repoRoot);
+      const input = { repoRoot, contractPath: CONTRACT_RELATIVE, subjectHash: SUBJECT_A };
+
+      const first = buildChecksLatestProjection(input, accepted, contractWithPolicy(null));
+      const second = buildChecksLatestProjection(input, accepted, contractWithPolicy(null));
+      expect(first.provenance.content_hash).toBe(second.provenance.content_hash);
+    });
+  });
+
+  test("an event carrying no run_trace field renders unsatisfied rather than fabricating content", () => {
+    withTempRepo("materializer-no-run-trace", (repoRoot) => {
+      seedGenesis(repoRoot);
+      appendEvidenceEvent(repoRoot, {
+        worktreeId: "fixture",
+        eventType: "verify_sprint.result",
+        trustClass: "authoritative_machine",
+        producer: "verify-sprint",
+        correlationRunId: "run-no-trace",
+        subjectIdentity: baseIdentity({ subject_hash: SUBJECT_A }),
+        payload: { kind: "json", value: { status: "pass", counts: {}, run_snapshot_id: "run-x" } },
+      });
+      const { accepted } = readAcceptedEvents(repoRoot);
+
+      const projection = buildChecksLatestProjection(
+        { repoRoot, contractPath: CONTRACT_RELATIVE, subjectHash: SUBJECT_A },
+        accepted,
+        contractWithPolicy(null),
+      );
+      expect(projection.status).toBe("unsatisfied");
+    });
+  });
+});
+
+describe("checks-materializer: writeChecksLatest overwrite semantics", () => {
+  test("a hand-edited checks/latest.json is fully overwritten by the next materialization and carries provenance", () => {
+    withTempRepo("materializer-hand-edit-overwrite", (repoRoot) => {
+      seedGenesis(repoRoot);
+      mkdirSync(join(repoRoot, "tasks", "contracts"), { recursive: true });
+      writeFileSync(join(repoRoot, CONTRACT_RELATIVE), contractWithPolicy(null));
+      seedEvent(repoRoot, { subjectHash: SUBJECT_A, runTraceMarker: "authoritative" });
+
+      const checksFilePath = ".ai/harness/checks/latest.json";
+      mkdirSync(join(repoRoot, ".ai/harness/checks"), { recursive: true });
+      writeFileSync(
+        join(repoRoot, checksFilePath),
+        JSON.stringify({ schema: "repo-harness-run-trace.v1", status: "pass", hand_edited_marker: "do-not-trust-me" }, null, 2),
+      );
+
+      const projection = writeChecksLatest({
+        repoRoot,
+        contractPath: CONTRACT_RELATIVE,
+        subjectHash: SUBJECT_A,
+        checksFilePath,
+      });
+
+      const onDisk = JSON.parse(readFileSync(join(repoRoot, checksFilePath), "utf-8"));
+      expect(onDisk.hand_edited_marker).toBeUndefined();
+      expect(onDisk.marker).toBe("authoritative");
+      expect(onDisk.provenance).toBeDefined();
+      expect(onDisk.provenance.content_hash).toBe(projection.provenance.content_hash);
+    });
+  });
+
+  test("end-to-end (gatekeeper CRITICAL regression): a realistic-length contract slug + real sha256:-prefixed review_subject_sha256 survives materialization byte-identical, D8-provenanced", () => {
+    withTempRepo("materializer-end-to-end-pass", (repoRoot) => {
+      setupGitFixtureRepo(repoRoot, LONG_SLUG_CONTRACT_RELATIVE);
+      const expectedSubject = recomputeExpectedSubject(repoRoot);
+      const runTrace = {
+        schema: "repo-harness-run-trace.v1",
+        status: "pass",
+        source: "verify-sprint",
+        exit_code: 0,
+        review_subject_sha256: expectedSubject,
+        run_file: LONG_SLUG_RUN_FILE,
+        lifecycle: { snapshot: LONG_SLUG_RUN_FILE, evidence_tier: "harness-trace-v1" },
+        contract: { file: LONG_SLUG_CONTRACT_RELATIVE, status: "pass" },
+        review: { file: "tasks/reviews/fixture.review.md", status: "pass" },
+        active_plan: LONG_SLUG_ACTIVE_PLAN,
+        guards: [{ name: "contract", status: "pass" }],
+      };
+      const emitResult = emitAuthoritativeVerifyEvidence({
+        repoRoot,
+        contractPath: LONG_SLUG_CONTRACT_RELATIVE,
+        commandLine: "repo-harness run verify-sprint --prepare-acceptance",
+        status: "pass",
+        runSnapshotPath: LONG_SLUG_RUN_FILE,
+        expectedSubjectSha256: expectedSubject,
+        runTrace,
+      });
+      expect(emitResult.ok).toBe(true);
+      if (!emitResult.ok) return;
+      expect(emitResult.event.subject_identity.subject_hash).toBe(expectedSubject);
+
+      const projection = writeChecksLatest({
+        repoRoot,
+        contractPath: emitResult.contractPath,
+        subjectHash: emitResult.event.subject_identity.subject_hash,
+        checksFilePath: ".ai/harness/checks/latest.json",
+      });
+
+      const { provenance, ...consumerFacing } = projection as typeof projection & Record<string, unknown>;
+      // Byte-equality (deep-equal) against the exact input run_trace -- the
+      // exact regression that slipped through: pre-fix, review_subject_sha256
+      // came back double-prefixed and every long-slug path field came back
+      // partially hashed, so this assertion alone would have caught it.
+      expect(consumerFacing).toEqual(runTrace);
+      expect(projection.provenance.source_event_ids).toEqual([emitResult.event.event_id]);
+      expect(projection.provenance.worktree_id).toBe(emitResult.genesis.worktree_id);
+
+      // Direct, named field-level proof of the CRITICAL finding.
+      expect((consumerFacing as typeof runTrace).review_subject_sha256).toBe(expectedSubject);
+      expect((consumerFacing as typeof runTrace).review_subject_sha256).not.toMatch(/^sha256:sha256:/);
+      expect((consumerFacing as typeof runTrace).run_file).toBe(LONG_SLUG_RUN_FILE);
+      expect((consumerFacing as typeof runTrace).run_file.startsWith(".ai/harness/runs/")).toBe(true);
+      expect((consumerFacing as typeof runTrace).contract.file).toBe(LONG_SLUG_CONTRACT_RELATIVE);
+      expect((consumerFacing as typeof runTrace).active_plan).toBe(LONG_SLUG_ACTIVE_PLAN);
+    });
+  });
+
+  test("end-to-end (gatekeeper CRITICAL regression, fail path): a realistic-length contract slug survives materialization byte-identical on a failing verify result too", () => {
+    withTempRepo("materializer-end-to-end-fail", (repoRoot) => {
+      setupGitFixtureRepo(repoRoot, LONG_SLUG_CONTRACT_RELATIVE);
+      const expectedSubject = recomputeExpectedSubject(repoRoot);
+      const runTrace = {
+        schema: "repo-harness-run-trace.v1",
+        status: "fail",
+        source: "verify-sprint",
+        exit_code: 1,
+        review_subject_sha256: expectedSubject,
+        run_file: LONG_SLUG_RUN_FILE,
+        lifecycle: { snapshot: LONG_SLUG_RUN_FILE },
+        contract: { file: LONG_SLUG_CONTRACT_RELATIVE, status: "fail" },
+        active_plan: LONG_SLUG_ACTIVE_PLAN,
+      };
+      const emitResult = emitAuthoritativeVerifyEvidence({
+        repoRoot,
+        contractPath: LONG_SLUG_CONTRACT_RELATIVE,
+        commandLine: "repo-harness run verify-sprint --prepare-acceptance",
+        status: "fail",
+        runSnapshotPath: LONG_SLUG_RUN_FILE,
+        expectedSubjectSha256: expectedSubject,
+        runTrace,
+      });
+      expect(emitResult.ok).toBe(true);
+      if (!emitResult.ok) return;
+
+      const projection = writeChecksLatest({
+        repoRoot,
+        contractPath: emitResult.contractPath,
+        subjectHash: emitResult.event.subject_identity.subject_hash,
+        checksFilePath: ".ai/harness/checks/latest.json",
+      });
+
+      const { provenance, ...consumerFacing } = projection as typeof projection & Record<string, unknown>;
+      expect(consumerFacing).toEqual(runTrace);
+      expect((consumerFacing as typeof runTrace).review_subject_sha256).not.toMatch(/^sha256:sha256:/);
+      expect((consumerFacing as typeof runTrace).run_file).toBe(LONG_SLUG_RUN_FILE);
+      expect(projection.status).toBe("fail");
+      expect((projection as Record<string, unknown>).exit_code).toBe(1);
+    });
+  });
+});
+
+describe("checks-materializer: parseAcceptancePolicySummary", () => {
+  test("mirrors acceptance-receipt.ts's own closed schema validation", () => {
+    expect(parseAcceptancePolicySummary(contractWithPolicy('{"protocol":1,"reviewer":"Claude","user_waiver":"allowed"}'))).toEqual({
+      present: true,
+      userWaiverAllowed: true,
+    });
+    expect(parseAcceptancePolicySummary(contractWithPolicy('{"protocol":1,"reviewer":"Codex","user_waiver":"forbidden"}'))).toEqual({
+      present: true,
+      userWaiverAllowed: false,
+    });
+    expect(parseAcceptancePolicySummary(contractWithPolicy(null))).toEqual({ present: false, userWaiverAllowed: false });
+    expect(parseAcceptancePolicySummary(contractWithPolicy('{"protocol":1,"reviewer":"Claude","user_waiver":"maybe"}'))).toEqual({
+      present: false,
+      userWaiverAllowed: false,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// git fixture helper (mirrors tests/evidence-verify-producer.test.ts's
+// setupFixtureRepo) for the two end-to-end producer+materializer tests above.
+// ---------------------------------------------------------------------------
+function git(repoRoot: string, args: readonly string[]): string {
+  return execFileSync("git", ["-C", repoRoot, ...args], { encoding: "utf-8" });
+}
+
+function setupGitFixtureRepo(repoRoot: string, contractPath: string = CONTRACT_RELATIVE): void {
+  mkdirSync(repoRoot, { recursive: true });
+  git(repoRoot, ["init", "-q", "-b", "main"]);
+  git(repoRoot, ["config", "user.email", "checks-materializer-test@example.com"]);
+  git(repoRoot, ["config", "user.name", "checks-materializer-test"]);
+  writeFileSync(join(repoRoot, ".gitignore"), ".ai/harness/evidence/\n");
+  writeFileSync(join(repoRoot, "README.md"), "base\n");
+  git(repoRoot, ["add", ".gitignore", "README.md"]);
+  git(repoRoot, ["commit", "-q", "-m", "base"]);
+  git(repoRoot, ["tag", "base-tag"]);
+
+  mkdirSync(join(repoRoot, ".ai", "harness"), { recursive: true });
+  writeFileSync(
+    join(repoRoot, ".ai", "harness", "policy.json"),
+    JSON.stringify({ worktree_strategy: { review_base: "base-tag" } }),
+  );
+
+  mkdirSync(join(repoRoot, dirname(contractPath)), { recursive: true });
+  mkdirSync(join(repoRoot, "tasks", "reviews"), { recursive: true });
+  writeFileSync(join(repoRoot, contractPath), contractWithPolicy(null));
+  writeFileSync(join(repoRoot, "tasks/reviews/fixture.review.md"), "# Task Review: fixture\n");
+
+  git(repoRoot, ["add", ".ai/harness/policy.json", contractPath, "tasks/reviews/fixture.review.md"]);
+  git(repoRoot, ["commit", "-q", "-m", "policy and contract"]);
+
+  mkdirSync(join(repoRoot, "src"), { recursive: true });
+  writeFileSync(join(repoRoot, "src", "example.ts"), "export const value = 1;\n");
+  git(repoRoot, ["add", "src/example.ts"]);
+  git(repoRoot, ["commit", "-q", "-m", "implement"]);
+}
+
+function recomputeExpectedSubject(repoRoot: string): string {
+  const subject = buildReviewSubject(repoRoot, { targetRef: "base-tag" });
+  expect(subject.status).toBe("ok");
+  return subject.review_subject_sha256;
+}
+
+// ---------------------------------------------------------------------------
+// No-independent-authoring: proves this row's own claim -- the only writer
+// of checks/latest.json anywhere in this repository is this materializer
+// module plus its single call site (scripts/emit-verify-evidence.ts).
+//
+// Scope: this sweep covers the operating repo's own live authority surfaces
+// -- the exact two sites EPC-00 froze as row 9's complete enumeration
+// (scripts/verify-sprint.sh's former `cp`, .ai/hooks/lib/workflow-state.sh's
+// former `{}` bootstrap) plus every other scripts/src/.ai/hooks file. It
+// EXCLUDES a small, closed, named allowlist of pre-existing
+// project-initialization/adoption scaffolding that seeds a DIFFERENT,
+// brand-new downstream repo's genesis placeholder files (a distinct
+// lifecycle: those files have no ledger yet by definition, and are
+// unrelated to this worktree's own D7/D8 authority) -- confirmed unchanged
+// by this package's own diff. Any writer OUTSIDE the materializer, its call
+// site, and this exact allowlist fails the test.
+//
+// src/cli/hook/mutation-observed.ts needs NO exclusion (orchestrator ruling,
+// residual finding 2b, closed in this same package): its continuous
+// contract-verification cascade was a third, previously-unnamed
+// direct-authoring path (`verify-contract.sh --report-file` defaulting to
+// the acceptance checks_file); the fix redirects it to a dedicated
+// `.ai/harness/checks/contract-verify.latest.json`, proven directly below
+// rather than by exclusion.
+// ---------------------------------------------------------------------------
+describe("checks-materializer: no-independent-authoring", () => {
+  const MATERIALIZER_MODULE = "src/effects/evidence/checks-materializer.ts";
+  const MATERIALIZER_CALL_SITE = "scripts/emit-verify-evidence.ts";
+  // Project-initialization / adoption scaffolding for a brand-new downstream
+  // repo (never this worktree's own checks/latest.json authority); a
+  // distinct, out-of-scope lifecycle per this package's Scope/Non-goals.
+  const OUT_OF_SCOPE_INIT_SCAFFOLDING = new Set([
+    "scripts/plan-to-todo.sh",
+    "scripts/ensure-task-workflow.sh",
+    "scripts/lib/project-init-lib.sh",
+  ]);
+
+  function listFiles(dir: string, exts: readonly string[]): string[] {
+    const out: string[] = [];
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return out;
+    }
+    for (const entry of entries) {
+      const abs = join(dir, entry);
+      const stat = statSync(abs);
+      if (stat.isDirectory()) {
+        out.push(...listFiles(abs, exts));
+      } else if (exts.some((ext) => entry.endsWith(ext))) {
+        out.push(abs);
+      }
+    }
+    return out;
+  }
+
+  // Matches actual WRITE syntax targeting checks/latest.json -- not mere
+  // reads (`jq -r '.status' "$checks_file"`, `readText(...)`, TS references
+  // to the path string in doc/comment/gitignore-pattern contexts).
+  const BASH_WRITE_PATTERNS: RegExp[] = [
+    /\bcp\s+\S+\s+"?\$checks_file"?/,
+    />\s*"?\$\(workflow_checks_file\)"?/,
+    />\s*"?\.ai\/harness\/checks\/latest\.json"?(?!\S)/,
+    />\s*"\$target_dir\/\.ai\/harness\/checks\/latest\.json"/,
+  ];
+  const TS_WRITE_PATTERNS: RegExp[] = [
+    /writeFileSync\([^)]*checks[^)]*latest\.json/i,
+    /writeFileDurably\([^)]*checks[^)]*latest\.json/i,
+    /Bun\.write\([^)]*checks[^)]*latest\.json/i,
+  ];
+
+  test("grep sweep over scripts/, src/, .ai/hooks/ finds no writer outside the materializer, its call site, and the documented allowlist", () => {
+    const roots = [
+      { dir: join(REPO_ROOT, "scripts"), exts: [".sh"], patterns: BASH_WRITE_PATTERNS, relPrefix: "scripts/" },
+      { dir: join(REPO_ROOT, ".ai/hooks"), exts: [".sh"], patterns: BASH_WRITE_PATTERNS, relPrefix: ".ai/hooks/" },
+      { dir: join(REPO_ROOT, "src"), exts: [".ts"], patterns: TS_WRITE_PATTERNS, relPrefix: "src/" },
+      { dir: join(REPO_ROOT, "scripts"), exts: [".ts"], patterns: TS_WRITE_PATTERNS, relPrefix: "scripts/" },
+    ];
+
+    const unexpectedWriters: string[] = [];
+    for (const root of roots) {
+      for (const absPath of listFiles(root.dir, root.exts)) {
+        const relPath = absPath.slice(REPO_ROOT.length + 1);
+        if (relPath === MATERIALIZER_MODULE || relPath === MATERIALIZER_CALL_SITE) continue;
+        if (OUT_OF_SCOPE_INIT_SCAFFOLDING.has(relPath)) continue;
+        const content = readFileSync(absPath, "utf-8");
+        if (root.patterns.some((pattern) => pattern.test(content))) {
+          unexpectedWriters.push(relPath);
+        }
+      }
+    }
+
+    expect(unexpectedWriters).toEqual([]);
+  });
+
+  test("the two EPC-00-named direct-authoring sites are actually gone", () => {
+    const verifySprint = readFileSync(join(REPO_ROOT, "scripts/verify-sprint.sh"), "utf-8");
+    expect(verifySprint).not.toMatch(/cp\s+"\$checks_report"\s+"\$checks_file"/);
+    expect(verifySprint).not.toMatch(/cp\s+"\$finalized_checks"\s+"\$checks_file"/);
+
+    const workflowState = readFileSync(join(REPO_ROOT, ".ai/hooks/lib/workflow-state.sh"), "utf-8");
+    expect(workflowState).not.toMatch(/printf "\{\}\\n" > "\$\(workflow_checks_file\)"/);
+
+    const mirror = readFileSync(join(REPO_ROOT, "assets/templates/helpers/verify-sprint.sh"), "utf-8");
+    expect(mirror).toBe(verifySprint);
+  });
+
+  // Residual finding 2b (orchestrator ruling): mutation-observed.ts's own
+  // continuous contract-verification cascade was a THIRD, previously
+  // unnamed direct-authoring path for checks/latest.json (verify-contract.sh
+  // --report-file defaulted to the acceptance checks_file). Proven directly
+  // here -- not by exclusion from the grep sweep above -- that a real
+  // qualifying edit's contract-verification target never resolves to the
+  // acceptance-evidence path.
+  test("mutation-observed.ts's continuous-verification report target is never the acceptance checks_file", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "materializer-mutation-observed-redirect-"));
+    try {
+      execFileSync("git", ["init", "-q", "-b", "main"], { cwd });
+      execFileSync("git", ["config", "user.email", "mutation-observed-redirect@example.com"], { cwd });
+      execFileSync("git", ["config", "user.name", "mutation-observed-redirect"], { cwd });
+      writeFileSync(join(cwd, "README.md"), "# fixture\n");
+      execFileSync("git", ["add", "."], { cwd });
+      execFileSync("git", ["commit", "-q", "-m", "seed"], { cwd });
+
+      const contractPath = "tasks/contracts/redirect-fixture.contract.md";
+      mkdirSync(join(cwd, "tasks/contracts"), { recursive: true });
+      writeFileSync(
+        join(cwd, contractPath),
+        [
+          "# Contract",
+          "",
+          "> **Status**: Pending",
+          "",
+          "```yaml",
+          "exit_criteria:",
+          "  files_exist:",
+          "    - src/target.ts",
+          "```",
+          "",
+        ].join("\n"),
+      );
+      const planPath = "plans/plan-20260722-0000-mutation-observed-redirect-fixture.md";
+      mkdirSync(join(cwd, "plans"), { recursive: true });
+      writeFileSync(
+        join(cwd, planPath),
+        ["# Plan: fixture", "", "> **Status**: Executing", `> **Task Contract**: ${contractPath}`, ""].join("\n"),
+      );
+      mkdirSync(join(cwd, ".ai/harness"), { recursive: true });
+      writeFileSync(join(cwd, ".ai/harness/active-plan"), planPath);
+      writeFileSync(join(cwd, ".ai/harness/active-worktree"), `${cwd}\n`);
+
+      const collector: MutationObservedCollector = {
+        getRepoRoot: () => cwd,
+        getWorktreeOwnership: () => ({ current: cwd, owner: null, ownedByCurrent: false }),
+        getActivePlanMarker: () => planPath,
+      };
+      const result = runMutationObserved({
+        collector,
+        input: JSON.stringify({ tool_input: { file_path: "src/target.ts" } }),
+      });
+      expect(result.exitCode).toBe(0);
+
+      const events = readPendingPostEditEvents(cwd);
+      expect(events.length).toBe(1);
+      expect(events[0]!.dirty["contract-verification"]).toBe(true);
+      const target = events[0]!.payload.contract_verification;
+      expect(target).toBeDefined();
+      expect(target!.checks_file).not.toBe(".ai/harness/checks/latest.json");
+      expect(target!.checks_file).toBe(".ai/harness/checks/contract-verify.latest.json");
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/evidence-event-store.test.ts
+++ b/tests/evidence-event-store.test.ts
@@ -13,6 +13,7 @@ import {
   readAcceptedEvents,
   type EvidenceEventInput,
 } from "../src/effects/evidence/event-log";
+import { redactPayloadStrings } from "../src/core/evidence/redaction";
 
 function withTempRepo(prefix: string, fn: (repoRoot: string) => void): void {
   const repoRoot = mkdtempSync(join(tmpdir(), `${prefix}-`));
@@ -307,6 +308,125 @@ describe("D6 construction-invariant safety", () => {
       const blobPath = join(repoRoot, ".ai/harness/evidence/blobs", record.blob_sha256!);
       expect(existsSync(blobPath)).toBe(true);
       expect(readFileSync(blobPath)).toEqual(content);
+    });
+  });
+});
+
+describe("D6 redaction: typed-field exemption (EPC-05 gatekeeper CRITICAL fix)", () => {
+  // Live repro that motivated this fix: evt-01KY4YMNNF0BFAPHV968AX04J6 in the
+  // EPC-05 worktree's own ledger -- a real verify-sprint run against this
+  // package's own realistic-length contract slug mangled review_subject_sha256
+  // (double-prefixed) and every long-slug path in the run_trace.
+  const LONG_SLUG_CONTRACT_PATH = "tasks/contracts/20260722-1929-epc-05-checks-latest-materializer.contract.md";
+  const LONG_SLUG_RUN_FILE = ".ai/harness/runs/run-20260722T210100-99999-20260722-1929-epc-05-checks-latest-materializer.json";
+  const LONG_SLUG_ACTIVE_PLAN = "plans/plan-20260722-1929-epc-05-checks-latest-materializer.md";
+
+  test("a declared hash value (bare 40-char git SHA, bare 64-char hex, or sha256:-prefixed) is exempt from entropy redaction", () => {
+    const bareSha40 = "5228d4ea0d7987cf6fb73be216d5b9cc638817c3";
+    const prefixedSha256 = "sha256:" + "a".repeat(64);
+    const bareSha256 = "b".repeat(64);
+    const result = redactPayloadStrings({ a: bareSha40, b: prefixedSha256, c: bareSha256 }, []) as Record<string, string>;
+    expect(result).toEqual({ a: bareSha40, b: prefixedSha256, c: bareSha256 });
+  });
+
+  test("double-prefix regression: an already sha256:-prefixed hash value is never re-hashed to sha256:sha256:...", () => {
+    const subjectHash = "sha256:" + "d".repeat(64);
+    const result = redactPayloadStrings({ review_subject_sha256: subjectHash }, []) as { review_subject_sha256: string };
+    expect(result.review_subject_sha256).toBe(subjectHash);
+    expect(result.review_subject_sha256).not.toMatch(/^sha256:sha256:/);
+  });
+
+  test("a hash embedded inside a longer free-text string is NOT exempt -- whole-value match only", () => {
+    const embedded = `contract sha256:${"c".repeat(64)} failed`;
+    const result = redactPayloadStrings({ message: embedded }, []) as { message: string };
+    expect(result.message).not.toBe(embedded);
+    expect(result.message.startsWith("contract ")).toBe(true);
+    expect(result.message.endsWith(" failed")).toBe(true);
+  });
+
+  test("a path-key-convention field (path/_path/Path suffix) is exempt from entropy redaction regardless of value shape", () => {
+    const result = redactPayloadStrings(
+      { contract_path: LONG_SLUG_CONTRACT_PATH, filePath: LONG_SLUG_CONTRACT_PATH, path: LONG_SLUG_CONTRACT_PATH },
+      [],
+    ) as Record<string, string>;
+    expect(result.contract_path).toBe(LONG_SLUG_CONTRACT_PATH);
+    expect(result.filePath).toBe(LONG_SLUG_CONTRACT_PATH);
+    expect(result.path).toBe(LONG_SLUG_CONTRACT_PATH);
+  });
+
+  test("a whole-value safe repo-relative path is exempt even when the key does not follow the path-key convention (run_file, lifecycle.snapshot, contract.file, active_plan)", () => {
+    const result = redactPayloadStrings(
+      {
+        run_file: LONG_SLUG_RUN_FILE,
+        lifecycle: { snapshot: LONG_SLUG_RUN_FILE },
+        contract: { file: LONG_SLUG_CONTRACT_PATH },
+        active_plan: LONG_SLUG_ACTIVE_PLAN,
+      },
+      [],
+    ) as { run_file: string; lifecycle: { snapshot: string }; contract: { file: string }; active_plan: string };
+    expect(result.run_file).toBe(LONG_SLUG_RUN_FILE);
+    expect(result.lifecycle.snapshot).toBe(LONG_SLUG_RUN_FILE);
+    expect(result.contract.file).toBe(LONG_SLUG_CONTRACT_PATH);
+    expect(result.active_plan).toBe(LONG_SLUG_ACTIVE_PLAN);
+  });
+
+  test("array entries that are whole-value safe repo-relative paths are exempt too (allowed_paths/files_changed)", () => {
+    const result = redactPayloadStrings(
+      { allowed_paths: [LONG_SLUG_CONTRACT_PATH, "scripts/verify-sprint.sh"] },
+      [],
+    ) as { allowed_paths: string[] };
+    expect(result.allowed_paths).toEqual([LONG_SLUG_CONTRACT_PATH, "scripts/verify-sprint.sh"]);
+  });
+
+  test("a path-shaped value with a .. traversal segment is NOT exempt and still gets entropy-redacted", () => {
+    const withTraversal = "../" + "a".repeat(40) + "/nested.txt";
+    const result = redactPayloadStrings({ note: withTraversal }, []) as { note: string };
+    expect(result.note).not.toBe(withTraversal);
+  });
+
+  test("the secret-value denylist still fires inside an exempted (path-shaped) field", () => {
+    const secret = "ghp_abcdefghijklmnopqrstuvwxyz0123456789AB";
+    const pathWithSecret = `tasks/contracts/${secret}.contract.md`;
+    const result = redactPayloadStrings({ contract_path: pathWithSecret }, [secret]) as { contract_path: string };
+    expect(result.contract_path).not.toContain(secret);
+    expect(result.contract_path).toContain("sha256:");
+  });
+
+  test("the secret-value denylist still fires inside an exempted (declared-hash-shaped) field", () => {
+    const secret = "ghp_abcdefghijklmnopqrstuvwxyz0123456789AB";
+    // Not hash-shaped once the secret is embedded (fails the whole-value hash
+    // pattern), but proves the denylist pass is unconditional regardless.
+    const result = redactPayloadStrings({ token_ref: secret }, [secret]) as { token_ref: string };
+    expect(result.token_ref).not.toContain(secret);
+    expect(result.token_ref).toContain("sha256:");
+  });
+
+  test("free-text fields keep entropy redaction unchanged (no exemption applies)", () => {
+    const token = "Zx9Qk3mP7vRt2Nw8Ly5Ju1Hb6Fg4Ds0Ac";
+    expect(token.length).toBeGreaterThanOrEqual(32);
+    const result = redactPayloadStrings({ detail: `secret=${token}` }, []) as { detail: string };
+    expect(result.detail).not.toContain(token);
+    expect(result.detail).toContain("sha256:");
+  });
+
+  test("end-to-end: a realistic run_trace payload with a long contract slug survives appendEvidenceEvent byte-intact for its consumer-facing fields", () => {
+    withTempRepo("evidence-redaction-run-trace-e2e", (repoRoot) => {
+      freshGenesisRepo(repoRoot);
+      const runTrace = {
+        schema: "repo-harness-run-trace.v1",
+        status: "pass",
+        review_subject_sha256: "sha256:" + "e".repeat(64),
+        run_file: LONG_SLUG_RUN_FILE,
+        lifecycle: { snapshot: LONG_SLUG_RUN_FILE },
+        contract: { file: LONG_SLUG_CONTRACT_PATH },
+        active_plan: LONG_SLUG_ACTIVE_PLAN,
+      };
+      const record = appendEvidenceEvent(
+        repoRoot,
+        baseInput({ payload: { kind: "json", value: { run_trace: runTrace } } }),
+      );
+      const stored = (record.payload as { run_trace: unknown }).run_trace;
+      expect(stored).toEqual(runTrace);
     });
   });
 });

--- a/tests/helper-scripts.test.ts
+++ b/tests/helper-scripts.test.ts
@@ -164,6 +164,36 @@ function writeValidSprintChecks(cwd: string) {
   );
 }
 
+// EPC-05: checks/latest.json is now materialized from the evidence ledger
+// (src/effects/evidence/checks-materializer.ts) rather than cp'd directly by
+// verify-sprint.sh. These deployed-helper fixtures never reach that ledger
+// (no git repo, no REPO_HARNESS_SOURCE_ROOT, and the ledger/materializer
+// tooling is source-repo-only -- never copied into
+// assets/templates/helpers/), so emission always cannot-binds (exit 3) and
+// checks/latest.json is genuinely absent after these runs. The exact same
+// rich content it used to receive via the deleted direct `cp` still lands,
+// byte-for-byte, in the run snapshot file (`.ai/harness/runs/*.json`,
+// unchanged by this package's cutover) -- these helpers read from there.
+function latestRunSnapshot(cwd: string): { path: string; content: any } {
+  const runsDir = join(cwd, ".ai/harness/runs");
+  const names = readdirSync(runsDir).filter((name) => name.endsWith(".json"));
+  let best: { path: string; content: any; generatedAt: string } | null = null;
+  for (const name of names) {
+    const candidatePath = join(runsDir, name);
+    const parsed = JSON.parse(readFileSync(candidatePath, "utf-8"));
+    const generatedAt = String(parsed.generated_at ?? "");
+    if (!best || generatedAt > best.generatedAt) {
+      best = { path: candidatePath, content: parsed, generatedAt };
+    }
+  }
+  if (!best) throw new Error(`no run snapshot found in ${runsDir}`);
+  return { path: best.path, content: best.content };
+}
+
+function expectChecksLatestAbsent(cwd: string): void {
+  expect(existsSync(join(cwd, ".ai/harness/checks/latest.json"))).toBe(false);
+}
+
 function writeFixtureCapabilityRegistry(cwd: string): void {
   mkdirSync(join(cwd, ".ai/context"), { recursive: true });
   writeFileSync(join(cwd, ".ai/context/capabilities.json"), JSON.stringify({
@@ -3391,12 +3421,13 @@ describe("Workflow helper scripts", () => {
         HOOK_HOST: "claude",
         REPO_HARNESS_HOOK_CLI: join(ROOT, "src/cli/hook-entry.ts"),
       });
-      expect(
-        res.status,
-        `${res.stdout}\n${res.stderr}\n${readFileSync(join(cwd, ".ai/harness/checks/latest.json"), "utf-8")}`,
-      ).toBe(0);
+      expect(res.status, `${res.stdout}\n${res.stderr}`).toBe(0);
       expect(res.stdout).toContain("Sprint verification passed");
-      const checks = JSON.parse(readFileSync(join(cwd, ".ai/harness/checks/latest.json"), "utf-8"));
+      // EPC-05: emission cannot-binds in this non-git, no-source-root
+      // fixture (see latestRunSnapshot's doc comment), so checks/latest.json
+      // is never (re)written by the materializer -- genuinely absent.
+      expectChecksLatestAbsent(cwd);
+      const { path: runFilePath, content: checks } = latestRunSnapshot(cwd);
       expect(checks.schema).toBe("repo-harness-run-trace.v1");
       expect(checks.status).toBe("pass");
       expect(checks.source).toBe("verify-sprint");
@@ -3418,9 +3449,8 @@ describe("Workflow helper scripts", () => {
       expect(checks.benchmark_evidence).toEqual({ status: "not_applicable", report_sha256: "", benchmark_subject_sha256: "" });
       expect(checks.allowed_paths_check.status).toBe("pass");
       expect(checks.run_file).toMatch(/^\.ai\/harness\/runs\/.+-demo\.json$/);
-      expect(existsSync(join(cwd, checks.run_file))).toBe(true);
-      const snapshot = JSON.parse(readFileSync(join(cwd, checks.run_file), "utf-8"));
-      expect(snapshot.lifecycle.evidence_tier).toBe("harness-trace-v1");
+      expect(join(cwd, checks.run_file)).toBe(runFilePath);
+      expect(checks.lifecycle.evidence_tier).toBe("harness-trace-v1");
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
@@ -3474,14 +3504,20 @@ describe("Workflow helper scripts", () => {
       expect(res.stdout).toContain("without rerunning verification");
       expect(existsSync(rerunMarker)).toBe(false);
       expect(existsSync(projectionMarker)).toBe(true);
+      // EPC-05: finalize's own evidence emission also cannot-binds in this
+      // non-git, no-source-root fixture (no scripts/emit-verify-evidence.ts
+      // is deployed here, mirroring every real downstream adopter), so the
+      // pending -> pass patch that used to reach checks/latest.json via the
+      // deleted direct `cp` is never applied to that file: it stays exactly
+      // as this test pre-seeded it. This is the documented residual finding
+      // for this row: the acceptance_receipt pending -> pass transition on
+      // checks/latest.json only becomes observable where the ledger is
+      // reachable (a real, git-backed, source-rooted worktree -- see
+      // tests/evidence-checks-materializer.test.ts's own end-to-end
+      // pass/fail producer+materializer tests for that path).
       const checks = JSON.parse(readFileSync(join(cwd, ".ai/harness/checks/latest.json"), "utf-8"));
-      expect(checks.acceptance_receipt).toMatchObject({
-        status: "pass",
-        disposition: "external_pass",
-        reviewer: "Claude",
-        source: "claude-review",
-      });
-      expect(checks.guards.find((guard: { name: string }) => guard.name === "acceptance_receipt")?.status).toBe("pass");
+      expect(checks.acceptance_receipt).toEqual({ status: "pending" });
+      expect(checks.guards.find((guard: { name: string }) => guard.name === "acceptance_receipt")?.status).toBe("pending");
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
@@ -3575,15 +3611,14 @@ describe("Workflow helper scripts", () => {
         REPO_HARNESS_HOOK_CLI: join(ROOT, "src/cli/hook-entry.ts"),
       });
 
-      expect(
-        baselineRes.status,
-        `${baselineRes.stdout}\n${baselineRes.stderr}\n${readFileSync(join(baseline, ".ai/harness/checks/latest.json"), "utf-8")}`,
-      ).toBe(0);
-      expect(
-        candidateRes.status,
-        `${candidateRes.stdout}\n${candidateRes.stderr}\n${readFileSync(join(withCandidate, ".ai/harness/checks/latest.json"), "utf-8")}`,
-      ).toBe(0);
+      expect(baselineRes.status, `${baselineRes.stdout}\n${baselineRes.stderr}`).toBe(0);
+      expect(candidateRes.status, `${candidateRes.stdout}\n${candidateRes.stderr}`).toBe(0);
       expect(candidateRes.status).toBe(baselineRes.status);
+      // EPC-05: emission cannot-binds in this non-git, no-source-root
+      // fixture, so checks/latest.json is never (re)written -- see
+      // latestRunSnapshot's doc comment.
+      expectChecksLatestAbsent(baseline);
+      expectChecksLatestAbsent(withCandidate);
       expect(baselineRes.stdout).toContain("Sprint verification passed");
       expect(candidateRes.stdout).toContain("Sprint verification passed");
       expect(baselineRes.stderr).not.toContain("[Maintenance] Notes list promotion candidates");
@@ -3656,7 +3691,13 @@ describe("Workflow helper scripts", () => {
         REPO_HARNESS_HOOK_CLI: join(ROOT, "src/cli/hook-entry.ts"),
       });
       expect(res.status).toBe(1);
-      const checks = JSON.parse(readFileSync(join(cwd, ".ai/harness/checks/latest.json"), "utf-8"));
+      // EPC-05: emission cannot-binds in this fixture (no
+      // scripts/emit-verify-evidence.ts is deployed here, mirroring every
+      // real downstream adopter), so checks/latest.json is never (re)written
+      // -- see latestRunSnapshot's doc comment. The exact same content still
+      // lands in the run snapshot, unaffected by this row's cutover.
+      expectChecksLatestAbsent(cwd);
+      const { content: checks } = latestRunSnapshot(cwd);
       expect(checks.status).toBe("fail");
       expect(checks.failure_class).toBe("allowed_paths");
       expect(checks.diff_base.ref).toBe("main");
@@ -3782,11 +3823,14 @@ describe("Workflow helper scripts", () => {
         HARNESS_DIFF_BASE: undefined,
       };
       const baselineRes = run("bash", ["scripts/verify-sprint.sh", "--prepare-acceptance"], cwd, metadataFallbackEnv);
-      expect(
-        baselineRes.status,
-        `${baselineRes.stdout}\n${baselineRes.stderr}\n${readFileSync(join(cwd, ".ai/harness/checks/latest.json"), "utf-8")}`,
-      ).toBe(0);
-      const baselineChecks = JSON.parse(readFileSync(join(cwd, ".ai/harness/checks/latest.json"), "utf-8"));
+      expect(baselineRes.status, `${baselineRes.stdout}\n${baselineRes.stderr}`).toBe(0);
+      // EPC-05: emission cannot-binds in this fixture (no
+      // scripts/emit-verify-evidence.ts is deployed here), so
+      // checks/latest.json is never (re)written across any of these three
+      // runs -- the identical content still lands in each run's own
+      // snapshot file, unaffected by this row's cutover.
+      expectChecksLatestAbsent(cwd);
+      const baselineChecks = latestRunSnapshot(cwd).content;
       expect(baselineChecks.diff_base.ref).toBe(taskBase);
       expect(baselineChecks.diff_base.merge_base).toBe(taskBase);
       expect(baselineChecks.files_changed).toContain("docs/task-change.md");
@@ -3809,9 +3853,7 @@ describe("Workflow helper scripts", () => {
       );
       const legacyMetadataRes = run("bash", ["scripts/verify-sprint.sh", "--prepare-acceptance"], cwd, metadataFallbackEnv);
       expect(legacyMetadataRes.status).toBe(0);
-      const legacyMetadataChecks = JSON.parse(
-        readFileSync(join(cwd, ".ai/harness/checks/latest.json"), "utf-8")
-      );
+      const legacyMetadataChecks = latestRunSnapshot(cwd).content;
       expect(legacyMetadataChecks.diff_base.ref).toBe(taskBase);
       expect(legacyMetadataChecks.allowed_paths_check.status).toBe("pass");
 
@@ -3820,7 +3862,7 @@ describe("Workflow helper scripts", () => {
         REPO_HARNESS_DIFF_BASE: "origin/main",
       });
       expect(overrideRes.status).toBe(1);
-      const overrideChecks = JSON.parse(readFileSync(join(cwd, ".ai/harness/checks/latest.json"), "utf-8"));
+      const overrideChecks = latestRunSnapshot(cwd).content;
       expect(overrideChecks.diff_base.ref).toBe("origin/main");
       expect(overrideChecks.allowed_paths_check.outside).toContain("plans/preexisting-on-local-main.md");
     } finally {
@@ -3878,7 +3920,12 @@ describe("Workflow helper scripts", () => {
 
       const res = run("bash", ["scripts/verify-sprint.sh", "--prepare-acceptance"], cwd);
       expect(res.status).toBe(0);
-      const checks = JSON.parse(readFileSync(join(cwd, ".ai/harness/checks/latest.json"), "utf-8"));
+      // EPC-05: emission cannot-binds in this fixture (no
+      // scripts/emit-verify-evidence.ts is deployed here), so
+      // checks/latest.json is never (re)written -- the identical content
+      // still lands in the run snapshot.
+      expectChecksLatestAbsent(cwd);
+      const checks = latestRunSnapshot(cwd).content;
       expect(checks.review.status).toBe("pass");
       expect(checks.review.card).toBeUndefined();
     } finally {
@@ -3984,7 +4031,12 @@ describe("Workflow helper scripts", () => {
 
       const res = run("bash", ["scripts/verify-sprint.sh", "--prepare-acceptance"], cwd);
       expect(res.status).toBe(0);
-      const checks = JSON.parse(readFileSync(join(cwd, ".ai/harness/checks/latest.json"), "utf-8"));
+      // EPC-05: emission cannot-binds in this fixture (no
+      // scripts/emit-verify-evidence.ts is deployed here), so
+      // checks/latest.json is never (re)written -- the identical content
+      // still lands in the run snapshot.
+      expectChecksLatestAbsent(cwd);
+      const checks = latestRunSnapshot(cwd).content;
       expect(checks.review.status).toBe("pass");
       expect(checks.review.card).toBeUndefined();
     } finally {
@@ -4032,14 +4084,22 @@ describe("Workflow helper scripts", () => {
 
       const res = run("bash", ["scripts/verify-sprint.sh", "--prepare-acceptance"], cwd);
       expect(res.status).toBe(1);
-      const checks = JSON.parse(readFileSync(join(cwd, ".ai/harness/checks/latest.json"), "utf-8"));
+      // EPC-05: emission cannot-binds in this fixture (no
+      // scripts/emit-verify-evidence.ts is deployed here), so
+      // checks/latest.json is never (re)written -- the identical content
+      // (including the "fail" status: this row extends emission to the
+      // fail path too, in the real ledger-reachable case, but this fixture
+      // never reaches the ledger regardless of that) still lands in the
+      // run snapshot.
+      expectChecksLatestAbsent(cwd);
+      const { path: runFilePath, content: checks } = latestRunSnapshot(cwd);
       expect(checks.status).toBe("fail");
       expect(checks.source).toBe("verify-sprint");
       expect(checks.contract.file).toBe("tasks/contracts/demo.contract.md");
       expect(checks.contract.status).toBe("fail");
       expect(checks.acceptance_receipt.status).toBe("pending");
       expect(checks.run_file).toMatch(/^\.ai\/harness\/runs\/.+-demo\.json$/);
-      expect(existsSync(join(cwd, checks.run_file))).toBe(true);
+      expect(join(cwd, checks.run_file)).toBe(runFilePath);
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }

--- a/tests/mutation-observed.test.ts
+++ b/tests/mutation-observed.test.ts
@@ -171,9 +171,15 @@ describe('mutation-observed: dirty-bit derivation', () => {
       const targetEvent = events.find((e) => e.changed_paths.includes('src/target.ts'))!;
       const otherEvent = events.find((e) => e.changed_paths.includes('src/other.ts'))!;
       expect(targetEvent.dirty['contract-verification']).toBe(true);
+      // EPC-05 orchestrator ruling (residual 2b): the continuous-verification
+      // report target is now a dedicated file, deliberately distinct from
+      // the acceptance-evidence path the checks-materializer exclusively
+      // authors -- see mutation-observed.ts's CONTRACT_VERIFICATION_REPORT_RELATIVE
+      // doc comment for the full rationale (last-writer-wins shadow
+      // authority this closes).
       expect(targetEvent.payload.contract_verification).toEqual({
         contract_file: contractPath,
-        checks_file: '.ai/harness/checks/latest.json',
+        checks_file: '.ai/harness/checks/contract-verify.latest.json',
       });
       expect(otherEvent.dirty['contract-verification']).toBe(false);
       expect(otherEvent.payload.contract_verification).toBeUndefined();


### PR DESCRIPTION
Sprint C backlog row 9. The Program's first authority cutover, per frozen decisions D4/D6/D7/D8.

- `src/effects/evidence/checks-materializer.ts`: `checks/latest.json` is now a deterministic materialization of the evidence ledger — frozen D7 selection predicate (exact subject, append-position winner, supersedes excluded, policy-gated attested trust, never mtime) with the frozen 9-field D8 provenance block; no subject match renders fail-closed `unsatisfied`.
- Three direct authoring paths deleted/closed same-package (R5): the verify-sprint `cp` (script + helper mirror), the `{}` bootstrap in workflow-state.sh (canonical assets source + projection + digest), and the Stop-time continuous contract verification in mutation-observed.ts (redirected to its own telemetry file `contract-verify.latest.json`; policy default unchanged). No-independent-authoring test + behavioral redirect test enforce this.
- Verify-producer payload upgrade: full run-trace rides a content-addressed blob; producer invariants unchanged.
- D6 redaction refinement (round-1 gatekeeper CRITICAL, fixed per orchestrator ruling at the construction boundary): whole-value declared-hash exemption `^(sha256:)?[0-9a-f]{40,64}$` and safe-repo-relative-path exemption; env-secret denylist unconditional including inside exempted fields; free-text entropy redaction unchanged. Red-first regression reproduces the double-prefix/path-mangling bug on revert.
- Consumers untouched and green unchanged: acceptance-receipt, prompt-handler, merge-gate, verify-contract.

Verification: full `bun test` 1779 pass / 0 fail / 1 skip (worker + two gatekeeper runs); live dogfood readback — materialized provenance `source_event_ids` resolve to accepted `authoritative_machine` ledger events, consumer fields byte-intact under 47-char slugs; this PR's own acceptance receipt was recorded against materializer-produced evidence. Acceptance: round-1 gatekeeper FAIL remediated, round-2 gatekeeper PASS.

Known intermediate states (EPC-09 closeout obligations, documented in notes): guarded only-if-absent `{}` seeds in plan-to-todo/ensure-task-workflow; downstream adopters lack ledger tooling until the next release; globally installed 0.10.1 still carries the pre-cutover cp locally.