### PR TITLE
test(workflow): bind fixtures to exact run snapshots

### DIFF
--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -13,6 +13,12 @@
 ## Active Lessons
 
 - Date: 2026-07-23
+- Triggered by correction: the `verify-sprint` metadata test launched three runs inside one second, then selected the "latest" snapshot using only second-resolution `generated_at`; GitHub CI intermittently read an earlier run and failed even though the behavior under test was correct.
+- Mistake pattern: generating multiple uniquely named evidence artifacts but asserting through a timestamp scan instead of binding each assertion to the producer's explicit run ID.
+- Prevention rule: tests that create more than one run/evidence artifact must assign deterministic run IDs and read the exact named artifact; do not use timestamp ordering as evidence authority.
+- Where to apply next time: workflow helper fixtures, run-trace tests, evidence materializer tests, and any test that emits multiple artifacts into one directory.
+
+- Date: 2026-07-23
 - Triggered by correction: EPC-07 added a private `planSlugFromPath` after Effective State had already declared `src/core/state/artifact-parsers.ts` as that symbol's canonical owner, so the merged `main` failed `check-state-boundaries` even though the EPC slice's focused tests passed.
 - Mistake pattern: treating a small parser as a harmless local helper without checking the canonical-symbol registry and the latest target branch before final verification.
 - Prevention rule: before adding or retaining a named parser/resolver helper under `src/`, check `scripts/check-state-boundaries.ts` and import the registered owner when one exists; after rebasing or merging the latest target, run `bun scripts/check-state-boundaries.ts` before push so concurrent authority changes cannot land a duplicate implementation.

--- a/tests/helper-scripts.test.ts
+++ b/tests/helper-scripts.test.ts
@@ -190,6 +190,11 @@ function latestRunSnapshot(cwd: string): { path: string; content: any } {
   return { path: best.path, content: best.content };
 }
 
+function runSnapshotById(cwd: string, runId: string, contractSlug: string): { path: string; content: any } {
+  const path = join(cwd, ".ai/harness/runs", `${runId}-${contractSlug}.json`);
+  return { path, content: JSON.parse(readFileSync(path, "utf-8")) };
+}
+
 function expectChecksLatestAbsent(cwd: string): void {
   expect(existsSync(join(cwd, ".ai/harness/checks/latest.json"))).toBe(false);
 }
@@ -3822,7 +3827,11 @@ describe("Workflow helper scripts", () => {
         REPO_HARNESS_DIFF_BASE: undefined,
         HARNESS_DIFF_BASE: undefined,
       };
-      const baselineRes = run("bash", ["scripts/verify-sprint.sh", "--prepare-acceptance"], cwd, metadataFallbackEnv);
+      const baselineRunId = "fixture-task-baseline";
+      const baselineRes = run("bash", ["scripts/verify-sprint.sh", "--prepare-acceptance"], cwd, {
+        ...metadataFallbackEnv,
+        HOOK_RUN_ID: baselineRunId,
+      });
       expect(baselineRes.status, `${baselineRes.stdout}\n${baselineRes.stderr}`).toBe(0);
       // EPC-05: emission cannot-binds in this fixture (no
       // scripts/emit-verify-evidence.ts is deployed here), so
@@ -3830,7 +3839,7 @@ describe("Workflow helper scripts", () => {
       // runs -- the identical content still lands in each run's own
       // snapshot file, unaffected by this row's cutover.
       expectChecksLatestAbsent(cwd);
-      const baselineChecks = latestRunSnapshot(cwd).content;
+      const baselineChecks = runSnapshotById(cwd, baselineRunId, "demo").content;
       expect(baselineChecks.diff_base.ref).toBe(taskBase);
       expect(baselineChecks.diff_base.merge_base).toBe(taskBase);
       expect(baselineChecks.files_changed).toContain("docs/task-change.md");
@@ -3851,18 +3860,24 @@ describe("Workflow helper scripts", () => {
           2
         ) + "\n"
       );
-      const legacyMetadataRes = run("bash", ["scripts/verify-sprint.sh", "--prepare-acceptance"], cwd, metadataFallbackEnv);
+      const legacyMetadataRunId = "fixture-legacy-metadata";
+      const legacyMetadataRes = run("bash", ["scripts/verify-sprint.sh", "--prepare-acceptance"], cwd, {
+        ...metadataFallbackEnv,
+        HOOK_RUN_ID: legacyMetadataRunId,
+      });
       expect(legacyMetadataRes.status).toBe(0);
-      const legacyMetadataChecks = latestRunSnapshot(cwd).content;
+      const legacyMetadataChecks = runSnapshotById(cwd, legacyMetadataRunId, "demo").content;
       expect(legacyMetadataChecks.diff_base.ref).toBe(taskBase);
       expect(legacyMetadataChecks.allowed_paths_check.status).toBe("pass");
 
+      const overrideRunId = "fixture-explicit-override";
       const overrideRes = run("bash", ["scripts/verify-sprint.sh", "--prepare-acceptance"], cwd, {
         HOOK_HOST: "claude",
+        HOOK_RUN_ID: overrideRunId,
         REPO_HARNESS_DIFF_BASE: "origin/main",
       });
       expect(overrideRes.status).toBe(1);
-      const overrideChecks = latestRunSnapshot(cwd).content;
+      const overrideChecks = runSnapshotById(cwd, overrideRunId, "demo").content;
       expect(overrideChecks.diff_base.ref).toBe("origin/main");
       expect(overrideChecks.allowed_paths_check.outside).toContain("plans/preexisting-on-local-main.md");
     } finally {


### PR DESCRIPTION
## Summary
- assign deterministic HOOK_RUN_ID values to the three verify-sprint fixture runs
- read each exact run artifact instead of inferring latest from second-resolution generated_at
- record the evidence-authority lesson

## Root cause
The test emitted three uniquely named snapshots within one second, while latestRunSnapshot compared only generated_at. Equal timestamps preserved an arbitrary earlier directory entry, so CI intermittently asserted against stale evidence.

## Verification
- targeted immutable contract-worktree metadata test: pass
- full tests/helper-scripts.test.ts host run: pass for the corrected path
- bun run check:type
- state boundaries, deploy SQL, architecture sync, task sync, strict task workflow, project inspection, and adopt dry-run all pass