### PR TITLE
EPC-07: Recovery-view cutover — single materializer per surviving view

### DIFF
--- a/.ai/harness/workflow-contract.json
+++ b/.ai/harness/workflow-contract.json
@@ -133,7 +133,8 @@
       "context-contract-sync.sh",
       "workstream-sync.sh",
       "prepare-codex-handoff.sh",
-      "codex-handoff-resume.sh"
+      "codex-handoff-resume.sh",
+      "recovery-view-cli.ts"
     ],
     "descriptions": {
       "new-spec": "Create docs/spec.md from the product spec template",
@@ -185,7 +186,8 @@
       "context-contract-sync": "Sync the latest or a given architecture event into local CLAUDE.md/AGENTS.md blocks",
       "workstream-sync": "Ensure a durable capability workstream ledger exists for a plan slice",
       "prepare-codex-handoff": "Refresh the handoff snapshot, resume packet, and global Codex handoff pointer",
-      "codex-handoff-resume": "Rebuild the repo's resume packet, optionally printing the resume prompt"
+      "codex-handoff-resume": "Rebuild the repo's resume packet, optionally printing the resume prompt",
+      "recovery-view-cli": "Materialize the handoff/resume recovery views (and optionally the Codex-global packet) from the last-published checkpoint plus live workflow context"
     },
     "dir": "package:assets/templates/helpers",
     "runtimeSource": "package"

--- a/.ai/hooks/.projection.json
+++ b/.ai/hooks/.projection.json
@@ -3,6 +3,6 @@
   "canonical_root": "assets/hooks",
   "projection_target": ".ai/hooks",
   "manifest": "assets/hooks/projection.json",
-  "digest": "sha256:006caba4b236504c0af72dbc97fa94a9f77d493918c91c4d6d6aa6813c7063b3",
+  "digest": "sha256:1804bee7efb3ffdb53202cc0c977661231a0aa7aadeaf3fd65be6fd9db16d9fa",
   "file_count": 3
 }

--- a/.ai/hooks/lib/workflow-state.sh
+++ b/.ai/hooks/lib/workflow-state.sh
@@ -119,8 +119,18 @@ workflow_ensure_harness_surface() {
   # workflow_acceptance_receipt_status, workflow_next_action's `[[ ! -f
   # "$checks_file" ]]` check above), so removing this bootstrap changes no
   # consumer's observable pass/fail outcome -- only which message they print.
-  [[ -f "$(workflow_handoff_file)" ]] || printf "# Harness Handoff\n\n> **Reason**: bootstrap\n" > "$(workflow_handoff_file)"
-  [[ -f "$(workflow_resume_packet_file)" ]] || printf "# Codex Resume Packet\n\n> **Reason**: bootstrap\n" > "$(workflow_resume_packet_file)"
+  #
+  # EPC-07: the same reasoning now applies to handoff/resume -- this was an
+  # undeclared fifth writer (Phase A inventory finding: any
+  # workflow_append_event/workflow_write_run_summary call, reachable from
+  # unrelated event-logging paths, silently planted a one-line placeholder
+  # here before the real materializer ever ran). Recovery views now render a
+  # typed minimal state even with no checkpoint published yet (see
+  # scripts/recovery-view-cli.ts / src/effects/evidence/recovery-materializer.ts),
+  # so the placeholder is redundant and reintroduces exactly the
+  # silently-satisfied-expectation risk EPC-05 already closed for
+  # checks/latest.json. A missing handoff/resume file is genuine absence
+  # until the single materializer runs.
   [[ -f "$(workflow_failure_log_file)" ]] || : > "$(workflow_failure_log_file)"
   [[ -f "$(workflow_events_file)" ]] || : > "$(workflow_events_file)"
 }
@@ -1778,222 +1788,27 @@ workflow_contract_allows_path() {
 }
 workflow_write_handoff() {
   local reason="${1:-session-stop}"
-  local handoff_file active_plan active_contract active_review active_notes checks_file next_task changed_files diff_stat spec_file source_plan parent_run_id supersedes
-  local next_action next_stage next_command next_message
-  local resume_file trace_file recent_commands blockers decisions goal latest_trace_file
-  local active_sprint active_sprint_row
-  local changed_count untracked_count
+  local source_plan parent_run_id bun_bin
 
+  # EPC-07: independent handoff/resume content assembly retired same-package
+  # (Phase A/B: tasks/contracts/20260722-2246-epc-07-recovery-view-cutover.contract.md).
+  # Rendering now lives in the single standalone materializer,
+  # scripts/recovery-view-cli.ts (mirrored byte-identically to
+  # assets/templates/helpers/recovery-view-cli.ts), kept consistent by
+  # inspection with src/effects/evidence/recovery-materializer.ts -- the
+  # authoritative in-process implementation the TS Stop handler imports
+  # directly at real Stop time. This function still owns the
+  # event-journal/run-summary bookkeeping below: those are not among
+  # EPC-07's four named recovery views.
   workflow_ensure_harness_surface
-  handoff_file="$(workflow_handoff_file)"
-  checks_file="$(workflow_checks_file)"
-  resume_file="$(workflow_resume_packet_file)"
-  spec_file="docs/spec.md"
-  active_plan="$(get_active_plan || true)"
-  active_contract="$(workflow_active_contract || true)"
-  active_review="$(workflow_active_review || true)"
-  active_notes="$(workflow_active_notes || true)"
-  active_sprint=""
-  if [[ -f ".ai/harness/sprint/active-sprint" ]]; then
-    active_sprint="$(cat ".ai/harness/sprint/active-sprint" 2>/dev/null | xargs)"
-  fi
-  active_sprint_row="(none)"
-  if [[ -n "$active_sprint" && -f "$active_sprint" ]]; then
-    active_sprint_row="$(
-      awk -v plan="$active_plan" '
-        /^\|[[:space:]]*[0-9]+[[:space:]]*\|/ {
-          if (plan != "" && index($0, plan) > 0) {
-            print
-            found = 1
-            exit
-          }
-        }
-        END { if (!found) exit 1 }
-      ' "$active_sprint" 2>/dev/null || true
-    )"
-    active_sprint_row="${active_sprint_row:-Active sprint: ${active_sprint}}"
-  fi
+  bun_bin="${REPO_HARNESS_BUN_BIN:-bun}"
+  "$bun_bin" "scripts/recovery-view-cli.ts" --reason "$reason" --quiet
+
   source_plan="$(get_todo_source_plan || true)"
   if [[ "$source_plan" == "(none)" ]]; then
     source_plan=""
   fi
   parent_run_id="${HOOK_RUN_ID:-${CLAUDE_RUN_ID:-${CODEX_RUN_ID:-run-$(date '+%Y%m%dT%H%M%S')-$$}}}"
-  supersedes="$(workflow_read_state_field "$(workflow_task_state_file)" 'source_plan' || true)"
-
-  next_action="$(workflow_next_action)"
-  next_stage="$(printf '%s\n' "$next_action" | cut -f1)"
-  next_command="$(printf '%s\n' "$next_action" | cut -f2)"
-  next_message="$(printf '%s\n' "$next_action" | cut -f3-)"
-  [[ "${next_command:-}" == "-" ]] && next_command=""
-  next_stage="${next_stage:-none}"
-  next_message="${next_message:-(none)}"
-  if [[ -n "${next_command:-}" ]]; then
-    next_task="${next_message} Command: ${next_command}"
-  else
-    next_task="$next_message"
-  fi
-
-  if is_git_repo; then
-    changed_files="$(
-      {
-        git diff --name-only HEAD 2>/dev/null || true
-        git ls-files --others --exclude-standard 2>/dev/null || true
-      } | sed '/^[[:space:]]*$/d' | sort -u
-    )"
-    changed_files="${changed_files:-(none)}"
-    changed_count="$(printf '%s\n' "$changed_files" | sed '/^(none)$/d; /^[[:space:]]*$/d' | wc -l | tr -d ' ')"
-    if [[ "$changed_count" -gt 80 ]]; then
-      changed_files="$(
-        {
-          printf '%s\n' "$changed_files" | head -80
-          printf '... (%s total changed/untracked paths; inspect git status --short)\n' "$changed_count"
-        }
-      )"
-    fi
-
-    diff_stat="$( (git diff --shortstat HEAD 2>/dev/null || true) | tr -d '\n' )"
-    untracked_count="$(git ls-files --others --exclude-standard 2>/dev/null | wc -l | tr -d ' ')"
-    if [[ "$untracked_count" -gt 0 ]]; then
-      diff_stat="${diff_stat:-no tracked diff}; ${untracked_count} untracked files"
-    fi
-    diff_stat="${diff_stat:-no uncommitted diff against HEAD}"
-  else
-    changed_files="(none)"
-    diff_stat="git repository not detected"
-  fi
-
-  trace_file="$(workflow_trace_file)"
-  if [[ -f "$trace_file" ]]; then
-    recent_commands="$(
-      tail -5 "$trace_file" 2>/dev/null \
-        | sed -E 's/^/- /'
-    )"
-  fi
-  recent_commands="${recent_commands:-- (none captured)}"
-
-  if [[ -n "$source_plan" ]]; then
-    goal="Continue task checklist sourced from ${source_plan}."
-  elif [[ -n "$active_plan" ]]; then
-    goal="Continue active plan ${active_plan}."
-  elif [[ "$next_stage" == "cleanup" ]]; then
-    goal="Clean up completed contract worktree."
-  elif [[ "$next_task" != "(none)" && "$next_task" != "No active execution checklist" ]]; then
-    goal="$next_task"
-  else
-    goal="No active plan. Continue from the latest user request and filesystem state."
-  fi
-  decisions="Use filesystem artifacts as source of truth; treat SQLite/thread state as a rebuildable read model only."
-  blockers="(none recorded)"
-  if [[ -f "$checks_file" ]] && command -v jq >/dev/null 2>&1; then
-    latest_trace_file="$(jq -r '.run_file // empty' "$checks_file" 2>/dev/null || true)"
-  else
-    latest_trace_file=""
-  fi
-  latest_trace_file="${latest_trace_file:-$checks_file}"
-
-  cat > "$handoff_file" <<EOF_HANDOFF
-# Harness Handoff
-
-> **Generated**: $(date '+%Y-%m-%d %H:%M:%S')
-> **Reason**: ${reason}
-
-## Goal
-
-${goal}
-
-## Decisions
-
-- ${decisions}
-
-## Files Touched
-
-\`\`\`
-${changed_files}
-\`\`\`
-
-## Commands Run
-
-${recent_commands}
-
-## Checks
-
-- Checks file: ${checks_file}
-- Latest trace: ${latest_trace_file}
-
-## Blockers
-
-- ${blockers}
-
-## Active Artifacts
-
-- Active plan: ${active_plan:-(none)}
-- Active contract: ${active_contract:-(none)}
-- Active sprint row: ${active_sprint_row}
-- Review file: ${active_review:-(none)}
-- Latest trace/checks file: ${latest_trace_file}
-- Resume packet: ${resume_file}
-
-## Exact Next Step
-
-- ${next_task}
-
-## Resume Prompt
-
-- Resume packet: ${resume_file}
-- Start a fresh Codex session and read source artifacts first, then this handoff, before continuing; do not rely on auto-compact.
-
-## Source Artifacts
-
-- Spec: ${spec_file}
-- Plan: ${active_plan:-(none)}
-- Todo Source Plan: ${source_plan:-(none)}
-- Contract: ${active_contract:-(none)}
-- Review: ${active_review:-(none)}
-- Notes: ${active_notes:-(none)}
-- Checks: ${checks_file}
-- Resume Packet: ${resume_file}
-- Policy: $(workflow_policy_file)
-- Context Map: $(workflow_context_map_file)
-
-## Current Status
-
-- Next action stage: ${next_stage}
-- Next recommended action: ${next_task}
-- Working tree: ${diff_stat}
-- Parent Run ID: ${parent_run_id}
-- Supersedes: ${supersedes:-(none)}
-
-## Changed Files
-
-\`\`\`
-${changed_files}
-\`\`\`
-EOF_HANDOFF
-
-  cat > "$resume_file" <<EOF_RESUME
-# Codex Resume Packet
-<!-- generated-by: workflow_write_handoff v1 -->
-
-> **Generated**: $(date '+%Y-%m-%d %H:%M:%S')
-> **Reason**: ${reason}
-
-## Resume Prompt
-
-Start a fresh session for this task; do not rely on auto-compact or prior chat history. Read the source artifacts below, then the handoff, before continuing from Exact Next Step.
-
-- ${next_task}
-
-## Source Artifacts
-
-- Handoff: ${handoff_file}
-- Spec: ${spec_file}
-- Active plan: ${active_plan:-(none)}
-- Active contract: ${active_contract:-(none)}
-- Review: ${active_review:-(none)}
-- Notes: ${active_notes:-(none)}
-- Research: $(workflow_policy_get '.tasks.research_dir' 'docs/researches')/
-- Checks: ${checks_file}
-EOF_RESUME
 
   workflow_append_event "handoff_refresh" "$reason" "{\"source_plan\":\"$(workflow_json_escape "${source_plan:-}")\",\"parent_run_id\":\"$(workflow_json_escape "$parent_run_id")\"}"
   workflow_write_run_summary "$reason"

--- a/assets/hooks/lib/workflow-state.sh
+++ b/assets/hooks/lib/workflow-state.sh
@@ -119,8 +119,18 @@ workflow_ensure_harness_surface() {
   # workflow_acceptance_receipt_status, workflow_next_action's `[[ ! -f
   # "$checks_file" ]]` check above), so removing this bootstrap changes no
   # consumer's observable pass/fail outcome -- only which message they print.
-  [[ -f "$(workflow_handoff_file)" ]] || printf "# Harness Handoff\n\n> **Reason**: bootstrap\n" > "$(workflow_handoff_file)"
-  [[ -f "$(workflow_resume_packet_file)" ]] || printf "# Codex Resume Packet\n\n> **Reason**: bootstrap\n" > "$(workflow_resume_packet_file)"
+  #
+  # EPC-07: the same reasoning now applies to handoff/resume -- this was an
+  # undeclared fifth writer (Phase A inventory finding: any
+  # workflow_append_event/workflow_write_run_summary call, reachable from
+  # unrelated event-logging paths, silently planted a one-line placeholder
+  # here before the real materializer ever ran). Recovery views now render a
+  # typed minimal state even with no checkpoint published yet (see
+  # scripts/recovery-view-cli.ts / src/effects/evidence/recovery-materializer.ts),
+  # so the placeholder is redundant and reintroduces exactly the
+  # silently-satisfied-expectation risk EPC-05 already closed for
+  # checks/latest.json. A missing handoff/resume file is genuine absence
+  # until the single materializer runs.
   [[ -f "$(workflow_failure_log_file)" ]] || : > "$(workflow_failure_log_file)"
   [[ -f "$(workflow_events_file)" ]] || : > "$(workflow_events_file)"
 }
@@ -1778,222 +1788,27 @@ workflow_contract_allows_path() {
 }
 workflow_write_handoff() {
   local reason="${1:-session-stop}"
-  local handoff_file active_plan active_contract active_review active_notes checks_file next_task changed_files diff_stat spec_file source_plan parent_run_id supersedes
-  local next_action next_stage next_command next_message
-  local resume_file trace_file recent_commands blockers decisions goal latest_trace_file
-  local active_sprint active_sprint_row
-  local changed_count untracked_count
+  local source_plan parent_run_id bun_bin
 
+  # EPC-07: independent handoff/resume content assembly retired same-package
+  # (Phase A/B: tasks/contracts/20260722-2246-epc-07-recovery-view-cutover.contract.md).
+  # Rendering now lives in the single standalone materializer,
+  # scripts/recovery-view-cli.ts (mirrored byte-identically to
+  # assets/templates/helpers/recovery-view-cli.ts), kept consistent by
+  # inspection with src/effects/evidence/recovery-materializer.ts -- the
+  # authoritative in-process implementation the TS Stop handler imports
+  # directly at real Stop time. This function still owns the
+  # event-journal/run-summary bookkeeping below: those are not among
+  # EPC-07's four named recovery views.
   workflow_ensure_harness_surface
-  handoff_file="$(workflow_handoff_file)"
-  checks_file="$(workflow_checks_file)"
-  resume_file="$(workflow_resume_packet_file)"
-  spec_file="docs/spec.md"
-  active_plan="$(get_active_plan || true)"
-  active_contract="$(workflow_active_contract || true)"
-  active_review="$(workflow_active_review || true)"
-  active_notes="$(workflow_active_notes || true)"
-  active_sprint=""
-  if [[ -f ".ai/harness/sprint/active-sprint" ]]; then
-    active_sprint="$(cat ".ai/harness/sprint/active-sprint" 2>/dev/null | xargs)"
-  fi
-  active_sprint_row="(none)"
-  if [[ -n "$active_sprint" && -f "$active_sprint" ]]; then
-    active_sprint_row="$(
-      awk -v plan="$active_plan" '
-        /^\|[[:space:]]*[0-9]+[[:space:]]*\|/ {
-          if (plan != "" && index($0, plan) > 0) {
-            print
-            found = 1
-            exit
-          }
-        }
-        END { if (!found) exit 1 }
-      ' "$active_sprint" 2>/dev/null || true
-    )"
-    active_sprint_row="${active_sprint_row:-Active sprint: ${active_sprint}}"
-  fi
+  bun_bin="${REPO_HARNESS_BUN_BIN:-bun}"
+  "$bun_bin" "scripts/recovery-view-cli.ts" --reason "$reason" --quiet
+
   source_plan="$(get_todo_source_plan || true)"
   if [[ "$source_plan" == "(none)" ]]; then
     source_plan=""
   fi
   parent_run_id="${HOOK_RUN_ID:-${CLAUDE_RUN_ID:-${CODEX_RUN_ID:-run-$(date '+%Y%m%dT%H%M%S')-$$}}}"
-  supersedes="$(workflow_read_state_field "$(workflow_task_state_file)" 'source_plan' || true)"
-
-  next_action="$(workflow_next_action)"
-  next_stage="$(printf '%s\n' "$next_action" | cut -f1)"
-  next_command="$(printf '%s\n' "$next_action" | cut -f2)"
-  next_message="$(printf '%s\n' "$next_action" | cut -f3-)"
-  [[ "${next_command:-}" == "-" ]] && next_command=""
-  next_stage="${next_stage:-none}"
-  next_message="${next_message:-(none)}"
-  if [[ -n "${next_command:-}" ]]; then
-    next_task="${next_message} Command: ${next_command}"
-  else
-    next_task="$next_message"
-  fi
-
-  if is_git_repo; then
-    changed_files="$(
-      {
-        git diff --name-only HEAD 2>/dev/null || true
-        git ls-files --others --exclude-standard 2>/dev/null || true
-      } | sed '/^[[:space:]]*$/d' | sort -u
-    )"
-    changed_files="${changed_files:-(none)}"
-    changed_count="$(printf '%s\n' "$changed_files" | sed '/^(none)$/d; /^[[:space:]]*$/d' | wc -l | tr -d ' ')"
-    if [[ "$changed_count" -gt 80 ]]; then
-      changed_files="$(
-        {
-          printf '%s\n' "$changed_files" | head -80
-          printf '... (%s total changed/untracked paths; inspect git status --short)\n' "$changed_count"
-        }
-      )"
-    fi
-
-    diff_stat="$( (git diff --shortstat HEAD 2>/dev/null || true) | tr -d '\n' )"
-    untracked_count="$(git ls-files --others --exclude-standard 2>/dev/null | wc -l | tr -d ' ')"
-    if [[ "$untracked_count" -gt 0 ]]; then
-      diff_stat="${diff_stat:-no tracked diff}; ${untracked_count} untracked files"
-    fi
-    diff_stat="${diff_stat:-no uncommitted diff against HEAD}"
-  else
-    changed_files="(none)"
-    diff_stat="git repository not detected"
-  fi
-
-  trace_file="$(workflow_trace_file)"
-  if [[ -f "$trace_file" ]]; then
-    recent_commands="$(
-      tail -5 "$trace_file" 2>/dev/null \
-        | sed -E 's/^/- /'
-    )"
-  fi
-  recent_commands="${recent_commands:-- (none captured)}"
-
-  if [[ -n "$source_plan" ]]; then
-    goal="Continue task checklist sourced from ${source_plan}."
-  elif [[ -n "$active_plan" ]]; then
-    goal="Continue active plan ${active_plan}."
-  elif [[ "$next_stage" == "cleanup" ]]; then
-    goal="Clean up completed contract worktree."
-  elif [[ "$next_task" != "(none)" && "$next_task" != "No active execution checklist" ]]; then
-    goal="$next_task"
-  else
-    goal="No active plan. Continue from the latest user request and filesystem state."
-  fi
-  decisions="Use filesystem artifacts as source of truth; treat SQLite/thread state as a rebuildable read model only."
-  blockers="(none recorded)"
-  if [[ -f "$checks_file" ]] && command -v jq >/dev/null 2>&1; then
-    latest_trace_file="$(jq -r '.run_file // empty' "$checks_file" 2>/dev/null || true)"
-  else
-    latest_trace_file=""
-  fi
-  latest_trace_file="${latest_trace_file:-$checks_file}"
-
-  cat > "$handoff_file" <<EOF_HANDOFF
-# Harness Handoff
-
-> **Generated**: $(date '+%Y-%m-%d %H:%M:%S')
-> **Reason**: ${reason}
-
-## Goal
-
-${goal}
-
-## Decisions
-
-- ${decisions}
-
-## Files Touched
-
-\`\`\`
-${changed_files}
-\`\`\`
-
-## Commands Run
-
-${recent_commands}
-
-## Checks
-
-- Checks file: ${checks_file}
-- Latest trace: ${latest_trace_file}
-
-## Blockers
-
-- ${blockers}
-
-## Active Artifacts
-
-- Active plan: ${active_plan:-(none)}
-- Active contract: ${active_contract:-(none)}
-- Active sprint row: ${active_sprint_row}
-- Review file: ${active_review:-(none)}
-- Latest trace/checks file: ${latest_trace_file}
-- Resume packet: ${resume_file}
-
-## Exact Next Step
-
-- ${next_task}
-
-## Resume Prompt
-
-- Resume packet: ${resume_file}
-- Start a fresh Codex session and read source artifacts first, then this handoff, before continuing; do not rely on auto-compact.
-
-## Source Artifacts
-
-- Spec: ${spec_file}
-- Plan: ${active_plan:-(none)}
-- Todo Source Plan: ${source_plan:-(none)}
-- Contract: ${active_contract:-(none)}
-- Review: ${active_review:-(none)}
-- Notes: ${active_notes:-(none)}
-- Checks: ${checks_file}
-- Resume Packet: ${resume_file}
-- Policy: $(workflow_policy_file)
-- Context Map: $(workflow_context_map_file)
-
-## Current Status
-
-- Next action stage: ${next_stage}
-- Next recommended action: ${next_task}
-- Working tree: ${diff_stat}
-- Parent Run ID: ${parent_run_id}
-- Supersedes: ${supersedes:-(none)}
-
-## Changed Files
-
-\`\`\`
-${changed_files}
-\`\`\`
-EOF_HANDOFF
-
-  cat > "$resume_file" <<EOF_RESUME
-# Codex Resume Packet
-<!-- generated-by: workflow_write_handoff v1 -->
-
-> **Generated**: $(date '+%Y-%m-%d %H:%M:%S')
-> **Reason**: ${reason}
-
-## Resume Prompt
-
-Start a fresh session for this task; do not rely on auto-compact or prior chat history. Read the source artifacts below, then the handoff, before continuing from Exact Next Step.
-
-- ${next_task}
-
-## Source Artifacts
-
-- Handoff: ${handoff_file}
-- Spec: ${spec_file}
-- Active plan: ${active_plan:-(none)}
-- Active contract: ${active_contract:-(none)}
-- Review: ${active_review:-(none)}
-- Notes: ${active_notes:-(none)}
-- Research: $(workflow_policy_get '.tasks.research_dir' 'docs/researches')/
-- Checks: ${checks_file}
-EOF_RESUME
 
   workflow_append_event "handoff_refresh" "$reason" "{\"source_plan\":\"$(workflow_json_escape "${source_plan:-}")\",\"parent_run_id\":\"$(workflow_json_escape "$parent_run_id")\"}"
   workflow_write_run_summary "$reason"

--- a/assets/templates/helpers/codex-handoff-resume.sh
+++ b/assets/templates/helpers/codex-handoff-resume.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 set -euo pipefail
 
+# Thin invoker (EPC-07 recovery-view cutover): zero independent content
+# assembly. All handoff/resume rendering + checkpoint evidence resolution
+# now lives in the single standalone materializer, scripts/recovery-view-cli.ts
+# (mirrored to assets/templates/helpers/recovery-view-cli.ts), which
+# src/effects/evidence/recovery-materializer.ts's authoritative in-process
+# implementation is kept consistent with by inspection. This script's public
+# name and flags are preserved -- hosts that call
+# `repo-harness run codex-handoff-resume` or invoke this file directly are
+# unaffected.
+
 usage() {
   cat <<'USAGE_EOF'
 Usage: scripts/codex-handoff-resume.sh --cwd <repo> [--print-prompt] [--reason <reason>]
@@ -41,229 +51,17 @@ if [[ -z "$cwd" ]]; then
   cwd="$(pwd)"
 fi
 
-cwd="$(cd "$cwd" && pwd)"
-cd "$cwd"
-
-policy_get() {
-  local jq_path="$1"
-  local default_value="$2"
-
-  if [[ -f ".ai/harness/policy.json" ]] && command -v jq >/dev/null 2>&1; then
-    local value
-    value="$(jq -r "$jq_path // empty" .ai/harness/policy.json 2>/dev/null || true)"
-    if [[ -n "$value" ]]; then
-      printf '%s' "$value"
-      return 0
-    fi
-  fi
-
-  printf '%s' "$default_value"
-}
-
-safe_repo_file() {
-  local value="$1"
-  local default_value="$2"
-  local allowed_prefix="${3:-}"
-
-  if [[ -z "$value" || "$value" == /* || "$value" == *$'\n'* || "$value" == *$'\r'* ]]; then
-    printf '%s' "$default_value"
-    return 0
-  fi
-
-  case "$value" in
-    ..|../*|*/..|*/../*)
-      printf '%s' "$default_value"
-      ;;
-    *)
-      if [[ -n "$allowed_prefix" && "$value" != "$allowed_prefix"* ]]; then
-        printf '%s' "$default_value"
-        return 0
-      fi
-      printf '%s' "$value"
-      ;;
-  esac
-}
-
-active_plan() {
-  for marker_file in ".ai/harness/active-plan"; do
-    if [[ ! -f "$marker_file" ]]; then
-      continue
-    fi
-    local marker
-    marker="$(cat "$marker_file" 2>/dev/null | xargs)"
-    if [[ -n "$marker" && -f "$marker" ]]; then
-      printf '%s' "$marker"
-      return 0
-    fi
-  done
-}
-
-plan_slug_from_path() {
-  local plan_file="$1"
-  local base slug
-  base="$(basename "$plan_file")"
-  slug="$(printf '%s' "$base" | sed -E 's/^plan-[0-9]{8}-[0-9]{4}-//; s/\.md$//')"
-  printf '%s' "$slug"
-}
-
-plan_original_artifact_stem_from_path() {
-  local plan_file="$1"
-  local base stem
-  base="$(basename "$plan_file")"
-  stem="$(printf '%s' "$base" | sed -E 's/^plan-//; s/\.md$//')"
-  if [[ "$stem" =~ ^[0-9]{8}-[0-9]{4}-.+ ]]; then
-    printf '%s' "$stem"
-  else
-    plan_slug_from_path "$plan_file"
-  fi
-}
-
-is_transient_plan_slug() {
-  case "$1" in
-    think-plan-[0-9]*|codex-plan-[0-9]*|approved-plan-[0-9]*)
-      return 0
-      ;;
-  esac
-  return 1
-}
-
-plan_title_slug_from_file() {
-  local plan_file="$1"
-  local title slug
-  [[ -f "$plan_file" ]] || return 1
-  title="$(awk '
-    /^# Plan:[[:space:]]*/ {
-      sub(/^# Plan:[[:space:]]*/, "")
-      print
-      exit
-    }
-  ' "$plan_file" | xargs)"
-  [[ -n "$title" ]] || return 1
-  slug="$(printf '%s' "$title" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-{2,}/-/g')"
-  [[ -n "$slug" ]] || return 1
-  printf '%s' "$slug"
-}
-
-plan_artifact_stem_from_path() {
-  local plan_file="$1"
-  local stem stamp slug title_slug
-  stem="$(plan_original_artifact_stem_from_path "$plan_file")"
-  if [[ "$stem" =~ ^[0-9]{8}-[0-9]{4}-.+ ]]; then
-    stamp="$(printf '%s' "$stem" | sed -E 's/^([0-9]{8}-[0-9]{4})-.+$/\1/')"
-    slug="$(printf '%s' "$stem" | sed -E 's/^[0-9]{8}-[0-9]{4}-//')"
-    if is_transient_plan_slug "$slug"; then
-      title_slug="$(plan_title_slug_from_file "$plan_file" || true)"
-      if [[ -n "$title_slug" && "$title_slug" != "$slug" ]]; then
-        printf '%s-%s' "$stamp" "$title_slug"
-        return 0
-      fi
-    fi
-    printf '%s' "$stem"
-  else
-    plan_slug_from_path "$plan_file"
-  fi
-}
-
-preferred_or_legacy_path() {
-  local preferred="$1"
-  local legacy="$2"
-  if [[ -f "$preferred" ]] || [[ ! -f "$legacy" ]]; then
-    printf '%s' "$preferred"
-  else
-    printf '%s' "$legacy"
-  fi
-}
-
-derive_contract() {
-  local plan_file="$1"
-  local slug stem
-  [[ -n "$plan_file" ]] || return 1
-  slug="$(plan_slug_from_path "$plan_file")"
-  stem="$(plan_artifact_stem_from_path "$plan_file")"
-  [[ -n "$slug" && -n "$stem" ]] || return 1
-  preferred_or_legacy_path "tasks/contracts/${stem}.contract.md" "tasks/contracts/${slug}.contract.md"
-}
-
-derive_notes() {
-  local plan_file="$1"
-  local slug stem notes_dir
-  [[ -n "$plan_file" ]] || return 1
-  slug="$(plan_slug_from_path "$plan_file")"
-  stem="$(plan_artifact_stem_from_path "$plan_file")"
-  [[ -n "$slug" && -n "$stem" ]] || return 1
-  notes_dir="$(safe_repo_file "$(policy_get '.tasks.notes_dir' 'tasks/notes')" 'tasks/notes' 'tasks/')"
-  preferred_or_legacy_path "${notes_dir}/${stem}.notes.md" "${notes_dir}/${slug}.notes.md"
-}
-
-latest_global_handoff() {
-  local codex_home="${CODEX_HOME:-$HOME/.codex}"
-  find "$codex_home/handoffs" -maxdepth 1 -type f -name 'handoff-*.md' 2>/dev/null | sort | tail -1
-}
-
-resume_file="$(safe_repo_file "$(policy_get '.handoff_resume.resume_packet_file' '.ai/harness/handoff/resume.md')" '.ai/harness/handoff/resume.md' '.ai/harness/')"
-repo_handoff="$(safe_repo_file "$(policy_get '.harness.handoff_file' '.ai/harness/handoff/current.md')" '.ai/harness/handoff/current.md' '.ai/harness/')"
-checks_file="$(safe_repo_file "$(policy_get '.harness.checks_file' '.ai/harness/checks/latest.json')" '.ai/harness/checks/latest.json' '.ai/harness/')"
-research_dir="$(safe_repo_file "$(policy_get '.tasks.research_dir' 'docs/researches')" 'docs/researches' 'docs/researches')"
-todo_file="$(safe_repo_file "$(policy_get '.tasks.todo_file' 'tasks/todos.md')" 'tasks/todos.md' 'tasks/')"
-plan_file="$(active_plan || true)"
-contract_file="$(derive_contract "$plan_file" || true)"
-notes_file="$(derive_notes "$plan_file" || true)"
-global_handoff="$(latest_global_handoff || true)"
-
-mkdir -p "$(dirname "$resume_file")"
-
-cat > "$resume_file" <<EOF_RESUME
-# Codex Resume Packet
-<!-- generated-by: repo-harness codex-handoff-resume v1 -->
-
-> **Generated**: $(date '+%Y-%m-%d %H:%M:%S')
-> **Reason**: ${reason}
-> **Working Directory**: ${cwd}
-
-## Resume Prompt
-
-You are starting a fresh Codex session for an existing long-running task. Do not rely on prior chat history or Codex auto-compact. First read the source artifacts listed below, then continue from the exact next step in the repo handoff.
-
-Current prompt files first:
-- If the current user message lists files under \`# Files mentioned by the user\`, references \`pasted-text.txt\`, or includes an explicit attachment/file path, read those current-input files before the repo recovery artifacts below.
-- Use handoff, resume, and \`tasks/current.md\` as recovery context only; they do not outrank the current user message.
-
-Required first reads:
-- AGENTS.md
-- ${repo_handoff}
-- ${todo_file}
-- ${notes_file:-(none)}
-- ${research_dir}/
-- ${checks_file}
-
-Conditional first reads:
-- Active plan: ${plan_file:-(none)}
-- Active contract: ${contract_file:-(none)}
-- Implementation notes: ${notes_file:-(none)}
-- Global handoff: ${global_handoff:-(none)}
-
-Execution rules:
-- Treat filesystem artifacts as the source of truth.
-- Decide in the main agent whether to use subagents, parallel sidecars, sidecar \`codex exec --json\`, or a bounded main-thread trace for broad research/log scans based on context impact and callable tools; do not ask the user for spawn confirmation.
-- Keep deep research conclusions in \`${research_dir}/\`, not only in chat.
-- Do not run \`/compact\` as the primary recovery path.
-- Preserve the current dirty worktree and do not touch unrelated untracked files.
-
-## Source Artifacts
-
-- Repo handoff: ${repo_handoff}
-- Resume packet: ${resume_file}
-- Checks: ${checks_file}
-- Todo: ${todo_file}
-- Research: ${research_dir}/
-- Plan: ${plan_file:-(none)}
-- Contract: ${contract_file:-(none)}
-- Notes: ${notes_file:-(none)}
-- Global handoff: ${global_handoff:-(none)}
-EOF_RESUME
-
-if [[ "$print_prompt" -eq 1 ]]; then
-  awk '/^## Resume Prompt$/ {printing=1; next} /^## Source Artifacts$/ {printing=0} printing == 1 {print}' "$resume_file" | sed -E '/^[[:space:]]*$/N; /^\n$/D'
-else
-  echo "Updated $resume_file"
+helper_source="$0"
+if [[ -n "${REPO_HARNESS_HELPER_SOURCE_PATH:-}" && -f "$REPO_HARNESS_HELPER_SOURCE_PATH" \
+      && "$(basename "$REPO_HARNESS_HELPER_SOURCE_PATH")" == "$(basename "$0")" ]]; then
+  helper_source="$REPO_HARNESS_HELPER_SOURCE_PATH"
 fi
+helper_dir="$(cd "$(dirname "$helper_source")" && pwd)"
+
+bun_bin="${REPO_HARNESS_BUN_BIN:-bun}"
+args=(--cwd "$cwd" --reason "$reason")
+if [[ "$print_prompt" -eq 1 ]]; then
+  args+=(--print-prompt)
+fi
+
+"$bun_bin" "$helper_dir/recovery-view-cli.ts" "${args[@]}"

--- a/assets/templates/helpers/prepare-codex-handoff.sh
+++ b/assets/templates/helpers/prepare-codex-handoff.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -euo pipefail
 
+# Thin invoker (EPC-07 recovery-view cutover): zero independent content
+# assembly. The task-handoff (Codex-global packet) payload is now an
+# additional output target of the same single materializer,
+# scripts/recovery-view-cli.ts (mirrored to
+# assets/templates/helpers/recovery-view-cli.ts) -- the prior independent
+# Node/Python heredoc that spliced the per-repo global-packet section is
+# retired same-package. This script's public name and flags are preserved.
+
 usage() {
   cat <<'USAGE_EOF'
 Usage: scripts/prepare-codex-handoff.sh [--reason <reason>] [--print-prompt]
@@ -41,169 +49,10 @@ if [[ -n "${REPO_HARNESS_HELPER_SOURCE_PATH:-}" && -f "$REPO_HARNESS_HELPER_SOUR
 fi
 helper_dir="$(cd "$(dirname "$helper_source")" && pwd)"
 
-if [[ -f "$helper_dir/prepare-handoff.sh" ]]; then
-  REPO_HARNESS_SKIP_RESUME_REFRESH=1 bash "$helper_dir/prepare-handoff.sh" "$reason"
-fi
-
-resume_args=("$helper_dir/codex-handoff-resume.sh" --cwd "$repo" --reason "$reason")
+bun_bin="${REPO_HARNESS_BUN_BIN:-bun}"
+args=(--cwd "$repo" --reason "$reason" --with-global-packet)
 if [[ "$print_prompt" -eq 1 ]]; then
-  resume_args+=(--print-prompt)
+  args+=(--print-prompt)
 fi
 
-resume_output=""
-if [[ -f "$helper_dir/codex-handoff-resume.sh" ]]; then
-  resume_output="$(bash "${resume_args[@]}")"
-fi
-
-codex_home="${CODEX_HOME:-$HOME/.codex}"
-global_dir="$codex_home/handoffs"
-global_file="$global_dir/handoff-$(date '+%y%m%d').md"
-repo_handoff=".ai/harness/handoff/current.md"
-resume_file=".ai/harness/handoff/resume.md"
-
-mkdir -p "$global_dir"
-
-repo_key="$(printf '%s' "$repo" | shasum | awk '{print substr($1, 1, 12)}')"
-
-if command -v node >/dev/null 2>&1; then
-  node - "$global_file" "$repo" "$repo_key" "$reason" "$repo_handoff" "$resume_file" <<'JS_EOF'
-const fs = require("fs");
-const path = require("path");
-
-const [, , globalFile, repo, repoKey, reason, repoHandoff, resumeFile] = process.argv;
-
-fs.mkdirSync(path.dirname(globalFile), { recursive: true });
-const start = `<!-- repo:${repoKey} start -->`;
-const end = `<!-- repo:${repoKey} end -->`;
-
-function pad(value) {
-  return String(value).padStart(2, "0");
-}
-
-function yymmdd(date) {
-  return `${String(date.getFullYear()).slice(-2)}${pad(date.getMonth() + 1)}${pad(date.getDate())}`;
-}
-
-function timestamp(date) {
-  return [
-    date.getFullYear(),
-    pad(date.getMonth() + 1),
-    pad(date.getDate()),
-  ].join("-") + ` ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
-}
-
-function readText(filePath, limit = 12000) {
-  try {
-    const text = fs.readFileSync(filePath, "utf8");
-    return text.length <= limit ? text : `${text.slice(0, limit - 1)}...`;
-  } catch {
-    return "(missing)";
-  }
-}
-
-const now = new Date();
-const header = `# Codex Handoff ${yymmdd(now)}\n\nFilesystem-first fallback handoffs for compact-independent Codex sessions.\n\n`;
-const section = [
-  start,
-  `## ${timestamp(now)} ${path.basename(repo)}`,
-  "",
-  `- cwd: \`${repo}\``,
-  `- reason: \`${reason}\``,
-  `- repo_handoff: \`${repoHandoff}\``,
-  `- resume_packet: \`${resumeFile}\``,
-  "",
-  "### Repo Handoff",
-  "",
-  readText(path.join(repo, repoHandoff), 8000).trim(),
-  "",
-  "### Resume Packet",
-  "",
-  readText(path.join(repo, resumeFile), 8000).trim(),
-  "",
-  end,
-  "",
-].join("\n");
-
-let content = fs.existsSync(globalFile) ? fs.readFileSync(globalFile, "utf8") : header;
-if (content.includes(start) && content.includes(end)) {
-  const [prefix, rest] = content.split(start, 2);
-  const suffix = rest.split(end, 2)[1] ?? "";
-  content = prefix + section + suffix.replace(/^\n+/, "");
-} else {
-  if (!content.endsWith("\n")) {
-    content += "\n";
-  }
-  content += section;
-}
-
-fs.writeFileSync(globalFile, content, "utf8");
-console.log(globalFile);
-JS_EOF
-else
-  python3 - "$global_file" "$repo" "$repo_key" "$reason" "$repo_handoff" "$resume_file" <<'PY_EOF'
-from __future__ import annotations
-
-import sys
-from datetime import datetime
-from pathlib import Path
-
-global_file = Path(sys.argv[1])
-repo = Path(sys.argv[2])
-repo_key = sys.argv[3]
-reason = sys.argv[4]
-repo_handoff = Path(sys.argv[5])
-resume_file = Path(sys.argv[6])
-
-global_file.parent.mkdir(parents=True, exist_ok=True)
-start = f"<!-- repo:{repo_key} start -->"
-end = f"<!-- repo:{repo_key} end -->"
-
-def read_text(path: Path, limit: int = 12000) -> str:
-    try:
-        text = path.read_text(encoding="utf-8")
-    except OSError:
-        return "(missing)"
-    return text if len(text) <= limit else text[: limit - 1] + "..."
-
-header = f"# Codex Handoff {datetime.now().strftime('%y%m%d')}\n\nFilesystem-first fallback handoffs for compact-independent Codex sessions.\n\n"
-section = "\n".join(
-    [
-        start,
-        f"## {datetime.now().strftime('%Y-%m-%d %H:%M:%S')} {repo.name}",
-        "",
-        f"- cwd: `{repo}`",
-        f"- reason: `{reason}`",
-        f"- repo_handoff: `{repo_handoff}`",
-        f"- resume_packet: `{resume_file}`",
-        "",
-        "### Repo Handoff",
-        "",
-        read_text(repo / repo_handoff, 8000).strip(),
-        "",
-        "### Resume Packet",
-        "",
-        read_text(repo / resume_file, 8000).strip(),
-        "",
-        end,
-        "",
-    ]
-)
-
-content = global_file.read_text(encoding="utf-8") if global_file.exists() else header
-if start in content and end in content:
-    prefix, rest = content.split(start, 1)
-    _, suffix = rest.split(end, 1)
-    content = prefix + section + suffix.lstrip("\n")
-else:
-    if not content.endswith("\n"):
-        content += "\n"
-    content += section
-
-global_file.write_text(content, encoding="utf-8")
-print(global_file)
-PY_EOF
-fi
-
-if [[ -n "$resume_output" ]]; then
-  printf '%s\n' "$resume_output"
-fi
+"$bun_bin" "$helper_dir/recovery-view-cli.ts" "${args[@]}"

--- a/assets/templates/helpers/recovery-view-cli.ts
+++ b/assets/templates/helpers/recovery-view-cli.ts
@@ -1,0 +1,833 @@
+#!/usr/bin/env bun
+// Standalone helper: materializes the handoff/resume recovery views (and
+// optionally the Codex-global packet) from the last-published checkpoint
+// plus live workflow context. Self-contained by necessity -- this file is
+// distributed to adopting downstream repos (mirrored byte-identically to
+// assets/templates/helpers/recovery-view-cli.ts) which never receive this
+// package's own src/ tree, so it imports Node/Bun builtins only and
+// duplicates (by inspection, kept consistent with) the rendering logic in
+// src/effects/evidence/recovery-materializer.ts, the authoritative
+// in-process implementation src/cli/hook/stop-handler.ts imports directly
+// at real Stop time. See
+// tasks/contracts/20260722-2246-epc-07-recovery-view-cutover.contract.md
+// for the full design record.
+//
+// This tool's checkpoint read is intentionally lighter-weight than the
+// authoritative reader (src/effects/evidence/checkpoint-store.ts): it does
+// not re-verify content_hash/full schema completeness, since it is a
+// manual/CI regeneration convenience, not the Stop-time authority. It still
+// never fabricates an evidence claim -- any read/parse failure degrades to
+// the same typed "unavailable" state a renderer shows honestly.
+import { createHash } from "crypto";
+import { execFileSync } from "child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { basename, dirname, join } from "path";
+
+const RECOVERY_SCHEMA_VERSION = 1;
+const RECOVERY_MATERIALIZER_VERSION = "1";
+const LEGACY_RESUME_MARKER = "<!-- generated-by: repo-harness codex-handoff-resume v1 -->";
+
+function pad2(value: number): string {
+  return String(value).padStart(2, "0");
+}
+
+function formatDisplay(date: Date): string {
+  return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())} ${pad2(date.getHours())}:${pad2(date.getMinutes())}:${pad2(date.getSeconds())}`;
+}
+
+function formatCompact(date: Date): string {
+  return `${date.getFullYear()}${pad2(date.getMonth() + 1)}${pad2(date.getDate())}T${pad2(date.getHours())}${pad2(date.getMinutes())}${pad2(date.getSeconds())}`;
+}
+
+function yymmdd(date: Date): string {
+  return `${String(date.getFullYear()).slice(-2)}${pad2(date.getMonth() + 1)}${pad2(date.getDate())}`;
+}
+
+function sha256Hex(text: string): string {
+  return createHash("sha256").update(text, "utf-8").digest("hex");
+}
+
+function readTextOrNull(path: string): string | null {
+  try {
+    return readFileSync(path, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+function policy(repoRoot: string): Record<string, unknown> {
+  try {
+    const value = JSON.parse(readFileSync(join(repoRoot, ".ai/harness/policy.json"), "utf8"));
+    return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function nestedString(root: Record<string, unknown>, keys: readonly string[]): string {
+  let value: unknown = root;
+  for (const key of keys) {
+    if (!value || typeof value !== "object") return "";
+    value = (value as Record<string, unknown>)[key];
+  }
+  return typeof value === "string" ? value : "";
+}
+
+/** Rejects absolute paths, `..` escapes, and anything outside `.ai/harness/`
+ * -- port of `codex-handoff-resume.sh`'s existing `safe_repo_file` guard
+ * (frozen behavior: `tests/helper-scripts.test.ts`'s "reject policy paths
+ * outside the repo/harness surface" characterize this exact fallback). */
+function safeHarnessPath(value: string, fallback: string): string {
+  if (!value || value.startsWith("/") || value.includes("\\") || value.includes("\n") || value.includes("\r")) return fallback;
+  if (value === ".." || value.startsWith("../") || value.includes("/../")) return fallback;
+  if (!value.startsWith(".ai/harness/")) return fallback;
+  return value;
+}
+
+function readJson(path: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8"));
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+function metadataValue(path: string, label: string): string {
+  try {
+    const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const match = readFileSync(path, "utf8").match(new RegExp(`^> \\*\\*${escaped}\\*\\*:\\s*(.+)$`, "m"));
+    return match?.[1]?.replace(/`/g, "").trim() ?? "";
+  } catch {
+    return "";
+  }
+}
+
+function declaredPath(repoRoot: string, plan: string, label: string): string {
+  if (!plan || !existsSync(join(repoRoot, plan))) return "";
+  const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = readFileSync(join(repoRoot, plan), "utf8").match(new RegExp(`^> \\*\\*${escaped}\\*\\*:\\s*(.+)$`, "m"));
+  return match?.[1]?.replace(/`/g, "").trim() ?? "";
+}
+
+function worktreeIdFor(contractRelative: string): string {
+  const base = contractRelative.split("/").pop() ?? contractRelative;
+  return base.replace(/\.contract\.md$/, "");
+}
+
+interface ArtifactPaths {
+  readonly plan: string;
+  readonly contract: string;
+  readonly review: string;
+  readonly notes: string;
+}
+
+function planSlugFromPath(planFile: string): string {
+  const base = basename(planFile);
+  const slug = base.replace(/^plan-\d{8}-\d{4}-/, "").replace(/\.md$/, "");
+  return slug.length > 0 && slug !== base ? slug : "";
+}
+
+function planStemFromPath(planFile: string): string {
+  const base = basename(planFile);
+  const stem = base.replace(/^plan-/, "").replace(/\.md$/, "");
+  return /^\d{8}-\d{4}-.+/.test(stem) ? stem : planSlugFromPath(planFile);
+}
+
+/** `workflow_preferred_or_legacy_path` port: preferred (stamped-stem)
+ * candidate wins if it exists; else the legacy (slug-only) candidate wins
+ * if IT exists; else fall back to the preferred candidate as a best-guess
+ * pointer (matches bash's `workflow_active_contract`/`_review`/`_notes` --
+ * a recovery view may legitimately point at where an artifact SHOULD live
+ * before it has been created). */
+function preferredOrLegacyArtifactPath(repoRoot: string, preferred: string, legacy: string): string {
+  if (existsSync(join(repoRoot, preferred))) return preferred;
+  if (!existsSync(join(repoRoot, legacy))) return preferred;
+  return legacy;
+}
+
+function activeArtifacts(repoRoot: string, activePlan: string | null): ArtifactPaths {
+  const plan = activePlan && existsSync(join(repoRoot, activePlan)) ? activePlan : "";
+  if (!plan) return { plan: "", contract: "", review: "", notes: "" };
+  const stem = planStemFromPath(plan);
+  const slug = planSlugFromPath(plan);
+  const derived = (directory: string, suffix: string): string => {
+    if (!stem || !slug) return "";
+    return preferredOrLegacyArtifactPath(repoRoot, `${directory}/${stem}${suffix}`, `${directory}/${slug}${suffix}`);
+  };
+  return {
+    plan,
+    contract: declaredPath(repoRoot, plan, "Task Contract") || declaredPath(repoRoot, plan, "Sprint Contract") || derived("tasks/contracts", ".contract.md"),
+    review: declaredPath(repoRoot, plan, "Task Review") || declaredPath(repoRoot, plan, "Sprint Review") || derived("tasks/reviews", ".review.md"),
+    notes: declaredPath(repoRoot, plan, "Implementation Notes") || declaredPath(repoRoot, plan, "Notes File") || derived("tasks/notes", ".notes.md"),
+  };
+}
+
+function todoSourcePlan(repoRoot: string): string {
+  const value = metadataValue(join(repoRoot, "tasks/todos.md"), "Source Plan");
+  return value === "(none)" ? "" : value;
+}
+
+function activeSprintRow(repoRoot: string, activePlan: string): string {
+  let sprint = "";
+  try {
+    sprint = readFileSync(join(repoRoot, ".ai/harness/sprint/active-sprint"), "utf8").trim();
+  } catch {
+    return "(none)";
+  }
+  if (!sprint || sprint.startsWith("/") || sprint === ".." || sprint.startsWith("../") || sprint.includes("/../")) return "(none)";
+  try {
+    const row = readFileSync(join(repoRoot, sprint), "utf8")
+      .split("\n")
+      .find((line) => /^\|\s*\d+\s*\|/.test(line) && activePlan && line.includes(activePlan));
+    return row || `Active sprint: ${sprint}`;
+  } catch {
+    return "(none)";
+  }
+}
+
+function firstTaskBreakdown(planText: string): { total: number; done: number; next: string } {
+  const lines = planText.split("\n");
+  let inSection = false;
+  let total = 0;
+  let done = 0;
+  let next = "";
+  for (const line of lines) {
+    if (!inSection && /^## Task Breakdown\s*$/.test(line)) {
+      inSection = true;
+      continue;
+    }
+    if (inSection && /^## /.test(line)) break;
+    const match = inSection ? line.match(/^\s*-\s*\[([ xX])\]\s+(.+)$/) : null;
+    if (!match) continue;
+    total += 1;
+    if (match[1]!.toLowerCase() === "x") done += 1;
+    else if (!next) next = match[2]!.replace(/\r/g, "");
+  }
+  return { total, done, next };
+}
+
+interface NextAction {
+  readonly stage: string;
+  readonly command: string;
+  readonly message: string;
+}
+
+function nextAction(repoRoot: string, artifacts: ArtifactPaths): NextAction {
+  if (!artifacts.plan) return { stage: "none", command: "", message: "(none)" };
+  let taskState = { total: 0, done: 0, next: "" };
+  try {
+    taskState = firstTaskBreakdown(readFileSync(join(repoRoot, artifacts.plan), "utf8"));
+  } catch {
+    // Missing/unreadable plan is treated as no active execution checklist.
+  }
+  if (taskState.total > taskState.done) {
+    const pending = taskState.next || "continue active plan Task Breakdown";
+    return {
+      stage: "task",
+      command: "",
+      message: `If a major module was just completed, stage its coherent diff first; then continue the next Task Breakdown item: ${pending}`,
+    };
+  }
+  return {
+    stage: "check",
+    command: "/check",
+    message: "Stage the completed module diff first; then run /check and let canonical workflow gates determine whether review, external acceptance, verification, or worktree finish is next.",
+  };
+}
+
+function recentCommands(repoRoot: string): string {
+  try {
+    const lines = readFileSync(join(repoRoot, ".claude/.trace.jsonl"), "utf8").trimEnd().split("\n").slice(-5);
+    return lines.length > 0 && lines.some(Boolean) ? lines.map((line) => `- ${line}`).join("\n") : "- (none captured)";
+  } catch {
+    return "- (none captured)";
+  }
+}
+
+function supersededPlan(repoRoot: string): string {
+  const state = readJson(join(repoRoot, ".claude/.task-state.json"));
+  return typeof state?.source_plan === "string" && state.source_plan ? state.source_plan : "(none)";
+}
+
+function changedFiles(repoRoot: string): { files: string; summary: string } {
+  try {
+    const tracked = execFileSync("git", ["-C", repoRoot, "diff", "--name-only", "HEAD"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const untrackedRaw = execFileSync("git", ["-C", repoRoot, "ls-files", "--others", "--exclude-standard"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const files = [...new Set(`${tracked}\n${untrackedRaw}`.split("\n").map((line) => line.trim()).filter(Boolean))].sort();
+    const visible = files.length > 80 ? [...files.slice(0, 80), `... (${files.length} total changed/untracked paths; inspect git status --short)`] : files;
+
+    // workflow_write_handoff's `diff_stat`/`untracked_count` port: a
+    // human-readable tracked-diff shortstat plus an explicit untracked
+    // count, not a flat "N changed/untracked paths" total.
+    let diffStat = "";
+    try {
+      diffStat = execFileSync("git", ["-C", repoRoot, "diff", "--shortstat", "HEAD"], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }).replace(/\n/g, "");
+    } catch {
+      diffStat = "";
+    }
+    const untrackedCount = untrackedRaw.split("\n").map((line) => line.trim()).filter(Boolean).length;
+    const summary = untrackedCount > 0
+      ? `${diffStat || "no tracked diff"}; ${untrackedCount} untracked files`
+      : (diffStat || "no uncommitted diff against HEAD");
+
+    return {
+      files: visible.length > 0 ? visible.join("\n") : "(none)",
+      summary,
+    };
+  } catch {
+    return { files: "(none)", summary: "git repository not detected" };
+  }
+}
+
+function latestGlobalHandoff(codexHome: string): string {
+  try {
+    const dir = join(codexHome, "handoffs");
+    if (!existsSync(dir)) return "";
+    const entries = execFileSync("find", [dir, "-maxdepth", "1", "-type", "f", "-name", "handoff-*.md"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .sort();
+    return entries.length > 0 ? entries[entries.length - 1]! : "";
+  } catch {
+    return "";
+  }
+}
+
+function resolveActivePlanMarker(repoRoot: string): string | null {
+  try {
+    const marker = readFileSync(join(repoRoot, ".ai/harness/active-plan"), "utf8").trim();
+    if (marker && existsSync(join(repoRoot, marker))) return marker;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+interface WorkflowContext {
+  readonly reason: string;
+  readonly runId: string;
+  readonly generatedAtDisplay: string;
+  readonly generatedAtIso: string;
+  readonly workingDirectory: string;
+  readonly artifacts: ArtifactPaths;
+  readonly sourcePlan: string;
+  readonly activeSprintRowText: string;
+  readonly action: NextAction;
+  readonly nextTask: string;
+  readonly goal: string;
+  readonly changed: { readonly files: string; readonly summary: string };
+  readonly recentCommandsText: string;
+  readonly supersedes: string;
+  readonly paths: {
+    readonly checks: string;
+    readonly handoff: string;
+    readonly resume: string;
+    readonly policyFile: string;
+    readonly contextMap: string;
+    readonly researchDir: string;
+    readonly todoFile: string;
+  };
+  readonly globalHandoffPath: string;
+}
+
+function buildContext(repoRoot: string, reason: string, codexHome: string): WorkflowContext {
+  const now = new Date();
+  const config = policy(repoRoot);
+  const checks = safeHarnessPath(nestedString(config, ["harness", "checks_file"]), ".ai/harness/checks/latest.json");
+  const handoff = safeHarnessPath(nestedString(config, ["harness", "handoff_file"]), ".ai/harness/handoff/current.md");
+  const resume = safeHarnessPath(nestedString(config, ["handoff_resume", "resume_packet_file"]), ".ai/harness/handoff/resume.md");
+  const policyFile = ".ai/harness/policy.json";
+  const contextMap = safeHarnessPath(nestedString(config, ["context", "map_file"]), ".ai/context/context-map.json");
+  const researchDir = nestedString(config, ["tasks", "research_dir"]) || "docs/researches";
+  const todoFile = safeHarnessPath(nestedString(config, ["tasks", "todo_file"]), "tasks/todos.md");
+  const runId = process.env.HOOK_RUN_ID ?? process.env.CLAUDE_RUN_ID ?? process.env.CODEX_RUN_ID ?? `run-${formatCompact(now)}-${process.pid}`;
+  const activePlan = resolveActivePlanMarker(repoRoot);
+  const artifacts = activeArtifacts(repoRoot, activePlan);
+  const changed = changedFiles(repoRoot);
+  const sourcePlan = todoSourcePlan(repoRoot);
+  const action = nextAction(repoRoot, artifacts);
+  const nextTask = action.command ? `${action.message} Command: ${action.command}` : action.message;
+  const goal = sourcePlan
+    ? `Continue task checklist sourced from ${sourcePlan}.`
+    : artifacts.plan
+      ? `Continue active plan ${artifacts.plan}.`
+      : nextTask !== "(none)"
+        ? nextTask
+        : "No active plan. Continue from the latest user request and filesystem state.";
+
+  return {
+    reason,
+    runId,
+    generatedAtDisplay: formatDisplay(now),
+    generatedAtIso: now.toISOString(),
+    workingDirectory: repoRoot,
+    artifacts,
+    sourcePlan,
+    activeSprintRowText: activeSprintRow(repoRoot, artifacts.plan),
+    action,
+    nextTask,
+    goal,
+    changed,
+    recentCommandsText: recentCommands(repoRoot),
+    supersedes: supersededPlan(repoRoot),
+    paths: { checks, handoff, resume, policyFile, contextMap, researchDir, todoFile },
+    globalHandoffPath: latestGlobalHandoff(codexHome),
+  };
+}
+
+interface EvidenceLatestByType {
+  readonly event_type: string;
+  readonly event_id: string;
+  readonly trust_class: string;
+  readonly created_at: string;
+}
+
+type Evidence =
+  | {
+      readonly available: true;
+      readonly checkpointId: string;
+      readonly worktreeId: string;
+      readonly generatedAt: string;
+      readonly coveredEventCount: number;
+      readonly sourceEventIds: readonly string[];
+      readonly latestByEventType: readonly EvidenceLatestByType[];
+    }
+  | {
+      readonly available: false;
+      readonly reason: "no-checkpoint" | "checkpoint-invalid";
+      readonly detail?: string;
+    };
+
+/** Best-effort, gracefully-degrading checkpoint read -- see module doc. */
+function resolveEvidence(repoRoot: string): Evidence {
+  const markerPath = join(repoRoot, ".ai/harness/evidence/checkpoints/last-published.json");
+  const markerText = readTextOrNull(markerPath);
+  if (markerText === null) return { available: false, reason: "no-checkpoint" };
+  try {
+    const marker = JSON.parse(markerText) as Record<string, unknown>;
+    if (typeof marker.checkpoint_id !== "string" || typeof marker.machine_path !== "string") {
+      return { available: false, reason: "checkpoint-invalid", detail: "marker missing required field" };
+    }
+    const machineText = readTextOrNull(join(repoRoot, marker.machine_path));
+    if (machineText === null) {
+      return { available: false, reason: "checkpoint-invalid", detail: `checkpoint file missing: ${marker.machine_path}` };
+    }
+    const projection = JSON.parse(machineText) as Record<string, unknown>;
+    if (projection.checkpoint_id !== marker.checkpoint_id) {
+      return { available: false, reason: "checkpoint-invalid", detail: "checkpoint_id mismatch" };
+    }
+    const provenance = (projection.provenance ?? {}) as Record<string, unknown>;
+    const sourceEventIds = Array.isArray(provenance.source_event_ids) ? (provenance.source_event_ids as string[]) : [];
+    const latestByEventType = Array.isArray(projection.latest_by_event_type) ? (projection.latest_by_event_type as EvidenceLatestByType[]) : [];
+    return {
+      available: true,
+      checkpointId: String(projection.checkpoint_id),
+      worktreeId: typeof projection.worktree_id === "string" ? projection.worktree_id : "unbound",
+      generatedAt: typeof provenance.generated_at === "string" ? provenance.generated_at : "",
+      coveredEventCount: typeof projection.covered_event_count === "number" ? projection.covered_event_count : 0,
+      sourceEventIds,
+      latestByEventType,
+    };
+  } catch (error) {
+    return { available: false, reason: "checkpoint-invalid", detail: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+function evidenceLines(evidence: Evidence): string[] {
+  const lines: string[] = [];
+  if (evidence.available) {
+    lines.push(`- Checkpoint: ${evidence.checkpointId} (generated ${evidence.generatedAt})`);
+    lines.push(`- Covered events: ${evidence.coveredEventCount}`);
+    lines.push("- Latest by type:");
+    if (evidence.latestByEventType.length === 0) {
+      lines.push("  (none)");
+    } else {
+      for (const entry of evidence.latestByEventType) {
+        lines.push(`  - ${entry.event_type}: ${entry.event_id} (${entry.trust_class}, accepted ${entry.created_at})`);
+      }
+    }
+  } else if (evidence.reason === "no-checkpoint") {
+    lines.push("- Checkpoint: (none published yet -- no ledger evidence recorded in this worktree)");
+    lines.push("- Covered events: 0");
+    lines.push("- Latest by type:");
+    lines.push("  (none)");
+  } else {
+    lines.push(`- Checkpoint: (unavailable -- last-published checkpoint failed validation: ${evidence.detail ?? evidence.reason})`);
+    lines.push("- Covered events: 0");
+    lines.push("- Latest by type:");
+    lines.push("  (none)");
+  }
+  return lines;
+}
+
+interface Provenance {
+  readonly schema_version: number;
+  readonly generated_at: string;
+  readonly materializer_version: string;
+  readonly source_event_ids: readonly string[];
+  readonly source_checkpoint_id: string | null;
+  readonly worktree_id: string;
+  readonly contract_id: string | null;
+  readonly content_hash: string;
+}
+
+function resolveWorktreeId(evidence: Evidence, contractPath: string): string {
+  if (evidence.available) return evidence.worktreeId;
+  if (contractPath) return worktreeIdFor(contractPath);
+  return "unbound";
+}
+
+function buildProvenance(context: WorkflowContext, evidence: Evidence, contractPath: string, body: string): Provenance {
+  return {
+    schema_version: RECOVERY_SCHEMA_VERSION,
+    generated_at: context.generatedAtIso,
+    materializer_version: RECOVERY_MATERIALIZER_VERSION,
+    source_event_ids: evidence.available ? evidence.sourceEventIds : [],
+    source_checkpoint_id: evidence.available ? evidence.checkpointId : null,
+    worktree_id: resolveWorktreeId(evidence, contractPath),
+    contract_id: contractPath || null,
+    content_hash: `sha256:${sha256Hex(body)}`,
+  };
+}
+
+function renderProvenanceSection(provenance: Provenance): string[] {
+  return [
+    "## Provenance",
+    "",
+    `- Schema version: ${provenance.schema_version}`,
+    `- Generated at: ${provenance.generated_at}`,
+    `- Materializer version: ${provenance.materializer_version}`,
+    `- Source checkpoint id: ${provenance.source_checkpoint_id ?? "(none -- no checkpoint published yet)"}`,
+    `- Source event ids: ${provenance.source_event_ids.length > 0 ? `${provenance.source_event_ids.length} covered` : "(none)"}`,
+    "- Subject hash: (none -- recovery view is not subject-bound)",
+    `- Worktree: ${provenance.worktree_id}`,
+    `- Contract: ${provenance.contract_id ?? "(none)"}`,
+    `- Content hash: ${provenance.content_hash}`,
+  ];
+}
+
+function renderHandoff(context: WorkflowContext, evidence: Evidence, contractPath: string): string {
+  const bodyLines = [
+    "# Harness Handoff",
+    "",
+    `> **Generated**: ${context.generatedAtDisplay}`,
+    `> **Reason**: ${context.reason}`,
+    "",
+    "## Goal",
+    "",
+    context.goal,
+    "",
+    "## Decisions",
+    "",
+    "- Use filesystem artifacts as source of truth; treat SQLite/thread state as a rebuildable read model only.",
+    "",
+    "## Files Touched",
+    "",
+    "```",
+    context.changed.files,
+    "```",
+    "",
+    "## Commands Run",
+    "",
+    context.recentCommandsText,
+    "",
+    "## Evidence",
+    "",
+    ...evidenceLines(evidence),
+    "",
+    "## Blockers",
+    "",
+    "- (none recorded)",
+    "",
+    "## Active Artifacts",
+    "",
+    `- Active plan: ${context.artifacts.plan || "(none)"}`,
+    `- Active contract: ${context.artifacts.contract || "(none)"}`,
+    `- Active sprint row: ${context.activeSprintRowText}`,
+    `- Review file: ${context.artifacts.review || "(none)"}`,
+    `- Resume packet: ${context.paths.resume}`,
+    "",
+    "## Exact Next Step",
+    "",
+    `- ${context.nextTask}`,
+    "",
+    "## Resume Prompt",
+    "",
+    `- Resume packet: ${context.paths.resume}`,
+    "- Start a fresh Codex session and read source artifacts first, then this handoff, before continuing; do not rely on auto-compact.",
+    "",
+    "## Source Artifacts",
+    "",
+    "- Spec: docs/spec.md",
+    `- Plan: ${context.artifacts.plan || "(none)"}`,
+    `- Todo Source Plan: ${context.sourcePlan || "(none)"}`,
+    `- Contract: ${context.artifacts.contract || "(none)"}`,
+    `- Review: ${context.artifacts.review || "(none)"}`,
+    `- Notes: ${context.artifacts.notes || "(none)"}`,
+    `- Checks: ${context.paths.checks}`,
+    `- Resume Packet: ${context.paths.resume}`,
+    `- Policy: ${context.paths.policyFile}`,
+    `- Context Map: ${context.paths.contextMap}`,
+    "",
+    "## Current Status",
+    "",
+    `- Next action stage: ${context.action.stage}`,
+    `- Next recommended action: ${context.nextTask}`,
+    `- Working tree: ${context.changed.summary}`,
+    `- Parent Run ID: ${context.runId}`,
+    `- Supersedes: ${context.supersedes}`,
+    "",
+    "## Changed Files",
+    "",
+    "```",
+    context.changed.files,
+    "```",
+    "",
+  ];
+  const body = bodyLines.join("\n");
+  const provenance = buildProvenance(context, evidence, contractPath, body);
+  return `${body}\n${renderProvenanceSection(provenance).join("\n")}\n`;
+}
+
+function renderResume(context: WorkflowContext, evidence: Evidence, contractPath: string): string {
+  const bodyLines = [
+    "# Codex Resume Packet",
+    LEGACY_RESUME_MARKER,
+    "",
+    `> **Generated**: ${context.generatedAtDisplay}`,
+    `> **Reason**: ${context.reason}`,
+    `> **Working Directory**: ${context.workingDirectory}`,
+    "",
+    "## Resume Prompt",
+    "",
+    "You are starting a fresh Codex session for an existing long-running task. Do not rely on prior chat history or Codex auto-compact. First read the source artifacts listed below, then continue from the exact next step in the repo handoff.",
+    "",
+    "Current prompt files first:",
+    "- If the current user message lists files under `# Files mentioned by the user`, references `pasted-text.txt`, or includes an explicit attachment/file path, read those current-input files before the repo recovery artifacts below.",
+    "- Use handoff, resume, and `tasks/current.md` as recovery context only; they do not outrank the current user message.",
+    "",
+    "Required first reads:",
+    "- AGENTS.md",
+    `- ${context.paths.handoff}`,
+    `- ${context.paths.todoFile}`,
+    `- ${context.artifacts.notes || "(none)"}`,
+    `- ${context.paths.researchDir}/`,
+    `- ${context.paths.checks}`,
+    "",
+    "Conditional first reads:",
+    `- Active plan: ${context.artifacts.plan || "(none)"}`,
+    `- Active contract: ${context.artifacts.contract || "(none)"}`,
+    `- Implementation notes: ${context.artifacts.notes || "(none)"}`,
+    `- Global handoff: ${context.globalHandoffPath || "(none)"}`,
+    "",
+    "Execution rules:",
+    "- Treat filesystem artifacts as the source of truth.",
+    "- Decide in the main agent whether to use subagents, parallel sidecars, sidecar `codex exec --json`, or a bounded main-thread trace for broad research/log scans based on context impact and callable tools; do not ask the user for spawn confirmation.",
+    `- Keep deep research conclusions in \`${context.paths.researchDir}/\`, not only in chat.`,
+    "- Do not run `/compact` as the primary recovery path.",
+    "- Preserve the current dirty worktree and do not touch unrelated untracked files.",
+    "",
+    "## Source Artifacts",
+    "",
+    `- Repo handoff: ${context.paths.handoff}`,
+    `- Resume packet: ${context.paths.resume}`,
+    `- Checks: ${context.paths.checks}`,
+    `- Todo: ${context.paths.todoFile}`,
+    `- Research: ${context.paths.researchDir}/`,
+    `- Plan: ${context.artifacts.plan || "(none)"}`,
+    `- Contract: ${context.artifacts.contract || "(none)"}`,
+    `- Notes: ${context.artifacts.notes || "(none)"}`,
+    `- Global handoff: ${context.globalHandoffPath || "(none)"}`,
+    "",
+  ];
+  const body = bodyLines.join("\n");
+  const provenance = buildProvenance(context, evidence, contractPath, body);
+  return `${body}\n${renderProvenanceSection(provenance).join("\n")}\n`;
+}
+
+function extractResumePrompt(resumeText: string): string {
+  const lines = resumeText.split("\n");
+  const out: string[] = [];
+  let printing = false;
+  for (const line of lines) {
+    if (line === "## Resume Prompt") {
+      printing = true;
+      continue;
+    }
+    if (line === "## Source Artifacts") break;
+    if (printing) out.push(line);
+  }
+  while (out.length > 0 && out[0] === "") out.shift();
+  while (out.length > 0 && out[out.length - 1] === "") out.pop();
+  return `${out.join("\n")}\n`;
+}
+
+function repoKeyFor(repoPath: string): string {
+  return createHash("sha1").update(repoPath, "utf-8").digest("hex").slice(0, 12);
+}
+
+function capText(text: string, limit = 8000): string {
+  return text.length <= limit ? text : `${text.slice(0, limit - 1)}...`;
+}
+
+function renderGlobalSection(params: {
+  readonly repoPath: string;
+  readonly repoKey: string;
+  readonly reason: string;
+  readonly repoHandoffRelative: string;
+  readonly resumeFileRelative: string;
+  readonly handoffText: string;
+  readonly resumeText: string;
+  readonly now: Date;
+}): string {
+  const start = `<!-- repo:${params.repoKey} start -->`;
+  const end = `<!-- repo:${params.repoKey} end -->`;
+  const lines = [
+    start,
+    `## ${formatDisplay(params.now)} ${basename(params.repoPath)}`,
+    "",
+    `- cwd: \`${params.repoPath}\``,
+    `- reason: \`${params.reason}\``,
+    `- repo_handoff: \`${params.repoHandoffRelative}\``,
+    `- resume_packet: \`${params.resumeFileRelative}\``,
+    "",
+    "### Repo Handoff",
+    "",
+    capText(params.handoffText).trim(),
+    "",
+    "### Resume Packet",
+    "",
+    capText(params.resumeText).trim(),
+    "",
+    end,
+    "",
+  ];
+  return lines.join("\n");
+}
+
+function updateGlobalHandoffFile(codexHome: string, repoKey: string, section: string, now: Date): string {
+  const globalDir = join(codexHome, "handoffs");
+  mkdirSync(globalDir, { recursive: true });
+  const globalFile = join(globalDir, `handoff-${yymmdd(now)}.md`);
+  const start = `<!-- repo:${repoKey} start -->`;
+  const end = `<!-- repo:${repoKey} end -->`;
+  const header = `# Codex Handoff ${yymmdd(now)}\n\nFilesystem-first fallback handoffs for compact-independent Codex sessions.\n\n`;
+
+  let content = existsSync(globalFile) ? readFileSync(globalFile, "utf-8") : header;
+  const startIdx = content.indexOf(start);
+  if (startIdx >= 0 && content.includes(end)) {
+    const afterStart = content.slice(startIdx + start.length);
+    const endIdx = afterStart.indexOf(end);
+    const prefix = content.slice(0, startIdx);
+    const suffix = afterStart.slice(endIdx + end.length).replace(/^\n+/, "");
+    content = prefix + section + suffix;
+  } else {
+    if (!content.endsWith("\n")) content += "\n";
+    content += section;
+  }
+  writeFileSync(globalFile, content, "utf-8");
+  return globalFile;
+}
+
+function writeFileDurable(path: string, content: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content, { mode: 0o600 });
+}
+
+function resolveRepoRoot(cwdOption: string | undefined): string {
+  if (process.env.REPO_HARNESS_TARGET_REPO_ROOT) return process.env.REPO_HARNESS_TARGET_REPO_ROOT;
+  const cwd = cwdOption ?? process.cwd();
+  try {
+    const out = execFileSync("git", ["-C", cwd, "rev-parse", "--show-toplevel"], { encoding: "utf8" }).trim();
+    return out || cwd;
+  } catch {
+    return cwd;
+  }
+}
+
+interface Options {
+  reason: string;
+  cwd?: string;
+  printPrompt: boolean;
+  withGlobalPacket: boolean;
+  quiet: boolean;
+}
+
+function parseArgs(argv: readonly string[]): Options {
+  const options: Options = { reason: "manual", printPrompt: false, withGlobalPacket: false, quiet: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--reason") {
+      options.reason = argv[i + 1] ?? "manual";
+      i += 1;
+    } else if (arg === "--cwd") {
+      options.cwd = argv[i + 1];
+      i += 1;
+    } else if (arg === "--print-prompt") {
+      options.printPrompt = true;
+    } else if (arg === "--with-global-packet") {
+      options.withGlobalPacket = true;
+    } else if (arg === "--quiet") {
+      options.quiet = true;
+    }
+  }
+  return options;
+}
+
+function main(): void {
+  const options = parseArgs(process.argv.slice(2));
+  const repoRoot = resolveRepoRoot(options.cwd);
+  const codexHome = process.env.CODEX_HOME || join(process.env.HOME || "", ".codex");
+  const context = buildContext(repoRoot, options.reason, codexHome);
+  const evidence = resolveEvidence(repoRoot);
+  const contractPath = context.artifacts.contract;
+  const handoffText = renderHandoff(context, evidence, contractPath);
+  const resumeText = renderResume(context, evidence, contractPath);
+
+  writeFileDurable(join(repoRoot, context.paths.handoff), handoffText);
+  writeFileDurable(join(repoRoot, context.paths.resume), resumeText);
+
+  let globalFile = "";
+  if (options.withGlobalPacket) {
+    const repoKey = repoKeyFor(repoRoot);
+    const section = renderGlobalSection({
+      repoPath: repoRoot,
+      repoKey,
+      reason: options.reason,
+      repoHandoffRelative: context.paths.handoff,
+      resumeFileRelative: context.paths.resume,
+      handoffText,
+      resumeText,
+      now: new Date(),
+    });
+    globalFile = updateGlobalHandoffFile(codexHome, repoKey, section, new Date());
+  }
+
+  if (options.printPrompt) {
+    process.stdout.write(extractResumePrompt(resumeText));
+    return;
+  }
+
+  if (options.withGlobalPacket && globalFile) {
+    console.log(globalFile);
+  }
+  if (!options.quiet) {
+    console.log(`Updated ${context.paths.resume}`);
+  }
+}
+
+main();

--- a/assets/workflow-contract.v1.json
+++ b/assets/workflow-contract.v1.json
@@ -133,7 +133,8 @@
       "context-contract-sync.sh",
       "workstream-sync.sh",
       "prepare-codex-handoff.sh",
-      "codex-handoff-resume.sh"
+      "codex-handoff-resume.sh",
+      "recovery-view-cli.ts"
     ],
     "descriptions": {
       "new-spec": "Create docs/spec.md from the product spec template",
@@ -185,7 +186,8 @@
       "context-contract-sync": "Sync the latest or a given architecture event into local CLAUDE.md/AGENTS.md blocks",
       "workstream-sync": "Ensure a durable capability workstream ledger exists for a plan slice",
       "prepare-codex-handoff": "Refresh the handoff snapshot, resume packet, and global Codex handoff pointer",
-      "codex-handoff-resume": "Rebuild the repo's resume packet, optionally printing the resume prompt"
+      "codex-handoff-resume": "Rebuild the repo's resume packet, optionally printing the resume prompt",
+      "recovery-view-cli": "Materialize the handoff/resume recovery views (and optionally the Codex-global packet) from the last-published checkpoint plus live workflow context"
     },
     "dir": "package:assets/templates/helpers",
     "runtimeSource": "package"

--- a/plans/plan-20260722-2246-epc-07-recovery-view-cutover.md
+++ b/plans/plan-20260722-2246-epc-07-recovery-view-cutover.md
@@ -1,0 +1,306 @@
+# Plan: EPC-07: Recovery-View Inventory and Minimal Cutover
+
+> **Status**: Executing
+> **Created**: 20260722-2246
+> **Slug**: epc-07-recovery-view-cutover
+> **Planning Source**: repo-harness-sprint
+> **Orchestration Kind**: host-plan
+> **Source Ref**: sprint:plans/sprints/20260722-0001-evidence-projection-convergence.sprint.md#epc-07
+> **Artifact Level**: work-package
+> **Promotion Reason**: rollback_boundary
+> **Verification Boundary**: Phase A inventory with file:line evidence reconciling frozen D9 verdicts recorded before edits; red-first projection-drift and no-independent-authoring suites; Stop external semantics unchanged; live Stop dogfood materializes handoff/resume from the last checkpoint byte-deterministically; full bun test green
+> **Rollback Surface**: Revert the single PR: restores the retired writers (bash handoff assembly, resume/packet authoring) and removes the recovery materializer + Stop internal swap; tracked tasks/current.md content untouched
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260722-2246-epc-07-recovery-view-cutover.contract.md`
+> **Task Review**: `tasks/reviews/20260722-2246-epc-07-recovery-view-cutover.review.md`
+> **Implementation Notes**: `tasks/notes/20260722-2246-epc-07-recovery-view-cutover.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from repo-harness-sprint planning output.
+- Source ref: sprint:plans/sprints/20260722-0001-evidence-projection-convergence.sprint.md#epc-07
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260722-2246-epc-07-recovery-view-cutover.md`
+- Sprint contract: `tasks/contracts/20260722-2246-epc-07-recovery-view-cutover.contract.md`
+- Sprint review: `tasks/reviews/20260722-2246-epc-07-recovery-view-cutover.review.md`
+- Implementation notes: `tasks/notes/20260722-2246-epc-07-recovery-view-cutover.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260722-2246-epc-07-recovery-view-cutover.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260722-2246-epc-07-recovery-view-cutover.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260722-2246-epc-07-recovery-view-cutover.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260722-2246-epc-07-recovery-view-cutover.contract.md`
+- Review file: `tasks/reviews/20260722-2246-epc-07-recovery-view-cutover.review.md`
+- Implementation notes file: `tasks/notes/20260722-2246-epc-07-recovery-view-cutover.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260722-2246-epc-07-recovery-view-cutover.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260722-2246-epc-07-recovery-view-cutover.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: Revert the single PR: restores the retired writers (bash handoff assembly, resume/packet authoring) and removes the recovery materializer + Stop internal swap; tracked tasks/current.md content untouched
+- **Verification boundary**: Phase A inventory with file:line evidence reconciling frozen D9 verdicts recorded before edits; red-first projection-drift and no-independent-authoring suites; Stop external semantics unchanged; live Stop dogfood materializes handoff/resume from the last checkpoint byte-deterministically; full bun test green
+- **Review/acceptance boundary**: `tasks/reviews/20260722-2246-epc-07-recovery-view-cutover.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: rollback_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260722-2246-epc-07-recovery-view-cutover.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260722-2246-epc-07-recovery-view-cutover.contract.md`, `tasks/reviews/20260722-2246-epc-07-recovery-view-cutover.review.md`, and `tasks/notes/20260722-2246-epc-07-recovery-view-cutover.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260722-2246-epc-07-recovery-view-cutover.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: Revert the single PR: restores the retired writers (bash handoff assembly, resume/packet authoring) and removes the recovery materializer + Stop internal swap; tracked tasks/current.md content untouched
+
+## Captured Planning Output
+
+> **Task Profile**: code-change
+
+## Decision Summary
+
+EPC-07 implements Sprint C backlog row 11: recovery-view inventory and
+minimal cutover. Phase A completes the evidence-cited consumer inventory
+over the four recovery views (handoff `current.md`, `resume.md`, tracked
+`tasks/current.md`, Codex-global task-handoff) — every writer, every
+reader, every trigger — and reconciles it against the frozen D9
+preliminary verdicts (handoff KEEP / resume MERGE / tasks-current KEEP
+with existing single materializer / task-handoff MERGE payload + RETIRE
+writer). A verdict that reality contradicts is revised in this package's
+contract with rationale (D9 explicitly assigns revision here, never ad
+hoc). Phase B executes the cutover: surviving views get exactly one
+materializer each, sourced from the EPC-06 checkpoint (machine projection)
+plus the minimal workflow-artifact context a recovery view legitimately
+needs; retired independent writers are deleted same-package (R5);
+projection-drift and no-independent-authoring tests pass. Base SHA pinned
+per R1 at fresh fetch: `e5fb55e11863fa51a6945f411327be3cb5bd4c50`
+(post-EPC-06 merge + row flip).
+
+## Why
+
+Four independent writers author recovery state today; the audit's finding
+is that a hand-written or divergent recovery projection can silently
+steer a fresh session. With the checkpoint (EPC-06) as the canonical
+evidence snapshot, recovery views can finally be deterministic
+projections with D8 provenance, and the writers that made them shadow
+authorities can be deleted rather than papered over.
+
+## Goal
+
+1. Phase A inventory (recorded in the contract + notes, file:line
+   evidence): for each of the four views — every writer (including the
+   TS Stop handler's `StopProjectionBatch` handoff/resume targets, the
+   bash `workflow_write_handoff`, `codex-handoff-resume.sh`,
+   `refresh-current-status.sh`, `prepare-codex-handoff.sh`, and any
+   undeclared fifth writer found), every reader/consumer (session
+   resume prompts, hooks, docs contracts), and every trigger. Reconcile
+   with the frozen D9 verdicts; record confirmations/revisions with
+   rationale in the contract before Phase B edits begin.
+2. Phase B cutover per the reconciled verdicts:
+   - One recovery materializer (`src/effects/evidence/recovery-materializer.ts`)
+     renders the surviving handoff view and the merged resume view from
+     the last-published checkpoint (via the EPC-06 reader, fail-closed)
+     plus the minimal live workflow context a recovery view needs
+     (active plan/contract identifiers and exact-next-step pointers) —
+     each output carrying a D8 provenance block (nulls per the
+     ratified not-applicable idiom; discriminate on schema, not
+     nullness). Deterministic: same checkpoint + same workflow context
+     ⇒ byte-identical views.
+   - The Stop path keeps its frozen HRD shape (one projection batch,
+     same target counts, one state resolution — the stop-handler suite
+     must stay green unmodified unless an assertion characterizes the
+     deleted assembly internals, in which case minimal updates are
+     documented); internally the handoff/resume content now comes from
+     the recovery materializer.
+   - Retired writers deleted same-package: the bash
+     `workflow_write_handoff` assembly (canonical `assets/hooks` source
+     + `.ai/hooks` projection + digest), `codex-handoff-resume.sh`'s
+     independent resume authoring, and `prepare-codex-handoff.sh`'s
+     independent packet authoring — each either fully deleted or
+     reduced to a thin invoker of the single materializer with zero
+     independent content assembly (choice per view documented; a thin
+     invoker keeps public command names stable where hosts call them,
+     which is not a compatibility shim — the authority moves, the
+     entrypoint stays).
+   - `tasks/current.md`: existing `refresh-current-status.sh` is
+     confirmed as the view's single materializer (tracked projection);
+     add the projection-drift check (regenerate → byte-compare) to the
+     test surface; no rewiring beyond what the inventory proves
+     necessary.
+3. Tests red-first: projection-drift (hand-edited handoff/resume is
+   fully overwritten by the next materialization; regenerated
+   tasks/current matches tracked content); no-independent-authoring
+   (grep/behavioral: no writer of the surviving view files outside
+   their single materializers); determinism; checkpoint-missing
+   fail-degrade (no checkpoint ⇒ views render a typed minimal state,
+   never fabricate evidence claims); Stop-path integration (counts
+   unchanged).
+4. All root required checks green; full `bun test` green; one
+   independent PR on `codex/epc-07-recovery-view-cutover`.
+
+## P1: Architecture Map
+
+- Design authority: frozen D9 (verdict framework + preliminary
+  verdicts), D8 (provenance), R5 (same-package deletion); EPC-06
+  checkpoint reader is the canonical evidence source; EPC-01..05
+  surfaces read-only.
+- The recovery views are allowed to include non-evidence workflow
+  context (active plan/contract, next step) — recovery is about where
+  work stands, not only what was proven; but every evidence CLAIM in a
+  view must trace to the checkpoint (no view may re-derive evidence
+  from `checks/*` or the ledger directly — single hop:
+  checkpoint → view).
+- Mirrors: any curated/projected file touched follows the EPC-05
+  precedent (canonical source + projection + digest; sync:hooks /
+  sync:helpers; byte-identical proof).
+
+## P2: Concrete Trace
+
+EPC-06 merges -> `main` at `e5fb55e1` -> EPC-07 fresh-fetches, pins it
+(R1) -> worktree opens on `codex/epc-07-recovery-view-cutover` -> Phase A
+inventory lands in contract/notes with file:line evidence and reconciled
+verdicts -> Phase B: recovery materializer + Stop internal swap + writer
+deletions/reductions + tasks-current drift check -> red-first suites
+green -> live dogfood: a real Stop in the worktree materializes
+handoff/resume from the last checkpoint, readback shows provenance and
+byte-determinism -> full suite green -> receipt via worktree scripts ->
+one PR merges -> EPC-08 pins its base.
+
+## P3: Design Decision
+
+- Inventory-before-edit is mandatory sequencing, not ceremony: the
+  Stop handler's TS projection batch and the bash writers overlap in
+  unknown ways until cited; cutting blind would risk the HRD-frozen
+  Stop surface.
+- Thin-invoker reduction (where chosen) keeps host-facing command
+  names while moving all content authority into the materializer —
+  the authority cutover is real (independent assembly deleted), and
+  no dual read/write path survives.
+- Views may carry minimal live workflow context: a recovery packet
+  that only restated evidence would not let a fresh session resume;
+  the boundary is that evidence claims come from the checkpoint only.
+- Checkpoint-missing renders a typed minimal state rather than
+  failing the Stop path: recovery views must exist even before the
+  first evidence lands; fabricating nothing, claiming nothing.
+
+## Task Breakdown
+
+- [x] Verify fresh fetch equals pinned base `e5fb55e1`; fill contract.
+- [x] Phase A inventory with file:line evidence; reconcile D9 verdicts
+      in the contract.
+- [x] Recovery materializer (red-first) + Stop internal swap.
+- [x] Writer deletions/reductions with mirrors + digests.
+- [x] tasks/current drift check; projection-drift +
+      no-independent-authoring suites.
+- [ ] Required checks; live Stop dogfood readback; commit; receipt via
+      worktree scripts; PR.
+      (Required checks green, live dogfood passed, and the single commit
+      landed on this branch; acceptance receipt and PR are the next
+      orchestrator/gatekeeper step, not part of this execution dispatch.)
+
+## Scope
+
+- In scope: `src/effects/evidence/recovery-materializer.ts` (new);
+  `src/cli/hook/stop-handler.ts` (internal content-source swap only);
+  the four writers' files as the inventory verdicts require —
+  `.ai/hooks/lib/workflow-state.sh` + `assets/hooks/lib/workflow-state.sh`
+  + `.ai/hooks/.projection.json`, `scripts/codex-handoff-resume.sh`,
+  `scripts/prepare-codex-handoff.sh`, `scripts/refresh-current-status.sh`
+  (drift-check wiring only) and their `assets/templates/helpers/`
+  mirrors; `tests/evidence-recovery-materializer.test.ts`; existing
+  characterization files ONLY where they assert deleted assembly
+  internals (each touched assertion documented); this package's
+  plan/contract/review/notes; `tasks/todos.md` projection;
+  `.ai/harness/worktrees/epc-07-recovery-view-cutover.json`.
+- Out of scope: Context Packet / SessionStart (EPC-08); checks/latest
+  materializer, verify producer, importers (EPC-02..05 surfaces);
+  EPC-01 store/fold; EPC-06 checkpoint modules (consumed read-only);
+  `tasks/current.md` content itself; the sprint document; any new npm
+  dependency.
+- Non-goals: redesigning view content beyond what materialization
+  requires; retiring `post-bash-latest.json`; downstream helper
+  deployment (EPC-09 release scope).
+
+## Stop Conditions
+
+- Stop if `origin/main` moves past `e5fb55e1` before worktree creation.
+- Stop if the inventory finds a consumer whose cutover would require
+  editing a surface outside this scope (e.g. SessionStart reader
+  internals beyond a filename) — report for a scope ruling.
+- Stop if the Stop handler cannot keep its frozen external semantics
+  under the internal swap.
+- Stop after three fail-fix-reverify rounds on one issue.
+
+## Falsifier
+
+The direction is wrong if a surviving recovery view cannot be rendered
+deterministically from checkpoint + minimal workflow context (i.e. a
+view genuinely needs an independent observation channel), or if
+deleting the writers breaks a host entrypoint the inventory failed to
+map. Cheapest proof: live Stop dogfood produces byte-deterministic
+views whose evidence claims all resolve to the checkpoint, with the
+full characterization suite green.
+
+## Cheapest Sufficient Proof
+
+- Fresh fetch equals `e5fb55e1` at pin time; contract records it.
+- Phase A inventory recorded with file:line citations; verdicts
+  reconciled in the contract before Phase B commits.
+- Red-first suites green; full `bun test` green; root checks green.
+- Live dogfood readback: handoff/resume materialized from the last
+  checkpoint with provenance; hand-edits overwritten; drift check
+  green for tasks/current.
+- `git diff --name-only <base>..HEAD` ⊆ `allowed_paths`.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [x] Verify fresh fetch equals pinned base `e5fb55e1`; fill contract.
+- [x] Phase A inventory with file:line evidence; reconcile D9 verdicts
+- [x] Recovery materializer (red-first) + Stop internal swap.
+- [x] Writer deletions/reductions with mirrors + digests.
+- [x] tasks/current drift check; projection-drift +
+- [ ] Required checks; live Stop dogfood readback; commit; receipt via

--- a/scripts/codex-handoff-resume.sh
+++ b/scripts/codex-handoff-resume.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 set -euo pipefail
 
+# Thin invoker (EPC-07 recovery-view cutover): zero independent content
+# assembly. All handoff/resume rendering + checkpoint evidence resolution
+# now lives in the single standalone materializer, scripts/recovery-view-cli.ts
+# (mirrored to assets/templates/helpers/recovery-view-cli.ts), which
+# src/effects/evidence/recovery-materializer.ts's authoritative in-process
+# implementation is kept consistent with by inspection. This script's public
+# name and flags are preserved -- hosts that call
+# `repo-harness run codex-handoff-resume` or invoke this file directly are
+# unaffected.
+
 usage() {
   cat <<'USAGE_EOF'
 Usage: scripts/codex-handoff-resume.sh --cwd <repo> [--print-prompt] [--reason <reason>]
@@ -41,229 +51,17 @@ if [[ -z "$cwd" ]]; then
   cwd="$(pwd)"
 fi
 
-cwd="$(cd "$cwd" && pwd)"
-cd "$cwd"
-
-policy_get() {
-  local jq_path="$1"
-  local default_value="$2"
-
-  if [[ -f ".ai/harness/policy.json" ]] && command -v jq >/dev/null 2>&1; then
-    local value
-    value="$(jq -r "$jq_path // empty" .ai/harness/policy.json 2>/dev/null || true)"
-    if [[ -n "$value" ]]; then
-      printf '%s' "$value"
-      return 0
-    fi
-  fi
-
-  printf '%s' "$default_value"
-}
-
-safe_repo_file() {
-  local value="$1"
-  local default_value="$2"
-  local allowed_prefix="${3:-}"
-
-  if [[ -z "$value" || "$value" == /* || "$value" == *$'\n'* || "$value" == *$'\r'* ]]; then
-    printf '%s' "$default_value"
-    return 0
-  fi
-
-  case "$value" in
-    ..|../*|*/..|*/../*)
-      printf '%s' "$default_value"
-      ;;
-    *)
-      if [[ -n "$allowed_prefix" && "$value" != "$allowed_prefix"* ]]; then
-        printf '%s' "$default_value"
-        return 0
-      fi
-      printf '%s' "$value"
-      ;;
-  esac
-}
-
-active_plan() {
-  for marker_file in ".ai/harness/active-plan"; do
-    if [[ ! -f "$marker_file" ]]; then
-      continue
-    fi
-    local marker
-    marker="$(cat "$marker_file" 2>/dev/null | xargs)"
-    if [[ -n "$marker" && -f "$marker" ]]; then
-      printf '%s' "$marker"
-      return 0
-    fi
-  done
-}
-
-plan_slug_from_path() {
-  local plan_file="$1"
-  local base slug
-  base="$(basename "$plan_file")"
-  slug="$(printf '%s' "$base" | sed -E 's/^plan-[0-9]{8}-[0-9]{4}-//; s/\.md$//')"
-  printf '%s' "$slug"
-}
-
-plan_original_artifact_stem_from_path() {
-  local plan_file="$1"
-  local base stem
-  base="$(basename "$plan_file")"
-  stem="$(printf '%s' "$base" | sed -E 's/^plan-//; s/\.md$//')"
-  if [[ "$stem" =~ ^[0-9]{8}-[0-9]{4}-.+ ]]; then
-    printf '%s' "$stem"
-  else
-    plan_slug_from_path "$plan_file"
-  fi
-}
-
-is_transient_plan_slug() {
-  case "$1" in
-    think-plan-[0-9]*|codex-plan-[0-9]*|approved-plan-[0-9]*)
-      return 0
-      ;;
-  esac
-  return 1
-}
-
-plan_title_slug_from_file() {
-  local plan_file="$1"
-  local title slug
-  [[ -f "$plan_file" ]] || return 1
-  title="$(awk '
-    /^# Plan:[[:space:]]*/ {
-      sub(/^# Plan:[[:space:]]*/, "")
-      print
-      exit
-    }
-  ' "$plan_file" | xargs)"
-  [[ -n "$title" ]] || return 1
-  slug="$(printf '%s' "$title" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-{2,}/-/g')"
-  [[ -n "$slug" ]] || return 1
-  printf '%s' "$slug"
-}
-
-plan_artifact_stem_from_path() {
-  local plan_file="$1"
-  local stem stamp slug title_slug
-  stem="$(plan_original_artifact_stem_from_path "$plan_file")"
-  if [[ "$stem" =~ ^[0-9]{8}-[0-9]{4}-.+ ]]; then
-    stamp="$(printf '%s' "$stem" | sed -E 's/^([0-9]{8}-[0-9]{4})-.+$/\1/')"
-    slug="$(printf '%s' "$stem" | sed -E 's/^[0-9]{8}-[0-9]{4}-//')"
-    if is_transient_plan_slug "$slug"; then
-      title_slug="$(plan_title_slug_from_file "$plan_file" || true)"
-      if [[ -n "$title_slug" && "$title_slug" != "$slug" ]]; then
-        printf '%s-%s' "$stamp" "$title_slug"
-        return 0
-      fi
-    fi
-    printf '%s' "$stem"
-  else
-    plan_slug_from_path "$plan_file"
-  fi
-}
-
-preferred_or_legacy_path() {
-  local preferred="$1"
-  local legacy="$2"
-  if [[ -f "$preferred" ]] || [[ ! -f "$legacy" ]]; then
-    printf '%s' "$preferred"
-  else
-    printf '%s' "$legacy"
-  fi
-}
-
-derive_contract() {
-  local plan_file="$1"
-  local slug stem
-  [[ -n "$plan_file" ]] || return 1
-  slug="$(plan_slug_from_path "$plan_file")"
-  stem="$(plan_artifact_stem_from_path "$plan_file")"
-  [[ -n "$slug" && -n "$stem" ]] || return 1
-  preferred_or_legacy_path "tasks/contracts/${stem}.contract.md" "tasks/contracts/${slug}.contract.md"
-}
-
-derive_notes() {
-  local plan_file="$1"
-  local slug stem notes_dir
-  [[ -n "$plan_file" ]] || return 1
-  slug="$(plan_slug_from_path "$plan_file")"
-  stem="$(plan_artifact_stem_from_path "$plan_file")"
-  [[ -n "$slug" && -n "$stem" ]] || return 1
-  notes_dir="$(safe_repo_file "$(policy_get '.tasks.notes_dir' 'tasks/notes')" 'tasks/notes' 'tasks/')"
-  preferred_or_legacy_path "${notes_dir}/${stem}.notes.md" "${notes_dir}/${slug}.notes.md"
-}
-
-latest_global_handoff() {
-  local codex_home="${CODEX_HOME:-$HOME/.codex}"
-  find "$codex_home/handoffs" -maxdepth 1 -type f -name 'handoff-*.md' 2>/dev/null | sort | tail -1
-}
-
-resume_file="$(safe_repo_file "$(policy_get '.handoff_resume.resume_packet_file' '.ai/harness/handoff/resume.md')" '.ai/harness/handoff/resume.md' '.ai/harness/')"
-repo_handoff="$(safe_repo_file "$(policy_get '.harness.handoff_file' '.ai/harness/handoff/current.md')" '.ai/harness/handoff/current.md' '.ai/harness/')"
-checks_file="$(safe_repo_file "$(policy_get '.harness.checks_file' '.ai/harness/checks/latest.json')" '.ai/harness/checks/latest.json' '.ai/harness/')"
-research_dir="$(safe_repo_file "$(policy_get '.tasks.research_dir' 'docs/researches')" 'docs/researches' 'docs/researches')"
-todo_file="$(safe_repo_file "$(policy_get '.tasks.todo_file' 'tasks/todos.md')" 'tasks/todos.md' 'tasks/')"
-plan_file="$(active_plan || true)"
-contract_file="$(derive_contract "$plan_file" || true)"
-notes_file="$(derive_notes "$plan_file" || true)"
-global_handoff="$(latest_global_handoff || true)"
-
-mkdir -p "$(dirname "$resume_file")"
-
-cat > "$resume_file" <<EOF_RESUME
-# Codex Resume Packet
-<!-- generated-by: repo-harness codex-handoff-resume v1 -->
-
-> **Generated**: $(date '+%Y-%m-%d %H:%M:%S')
-> **Reason**: ${reason}
-> **Working Directory**: ${cwd}
-
-## Resume Prompt
-
-You are starting a fresh Codex session for an existing long-running task. Do not rely on prior chat history or Codex auto-compact. First read the source artifacts listed below, then continue from the exact next step in the repo handoff.
-
-Current prompt files first:
-- If the current user message lists files under \`# Files mentioned by the user\`, references \`pasted-text.txt\`, or includes an explicit attachment/file path, read those current-input files before the repo recovery artifacts below.
-- Use handoff, resume, and \`tasks/current.md\` as recovery context only; they do not outrank the current user message.
-
-Required first reads:
-- AGENTS.md
-- ${repo_handoff}
-- ${todo_file}
-- ${notes_file:-(none)}
-- ${research_dir}/
-- ${checks_file}
-
-Conditional first reads:
-- Active plan: ${plan_file:-(none)}
-- Active contract: ${contract_file:-(none)}
-- Implementation notes: ${notes_file:-(none)}
-- Global handoff: ${global_handoff:-(none)}
-
-Execution rules:
-- Treat filesystem artifacts as the source of truth.
-- Decide in the main agent whether to use subagents, parallel sidecars, sidecar \`codex exec --json\`, or a bounded main-thread trace for broad research/log scans based on context impact and callable tools; do not ask the user for spawn confirmation.
-- Keep deep research conclusions in \`${research_dir}/\`, not only in chat.
-- Do not run \`/compact\` as the primary recovery path.
-- Preserve the current dirty worktree and do not touch unrelated untracked files.
-
-## Source Artifacts
-
-- Repo handoff: ${repo_handoff}
-- Resume packet: ${resume_file}
-- Checks: ${checks_file}
-- Todo: ${todo_file}
-- Research: ${research_dir}/
-- Plan: ${plan_file:-(none)}
-- Contract: ${contract_file:-(none)}
-- Notes: ${notes_file:-(none)}
-- Global handoff: ${global_handoff:-(none)}
-EOF_RESUME
-
-if [[ "$print_prompt" -eq 1 ]]; then
-  awk '/^## Resume Prompt$/ {printing=1; next} /^## Source Artifacts$/ {printing=0} printing == 1 {print}' "$resume_file" | sed -E '/^[[:space:]]*$/N; /^\n$/D'
-else
-  echo "Updated $resume_file"
+helper_source="$0"
+if [[ -n "${REPO_HARNESS_HELPER_SOURCE_PATH:-}" && -f "$REPO_HARNESS_HELPER_SOURCE_PATH" \
+      && "$(basename "$REPO_HARNESS_HELPER_SOURCE_PATH")" == "$(basename "$0")" ]]; then
+  helper_source="$REPO_HARNESS_HELPER_SOURCE_PATH"
 fi
+helper_dir="$(cd "$(dirname "$helper_source")" && pwd)"
+
+bun_bin="${REPO_HARNESS_BUN_BIN:-bun}"
+args=(--cwd "$cwd" --reason "$reason")
+if [[ "$print_prompt" -eq 1 ]]; then
+  args+=(--print-prompt)
+fi
+
+"$bun_bin" "$helper_dir/recovery-view-cli.ts" "${args[@]}"

--- a/scripts/prepare-codex-handoff.sh
+++ b/scripts/prepare-codex-handoff.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -euo pipefail
 
+# Thin invoker (EPC-07 recovery-view cutover): zero independent content
+# assembly. The task-handoff (Codex-global packet) payload is now an
+# additional output target of the same single materializer,
+# scripts/recovery-view-cli.ts (mirrored to
+# assets/templates/helpers/recovery-view-cli.ts) -- the prior independent
+# Node/Python heredoc that spliced the per-repo global-packet section is
+# retired same-package. This script's public name and flags are preserved.
+
 usage() {
   cat <<'USAGE_EOF'
 Usage: scripts/prepare-codex-handoff.sh [--reason <reason>] [--print-prompt]
@@ -41,169 +49,10 @@ if [[ -n "${REPO_HARNESS_HELPER_SOURCE_PATH:-}" && -f "$REPO_HARNESS_HELPER_SOUR
 fi
 helper_dir="$(cd "$(dirname "$helper_source")" && pwd)"
 
-if [[ -f "$helper_dir/prepare-handoff.sh" ]]; then
-  REPO_HARNESS_SKIP_RESUME_REFRESH=1 bash "$helper_dir/prepare-handoff.sh" "$reason"
-fi
-
-resume_args=("$helper_dir/codex-handoff-resume.sh" --cwd "$repo" --reason "$reason")
+bun_bin="${REPO_HARNESS_BUN_BIN:-bun}"
+args=(--cwd "$repo" --reason "$reason" --with-global-packet)
 if [[ "$print_prompt" -eq 1 ]]; then
-  resume_args+=(--print-prompt)
+  args+=(--print-prompt)
 fi
 
-resume_output=""
-if [[ -f "$helper_dir/codex-handoff-resume.sh" ]]; then
-  resume_output="$(bash "${resume_args[@]}")"
-fi
-
-codex_home="${CODEX_HOME:-$HOME/.codex}"
-global_dir="$codex_home/handoffs"
-global_file="$global_dir/handoff-$(date '+%y%m%d').md"
-repo_handoff=".ai/harness/handoff/current.md"
-resume_file=".ai/harness/handoff/resume.md"
-
-mkdir -p "$global_dir"
-
-repo_key="$(printf '%s' "$repo" | shasum | awk '{print substr($1, 1, 12)}')"
-
-if command -v node >/dev/null 2>&1; then
-  node - "$global_file" "$repo" "$repo_key" "$reason" "$repo_handoff" "$resume_file" <<'JS_EOF'
-const fs = require("fs");
-const path = require("path");
-
-const [, , globalFile, repo, repoKey, reason, repoHandoff, resumeFile] = process.argv;
-
-fs.mkdirSync(path.dirname(globalFile), { recursive: true });
-const start = `<!-- repo:${repoKey} start -->`;
-const end = `<!-- repo:${repoKey} end -->`;
-
-function pad(value) {
-  return String(value).padStart(2, "0");
-}
-
-function yymmdd(date) {
-  return `${String(date.getFullYear()).slice(-2)}${pad(date.getMonth() + 1)}${pad(date.getDate())}`;
-}
-
-function timestamp(date) {
-  return [
-    date.getFullYear(),
-    pad(date.getMonth() + 1),
-    pad(date.getDate()),
-  ].join("-") + ` ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
-}
-
-function readText(filePath, limit = 12000) {
-  try {
-    const text = fs.readFileSync(filePath, "utf8");
-    return text.length <= limit ? text : `${text.slice(0, limit - 1)}...`;
-  } catch {
-    return "(missing)";
-  }
-}
-
-const now = new Date();
-const header = `# Codex Handoff ${yymmdd(now)}\n\nFilesystem-first fallback handoffs for compact-independent Codex sessions.\n\n`;
-const section = [
-  start,
-  `## ${timestamp(now)} ${path.basename(repo)}`,
-  "",
-  `- cwd: \`${repo}\``,
-  `- reason: \`${reason}\``,
-  `- repo_handoff: \`${repoHandoff}\``,
-  `- resume_packet: \`${resumeFile}\``,
-  "",
-  "### Repo Handoff",
-  "",
-  readText(path.join(repo, repoHandoff), 8000).trim(),
-  "",
-  "### Resume Packet",
-  "",
-  readText(path.join(repo, resumeFile), 8000).trim(),
-  "",
-  end,
-  "",
-].join("\n");
-
-let content = fs.existsSync(globalFile) ? fs.readFileSync(globalFile, "utf8") : header;
-if (content.includes(start) && content.includes(end)) {
-  const [prefix, rest] = content.split(start, 2);
-  const suffix = rest.split(end, 2)[1] ?? "";
-  content = prefix + section + suffix.replace(/^\n+/, "");
-} else {
-  if (!content.endsWith("\n")) {
-    content += "\n";
-  }
-  content += section;
-}
-
-fs.writeFileSync(globalFile, content, "utf8");
-console.log(globalFile);
-JS_EOF
-else
-  python3 - "$global_file" "$repo" "$repo_key" "$reason" "$repo_handoff" "$resume_file" <<'PY_EOF'
-from __future__ import annotations
-
-import sys
-from datetime import datetime
-from pathlib import Path
-
-global_file = Path(sys.argv[1])
-repo = Path(sys.argv[2])
-repo_key = sys.argv[3]
-reason = sys.argv[4]
-repo_handoff = Path(sys.argv[5])
-resume_file = Path(sys.argv[6])
-
-global_file.parent.mkdir(parents=True, exist_ok=True)
-start = f"<!-- repo:{repo_key} start -->"
-end = f"<!-- repo:{repo_key} end -->"
-
-def read_text(path: Path, limit: int = 12000) -> str:
-    try:
-        text = path.read_text(encoding="utf-8")
-    except OSError:
-        return "(missing)"
-    return text if len(text) <= limit else text[: limit - 1] + "..."
-
-header = f"# Codex Handoff {datetime.now().strftime('%y%m%d')}\n\nFilesystem-first fallback handoffs for compact-independent Codex sessions.\n\n"
-section = "\n".join(
-    [
-        start,
-        f"## {datetime.now().strftime('%Y-%m-%d %H:%M:%S')} {repo.name}",
-        "",
-        f"- cwd: `{repo}`",
-        f"- reason: `{reason}`",
-        f"- repo_handoff: `{repo_handoff}`",
-        f"- resume_packet: `{resume_file}`",
-        "",
-        "### Repo Handoff",
-        "",
-        read_text(repo / repo_handoff, 8000).strip(),
-        "",
-        "### Resume Packet",
-        "",
-        read_text(repo / resume_file, 8000).strip(),
-        "",
-        end,
-        "",
-    ]
-)
-
-content = global_file.read_text(encoding="utf-8") if global_file.exists() else header
-if start in content and end in content:
-    prefix, rest = content.split(start, 1)
-    _, suffix = rest.split(end, 1)
-    content = prefix + section + suffix.lstrip("\n")
-else:
-    if not content.endswith("\n"):
-        content += "\n"
-    content += section
-
-global_file.write_text(content, encoding="utf-8")
-print(global_file)
-PY_EOF
-fi
-
-if [[ -n "$resume_output" ]]; then
-  printf '%s\n' "$resume_output"
-fi
+"$bun_bin" "$helper_dir/recovery-view-cli.ts" "${args[@]}"

--- a/scripts/recovery-view-cli.ts
+++ b/scripts/recovery-view-cli.ts
@@ -1,0 +1,833 @@
+#!/usr/bin/env bun
+// Standalone helper: materializes the handoff/resume recovery views (and
+// optionally the Codex-global packet) from the last-published checkpoint
+// plus live workflow context. Self-contained by necessity -- this file is
+// distributed to adopting downstream repos (mirrored byte-identically to
+// assets/templates/helpers/recovery-view-cli.ts) which never receive this
+// package's own src/ tree, so it imports Node/Bun builtins only and
+// duplicates (by inspection, kept consistent with) the rendering logic in
+// src/effects/evidence/recovery-materializer.ts, the authoritative
+// in-process implementation src/cli/hook/stop-handler.ts imports directly
+// at real Stop time. See
+// tasks/contracts/20260722-2246-epc-07-recovery-view-cutover.contract.md
+// for the full design record.
+//
+// This tool's checkpoint read is intentionally lighter-weight than the
+// authoritative reader (src/effects/evidence/checkpoint-store.ts): it does
+// not re-verify content_hash/full schema completeness, since it is a
+// manual/CI regeneration convenience, not the Stop-time authority. It still
+// never fabricates an evidence claim -- any read/parse failure degrades to
+// the same typed "unavailable" state a renderer shows honestly.
+import { createHash } from "crypto";
+import { execFileSync } from "child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { basename, dirname, join } from "path";
+
+const RECOVERY_SCHEMA_VERSION = 1;
+const RECOVERY_MATERIALIZER_VERSION = "1";
+const LEGACY_RESUME_MARKER = "<!-- generated-by: repo-harness codex-handoff-resume v1 -->";
+
+function pad2(value: number): string {
+  return String(value).padStart(2, "0");
+}
+
+function formatDisplay(date: Date): string {
+  return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())} ${pad2(date.getHours())}:${pad2(date.getMinutes())}:${pad2(date.getSeconds())}`;
+}
+
+function formatCompact(date: Date): string {
+  return `${date.getFullYear()}${pad2(date.getMonth() + 1)}${pad2(date.getDate())}T${pad2(date.getHours())}${pad2(date.getMinutes())}${pad2(date.getSeconds())}`;
+}
+
+function yymmdd(date: Date): string {
+  return `${String(date.getFullYear()).slice(-2)}${pad2(date.getMonth() + 1)}${pad2(date.getDate())}`;
+}
+
+function sha256Hex(text: string): string {
+  return createHash("sha256").update(text, "utf-8").digest("hex");
+}
+
+function readTextOrNull(path: string): string | null {
+  try {
+    return readFileSync(path, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+function policy(repoRoot: string): Record<string, unknown> {
+  try {
+    const value = JSON.parse(readFileSync(join(repoRoot, ".ai/harness/policy.json"), "utf8"));
+    return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function nestedString(root: Record<string, unknown>, keys: readonly string[]): string {
+  let value: unknown = root;
+  for (const key of keys) {
+    if (!value || typeof value !== "object") return "";
+    value = (value as Record<string, unknown>)[key];
+  }
+  return typeof value === "string" ? value : "";
+}
+
+/** Rejects absolute paths, `..` escapes, and anything outside `.ai/harness/`
+ * -- port of `codex-handoff-resume.sh`'s existing `safe_repo_file` guard
+ * (frozen behavior: `tests/helper-scripts.test.ts`'s "reject policy paths
+ * outside the repo/harness surface" characterize this exact fallback). */
+function safeHarnessPath(value: string, fallback: string): string {
+  if (!value || value.startsWith("/") || value.includes("\\") || value.includes("\n") || value.includes("\r")) return fallback;
+  if (value === ".." || value.startsWith("../") || value.includes("/../")) return fallback;
+  if (!value.startsWith(".ai/harness/")) return fallback;
+  return value;
+}
+
+function readJson(path: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8"));
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+function metadataValue(path: string, label: string): string {
+  try {
+    const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const match = readFileSync(path, "utf8").match(new RegExp(`^> \\*\\*${escaped}\\*\\*:\\s*(.+)$`, "m"));
+    return match?.[1]?.replace(/`/g, "").trim() ?? "";
+  } catch {
+    return "";
+  }
+}
+
+function declaredPath(repoRoot: string, plan: string, label: string): string {
+  if (!plan || !existsSync(join(repoRoot, plan))) return "";
+  const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = readFileSync(join(repoRoot, plan), "utf8").match(new RegExp(`^> \\*\\*${escaped}\\*\\*:\\s*(.+)$`, "m"));
+  return match?.[1]?.replace(/`/g, "").trim() ?? "";
+}
+
+function worktreeIdFor(contractRelative: string): string {
+  const base = contractRelative.split("/").pop() ?? contractRelative;
+  return base.replace(/\.contract\.md$/, "");
+}
+
+interface ArtifactPaths {
+  readonly plan: string;
+  readonly contract: string;
+  readonly review: string;
+  readonly notes: string;
+}
+
+function planSlugFromPath(planFile: string): string {
+  const base = basename(planFile);
+  const slug = base.replace(/^plan-\d{8}-\d{4}-/, "").replace(/\.md$/, "");
+  return slug.length > 0 && slug !== base ? slug : "";
+}
+
+function planStemFromPath(planFile: string): string {
+  const base = basename(planFile);
+  const stem = base.replace(/^plan-/, "").replace(/\.md$/, "");
+  return /^\d{8}-\d{4}-.+/.test(stem) ? stem : planSlugFromPath(planFile);
+}
+
+/** `workflow_preferred_or_legacy_path` port: preferred (stamped-stem)
+ * candidate wins if it exists; else the legacy (slug-only) candidate wins
+ * if IT exists; else fall back to the preferred candidate as a best-guess
+ * pointer (matches bash's `workflow_active_contract`/`_review`/`_notes` --
+ * a recovery view may legitimately point at where an artifact SHOULD live
+ * before it has been created). */
+function preferredOrLegacyArtifactPath(repoRoot: string, preferred: string, legacy: string): string {
+  if (existsSync(join(repoRoot, preferred))) return preferred;
+  if (!existsSync(join(repoRoot, legacy))) return preferred;
+  return legacy;
+}
+
+function activeArtifacts(repoRoot: string, activePlan: string | null): ArtifactPaths {
+  const plan = activePlan && existsSync(join(repoRoot, activePlan)) ? activePlan : "";
+  if (!plan) return { plan: "", contract: "", review: "", notes: "" };
+  const stem = planStemFromPath(plan);
+  const slug = planSlugFromPath(plan);
+  const derived = (directory: string, suffix: string): string => {
+    if (!stem || !slug) return "";
+    return preferredOrLegacyArtifactPath(repoRoot, `${directory}/${stem}${suffix}`, `${directory}/${slug}${suffix}`);
+  };
+  return {
+    plan,
+    contract: declaredPath(repoRoot, plan, "Task Contract") || declaredPath(repoRoot, plan, "Sprint Contract") || derived("tasks/contracts", ".contract.md"),
+    review: declaredPath(repoRoot, plan, "Task Review") || declaredPath(repoRoot, plan, "Sprint Review") || derived("tasks/reviews", ".review.md"),
+    notes: declaredPath(repoRoot, plan, "Implementation Notes") || declaredPath(repoRoot, plan, "Notes File") || derived("tasks/notes", ".notes.md"),
+  };
+}
+
+function todoSourcePlan(repoRoot: string): string {
+  const value = metadataValue(join(repoRoot, "tasks/todos.md"), "Source Plan");
+  return value === "(none)" ? "" : value;
+}
+
+function activeSprintRow(repoRoot: string, activePlan: string): string {
+  let sprint = "";
+  try {
+    sprint = readFileSync(join(repoRoot, ".ai/harness/sprint/active-sprint"), "utf8").trim();
+  } catch {
+    return "(none)";
+  }
+  if (!sprint || sprint.startsWith("/") || sprint === ".." || sprint.startsWith("../") || sprint.includes("/../")) return "(none)";
+  try {
+    const row = readFileSync(join(repoRoot, sprint), "utf8")
+      .split("\n")
+      .find((line) => /^\|\s*\d+\s*\|/.test(line) && activePlan && line.includes(activePlan));
+    return row || `Active sprint: ${sprint}`;
+  } catch {
+    return "(none)";
+  }
+}
+
+function firstTaskBreakdown(planText: string): { total: number; done: number; next: string } {
+  const lines = planText.split("\n");
+  let inSection = false;
+  let total = 0;
+  let done = 0;
+  let next = "";
+  for (const line of lines) {
+    if (!inSection && /^## Task Breakdown\s*$/.test(line)) {
+      inSection = true;
+      continue;
+    }
+    if (inSection && /^## /.test(line)) break;
+    const match = inSection ? line.match(/^\s*-\s*\[([ xX])\]\s+(.+)$/) : null;
+    if (!match) continue;
+    total += 1;
+    if (match[1]!.toLowerCase() === "x") done += 1;
+    else if (!next) next = match[2]!.replace(/\r/g, "");
+  }
+  return { total, done, next };
+}
+
+interface NextAction {
+  readonly stage: string;
+  readonly command: string;
+  readonly message: string;
+}
+
+function nextAction(repoRoot: string, artifacts: ArtifactPaths): NextAction {
+  if (!artifacts.plan) return { stage: "none", command: "", message: "(none)" };
+  let taskState = { total: 0, done: 0, next: "" };
+  try {
+    taskState = firstTaskBreakdown(readFileSync(join(repoRoot, artifacts.plan), "utf8"));
+  } catch {
+    // Missing/unreadable plan is treated as no active execution checklist.
+  }
+  if (taskState.total > taskState.done) {
+    const pending = taskState.next || "continue active plan Task Breakdown";
+    return {
+      stage: "task",
+      command: "",
+      message: `If a major module was just completed, stage its coherent diff first; then continue the next Task Breakdown item: ${pending}`,
+    };
+  }
+  return {
+    stage: "check",
+    command: "/check",
+    message: "Stage the completed module diff first; then run /check and let canonical workflow gates determine whether review, external acceptance, verification, or worktree finish is next.",
+  };
+}
+
+function recentCommands(repoRoot: string): string {
+  try {
+    const lines = readFileSync(join(repoRoot, ".claude/.trace.jsonl"), "utf8").trimEnd().split("\n").slice(-5);
+    return lines.length > 0 && lines.some(Boolean) ? lines.map((line) => `- ${line}`).join("\n") : "- (none captured)";
+  } catch {
+    return "- (none captured)";
+  }
+}
+
+function supersededPlan(repoRoot: string): string {
+  const state = readJson(join(repoRoot, ".claude/.task-state.json"));
+  return typeof state?.source_plan === "string" && state.source_plan ? state.source_plan : "(none)";
+}
+
+function changedFiles(repoRoot: string): { files: string; summary: string } {
+  try {
+    const tracked = execFileSync("git", ["-C", repoRoot, "diff", "--name-only", "HEAD"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const untrackedRaw = execFileSync("git", ["-C", repoRoot, "ls-files", "--others", "--exclude-standard"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const files = [...new Set(`${tracked}\n${untrackedRaw}`.split("\n").map((line) => line.trim()).filter(Boolean))].sort();
+    const visible = files.length > 80 ? [...files.slice(0, 80), `... (${files.length} total changed/untracked paths; inspect git status --short)`] : files;
+
+    // workflow_write_handoff's `diff_stat`/`untracked_count` port: a
+    // human-readable tracked-diff shortstat plus an explicit untracked
+    // count, not a flat "N changed/untracked paths" total.
+    let diffStat = "";
+    try {
+      diffStat = execFileSync("git", ["-C", repoRoot, "diff", "--shortstat", "HEAD"], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }).replace(/\n/g, "");
+    } catch {
+      diffStat = "";
+    }
+    const untrackedCount = untrackedRaw.split("\n").map((line) => line.trim()).filter(Boolean).length;
+    const summary = untrackedCount > 0
+      ? `${diffStat || "no tracked diff"}; ${untrackedCount} untracked files`
+      : (diffStat || "no uncommitted diff against HEAD");
+
+    return {
+      files: visible.length > 0 ? visible.join("\n") : "(none)",
+      summary,
+    };
+  } catch {
+    return { files: "(none)", summary: "git repository not detected" };
+  }
+}
+
+function latestGlobalHandoff(codexHome: string): string {
+  try {
+    const dir = join(codexHome, "handoffs");
+    if (!existsSync(dir)) return "";
+    const entries = execFileSync("find", [dir, "-maxdepth", "1", "-type", "f", "-name", "handoff-*.md"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .sort();
+    return entries.length > 0 ? entries[entries.length - 1]! : "";
+  } catch {
+    return "";
+  }
+}
+
+function resolveActivePlanMarker(repoRoot: string): string | null {
+  try {
+    const marker = readFileSync(join(repoRoot, ".ai/harness/active-plan"), "utf8").trim();
+    if (marker && existsSync(join(repoRoot, marker))) return marker;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+interface WorkflowContext {
+  readonly reason: string;
+  readonly runId: string;
+  readonly generatedAtDisplay: string;
+  readonly generatedAtIso: string;
+  readonly workingDirectory: string;
+  readonly artifacts: ArtifactPaths;
+  readonly sourcePlan: string;
+  readonly activeSprintRowText: string;
+  readonly action: NextAction;
+  readonly nextTask: string;
+  readonly goal: string;
+  readonly changed: { readonly files: string; readonly summary: string };
+  readonly recentCommandsText: string;
+  readonly supersedes: string;
+  readonly paths: {
+    readonly checks: string;
+    readonly handoff: string;
+    readonly resume: string;
+    readonly policyFile: string;
+    readonly contextMap: string;
+    readonly researchDir: string;
+    readonly todoFile: string;
+  };
+  readonly globalHandoffPath: string;
+}
+
+function buildContext(repoRoot: string, reason: string, codexHome: string): WorkflowContext {
+  const now = new Date();
+  const config = policy(repoRoot);
+  const checks = safeHarnessPath(nestedString(config, ["harness", "checks_file"]), ".ai/harness/checks/latest.json");
+  const handoff = safeHarnessPath(nestedString(config, ["harness", "handoff_file"]), ".ai/harness/handoff/current.md");
+  const resume = safeHarnessPath(nestedString(config, ["handoff_resume", "resume_packet_file"]), ".ai/harness/handoff/resume.md");
+  const policyFile = ".ai/harness/policy.json";
+  const contextMap = safeHarnessPath(nestedString(config, ["context", "map_file"]), ".ai/context/context-map.json");
+  const researchDir = nestedString(config, ["tasks", "research_dir"]) || "docs/researches";
+  const todoFile = safeHarnessPath(nestedString(config, ["tasks", "todo_file"]), "tasks/todos.md");
+  const runId = process.env.HOOK_RUN_ID ?? process.env.CLAUDE_RUN_ID ?? process.env.CODEX_RUN_ID ?? `run-${formatCompact(now)}-${process.pid}`;
+  const activePlan = resolveActivePlanMarker(repoRoot);
+  const artifacts = activeArtifacts(repoRoot, activePlan);
+  const changed = changedFiles(repoRoot);
+  const sourcePlan = todoSourcePlan(repoRoot);
+  const action = nextAction(repoRoot, artifacts);
+  const nextTask = action.command ? `${action.message} Command: ${action.command}` : action.message;
+  const goal = sourcePlan
+    ? `Continue task checklist sourced from ${sourcePlan}.`
+    : artifacts.plan
+      ? `Continue active plan ${artifacts.plan}.`
+      : nextTask !== "(none)"
+        ? nextTask
+        : "No active plan. Continue from the latest user request and filesystem state.";
+
+  return {
+    reason,
+    runId,
+    generatedAtDisplay: formatDisplay(now),
+    generatedAtIso: now.toISOString(),
+    workingDirectory: repoRoot,
+    artifacts,
+    sourcePlan,
+    activeSprintRowText: activeSprintRow(repoRoot, artifacts.plan),
+    action,
+    nextTask,
+    goal,
+    changed,
+    recentCommandsText: recentCommands(repoRoot),
+    supersedes: supersededPlan(repoRoot),
+    paths: { checks, handoff, resume, policyFile, contextMap, researchDir, todoFile },
+    globalHandoffPath: latestGlobalHandoff(codexHome),
+  };
+}
+
+interface EvidenceLatestByType {
+  readonly event_type: string;
+  readonly event_id: string;
+  readonly trust_class: string;
+  readonly created_at: string;
+}
+
+type Evidence =
+  | {
+      readonly available: true;
+      readonly checkpointId: string;
+      readonly worktreeId: string;
+      readonly generatedAt: string;
+      readonly coveredEventCount: number;
+      readonly sourceEventIds: readonly string[];
+      readonly latestByEventType: readonly EvidenceLatestByType[];
+    }
+  | {
+      readonly available: false;
+      readonly reason: "no-checkpoint" | "checkpoint-invalid";
+      readonly detail?: string;
+    };
+
+/** Best-effort, gracefully-degrading checkpoint read -- see module doc. */
+function resolveEvidence(repoRoot: string): Evidence {
+  const markerPath = join(repoRoot, ".ai/harness/evidence/checkpoints/last-published.json");
+  const markerText = readTextOrNull(markerPath);
+  if (markerText === null) return { available: false, reason: "no-checkpoint" };
+  try {
+    const marker = JSON.parse(markerText) as Record<string, unknown>;
+    if (typeof marker.checkpoint_id !== "string" || typeof marker.machine_path !== "string") {
+      return { available: false, reason: "checkpoint-invalid", detail: "marker missing required field" };
+    }
+    const machineText = readTextOrNull(join(repoRoot, marker.machine_path));
+    if (machineText === null) {
+      return { available: false, reason: "checkpoint-invalid", detail: `checkpoint file missing: ${marker.machine_path}` };
+    }
+    const projection = JSON.parse(machineText) as Record<string, unknown>;
+    if (projection.checkpoint_id !== marker.checkpoint_id) {
+      return { available: false, reason: "checkpoint-invalid", detail: "checkpoint_id mismatch" };
+    }
+    const provenance = (projection.provenance ?? {}) as Record<string, unknown>;
+    const sourceEventIds = Array.isArray(provenance.source_event_ids) ? (provenance.source_event_ids as string[]) : [];
+    const latestByEventType = Array.isArray(projection.latest_by_event_type) ? (projection.latest_by_event_type as EvidenceLatestByType[]) : [];
+    return {
+      available: true,
+      checkpointId: String(projection.checkpoint_id),
+      worktreeId: typeof projection.worktree_id === "string" ? projection.worktree_id : "unbound",
+      generatedAt: typeof provenance.generated_at === "string" ? provenance.generated_at : "",
+      coveredEventCount: typeof projection.covered_event_count === "number" ? projection.covered_event_count : 0,
+      sourceEventIds,
+      latestByEventType,
+    };
+  } catch (error) {
+    return { available: false, reason: "checkpoint-invalid", detail: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+function evidenceLines(evidence: Evidence): string[] {
+  const lines: string[] = [];
+  if (evidence.available) {
+    lines.push(`- Checkpoint: ${evidence.checkpointId} (generated ${evidence.generatedAt})`);
+    lines.push(`- Covered events: ${evidence.coveredEventCount}`);
+    lines.push("- Latest by type:");
+    if (evidence.latestByEventType.length === 0) {
+      lines.push("  (none)");
+    } else {
+      for (const entry of evidence.latestByEventType) {
+        lines.push(`  - ${entry.event_type}: ${entry.event_id} (${entry.trust_class}, accepted ${entry.created_at})`);
+      }
+    }
+  } else if (evidence.reason === "no-checkpoint") {
+    lines.push("- Checkpoint: (none published yet -- no ledger evidence recorded in this worktree)");
+    lines.push("- Covered events: 0");
+    lines.push("- Latest by type:");
+    lines.push("  (none)");
+  } else {
+    lines.push(`- Checkpoint: (unavailable -- last-published checkpoint failed validation: ${evidence.detail ?? evidence.reason})`);
+    lines.push("- Covered events: 0");
+    lines.push("- Latest by type:");
+    lines.push("  (none)");
+  }
+  return lines;
+}
+
+interface Provenance {
+  readonly schema_version: number;
+  readonly generated_at: string;
+  readonly materializer_version: string;
+  readonly source_event_ids: readonly string[];
+  readonly source_checkpoint_id: string | null;
+  readonly worktree_id: string;
+  readonly contract_id: string | null;
+  readonly content_hash: string;
+}
+
+function resolveWorktreeId(evidence: Evidence, contractPath: string): string {
+  if (evidence.available) return evidence.worktreeId;
+  if (contractPath) return worktreeIdFor(contractPath);
+  return "unbound";
+}
+
+function buildProvenance(context: WorkflowContext, evidence: Evidence, contractPath: string, body: string): Provenance {
+  return {
+    schema_version: RECOVERY_SCHEMA_VERSION,
+    generated_at: context.generatedAtIso,
+    materializer_version: RECOVERY_MATERIALIZER_VERSION,
+    source_event_ids: evidence.available ? evidence.sourceEventIds : [],
+    source_checkpoint_id: evidence.available ? evidence.checkpointId : null,
+    worktree_id: resolveWorktreeId(evidence, contractPath),
+    contract_id: contractPath || null,
+    content_hash: `sha256:${sha256Hex(body)}`,
+  };
+}
+
+function renderProvenanceSection(provenance: Provenance): string[] {
+  return [
+    "## Provenance",
+    "",
+    `- Schema version: ${provenance.schema_version}`,
+    `- Generated at: ${provenance.generated_at}`,
+    `- Materializer version: ${provenance.materializer_version}`,
+    `- Source checkpoint id: ${provenance.source_checkpoint_id ?? "(none -- no checkpoint published yet)"}`,
+    `- Source event ids: ${provenance.source_event_ids.length > 0 ? `${provenance.source_event_ids.length} covered` : "(none)"}`,
+    "- Subject hash: (none -- recovery view is not subject-bound)",
+    `- Worktree: ${provenance.worktree_id}`,
+    `- Contract: ${provenance.contract_id ?? "(none)"}`,
+    `- Content hash: ${provenance.content_hash}`,
+  ];
+}
+
+function renderHandoff(context: WorkflowContext, evidence: Evidence, contractPath: string): string {
+  const bodyLines = [
+    "# Harness Handoff",
+    "",
+    `> **Generated**: ${context.generatedAtDisplay}`,
+    `> **Reason**: ${context.reason}`,
+    "",
+    "## Goal",
+    "",
+    context.goal,
+    "",
+    "## Decisions",
+    "",
+    "- Use filesystem artifacts as source of truth; treat SQLite/thread state as a rebuildable read model only.",
+    "",
+    "## Files Touched",
+    "",
+    "```",
+    context.changed.files,
+    "```",
+    "",
+    "## Commands Run",
+    "",
+    context.recentCommandsText,
+    "",
+    "## Evidence",
+    "",
+    ...evidenceLines(evidence),
+    "",
+    "## Blockers",
+    "",
+    "- (none recorded)",
+    "",
+    "## Active Artifacts",
+    "",
+    `- Active plan: ${context.artifacts.plan || "(none)"}`,
+    `- Active contract: ${context.artifacts.contract || "(none)"}`,
+    `- Active sprint row: ${context.activeSprintRowText}`,
+    `- Review file: ${context.artifacts.review || "(none)"}`,
+    `- Resume packet: ${context.paths.resume}`,
+    "",
+    "## Exact Next Step",
+    "",
+    `- ${context.nextTask}`,
+    "",
+    "## Resume Prompt",
+    "",
+    `- Resume packet: ${context.paths.resume}`,
+    "- Start a fresh Codex session and read source artifacts first, then this handoff, before continuing; do not rely on auto-compact.",
+    "",
+    "## Source Artifacts",
+    "",
+    "- Spec: docs/spec.md",
+    `- Plan: ${context.artifacts.plan || "(none)"}`,
+    `- Todo Source Plan: ${context.sourcePlan || "(none)"}`,
+    `- Contract: ${context.artifacts.contract || "(none)"}`,
+    `- Review: ${context.artifacts.review || "(none)"}`,
+    `- Notes: ${context.artifacts.notes || "(none)"}`,
+    `- Checks: ${context.paths.checks}`,
+    `- Resume Packet: ${context.paths.resume}`,
+    `- Policy: ${context.paths.policyFile}`,
+    `- Context Map: ${context.paths.contextMap}`,
+    "",
+    "## Current Status",
+    "",
+    `- Next action stage: ${context.action.stage}`,
+    `- Next recommended action: ${context.nextTask}`,
+    `- Working tree: ${context.changed.summary}`,
+    `- Parent Run ID: ${context.runId}`,
+    `- Supersedes: ${context.supersedes}`,
+    "",
+    "## Changed Files",
+    "",
+    "```",
+    context.changed.files,
+    "```",
+    "",
+  ];
+  const body = bodyLines.join("\n");
+  const provenance = buildProvenance(context, evidence, contractPath, body);
+  return `${body}\n${renderProvenanceSection(provenance).join("\n")}\n`;
+}
+
+function renderResume(context: WorkflowContext, evidence: Evidence, contractPath: string): string {
+  const bodyLines = [
+    "# Codex Resume Packet",
+    LEGACY_RESUME_MARKER,
+    "",
+    `> **Generated**: ${context.generatedAtDisplay}`,
+    `> **Reason**: ${context.reason}`,
+    `> **Working Directory**: ${context.workingDirectory}`,
+    "",
+    "## Resume Prompt",
+    "",
+    "You are starting a fresh Codex session for an existing long-running task. Do not rely on prior chat history or Codex auto-compact. First read the source artifacts listed below, then continue from the exact next step in the repo handoff.",
+    "",
+    "Current prompt files first:",
+    "- If the current user message lists files under `# Files mentioned by the user`, references `pasted-text.txt`, or includes an explicit attachment/file path, read those current-input files before the repo recovery artifacts below.",
+    "- Use handoff, resume, and `tasks/current.md` as recovery context only; they do not outrank the current user message.",
+    "",
+    "Required first reads:",
+    "- AGENTS.md",
+    `- ${context.paths.handoff}`,
+    `- ${context.paths.todoFile}`,
+    `- ${context.artifacts.notes || "(none)"}`,
+    `- ${context.paths.researchDir}/`,
+    `- ${context.paths.checks}`,
+    "",
+    "Conditional first reads:",
+    `- Active plan: ${context.artifacts.plan || "(none)"}`,
+    `- Active contract: ${context.artifacts.contract || "(none)"}`,
+    `- Implementation notes: ${context.artifacts.notes || "(none)"}`,
+    `- Global handoff: ${context.globalHandoffPath || "(none)"}`,
+    "",
+    "Execution rules:",
+    "- Treat filesystem artifacts as the source of truth.",
+    "- Decide in the main agent whether to use subagents, parallel sidecars, sidecar `codex exec --json`, or a bounded main-thread trace for broad research/log scans based on context impact and callable tools; do not ask the user for spawn confirmation.",
+    `- Keep deep research conclusions in \`${context.paths.researchDir}/\`, not only in chat.`,
+    "- Do not run `/compact` as the primary recovery path.",
+    "- Preserve the current dirty worktree and do not touch unrelated untracked files.",
+    "",
+    "## Source Artifacts",
+    "",
+    `- Repo handoff: ${context.paths.handoff}`,
+    `- Resume packet: ${context.paths.resume}`,
+    `- Checks: ${context.paths.checks}`,
+    `- Todo: ${context.paths.todoFile}`,
+    `- Research: ${context.paths.researchDir}/`,
+    `- Plan: ${context.artifacts.plan || "(none)"}`,
+    `- Contract: ${context.artifacts.contract || "(none)"}`,
+    `- Notes: ${context.artifacts.notes || "(none)"}`,
+    `- Global handoff: ${context.globalHandoffPath || "(none)"}`,
+    "",
+  ];
+  const body = bodyLines.join("\n");
+  const provenance = buildProvenance(context, evidence, contractPath, body);
+  return `${body}\n${renderProvenanceSection(provenance).join("\n")}\n`;
+}
+
+function extractResumePrompt(resumeText: string): string {
+  const lines = resumeText.split("\n");
+  const out: string[] = [];
+  let printing = false;
+  for (const line of lines) {
+    if (line === "## Resume Prompt") {
+      printing = true;
+      continue;
+    }
+    if (line === "## Source Artifacts") break;
+    if (printing) out.push(line);
+  }
+  while (out.length > 0 && out[0] === "") out.shift();
+  while (out.length > 0 && out[out.length - 1] === "") out.pop();
+  return `${out.join("\n")}\n`;
+}
+
+function repoKeyFor(repoPath: string): string {
+  return createHash("sha1").update(repoPath, "utf-8").digest("hex").slice(0, 12);
+}
+
+function capText(text: string, limit = 8000): string {
+  return text.length <= limit ? text : `${text.slice(0, limit - 1)}...`;
+}
+
+function renderGlobalSection(params: {
+  readonly repoPath: string;
+  readonly repoKey: string;
+  readonly reason: string;
+  readonly repoHandoffRelative: string;
+  readonly resumeFileRelative: string;
+  readonly handoffText: string;
+  readonly resumeText: string;
+  readonly now: Date;
+}): string {
+  const start = `<!-- repo:${params.repoKey} start -->`;
+  const end = `<!-- repo:${params.repoKey} end -->`;
+  const lines = [
+    start,
+    `## ${formatDisplay(params.now)} ${basename(params.repoPath)}`,
+    "",
+    `- cwd: \`${params.repoPath}\``,
+    `- reason: \`${params.reason}\``,
+    `- repo_handoff: \`${params.repoHandoffRelative}\``,
+    `- resume_packet: \`${params.resumeFileRelative}\``,
+    "",
+    "### Repo Handoff",
+    "",
+    capText(params.handoffText).trim(),
+    "",
+    "### Resume Packet",
+    "",
+    capText(params.resumeText).trim(),
+    "",
+    end,
+    "",
+  ];
+  return lines.join("\n");
+}
+
+function updateGlobalHandoffFile(codexHome: string, repoKey: string, section: string, now: Date): string {
+  const globalDir = join(codexHome, "handoffs");
+  mkdirSync(globalDir, { recursive: true });
+  const globalFile = join(globalDir, `handoff-${yymmdd(now)}.md`);
+  const start = `<!-- repo:${repoKey} start -->`;
+  const end = `<!-- repo:${repoKey} end -->`;
+  const header = `# Codex Handoff ${yymmdd(now)}\n\nFilesystem-first fallback handoffs for compact-independent Codex sessions.\n\n`;
+
+  let content = existsSync(globalFile) ? readFileSync(globalFile, "utf-8") : header;
+  const startIdx = content.indexOf(start);
+  if (startIdx >= 0 && content.includes(end)) {
+    const afterStart = content.slice(startIdx + start.length);
+    const endIdx = afterStart.indexOf(end);
+    const prefix = content.slice(0, startIdx);
+    const suffix = afterStart.slice(endIdx + end.length).replace(/^\n+/, "");
+    content = prefix + section + suffix;
+  } else {
+    if (!content.endsWith("\n")) content += "\n";
+    content += section;
+  }
+  writeFileSync(globalFile, content, "utf-8");
+  return globalFile;
+}
+
+function writeFileDurable(path: string, content: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content, { mode: 0o600 });
+}
+
+function resolveRepoRoot(cwdOption: string | undefined): string {
+  if (process.env.REPO_HARNESS_TARGET_REPO_ROOT) return process.env.REPO_HARNESS_TARGET_REPO_ROOT;
+  const cwd = cwdOption ?? process.cwd();
+  try {
+    const out = execFileSync("git", ["-C", cwd, "rev-parse", "--show-toplevel"], { encoding: "utf8" }).trim();
+    return out || cwd;
+  } catch {
+    return cwd;
+  }
+}
+
+interface Options {
+  reason: string;
+  cwd?: string;
+  printPrompt: boolean;
+  withGlobalPacket: boolean;
+  quiet: boolean;
+}
+
+function parseArgs(argv: readonly string[]): Options {
+  const options: Options = { reason: "manual", printPrompt: false, withGlobalPacket: false, quiet: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--reason") {
+      options.reason = argv[i + 1] ?? "manual";
+      i += 1;
+    } else if (arg === "--cwd") {
+      options.cwd = argv[i + 1];
+      i += 1;
+    } else if (arg === "--print-prompt") {
+      options.printPrompt = true;
+    } else if (arg === "--with-global-packet") {
+      options.withGlobalPacket = true;
+    } else if (arg === "--quiet") {
+      options.quiet = true;
+    }
+  }
+  return options;
+}
+
+function main(): void {
+  const options = parseArgs(process.argv.slice(2));
+  const repoRoot = resolveRepoRoot(options.cwd);
+  const codexHome = process.env.CODEX_HOME || join(process.env.HOME || "", ".codex");
+  const context = buildContext(repoRoot, options.reason, codexHome);
+  const evidence = resolveEvidence(repoRoot);
+  const contractPath = context.artifacts.contract;
+  const handoffText = renderHandoff(context, evidence, contractPath);
+  const resumeText = renderResume(context, evidence, contractPath);
+
+  writeFileDurable(join(repoRoot, context.paths.handoff), handoffText);
+  writeFileDurable(join(repoRoot, context.paths.resume), resumeText);
+
+  let globalFile = "";
+  if (options.withGlobalPacket) {
+    const repoKey = repoKeyFor(repoRoot);
+    const section = renderGlobalSection({
+      repoPath: repoRoot,
+      repoKey,
+      reason: options.reason,
+      repoHandoffRelative: context.paths.handoff,
+      resumeFileRelative: context.paths.resume,
+      handoffText,
+      resumeText,
+      now: new Date(),
+    });
+    globalFile = updateGlobalHandoffFile(codexHome, repoKey, section, new Date());
+  }
+
+  if (options.printPrompt) {
+    process.stdout.write(extractResumePrompt(resumeText));
+    return;
+  }
+
+  if (options.withGlobalPacket && globalFile) {
+    console.log(globalFile);
+  }
+  if (!options.quiet) {
+    console.log(`Updated ${context.paths.resume}`);
+  }
+}
+
+main();

--- a/src/cli/hook/stop-handler.ts
+++ b/src/cli/hook/stop-handler.ts
@@ -30,6 +30,12 @@ import {
 import { consumePendingPostEditEvents } from './mutation-observed';
 import { runMinimalChangeCli } from './minimal-change-cli';
 import { publishCheckpointFromLedger } from '../../effects/evidence/checkpoint-store';
+import {
+  buildRecoveryContext,
+  renderRecoveryHandoff,
+  renderRecoveryResume,
+  resolveRecoveryEvidence,
+} from '../../effects/evidence/recovery-materializer';
 
 export interface StopCollector {
   getRepoRoot(): string;
@@ -85,12 +91,6 @@ interface ProjectionPaths {
   readonly runSummary: string;
 }
 
-interface NextAction {
-  readonly stage: string;
-  readonly command: string;
-  readonly message: string;
-}
-
 function parsePayload(input: string | Buffer | undefined): StopPayload {
   if (input === undefined) return {};
   const text = input.toString().trim();
@@ -128,23 +128,13 @@ function safeHarnessPath(value: string, fallback: string): string {
   return value;
 }
 
-function runId(env: NodeJS.ProcessEnv, now: Date): string {
-  return env.HOOK_RUN_ID
-    ?? env.CLAUDE_RUN_ID
-    ?? env.CODEX_RUN_ID
-    ?? `run-${formatCompact(now)}-${process.pid}`;
-}
-
-function formatCompact(date: Date): string {
-  const pad = (value: number) => String(value).padStart(2, '0');
-  return `${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(date.getDate())}T${pad(date.getHours())}${pad(date.getMinutes())}${pad(date.getSeconds())}`;
-}
-
-function formatDisplay(date: Date): string {
-  const pad = (value: number) => String(value).padStart(2, '0');
-  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
-}
-
+// EPC-07: runId/formatCompact/formatDisplay moved to
+// src/effects/evidence/recovery-materializer.ts's buildRecoveryContext (run
+// id + display timestamp are now part of the shared recovery context every
+// caller of this module reads from `context.runId`/`context.generatedAtDisplay`).
+// formatOffset stays here -- it is only used by this file's own
+// event/run-summary JSON content, which is not one of EPC-07's four named
+// recovery views.
 function formatOffset(date: Date): string {
   const pad = (value: number) => String(value).padStart(2, '0');
   const offset = -date.getTimezoneOffset();
@@ -153,150 +143,15 @@ function formatOffset(date: Date): string {
   return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}${sign}${pad(Math.floor(absolute / 60))}${pad(absolute % 60)}`;
 }
 
-function declaredPath(repoRoot: string, plan: string, label: string): string {
-  if (!plan || !existsSync(join(repoRoot, plan))) return '';
-  const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const match = readFileSync(join(repoRoot, plan), 'utf8').match(new RegExp(`^> \\*\\*${escaped}\\*\\*:\\s*(.+)$`, 'm'));
-  return match?.[1]?.replace(/`/g, '').trim() ?? '';
-}
-
-function activeArtifacts(repoRoot: string, activePlan: string | null): {
-  plan: string;
-  contract: string;
-  review: string;
-  notes: string;
-} {
-  const plan = activePlan && existsSync(join(repoRoot, activePlan)) ? activePlan : '';
-  const stem = plan ? basename(plan).replace(/^plan-/, '').replace(/\.md$/, '') : '';
-  const derived = (directory: string, suffix: string): string => {
-    if (!stem) return '';
-    const candidate = `${directory}/${stem}${suffix}`;
-    return existsSync(join(repoRoot, candidate)) ? candidate : '';
-  };
-  return {
-    plan,
-    contract: declaredPath(repoRoot, plan, 'Task Contract') || declaredPath(repoRoot, plan, 'Sprint Contract') || derived('tasks/contracts', '.contract.md'),
-    review: declaredPath(repoRoot, plan, 'Task Review') || declaredPath(repoRoot, plan, 'Sprint Review') || derived('tasks/reviews', '.review.md'),
-    notes: declaredPath(repoRoot, plan, 'Implementation Notes') || declaredPath(repoRoot, plan, 'Notes File') || derived('tasks/notes', '.notes.md'),
-  };
-}
-
-function metadataValue(path: string, label: string): string {
-  try {
-    const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const match = readFileSync(path, 'utf8').match(new RegExp(`^> \\*\\*${escaped}\\*\\*:\\s*(.+)$`, 'm'));
-    return match?.[1]?.replace(/`/g, '').trim() ?? '';
-  } catch {
-    return '';
-  }
-}
-
-function todoSourcePlan(repoRoot: string): string {
-  const value = metadataValue(join(repoRoot, 'tasks/todos.md'), 'Source Plan');
-  return value === '(none)' ? '' : value;
-}
-
-function activeSprintRow(repoRoot: string, activePlan: string): string {
-  let sprint = '';
-  try {
-    sprint = readFileSync(join(repoRoot, '.ai/harness/sprint/active-sprint'), 'utf8').trim();
-  } catch {
-    return '(none)';
-  }
-  if (!sprint || sprint.startsWith('/') || sprint === '..' || sprint.startsWith('../') || sprint.includes('/../')) return '(none)';
-  try {
-    const row = readFileSync(join(repoRoot, sprint), 'utf8')
-      .split('\n')
-      .find((line) => /^\|\s*\d+\s*\|/.test(line) && activePlan && line.includes(activePlan));
-    return row || `Active sprint: ${sprint}`;
-  } catch {
-    return '(none)';
-  }
-}
-
-function firstTaskBreakdown(planText: string): { total: number; done: number; next: string } {
-  const lines = planText.split('\n');
-  let inSection = false;
-  let total = 0;
-  let done = 0;
-  let next = '';
-  for (const line of lines) {
-    if (!inSection && /^## Task Breakdown\s*$/.test(line)) {
-      inSection = true;
-      continue;
-    }
-    if (inSection && /^## /.test(line)) break;
-    const match = inSection ? line.match(/^\s*-\s*\[([ xX])\]\s+(.+)$/) : null;
-    if (!match) continue;
-    total += 1;
-    if (match[1].toLowerCase() === 'x') done += 1;
-    else if (!next) next = match[2].replace(/\r/g, '');
-  }
-  return { total, done, next };
-}
-
-function nextAction(repoRoot: string, artifacts: ReturnType<typeof activeArtifacts>): NextAction {
-  if (!artifacts.plan) return { stage: 'none', command: '', message: '(none)' };
-  let taskState = { total: 0, done: 0, next: '' };
-  try {
-    taskState = firstTaskBreakdown(readFileSync(join(repoRoot, artifacts.plan), 'utf8'));
-  } catch {
-    // Missing/unreadable plan is treated as no active execution checklist.
-  }
-  if (taskState.total > taskState.done) {
-    const pending = taskState.next || 'continue active plan Task Breakdown';
-    return {
-      stage: 'task',
-      command: '',
-      message: `If a major module was just completed, stage its coherent diff first; then continue the next Task Breakdown item: ${pending}`,
-    };
-  }
-  return {
-    stage: 'check',
-    command: '/check',
-    message: 'Stage the completed module diff first; then run /check and let canonical workflow gates determine whether review, external acceptance, verification, or worktree finish is next.',
-  };
-}
-
-function recentCommands(repoRoot: string): string {
-  try {
-    const lines = readFileSync(join(repoRoot, '.claude/.trace.jsonl'), 'utf8').trimEnd().split('\n').slice(-5);
-    return lines.length > 0 && lines.some(Boolean) ? lines.map((line) => `- ${line}`).join('\n') : '- (none captured)';
-  } catch {
-    return '- (none captured)';
-  }
-}
-
-function latestTrace(repoRoot: string, checksRel: string): string {
-  const checks = readJson(join(repoRoot, checksRel));
-  return typeof checks?.run_file === 'string' && checks.run_file ? checks.run_file : checksRel;
-}
-
-function supersededPlan(repoRoot: string): string {
-  const state = readJson(join(repoRoot, '.claude/.task-state.json'));
-  return typeof state?.source_plan === 'string' && state.source_plan ? state.source_plan : '(none)';
-}
-
-function changedFiles(repoRoot: string): { files: string; summary: string } {
-  try {
-    const tracked = execFileSync('git', ['-C', repoRoot, 'diff', '--name-only', 'HEAD'], {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-    });
-    const untracked = execFileSync('git', ['-C', repoRoot, 'ls-files', '--others', '--exclude-standard'], {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-    });
-    const files = [...new Set(`${tracked}\n${untracked}`.split('\n').map((line) => line.trim()).filter(Boolean))].sort();
-    const visible = files.length > 80 ? [...files.slice(0, 80), `... (${files.length} total changed/untracked paths; inspect git status --short)`] : files;
-    return {
-      files: visible.length > 0 ? visible.join('\n') : '(none)',
-      summary: files.length > 0 ? `${files.length} changed/untracked paths` : 'no uncommitted diff against HEAD',
-    };
-  } catch {
-    return { files: '(none)', summary: 'git repository not detected' };
-  }
-}
+// EPC-07: activeArtifacts/changedFiles/nextAction/recentCommands/
+// activeSprintRow/supersededPlan/todoSourcePlan/firstTaskBreakdown/
+// metadataValue/declaredPath/latestTrace moved to
+// src/effects/evidence/recovery-materializer.ts's buildRecoveryContext --
+// single source of truth for the workflow context every recovery view
+// needs. `latestTrace` (checks/latest.json's `run_file` field folded
+// directly into a handoff line) is retired outright: it was a single-hop
+// violation (re-deriving an evidence claim from checks/* instead of the
+// checkpoint); the materializer's Evidence/Provenance sections replace it.
 
 function assertSafeRepoWritePath(repoRoot: string, path: string): void {
   const root = resolve(repoRoot);
@@ -479,58 +334,42 @@ function projection(repoRoot: string, activePlan: string | null, env: NodeJS.Pro
   paths: ProjectionPaths;
   content: { handoff: string; resume: string; event: string; runSummary: string };
 } {
-  const config = policy(repoRoot);
-  const checks = safeHarnessPath(nestedString(config, ['harness', 'checks_file']), '.ai/harness/checks/latest.json');
-  const handoff = safeHarnessPath(nestedString(config, ['harness', 'handoff_file']), '.ai/harness/handoff/current.md');
-  const resume = safeHarnessPath(nestedString(config, ['handoff_resume', 'resume_packet_file']), '.ai/harness/handoff/resume.md');
-  const events = safeHarnessPath(nestedString(config, ['harness', 'events_file']), '.ai/harness/events.jsonl');
-  const runsDir = safeHarnessPath(nestedString(config, ['harness', 'runs_dir']), '.ai/harness/runs');
-  const policyFile = '.ai/harness/policy.json';
-  const contextMap = safeHarnessPath(nestedString(config, ['context', 'map_file']), '.ai/context/context-map.json');
-  const researchDir = nestedString(config, ['tasks', 'research_dir']) || 'docs/researches';
-  const id = runId(env, now);
-  const runSummary = `${runsDir}/${id}.json`;
-  const artifacts = activeArtifacts(repoRoot, activePlan);
-  const changed = changedFiles(repoRoot);
-  const sourcePlan = todoSourcePlan(repoRoot);
-  const action = nextAction(repoRoot, artifacts);
-  const nextTask = action.command ? `${action.message} Command: ${action.command}` : action.message;
-  const goal = sourcePlan
-    ? `Continue task checklist sourced from ${sourcePlan}.`
-    : artifacts.plan
-      ? `Continue active plan ${artifacts.plan}.`
-      : nextTask !== '(none)'
-        ? nextTask
-        : 'No active plan. Continue from the latest user request and filesystem state.';
-  const commands = recentCommands(repoRoot);
-  const trace = latestTrace(repoRoot, checks);
-  const sprintRow = activeSprintRow(repoRoot, artifacts.plan);
-  const supersedes = supersededPlan(repoRoot);
-  const displayed = formatDisplay(now);
-  const handoffContent = `# Harness Handoff\n\n> **Generated**: ${displayed}\n> **Reason**: session-stop\n\n## Goal\n\n${goal}\n\n## Decisions\n\n- Use filesystem artifacts as source of truth; treat SQLite/thread state as a rebuildable read model only.\n\n## Files Touched\n\n\`\`\`\n${changed.files}\n\`\`\`\n\n## Commands Run\n\n${commands}\n\n## Checks\n\n- Checks file: ${checks}\n- Latest trace: ${trace}\n\n## Blockers\n\n- (none recorded)\n\n## Active Artifacts\n\n- Active plan: ${artifacts.plan || '(none)'}\n- Active contract: ${artifacts.contract || '(none)'}\n- Active sprint row: ${sprintRow}\n- Review file: ${artifacts.review || '(none)'}\n- Latest trace/checks file: ${trace}\n- Resume packet: ${resume}\n\n## Exact Next Step\n\n- ${nextTask}\n\n## Resume Prompt\n\n- Resume packet: ${resume}\n- Start a fresh Codex session and read source artifacts first, then this handoff, before continuing; do not rely on auto-compact.\n\n## Source Artifacts\n\n- Spec: docs/spec.md\n- Plan: ${artifacts.plan || '(none)'}\n- Todo Source Plan: ${sourcePlan || '(none)'}\n- Contract: ${artifacts.contract || '(none)'}\n- Review: ${artifacts.review || '(none)'}\n- Notes: ${artifacts.notes || '(none)'}\n- Checks: ${checks}\n- Resume Packet: ${resume}\n- Policy: ${policyFile}\n- Context Map: ${contextMap}\n\n## Current Status\n\n- Next action stage: ${action.stage}\n- Next recommended action: ${nextTask}\n- Working tree: ${changed.summary}\n- Parent Run ID: ${id}\n- Supersedes: ${supersedes}\n\n## Changed Files\n\n\`\`\`\n${changed.files}\n\`\`\`\n`;
-  const resumeContent = `# Codex Resume Packet\n<!-- generated-by: workflow_write_handoff v1 -->\n\n> **Generated**: ${displayed}\n> **Reason**: session-stop\n\n## Resume Prompt\n\nStart a fresh session for this task; do not rely on auto-compact or prior chat history. Read the source artifacts below, then the handoff, before continuing from Exact Next Step.\n\n- ${nextTask}\n\n## Source Artifacts\n\n- Handoff: ${handoff}\n- Spec: docs/spec.md\n- Active plan: ${artifacts.plan || '(none)'}\n- Active contract: ${artifacts.contract || '(none)'}\n- Review: ${artifacts.review || '(none)'}\n- Notes: ${artifacts.notes || '(none)'}\n- Research: ${researchDir}/\n- Checks: ${checks}\n`;
+  // EPC-07: handoff/resume content now comes from the single recovery
+  // materializer (src/effects/evidence/recovery-materializer.ts) instead of
+  // this function's own independent Markdown assembly. External shape is
+  // unchanged: same four projection targets, same paths resolution
+  // (buildRecoveryContext resolves the identical policy-driven paths this
+  // function used to resolve itself), same event/run-summary content this
+  // function still owns directly (those two targets are not among EPC-07's
+  // four named recovery views).
+  const context = buildRecoveryContext(repoRoot, activePlan, env, { reason: 'session-stop', now: () => now });
+  const evidence = resolveRecoveryEvidence(repoRoot);
+  const contractPath = context.artifacts.contract;
+  const handoffContent = renderRecoveryHandoff(context, evidence, contractPath);
+  const resumeContent = renderRecoveryResume(context, evidence, contractPath);
+  const runSummary = `${context.paths.runsDir}/${context.runId}.json`;
   const eventContent = `${JSON.stringify({
     ts: formatOffset(now),
     event_type: 'handoff_refresh',
     reason: 'session-stop',
-    run_id: id,
-    extra: { source_plan: sourcePlan, parent_run_id: id },
+    run_id: context.runId,
+    extra: { source_plan: context.sourcePlan, parent_run_id: context.runId },
   })}\n`;
   const runSummaryContent = `${JSON.stringify({
     generated_at: formatOffset(now),
-    run_id: id,
+    run_id: context.runId,
     reason: 'session-stop',
-    active_plan: artifacts.plan,
-    active_contract: artifacts.contract,
-    active_review: artifacts.review,
-    active_notes: artifacts.notes,
-    checks_file: checks,
-    handoff_file: handoff,
-    policy_file: policyFile,
-    context_map_file: contextMap,
+    active_plan: context.artifacts.plan,
+    active_contract: context.artifacts.contract,
+    active_review: context.artifacts.review,
+    active_notes: context.artifacts.notes,
+    checks_file: context.paths.checks,
+    handoff_file: context.paths.handoff,
+    policy_file: context.paths.policyFile,
+    context_map_file: context.paths.contextMap,
   }, null, 2)}\n`;
   return {
-    paths: { handoff, resume, events, runSummary },
+    paths: { handoff: context.paths.handoff, resume: context.paths.resume, events: context.paths.events, runSummary },
     content: { handoff: handoffContent, resume: resumeContent, event: eventContent, runSummary: runSummaryContent },
   };
 }
@@ -651,6 +490,26 @@ export function runStopHandler(opts: StopHandlerInput): StopHandlerResult {
     // Deferred journal housekeeping never blocks Stop.
   }
 
+  // EPC-07 (reordered from EPC-06's additive placement, documented in
+  // tasks/contracts/20260722-2246-epc-07-recovery-view-cutover.contract.md):
+  // publish the checkpoint BEFORE building the projection batch below, so
+  // the recovery materializer's evidence read reflects the freshest
+  // possible checkpoint for this Stop (including any ledger events the
+  // PostEdit flush above just accepted), not the previous Stop's stale
+  // snapshot. Still a quiet, expected skip inside
+  // `publishCheckpointFromLedger` itself when a worktree has no ledger yet
+  // (no exception), and any unexpected storage fault here is caught and
+  // discarded the same way, so this best-effort publish still can never
+  // block, reorder, or change Stop's existing
+  // handoff/resume/event/run-summary projection outputs below -- only their
+  // relative ordering to this publish call changed, not their own shape,
+  // count, or the single downstream state resolution.
+  try {
+    publishCheckpointFromLedger(repoRoot, () => now);
+  } catch {
+    // Checkpoint publication never blocks Stop.
+  }
+
   const projected = projection(repoRoot, activePlan, env, now);
   new StopProjectionBatch(
     repoRoot,
@@ -659,20 +518,6 @@ export function runStopHandler(opts: StopHandlerInput): StopHandlerResult {
     dependencies.observeProjectionWrite,
   ).commit();
   dependencies.observeProjectionTransaction?.();
-
-  // EPC-06 (additive): publish a checkpoint of the current accepted evidence
-  // set at this same Stop transaction point. Mirrors the PostEdit-flush
-  // try/catch above -- a worktree with no ledger yet (the common case today)
-  // is a quiet, expected skip inside `publishCheckpointFromLedger` itself
-  // (no exception), and any unexpected storage fault here is caught and
-  // discarded the same way, so this best-effort publish can never block,
-  // reorder, or change Stop's existing handoff/resume/event/run-summary
-  // projection outputs above.
-  try {
-    publishCheckpointFromLedger(repoRoot, () => now);
-  } catch {
-    // Checkpoint publication never blocks Stop.
-  }
 
   const stderr: string[] = [`[FinalizeHandoff] Refreshed ${projected.paths.handoff}.\n`];
   let state: EffectiveState | null = null;

--- a/src/effects/evidence/recovery-materializer.ts
+++ b/src/effects/evidence/recovery-materializer.ts
@@ -1,0 +1,855 @@
+/**
+ * Recovery-view materialization (Sprint C backlog row 11 / D9 recovery-view
+ * minimization / D8 provenance). Single materializer for the two surviving
+ * repo-local recovery views -- handoff (`handoff/current.md`) and the merged
+ * resume (`handoff/resume.md`) -- plus the task-handoff payload (the
+ * Codex-global packet's per-repo section). See
+ * `tasks/contracts/20260722-2246-epc-07-recovery-view-cutover.contract.md`
+ * for the full Phase A inventory and reconciled D9 verdicts.
+ *
+ * Single-hop discipline: every EVIDENCE claim in a rendered view traces to
+ * `resolveLastPublishedCheckpoint`'s already-validated projection (EPC-06,
+ * read-only import) -- this module never reads `.ai/harness/checks/*` or the
+ * event ledger directly. Workflow CONTEXT (goal, next step, changed files,
+ * active plan/contract/review/notes, active sprint row) is a different kind
+ * of fact -- "where work stands," not "what was proven" -- and is read fresh
+ * from the live repo on every call, exactly as the retired writers did.
+ *
+ * Determinism: `renderRecoveryHandoff`/`renderRecoveryResume` are pure
+ * functions of (context, evidence, contractPath, now) -- the same inputs
+ * (including the same injected clock) always render the same bytes.
+ * `content_hash` inside each view's own Provenance block is computed over
+ * that view's body EXCLUDING the Provenance block itself (mirrors
+ * `checkpoint.ts`'s `bodyAsJson` exclusion), so the volatile `generated_at`
+ * line never perturbs the hash.
+ */
+import { createHash } from 'crypto';
+import { execFileSync } from 'child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { basename, join } from 'path';
+import {
+  CheckpointResolutionError,
+  resolveLastPublishedCheckpoint,
+} from './checkpoint-store';
+
+export const RECOVERY_SCHEMA_VERSION = 1;
+export const RECOVERY_MATERIALIZER_VERSION = '1';
+
+/**
+ * Preserved verbatim as the merged resume view's identity marker. This is
+ * NOT a compatibility shim for a retired dual-writer path -- there is
+ * exactly one writer of `resume.md` going forward. It is a stable,
+ * documented external-observable-contract string that
+ * `src/cli/hook/session-context.ts`'s `resumeAvailable()` (an EPC-08
+ * SessionStart internal, out of this package's scope beyond a filename-level
+ * reference) already greps for. The `## Provenance` block below is the real,
+ * machine-checkable materializer identity; this legacy marker is a stable
+ * display-compatible discriminator, exactly the same "internal swap,
+ * external semantics frozen" principle already applied to the Stop
+ * handler's own shape.
+ */
+export const LEGACY_RESUME_MARKER = '<!-- generated-by: repo-harness codex-handoff-resume v1 -->';
+
+// ---------------------------------------------------------------------------
+// Small generic helpers. Duplicated deliberately rather than imported across
+// module boundaries, matching this repo's established convention for tiny
+// generic helpers (see `verify-producer.ts`/`attested-import.ts`'s duplicated
+// `worktreeIdFor`/`sha256Hex`/`gitOutput`, each documented "necessarily
+// duplicated, not imported").
+// ---------------------------------------------------------------------------
+
+function sha256Hex(text: string): string {
+  return createHash('sha256').update(text, 'utf-8').digest('hex');
+}
+
+function pad2(value: number): string {
+  return String(value).padStart(2, '0');
+}
+
+function formatDisplay(date: Date): string {
+  return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())} ${pad2(date.getHours())}:${pad2(date.getMinutes())}:${pad2(date.getSeconds())}`;
+}
+
+function formatCompact(date: Date): string {
+  return `${date.getFullYear()}${pad2(date.getMonth() + 1)}${pad2(date.getDate())}T${pad2(date.getHours())}${pad2(date.getMinutes())}${pad2(date.getSeconds())}`;
+}
+
+function yymmdd(date: Date): string {
+  return `${String(date.getFullYear()).slice(-2)}${pad2(date.getMonth() + 1)}${pad2(date.getDate())}`;
+}
+
+function policy(repoRoot: string): Record<string, unknown> {
+  try {
+    const value = JSON.parse(readFileSync(join(repoRoot, '.ai/harness/policy.json'), 'utf8'));
+    return value && typeof value === 'object' ? value as Record<string, unknown> : {};
+  } catch {
+    return {};
+  }
+}
+
+function nestedString(root: Record<string, unknown>, keys: readonly string[]): string {
+  let value: unknown = root;
+  for (const key of keys) {
+    if (!value || typeof value !== 'object') return '';
+    value = (value as Record<string, unknown>)[key];
+  }
+  return typeof value === 'string' ? value : '';
+}
+
+function safeHarnessPath(value: string, fallback: string): string {
+  if (!value || value.startsWith('/') || value.includes('\\') || value.includes('\n') || value.includes('\r')) return fallback;
+  if (value === '..' || value.startsWith('../') || value.includes('/../')) return fallback;
+  if (!value.startsWith('.ai/harness/')) return fallback;
+  return value;
+}
+
+function readJson(path: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8'));
+    return parsed && typeof parsed === 'object' ? parsed as Record<string, unknown> : null;
+  } catch {
+    return null;
+  }
+}
+
+function metadataValue(path: string, label: string): string {
+  try {
+    const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const match = readFileSync(path, 'utf8').match(new RegExp(`^> \\*\\*${escaped}\\*\\*:\\s*(.+)$`, 'm'));
+    return match?.[1]?.replace(/`/g, '').trim() ?? '';
+  } catch {
+    return '';
+  }
+}
+
+function declaredPath(repoRoot: string, plan: string, label: string): string {
+  if (!plan || !existsSync(join(repoRoot, plan))) return '';
+  const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = readFileSync(join(repoRoot, plan), 'utf8').match(new RegExp(`^> \\*\\*${escaped}\\*\\*:\\s*(.+)$`, 'm'));
+  return match?.[1]?.replace(/`/g, '').trim() ?? '';
+}
+
+/** Contract-path-derived worktree identity (pattern reference:
+ * `verify-producer.ts`/`checks-materializer.ts`'s own `worktreeIdFor` --
+ * necessarily duplicated, same reasoning as the block comment above). Used
+ * only as the fallback when no checkpoint is available to source
+ * `worktree_id` from directly. */
+function worktreeIdFor(contractRelative: string): string {
+  const base = contractRelative.split('/').pop() ?? contractRelative;
+  return base.replace(/\.contract\.md$/, '');
+}
+
+// ---------------------------------------------------------------------------
+// Workflow context (ported verbatim from `stop-handler.ts`'s prior private
+// `projection()` helpers -- single source of truth going forward; the Stop
+// handler now imports these instead of keeping its own copies).
+// ---------------------------------------------------------------------------
+
+export interface RecoveryArtifactPaths {
+  readonly plan: string;
+  readonly contract: string;
+  readonly review: string;
+  readonly notes: string;
+}
+
+function planSlugFromPath(planFile: string): string {
+  const base = basename(planFile);
+  const slug = base.replace(/^plan-\d{8}-\d{4}-/, '').replace(/\.md$/, '');
+  return slug.length > 0 && slug !== base ? slug : '';
+}
+
+function planStemFromPath(planFile: string): string {
+  const base = basename(planFile);
+  const stem = base.replace(/^plan-/, '').replace(/\.md$/, '');
+  return /^\d{8}-\d{4}-.+/.test(stem) ? stem : planSlugFromPath(planFile);
+}
+
+/** `workflow_preferred_or_legacy_path` port: preferred (stamped-stem)
+ * candidate wins if it exists; else the legacy (slug-only) candidate wins
+ * if IT exists; else fall back to the preferred candidate as a best-guess
+ * pointer (matches bash's `workflow_active_contract`/`_review`/`_notes` --
+ * a recovery view may legitimately point at where an artifact SHOULD live
+ * before it has been created). */
+function preferredOrLegacyArtifactPath(repoRoot: string, preferred: string, legacy: string): string {
+  if (existsSync(join(repoRoot, preferred))) return preferred;
+  if (!existsSync(join(repoRoot, legacy))) return preferred;
+  return legacy;
+}
+
+export function recoveryArtifacts(repoRoot: string, activePlan: string | null): RecoveryArtifactPaths {
+  const plan = activePlan && existsSync(join(repoRoot, activePlan)) ? activePlan : '';
+  if (!plan) return { plan: '', contract: '', review: '', notes: '' };
+  const stem = planStemFromPath(plan);
+  const slug = planSlugFromPath(plan);
+  const derived = (directory: string, suffix: string): string => {
+    if (!stem || !slug) return '';
+    return preferredOrLegacyArtifactPath(repoRoot, `${directory}/${stem}${suffix}`, `${directory}/${slug}${suffix}`);
+  };
+  return {
+    plan,
+    contract: declaredPath(repoRoot, plan, 'Task Contract') || declaredPath(repoRoot, plan, 'Sprint Contract') || derived('tasks/contracts', '.contract.md'),
+    review: declaredPath(repoRoot, plan, 'Task Review') || declaredPath(repoRoot, plan, 'Sprint Review') || derived('tasks/reviews', '.review.md'),
+    notes: declaredPath(repoRoot, plan, 'Implementation Notes') || declaredPath(repoRoot, plan, 'Notes File') || derived('tasks/notes', '.notes.md'),
+  };
+}
+
+function todoSourcePlan(repoRoot: string): string {
+  const value = metadataValue(join(repoRoot, 'tasks/todos.md'), 'Source Plan');
+  return value === '(none)' ? '' : value;
+}
+
+function activeSprintRow(repoRoot: string, activePlan: string): string {
+  let sprint = '';
+  try {
+    sprint = readFileSync(join(repoRoot, '.ai/harness/sprint/active-sprint'), 'utf8').trim();
+  } catch {
+    return '(none)';
+  }
+  if (!sprint || sprint.startsWith('/') || sprint === '..' || sprint.startsWith('../') || sprint.includes('/../')) return '(none)';
+  try {
+    const row = readFileSync(join(repoRoot, sprint), 'utf8')
+      .split('\n')
+      .find((line) => /^\|\s*\d+\s*\|/.test(line) && activePlan && line.includes(activePlan));
+    return row || `Active sprint: ${sprint}`;
+  } catch {
+    return '(none)';
+  }
+}
+
+function firstTaskBreakdown(planText: string): { total: number; done: number; next: string } {
+  const lines = planText.split('\n');
+  let inSection = false;
+  let total = 0;
+  let done = 0;
+  let next = '';
+  for (const line of lines) {
+    if (!inSection && /^## Task Breakdown\s*$/.test(line)) {
+      inSection = true;
+      continue;
+    }
+    if (inSection && /^## /.test(line)) break;
+    const match = inSection ? line.match(/^\s*-\s*\[([ xX])\]\s+(.+)$/) : null;
+    if (!match) continue;
+    total += 1;
+    if (match[1].toLowerCase() === 'x') done += 1;
+    else if (!next) next = match[2].replace(/\r/g, '');
+  }
+  return { total, done, next };
+}
+
+export interface RecoveryNextAction {
+  readonly stage: string;
+  readonly command: string;
+  readonly message: string;
+}
+
+function nextAction(repoRoot: string, artifacts: RecoveryArtifactPaths): RecoveryNextAction {
+  if (!artifacts.plan) return { stage: 'none', command: '', message: '(none)' };
+  let taskState = { total: 0, done: 0, next: '' };
+  try {
+    taskState = firstTaskBreakdown(readFileSync(join(repoRoot, artifacts.plan), 'utf8'));
+  } catch {
+    // Missing/unreadable plan is treated as no active execution checklist.
+  }
+  if (taskState.total > taskState.done) {
+    const pending = taskState.next || 'continue active plan Task Breakdown';
+    return {
+      stage: 'task',
+      command: '',
+      message: `If a major module was just completed, stage its coherent diff first; then continue the next Task Breakdown item: ${pending}`,
+    };
+  }
+  return {
+    stage: 'check',
+    command: '/check',
+    message: 'Stage the completed module diff first; then run /check and let canonical workflow gates determine whether review, external acceptance, verification, or worktree finish is next.',
+  };
+}
+
+function recentCommands(repoRoot: string): string {
+  try {
+    const lines = readFileSync(join(repoRoot, '.claude/.trace.jsonl'), 'utf8').trimEnd().split('\n').slice(-5);
+    return lines.length > 0 && lines.some(Boolean) ? lines.map((line) => `- ${line}`).join('\n') : '- (none captured)';
+  } catch {
+    return '- (none captured)';
+  }
+}
+
+function supersededPlan(repoRoot: string): string {
+  const state = readJson(join(repoRoot, '.claude/.task-state.json'));
+  return typeof state?.source_plan === 'string' && state.source_plan ? state.source_plan : '(none)';
+}
+
+function changedFiles(repoRoot: string): { files: string; summary: string } {
+  try {
+    const tracked = execFileSync('git', ['-C', repoRoot, 'diff', '--name-only', 'HEAD'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    const untrackedRaw = execFileSync('git', ['-C', repoRoot, 'ls-files', '--others', '--exclude-standard'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    const files = [...new Set(`${tracked}\n${untrackedRaw}`.split('\n').map((line) => line.trim()).filter(Boolean))].sort();
+    const visible = files.length > 80 ? [...files.slice(0, 80), `... (${files.length} total changed/untracked paths; inspect git status --short)`] : files;
+
+    // workflow_write_handoff's `diff_stat`/`untracked_count` port: a
+    // human-readable tracked-diff shortstat plus an explicit untracked
+    // count, not a flat "N changed/untracked paths" total.
+    let diffStat = '';
+    try {
+      diffStat = execFileSync('git', ['-C', repoRoot, 'diff', '--shortstat', 'HEAD'], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).replace(/\n/g, '');
+    } catch {
+      diffStat = '';
+    }
+    const untrackedCount = untrackedRaw.split('\n').map((line) => line.trim()).filter(Boolean).length;
+    const summary = untrackedCount > 0
+      ? `${diffStat || 'no tracked diff'}; ${untrackedCount} untracked files`
+      : (diffStat || 'no uncommitted diff against HEAD');
+
+    return {
+      files: visible.length > 0 ? visible.join('\n') : '(none)',
+      summary,
+    };
+  } catch {
+    return { files: '(none)', summary: 'git repository not detected' };
+  }
+}
+
+function latestGlobalHandoff(codexHome: string): string {
+  try {
+    const dir = join(codexHome, 'handoffs');
+    if (!existsSync(dir)) return '';
+    const entries = execFileSync('find', [dir, '-maxdepth', '1', '-type', 'f', '-name', 'handoff-*.md'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).split('\n').map((line) => line.trim()).filter(Boolean).sort();
+    return entries.length > 0 ? entries[entries.length - 1]! : '';
+  } catch {
+    return '';
+  }
+}
+
+export interface RecoveryWorkflowContext {
+  readonly repoRoot: string;
+  readonly reason: string;
+  readonly runId: string;
+  readonly generatedAtDisplay: string;
+  readonly generatedAtIso: string;
+  readonly workingDirectory: string;
+  readonly artifacts: RecoveryArtifactPaths;
+  readonly sourcePlan: string;
+  readonly activeSprintRowText: string;
+  readonly action: RecoveryNextAction;
+  readonly nextTask: string;
+  readonly goal: string;
+  readonly changed: { readonly files: string; readonly summary: string };
+  readonly recentCommandsText: string;
+  readonly supersedes: string;
+  readonly paths: {
+    readonly checks: string;
+    readonly handoff: string;
+    readonly resume: string;
+    readonly events: string;
+    readonly runsDir: string;
+    readonly policyFile: string;
+    readonly contextMap: string;
+    readonly researchDir: string;
+    readonly todoFile: string;
+  };
+  readonly globalHandoffPath: string;
+}
+
+export interface BuildRecoveryContextOptions {
+  readonly reason?: string;
+  readonly now?: () => Date;
+  readonly codexHome?: string;
+}
+
+/** The "minimal live workflow context" a recovery view legitimately needs
+ * (recovery is about where work stands, not only what was proven). Reads
+ * fresh from the live repo on every call -- never cached, never itself an
+ * evidence claim. */
+export function buildRecoveryContext(
+  repoRoot: string,
+  activePlan: string | null,
+  env: NodeJS.ProcessEnv,
+  options: BuildRecoveryContextOptions = {},
+): RecoveryWorkflowContext {
+  const now = (options.now ?? (() => new Date()))();
+  const reason = options.reason ?? 'session-stop';
+  const config = policy(repoRoot);
+  const checks = safeHarnessPath(nestedString(config, ['harness', 'checks_file']), '.ai/harness/checks/latest.json');
+  const handoff = safeHarnessPath(nestedString(config, ['harness', 'handoff_file']), '.ai/harness/handoff/current.md');
+  const resume = safeHarnessPath(nestedString(config, ['handoff_resume', 'resume_packet_file']), '.ai/harness/handoff/resume.md');
+  const events = safeHarnessPath(nestedString(config, ['harness', 'events_file']), '.ai/harness/events.jsonl');
+  const runsDir = safeHarnessPath(nestedString(config, ['harness', 'runs_dir']), '.ai/harness/runs');
+  const policyFile = '.ai/harness/policy.json';
+  const contextMap = safeHarnessPath(nestedString(config, ['context', 'map_file']), '.ai/context/context-map.json');
+  const researchDir = nestedString(config, ['tasks', 'research_dir']) || 'docs/researches';
+  const todoFile = safeHarnessPath(nestedString(config, ['tasks', 'todo_file']), 'tasks/todos.md');
+  const runId = env.HOOK_RUN_ID ?? env.CLAUDE_RUN_ID ?? env.CODEX_RUN_ID ?? `run-${formatCompact(now)}-${process.pid}`;
+  const artifacts = recoveryArtifacts(repoRoot, activePlan);
+  const changed = changedFiles(repoRoot);
+  const sourcePlan = todoSourcePlan(repoRoot);
+  const action = nextAction(repoRoot, artifacts);
+  const nextTask = action.command ? `${action.message} Command: ${action.command}` : action.message;
+  const goal = sourcePlan
+    ? `Continue task checklist sourced from ${sourcePlan}.`
+    : artifacts.plan
+      ? `Continue active plan ${artifacts.plan}.`
+      : nextTask !== '(none)'
+        ? nextTask
+        : 'No active plan. Continue from the latest user request and filesystem state.';
+  const codexHome = options.codexHome ?? env.CODEX_HOME ?? join(env.HOME ?? '', '.codex');
+
+  return {
+    repoRoot,
+    reason,
+    runId,
+    generatedAtDisplay: formatDisplay(now),
+    generatedAtIso: now.toISOString(),
+    workingDirectory: repoRoot,
+    artifacts,
+    sourcePlan,
+    activeSprintRowText: activeSprintRow(repoRoot, artifacts.plan),
+    action,
+    nextTask,
+    goal,
+    changed,
+    recentCommandsText: recentCommands(repoRoot),
+    supersedes: supersededPlan(repoRoot),
+    paths: { checks, handoff, resume, events, runsDir, policyFile, contextMap, researchDir, todoFile },
+    globalHandoffPath: latestGlobalHandoff(codexHome),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Evidence (single hop: checkpoint -> view; never checks/* or the ledger
+// directly).
+// ---------------------------------------------------------------------------
+
+export interface RecoveryEvidenceLatestByType {
+  readonly event_type: string;
+  readonly event_id: string;
+  readonly trust_class: string;
+  readonly created_at: string;
+}
+
+export type RecoveryEvidence =
+  | {
+      readonly available: true;
+      readonly checkpointId: string;
+      readonly worktreeId: string;
+      readonly generatedAt: string;
+      readonly coveredEventCount: number;
+      readonly sourceEventIds: readonly string[];
+      readonly latestByEventType: readonly RecoveryEvidenceLatestByType[];
+    }
+  | {
+      readonly available: false;
+      readonly reason: 'no-checkpoint' | 'checkpoint-invalid';
+      readonly detail?: string;
+    };
+
+/**
+ * Resolves the last-published checkpoint for use as this materializer's
+ * sole evidence source. `resolveLastPublishedCheckpoint` itself stays
+ * fail-closed/unmodified (throws `CheckpointResolutionError` on a dangling
+ * marker) -- this is a consumer-side catch: a recovery view must never crash
+ * Stop over a stale/invalid marker, so both "no checkpoint published yet"
+ * and "marker present but invalid" degrade to the same typed
+ * `available: false` shape a renderer can safely show as a minimal state,
+ * never fabricating an evidence claim.
+ */
+export function resolveRecoveryEvidence(repoRoot: string): RecoveryEvidence {
+  try {
+    const result = resolveLastPublishedCheckpoint(repoRoot);
+    if (!result.found) return { available: false, reason: 'no-checkpoint' };
+    const { projection } = result.resolved;
+    return {
+      available: true,
+      checkpointId: projection.checkpoint_id,
+      worktreeId: projection.worktree_id,
+      generatedAt: projection.provenance.generated_at,
+      coveredEventCount: projection.covered_event_count,
+      sourceEventIds: projection.provenance.source_event_ids,
+      latestByEventType: projection.latest_by_event_type.map((entry) => ({
+        event_type: entry.event_type,
+        event_id: entry.event_id,
+        trust_class: entry.trust_class,
+        created_at: entry.created_at,
+      })),
+    };
+  } catch (error) {
+    if (error instanceof CheckpointResolutionError) {
+      return { available: false, reason: 'checkpoint-invalid', detail: error.message };
+    }
+    throw error;
+  }
+}
+
+function evidenceLines(evidence: RecoveryEvidence): string[] {
+  const lines: string[] = [];
+  if (evidence.available) {
+    lines.push(`- Checkpoint: ${evidence.checkpointId} (generated ${evidence.generatedAt})`);
+    lines.push(`- Covered events: ${evidence.coveredEventCount}`);
+    lines.push('- Latest by type:');
+    if (evidence.latestByEventType.length === 0) {
+      lines.push('  (none)');
+    } else {
+      for (const entry of evidence.latestByEventType) {
+        lines.push(`  - ${entry.event_type}: ${entry.event_id} (${entry.trust_class}, accepted ${entry.created_at})`);
+      }
+    }
+  } else if (evidence.reason === 'no-checkpoint') {
+    lines.push('- Checkpoint: (none published yet -- no ledger evidence recorded in this worktree)');
+    lines.push('- Covered events: 0');
+    lines.push('- Latest by type:');
+    lines.push('  (none)');
+  } else {
+    lines.push(`- Checkpoint: (unavailable -- last-published checkpoint failed validation: ${evidence.detail ?? evidence.reason})`);
+    lines.push('- Covered events: 0');
+    lines.push('- Latest by type:');
+    lines.push('  (none)');
+  }
+  return lines;
+}
+
+// ---------------------------------------------------------------------------
+// D8 provenance.
+// ---------------------------------------------------------------------------
+
+export interface RecoveryProvenance {
+  readonly schema_version: number;
+  readonly generated_at: string;
+  readonly materializer_version: string;
+  readonly source_event_ids: readonly string[];
+  readonly source_checkpoint_id: string | null;
+  readonly subject_hash: null;
+  readonly content_hash: string;
+  readonly worktree_id: string;
+  readonly contract_id: string | null;
+}
+
+function resolveWorktreeId(evidence: RecoveryEvidence, contractPath: string): string {
+  if (evidence.available) return evidence.worktreeId;
+  if (contractPath) return worktreeIdFor(contractPath);
+  return 'unbound';
+}
+
+function buildProvenance(
+  context: RecoveryWorkflowContext,
+  evidence: RecoveryEvidence,
+  contractPath: string,
+  body: string,
+): RecoveryProvenance {
+  return {
+    schema_version: RECOVERY_SCHEMA_VERSION,
+    generated_at: context.generatedAtIso,
+    materializer_version: RECOVERY_MATERIALIZER_VERSION,
+    source_event_ids: evidence.available ? evidence.sourceEventIds : [],
+    source_checkpoint_id: evidence.available ? evidence.checkpointId : null,
+    subject_hash: null,
+    content_hash: `sha256:${sha256Hex(body)}`,
+    worktree_id: resolveWorktreeId(evidence, contractPath),
+    contract_id: contractPath || null,
+  };
+}
+
+function renderProvenanceSection(provenance: RecoveryProvenance): string[] {
+  return [
+    '## Provenance',
+    '',
+    `- Schema version: ${provenance.schema_version}`,
+    `- Generated at: ${provenance.generated_at}`,
+    `- Materializer version: ${provenance.materializer_version}`,
+    `- Source checkpoint id: ${provenance.source_checkpoint_id ?? '(none -- no checkpoint published yet)'}`,
+    `- Source event ids: ${provenance.source_event_ids.length > 0 ? `${provenance.source_event_ids.length} covered` : '(none)'}`,
+    '- Subject hash: (none -- recovery view is not subject-bound)',
+    `- Worktree: ${provenance.worktree_id}`,
+    `- Contract: ${provenance.contract_id ?? '(none)'}`,
+    `- Content hash: ${provenance.content_hash}`,
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Renderers (pure: no fs, no process -- everything comes from the context +
+// evidence + contract path already resolved by the caller).
+// ---------------------------------------------------------------------------
+
+export function renderRecoveryHandoff(
+  context: RecoveryWorkflowContext,
+  evidence: RecoveryEvidence,
+  contractPath: string,
+): string {
+  const bodyLines = [
+    '# Harness Handoff',
+    '',
+    `> **Generated**: ${context.generatedAtDisplay}`,
+    `> **Reason**: ${context.reason}`,
+    '',
+    '## Goal',
+    '',
+    context.goal,
+    '',
+    '## Decisions',
+    '',
+    '- Use filesystem artifacts as source of truth; treat SQLite/thread state as a rebuildable read model only.',
+    '',
+    '## Files Touched',
+    '',
+    '```',
+    context.changed.files,
+    '```',
+    '',
+    '## Commands Run',
+    '',
+    context.recentCommandsText,
+    '',
+    '## Evidence',
+    '',
+    ...evidenceLines(evidence),
+    '',
+    '## Blockers',
+    '',
+    '- (none recorded)',
+    '',
+    '## Active Artifacts',
+    '',
+    `- Active plan: ${context.artifacts.plan || '(none)'}`,
+    `- Active contract: ${context.artifacts.contract || '(none)'}`,
+    `- Active sprint row: ${context.activeSprintRowText}`,
+    `- Review file: ${context.artifacts.review || '(none)'}`,
+    `- Resume packet: ${context.paths.resume}`,
+    '',
+    '## Exact Next Step',
+    '',
+    `- ${context.nextTask}`,
+    '',
+    '## Resume Prompt',
+    '',
+    `- Resume packet: ${context.paths.resume}`,
+    '- Start a fresh Codex session and read source artifacts first, then this handoff, before continuing; do not rely on auto-compact.',
+    '',
+    '## Source Artifacts',
+    '',
+    '- Spec: docs/spec.md',
+    `- Plan: ${context.artifacts.plan || '(none)'}`,
+    `- Todo Source Plan: ${context.sourcePlan || '(none)'}`,
+    `- Contract: ${context.artifacts.contract || '(none)'}`,
+    `- Review: ${context.artifacts.review || '(none)'}`,
+    `- Notes: ${context.artifacts.notes || '(none)'}`,
+    `- Checks: ${context.paths.checks}`,
+    `- Resume Packet: ${context.paths.resume}`,
+    `- Policy: ${context.paths.policyFile}`,
+    `- Context Map: ${context.paths.contextMap}`,
+    '',
+    '## Current Status',
+    '',
+    `- Next action stage: ${context.action.stage}`,
+    `- Next recommended action: ${context.nextTask}`,
+    `- Working tree: ${context.changed.summary}`,
+    `- Parent Run ID: ${context.runId}`,
+    `- Supersedes: ${context.supersedes}`,
+    '',
+    '## Changed Files',
+    '',
+    '```',
+    context.changed.files,
+    '```',
+    '',
+  ];
+  const body = `${bodyLines.join('\n')}`;
+  const provenance = buildProvenance(context, evidence, contractPath, body);
+  return `${body}\n${renderProvenanceSection(provenance).join('\n')}\n`;
+}
+
+export function renderRecoveryResume(
+  context: RecoveryWorkflowContext,
+  evidence: RecoveryEvidence,
+  contractPath: string,
+): string {
+  const bodyLines = [
+    '# Codex Resume Packet',
+    LEGACY_RESUME_MARKER,
+    '',
+    `> **Generated**: ${context.generatedAtDisplay}`,
+    `> **Reason**: ${context.reason}`,
+    `> **Working Directory**: ${context.workingDirectory}`,
+    '',
+    '## Resume Prompt',
+    '',
+    'You are starting a fresh Codex session for an existing long-running task. Do not rely on prior chat history or Codex auto-compact. First read the source artifacts listed below, then continue from the exact next step in the repo handoff.',
+    '',
+    'Current prompt files first:',
+    '- If the current user message lists files under `# Files mentioned by the user`, references `pasted-text.txt`, or includes an explicit attachment/file path, read those current-input files before the repo recovery artifacts below.',
+    '- Use handoff, resume, and `tasks/current.md` as recovery context only; they do not outrank the current user message.',
+    '',
+    'Required first reads:',
+    '- AGENTS.md',
+    `- ${context.paths.handoff}`,
+    `- ${context.paths.todoFile}`,
+    `- ${context.artifacts.notes || '(none)'}`,
+    `- ${context.paths.researchDir}/`,
+    `- ${context.paths.checks}`,
+    '',
+    'Conditional first reads:',
+    `- Active plan: ${context.artifacts.plan || '(none)'}`,
+    `- Active contract: ${context.artifacts.contract || '(none)'}`,
+    `- Implementation notes: ${context.artifacts.notes || '(none)'}`,
+    `- Global handoff: ${context.globalHandoffPath || '(none)'}`,
+    '',
+    'Execution rules:',
+    '- Treat filesystem artifacts as the source of truth.',
+    '- Decide in the main agent whether to use subagents, parallel sidecars, sidecar `codex exec --json`, or a bounded main-thread trace for broad research/log scans based on context impact and callable tools; do not ask the user for spawn confirmation.',
+    `- Keep deep research conclusions in \`${context.paths.researchDir}/\`, not only in chat.`,
+    '- Do not run `/compact` as the primary recovery path.',
+    '- Preserve the current dirty worktree and do not touch unrelated untracked files.',
+    '',
+    '## Source Artifacts',
+    '',
+    `- Repo handoff: ${context.paths.handoff}`,
+    `- Resume packet: ${context.paths.resume}`,
+    `- Checks: ${context.paths.checks}`,
+    `- Todo: ${context.paths.todoFile}`,
+    `- Research: ${context.paths.researchDir}/`,
+    `- Plan: ${context.artifacts.plan || '(none)'}`,
+    `- Contract: ${context.artifacts.contract || '(none)'}`,
+    `- Notes: ${context.artifacts.notes || '(none)'}`,
+    `- Global handoff: ${context.globalHandoffPath || '(none)'}`,
+    '',
+  ];
+  const body = `${bodyLines.join('\n')}`;
+  const provenance = buildProvenance(context, evidence, contractPath, body);
+  return `${body}\n${renderProvenanceSection(provenance).join('\n')}\n`;
+}
+
+/** Extracts just the "## Resume Prompt" section body, matching
+ * `codex-handoff-resume.sh --print-prompt`'s existing awk/sed behavior. */
+export function extractResumePrompt(resumeText: string): string {
+  const lines = resumeText.split('\n');
+  const out: string[] = [];
+  let printing = false;
+  for (const line of lines) {
+    if (line === '## Resume Prompt') {
+      printing = true;
+      continue;
+    }
+    if (line === '## Source Artifacts') break;
+    if (printing) out.push(line);
+  }
+  while (out.length > 0 && out[0] === '') out.shift();
+  while (out.length > 0 && out[out.length - 1] === '') out.pop();
+  return `${out.join('\n')}\n`;
+}
+
+// ---------------------------------------------------------------------------
+// Task-handoff payload (Codex-global packet). MERGE-payload verdict: this
+// becomes an additional output target of the same single materializer
+// rather than `prepare-codex-handoff.sh`'s own independent Node/Python
+// heredoc.
+// ---------------------------------------------------------------------------
+
+export function repoKeyFor(repoPath: string): string {
+  return createHash('sha1').update(repoPath, 'utf-8').digest('hex').slice(0, 12);
+}
+
+function capText(text: string, limit = 8000): string {
+  return text.length <= limit ? text : `${text.slice(0, limit - 1)}...`;
+}
+
+export function renderGlobalHandoffSection(params: {
+  readonly repoPath: string;
+  readonly repoKey: string;
+  readonly reason: string;
+  readonly repoHandoffRelative: string;
+  readonly resumeFileRelative: string;
+  readonly handoffText: string;
+  readonly resumeText: string;
+  readonly now: Date;
+}): string {
+  const start = `<!-- repo:${params.repoKey} start -->`;
+  const end = `<!-- repo:${params.repoKey} end -->`;
+  const lines = [
+    start,
+    `## ${formatDisplay(params.now)} ${basename(params.repoPath)}`,
+    '',
+    `- cwd: \`${params.repoPath}\``,
+    `- reason: \`${params.reason}\``,
+    `- repo_handoff: \`${params.repoHandoffRelative}\``,
+    `- resume_packet: \`${params.resumeFileRelative}\``,
+    '',
+    '### Repo Handoff',
+    '',
+    capText(params.handoffText).trim(),
+    '',
+    '### Resume Packet',
+    '',
+    capText(params.resumeText).trim(),
+    '',
+    end,
+    '',
+  ];
+  return lines.join('\n');
+}
+
+/** Splices `section` into the rolling per-day global handoff file, replacing
+ * this repo's own prior section (by `repoKey`) or appending a new one --
+ * exact port of `prepare-codex-handoff.sh`'s Node/Python heredoc logic. */
+export function updateGlobalHandoffFile(codexHome: string, repoKey: string, section: string, now: () => Date = () => new Date()): string {
+  const globalDir = join(codexHome, 'handoffs');
+  mkdirSync(globalDir, { recursive: true });
+  const globalFile = join(globalDir, `handoff-${yymmdd(now())}.md`);
+  const start = `<!-- repo:${repoKey} start -->`;
+  const end = `<!-- repo:${repoKey} end -->`;
+  const header = `# Codex Handoff ${yymmdd(now())}\n\nFilesystem-first fallback handoffs for compact-independent Codex sessions.\n\n`;
+
+  let content = existsSync(globalFile) ? readFileSync(globalFile, 'utf-8') : header;
+  const startIdx = content.indexOf(start);
+  if (startIdx >= 0 && content.includes(end)) {
+    const afterStart = content.slice(startIdx + start.length);
+    const endIdx = afterStart.indexOf(end);
+    const prefix = content.slice(0, startIdx);
+    const suffix = afterStart.slice(endIdx + end.length).replace(/^\n+/, '');
+    content = prefix + section + suffix;
+  } else {
+    if (!content.endsWith('\n')) content += '\n';
+    content += section;
+  }
+  writeFileSync(globalFile, content, 'utf-8');
+  return globalFile;
+}
+
+// ---------------------------------------------------------------------------
+// Orchestrator: content only, no disk write for handoff/resume themselves --
+// callers keep their own write path (`StopProjectionBatch.commit()`'s
+// existing `atomicWrite`, or the CLI command's own writer).
+// ---------------------------------------------------------------------------
+
+export interface MaterializeRecoveryViewsResult {
+  readonly handoff: string;
+  readonly resume: string;
+  readonly context: RecoveryWorkflowContext;
+  readonly evidence: RecoveryEvidence;
+}
+
+export function materializeRecoveryViews(
+  repoRoot: string,
+  activePlan: string | null,
+  env: NodeJS.ProcessEnv,
+  options: BuildRecoveryContextOptions = {},
+): MaterializeRecoveryViewsResult {
+  const context = buildRecoveryContext(repoRoot, activePlan, env, options);
+  const evidence = resolveRecoveryEvidence(repoRoot);
+  const contractPath = context.artifacts.contract;
+  return {
+    handoff: renderRecoveryHandoff(context, evidence, contractPath),
+    resume: renderRecoveryResume(context, evidence, contractPath),
+    context,
+    evidence,
+  };
+}

--- a/tasks/contracts/20260722-2246-epc-07-recovery-view-cutover.contract.md
+++ b/tasks/contracts/20260722-2246-epc-07-recovery-view-cutover.contract.md
@@ -1,0 +1,651 @@
+# Task Contract: epc-07-recovery-view-cutover
+
+> **Status**: Active
+> **Plan**: plans/plan-20260722-2246-epc-07-recovery-view-cutover.md
+> **Task Profile**: code-change
+> **Owner**: kito
+> **Reviewer**: Claude
+> **Waiver Policy**: user_waiver allowed, owner kito only, per Acceptance Policy below
+> **Base SHA**: `e5fb55e11863fa51a6945f411327be3cb5bd4c50` (pinned per R1 post-EPC-06: fresh fetch after EPC-06 merged (PR #122) plus its row-flip commit; verified equal to `origin/main` and this worktree's HEAD at task start -- `git merge-base --is-ancestor e5fb55e1... HEAD` holds)
+> **Target Branch**: main (via one independent PR)
+> **Working Branch**: `codex/epc-07-recovery-view-cutover`
+> **PR Unit**: one PR carrying the recovery materializer, the Stop internal content-source swap, the retired/thinned writer scripts, the red-first test suite, and this package's workflow artifacts
+> **Capability ID**: root
+> **Last Updated**: 2026-07-22 23:40
+> **Review File**: `tasks/reviews/20260722-2246-epc-07-recovery-view-cutover.review.md`
+> **Notes File**: `tasks/notes/20260722-2246-epc-07-recovery-view-cutover.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+Four independent authoring paths (plus one undeclared, found below) can each
+write `handoff/current.md` and `handoff/resume.md`. A hand-edited or
+divergent recovery projection can silently steer a fresh session, and the
+current split leaves `resume.md` in one of TWO different shapes depending on
+which writer last ran (a minimal projection at real Stop time vs. an
+elaborate one only when a human/CI explicitly runs
+`codex-handoff-resume.sh`). With the EPC-06 checkpoint as the canonical
+evidence snapshot, the surviving views become deterministic, D8-provenanced
+projections, and the writers that made them shadow authorities are deleted
+same-package rather than papered over.
+
+## Goal
+
+Phase A (this section) inventories every writer/consumer/trigger for the
+four recovery views with file:line evidence and reconciles each against the
+frozen D9 preliminary verdicts, revising in this contract where reality
+disagrees (D9 explicitly assigns revision authority here). Phase B (Detailed
+Design + Task Breakdown) implements the reconciled cutover: one recovery
+materializer renders the handoff view and the merged resume view (plus the
+task-handoff payload) from `resolveLastPublishedCheckpoint` (fail-closed)
+plus minimal live workflow context; the Stop handler's internal content
+source swaps to it with frozen external semantics; retired writers are
+deleted/thinned same-package; tests are red-first.
+
+## Phase A: Inventory (recorded before any Phase B edit)
+
+### View 1 -- handoff (`.ai/harness/handoff/current.md`)
+
+**Writers found:**
+
+1. **TS Stop handler** -- `src/cli/hook/stop-handler.ts:478-536` (`projection()`
+   builds `handoffContent`), committed by `StopProjectionBatch.commit()`
+   (`stop-handler.ts:414-430`) via `atomicWrite` (`stop-handler.ts:320-337`).
+   This is the ONLY writer that runs automatically, at every real Stop (root
+   `CLAUDE.md`: hooks route through one in-process handler). It is a
+   **complete independent reimplementation** of the bash logic below (same
+   Markdown shape, same field derivations, ported without a shared module --
+   confirmed by the copy-paste artifact at `stop-handler.ts:511`, whose
+   resume marker literally still reads
+   `<!-- generated-by: workflow_write_handoff v1 -->`, i.e. the TS port never
+   updated the marker it inherited from the bash source it was ported from).
+2. **Bash `workflow_write_handoff`** -- `.ai/hooks/lib/workflow-state.sh:1779-1971`
+   (canonical source `assets/hooks/lib/workflow-state.sh:1779`, identical by
+   `diff`). Writes `$handoff_file` via heredoc (`:1894-1971`). Its only
+   caller is `scripts/prepare-handoff.sh:54` (`workflow_write_handoff "$reason"`,
+   library-present branch) -- confirmed by a repo-wide grep for invocation
+   sites (not the definition): no other caller exists.
+3. **`workflow_ensure_harness_surface` bootstrap** -- `.ai/hooks/lib/workflow-state.sh:122`
+   (`[[ -f "$(workflow_handoff_file)" ]] || printf "# Harness Handoff\n\n> **Reason**: bootstrap\n" > "$(workflow_handoff_file)"`).
+   **This is the undeclared fifth writer** (see "Undeclared writer" below).
+4. **`scripts/prepare-handoff.sh`'s own no-library fallback** --
+   `scripts/prepare-handoff.sh:71-79` (heredoc, fires only when
+   `.ai/hooks/lib/workflow-state.sh` itself is absent). Classified
+   out-of-scope bootstrap content (see "Classified out of scope" below).
+
+**Readers/consumers found:**
+
+- `src/core/state/project-effective-state.ts:318-326` -- `durable_recovery_state`
+  readiness requirement, satisfied purely by
+  `handoffFreshness !== 'missing' && resumeFreshness !== 'missing'`
+  (existence + mtime; **content-independent**). Feeds
+  `allowedToStop`/`readyToShip` via `src/core/workflow/operation-readiness.ts`
+  and `artifact-requirement-policy.ts`.
+- `src/effects/state/resolve-effective-state.ts:211-213` -- `HANDOFF_PATH`/
+  `RESUME_PATH`/`CURRENT_SNAPSHOT_PATH` constants feeding the freshness
+  computation above.
+- `src/cli/hook/session-context.ts:239-247,557-593` (EPC-08 SessionStart
+  surface, read-only for this package) --
+  `workflowHandoffFile`/`workflowResumePacketFile` path resolvers;
+  `handoffSectionHasSignal(repoRoot, handoffFile, header)` scanning for
+  non-empty `## Blockers` (`:628`) and `## Changed Files` (`:629`) sections
+  -- **both headers must survive verbatim** in the new handoff template.
+  `resumeAvailable()` (`:577-584`) additionally requires the LITERAL marker
+  `<!-- generated-by: repo-harness codex-handoff-resume v1 -->` plus a
+  `## Resume Prompt` header inside `resume.md` -- see View 2 below for the
+  reconciliation this forces.
+- `scripts/check-task-workflow.sh:939,592-602` -- `handoff_file` policy
+  resolution; mtime-only freshness checks (resume vs. handoff, resume vs.
+  `tasks/current.md`); `is_contract_helper_path` (`:662-680`) recognizes
+  `prepare-codex-handoff.sh`/`codex-handoff-resume.sh` as known helper
+  basenames (existence-of-file check only, content-independent).
+- `scripts/refresh-current-status.sh:215-231` (`handoff_next_step`) --
+  scans handoff for `## Exact Next Step` -- **this header must survive
+  verbatim**.
+- `src/cli/mcp/tools.ts:1178-1190` (`latest_handoff` MCP tool) -- reads
+  `resume.md` (not `current.md`) plus two unrelated files, previews first 10
+  lines; content-shape-agnostic.
+- `scripts/verify-sprint.sh:634-635` -- existence-only trigger, re-runs
+  `prepare-codex-handoff.sh` opportunistically when either file exists.
+- Docs/partials (`AGENTS.md`, `CLAUDE.md`, `assets/partials*`,
+  `docs/reference-configs/handoff-protocol.md`, `README*.md`) -- human-facing
+  references to the files' existence/purpose; not structural.
+
+**Trigger:** exactly one automatic trigger (real Stop, in-process TS
+handler); the bash writer only fires on manual/CI invocation
+(`scripts/prepare-handoff.sh`, `scripts/check-ci.sh:66-67`, release
+checklists, `src/cli/commands/init.ts:713` adopt-verify flow).
+
+### View 2 -- resume (`.ai/harness/handoff/resume.md`)
+
+**Writers found:**
+
+1. **TS Stop handler** -- `stop-handler.ts:511` (`resumeContent`), same
+   `projection()`/`StopProjectionBatch` path as View 1. Writes a **minimal**
+   resume (Resume Prompt one-liner + Source Artifacts only), marked
+   `<!-- generated-by: workflow_write_handoff v1 -->`.
+2. **Bash `workflow_write_handoff`** -- `.ai/hooks/lib/workflow-state.sh:1973-1996`.
+   Writes the same **minimal** shape as (1), same marker.
+3. **`scripts/codex-handoff-resume.sh:215-263`** -- writes an **elaborate**
+   resume (Resume Prompt with required/conditional first reads + execution
+   rules, marked `<!-- generated-by: repo-harness codex-handoff-resume v1 -->`).
+   Callers: directly (CI, release checklists, `repo-harness run
+   codex-handoff-resume`), chained from `scripts/prepare-handoff.sh:56-58,80-81`
+   (unless `REPO_HARNESS_SKIP_RESUME_REFRESH=1`), chained from
+   `scripts/prepare-codex-handoff.sh:48-56`.
+4. **`workflow_ensure_harness_surface` bootstrap** --
+   `.ai/hooks/lib/workflow-state.sh:123` -- same undeclared-fifth-writer
+   finding as View 1 (see below).
+
+**Reality vs. today's two-tier split:** at every real Stop, resume.md gets
+the **minimal** shape (marker `workflow_write_handoff v1`); the **elaborate**
+shape only exists when a human/CI separately runs `codex-handoff-resume.sh`
+afterward. `resumeAvailable()` (`session-context.ts:577-584`) checks for the
+elaborate marker specifically, so **today, immediately after a bare Stop
+with no follow-up manual refresh, `resumeAvailable()` returns false** -- an
+existing, pre-EPC-07 gap this package's merge verdict closes by construction
+(one materializer, one resume shape, every time).
+
+**Readers/consumers:** same `durable_recovery_state` (content-independent)
+and `resumeAvailable()`/`resumeCurrentForHandoff()` (marker- and
+header-dependent, EPC-08 surface, read-only) as above; `latest_handoff` MCP
+tool; `check-task-workflow.sh` mtime checks.
+
+### View 3 -- tracked `tasks/current.md`
+
+**Writer:** `scripts/refresh-current-status.sh` (single materializer,
+confirmed; marker `<!-- generated-by: repo-harness refresh-current-status v1 -->`
+at `:391`). Invoked by: `ensure-task-workflow.sh:830-831` (bootstrap,
+`--clear --write`), `archive-workflow.sh:606` (finish, `--clear --write`),
+direct/manual/test invocation. No independent competing writer found. **D9
+KEEP verdict confirmed as-is; no rewiring required.**
+
+**Readers:** `stop-handler.ts` does not read it; `session-context.ts`'s
+`CURRENT_SNAPSHOT_PATH`; `check-task-workflow.sh` freshness checks (mtime vs.
+resume); human/doc references. Unaffected by this package.
+
+### View 4 -- Codex-global task-handoff packet
+
+**Writer:** `scripts/prepare-codex-handoff.sh:58-205` -- after chaining (1)
+`prepare-handoff.sh` (resume-refresh skipped) and (2) `codex-handoff-resume.sh`
+(elaborate resume), writes/updates
+`$CODEX_HOME/handoffs/handoff-<yymmdd>.md`, splicing a per-repo
+`<!-- repo:<key> start/end -->` block containing cwd, reason, and up to
+8000-char excerpts of the repo handoff and resume files (Node primary,
+Python3 fallback, inline heredocs, no separate tracked file). **This is the
+"unique payload" D9's task-handoff verdict refers to.**
+
+**Readers:** `scripts/codex-handoff-resume.sh:198-201`
+(`latest_global_handoff`, referenced from the elaborate resume's
+"Conditional first reads"); human/doc references
+(`docs/reference-configs/handoff-protocol.md`).
+
+**Trigger:** manual/CI only (`verify-sprint.sh:634-635`,
+`src/cli/commands/init.ts:713`, release checklists). Never automatic at
+Stop.
+
+### Undeclared writer found (Phase A discovery)
+
+`workflow_ensure_harness_surface` (`.ai/hooks/lib/workflow-state.sh:101-126`,
+canonical mirror identical) seeds **both** `handoff/current.md` (`:122`) and
+`handoff/resume.md` (`:123`) with a one-line bootstrap placeholder
+(`# Harness Handoff\n\n> **Reason**: bootstrap\n` /
+`# Codex Resume Packet\n\n> **Reason**: bootstrap\n`) whenever those files
+don't already exist. This function is called from THREE sites:
+`workflow_write_handoff` itself (`:1787`, harmless -- immediately
+superseded by that same function's own full write moments later),
+`workflow_append_event` (`:1205`), and `workflow_write_run_summary`
+(`:1239`). The latter two are called from many unrelated event-logging call
+paths across the hook surface -- meaning **any** event append that happens
+to run before the first real handoff/resume write in a fresh worktree
+silently plants placeholder content as a side effect, fully independent of
+all four named writers above. This is structurally identical to the
+`checks/latest.json` `{}` bootstrap EPC-05 already deleted from this exact
+function -- confirmed by the code comment already sitting directly above
+these two lines (`:113-121`): *"EPC-05: no `{}` bootstrap for
+checks/latest.json here anymore -- it is now materialized exclusively from
+the evidence ledger... a missing file is genuine absence, not a placeholder
+this library should paper over."* The same rationale is adopted here for
+handoff/resume (see Phase B, Reconciled Verdicts).
+
+### Classified out of scope (found, not writers of the live materializer)
+
+- **`scripts/prepare-handoff.sh:71-79`'s no-library fallback** -- fires only
+  when `.ai/hooks/lib/workflow-state.sh` is entirely absent (a repo that
+  hasn't been through `ensure-task-workflow`/adoption yet). Same class as
+  the adoption/bootstrap scaffolding below; not a competing authority for
+  this repo's own live recovery materializer. No edit.
+- **`src/core/adoption/standard-plan.ts:76-77`**, **`scripts/ensure-task-workflow.sh:910-911`**,
+  **`scripts/lib/project-init-lib.sh:2327`**,
+  **`scripts/run-harness-profile-benchmark.ts:685+`
+  (`writeResumeProjection`, a benchmark-fixture writer building isolated
+  sandbox workspaces -- explicitly a Layer-2 benchmark-subject input per the
+  sprint's R2, not this package's surface)** -- all one-time placeholder/
+  fixture writers for a brand-new downstream repo or an isolated benchmark
+  sandbox, never this repo's own live per-session recovery projection. No
+  edit.
+- **`evals/harness/scenarios.json`** -- a benchmark scenario prompt
+  referencing "the recorded next action" in resume.md; consumed against the
+  benchmark's own synthetic fixture, not the real materializer. No edit.
+
+### Reconciliation against frozen D9 verdicts
+
+- **handoff -- KEEP, retire bash writer, regenerate from checkpoint
+  (CONFIRMED as written).** The TS Stop-handler reimplementation is folded
+  into the single materializer (it was never a second file-writer in the D9
+  sense -- one process, one commit path -- but it WAS a second independent
+  content-assembly implementation, which the merge below eliminates).
+- **resume -- MERGE into the handoff materializer (CONFIRMED, verdict
+  extended with evidence found here).** One materializer emits both views.
+  The merged resume adopts the **elaborate** shape (today's
+  `codex-handoff-resume.sh` content), not the minimal one, because the
+  elaborate shape is what `resumeAvailable()` (an existing, real, EPC-08
+  consumer) already requires, and because the two-tier split itself is the
+  shadow-authority pattern D9 exists to close. The legacy marker
+  `<!-- generated-by: repo-harness codex-handoff-resume v1 -->` is
+  **preserved verbatim** in the rendered output as a stable, documented
+  external-observable-contract string for `resumeAvailable()` (an EPC-08
+  SessionStart internal this package must not edit beyond a filename-level
+  reference); the new D8 Provenance block is the actual machine-checkable
+  materializer identity going forward, so the legacy string is a stable
+  display-compatible discriminator, not a second source of truth -- exactly
+  the same "internal swap, external semantics frozen" principle this
+  package already applies to the Stop handler's own shape.
+- **tasks-current -- KEEP with `refresh-current-status.sh` as existing
+  single materializer (CONFIRMED as written).** No rewiring; a
+  regenerate-and-byte-compare drift check is added to the test surface only.
+- **task-handoff -- MERGE payload / RETIRE independent writer (CONFIRMED as
+  written).** The global-packet section-splice logic becomes an additional
+  output of the same single materializer; `prepare-codex-handoff.sh` becomes
+  a thin invoker with zero independent content assembly.
+- **REVISION (new, this contract, D9 revision authority exercised): the
+  `workflow_ensure_harness_surface` bootstrap writer for handoff/resume
+  (`.ai/hooks/lib/workflow-state.sh:122-123`) is retired same-package,**
+  matching the EPC-05 precedent already recorded in the adjacent code
+  comment. Rationale: it is an undeclared, silent, side-effect writer
+  reachable from unrelated event-logging call paths; once the materializer
+  can always render a typed minimal state with no checkpoint present, the
+  placeholder is redundant and re-introduces exactly the "placeholder
+  silently satisfies downstream expectations" anti-pattern EPC-05 already
+  closed for `checks/latest.json`.
+- **`scripts/prepare-handoff.sh` requires no code edit.** Its
+  library-present branch calls `workflow_write_handoff "$reason"` (now a
+  thin invoker of the single materializer) and conditionally chains
+  `codex-handoff-resume.sh` (now also a thin invoker of the same
+  materializer). Both callees change internally; the call sites are
+  untouched. The post-merge double-invocation is idempotent (same
+  deterministic content both times) and removing it is an optimization the
+  Goal does not require -- left alone per the EXECUTION_BOUNDARY.
+
+## Detailed Design (Phase B)
+
+### New module: `src/effects/evidence/recovery-materializer.ts`
+
+- `resolveRecoveryEvidence(repoRoot)`: wraps
+  `resolveLastPublishedCheckpoint`; catches `CheckpointResolutionError` so a
+  dangling/invalid marker degrades to the same typed "unavailable" state as
+  "no checkpoint yet" rather than throwing (Stop must never crash on a
+  recovery-view read; the checkpoint reader itself stays fail-closed/
+  unmodified -- this is a consumer-side catch, not a change to
+  `checkpoint-store.ts`). Returns a discriminated union:
+  `{available:true, checkpointId, generatedAt, coveredEventCount,
+  latestByEventType, sourceEventIds}` |
+  `{available:false, reason:'no-checkpoint'|'checkpoint-invalid', detail?}`.
+- `buildRecoveryContext(repoRoot, activePlanMarker, env, now)`: the "minimal
+  live workflow context" -- ported verbatim (single source of truth) from
+  `stop-handler.ts`'s existing `activeArtifacts`/`changedFiles`/`nextAction`/
+  `recentCommands`/`activeSprintRow`/`supersededPlan`/`todoSourcePlan`/
+  `policy`/`safeHarnessPath` helpers. `stop-handler.ts` imports and reuses
+  these instead of keeping its own copies.
+- `buildRecoveryProvenance(context, evidence, contractPath, now)`: D8 block
+  -- `source_event_ids`/`source_checkpoint_id` from the checkpoint when
+  available (else `[]`/`null`, the established "not materialized from a
+  checkpoint" idiom already used by `checks-materializer.ts`);
+  `subject_hash: null` (recovery views are not subject-filtered, same idiom
+  checkpoint.ts itself uses for "whole thing, not one subject"); `content_hash`
+  = sha256 of the rendered body excluding the provenance block itself
+  (mirrors `checkpoint.ts`'s `bodyAsJson` exclusion, so `generated_at`
+  staying volatile never perturbs the hash).
+- `renderRecoveryHandoff` / `renderRecoveryResume` (pure functions of
+  context + evidence + provenance; no fs): same section shape as today's
+  handoff (Goal/Decisions/Files Touched/Commands Run/Evidence/Blockers/
+  Active Artifacts/Exact Next Step/Resume Prompt/Source Artifacts/Current
+  Status/Changed Files/Provenance) and today's elaborate resume (Resume
+  Prompt/Required+Conditional first reads/Execution rules/Source
+  Artifacts/Provenance), with `## Blockers`, `## Changed Files`,
+  `## Exact Next Step`, `## Resume Prompt` headers preserved verbatim for
+  the consumers above, and a new `## Evidence`/`## Provenance` section
+  sourced only from `evidence` (never re-deriving from `checks/*` or the
+  ledger directly -- single hop).
+- `renderGlobalHandoffSection` / `updateGlobalHandoffFile`: the task-handoff
+  payload (per-repo spliced section), ported from
+  `prepare-codex-handoff.sh`'s Node/Python heredoc into one TypeScript
+  implementation.
+- `materializeRecoveryViews(repoRoot, options)`: orchestrates the above and
+  returns `{handoff, resume}` content strings (no disk write -- callers keep
+  their own write path: `StopProjectionBatch.commit()`'s existing
+  `atomicWrite`, or the new CLI command below).
+
+### `src/cli/hook/stop-handler.ts` (internal content-source swap only)
+
+- `projection()`'s handoff/resume content construction is replaced by calls
+  into `recovery-materializer.ts`. External shape frozen: same
+  `StopProjectionTarget` kinds/order/count, same `atomicWrite`/lock/observer
+  wiring, same stdout/stderr lines.
+- **Reordering (documented internal change):** `publishCheckpointFromLedger`
+  moves to run BEFORE `StopProjectionBatch.commit()` instead of after, so
+  the checkpoint the materializer reads for THIS Stop's handoff/resume is
+  the freshest possible one (including any ledger events accepted earlier
+  in this same turn), not the previous Stop's stale snapshot. This changes
+  no tested observable: `tests/stop-handler.test.ts` asserts checkpoint
+  publication only indirectly (never asserts its ordering relative to the
+  projection batch), and `tests/evidence-checkpoint.test.ts` tests
+  `publishCheckpointFromLedger` in isolation. Still wrapped in its own
+  try/catch (unaffected: a checkpoint-publish fault still never blocks
+  Stop).
+- One frozen-suite assertion needs a minimal documented update:
+  `tests/stop-handler.test.ts:155` currently asserts
+  `resume.toContain('<!-- generated-by: workflow_write_handoff v1 -->')` --
+  this literally characterizes the deleted minimal-resume assembly
+  internals. Updated to assert the new merged resume's actual marker
+  (`<!-- generated-by: repo-harness codex-handoff-resume v1 -->`, preserved
+  per the reconciliation above) plus presence of the new Provenance section.
+
+### New standalone helper: `scripts/recovery-view-cli.ts` (+ mirror)
+
+**Design correction found during Phase B (recorded here, not ad hoc):** the
+first draft of this section proposed a `src/cli/commands/` subcommand that
+the three bash scripts would shell into via `bun src/cli/index.ts`. That is
+wrong: `codex-handoff-resume.sh`/`prepare-codex-handoff.sh`/
+`prepare-handoff.sh` are **distributed** helpers (registered in
+`assets/workflow-contract.v1.json`, mirrored byte-identically to
+`assets/templates/helpers/`) that must run standalone in any adopting
+downstream repo, which never receives this package's own `src/` tree --
+confirmed by `tests/helper-scripts.test.ts`'s `copyHelpers()` fixture, which
+populates a bare temp workspace's `scripts/` directory from
+`assets/templates/helpers/` alone and runs these scripts with `bash
+scripts/<name>.sh` directly (no `REPO_HARNESS_BUN_BIN`/
+`REPO_HARNESS_HELPER_SOURCE_PATH` env, no `src/`). This is exactly why
+`prepare-codex-handoff.sh`'s existing global-packet logic is already a
+self-contained Node/Python heredoc with zero imports, and why
+`assets/templates/helpers/capability-resolver.ts` documents itself as a
+"Standalone typed Bun projection."
+
+Corrected design: `scripts/recovery-view-cli.ts` is a new, standalone,
+`#!/usr/bin/env bun` TypeScript helper (Bun already the repo-wide required
+runtime, `package.json` `engines.bun >= 1.1.35` -- not a new dependency) that
+reimplements the context-building and Markdown rendering logic (duplicated
+from, and kept consistent with, `src/effects/evidence/recovery-materializer.ts`
+by inspection -- the authoritative real-time path stays `stop-handler.ts`'s
+direct TS import; this standalone copy exists only because the distributed
+bash scripts have no other way to reach equivalent logic) plus a
+best-effort, gracefully-degrading read of
+`.ai/harness/evidence/checkpoints/last-published.json` ->
+`checkpoint.json` (never fabricates evidence on a read/parse failure --
+falls back to the same typed "unavailable" shape).
+
+**Second correction (found running `bun run sync:helpers` after the first
+correction above):** `scripts/sync-helper-sources.ts --write` fails closed
+with `unclassified package helper` on any file under
+`assets/templates/helpers/` that is not in the contract's `helpers.scripts`
+inventory -- a manually-placed, unregistered mirror copy is not a valid
+shortcut; it breaks the shared sync tool for every other helper too. So
+`recovery-view-cli.ts` IS registered in `assets/workflow-contract.v1.json`'s
+`helpers.scripts`/`helpers.descriptions` (and the byte-identical self-hosted
+copy at `.ai/harness/workflow-contract.json`, which
+`tests/workflow-contract.test.ts` asserts is exactly equal to the asset
+file), then mirrored via `bun run sync:helpers` like every other helper --
+no special-case handling needed once registered (default byte-identical
+mirroring, same as most `scripts/*.ts` helpers, since this file never
+imports `src/`). It is also now independently invocable via `repo-harness
+run recovery-view-cli`, a harmless side effect of registration, not a goal.
+
+The three retained scripts invoke it directly via
+`bun "$helper_dir/recovery-view-cli.ts" ...`, the same `$helper_dir`
+resolution pattern `prepare-codex-handoff.sh` already uses to invoke
+`codex-handoff-resume.sh`. Flags: `--reason`, `--cwd`, `--print-prompt`
+(print only the Resume Prompt body, matching `codex-handoff-resume.sh`'s
+existing flag), `--with-global-packet` (also update the Codex-home global
+packet).
+
+### Writer retirement (per reconciled verdicts)
+
+- `.ai/hooks/lib/workflow-state.sh` (+ canonical `assets/hooks/lib/workflow-state.sh`):
+  `workflow_write_handoff` body reduced to a thin invoker (resolve reason,
+  shell out to the new CLI subcommand for handoff+resume materialization,
+  keep the existing `workflow_append_event "handoff_refresh" ...` and
+  `workflow_write_run_summary` calls, which are not part of the four named
+  views); `workflow_ensure_harness_surface`'s two bootstrap lines
+  (`:122-123`) deleted. `.ai/hooks/.projection.json` refreshed only via
+  `bun run sync:hooks` (never hand-edited).
+- `scripts/codex-handoff-resume.sh` (+ mirror): body reduced to a thin
+  invoker of the new CLI subcommand with `--print-prompt` passthrough; zero
+  independent content assembly.
+- `scripts/prepare-codex-handoff.sh` (+ mirror): body reduced to a thin
+  invoker of the new CLI subcommand with `--with-global-packet`; the
+  inline Node/Python heredoc is deleted (superseded by
+  `updateGlobalHandoffFile` in the TS materializer).
+- `scripts/refresh-current-status.sh`: no code change (confirmed sole
+  materializer); a regenerate -> byte-compare drift check is added to
+  `tests/evidence-recovery-materializer.test.ts`.
+- `scripts/prepare-handoff.sh` (+ mirror): no code change (see
+  Reconciliation above).
+
+### Tests (red-first): `tests/evidence-recovery-materializer.test.ts`
+
+Determinism (same checkpoint resolution + same context + same injected
+clock => byte-identical handoff/resume); hand-edit overwrite (a hand-edited
+published view is fully overwritten by the next materialization);
+checkpoint-missing typed minimal state (no fabricated evidence claims);
+checkpoint-invalid (dangling marker) degrades the same way, never crashes;
+no-independent-authoring (grep/behavioral sweep over `src/`, `scripts/`,
+`.ai/hooks/` proving no writer of `handoff/current.md` or `handoff/resume.md`
+exists outside `stop-handler.ts`'s `atomicWrite` call and the new CLI
+subcommand's write path); Stop integration counts unchanged (delegates to
+the existing `tests/stop-handler.test.ts` four-target assertion, unmodified
+except the one documented line above); `tasks/current.md` drift check
+(regenerate via `refresh-current-status.sh --write` into a temp path,
+byte-compare against tracked content in a clean worktree state).
+
+## Scope
+
+- In scope: `src/effects/evidence/recovery-materializer.ts` (new, the
+  authoritative in-process implementation `stop-handler.ts` imports
+  directly); `src/cli/hook/stop-handler.ts` (internal content-source swap +
+  checkpoint-publish reordering only); `scripts/recovery-view-cli.ts` (new,
+  standalone) + `assets/templates/helpers/recovery-view-cli.ts` (mirror);
+  `.ai/hooks/lib/workflow-state.sh` + `assets/hooks/lib/workflow-state.sh`
+  + `.ai/hooks/.projection.json` (thin `workflow_write_handoff` +
+  bootstrap-line deletion); `scripts/codex-handoff-resume.sh`,
+  `scripts/prepare-codex-handoff.sh` and their
+  `assets/templates/helpers/` mirrors (thin-invoker reduction);
+  `tests/evidence-recovery-materializer.test.ts` (new);
+  `tests/stop-handler.test.ts` (the one documented assertion at `:155`
+  only); `tests/helper-scripts.test.ts` (found during Phase B: one
+  assertion in "prepare-handoff should write harness handoff using
+  workflow-state helpers" characterizes the retired `checks/latest.json`
+  `run_file` single-hop violation the same way `stop-handler.test.ts:155`
+  did -- documented minimal update, same class); `tests/workflow-state-lib.test.ts`
+  (found running the full suite post-implementation: one assertion in
+  "exports the shared workflow helper functions" characterized the exact
+  `next_action="$(workflow_next_action)"` call site retired from
+  `workflow_write_handoff`'s thinned body -- `workflow_next_action()` the
+  function definition is untouched and still asserted separately on the
+  preceding line; only the now-nonexistent call-site literal is removed,
+  documented, same class as the other two); this package's
+  plan/contract/review/notes; `tasks/todos.md` projection;
+  `.ai/harness/worktrees/epc-07-recovery-view-cutover.json`;
+  `assets/workflow-contract.v1.json` + `.ai/harness/workflow-contract.json`
+  (mechanical registration of the one new helper id only -- found necessary
+  during Phase B, see the standalone-helper section's second correction).
+- Out of scope: Context Packet / SessionStart internals beyond the
+  filename-level references already inventoried (EPC-08); `checks/latest`
+  materializer, verify producer, importers (EPC-02..05 surfaces); EPC-01
+  store/fold; EPC-06 checkpoint modules (consumed read-only); `tasks/current.md`
+  content itself and `scripts/refresh-current-status.sh` code (confirmed
+  sole materializer, no rewiring); `scripts/prepare-handoff.sh` and its
+  mirror (no code change required, see Reconciliation); the six
+  classified-out-of-scope bootstrap/fixture writers found in Phase A; the
+  sprint document; any new npm dependency; any other field of the workflow
+  contract manifest beyond the one new helper registration.
+- Non-goals: redesigning view content beyond what materialization requires;
+  retiring `post-bash-latest.json`; removing the now-redundant
+  `prepare-handoff.sh` -> `codex-handoff-resume.sh` double-invocation
+  (harmless, out of Goal's requirement); downstream helper deployment
+  (EPC-09 release scope).
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+- Stop if `check-architecture-sync` BLOCKS (not merely advises) on the
+  changed capability surfaces -- report rather than editing `.ai/context/`
+  or architecture files.
+- Stop if the Stop handler cannot take the internal content-source swap
+  (plus the documented checkpoint-publish reordering) without changing its
+  HRD-frozen external semantics (four-target projection batch, single
+  `getStopEffectiveState()` resolution, stdout/stderr shape) -- report for a
+  scope ruling rather than altering the frozen shape.
+- Stop after three fail-fix-reverify rounds on one issue.
+
+## Falsifier
+
+The direction is wrong if a surviving recovery view cannot be rendered
+deterministically from checkpoint + minimal workflow context (i.e. a view
+genuinely needs an independent observation channel), or if retiring/thinning
+a writer breaks a host entrypoint the Phase A inventory failed to map.
+Cheapest proof: live Stop dogfood produces byte-deterministic views (modulo
+the injected clock) whose evidence claims all resolve to the checkpoint,
+with the full characterization suite green and the one documented assertion
+update visible in the diff.
+
+## Root Cause Evidence
+
+Not applicable: Task Profile is `code-change`, not `bugfix`.
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260722-2246-epc-07-recovery-view-cutover.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260722-2246-epc-07-recovery-view-cutover.review.md`
+- Notes file: `tasks/notes/20260722-2246-epc-07-recovery-view-cutover.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Acceptance Policy
+
+```json
+{"protocol":1,"reviewer":"Claude","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - plans/plan-20260722-2246-epc-07-recovery-view-cutover.md
+  - tasks/contracts/20260722-2246-epc-07-recovery-view-cutover.contract.md
+  - tasks/reviews/20260722-2246-epc-07-recovery-view-cutover.review.md
+  - tasks/notes/20260722-2246-epc-07-recovery-view-cutover.notes.md
+  - tasks/todos.md
+  - src/effects/evidence/recovery-materializer.ts
+  - src/cli/hook/stop-handler.ts
+  - scripts/recovery-view-cli.ts
+  - assets/templates/helpers/recovery-view-cli.ts
+  - assets/workflow-contract.v1.json
+  - .ai/harness/workflow-contract.json
+  - .ai/hooks/lib/workflow-state.sh
+  - assets/hooks/lib/workflow-state.sh
+  - .ai/hooks/.projection.json
+  - scripts/codex-handoff-resume.sh
+  - scripts/prepare-codex-handoff.sh
+  - assets/templates/helpers/codex-handoff-resume.sh
+  - assets/templates/helpers/prepare-codex-handoff.sh
+  - tests/evidence-recovery-materializer.test.ts
+  - tests/stop-handler.test.ts
+  - tests/helper-scripts.test.ts
+  - tests/workflow-state-lib.test.ts
+  - .ai/harness/worktrees/epc-07-recovery-view-cutover.json
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+      - codex-exec
+      - main-thread
+    fallback: main-thread
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - src/effects/evidence/recovery-materializer.ts
+    - scripts/recovery-view-cli.ts
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260722-2246-epc-07-recovery-view-cutover.notes.md
+  tests_pass:
+    - path: tests/evidence-recovery-materializer.test.ts
+    - path: tests/stop-handler.test.ts
+  commands_succeed:
+    - bun run check:type
+    - bash scripts/check-task-workflow.sh --strict
+  manual_checks:
+    - "Phase A inventory recorded with file:line evidence and reconciled verdicts before Phase B edits"
+    - "Live Stop dogfood: handoff/resume materialized from last checkpoint, evidence claims resolve to checkpoint, hand-edit overwritten"
+    - "tasks/current.md untouched"
+```
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior:
+- Edge cases:
+- Regression risks:
+
+## Rollback Point
+
+- Commit / checkpoint: the single commit on `codex/epc-07-recovery-view-cutover` before it merges.
+- Revert strategy: revert the single PR -- restores the retired writers
+  (bash handoff/resume assembly, the independent `codex-handoff-resume.sh`/
+  `prepare-codex-handoff.sh` content assembly) and removes the recovery
+  materializer + Stop internal swap + new CLI subcommand; `tasks/current.md`
+  content and `scripts/refresh-current-status.sh` were never modified, so
+  reverting cannot regress that view.

--- a/tasks/notes/20260722-2246-epc-07-recovery-view-cutover.notes.md
+++ b/tasks/notes/20260722-2246-epc-07-recovery-view-cutover.notes.md
@@ -1,0 +1,103 @@
+# Implementation Notes: epc-07-recovery-view-cutover
+
+> **Status**: Active
+> **Plan**: plans/plan-20260722-2246-epc-07-recovery-view-cutover.md
+> **Contract**: tasks/contracts/20260722-2246-epc-07-recovery-view-cutover.contract.md
+> **Review**: tasks/reviews/20260722-2246-epc-07-recovery-view-cutover.review.md
+> **Last Updated**: 2026-07-23 00:00
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- Single materializer split into a pure-ish TS module
+  (`src/effects/evidence/recovery-materializer.ts`) consumed directly by
+  `stop-handler.ts` (the authoritative, real-time path) and a standalone,
+  self-contained `scripts/recovery-view-cli.ts` (mirrored to
+  `assets/templates/helpers/recovery-view-cli.ts`) consumed by the three
+  retained bash entrypoints. The two implementations are intentionally
+  duplicated, not shared via import, because the bash scripts are
+  distributed to downstream repos that never receive this package's `src/`
+  tree (proven by `tests/helper-scripts.test.ts`'s `copyHelpers()` fixture).
+  Both were fixed for the same two behavioral divergences discovered while
+  making `tests/helper-scripts.test.ts` pass (legacy-slug artifact-path
+  fallback; git-shortstat + "N untracked files" working-tree summary) --
+  see Deviations below.
+- Checkpoint publish reordered to run before the projection-batch commit in
+  `runStopHandler` so the materializer's evidence read reflects the
+  freshest checkpoint for the current Stop, not the previous one.
+- Resume view's legacy marker (`generated-by: repo-harness
+  codex-handoff-resume v1`) preserved verbatim as a stable
+  external-observable-contract string for `session-context.ts`'s
+  `resumeAvailable()` (EPC-08 surface, not touched). The D8 Provenance block
+  is the real, machine-checkable materializer identity going forward.
+- `workflow_ensure_harness_surface`'s handoff/resume bootstrap placeholder
+  (an undeclared fifth writer, Phase A finding) retired same-package,
+  mirroring the EPC-05 precedent already documented in the adjacent code
+  comment for `checks/latest.json`'s own retired `{}` bootstrap.
+- `scripts/recovery-view-cli.ts` had to be registered in
+  `assets/workflow-contract.v1.json`'s `helpers.scripts`/`helpers.descriptions`
+  (plus the byte-identical `.ai/harness/workflow-contract.json` copy) after
+  discovering `scripts/sync-helper-sources.ts --write` fails closed on any
+  unregistered file under `assets/templates/helpers/` -- a manually placed
+  mirror is not a valid shortcut. See contract Detailed Design for the full
+  two-correction record.
+
+## Deviations From Plan Or Spec
+
+- The plan's first Phase-B draft proposed a `src/cli/commands/` subcommand
+  for the three bash scripts to shell into. Corrected during Phase B (before
+  any bash script was written) once `tests/helper-scripts.test.ts`'s
+  `copyHelpers()` fixture proved the distributed scripts never receive
+  `src/`. Replaced with the standalone `scripts/recovery-view-cli.ts`
+  design. Recorded with rationale in the contract, not ad hoc.
+- Two real, pre-existing behavioral divergences between the bash
+  `workflow_write_handoff`/`workflow_active_contract` family and
+  `stop-handler.ts`'s own private helpers were discovered while making
+  `tests/helper-scripts.test.ts` pass against the unified materializer
+  (these existed silently before EPC-07; unifying the two paths onto one
+  implementation surfaced them for the first time):
+  1. Contract/review/notes artifact-path resolution was missing the
+     legacy slug-only fallback (`workflow_preferred_or_legacy_path`)
+     bash's resolvers already had. Fixed in both implementations by
+     porting `workflow_plan_slug_from_path`/`workflow_plan_artifact_stem_from_path`-equivalent
+     logic (the "transient plan slug" title-based rename refinement was
+     deliberately not ported -- unexercised by any test, out of the
+     EXECUTION_BOUNDARY as an absent requirement).
+  2. The handoff "Working tree" summary was a flat "N changed/untracked
+     paths" count in `stop-handler.ts`'s TS port, not bash's
+     `git diff --shortstat` + "; N untracked files" wording. Fixed in both
+     implementations to match bash's exact wording.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| Register `recovery-view-cli.ts` as an independently-invocable `repo-harness run` helper vs. keep it purely internal connective tissue | Registered (required, not optional) | `sync-helper-sources.ts --write` fails closed on any unregistered file under `assets/templates/helpers/`; registration was a hard requirement discovered at implementation time, not a design preference |
+| Keep the legacy resume marker literal vs. rename to a materializer-specific marker | Keep literal | Preserves `session-context.ts`'s `resumeAvailable()` external contract without touching EPC-08 internals; the D8 Provenance block is the honest machine-checkable identity |
+| Drop the now-redundant `prepare-handoff.sh` -> `codex-handoff-resume.sh` double-invocation | Left alone | Harmless (idempotent, same deterministic content both times); removing it is an optimization the Goal does not require |
+| Port the "transient plan slug" title-based rename refinement | Not ported | Unexercised by any relevant test; absent requirement under EXECUTION_BOUNDARY |
+
+## Open Questions
+
+- None.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Phase A inventory + reconciled verdicts: `tasks/contracts/20260722-2246-epc-07-recovery-view-cutover.contract.md`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- The `sync-helper-sources.ts --write` fail-closed-on-unregistered-file
+  behavior is a real, repeat-relevant discovery for any future new
+  `scripts/*.ts` helper -- candidate for `tasks/lessons.md` if another task
+  independently rediscovers it.
+- Promote to `docs/researches/` only when it is durable repo knowledge with
+  evidence.
+- Promote to harness asset files only after verification across more than
+  one task or fixture.

--- a/tasks/reviews/20260722-2246-epc-07-recovery-view-cutover.review.md
+++ b/tasks/reviews/20260722-2246-epc-07-recovery-view-cutover.review.md
@@ -49,17 +49,17 @@
 
 ## Acceptance Receipt Projection
 
-> **Disposition**: unavailable
-> **Reviewer**: unavailable
-> **Source**: unavailable
+> **Disposition**: external_pass
+> **Reviewer**: Claude
+> **Source**: claude-review
 > **Actor**: not-applicable
-> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject SHA256**: sha256:9f5180fce50fa3b8a6937d9172c06f0ae6a9d8817fd64fcd409d6b5ea4dff4cf
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: pending
-> **Verification Evidence SHA256**: pending
-> **Issued At**: pending
+> **Reviewed Target Revision**: e5fb55e11863fa51a6945f411327be3cb5bd4c50
+> **Verification Evidence SHA256**: sha256:ba47b3820f528ee1b441ca234ab5c640da9f7d2fe76ed2bb27044073f89dcbfd
+> **Issued At**: 2026-07-22T16:20:14.798Z
 
-- Summary: No AcceptanceReceipt has been recorded.
+- Summary: EPC-07 accepted: recovery-view cutover — evidence-cited inventory incl. fifth-writer retirement, single materializer per surviving view single-hop from checkpoint, retired writers deleted with mirrors in lockstep, Stop semantics untouched, bare-Stop resume gap closed; gatekeeper PASS
 - Findings: none
 
 ## Behavior Diff Notes

--- a/tasks/reviews/20260722-2246-epc-07-recovery-view-cutover.review.md
+++ b/tasks/reviews/20260722-2246-epc-07-recovery-view-cutover.review.md
@@ -1,12 +1,12 @@
 # Task Review: epc-07-recovery-view-cutover
 
-> **Status**: Pending
+> **Status**: Reviewed
 > **Plan**: plans/plan-20260722-2246-epc-07-recovery-view-cutover.md
 > **Contract**: tasks/contracts/20260722-2246-epc-07-recovery-view-cutover.contract.md
 > **Notes File**: tasks/notes/20260722-2246-epc-07-recovery-view-cutover.notes.md
 > **Checks File**: .ai/harness/checks/latest.json
-> **Last Updated**: 2026-07-22 22:46
-> **Recommendation**: fail
+> **Last Updated**: 2026-07-23 00:45
+> **Recommendation**: pass
 > **Review Rubric Version**: 2
 > **Reviewed Subject SHA256**: pending
 > **Reviewed Subject Scope**: normalized-final-content
@@ -14,29 +14,38 @@
 
 ## Human Review Card
 
-- Verdict: pending
-- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
-- Intended files changed:
-- Actual files changed:
-- Commands passed:
-- Residual risks:
-- Reviewer action required: inspect diff and card
-- Rollback:
+- Verdict: pass
+- Change type: code-change
+- Intended files changed: new `src/effects/evidence/recovery-materializer.ts`, standalone `scripts/recovery-view-cli.ts` (+ helper mirror + manifest registration in `assets/workflow-contract.v1.json` + byte-identical `.ai/harness/workflow-contract.json`), Stop internal content-source swap, retired writers thinned/deleted (bash handoff assembly, resume/packet authoring, fifth-writer bootstrap) with canonical+projection+digest lockstep, new 14-test suite, three documented characterization updates, package plan/contract/review/notes, `tasks/todos.md` projection
+- Actual files changed: exactly that set — 22 paths, single commit `24bfd715` on base `e5fb55e1`; `session-context.ts`, `tasks/current.md`, `refresh-current-status.sh`, sprint doc untouched; EPC-06 checkpoint modules consumed read-only; all five mirror pairs byte-identical (`cmp` clean)
+- Commands passed: new suite 14 pass (red-first), stop-handler/helper-scripts/workflow-state-lib 144 pass with only the three documented updates, full `bun test` 1813 pass / 1 skip / 0 fail (worker + gatekeeper independent runs), `check:type` clean, worktree `check-task-workflow --strict` OK, `contract-run preflight` preflight_pass, deploy-sql/task-sync/architecture-sync (advisory blocking=0) green, `inspect-project-state` no drift, `adopt --dry-run` 0 operations
+- Residual risks: globally installed repo-harness 0.10.1 lacks the newly registered packaged helper (`recovery-view-cli.ts`) — global-CLI strict checks fail in this repo until the standard-profile global refresh lands post-merge (environmental, flagged by gatekeeper); two test implementations deliberately narrower than the contract prose with sound inline rationale (drift check via double regeneration; no-independent-authoring over the six retired-writer files), the stronger property independently verified by gatekeeper
+- Reviewer action required: none further — gatekeeper acceptance review (fresh context, read-only) verdict PASS with base-revision spot-checks of every load-bearing inventory claim and an independent live Stop readback (12/12)
+- Rollback: revert the single PR — restores the retired writers and removes the materializer + Stop swap; tracked `tasks/current.md` content untouched throughout
 
 ## Mode Evidence
 
-- Selected route:
-- P1/P2/P3 evidence:
-- Root cause or plan evidence:
+- Selected route: planning (captured work-package plan, code-change profile; Phase A inventory-before-edit sequencing honored)
+- P1/P2/P3 evidence: plan Captured Planning Output; frozen D8/D9 + row-10 D8 ratification; Phase A inventory with file:line citations recorded in the contract before Phase B edits
+- Root cause or plan evidence: cutover package; the pre-existing bare-Stop `resumeAvailable()` gap and the two bash/TS divergences documented with base-revision evidence
 
 ## Verification Evidence
 
-- Waza `/check` run:
-- Commands run:
-- Manual checks:
-- Supporting artifacts:
-- Implementation notes reviewed:
-- Run snapshot:
+- Waza `/check` run: gatekeeper acceptance review (fresh context, read-only) — verdict PASS; inventory claims verified against `git show e5fb55e1:`; independent repo-wide writer sweep confirmed the Phase A classification
+- Commands run: see Human Review Card; executed in the contract worktree at `24bfd715`
+- Manual checks: see Manual Check Evidence below
+- Supporting artifacts: `.ai/harness/checks/latest.json`; live Stop readback fixtures (worker + gatekeeper, cleaned after)
+- Implementation notes reviewed: yes — fifth-writer retirement under D9 revision authority, standalone-CLI correction (distributed helpers never receive src/), manifest fail-closed registration, thin-invoker choices per view, bash/TS divergence fixes
+- Run snapshot: `.ai/harness/runs/`
+
+## Manual Check Evidence
+
+- [x] Phase A inventory recorded with file:line evidence and reconciled verdicts before Phase B edits
+  - Evidence: contract Phase A section enumerates every writer/reader/trigger for the four views with file:line citations; gatekeeper spot-checked the load-bearing claims at the base revision (fifth-writer bootstrap at `workflow-state.sh:122-123`; TS reimplementation with the `workflow_write_handoff v1` copy-paste marker; `resumeAvailable()` marker mismatch at `session-context.ts:577-584`) — all real; the one D9 revision (fifth-writer retirement) is recorded with rationale.
+- [x] Live Stop dogfood: handoff/resume materialized from last checkpoint, evidence claims resolve to checkpoint, hand-edit overwritten
+  - Evidence: worker dogfood plus gatekeeper independent scratch-fixture readback (12/12): real `runStopHandler` over a seeded ledger materialized handoff/resume with provenance; the Evidence section cites the checkpoint published in the same Stop; a bare Stop now writes the `resumeAvailable()`-required marker + `## Resume Prompt` (pre-existing gap closed); hand-edited views fully overwritten by the next Stop.
+- [x] tasks/current.md untouched
+  - Evidence: `git diff e5fb55e1..HEAD -- tasks/current.md` is empty; `git status --porcelain` shows no entry for `tasks/current.md`.
 
 ## Acceptance Receipt Projection
 
@@ -55,30 +64,32 @@
 
 ## Behavior Diff Notes
 
-- ...
+- Recovery views (handoff, resume, Codex task-handoff payload) are now rendered by one materializer from the last-published checkpoint plus minimal workflow context, single-hop, with D8 provenance; the bash assembly, independent resume/packet authoring, and the fifth-writer placeholder bootstrap are deleted; Stop external semantics unchanged (four-target batch, counts, readiness ordering); a bare Stop now produces a resume that `session-context.ts` actually accepts.
 
 ## Residual Risks / Follow-ups
 
-- ...
+- Post-merge: refresh the local global repo-harness install (standard profile) so global-CLI strict checks regain the packaged helper; until then use repo-local scripts (EPC-05 discipline already in force).
+- Optional one-line contract amendment ratifying the two narrower test implementations (gatekeeper non-blocking observation).
+- EPC-09 carry-forwards unchanged (guarded seeds, downstream availability, 0.10.1 legacy writer).
 
 ## Scorecard
 
 | Dimension | Score | Notes |
 |-----------|-------|-------|
-| Functionality | 0/10 | |
-| Product depth | 0/10 | |
-| Design quality | 0/10 | |
-| Code quality | 0/10 | |
+| Functionality | 9/10 | Row-11 acceptance satisfied; fifth writer found and retired |
+| Product depth | 9/10 | Latent resumeAvailable gap closed by construction; divergences unified |
+| Design quality | 9/10 | Single-hop checkpoint→view; thin invokers keep host entrypoints without dual authority |
+| Code quality | 9/10 | 1813 green twice independently; mirrors byte-identical |
 
 ## Failing Items
 
-- ...
+- none
 
 ## Retest Steps
 
-- Re-run:
-- Re-check:
+- Re-run: `bun test tests/evidence-recovery-materializer.test.ts`; `bun test tests/stop-handler.test.ts`
+- Re-check: mirror `cmp` pairs; live bare-Stop resume marker
 
 ## Summary
 
-- ...
+- EPC-07 completes the recovery-view cutover per frozen D9: evidence-cited inventory (including an undeclared fifth writer, retired under D9's revision authority), one materializer per surviving view sourced single-hop from the EPC-06 checkpoint, retired writers deleted same-package with mirrors in lockstep, Stop external semantics untouched, and the pre-existing bare-Stop resume gap closed by construction. Gatekeeper verdict: PASS. Ready to ship as one PR.

--- a/tasks/reviews/20260722-2246-epc-07-recovery-view-cutover.review.md
+++ b/tasks/reviews/20260722-2246-epc-07-recovery-view-cutover.review.md
@@ -1,0 +1,84 @@
+# Task Review: epc-07-recovery-view-cutover
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260722-2246-epc-07-recovery-view-cutover.md
+> **Contract**: tasks/contracts/20260722-2246-epc-07-recovery-view-cutover.contract.md
+> **Notes File**: tasks/notes/20260722-2246-epc-07-recovery-view-cutover.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-07-22 22:46
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Commands passed:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+- Waza `/check` run:
+- Commands run:
+- Manual checks:
+- Supporting artifacts:
+- Implementation notes reviewed:
+- Run snapshot:
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -1,7 +1,7 @@
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: 2026-07-22 21:56
+> **Updated**: 2026-07-22 22:46
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.

--- a/tests/evidence-recovery-materializer.test.ts
+++ b/tests/evidence-recovery-materializer.test.ts
@@ -1,0 +1,355 @@
+import { describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { spawnSync } from "child_process";
+
+import type { SubjectIdentity, TrustClass } from "../src/core/evidence/types";
+import { appendEvidenceEvent, appendGenesisRecord } from "../src/effects/evidence/event-log";
+import { LEDGER_EPOCH_START_SHA } from "../src/effects/evidence/epoch";
+import { publishCheckpointFromLedger } from "../src/effects/evidence/checkpoint-store";
+import {
+  buildRecoveryContext,
+  renderRecoveryHandoff,
+  renderRecoveryResume,
+  resolveRecoveryEvidence,
+} from "../src/effects/evidence/recovery-materializer";
+
+const REPO_ROOT = join(import.meta.dir, "..");
+const SUBJECT_A = `sha256:${"a".repeat(64)}`;
+const FIXED_NOW = () => new Date("2026-07-22T22:00:00.000Z");
+
+function withTempRepo(prefix: string, fn: (repoRoot: string) => void): void {
+  const repoRoot = mkdtempSync(join(tmpdir(), `${prefix}-`));
+  try {
+    mkdirSync(join(repoRoot, ".ai/harness"), { recursive: true });
+    writeFileSync(join(repoRoot, ".ai/harness/policy.json"), "{}\n");
+    fn(repoRoot);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+}
+
+function baseIdentity(overrides: Partial<SubjectIdentity> = {}): SubjectIdentity {
+  return {
+    authority_commit: "a".repeat(40),
+    base_commit: "b".repeat(40),
+    target_commit: "c".repeat(40),
+    scope_hash: `sha256:${"d".repeat(64)}`,
+    subject_hash: SUBJECT_A,
+    contract_hash: `sha256:${"f".repeat(64)}`,
+    command_hash: `sha256:${"0".repeat(64)}`,
+    env_provider_id: "repo-harness/0.0.0/ws-test",
+    ...overrides,
+  };
+}
+
+function seedGenesis(repoRoot: string, worktreeId = "fixture"): void {
+  appendGenesisRecord(repoRoot, LEDGER_EPOCH_START_SHA, { worktreeId });
+}
+
+function seedEvent(
+  repoRoot: string,
+  opts: {
+    readonly worktreeId?: string;
+    readonly eventType?: string;
+    readonly trustClass?: TrustClass;
+    readonly marker?: string;
+  } = {},
+) {
+  return appendEvidenceEvent(repoRoot, {
+    worktreeId: opts.worktreeId ?? "fixture",
+    eventType: opts.eventType ?? "verify_sprint.result",
+    trustClass: opts.trustClass ?? "authoritative_machine",
+    producer: "verify-sprint",
+    correlationRunId: `run-${Math.random().toString(36).slice(2)}`,
+    subjectIdentity: baseIdentity(),
+    payload: { kind: "json", value: { marker: opts.marker ?? "default" } },
+  });
+}
+
+function run(cmd: string, args: string[], cwd: string, env?: NodeJS.ProcessEnv) {
+  return spawnSync(cmd, args, { cwd, encoding: "utf-8", env: { ...process.env, ...env } });
+}
+
+describe("recovery-materializer: determinism", () => {
+  test("same context + evidence + injected clock renders byte-identical handoff and resume", () => {
+    withTempRepo("recovery-determinism", (repoRoot) => {
+      const context = buildRecoveryContext(repoRoot, null, {}, { reason: "unit-test", now: FIXED_NOW });
+      const evidence = resolveRecoveryEvidence(repoRoot);
+
+      const handoffA = renderRecoveryHandoff(context, evidence, "");
+      const handoffB = renderRecoveryHandoff(context, evidence, "");
+      const resumeA = renderRecoveryResume(context, evidence, "");
+      const resumeB = renderRecoveryResume(context, evidence, "");
+
+      expect(handoffA).toBe(handoffB);
+      expect(resumeA).toBe(resumeB);
+    });
+  });
+
+  test("a different injected clock changes the rendered generated-at text (and, since the display timestamp is part of the hashed body, its content_hash) but not the rest of the workflow-context fields", () => {
+    withTempRepo("recovery-determinism-clock", (repoRoot) => {
+      const env = { HOOK_RUN_ID: "fixed-run-id" };
+      const contextA = buildRecoveryContext(repoRoot, null, env, { reason: "unit-test", now: FIXED_NOW });
+      const contextB = buildRecoveryContext(repoRoot, null, env, { reason: "unit-test", now: () => new Date("2026-07-23T00:00:00.000Z") });
+      const evidence = resolveRecoveryEvidence(repoRoot);
+
+      const handoffA = renderRecoveryHandoff(contextA, evidence, "");
+      const handoffB = renderRecoveryHandoff(contextB, evidence, "");
+      expect(handoffA).not.toBe(handoffB);
+      expect(contextA.runId).toBe(contextB.runId);
+      // Every workflow-context field besides the two rendered timestamps
+      // (the "Generated" display line and the Provenance "Generated at"/
+      // "Content hash" lines) is identical -- the clock only ever touches
+      // its own rendered text and the hash that covers it.
+      const strip = (text: string) => text
+        .replace(/^> \*\*Generated\*\*:.*$/m, "")
+        .replace(/^- Generated at:.*$/m, "")
+        .replace(/^- Content hash:.*$/m, "");
+      expect(strip(handoffA)).toBe(strip(handoffB));
+    });
+  });
+});
+
+describe("recovery-materializer: evidence (single hop: checkpoint -> view)", () => {
+  test("no checkpoint published yet renders a typed minimal state, never a fabricated claim", () => {
+    withTempRepo("recovery-no-checkpoint", (repoRoot) => {
+      const evidence = resolveRecoveryEvidence(repoRoot);
+      expect(evidence.available).toBe(false);
+      if (!evidence.available) expect(evidence.reason).toBe("no-checkpoint");
+
+      const context = buildRecoveryContext(repoRoot, null, {}, { reason: "unit-test", now: FIXED_NOW });
+      const handoff = renderRecoveryHandoff(context, evidence, "");
+      expect(handoff).toContain("- Checkpoint: (none published yet -- no ledger evidence recorded in this worktree)");
+      expect(handoff).toContain("- Covered events: 0");
+      expect(handoff).not.toContain("chk-");
+    });
+  });
+
+  test("a dangling/invalid checkpoint marker degrades to the same typed unavailable shape, never throws", () => {
+    withTempRepo("recovery-invalid-checkpoint", (repoRoot) => {
+      mkdirSync(join(repoRoot, ".ai/harness/evidence/checkpoints"), { recursive: true });
+      writeFileSync(
+        join(repoRoot, ".ai/harness/evidence/checkpoints/last-published.json"),
+        `${JSON.stringify({ schema_version: 1, checkpoint_id: "chk-missing", checkpoint_dir: "x", machine_path: "does/not/exist.json", human_path: "does/not/exist.md", content_hash: "sha256:0", published_at: "now" })}\n`,
+      );
+
+      let evidence: ReturnType<typeof resolveRecoveryEvidence>;
+      expect(() => {
+        evidence = resolveRecoveryEvidence(repoRoot);
+      }).not.toThrow();
+      evidence = resolveRecoveryEvidence(repoRoot);
+      expect(evidence.available).toBe(false);
+      if (!evidence.available) expect(evidence.reason).toBe("checkpoint-invalid");
+
+      const context = buildRecoveryContext(repoRoot, null, {}, { reason: "unit-test", now: FIXED_NOW });
+      const handoff = renderRecoveryHandoff(context, evidence, "");
+      expect(handoff).toContain("- Checkpoint: (unavailable");
+    });
+  });
+
+  test("a real published checkpoint's covered events and latest-by-type surface as the view's evidence claims", () => {
+    withTempRepo("recovery-real-checkpoint", (repoRoot) => {
+      seedGenesis(repoRoot);
+      const event = seedEvent(repoRoot, { marker: "authoritative" });
+      const published = publishCheckpointFromLedger(repoRoot, FIXED_NOW);
+      expect(published.status).toBe("published");
+
+      const evidence = resolveRecoveryEvidence(repoRoot);
+      expect(evidence.available).toBe(true);
+      if (!evidence.available) throw new Error("unreachable");
+      expect(evidence.coveredEventCount).toBe(1);
+      expect(evidence.sourceEventIds).toEqual([event.event_id]);
+
+      const context = buildRecoveryContext(repoRoot, null, {}, { reason: "unit-test", now: FIXED_NOW });
+      const handoff = renderRecoveryHandoff(context, evidence, "");
+      expect(handoff).toContain(`- Checkpoint: ${evidence.checkpointId}`);
+      expect(handoff).toContain(`verify_sprint.result: ${event.event_id}`);
+      expect(handoff).toContain("## Provenance");
+      expect(handoff).toContain(`- Source checkpoint id: ${evidence.checkpointId}`);
+      expect(handoff).toContain("- Content hash: sha256:");
+    });
+  });
+});
+
+describe("recovery-materializer: resume view carries the preserved external-observable contract", () => {
+  test("resume keeps the legacy marker and a Resume Prompt header the EPC-08 SessionStart reader depends on", () => {
+    withTempRepo("recovery-resume-contract", (repoRoot) => {
+      const context = buildRecoveryContext(repoRoot, null, {}, { reason: "unit-test", now: FIXED_NOW });
+      const evidence = resolveRecoveryEvidence(repoRoot);
+      const resume = renderRecoveryResume(context, evidence, "");
+      expect(resume).toContain("<!-- generated-by: repo-harness codex-handoff-resume v1 -->");
+      expect(resume).toContain("## Resume Prompt");
+      expect(resume).toContain("## Provenance");
+    });
+  });
+});
+
+describe("recovery-view-cli.ts: standalone end-to-end", () => {
+  function initGitRepo(cwd: string): void {
+    expect(run("git", ["init", "-q", "-b", "main"], cwd).status).toBe(0);
+    expect(run("git", ["config", "user.email", "test@example.com"], cwd).status).toBe(0);
+    expect(run("git", ["config", "user.name", "Test"], cwd).status).toBe(0);
+  }
+
+  test("materializes handoff and resume, and a hand edit is fully overwritten by the next run", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "recovery-cli-e2e-"));
+    try {
+      initGitRepo(cwd);
+      mkdirSync(join(cwd, ".ai/harness"), { recursive: true });
+      mkdirSync(join(cwd, "tasks"), { recursive: true });
+      writeFileSync(join(cwd, "tasks/todos.md"), "");
+      writeFileSync(join(cwd, "README.md"), "hello\n");
+      expect(run("git", ["add", "-A"], cwd).status).toBe(0);
+      expect(run("git", ["commit", "-q", "-m", "init"], cwd).status).toBe(0);
+
+      const first = run("bun", [join(REPO_ROOT, "scripts/recovery-view-cli.ts"), "--cwd", cwd, "--reason", "first-run"], cwd);
+      expect(first.status).toBe(0);
+      const handoffPath = join(cwd, ".ai/harness/handoff/current.md");
+      const resumePath = join(cwd, ".ai/harness/handoff/resume.md");
+      expect(existsSync(handoffPath)).toBe(true);
+      expect(existsSync(resumePath)).toBe(true);
+      const firstHandoff = readFileSync(handoffPath, "utf-8");
+      expect(firstHandoff).toContain("**Reason**: first-run");
+      expect(firstHandoff).toContain("## Provenance");
+
+      // Hand-edit: a stale/divergent hand-written recovery projection.
+      writeFileSync(handoffPath, "# HAND EDITED -- SHOULD NOT SURVIVE\n");
+      writeFileSync(resumePath, "# HAND EDITED -- SHOULD NOT SURVIVE\n");
+
+      const second = run("bun", [join(REPO_ROOT, "scripts/recovery-view-cli.ts"), "--cwd", cwd, "--reason", "second-run"], cwd);
+      expect(second.status).toBe(0);
+      const secondHandoff = readFileSync(handoffPath, "utf-8");
+      const secondResume = readFileSync(resumePath, "utf-8");
+      expect(secondHandoff).not.toContain("HAND EDITED");
+      expect(secondResume).not.toContain("HAND EDITED");
+      expect(secondHandoff).toContain("**Reason**: second-run");
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test("--print-prompt prints only the Resume Prompt body and writes no output besides the recovery views", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "recovery-cli-print-prompt-"));
+    try {
+      mkdirSync(join(cwd, ".ai/harness"), { recursive: true });
+      mkdirSync(join(cwd, "tasks"), { recursive: true });
+      writeFileSync(join(cwd, "tasks/todos.md"), "");
+
+      const result = run("bun", [join(REPO_ROOT, "scripts/recovery-view-cli.ts"), "--cwd", cwd, "--reason", "prompt-test", "--print-prompt"], cwd);
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("fresh Codex session");
+      expect(result.stdout).not.toContain("## Source Artifacts");
+      expect(result.stdout).not.toContain("## Provenance");
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test("--with-global-packet updates the Codex-global handoff file with a per-repo spliced section", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "recovery-cli-global-"));
+    const codexHome = mkdtempSync(join(tmpdir(), "recovery-cli-codex-home-"));
+    try {
+      mkdirSync(join(cwd, ".ai/harness"), { recursive: true });
+      mkdirSync(join(cwd, "tasks"), { recursive: true });
+      writeFileSync(join(cwd, "tasks/todos.md"), "");
+
+      const result = run(
+        "bun",
+        [join(REPO_ROOT, "scripts/recovery-view-cli.ts"), "--cwd", cwd, "--reason", "global-test", "--with-global-packet"],
+        cwd,
+        { CODEX_HOME: codexHome },
+      );
+      expect(result.status).toBe(0);
+      const handoffs = readdirSync(join(codexHome, "handoffs")).filter((name) => /^handoff-\d{6}\.md$/.test(name));
+      expect(handoffs.length).toBe(1);
+      const global = readFileSync(join(codexHome, "handoffs", handoffs[0]), "utf-8");
+      expect(global).toContain("Filesystem-first fallback handoffs");
+      expect(global).toContain("### Repo Handoff");
+      expect(global).toContain("### Resume Packet");
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+      rmSync(codexHome, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("no-independent-authoring: the retired writers carry zero content assembly", () => {
+  const CANDIDATE_FILES = [
+    ".ai/hooks/lib/workflow-state.sh",
+    "assets/hooks/lib/workflow-state.sh",
+    "scripts/codex-handoff-resume.sh",
+    "assets/templates/helpers/codex-handoff-resume.sh",
+    "scripts/prepare-codex-handoff.sh",
+    "assets/templates/helpers/prepare-codex-handoff.sh",
+  ];
+
+  test("the retired heredoc content-assembly markers no longer appear in any thinned writer", () => {
+    const retiredMarkers = [
+      "<<EOF_HANDOFF",
+      "<<EOF_RESUME",
+      "generated-by: workflow_write_handoff v1",
+    ];
+    for (const relPath of CANDIDATE_FILES) {
+      const text = readFileSync(join(REPO_ROOT, relPath), "utf-8");
+      for (const marker of retiredMarkers) {
+        expect(text.includes(marker)).toBe(false);
+      }
+    }
+  });
+
+  test("the thinned writers delegate to the single standalone materializer and nowhere else", () => {
+    for (const relPath of CANDIDATE_FILES) {
+      const text = readFileSync(join(REPO_ROOT, relPath), "utf-8");
+      expect(text).toContain("recovery-view-cli");
+    }
+  });
+
+  test("scripts/recovery-view-cli.ts and its packaged mirror stay byte-identical", () => {
+    const canonical = readFileSync(join(REPO_ROOT, "scripts/recovery-view-cli.ts"), "utf-8");
+    const mirrored = readFileSync(join(REPO_ROOT, "assets/templates/helpers/recovery-view-cli.ts"), "utf-8");
+    expect(mirrored).toBe(canonical);
+  });
+
+  test("workflow_ensure_harness_surface no longer bootstraps handoff/resume placeholder content", () => {
+    const text = readFileSync(join(REPO_ROOT, "assets/hooks/lib/workflow-state.sh"), "utf-8");
+    const start = text.indexOf("workflow_ensure_harness_surface() {");
+    const end = text.indexOf("\n}\n", start);
+    const body = text.slice(start, end);
+    expect(body).not.toContain("Harness Handoff");
+    expect(body).not.toContain("Codex Resume Packet");
+  });
+});
+
+describe("tasks/current.md: refresh-current-status.sh stays the sole materializer (drift check)", () => {
+  test("two independent non-mutating preview regenerations agree byte-for-byte modulo the volatile updated_at timestamp", () => {
+    // Non-mutating: no --write, so this never touches the tracked file --
+    // deliberately not compared against tasks/current.md itself, which is
+    // a point-in-time snapshot only refreshed at explicit lifecycle
+    // boundaries (root CLAUDE.md) and is legitimately stale mid-task; the
+    // regenerate -> compare drift check instead proves the materializer
+    // itself is stable across repeated regenerations of the same live
+    // source-of-truth artifacts, the actual no-drift property this row
+    // requires.
+    const first = run("bash", ["scripts/refresh-current-status.sh"], REPO_ROOT);
+    const second = run("bash", ["scripts/refresh-current-status.sh"], REPO_ROOT);
+    expect(first.status).toBe(0);
+    expect(second.status).toBe(0);
+    expect(first.stdout).toContain("<!-- generated-by: repo-harness refresh-current-status v1 -->");
+
+    const strip = (text: string) => text
+      .replace(/^<!-- updated_at:.*$/m, "")
+      .replace(/^> \*\*Updated At\*\*:.*$/m, "");
+    expect(strip(first.stdout)).toBe(strip(second.stdout));
+  });
+});

--- a/tests/helper-scripts.test.ts
+++ b/tests/helper-scripts.test.ts
@@ -4168,7 +4168,12 @@ describe("Workflow helper scripts", () => {
       expect(handoff).toContain("Plan: plans/plan-20260327-2200-alpha.md");
       expect(handoff).toContain("Contract: tasks/contracts/alpha.contract.md");
       expect(handoff).toContain("Checks: .ai/harness/checks/latest.json");
-      expect(handoff).toContain("Latest trace/checks file:");
+      // EPC-07: the old "Latest trace/checks file:" line re-derived evidence
+      // directly from checks/latest.json content (a single-hop violation this
+      // package fixes); the recovery materializer's "## Evidence" section now
+      // sources only from the checkpoint, rendering a typed minimal state when
+      // none is published yet (this fixture seeds no ledger/checkpoint).
+      expect(handoff).toContain("- Checkpoint: (none published yet -- no ledger evidence recorded in this worktree)");
       expect(handoff).toContain("## Active Artifacts");
       expect(handoff).toContain("Active sprint row:");
       expect(handoff).toContain("Alpha handoff");

--- a/tests/stop-handler.test.ts
+++ b/tests/stop-handler.test.ts
@@ -108,7 +108,7 @@ describe('runStopHandler', () => {
     expect(readFileSync(join(cwd, '.ai/harness/handoff/current.md'), 'utf8')).not.toContain('Minimal Change Review');
   });
 
-  test('preserves the recovery projection fields owned by workflow_write_handoff', () => {
+  test('preserves the recovery projection workflow-context fields (EPC-07: content source moved to the recovery materializer; two evidence-shaped assertions below updated -- see contract Phase A)', () => {
     const cwd = fixture();
     const plan = 'plans/plan-20260720-0000-projection.md';
     const contract = 'tasks/contracts/20260720-0000-projection.contract.md';
@@ -146,13 +146,23 @@ describe('runStopHandler', () => {
     expect(handoff).toContain('Continue task checklist sourced from plans/source-plan.md.');
     expect(handoff).toContain(`- Active sprint row: | 6 | hrd-06 | ${plan} |`);
     expect(handoff).toContain('- {"command":"one"}\n- {"command":"two"}');
-    expect(handoff).toContain('- Latest trace: .ai/harness/runs/verified.json');
+    // EPC-07: the old "Latest trace" line re-derived evidence directly from
+    // checks/latest.json content (a single-hop violation this package fixes);
+    // the recovery materializer's "## Evidence" section now sources only from
+    // the checkpoint, rendering a typed minimal state when none is published
+    // yet (this fixture seeds no ledger/checkpoint).
+    expect(handoff).toContain('- Checkpoint: (none published yet -- no ledger evidence recorded in this worktree)');
     expect(handoff).toContain('continue the next Task Breakdown item: preserve the real next action');
     expect(handoff).toContain('- Next action stage: task');
     expect(handoff).toContain('- Supersedes: plans/superseded.md');
     expect(handoff).toContain('- Todo Source Plan: plans/source-plan.md');
     const resume = readFileSync(join(cwd, '.ai/harness/handoff/resume.md'), 'utf8');
-    expect(resume).toContain('<!-- generated-by: workflow_write_handoff v1 -->');
+    // EPC-07: resume.md is now the single merged materializer output (the
+    // two-tier minimal/elaborate split is retired); the legacy elaborate-resume
+    // marker is preserved verbatim as the stable external-observable contract
+    // session-context.ts's resumeAvailable() already depends on (see contract).
+    expect(resume).toContain('<!-- generated-by: repo-harness codex-handoff-resume v1 -->');
+    expect(resume).toContain('## Provenance');
     const event = JSON.parse(readFileSync(join(cwd, '.ai/harness/events.jsonl'), 'utf8'));
     expect(event.extra.source_plan).toBe('plans/source-plan.md');
   });

--- a/tests/workflow-state-lib.test.ts
+++ b/tests/workflow-state-lib.test.ts
@@ -159,7 +159,11 @@ describe("workflow-state shared library", () => {
     expect(content).toContain("has_research_for_new_plan()");
     expect(content).toContain("validate_plan_transition()");
     expect(content).toContain("contract_references_path()");
-    expect(content).toContain("next_action=\"$(workflow_next_action)\"");
+    // EPC-07: workflow_write_handoff's own `next_action="$(workflow_next_action)"`
+    // call site was retired along with the rest of its independent
+    // handoff/resume content assembly (now scripts/recovery-view-cli.ts's
+    // job); workflow_next_action() the function definition is still
+    // asserted two lines above and remains a callable library export.
     expect(content).toContain("## Task Breakdown");
   });
 


### PR DESCRIPTION
Sprint C backlog row 11, per frozen decisions D8/D9 (+ row-10 D8 ratification). Second-largest authority cutover of the Program.

**Phase A inventory** (contract-recorded with file:line evidence, verified by gatekeeper at the base revision): the TS Stop handler was a full reimplementation of the bash writer (copy-paste marker artifact); bare Stop wrote a minimal resume that `session-context.ts` `resumeAvailable()` rejected (pre-existing latent gap); an undeclared FIFTH writer (`workflow_ensure_harness_surface` placeholder bootstrap) found and retired same-package under D9's revision authority, matching the EPC-05 bootstrap precedent; six other candidate writers classified out of scope with rationale.

**Phase B cutover**:
- `src/effects/evidence/recovery-materializer.ts`: one materializer renders handoff + merged resume + Codex task-handoff payload from the last-published checkpoint (fail-closed reader) + minimal workflow context — evidence claims single-hop from the checkpoint (zero direct reads of checks/* or the ledger), D8 provenance per output, deterministic.
- Standalone `scripts/recovery-view-cli.ts` (no src/ imports — distributed helpers never receive src/) + helper-mirror + manifest registration (sync fails closed on unregistered helpers).
- Retired writers deleted/thinned with canonical+projection+digest lockstep: bash `workflow_write_handoff` assembly excised; `codex-handoff-resume.sh` / `prepare-codex-handoff.sh` reduced to thin invokers (zero independent assembly); fifth-writer bootstrap lines deleted.
- Stop external semantics frozen (four-target batch, counts, readiness ordering unmodified); a bare Stop now writes a resume `resumeAvailable()` accepts — the latent gap closed by construction. Two pre-existing bash/TS divergences (legacy-slug path fallback, shortstat wording) unified.
- 14 red-first tests + three documented characterization updates.

Verification: full `bun test` 1813 pass / 0 fail / 1 skip (worker + gatekeeper independent runs); type-check clean; preflight pass; live Stop readbacks 12/12 (worker + gatekeeper independent fixtures). Acceptance: gatekeeper PASS; external_pass receipt against materialized evidence.

Post-merge note: the globally installed 0.10.1 CLI lacks the newly registered packaged helper — refresh the global install (standard profile) after merge; repo-local scripts unaffected.