### PR TITLE
fix(state): reuse canonical plan slug parser

### DIFF
--- a/src/effects/evidence/recovery-materializer.ts
+++ b/src/effects/evidence/recovery-materializer.ts
@@ -27,6 +27,7 @@ import { createHash } from 'crypto';
 import { execFileSync } from 'child_process';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { basename, join } from 'path';
+import { planSlugFromPath } from '../../core/state/artifact-parsers';
 import {
   CheckpointResolutionError,
   resolveLastPublishedCheckpoint,
@@ -152,16 +153,10 @@ export interface RecoveryArtifactPaths {
   readonly notes: string;
 }
 
-function planSlugFromPath(planFile: string): string {
-  const base = basename(planFile);
-  const slug = base.replace(/^plan-\d{8}-\d{4}-/, '').replace(/\.md$/, '');
-  return slug.length > 0 && slug !== base ? slug : '';
-}
-
 function planStemFromPath(planFile: string): string {
   const base = basename(planFile);
   const stem = base.replace(/^plan-/, '').replace(/\.md$/, '');
-  return /^\d{8}-\d{4}-.+/.test(stem) ? stem : planSlugFromPath(planFile);
+  return /^\d{8}-\d{4}-.+/.test(stem) ? stem : (planSlugFromPath(planFile) ?? '');
 }
 
 /** `workflow_preferred_or_legacy_path` port: preferred (stamped-stem)

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -12,6 +12,12 @@
 
 ## Active Lessons
 
+- Date: 2026-07-23
+- Triggered by correction: EPC-07 added a private `planSlugFromPath` after Effective State had already declared `src/core/state/artifact-parsers.ts` as that symbol's canonical owner, so the merged `main` failed `check-state-boundaries` even though the EPC slice's focused tests passed.
+- Mistake pattern: treating a small parser as a harmless local helper without checking the canonical-symbol registry and the latest target branch before final verification.
+- Prevention rule: before adding or retaining a named parser/resolver helper under `src/`, check `scripts/check-state-boundaries.ts` and import the registered owner when one exists; after rebasing or merging the latest target, run `bun scripts/check-state-boundaries.ts` before push so concurrent authority changes cannot land a duplicate implementation.
+- Where to apply next time: new `src/` materializers, hook handlers, state/evidence projections, and any branch that ports private helpers from an older implementation.
+
 - Date: 2026-07-20
 - Triggered by correction: HRD-03's script retirement needed four separate contract amendment rounds because live consumers (installer evidence lists, sync-tool checks, generated-rule emitters, five locale READMEs, nine test files) were discovered one gate round at a time; HRD-04/05 then landed the same class of cutover with a single amendment round each by enumerating first.
 - Mistake pattern: starting a retirement/cutover implementation before enumerating every live consumer of the retired surface, so the allowlist grows reactively through repeated fail-fix-regate rounds.


### PR DESCRIPTION
## Summary
- remove the competing recovery-materializer implementation of planSlugFromPath
- reuse the canonical parser owned by src/core/state/artifact-parsers.ts
- record the canonical-owner regression lesson

## Root cause
EPC-07 introduced a private helper after Effective State had already registered the canonical symbol owner, so the latest main failed check-state-boundaries.

## Verification
- bun scripts/check-state-boundaries.ts
- targeted recovery/state tests: 33 pass, 0 fail
- bun run check:type
- full test suite: 1848 pass, 1 skip, 0 fail
- deploy SQL, architecture sync, task sync, strict task workflow, project inspection, and adopt dry-run all pass