### PR TITLE
EPC-08: Context Packet cutover — canonical projections + 27-state panel gate

### DIFF
--- a/plans/plan-20260723-0024-epc-08-context-packet-cutover.md
+++ b/plans/plan-20260723-0024-epc-08-context-packet-cutover.md
@@ -1,0 +1,277 @@
+# Plan: EPC-08: Context Packet Cutover
+
+> **Status**: Executing
+> **Created**: 20260723-0024
+> **Slug**: epc-08-context-packet-cutover
+> **Planning Source**: repo-harness-sprint
+> **Orchestration Kind**: host-plan
+> **Source Ref**: sprint:plans/sprints/20260722-0001-evidence-projection-convergence.sprint.md#epc-08
+> **Artifact Level**: work-package
+> **Promotion Reason**: verification_boundary
+> **Verification Boundary**: 27-state Authority×Profile panel measured with the frozen token gates (every sample estimated_tokens <= 1500 and within_budget, panel p95 <= 700, method utf8_bytes_div_4), per-sample table committed; no-independent-assembly test proves the old path is gone; full bun test green
+> **Rollback Surface**: Revert the single PR: restores the independent assembly reads and removes the projection sourcing + panel runner; budget mechanics unchanged either way
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260723-0024-epc-08-context-packet-cutover.contract.md`
+> **Task Review**: `tasks/reviews/20260723-0024-epc-08-context-packet-cutover.review.md`
+> **Implementation Notes**: `tasks/notes/20260723-0024-epc-08-context-packet-cutover.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from repo-harness-sprint planning output.
+- Source ref: sprint:plans/sprints/20260722-0001-evidence-projection-convergence.sprint.md#epc-08
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260723-0024-epc-08-context-packet-cutover.md`
+- Sprint contract: `tasks/contracts/20260723-0024-epc-08-context-packet-cutover.contract.md`
+- Sprint review: `tasks/reviews/20260723-0024-epc-08-context-packet-cutover.review.md`
+- Implementation notes: `tasks/notes/20260723-0024-epc-08-context-packet-cutover.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260723-0024-epc-08-context-packet-cutover.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260723-0024-epc-08-context-packet-cutover.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260723-0024-epc-08-context-packet-cutover.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260723-0024-epc-08-context-packet-cutover.contract.md`
+- Review file: `tasks/reviews/20260723-0024-epc-08-context-packet-cutover.review.md`
+- Implementation notes file: `tasks/notes/20260723-0024-epc-08-context-packet-cutover.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260723-0024-epc-08-context-packet-cutover.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260723-0024-epc-08-context-packet-cutover.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: Revert the single PR: restores the independent assembly reads and removes the projection sourcing + panel runner; budget mechanics unchanged either way
+- **Verification boundary**: 27-state Authority×Profile panel measured with the frozen token gates (every sample estimated_tokens <= 1500 and within_budget, panel p95 <= 700, method utf8_bytes_div_4), per-sample table committed; no-independent-assembly test proves the old path is gone; full bun test green
+- **Review/acceptance boundary**: `tasks/reviews/20260723-0024-epc-08-context-packet-cutover.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: verification_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260723-0024-epc-08-context-packet-cutover.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260723-0024-epc-08-context-packet-cutover.contract.md`, `tasks/reviews/20260723-0024-epc-08-context-packet-cutover.review.md`, and `tasks/notes/20260723-0024-epc-08-context-packet-cutover.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260723-0024-epc-08-context-packet-cutover.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: Revert the single PR: restores the independent assembly reads and removes the projection sourcing + panel runner; budget mechanics unchanged either way
+
+## Captured Planning Output
+
+> **Task Profile**: code-change
+
+## Decision Summary
+
+EPC-08 implements Sprint C backlog row 12 (acceptance line as amended by
+EPC-00): the SessionStart Context Packet is served from canonical
+projections — the EPC-06/07 checkpoint-backed recovery views, the EPC-05
+materialized `checks/latest`, and the tracked `tasks/current.md`
+projection — instead of its own independent assembly reads; the old
+assembly path is deleted same-package (R5). Acceptance is machine-checked
+against the EPC-00-frozen token gate: across the 27-state
+Authority×Profile panel (9 authority states × 3 profiles), every sample
+has `estimated_tokens <= 1500` with `within_budget == true`, and panel
+`p95(estimated_tokens) <= 700`, method `utf8_bytes_div_4`, with the
+per-sample table committed in the package's measurement report. Base SHA
+pinned per R1 at fresh fetch: `9ea195b99db26895821e9ee3e29ad2f460895649`
+(post-EPC-07 merge + row flip + global CLI refresh commit state).
+
+## Why
+
+The Context Packet is the last consumer still assembling recovery/evidence
+state from primary sources on its own: HRD-04 consolidated it to one
+budgeted render, but its content still comes from ad-hoc reads that can
+diverge from what the canonical projections say. With checkpoint-backed
+views (EPC-07), materialized checks (EPC-05), and the tracked status
+snapshot as the only authorities, SessionStart must become a projection
+consumer, or it remains a shadow re-derivation the audit's trust model
+forbids.
+
+## Goal
+
+1. Inventory the current SessionStart Context Packet assembly
+   (`src/cli/hook/session-context.ts` and its collaborators): every
+   source it reads today, classified as (a) canonical projection
+   (keep, read via the projection), (b) primary-source re-derivation
+   (cut over to the corresponding projection), or (c) live session
+   context that is not evidence/recovery state (legitimate direct read
+   — e.g. current git branch identity; enumerate and justify each).
+   Record in the contract before cutover edits.
+2. Cutover: evidence and recovery content in the packet is served from
+   canonical projections only — the EPC-07 recovery views / EPC-06
+   checkpoint reader for evidence claims, `checks/latest` (materialized)
+   for verification state, `tasks/current.md` for the derived status
+   snapshot. The replaced independent assembly reads are deleted in this
+   package. `SESSION_CONTEXT_TOKEN_BUDGET = 1500` and the
+   `utf8_bytes_div_4` estimator stay the binding budget mechanics
+   (unchanged surface).
+3. Panel measurement: implement/extend a measurement runner (following
+   the existing `scripts/hook-dispatch-diet-report.ts` percentile/SLO
+   machinery) that renders the SessionStart Context Packet across the
+   27-state panel — authority states {no plan, draft plan, approved
+   work package, executing, completed, foreign worktree, missing/corrupt
+   policy, invalid capability registry, conflicting active markers} ×
+   profiles {Lite, Standard, Strict} — one deterministic sample per
+   state, recording `estimated_tokens` and `within_budget` per sample.
+   Gate: every sample <= 1500 and `within_budget == true`; panel
+   p95 <= 700. SessionStart latency reported descriptively (>= 20
+   iterations per state), not gated (EPC-00 confirmation).
+4. Measurement report: the per-sample table (27 rows: state, profile,
+   estimated_tokens, within_budget, p50/p95 latency) plus the two gate
+   numbers, committed as this package's tracked report artifact
+   (`tasks/reviews/` measurement appendix or a dedicated report file
+   under the package's notes surface — exact placement recorded in the
+   contract).
+5. Old assembly path deleted same-package: the replaced reads/renderers
+   removed; a no-independent-assembly test (grep/behavioral) proves the
+   packet's evidence/recovery sections cannot be produced from primary
+   sources anymore.
+6. Characterization suites stay green with only documented updates where
+   they asserted the deleted assembly internals; session-context budget
+   evidence file (`session-context-budget.json`) semantics unchanged.
+7. All root required checks green; full `bun test` green; one
+   independent PR on `codex/epc-08-context-packet-cutover`.
+
+## P1: Architecture Map
+
+- Design authority: EPC-00's amended row-12 acceptance line (panel, both
+  token gates, method) and frozen D4 (projections carry no independent
+  trust — the packet may cite, never re-derive); EPC-05/06/07 surfaces
+  consumed read-only via their public readers.
+- Owned surface: `src/cli/hook/session-context.ts` (+ its direct
+  assembly collaborators identified in Goal 1), the measurement runner
+  script, tests. The Stop path, recovery materializer, and checkpoint
+  modules are not modified.
+- The 27-state fixtures likely exist in prior HRD/LSC characterization
+  suites (Authority×Profile matrix) — reuse/extend those fixture
+  builders rather than inventing a parallel state factory; cite what is
+  reused.
+
+## P2: Concrete Trace
+
+EPC-07 merges -> `main` at `9ea195b9` -> EPC-08 fresh-fetches, pins it
+(R1) -> worktree opens on `codex/epc-08-context-packet-cutover` ->
+assembly inventory recorded -> cutover lands with old path deleted ->
+panel runner measures 27 states -> report committed with per-sample
+table; both token gates pass -> full suite green -> receipt via worktree
+scripts -> one PR merges -> EPC-09 pins its base per R1.
+
+## P3: Design Decision
+
+- The packet remains a renderer with a hard budget; what changes is the
+  provenance of its content (projections in, primary sources out). Live
+  session identity (branch, worktree path, host) is not evidence and
+  stays a direct read — the trust model governs evidence claims, not
+  every string.
+- One deterministic sample per panel state (not repeated-iteration token
+  percentiles): packet content is deterministic per state (EPC-00
+  confirmation); latency, which is not deterministic, gets the >= 20
+  iteration descriptive treatment.
+- The measurement report is a tracked package artifact so EPC-09's
+  closeout can cite measured numbers without re-running the panel.
+
+## Task Breakdown
+
+- [ ] Verify fresh fetch equals pinned base `9ea195b9`; fill contract.
+- [ ] Assembly inventory (keep/cutover/legitimate-direct classification)
+      recorded in the contract.
+- [ ] Cutover edits + old-path deletion (red-first where feasible).
+- [ ] Panel measurement runner + 27-state fixtures.
+- [ ] Report with per-sample table; both token gates green.
+- [ ] Required checks; commit; receipt via worktree scripts; PR.
+
+## Scope
+
+- In scope: `src/cli/hook/session-context.ts` and the direct assembly
+  collaborators the inventory names (each listed in the contract's
+  allowed_paths before editing); the panel measurement runner script
+  (new or extension of the existing diet-report harness); panel fixtures;
+  `tests/` files for the cutover + panel; the tracked measurement report
+  artifact; this package's plan/contract/review/notes; `tasks/todos.md`
+  projection; `.ai/harness/worktrees/epc-08-context-packet-cutover.json`.
+- Out of scope: Stop handler, recovery materializer, checkpoint modules,
+  checks materializer, producers/importers (EPC-02..07 surfaces);
+  `SESSION_CONTEXT_TOKEN_BUDGET` value or estimator method changes;
+  `tasks/current.md`; the sprint document; any new npm dependency.
+- Non-goals: latency gating (descriptive only); benchmark subject
+  surfaces (R2 list) — none of them are touched.
+
+## Stop Conditions
+
+- Stop if `origin/main` moves past `9ea195b9` before worktree creation.
+- Stop if a panel state cannot reach the token gates without content
+  redesign beyond projection sourcing — report with the measured
+  numbers for an orchestrator ruling (the gate numbers are frozen; the
+  content knife is a design decision).
+- Stop if the inventory shows the packet needs a projection that does
+  not exist yet (missing canonical surface) — report, do not invent a
+  new authority.
+- Stop after three fail-fix-reverify rounds on one issue.
+
+## Falsifier
+
+The direction is wrong if the packet cannot be served from canonical
+projections without exceeding the frozen token gates (projection content
+too heavy), or if a required packet section has no canonical source.
+Cheapest proof: the 27-row panel table with every sample <= 1500 /
+within_budget and p95 <= 700, produced by the committed runner against
+the cutover code.
+
+## Cheapest Sufficient Proof
+
+- Fresh fetch equals `9ea195b9` at pin time; contract records it.
+- Panel report committed: 27 rows, both gates green, method
+  `utf8_bytes_div_4`.
+- Old-path deletion proven by the no-independent-assembly test.
+- Full `bun test` green; root checks green in the worktree.
+- `git diff --name-only <base>..HEAD` ⊆ `allowed_paths`.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [ ] Verify fresh fetch equals pinned base `9ea195b9`; fill contract.
+- [ ] Assembly inventory (keep/cutover/legitimate-direct classification)
+- [ ] Cutover edits + old-path deletion (red-first where feasible).
+- [ ] Panel measurement runner + 27-state fixtures.
+- [ ] Report with per-sample table; both token gates green.
+- [ ] Required checks; commit; receipt via worktree scripts; PR.

--- a/scripts/session-context-packet-panel.ts
+++ b/scripts/session-context-packet-panel.ts
@@ -1,0 +1,554 @@
+#!/usr/bin/env bun
+/**
+ * EPC-08 Context Packet panel measurement runner.
+ *
+ * Renders the full SessionStart Context Packet -- exactly as a live host
+ * receives it: the `effective-state` section, the post-edit-journal
+ * section, and the three `buildSessionStartSections()` sections, all
+ * budgeted by the existing `budgetSessionContext` -- across a 27-state
+ * Authority×Profile panel (9 authority states x {lite, standard, strict}
+ * profiles) via the real `bun src/cli/hook-entry.ts SessionStart --route
+ * default` subprocess. One deterministic sample per state is recorded for
+ * the two EPC-00-frozen token gates: every sample's `estimated_tokens <=
+ * SESSION_CONTEXT_TOKEN_BUDGET` (1500) with `within_budget == true`, and
+ * panel `p95(estimated_tokens) <= 700` -- both computed over the token
+ * counts themselves, method `utf8_bytes_div_4`. SessionStart LATENCY is
+ * reported purely descriptively (>=20 iterations per state, p50/p95 ms)
+ * and carries no gate at all -- EPC-00 confirmation: "the audit sets no
+ * SessionStart-latency gate, so EPC-08 gates only on the two token
+ * numbers."
+ *
+ * Sibling to `scripts/hook-dispatch-diet-report.ts` (HRD-08): this script
+ * mirrors, rather than imports, that script's `percentile()` /
+ * `utf8_bytes_div_4` token-estimator / synthetic-subprocess-probe shape,
+ * since none of those are exported from that file and this repo's own
+ * convention is to duplicate small cross-boundary helpers rather than
+ * import them (see `recovery-materializer.ts` / `checks-materializer.ts`'s
+ * own module docs for the same "necessarily duplicated, not imported"
+ * reasoning). The `>=20` iteration default mirrors HRD-08's own
+ * `HRD08_CHARACTERIZATION_CYCLES=20` characterization-cycle precedent.
+ *
+ * `SESSION_CONTEXT_TOKEN_BUDGET` itself IS imported (not duplicated) from
+ * `session-context-budget.ts` -- it is an exported, frozen constant, so
+ * importing it (read-only) is the single-source-of-truth choice; only the
+ * *estimator formula* (`utf8_bytes_div_4`, a private, unexported one-liner
+ * in that module) is duplicated, matching HRD-08's own script, which
+ * duplicates the exact same formula for the exact same reason.
+ *
+ * Fixture builder mirrors, rather than imports, the shape of
+ * `tests/state/effective-state-fixture.ts`'s `createEffectiveStateFixture` /
+ * `EFFECTIVE_STATE_SCENARIOS` / `replaceContractProfile` (a git-initialized
+ * repo with a plan/contract/review/`checks/latest.json`/`tasks/current.md`,
+ * scenario setups including `foreign-worktree-owner` and
+ * `invalid-capability-registry`, and a Workflow-Profile-field rewrite
+ * helper) -- no script in this repo imports from `tests/`, and
+ * `tsconfig.json`'s `include` never covers `scripts/**` (so `bun run
+ * check:type` never even typechecks this file), so this is a small,
+ * self-contained duplicate of that same fixture shape, not a parallel state
+ * factory invented from scratch.
+ */
+
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { dirname, isAbsolute, join, resolve } from "path";
+import { spawnSync } from "child_process";
+import { performance } from "perf_hooks";
+import { fileURLToPath } from "url";
+import { SESSION_CONTEXT_TOKEN_BUDGET } from "../src/cli/hook/session-context-budget";
+
+export const PANEL_PROTOCOL = "epc-08-context-packet-panel/v1" as const;
+export const PANEL_TOKEN_ESTIMATE_METHOD = "utf8_bytes_div_4" as const;
+/** Frozen EPC-00 gate: panel p95(estimated_tokens) <= 700 -- a token count,
+ * NOT a latency figure. SessionStart latency (see PanelCellResult's own
+ * latency_p50_ms/latency_p95_ms) is reported purely descriptively and
+ * carries no gate at all. */
+export const PANEL_TOKEN_P95_GATE = 700;
+export const DEFAULT_ITERATIONS = 20;
+export const SCRIPT_PATH = "scripts/session-context-packet-panel.ts";
+
+const REPO_ROOT_SELF = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+export type AuthorityState =
+  | "no-plan"
+  | "draft-plan"
+  | "approved-work-package"
+  | "executing"
+  | "completed"
+  | "foreign-worktree"
+  | "corrupt-policy"
+  | "invalid-capability-registry"
+  | "conflicting-active-markers";
+
+export const AUTHORITY_STATES: readonly AuthorityState[] = [
+  "no-plan",
+  "draft-plan",
+  "approved-work-package",
+  "executing",
+  "completed",
+  "foreign-worktree",
+  "corrupt-policy",
+  "invalid-capability-registry",
+  "conflicting-active-markers",
+];
+
+export type PanelProfile = "lite" | "standard" | "strict";
+export const PROFILES: readonly PanelProfile[] = ["lite", "standard", "strict"];
+
+// ---------------------------------------------------------------------------
+// Fixture builder (mirrors tests/state/effective-state-fixture.ts; see
+// module doc for why this is a duplicate rather than an import).
+// ---------------------------------------------------------------------------
+
+const FIXTURE_GIT_ENV = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "epc08-panel-fixture",
+  GIT_AUTHOR_EMAIL: "epc08-panel-fixture@example.com",
+  GIT_COMMITTER_NAME: "epc08-panel-fixture",
+  GIT_COMMITTER_EMAIL: "epc08-panel-fixture@example.com",
+  GIT_AUTHOR_DATE: "2020-01-01T00:00:00Z",
+  GIT_COMMITTER_DATE: "2020-01-01T00:00:00Z",
+};
+
+function gitFixture(cwd: string, args: string[]): void {
+  const result = spawnSync("git", args, { cwd, encoding: "utf-8", env: FIXTURE_GIT_ENV });
+  if (result.status !== 0) throw new Error(`git ${args.join(" ")} failed in fixture ${cwd}: ${result.stderr}`);
+}
+
+function writeFixtureFile(cwd: string, relPath: string, content: string): void {
+  const target = join(cwd, relPath);
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, content);
+}
+
+const PLAN_PATH = "plans/plan-20260723-0024-epc-08-panel-fixture.md";
+const CONTRACT_PATH = "tasks/contracts/20260723-0024-epc-08-panel-fixture.contract.md";
+const REVIEW_PATH = "tasks/reviews/20260723-0024-epc-08-panel-fixture.review.md";
+const SECOND_PLAN_PATH = "plans/plan-20260723-0024-epc-08-panel-fixture-legacy.md";
+
+function panelPlanBody(status: string): string {
+  return [
+    "# Plan: EPC-08 Panel Fixture",
+    "",
+    `> **Status**: ${status}`,
+    `> **Task Contract**: \`${CONTRACT_PATH}\``,
+    "",
+    "## Task Breakdown",
+    "- [ ] fixture task",
+    "",
+  ].join("\n");
+}
+
+function panelContractBody(profile: PanelProfile): string {
+  return [
+    "# Task Contract: epc-08-panel-fixture",
+    "",
+    "> **Status**: Active",
+    `> **Plan**: ${PLAN_PATH}`,
+    "> **Task Profile**: code-change",
+    `> **Workflow Profile**: ${profile}`,
+    `> **Review File**: \`${REVIEW_PATH}\``,
+    "",
+    "## Allowed Paths",
+    "",
+    "```yaml",
+    "allowed_paths:",
+    "  - src/",
+    "```",
+    "",
+  ].join("\n");
+}
+
+function panelReviewBody(): string {
+  return [
+    "# Review",
+    "> **Recommendation**: fail",
+    "> **Reviewed Subject SHA256**: pending",
+    "## External Acceptance Advice",
+    "> **External Acceptance**: unavailable",
+    "",
+  ].join("\n");
+}
+
+export interface PanelFixture {
+  readonly cwd: string;
+  cleanup(): void;
+}
+
+/**
+ * Builds one fresh git-initialized fixture repo for one (authority, profile)
+ * panel cell. Every state carries the SAME base scaffold (plan, contract,
+ * review, `checks/latest.json`, `tasks/current.md`, the
+ * `workflow-contract.json` opt-in marker `isOptIn()` requires); the
+ * authority-specific mutation is applied on top, matching the plan's own
+ * 9-state naming.
+ */
+export function buildPanelFixture(authority: AuthorityState, profile: PanelProfile): PanelFixture {
+  const cwd = mkdtempSync(join(tmpdir(), `epc08-panel-${authority}-`));
+  try {
+    for (const dir of ["plans", "tasks/contracts", "tasks/reviews", ".ai/harness/handoff", ".ai/harness/checks"]) {
+      mkdirSync(join(cwd, dir), { recursive: true });
+    }
+    // Required for runtime.ts's isOptIn() gate -- absent this marker the
+    // whole hook is a silent non-opt-in no-op (content: undefined), not a
+    // measurable panel cell.
+    writeFixtureFile(cwd, ".ai/harness/workflow-contract.json", "{}\n");
+    writeFixtureFile(cwd, ".ai/harness/active-plan", `${PLAN_PATH}\n`);
+    writeFixtureFile(cwd, ".ai/harness/active-worktree", `${cwd}\n`);
+    writeFixtureFile(cwd, PLAN_PATH, panelPlanBody("Executing"));
+    writeFixtureFile(cwd, CONTRACT_PATH, panelContractBody(profile));
+    writeFixtureFile(cwd, REVIEW_PATH, panelReviewBody());
+    writeFixtureFile(
+      cwd,
+      ".ai/harness/checks/latest.json",
+      `${JSON.stringify({ schema: "repo-harness-run-trace.v1", status: "unsatisfied" })}\n`,
+    );
+    writeFixtureFile(cwd, "tasks/current.md", [
+      "# Current",
+      "> **Status**: Executing",
+      "> **Updated At**: 2026-07-23T00:00:00.000Z",
+      `- Active Plan: ${PLAN_PATH}`,
+      "",
+    ].join("\n"));
+    writeFixtureFile(
+      cwd,
+      "tasks/todos.md",
+      [
+        "# Deferred Goal Ledger",
+        "",
+        "> **Status**: Backlog",
+        "",
+        "Current plan tasks live in the active plan's `## Task Breakdown`.",
+        "",
+      ].join("\n"),
+    );
+    writeFixtureFile(
+      cwd,
+      ".gitignore",
+      [".ai/harness/state/", ".ai/harness/security/", ".ai/harness/evidence/", ""].join("\n"),
+    );
+
+    switch (authority) {
+      case "no-plan":
+        rmSync(join(cwd, ".ai/harness/active-plan"), { force: true });
+        break;
+      case "draft-plan":
+        writeFixtureFile(cwd, PLAN_PATH, panelPlanBody("Draft"));
+        break;
+      case "approved-work-package":
+        writeFixtureFile(cwd, PLAN_PATH, panelPlanBody("Approved"));
+        break;
+      case "executing":
+        break; // base scaffold default
+      case "completed":
+        writeFixtureFile(cwd, PLAN_PATH, panelPlanBody("Completed"));
+        break;
+      case "foreign-worktree":
+        writeFixtureFile(cwd, ".ai/harness/active-worktree", "/tmp/epc-08-panel-foreign-worktree\n");
+        break;
+      case "corrupt-policy":
+        writeFixtureFile(cwd, ".ai/harness/policy.json", "{not json");
+        break;
+      case "invalid-capability-registry":
+        writeFixtureFile(cwd, ".ai/context/capabilities.json", "{not json");
+        break;
+      case "conflicting-active-markers":
+        writeFixtureFile(cwd, SECOND_PLAN_PATH, panelPlanBody("Draft"));
+        writeFixtureFile(cwd, ".claude/.active-plan", `${SECOND_PLAN_PATH}\n`);
+        break;
+      default: {
+        const exhaustive: never = authority;
+        throw new Error(`unhandled authority state: ${exhaustive}`);
+      }
+    }
+
+    gitFixture(cwd, ["init", "-q", "-b", "main"]);
+    gitFixture(cwd, ["add", "."]);
+    gitFixture(cwd, ["commit", "-q", "-m", `panel fixture: ${authority}/${profile}`]);
+    return { cwd, cleanup: () => rmSync(cwd, { recursive: true, force: true }) };
+  } catch (error) {
+    rmSync(cwd, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Measurement (mirrors hook-dispatch-diet-report.ts's own percentile() /
+// sessionStartContext() / defaultProbeRunner() shape -- duplicated, not
+// imported; see module doc).
+// ---------------------------------------------------------------------------
+
+function roundMs(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+export function percentile(values: readonly number[], quantile: number): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((left, right) => left - right);
+  const index = Math.max(0, Math.ceil(quantile * sorted.length) - 1);
+  return roundMs(sorted[index] ?? sorted[sorted.length - 1]!);
+}
+
+/** `utf8_bytes_div_4` -- the frozen estimator formula (mirrored from
+ * `session-context-budget.ts`'s private `estimatedTokens`, which is not
+ * exported; identical to `hook-dispatch-diet-report.ts`'s own duplicate). */
+export function estimatedTokens(text: string): number {
+  return Math.ceil(Buffer.byteLength(text, "utf-8") / 4);
+}
+
+function parseSessionStartContext(stdout: string): string {
+  const text = stdout.trim();
+  if (text.length === 0) return "";
+  if (!text.startsWith("{")) return "";
+  try {
+    const parsed = JSON.parse(text) as { hookSpecificOutput?: { hookEventName?: unknown; additionalContext?: unknown } };
+    const specific = parsed.hookSpecificOutput;
+    if (specific?.hookEventName === "SessionStart" && typeof specific.additionalContext === "string") {
+      return specific.additionalContext;
+    }
+    return "";
+  } catch {
+    return "";
+  }
+}
+
+export interface PanelSampleRun {
+  readonly context: string;
+  readonly durationMs: number;
+  readonly exitCode: number;
+}
+
+function runSessionStartOnce(repoRoot: string, fixtureCwd: string): PanelSampleRun {
+  const hookEntry = join(repoRoot, "src/cli/hook-entry.ts");
+  const env = {
+    ...process.env,
+    // Deterministic panel content: never let the tooling-advisory section
+    // spawn a detached background populate or vary by ambient tool state.
+    REPO_HARNESS_TOOLING_ADVISORY: "0",
+  };
+  const start = performance.now();
+  const result = spawnSync(process.execPath, [hookEntry, "SessionStart", "--route", "default"], {
+    cwd: fixtureCwd,
+    encoding: "utf-8",
+    env,
+  });
+  const durationMs = performance.now() - start;
+  return {
+    context: result.status === 0 ? parseSessionStartContext(result.stdout ?? "") : "",
+    durationMs,
+    exitCode: result.status ?? 1,
+  };
+}
+
+export interface PanelCellResult {
+  readonly authority: AuthorityState;
+  readonly profile: PanelProfile;
+  readonly estimated_tokens: number;
+  readonly within_budget: boolean;
+  readonly latency_p50_ms: number | null;
+  readonly latency_p95_ms: number | null;
+  readonly sample_count: number;
+  readonly exit_codes: readonly number[];
+}
+
+export function measurePanelCell(
+  repoRoot: string,
+  authority: AuthorityState,
+  profile: PanelProfile,
+  iterations: number,
+): PanelCellResult {
+  const fixture = buildPanelFixture(authority, profile);
+  try {
+    const runs: PanelSampleRun[] = [];
+    for (let i = 0; i < iterations; i += 1) {
+      runs.push(runSessionStartOnce(repoRoot, fixture.cwd));
+    }
+    // One deterministic sample: packet content is deterministic per fixture
+    // state (EPC-00 confirmation), so the first run's content is the
+    // recorded sample for estimated_tokens/within_budget. Latency is NOT
+    // deterministic and gets the full >=20-iteration descriptive treatment
+    // (p50/p95 below) -- purely informational, never gated.
+    const sampleContext = runs[0]!.context;
+    const tokens = estimatedTokens(sampleContext);
+    const durations = runs.map((run) => run.durationMs);
+    return {
+      authority,
+      profile,
+      estimated_tokens: tokens,
+      within_budget: tokens <= SESSION_CONTEXT_TOKEN_BUDGET,
+      latency_p50_ms: percentile(durations, 0.5),
+      latency_p95_ms: percentile(durations, 0.95),
+      sample_count: runs.length,
+      exit_codes: runs.map((run) => run.exitCode),
+    };
+  } finally {
+    fixture.cleanup();
+  }
+}
+
+export interface PanelReport {
+  readonly protocol: typeof PANEL_PROTOCOL;
+  readonly generated_at: string;
+  readonly base_sha: string;
+  readonly method: typeof PANEL_TOKEN_ESTIMATE_METHOD;
+  readonly runner_command: string;
+  readonly iterations_per_state: number;
+  readonly cells: readonly PanelCellResult[];
+  readonly gates: {
+    readonly max_estimated_tokens: number;
+    readonly panel_token_p95_gate: number;
+    readonly every_sample_within_budget: boolean;
+    readonly every_sample_at_or_under_budget: boolean;
+    readonly panel_p95_estimated_tokens: number | null;
+    readonly panel_p95_within_gate: boolean;
+    readonly pass: boolean;
+  };
+}
+
+function resolveBaseSha(repoRoot: string): string {
+  const result = spawnSync("git", ["-C", repoRoot, "rev-parse", "HEAD"], { encoding: "utf-8" });
+  return result.status === 0 ? result.stdout.trim() : "unknown";
+}
+
+export function buildPanelReport(options: { repo: string; iterations: number; now?: Date }): PanelReport {
+  const repoRoot = resolve(options.repo);
+  const cells: PanelCellResult[] = [];
+  for (const authority of AUTHORITY_STATES) {
+    for (const profile of PROFILES) {
+      cells.push(measurePanelCell(repoRoot, authority, profile, options.iterations));
+    }
+  }
+  const allTokenSamples = cells.map((cell) => cell.estimated_tokens);
+  const everyAtOrUnderBudget = allTokenSamples.every((value) => value <= SESSION_CONTEXT_TOKEN_BUDGET);
+  const everyWithinBudget = cells.every((cell) => cell.within_budget);
+  // Frozen EPC-00 gate: panel p95(estimated_tokens) <= 700 -- computed over
+  // the 27 token samples themselves, NOT over latency. Latency (p50/p95 ms,
+  // per cell above) stays purely descriptive and is never gated.
+  const panelP95Tokens = percentile(allTokenSamples, 0.95);
+  const panelP95WithinGate = panelP95Tokens !== null && panelP95Tokens <= PANEL_TOKEN_P95_GATE;
+  return {
+    protocol: PANEL_PROTOCOL,
+    generated_at: (options.now ?? new Date()).toISOString(),
+    base_sha: resolveBaseSha(repoRoot),
+    method: PANEL_TOKEN_ESTIMATE_METHOD,
+    runner_command: `bun ${SCRIPT_PATH} --repo . --iterations ${options.iterations}`,
+    iterations_per_state: options.iterations,
+    cells,
+    gates: {
+      max_estimated_tokens: SESSION_CONTEXT_TOKEN_BUDGET,
+      panel_token_p95_gate: PANEL_TOKEN_P95_GATE,
+      every_sample_within_budget: everyWithinBudget,
+      every_sample_at_or_under_budget: everyAtOrUnderBudget,
+      panel_p95_estimated_tokens: panelP95Tokens,
+      panel_p95_within_gate: panelP95WithinGate,
+      pass: everyAtOrUnderBudget && everyWithinBudget && panelP95WithinGate,
+    },
+  };
+}
+
+export function panelReportPasses(report: PanelReport): boolean {
+  return report.gates.pass;
+}
+
+export function renderPanelMarkdown(report: PanelReport): string {
+  const rows = report.cells.map((cell) => `| ${cell.authority} | ${cell.profile} | ${cell.estimated_tokens} | ${cell.within_budget ? "true" : "false"} | ${cell.latency_p50_ms ?? "unavailable"} | ${cell.latency_p95_ms ?? "unavailable"} |`).join("\n");
+  return [
+    "# EPC-08 Context Packet Panel Report",
+    "",
+    `- Protocol: \`${report.protocol}\``,
+    `- Generated: ${report.generated_at}`,
+    `- Base SHA: \`${report.base_sha}\``,
+    `- Method: \`${report.method}\``,
+    `- Runner command: \`${report.runner_command}\``,
+    `- Iterations per state (latency, descriptive): ${report.iterations_per_state}`,
+    "",
+    "## Panel (27 rows: 9 authority states x 3 profiles)",
+    "",
+    "| Authority state | Profile | estimated_tokens | within_budget | latency p50 (ms) | latency p95 (ms) |",
+    "|---|---|---:|---|---:|---:|",
+    rows,
+    "",
+    "## Gate numbers (frozen, EPC-00)",
+    "",
+    `- Max estimated_tokens per sample: ${report.gates.max_estimated_tokens}`,
+    `- Panel p95(estimated_tokens) gate: ${report.gates.panel_token_p95_gate}`,
+    `- Every sample <= ${report.gates.max_estimated_tokens} and within_budget == true: ${report.gates.every_sample_within_budget && report.gates.every_sample_at_or_under_budget ? "PASS" : "FAIL"}`,
+    `- Panel p95(estimated_tokens): ${report.gates.panel_p95_estimated_tokens ?? "unavailable"} (${report.gates.panel_p95_within_gate ? "PASS" : "FAIL"}, gate <= ${report.gates.panel_token_p95_gate})`,
+    `- Overall: ${report.gates.pass ? "PASS" : "FAIL"}`,
+    "",
+    "## Notes",
+    "",
+    "- One deterministic sample per state for `estimated_tokens`/`within_budget` (packet content is deterministic per fixture state, EPC-00 confirmation).",
+    "- The panel p95 gate above is computed over the 27 `estimated_tokens` samples (method `utf8_bytes_div_4`), per the frozen EPC-00 acceptance line -- it is NOT a latency gate.",
+    `- Latency is reported purely descriptively across ${report.iterations_per_state} iterations per state (p50/p95 ms in the table above); EPC-00 sets no SessionStart-latency gate at all.`,
+    "",
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+interface CliOptions {
+  repo: string;
+  iterations: number;
+  out?: string;
+  format: "json" | "markdown";
+}
+
+function usage(): string {
+  return [
+    "Usage: scripts/session-context-packet-panel.ts [--repo PATH] [--iterations N] [--out PATH] [--json|--markdown]",
+    "",
+    "Renders the SessionStart Context Packet across the 27-state Authority×Profile panel.",
+  ].join("\n");
+}
+
+function parseArgs(argv: readonly string[]): CliOptions | { error: string; help?: boolean } {
+  const opts: CliOptions = { repo: process.cwd(), iterations: DEFAULT_ITERATIONS, format: "markdown" };
+  let formatExplicit = false;
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--help" || arg === "-h") return { error: "", help: true };
+    else if (arg === "--repo") opts.repo = argv[++i] ?? "";
+    else if (arg === "--out") opts.out = argv[++i] ?? "";
+    else if (arg === "--iterations") {
+      const parsed = Number.parseInt(argv[++i] ?? "", 10);
+      if (!Number.isFinite(parsed) || parsed <= 0) return { error: "invalid --iterations" };
+      opts.iterations = parsed;
+    } else if (arg === "--json") {
+      opts.format = "json";
+      formatExplicit = true;
+    } else if (arg === "--markdown") {
+      opts.format = "markdown";
+      formatExplicit = true;
+    } else return { error: `unknown argument: ${arg}` };
+  }
+  if (!formatExplicit && opts.out && opts.out.toLowerCase().endsWith(".json")) opts.format = "json";
+  if (!opts.repo) return { error: "missing --repo value" };
+  return opts;
+}
+
+function main(argv: readonly string[]): number {
+  const parsed = parseArgs(argv);
+  if ("error" in parsed) {
+    if (parsed.help) {
+      console.log(usage());
+      return 0;
+    }
+    console.error(`session-context-packet-panel: ${parsed.error}`);
+    console.error(usage());
+    return 2;
+  }
+  const report = buildPanelReport({ repo: parsed.repo, iterations: parsed.iterations });
+  const markdown = renderPanelMarkdown(report);
+  const rendered = parsed.format === "json" ? `${JSON.stringify(report, null, 2)}\n` : markdown;
+  if (parsed.out) {
+    const outPath = isAbsolute(parsed.out) ? parsed.out : resolve(parsed.repo, parsed.out);
+    mkdirSync(dirname(outPath), { recursive: true });
+    writeFileSync(outPath, rendered);
+  }
+  console.log(parsed.format === "json" ? JSON.stringify(report) : markdown);
+  return panelReportPasses(report) ? 0 : 1;
+}
+
+if (import.meta.main) process.exit(main(process.argv.slice(2)));

--- a/src/cli/hook/session-context.ts
+++ b/src/cli/hook/session-context.ts
@@ -32,6 +32,7 @@ import { renderMinimalChangeSessionContext } from './minimal-change-context';
 import { runSecurityScan, type SecurityScanReport } from '../commands/security';
 import { fileExists, readText } from '../../effects/state/collect-state-inputs';
 import type { WorktreeOwnership } from '../../effects/loop/state-input-collector';
+import { resolveRecoveryEvidence } from '../../effects/evidence/recovery-materializer';
 
 // ---------------------------------------------------------------------------
 // minimal-change-context.sh port (16 lines)
@@ -574,17 +575,24 @@ function handoffSectionHasSignal(repoRoot: string, handoffFile: string, header: 
   return found;
 }
 
-function resumeAvailable(repoRoot: string, resumeFile: string): boolean {
-  const text = readText(repoRoot, resumeFile);
-  if (text === null) return false;
-  return (
-    text.includes('<!-- generated-by: repo-harness codex-handoff-resume v1 -->') &&
-    text.includes('## Resume Prompt')
-  );
+/**
+ * EPC-08 cutover: availability is resolved from the canonical
+ * checkpoint-backed evidence reader (`resolveRecoveryEvidence`, EPC-06/07,
+ * read-only import) instead of re-deriving it by scanning the rendered
+ * resume.md for a legacy marker/header string. `resolveRecoveryEvidence`
+ * already degrades to `available: false` for both "no checkpoint yet" and
+ * "dangling/invalid marker" and never throws for those cases, so this stays
+ * exactly as safe as the string-scan it replaces; `resumeFile`'s own text is
+ * still read separately below (`capResumeContent`) to quote the projection's
+ * rendered body verbatim -- only the availability PREDICATE moves off the
+ * Markdown scan.
+ */
+function resumeAvailable(repoRoot: string): boolean {
+  return resolveRecoveryEvidence(repoRoot).available;
 }
 
 function resumeCurrentForHandoff(repoRoot: string, resumeFile: string, handoffFile: string): boolean {
-  if (!resumeAvailable(repoRoot, resumeFile)) return false;
+  if (!resumeAvailable(repoRoot)) return false;
   if (!fileExists(repoRoot, handoffFile)) return true;
   const resumeMtime = fileMtimeSec(repoRoot, resumeFile);
   const handoffMtime = fileMtimeSec(repoRoot, handoffFile);

--- a/tasks/contracts/20260723-0024-epc-08-context-packet-cutover.contract.md
+++ b/tasks/contracts/20260723-0024-epc-08-context-packet-cutover.contract.md
@@ -1,0 +1,466 @@
+# Task Contract: epc-08-context-packet-cutover
+
+> **Status**: Active
+> **Plan**: plans/plan-20260723-0024-epc-08-context-packet-cutover.md
+> **Task Profile**: code-change
+> **Owner**: kito
+> **Reviewer**: Claude
+> **Waiver Policy**: user_waiver allowed, owner kito only, per Acceptance Policy below
+> **Base SHA**: `9ea195b99db26895821e9ee3e29ad2f460895649` (pinned per R1 post-EPC-07: fresh worktree branched from `origin/main` after EPC-07 merged (PR #123) plus its row-flip commit; verified equal to this worktree's HEAD at task start -- `git rev-parse HEAD` = `9ea195b9...` and `git merge-base --is-ancestor 9ea195b9... HEAD` holds)
+> **Target Branch**: main (via one independent PR)
+> **Working Branch**: `codex/epc-08-context-packet-cutover`
+> **PR Unit**: one PR carrying the Goal-1 inventory (this contract), the session-context.ts evidence-availability cutover, the deleted ad-hoc marker-scan, the 27-state panel measurement runner, the committed panel report, the red-first/characterization test updates, and this package's workflow artifacts
+> **Capability ID**: root
+> **Last Updated**: 2026-07-23 00:24
+> **Review File**: `tasks/reviews/20260723-0024-epc-08-context-packet-cutover.review.md`
+> **Notes File**: `tasks/notes/20260723-0024-epc-08-context-packet-cutover.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+The SessionStart Context Packet (`src/cli/hook/session-context.ts`, consolidated
+into one budgeted render by HRD-04) is the last consumer named by the sprint's
+row-12 acceptance line. EPC-05/06/07 already built every canonical projection
+this repo has (materialized `checks/latest`, the EPC-06 checkpoint, the EPC-07
+recovery views) specifically so downstream consumers stop re-deriving
+evidence/recovery claims on their own. Both the EPC-07 contract's Phase A
+inventory and `recovery-materializer.ts`'s own module doc single out
+`session-context.ts`'s `resumeAvailable()` by name as "an EPC-08 SessionStart
+internal, out of this package's scope" -- i.e. explicitly deferred to this
+package's own inventory-and-cutover decision, not resolved by EPC-07.
+
+## Goal
+
+1. Inventory (Goal 1, binding sequencing -- recorded below, before any Phase B
+   edit) every source `session-context.ts` reads for packet content,
+   classified (a) already-canonical projection, (b) primary-source
+   re-derivation to cut over, or (c) legitimate live session context.
+2. Cutover (Goal 2): the one (b) finding -- `resumeAvailable()`'s ad-hoc
+   marker/header string-scan of the rendered resume.md -- is deleted and
+   replaced by a direct call into the canonical checkpoint-backed evidence
+   reader (`resolveRecoveryEvidence`, EPC-06/07, read-only import). Budget
+   mechanics (`SESSION_CONTEXT_TOKEN_BUDGET = 1500`, `utf8_bytes_div_4`)
+   stay frozen and unchanged.
+3. Panel measurement runner (sibling script) renders the full SessionStart
+   Context Packet across the 27-state Authority×Profile panel and gates on
+   the two EPC-00-frozen token numbers.
+4. Measurement report committed as a tracked package artifact.
+5. Red-first tests prove the deleted ad-hoc scan is gone and the packet's
+   evidence-availability gate now resolves from the canonical reader.
+
+## Phase A: Inventory (recorded before any Phase B edit)
+
+Every source read by `src/cli/hook/session-context.ts` for packet content,
+in the file's own composition order
+(`sessionStartMainContent`'s 8 sub-blocks, then `minimalChangeSessionSection`,
+then `securitySentinelSessionSection`). "Packet" here is the full SessionStart
+`additionalContext` string as actually delivered: `handler-registry.ts`'s
+`session-context` handler also prepends an `effective-state` section
+(`runtime.ts:179-244`, out of this package's owned surface -- see note below)
+and `pendingPostEditJournalSection` (`mutation-observed.ts`, an EPC-03
+producer/importer surface, explicitly read-only per this package's
+EXECUTION_BOUNDARY) before `buildSessionStartSections()`'s three sections.
+
+### 1. `resumeBlock` (`session-context.ts:621-631`)
+
+- `workflowResumePacketFile`/`workflowHandoffFile` (`:239-247`) resolve the
+  resume/handoff file paths via `.ai/harness/policy.json` (`policyGet`).
+  **(c) legitimate** -- path/config resolution, not an evidence claim.
+- `resumeCurrentForHandoff` -> `resumeAvailable` (`:577-593`): **today**, reads
+  `resume.md`'s raw text and does
+  `text.includes('<!-- generated-by: repo-harness codex-handoff-resume v1 -->') && text.includes('## Resume Prompt')`.
+  **(b) primary-source re-derivation -- CUT OVER.** This re-derives "is there
+  evidence-backed recovery state" by string-scanning the rendered Markdown
+  instead of asking the checkpoint resolver that already knows the answer in
+  typed form. Both the EPC-07 contract and `recovery-materializer.ts`'s own
+  header comment name this exact function as deferred to EPC-08. Replacing
+  projection: `resolveRecoveryEvidence(repoRoot).available`
+  (`src/effects/evidence/recovery-materializer.ts`, wraps
+  `resolveLastPublishedCheckpoint`, EPC-06/07, read-only import). Post-EPC-07
+  every Stop produces the SAME one-shape resume.md via the single
+  materializer, so the marker string is now a constant, format-coupled
+  vestige of the pre-EPC-07 two-writer split this exact check used to
+  discriminate; the checkpoint's own `available: true/false` is the
+  authoritative signal the materializer itself already resolved when it
+  rendered the file. `handoffSectionHasSignal`'s mtime/marker-independent
+  gate (whether it fires at all) is unaffected; only the availability
+  predicate changes.
+- `resumeCurrentForHandoff`'s mtime comparison (`resumeMtime >= handoffMtime`,
+  `:589-592`): **(c) legitimate**, kept as-is. This is a same-materializer-pass
+  plumbing check (was resume written in the same or a later pass than
+  handoff), not an evidence claim; EPC-07 already made both views one atomic
+  write, so this gate is now nearly always true by construction, and it
+  never asserts anything about evidence content.
+- `activePlanExists`/`activeTodoExists` (`:542-555`) read the active plan file
+  and `tasks/todos.md` for their own `Status`/checkbox state. **(c)
+  legitimate** -- these are the ledger/plan's own tracked source of truth for
+  "is there an active plan/todo," not a re-derivation of anything the
+  EvidenceEvent ledger governs; there is no more-canonical projection of
+  "plan status" than the plan file's own `Status` header.
+- `handoffSectionHasSignal` (`:557-575`) scans the ALREADY-RENDERED
+  `handoff/current.md` (the EPC-07 canonical view) for non-empty
+  `## Blockers`/`## Changed Files` sections. **(a) already-canonical
+  projection** -- reads the rendered view file itself, which
+  `recovery-materializer.ts`'s own module doc explicitly classifies as
+  workflow CONTEXT ("where work stands"), a different kind of fact from
+  evidence ("what was proven") that the materializer itself reads fresh from
+  the live repo on every render; no independent re-derivation happens here,
+  only a presence check on the projection's own rendered section.
+- `capResumeContent(readText(repoRoot, resumeFile))` (`:631`): **(a)
+  already-canonical projection** -- quotes resume.md's own rendered text
+  verbatim (capped at 12000 chars); this is "the view file it renders," named
+  explicitly as an acceptable canonical-projection read.
+
+### 2. `capabilityContextPendingContext` (`:635-671`)
+
+Reads `.ai/harness/capability-context/requests.jsonl`. **(c) legitimate** --
+an unrelated queue subsystem (capability-context sync requests), orthogonal to
+the D1-D9 EvidenceEvent/checkpoint/checks topology; the queue file is its own
+source of truth, not a re-derivation of ledger state.
+
+### 3. `architectureQueuePendingContext` (`:674-720`)
+
+Reads `docs/architecture/requests/*.md`. **(c) legitimate** -- the
+architecture-drift queue, a separate tracked subsystem with its own
+Status/Detected headers as source of truth; not evidence/recovery state.
+
+### 4. `pendingPlanCaptureContext` (`:726-815`)
+
+Reads `.ai/harness/planning/pending.json` + the active plan file. **(c)
+legitimate** -- pending-orchestration marker, its own tracked source of truth
+for "is a plan capture pending"; not an evidence claim.
+
+### 5. `currentStatusSnapshotContext` (`:817-863`)
+
+Reads `tasks/current.md` directly, plus `git show <target>:tasks/current.md`
+for the target-branch copy of the SAME tracked file. **(a) already-canonical
+projection** -- `tasks/current.md` is explicitly named as the canonical
+tracked derived-status-snapshot projection (materialized by
+`refresh-current-status.sh`, D9 KEEP verdict, EPC-07 Phase A); reading it (at
+either ref) is reading the projection, not re-deriving it.
+
+### 6. `activeSprintContext` (`:865-923`)
+
+Reads `.ai/harness/sprint/active-sprint` + the referenced sprint file's own
+`Status`/backlog table. **(c) legitimate** -- the sprint document is its own
+tracked source of truth for backlog progress; not evidence/recovery state.
+
+### 7. `toolingUpdateAdvisoryContext` (`:927-1208`)
+
+Reads/writes `.ai/harness/security/tooling-update-advisory-*.{json,rendered,lock}`
+via a `repo-harness setup check` subprocess (sync or detached). **(c)
+legitimate** -- a version/tooling advisory cache, unrelated to the evidence
+ledger; writes its own namespaced cache files, never touches
+`checks/*` or the evidence store.
+
+### 8. `codexDelegationAutoContext` (`:1210-1277`)
+
+Reads `.ai/harness/policy.json` (`delegation.mode`/`max_agents`) and
+`~/.repo-harness/config.json`. **(c) legitimate** -- policy/config resolution,
+not an evidence claim.
+
+### 9. `minimalChangeSessionSection` -> `loadMinimalChangePolicy` (`:51-68`)
+
+Reads the minimal-change policy file. **(c) legitimate** -- policy-driven
+advisory text, unrelated to evidence/recovery.
+
+### 10. `securitySentinelSessionSection` -> `runSecurityScan` (`:153-195`)
+
+Fingerprints `.claude/settings.json`/`.codex/hooks.json`/`.vscode/tasks.json`,
+runs a security scan, writes `.ai/harness/security/{latest.json,state.sha256}`
+(a DIFFERENT namespace from `.ai/harness/checks/latest.json`). **(c)
+legitimate** -- its own scan/cache authority for a distinct domain (repo
+config safety), never overlaps the D7/D8 evidence provenance this package
+governs.
+
+### Cold-path housekeeping (not packet content)
+
+`rotateSessionStartEventLogs` (`:520-532`) rotates `.ai/harness/events.jsonl`
+and `.ai/harness/architecture/events.jsonl` -- the pre-existing WORKFLOW event
+log (`workflow_append_event`), a different, older subsystem from the
+per-worktree EvidenceEvent ledger (`.ai/harness/evidence/events/`, D1). Byte
+rotation only, never parsed/interpreted as content; produces zero session
+content. Not classified (a)/(b)/(c) -- out of the packet-content inventory by
+construction.
+
+### Packet siblings outside `session-context.ts` (found, not owned by this package)
+
+- **`effective-state` section** (`runtime.ts:179-244`, added directly by
+  `handler-registry.ts`, not via `session-context.ts`): already sources
+  verification state canonically -- `resolve-effective-state.ts:214`
+  (`CHECKS_PATH = '.ai/harness/checks/latest.json'`) reads the SAME
+  materialized file `checks-materializer.ts` (EPC-05) writes. This already
+  satisfies the sprint's "checks/latest for verification state" requirement
+  for the packet as a whole; it is a pre-existing, independently-owned core
+  state resolution used by every hook route (not SessionStart-specific), well
+  outside "`session-context.ts` and its direct assembly collaborators" --
+  out of scope, not touched.
+- **`pendingPostEditJournalSection`** (`mutation-observed.ts`, added directly
+  by `handler-registry.ts`): an EPC-03 producer/importer surface, explicitly
+  read-only per this package's EXECUTION_BOUNDARY. Out of scope, not touched.
+
+### Conclusion
+
+Exactly one (b) finding: `resumeAvailable()`'s marker/header string-scan.
+Every other read is either (a) already reading a canonical projection file
+(handoff/resume views, `tasks/current.md`) or (c) a legitimate direct read of
+a tracked subsystem's own source of truth that the D1-D9 evidence topology
+never claimed authority over. The "materialized checks/latest for
+verification state" and "tasks/current.md for the derived snapshot" bullets
+of the sprint's Goal 2 are both already satisfied -- the former by the
+pre-existing, out-of-scope `effective-state` section, the latter by
+`currentStatusSnapshotContext` -- so Goal 2's only in-package code change is
+the `resumeAvailable()` cutover.
+
+## P1: Architecture Map
+
+- Design authority: EPC-00's amended row-12 acceptance line (panel, both
+  token gates, method `utf8_bytes_div_4`) and frozen D4 (projections carry no
+  independent trust -- the packet may cite, never re-derive); EPC-05/06/07
+  surfaces consumed read-only via their public readers
+  (`resolveRecoveryEvidence`/`resolveLastPublishedCheckpoint`).
+- Owned surface: `src/cli/hook/session-context.ts` (the one cutover edit),
+  the new panel measurement runner script, and its tests. Stop handler,
+  recovery-materializer, checkpoint modules, checks-materializer, and
+  producers/importers are read-only (consumed only via their existing public
+  exports) per this package's EXECUTION_BOUNDARY.
+- Authority×Profile fixtures reused: `tests/state/effective-state-fixture.ts`
+  (`createEffectiveStateFixture`, `EFFECTIVE_STATE_SCENARIOS`,
+  `replaceContractProfile`) is the existing HRD/LSC-era characterization
+  fixture builder for exactly this shape of state (a git-initialized fixture
+  repo with plan/contract/review/`checks/latest.json`/`tasks/current.md`,
+  scenario setups including `foreign-worktree-owner` and
+  `invalid-capability-registry`, and a `replaceContractProfile` helper for the
+  Workflow Profile field). The panel runner (`scripts/`) cannot import this
+  test-only module (no script in this repo imports from `tests/`, and
+  `tsconfig.json`'s `include` never covers `scripts/**`), so its fixture
+  builder is a small, self-contained duplicate of the same shape, documented
+  as reusing this pattern -- consistent with this package's own established
+  "small helper duplicated across a layer boundary, not imported" convention
+  (`recovery-materializer.ts`/`checks-materializer.ts` both do this
+  explicitly for their own tiny generic helpers).
+
+## P2: Concrete Trace
+
+EPC-07 merges -> `main` at `9ea195b9` -> EPC-08 worktree branches from it
+(verified equal) -> Phase A inventory recorded in this contract -> the one
+(b) finding cut over (`resumeAvailable` -> `resolveRecoveryEvidence`) with
+the old marker-scan deleted -> panel runner renders 27 states (9 authority
+states x 3 profiles) via the real `bun src/cli/hook-entry.ts SessionStart
+--route default` subprocess, one deterministic token/within_budget sample per
+state plus a >=20-iteration descriptive latency sample -> report committed
+with both gate numbers green -> red-first tests updated/added -> full suite
+green -> one PR.
+
+## P3: Design Decision
+
+- The (b) cutover is deliberately narrow: `resumeAvailable()`'s body changes
+  from a string scan to one call into `resolveRecoveryEvidence`; nothing else
+  in `session-context.ts` re-derives evidence/recovery state independently
+  today (EPC-05/06/07 already built every canonical projection this file
+  needed, so the remaining gap really is this small). No new
+  verification-state section is added to `session-context.ts` itself --
+  Goal 2's "checks/latest for verification state" requirement is already
+  satisfied for the delivered packet by the pre-existing, out-of-scope
+  `effective-state` section (confirmed by tracing `CHECKS_PATH` in
+  `resolve-effective-state.ts` to the same materialized file
+  `checks-materializer.ts` writes). Adding a duplicate section would be an
+  unrequested extra, not a cutover.
+- The panel is a NEW measurement capability (Goal 3/4), independent in size
+  from the Goal-2 code diff; it renders the FULL packet (not just
+  `session-context.ts`'s own sections) via the real SessionStart subprocess,
+  matching how a live host actually invokes it and how
+  `hook-dispatch-diet-report.ts`'s own `session_start_context` probe already
+  measures this exact packet (mirrored, not imported: that file's
+  `percentile`/token-estimator/subprocess-probe shape is duplicated in the
+  new sibling script per the same small-helper-duplication convention, since
+  neither is exported).
+- One deterministic sample per state for tokens (packet content is
+  deterministic per fixture state, EPC-00 confirmation); latency is
+  non-deterministic and gets the `>=20`-iteration descriptive treatment only
+  (matching HRD-08's own `HRD08_CHARACTERIZATION_CYCLES=20` precedent),
+  never gated.
+
+## Concurrency
+
+- **R2 Layer 1 (repository ownership):** this package's changed paths
+  (`src/cli/hook/session-context.ts`, `scripts/session-context-packet-panel.ts`,
+  two test files, this package's own workflow artifacts) intersect no other
+  active package's `allowed_paths` -- EPC-07 is Done/merged, EPC-09 has not
+  started.
+- **R2 Layer 2 / R3 (verification-subject freeze):** `src/cli/hook/` sits
+  under `src/cli`, one of the benchmark subject inputs named by R2. **No
+  benchmark subject freeze is active at this contract's pin time** -- the
+  VGBR-R quiescence window closed when its report PR (#115) merged (git log:
+  "quiescence window lifted"), and no later row has re-opened a frozen
+  verification subject. This package's `src/cli` edit is therefore
+  unconstrained by R2/R3 at pin time; if a future row opens a new subject
+  freeze before this package's PR merges, re-check before merging rather than
+  assuming this note still holds.
+
+## Scope
+
+- In scope: `src/cli/hook/session-context.ts` (the one `resumeAvailable()`
+  cutover edit named in Phase A); `scripts/session-context-packet-panel.ts`
+  (new panel measurement runner); `tests/session-context.test.ts` (resume-
+  availability test updates + the no-independent-assembly proof);
+  `tests/session-context-packet-panel.test.ts` (new, panel shape/gate/
+  determinism tests); the tracked panel report
+  `tasks/reviews/20260723-0024-epc-08-context-packet-cutover.panel.md`; this
+  package's own plan/contract/review/notes; `tasks/todos.md` projection;
+  `.ai/harness/worktrees/epc-08-context-packet-cutover.json`.
+- Out of scope: Stop handler, recovery materializer, checkpoint modules,
+  checks materializer, producers/importers (EPC-02..07 surfaces, read-only
+  consumed via their existing public exports only);
+  `SESSION_CONTEXT_TOKEN_BUDGET` value or the `utf8_bytes_div_4` estimator
+  method (frozen surfaces, imported/mirrored read-only, never modified);
+  `resolve-effective-state.ts` / the `effective-state` SessionStart section
+  (pre-existing, independently-owned, out of "`session-context.ts` and its
+  direct assembly collaborators"); `tasks/current.md` content and
+  `scripts/refresh-current-status.sh`; the sprint document; any new npm
+  dependency.
+- Taste constraints: none beyond the repo's default minimal-change policy.
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+- Stop if `check-architecture-sync` BLOCKS (not merely advises) on the
+  changed capability surfaces -- report rather than editing `.ai/context/`
+  or architecture files.
+- Stop if a panel state cannot reach the token gates without a content
+  redesign beyond the one named cutover -- report the measured numbers for
+  an orchestrator ruling (the gate numbers are frozen; the content knife is
+  a design decision, not this contract's to make unilaterally).
+- Stop after three fail-fix-reverify rounds on one issue.
+
+## Falsifier
+
+The direction is wrong if `session-context.ts` needs to independently
+re-derive evidence/recovery/verification claims that a canonical projection
+cannot supply (i.e. Goal 1's inventory finds a real gap, not just the one
+`resumeAvailable()` finding), or if the cutover or the panel cannot keep the
+full SessionStart packet within the two frozen token gates across all 27
+states. Cheapest proof: the committed 27-row panel table with every sample
+<= 1500 / within_budget and p95 <= 700, produced by the committed runner
+against the cutover code, plus the no-independent-assembly test proving the
+old marker-scan is gone.
+
+## Root Cause Evidence
+
+Not applicable: Task Profile is `code-change`, not `bugfix`.
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260723-0024-epc-08-context-packet-cutover.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260723-0024-epc-08-context-packet-cutover.review.md`
+- Notes file: `tasks/notes/20260723-0024-epc-08-context-packet-cutover.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Acceptance Policy
+
+```json
+{"protocol":1,"reviewer":"Claude","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - plans/plan-20260723-0024-epc-08-context-packet-cutover.md
+  - tasks/contracts/20260723-0024-epc-08-context-packet-cutover.contract.md
+  - tasks/reviews/20260723-0024-epc-08-context-packet-cutover.review.md
+  - tasks/reviews/20260723-0024-epc-08-context-packet-cutover.panel.md
+  - tasks/notes/20260723-0024-epc-08-context-packet-cutover.notes.md
+  - tasks/todos.md
+  - src/cli/hook/session-context.ts
+  - scripts/session-context-packet-panel.ts
+  - tests/session-context.test.ts
+  - tests/session-context-packet-panel.test.ts
+  - .ai/harness/worktrees/epc-08-context-packet-cutover.json
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+      - codex-exec
+      - main-thread
+    fallback: main-thread
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - src/cli/hook/session-context.ts
+    - scripts/session-context-packet-panel.ts
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260723-0024-epc-08-context-packet-cutover.notes.md
+    - tasks/reviews/20260723-0024-epc-08-context-packet-cutover.panel.md
+  tests_pass:
+    - path: tests/session-context.test.ts
+    - path: tests/session-context-packet-panel.test.ts
+  commands_succeed:
+    - bun run check:type
+    - bun scripts/session-context-packet-panel.ts --repo . --iterations 20
+  manual_checks:
+    - "Panel report committed: 27 rows, every sample <= 1500 with within_budget true, p95 <= 700, method utf8_bytes_div_4"
+    - "No-independent-assembly test green (old path deleted)"
+    - "tasks/current.md untouched"
+```
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior:
+- Edge cases:
+- Regression risks:
+
+## Rollback Point
+
+- Commit / checkpoint: the single commit on `codex/epc-08-context-packet-cutover` before it merges.
+- Revert strategy: revert the single PR -- restores `resumeAvailable()`'s
+  marker/header string-scan and removes the panel runner + report; budget
+  mechanics (`SESSION_CONTEXT_TOKEN_BUDGET`, `utf8_bytes_div_4`) were never
+  modified either way, and `tasks/current.md` content was never touched, so
+  reverting cannot regress either.

--- a/tasks/notes/20260723-0024-epc-08-context-packet-cutover.notes.md
+++ b/tasks/notes/20260723-0024-epc-08-context-packet-cutover.notes.md
@@ -1,0 +1,93 @@
+# Implementation Notes: epc-08-context-packet-cutover
+
+> **Status**: Active
+> **Plan**: plans/plan-20260723-0024-epc-08-context-packet-cutover.md
+> **Contract**: tasks/contracts/20260723-0024-epc-08-context-packet-cutover.contract.md
+> **Review**: tasks/reviews/20260723-0024-epc-08-context-packet-cutover.review.md
+> **Last Updated**: 2026-07-23 00:24
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- Goal 1's inventory (recorded in the contract) found exactly ONE
+  primary-source re-derivation in `session-context.ts`: `resumeAvailable()`'s
+  marker/header string-scan of the rendered resume.md. Every other read is
+  either already a canonical-projection read (handoff/resume view files,
+  `tasks/current.md`) or a legitimate direct read of a tracked subsystem's
+  own source of truth (plan status, todos, capability/architecture queues,
+  sprint backlog, tooling advisory cache, delegation/minimal-change policy).
+  Cut over to `resolveRecoveryEvidence(repoRoot).available`
+  (`src/effects/evidence/recovery-materializer.ts`, read-only import).
+- The sprint's "materialized checks/latest for verification state" and
+  "tasks/current.md for the derived snapshot" Goal-2 bullets were both
+  already satisfied before this package started: the former by the
+  pre-existing `effective-state` section (`runtime.ts`, sourced from
+  `resolve-effective-state.ts`'s own `CHECKS_PATH` constant pointing at the
+  same materialized file `checks-materializer.ts` writes), the latter by
+  `currentStatusSnapshotContext`. Neither required a code change; adding a
+  duplicate verification-state section to `session-context.ts` itself would
+  have been an unrequested extra.
+- Panel measurement runner (`scripts/session-context-packet-panel.ts`) is a
+  new sibling script to `scripts/hook-dispatch-diet-report.ts` (HRD-08), not
+  an extension of it -- kept separate to avoid touching that script's own
+  tested surface (`tests/hook-dispatch-diet-report.test.ts`,
+  `tests/unit/hrd-08-event-telemetry-and-benchmark.test.ts`). It mirrors
+  (does not import) that script's `percentile()`/token-estimator/
+  synthetic-subprocess-probe shape, and mirrors (does not import)
+  `tests/state/effective-state-fixture.ts`'s fixture-builder shape --
+  neither is exported, and no script in this repo imports from `tests/`
+  (`tsconfig.json`'s `include` never even covers `scripts/**`), so this
+  follows the repo's own established "small helper duplicated across a
+  layer boundary" convention (`recovery-materializer.ts`/
+  `checks-materializer.ts`).
+- The panel renders the FULL SessionStart packet (effective-state +
+  post-edit-journal + `buildSessionStartSections()`'s three sections, all
+  budgeted) via the real `bun src/cli/hook-entry.ts SessionStart --route
+  default` subprocess against a freshly git-initialized fixture repo per
+  (authority, profile) cell -- not just `session-context.ts`'s own output --
+  since that is what a live host actually receives, and it is exactly what
+  `hook-dispatch-diet-report.ts`'s own `session_start_context` probe already
+  measures for this same packet.
+
+## Deviations From Plan Or Spec
+
+- None. The plan's Goal 1 inventory-first sequencing was followed exactly:
+  contract inventory recorded before any Phase B (cutover) edit; the red
+  test run (32 pass / 3 fail, all three tied directly to the not-yet-applied
+  cutover) was captured before applying the code change.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| Extend `hook-dispatch-diet-report.ts` in place for the panel | Rejected; new sibling script | Different measurement shape (27-state grid vs. dispatch/phase-probe/runtime-evidence); avoids risk to that script's own characterized tests |
+| Import `tests/state/effective-state-fixture.ts` fixture builder from the new script | Rejected; duplicated the fixture shape instead | No script in this repo imports from `tests/`; `tsconfig.json` never typechecks `scripts/**`; matches this repo's existing small-helper-duplication convention |
+| Also cut over `resumeCurrentForHandoff`'s mtime comparison to the checkpoint reader | Rejected; kept as-is | It is a same-materializer-pass plumbing check (was resume written in the same/later pass as handoff), not an evidence claim; EPC-07 already made both views one atomic write so it is nearly always true by construction |
+| Add a new verification-state section to `session-context.ts` reading `checks/latest.json` directly | Rejected; not needed | The delivered packet already sources verification state canonically via the pre-existing, out-of-scope `effective-state` section; adding a second one would be an unrequested extra |
+
+## Open Questions
+
+- None blocking. One observed-but-not-diagnosed-further artifact: the
+  `corrupt-policy` panel state renders a deterministic EMPTY (0-token)
+  packet, same as `no-plan`, even though it retains an active plan/contract.
+  Tracing this fully would require entering `resolve-effective-state.ts`'s
+  own policy-parsing path, which is out of this package's owned surface (not
+  `session-context.ts` or a named collaborator); the observed behavior is
+  safe (fail-closed to an empty, well-under-budget packet, exit code 0, no
+  crash), so it is recorded here rather than chased further.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Panel report: `tasks/reviews/20260723-0024-epc-08-context-packet-cutover.panel.md`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/reviews/20260723-0024-epc-08-context-packet-cutover.panel.md
+++ b/tasks/reviews/20260723-0024-epc-08-context-packet-cutover.panel.md
@@ -1,0 +1,54 @@
+# EPC-08 Context Packet Panel Report
+
+- Protocol: `epc-08-context-packet-panel/v1`
+- Generated: 2026-07-22T17:08:02.409Z
+- Base SHA: `9ea195b99db26895821e9ee3e29ad2f460895649`
+- Method: `utf8_bytes_div_4`
+- Runner command: `bun scripts/session-context-packet-panel.ts --repo . --iterations 20`
+- Iterations per state (latency, descriptive): 20
+
+## Panel (27 rows: 9 authority states x 3 profiles)
+
+| Authority state | Profile | estimated_tokens | within_budget | latency p50 (ms) | latency p95 (ms) |
+|---|---|---:|---|---:|---:|
+| no-plan | lite | 0 | true | 619.08 | 669.73 |
+| no-plan | standard | 0 | true | 625.38 | 661.47 |
+| no-plan | strict | 0 | true | 626.92 | 658.99 |
+| draft-plan | lite | 318 | true | 639.35 | 690.06 |
+| draft-plan | standard | 318 | true | 638.28 | 665.61 |
+| draft-plan | strict | 323 | true | 631.03 | 659.77 |
+| approved-work-package | lite | 318 | true | 640.25 | 660.96 |
+| approved-work-package | standard | 318 | true | 634.64 | 685.49 |
+| approved-work-package | strict | 323 | true | 633.23 | 663.5 |
+| executing | lite | 318 | true | 643.4 | 675.46 |
+| executing | standard | 318 | true | 629.12 | 665.98 |
+| executing | strict | 324 | true | 632.8 | 675.98 |
+| completed | lite | 318 | true | 640.31 | 679.87 |
+| completed | standard | 318 | true | 639 | 659.15 |
+| completed | strict | 323 | true | 668.39 | 736.81 |
+| foreign-worktree | lite | 306 | true | 660.13 | 688.42 |
+| foreign-worktree | standard | 306 | true | 623.74 | 656.22 |
+| foreign-worktree | strict | 306 | true | 627.73 | 661.65 |
+| corrupt-policy | lite | 0 | true | 339.33 | 362.48 |
+| corrupt-policy | standard | 0 | true | 342.36 | 370.15 |
+| corrupt-policy | strict | 0 | true | 344.1 | 368.75 |
+| invalid-capability-registry | lite | 318 | true | 636.38 | 661.51 |
+| invalid-capability-registry | standard | 318 | true | 632.43 | 659.17 |
+| invalid-capability-registry | strict | 324 | true | 634.12 | 677.81 |
+| conflicting-active-markers | lite | 318 | true | 632.79 | 662.64 |
+| conflicting-active-markers | standard | 318 | true | 631.24 | 665.37 |
+| conflicting-active-markers | strict | 324 | true | 629.53 | 675.44 |
+
+## Gate numbers (frozen, EPC-00)
+
+- Max estimated_tokens per sample: 1500
+- Panel p95(estimated_tokens) gate: 700
+- Every sample <= 1500 and within_budget == true: PASS
+- Panel p95(estimated_tokens): 324 (PASS, gate <= 700)
+- Overall: PASS
+
+## Notes
+
+- One deterministic sample per state for `estimated_tokens`/`within_budget` (packet content is deterministic per fixture state, EPC-00 confirmation).
+- The panel p95 gate above is computed over the 27 `estimated_tokens` samples (method `utf8_bytes_div_4`), per the frozen EPC-00 acceptance line -- it is NOT a latency gate.
+- Latency is reported purely descriptively across 20 iterations per state (p50/p95 ms in the table above); EPC-00 sets no SessionStart-latency gate at all.

--- a/tasks/reviews/20260723-0024-epc-08-context-packet-cutover.review.md
+++ b/tasks/reviews/20260723-0024-epc-08-context-packet-cutover.review.md
@@ -1,0 +1,84 @@
+# Task Review: epc-08-context-packet-cutover
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260723-0024-epc-08-context-packet-cutover.md
+> **Contract**: tasks/contracts/20260723-0024-epc-08-context-packet-cutover.contract.md
+> **Notes File**: tasks/notes/20260723-0024-epc-08-context-packet-cutover.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-07-23 00:24
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Commands passed:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+- Waza `/check` run:
+- Commands run:
+- Manual checks:
+- Supporting artifacts:
+- Implementation notes reviewed:
+- Run snapshot:
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...

--- a/tasks/reviews/20260723-0024-epc-08-context-packet-cutover.review.md
+++ b/tasks/reviews/20260723-0024-epc-08-context-packet-cutover.review.md
@@ -49,17 +49,17 @@
 
 ## Acceptance Receipt Projection
 
-> **Disposition**: unavailable
-> **Reviewer**: unavailable
-> **Source**: unavailable
+> **Disposition**: external_pass
+> **Reviewer**: Claude
+> **Source**: claude-review
 > **Actor**: not-applicable
-> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject SHA256**: sha256:6703dd6bc3cf25672a44cb2be2ea02354eb409bac77a6adad824149cff202a4d
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: pending
-> **Verification Evidence SHA256**: pending
-> **Issued At**: pending
+> **Reviewed Target Revision**: 9ea195b99db26895821e9ee3e29ad2f460895649
+> **Verification Evidence SHA256**: sha256:7e228aa05757f59355eb7796cb92fccb43814cf1d09994112219cb51a0ce5cb7
+> **Issued At**: 2026-07-22T17:40:59.376Z
 
-- Summary: No AcceptanceReceipt has been recorded.
+- Summary: EPC-08 accepted: Context Packet served from canonical projections (last primary-source re-derivation deleted), 27-state panel passes both frozen token gates (max 324, p95 324, utf8_bytes_div_4) with committed per-sample table; gatekeeper PASS with independent panel re-run
 - Findings: none
 
 ## Behavior Diff Notes

--- a/tasks/reviews/20260723-0024-epc-08-context-packet-cutover.review.md
+++ b/tasks/reviews/20260723-0024-epc-08-context-packet-cutover.review.md
@@ -1,12 +1,12 @@
 # Task Review: epc-08-context-packet-cutover
 
-> **Status**: Pending
+> **Status**: Reviewed
 > **Plan**: plans/plan-20260723-0024-epc-08-context-packet-cutover.md
 > **Contract**: tasks/contracts/20260723-0024-epc-08-context-packet-cutover.contract.md
 > **Notes File**: tasks/notes/20260723-0024-epc-08-context-packet-cutover.notes.md
 > **Checks File**: .ai/harness/checks/latest.json
-> **Last Updated**: 2026-07-23 00:24
-> **Recommendation**: fail
+> **Last Updated**: 2026-07-23 02:05
+> **Recommendation**: pass
 > **Review Rubric Version**: 2
 > **Reviewed Subject SHA256**: pending
 > **Reviewed Subject Scope**: normalized-final-content
@@ -14,29 +14,38 @@
 
 ## Human Review Card
 
-- Verdict: pending
-- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
-- Intended files changed:
-- Actual files changed:
-- Commands passed:
-- Residual risks:
-- Reviewer action required: inspect diff and card
-- Rollback:
+- Verdict: pass
+- Change type: code-change
+- Intended files changed: `src/cli/hook/session-context.ts` (single cutover: `resumeAvailable` delegates to `resolveRecoveryEvidence`, old marker string-scan deleted), new `scripts/session-context-packet-panel.ts` runner, new panel suite + updated session-context suite, tracked panel report `tasks/reviews/20260723-0024-epc-08-context-packet-cutover.panel.md`, package plan/contract/review/notes, `tasks/todos.md` projection
+- Actual files changed: exactly that set — 10 paths, single commit `2e44fc55` on base `9ea195b9`; Stop handler, recovery-materializer, checkpoint modules, checks-materializer, producers/importers, `resolve-effective-state.ts`, `session-context-budget.ts` (budget constant + estimator), `tasks/current.md` all untouched
+- Commands passed: `bun test tests/session-context.test.ts tests/session-context-packet-panel.test.ts` (46 pass; red-first — 3 fail before the cutover), full `bun test` (1827 pass / 1 skip / 0 fail — worker + gatekeeper independent runs), panel runner exit 0 (worker + gatekeeper independent runs, byte-identical token distribution), `check:type` clean, `check-task-workflow --strict` OK, `contract-run preflight` preflight_pass, deploy-sql/task-sync/architecture-sync (advisory blocking=0) green, `inspect-project-state` no drift, `adopt --dry-run` 0 operations
+- Residual risks: gate-composition of `buildPanelReport` proven by the live runner run rather than a dedicated unit test (gatekeeper non-blocking observation); panel report's recorded base SHA reflects pre-commit generation (cosmetic — gatekeeper re-run at HEAD reproduced identical numbers); latency p95 ungated by design (EPC-00 confirmation)
+- Reviewer action required: none further — gatekeeper acceptance review (fresh context, read-only) verdict PASS with base-revision inventory spot-checks and an independent panel re-run
+- Rollback: revert the single PR — restores the string-scan and removes the projection delegation + panel runner; budget mechanics unchanged either way
 
 ## Mode Evidence
 
-- Selected route:
-- P1/P2/P3 evidence:
-- Root cause or plan evidence:
+- Selected route: planning (captured work-package plan, code-change profile; inventory-first sequencing honored)
+- P1/P2/P3 evidence: plan Captured Planning Output; EPC-00-amended row 12 acceptance line + frozen D4; inventory recorded in the contract before the cutover edit
+- Root cause or plan evidence: cutover package; the single remaining primary-source re-derivation was pre-named by EPC-07's deferral notes
 
 ## Verification Evidence
 
-- Waza `/check` run:
-- Commands run:
-- Manual checks:
-- Supporting artifacts:
-- Implementation notes reviewed:
-- Run snapshot:
+- Waza `/check` run: gatekeeper acceptance review (fresh context, read-only) — verdict PASS; inventory verified at `git show 9ea195b9:`; zero direct reads of `harness/checks` or `harness/evidence` in session-context confirmed by grep
+- Commands run: see Human Review Card; executed in the contract worktree at `2e44fc55`
+- Manual checks: see Manual Check Evidence below
+- Supporting artifacts: `.ai/harness/checks/latest.json`; `tasks/reviews/20260723-0024-epc-08-context-packet-cutover.panel.md`
+- Implementation notes reviewed: yes — inventory classification, the caught-and-fixed p95-over-latency runner bug, panel fixture reuse
+- Run snapshot: `.ai/harness/runs/`
+
+## Manual Check Evidence
+
+- [x] Panel report committed: 27 rows, every sample <= 1500 with within_budget true, p95 <= 700, method utf8_bytes_div_4
+  - Evidence: `tasks/reviews/20260723-0024-epc-08-context-packet-cutover.panel.md` carries the 27-row table (9 authority states × 3 profiles); token distribution 6×0, 3×306, 12×318, 3×323, 3×324 — max 324 ≤ 1500, 27/27 `within_budget: true`, panel p95(estimated_tokens) = 324 ≤ 700, method `utf8_bytes_div_4`; gatekeeper's independent runner re-run at HEAD exited 0 with byte-identical numbers; the committed runner computes p95 over token samples and drives its exit code from the gates.
+- [x] No-independent-assembly test green (old path deleted)
+  - Evidence: the old marker/header string-scan is deleted from `session-context.ts` (base-revision diff confirms); remaining marker occurrences are the writer's own constant and test fixtures; behavior-flip tests prove both directions (marked resume without checkpoint withheld; unmarked resume with published checkpoint surfaces) plus the structural source-scan test; suite green (46/46).
+- [x] tasks/current.md untouched
+  - Evidence: `git diff 9ea195b9..HEAD -- tasks/current.md` is empty; `git status --porcelain` shows no entry for `tasks/current.md`.
 
 ## Acceptance Receipt Projection
 
@@ -55,30 +64,31 @@
 
 ## Behavior Diff Notes
 
-- ...
+- SessionStart's `resumeAvailable` now derives from the checkpoint-backed recovery resolver instead of scanning the rendered resume Markdown — the last primary-source re-derivation in the Context Packet is gone; every other packet section was already projection-sourced or a legitimate non-evidence subsystem read. Budget mechanics unchanged; measured packet sizes far under both frozen gates.
 
 ## Residual Risks / Follow-ups
 
-- ...
+- Optional: a dedicated unit test for `buildPanelReport` gate composition (currently proven live).
+- EPC-09 carry-forwards unchanged.
 
 ## Scorecard
 
 | Dimension | Score | Notes |
 |-----------|-------|-------|
-| Functionality | 0/10 | |
-| Product depth | 0/10 | |
-| Design quality | 0/10 | |
-| Code quality | 0/10 | |
+| Functionality | 9/10 | Row-12 acceptance satisfied; both token gates pass with wide margin |
+| Product depth | 9/10 | Behavior-flip tests prove the trust-model change in both directions |
+| Design quality | 9/10 | Minimal true-to-inventory cutover; no invented sections |
+| Code quality | 9/10 | 1827 green twice independently; runner p95 bug caught pre-commit |
 
 ## Failing Items
 
-- ...
+- none
 
 ## Retest Steps
 
-- Re-run:
-- Re-check:
+- Re-run: `bun test tests/session-context.test.ts tests/session-context-packet-panel.test.ts`; `bun scripts/session-context-packet-panel.ts --repo . --iterations 20`
+- Re-check: panel report numbers vs runner output; string-scan absence in session-context.ts
 
 ## Summary
 
-- ...
+- EPC-08 completes the Context Packet cutover: the last primary-source re-derivation (`resumeAvailable` string-scan) is replaced by the checkpoint-backed recovery resolver and deleted same-package; the 27-state Authority×Profile panel passes both frozen token gates with wide margin (max 324, p95 324, method utf8_bytes_div_4) with the per-sample table committed. Gatekeeper verdict: PASS. Ready to ship as one PR.

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -1,7 +1,7 @@
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: 2026-07-22 22:46
+> **Updated**: 2026-07-23 00:24
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.

--- a/tests/session-context-packet-panel.test.ts
+++ b/tests/session-context-packet-panel.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from "bun:test";
+import { resolve } from "path";
+import {
+  AUTHORITY_STATES,
+  PROFILES,
+  PANEL_TOKEN_ESTIMATE_METHOD,
+  buildPanelFixture,
+  estimatedTokens,
+  measurePanelCell,
+  panelReportPasses,
+  percentile,
+  renderPanelMarkdown,
+  type PanelReport,
+} from "../scripts/session-context-packet-panel";
+
+const REPO_ROOT = resolve(import.meta.dir, "..");
+
+describe("session-context-packet-panel: 27-state shape", () => {
+  test("9 authority states x 3 profiles = 27 panel cells", () => {
+    expect(AUTHORITY_STATES.length).toBe(9);
+    expect(PROFILES.length).toBe(3);
+    expect(AUTHORITY_STATES.length * PROFILES.length).toBe(27);
+    expect(new Set(AUTHORITY_STATES).size).toBe(9);
+  });
+
+  test("method is the frozen utf8_bytes_div_4 estimator", () => {
+    expect(PANEL_TOKEN_ESTIMATE_METHOD).toBe("utf8_bytes_div_4");
+    expect(estimatedTokens("abcd")).toBe(1);
+    expect(estimatedTokens("a".repeat(4001))).toBe(1001);
+  });
+});
+
+describe("session-context-packet-panel: percentile()", () => {
+  test("p50/p95 over a known array match manual quantile computation", () => {
+    const values = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
+    expect(percentile(values, 0.5)).toBe(50);
+    expect(percentile(values, 0.95)).toBe(100);
+    expect(percentile([], 0.5)).toBeNull();
+  });
+});
+
+describe("session-context-packet-panel: fixture builder produces a valid opt-in git repo per authority state", () => {
+  test("every authority state's fixture is git-initialized with the opt-in marker present", () => {
+    for (const authority of AUTHORITY_STATES) {
+      const fixture = buildPanelFixture(authority, "standard");
+      try {
+        const marker = Bun.file(`${fixture.cwd}/.ai/harness/workflow-contract.json`);
+        expect(marker.size).toBeGreaterThan(0);
+      } finally {
+        fixture.cleanup();
+      }
+    }
+  });
+});
+
+describe("session-context-packet-panel: packet determinism per state", () => {
+  test("two independent measurement passes over the SAME authority/profile state agree on estimated_tokens and within_budget", () => {
+    const first = measurePanelCell(REPO_ROOT, "executing", "standard", 2);
+    const second = measurePanelCell(REPO_ROOT, "executing", "standard", 2);
+    expect(first.estimated_tokens).toBe(second.estimated_tokens);
+    expect(first.within_budget).toBe(second.within_budget);
+    expect(first.exit_codes.every((code) => code === 0)).toBe(true);
+    expect(second.exit_codes.every((code) => code === 0)).toBe(true);
+  }, 30000);
+
+  test("a state with no active plan renders a deterministic empty (0-token) packet", () => {
+    const result = measurePanelCell(REPO_ROOT, "no-plan", "lite", 1);
+    expect(result.estimated_tokens).toBe(0);
+    expect(result.within_budget).toBe(true);
+  }, 15000);
+});
+
+describe("session-context-packet-panel: gate logic", () => {
+  function syntheticReport(overrides: Partial<PanelReport["gates"]>): PanelReport {
+    return {
+      protocol: "epc-08-context-packet-panel/v1",
+      generated_at: "2026-07-23T00:00:00.000Z",
+      base_sha: "test",
+      method: "utf8_bytes_div_4",
+      runner_command: "test",
+      iterations_per_state: 1,
+      cells: [],
+      gates: {
+        max_estimated_tokens: 1500,
+        panel_token_p95_gate: 700,
+        every_sample_within_budget: true,
+        every_sample_at_or_under_budget: true,
+        panel_p95_estimated_tokens: 320,
+        panel_p95_within_gate: true,
+        pass: true,
+        ...overrides,
+      },
+    };
+  }
+
+  test("passes when both gates are satisfied", () => {
+    expect(panelReportPasses(syntheticReport({ pass: true }))).toBe(true);
+  });
+
+  test("fails when a sample exceeds the token budget", () => {
+    const report = syntheticReport({ every_sample_at_or_under_budget: false, pass: false });
+    expect(panelReportPasses(report)).toBe(false);
+  });
+
+  test("fails when within_budget is false for any sample", () => {
+    const report = syntheticReport({ every_sample_within_budget: false, pass: false });
+    expect(panelReportPasses(report)).toBe(false);
+  });
+
+  test("fails when panel p95(estimated_tokens) exceeds the frozen gate", () => {
+    const report = syntheticReport({ panel_p95_within_gate: false, pass: false });
+    expect(panelReportPasses(report)).toBe(false);
+  });
+
+  test("renderPanelMarkdown includes all 27 rows, the two gate numbers, method, command, and base SHA", () => {
+    const cells = AUTHORITY_STATES.flatMap((authority) =>
+      PROFILES.map((profile) => ({
+        authority,
+        profile,
+        estimated_tokens: 100,
+        within_budget: true,
+        latency_p50_ms: 10,
+        latency_p95_ms: 20,
+        sample_count: 1,
+        exit_codes: [0],
+      })),
+    );
+    const report: PanelReport = {
+      protocol: "epc-08-context-packet-panel/v1",
+      generated_at: "2026-07-23T00:00:00.000Z",
+      base_sha: "deadbeef",
+      method: "utf8_bytes_div_4",
+      runner_command: "bun scripts/session-context-packet-panel.ts --repo . --iterations 20",
+      iterations_per_state: 20,
+      cells,
+      gates: {
+        max_estimated_tokens: 1500,
+        panel_token_p95_gate: 700,
+        every_sample_within_budget: true,
+        every_sample_at_or_under_budget: true,
+        panel_p95_estimated_tokens: 100,
+        panel_p95_within_gate: true,
+        pass: true,
+      },
+    };
+    const markdown = renderPanelMarkdown(report);
+    const rowCount = report.cells.length;
+    expect(rowCount).toBe(27);
+    for (const authority of AUTHORITY_STATES) {
+      expect(markdown).toContain(authority);
+    }
+    expect(markdown).toContain("1500");
+    expect(markdown).toContain("700");
+    expect(markdown).toContain("utf8_bytes_div_4");
+    expect(markdown).toContain("bun scripts/session-context-packet-panel.ts");
+    expect(markdown).toContain("deadbeef");
+  });
+});

--- a/tests/session-context.test.ts
+++ b/tests/session-context.test.ts
@@ -24,6 +24,44 @@ import {
 } from "../src/cli/hook/session-context";
 import { budgetSessionContext } from "../src/cli/hook/session-context-budget";
 import { createStateInputCollector } from "../src/effects/loop/state-input-collector";
+import { appendEvidenceEvent, appendGenesisRecord } from "../src/effects/evidence/event-log";
+import { LEDGER_EPOCH_START_SHA } from "../src/effects/evidence/epoch";
+import { publishCheckpointFromLedger } from "../src/effects/evidence/checkpoint-store";
+
+// EPC-08: resume availability is now resolved from the canonical
+// checkpoint-backed evidence reader (`resolveRecoveryEvidence`, consumed
+// internally by `resumeAvailable()`), not from a marker/header string-scan
+// of the rendered resume.md. Publishing a real checkpoint here is what
+// `resumeAvailable()` now requires before it will surface a resume block --
+// mirrors `tests/evidence-recovery-materializer.test.ts`'s own
+// seedGenesis/seedEvent/publishCheckpointFromLedger pattern (duplicated, not
+// imported -- same tiny-fixture-helper convention this repo already uses
+// across evidence test files).
+function publishFixtureCheckpoint(repoRoot: string): void {
+  appendGenesisRecord(repoRoot, LEDGER_EPOCH_START_SHA, { worktreeId: "fixture" });
+  appendEvidenceEvent(repoRoot, {
+    worktreeId: "fixture",
+    eventType: "verify_sprint.result",
+    trustClass: "authoritative_machine",
+    producer: "verify-sprint",
+    correlationRunId: `run-${Math.random().toString(36).slice(2)}`,
+    subjectIdentity: {
+      authority_commit: "a".repeat(40),
+      base_commit: "b".repeat(40),
+      target_commit: "c".repeat(40),
+      scope_hash: `sha256:${"d".repeat(64)}`,
+      subject_hash: `sha256:${"e".repeat(64)}`,
+      contract_hash: `sha256:${"f".repeat(64)}`,
+      command_hash: `sha256:${"0".repeat(64)}`,
+      env_provider_id: "repo-harness/0.0.0/ws-test",
+    },
+    payload: { kind: "json", value: { marker: "fixture" } },
+  });
+  const published = publishCheckpointFromLedger(repoRoot, () => new Date("2026-07-23T00:00:00.000Z"));
+  if (published.status !== "published") {
+    throw new Error(`fixture checkpoint publish failed: ${JSON.stringify(published)}`);
+  }
+}
 
 function tmpRepo(prefix: string): string {
   const dir = mkdtempSync(join(tmpdir(), `${prefix}-`));
@@ -206,16 +244,50 @@ describe("sessionStartMainContent (session-start-context.sh port) — empty/gati
     });
   });
 
-  test("resume packet without the generated-by marker is not injected", () => {
-    withTmpRepo("main-resume-no-marker", (repoRoot) => {
+  test("EPC-08: no checkpoint published -> resume block absent even with a well-formed, correctly-marked resume.md", () => {
+    // Supersedes the pre-cutover "without the generated-by marker" premise:
+    // availability is no longer a marker/header string-scan of resume.md
+    // (`resumeAvailable()` now calls `resolveRecoveryEvidence` directly), so
+    // a perfectly well-formed resume.md is still withheld when no
+    // checkpoint has ever been published in this worktree.
+    withTmpRepo("main-resume-no-checkpoint", (repoRoot) => {
       mkdirSync(join(repoRoot, ".ai/harness/handoff"), { recursive: true });
-      writeFileSync(join(repoRoot, ".ai/harness/handoff/resume.md"), "# Codex Resume Packet\n\n> **Reason**: bootstrap\n");
+      writeFileSync(
+        join(repoRoot, ".ai/harness/handoff/resume.md"),
+        [
+          "<!-- generated-by: repo-harness codex-handoff-resume v1 -->",
+          "# Codex Resume Packet",
+          "",
+          "## Resume Prompt",
+          "",
+          "Continue the widget work.",
+        ].join("\n"),
+      );
       expect(sessionStartMainContent(freshCollector(repoRoot), process.env, Date.now())).toBeNull();
+    });
+  });
+
+  test("EPC-08: a published checkpoint makes resume available even when resume.md is missing the legacy marker/header", () => {
+    // Proves the cutover in the OTHER direction: the old marker/header text
+    // is no longer load-bearing for availability -- only checkpoint
+    // existence is. A checkpoint-backed evidence claim plus a todo signal
+    // still surfaces the resume blob verbatim.
+    withTmpRepo("main-resume-checkpoint-no-marker", (repoRoot) => {
+      publishFixtureCheckpoint(repoRoot);
+      mkdirSync(join(repoRoot, ".ai/harness/handoff"), { recursive: true });
+      writeFileSync(join(repoRoot, ".ai/harness/handoff/resume.md"), "# Codex Resume Packet\n\nContinue the widget work.\n");
+      mkdirSync(join(repoRoot, "tasks"), { recursive: true });
+      writeFileSync(join(repoRoot, "tasks/todos.md"), "# Deferred Goal Ledger\n\n- [ ] revisit caching\n");
+
+      const content = sessionStartMainContent(freshCollector(repoRoot), process.env, Date.now());
+      expect(content).not.toBeNull();
+      expect(content).toContain("Continue the widget work.");
     });
   });
 
   test("resume packet current for handoff + a todo signal -> injected, capped, prefixed with Input Priority", () => {
     withTmpRepo("main-resume-signal", (repoRoot) => {
+      publishFixtureCheckpoint(repoRoot);
       mkdirSync(join(repoRoot, ".ai/harness/handoff"), { recursive: true });
       writeFileSync(
         join(repoRoot, ".ai/harness/handoff/resume.md"),
@@ -246,6 +318,7 @@ describe("sessionStartMainContent (session-start-context.sh port) — empty/gati
   // output below is the parity fixture.
   test("S5 parity: resume packet + a later section (active sprint) join with no blank line between them", () => {
     withTmpRepo("main-resume-plus-sprint", (repoRoot) => {
+      publishFixtureCheckpoint(repoRoot);
       mkdirSync(join(repoRoot, ".ai/harness/handoff"), { recursive: true });
       const resumeBlob = [
         "<!-- generated-by: repo-harness codex-handoff-resume v1 -->",
@@ -764,4 +837,19 @@ describe("tooling-advisory detached populate (gatekeeper MEDIUM finding)", () =>
       expect(reportWritten).toBe(true);
     });
   }, 10000);
+});
+
+describe("no-independent-assembly: resumeAvailable no longer re-derives evidence from rendered Markdown", () => {
+  const SOURCE_PATH = join(import.meta.dir, "..", "src/cli/hook/session-context.ts");
+
+  test("the retired marker/header string-scan literal is gone from the source", () => {
+    const text = readFileSync(SOURCE_PATH, "utf-8");
+    expect(text.includes("generated-by: repo-harness codex-handoff-resume v1")).toBe(false);
+  });
+
+  test("resumeAvailable delegates to the canonical checkpoint-backed evidence reader (read-only import)", () => {
+    const text = readFileSync(SOURCE_PATH, "utf-8");
+    expect(text).toContain("resolveRecoveryEvidence");
+    expect(text).toContain("effects/evidence/recovery-materializer");
+  });
 });


### PR DESCRIPTION
Sprint C backlog row 12 (EPC-00-amended acceptance line).

- Inventory-first (contract-recorded, gatekeeper-verified at base): exactly ONE primary-source re-derivation remained in the SessionStart Context Packet — `resumeAvailable()`'s marker string-scan of the rendered resume.md (pre-named as deferred-to-EPC-08 by EPC-07's contract and the recovery-materializer module docs). Every other section was already projection-sourced or a legitimate non-evidence subsystem read; the verification-state bullet was already satisfied via the effective-state section reading the materialized `checks/latest`.
- Cutover: `resumeAvailable` now delegates to `resolveRecoveryEvidence().available` (checkpoint-backed, fail-degrade); the string-scan is deleted same-package. Behavior-flip tests prove both directions (marked-resume-without-checkpoint withheld; unmarked-resume-with-checkpoint surfaces) plus a structural no-independent-assembly test.
- 27-state Authority×Profile panel runner (`scripts/session-context-packet-panel.ts`, gates drive exit code): every sample estimated_tokens ≤ 1500 with within_budget true (max 324); panel p95(estimated_tokens) = 324 ≤ 700; method utf8_bytes_div_4; latency descriptive (≥20 iterations). Per-sample table committed at `tasks/reviews/20260723-0024-epc-08-context-packet-cutover.panel.md`. Gatekeeper independently re-ran the panel at HEAD: exit 0, byte-identical distribution.
- Budget mechanics (1500 constant, estimator) unchanged.

Verification: full `bun test` 1827 pass / 0 fail / 1 skip (worker + gatekeeper independent runs); red-first (3 fail pre-cutover); type-check clean; preflight pass. Acceptance: gatekeeper PASS; external_pass receipt against materialized evidence.