### PR TITLE
fix(hook): partition transient resolution instability from real blockers

### DIFF
--- a/plans/plan-20260723-0620-hook-guard-stability.md
+++ b/plans/plan-20260723-0620-hook-guard-stability.md
@@ -1,0 +1,225 @@
+# Plan: Hook guard: partition transient resolution instability from real blockers
+
+> **Status**: Executing
+> **Created**: 20260723-0620
+> **Slug**: hook-guard-stability
+> **Planning Source**: repo-harness-hunt
+> **Orchestration Kind**: host-plan
+> **Source Ref**: diagnosis:root-cause-prover-20260723
+> **Artifact Level**: work-package
+> **Promotion Reason**: rollback_boundary
+> **Verification Boundary**: Commands named in the captured planning output plus `repo-harness run verify-contract --contract tasks/contracts/20260723-0620-hook-guard-stability.contract.md --strict`.
+> **Rollback Surface**: Before execution remove `plans/plan-20260723-0620-hook-guard-stability.md`; after execution revert branch `codex/hook-guard-stability` or the explicitly reviewed diff.
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260723-0620-hook-guard-stability.contract.md`
+> **Task Review**: `tasks/reviews/20260723-0620-hook-guard-stability.review.md`
+> **Implementation Notes**: `tasks/notes/20260723-0620-hook-guard-stability.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from repo-harness-hunt planning output.
+- Source ref: diagnosis:root-cause-prover-20260723
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260723-0620-hook-guard-stability.md`
+- Sprint contract: `tasks/contracts/20260723-0620-hook-guard-stability.contract.md`
+- Sprint review: `tasks/reviews/20260723-0620-hook-guard-stability.review.md`
+- Implementation notes: `tasks/notes/20260723-0620-hook-guard-stability.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260723-0620-hook-guard-stability.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260723-0620-hook-guard-stability.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260723-0620-hook-guard-stability.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260723-0620-hook-guard-stability.contract.md`
+- Review file: `tasks/reviews/20260723-0620-hook-guard-stability.review.md`
+- Implementation notes file: `tasks/notes/20260723-0620-hook-guard-stability.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260723-0620-hook-guard-stability.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260723-0620-hook-guard-stability.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: Before execution remove `plans/plan-20260723-0620-hook-guard-stability.md`; after execution revert branch `codex/hook-guard-stability` or the explicitly reviewed diff.
+- **Verification boundary**: Commands named in the captured planning output plus `repo-harness run verify-contract --contract tasks/contracts/20260723-0620-hook-guard-stability.contract.md --strict`.
+- **Review/acceptance boundary**: `tasks/reviews/20260723-0620-hook-guard-stability.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: rollback_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260723-0620-hook-guard-stability.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260723-0620-hook-guard-stability.contract.md`, `tasks/reviews/20260723-0620-hook-guard-stability.review.md`, and `tasks/notes/20260723-0620-hook-guard-stability.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260723-0620-hook-guard-stability.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: Before execution remove `plans/plan-20260723-0620-hook-guard-stability.md`; after execution revert branch `codex/hook-guard-stability` or the explicitly reviewed diff.
+
+## Captured Planning Output
+
+## Why
+
+The PreEdit WorkflowProfileGuard blocks edits with one undifferentiated
+banner ("Deterministic workflow profile resolution failed") for three
+unrelated causes: a genuinely blocked effective state, an unsupported
+profile, and — the defect — any exception thrown during resolution,
+because `resolvePreEditEffectiveState` (src/cli/hook/runtime.ts:246-261)
+collapses every throw into `null` via a catch-all. The dominant throw is
+the stability contract in `resolveEffectiveState`
+(src/effects/state/resolve-effective-state.ts:582-634): it re-reads all
+workflow sources up to 4 times and throws "workflow authority changed
+repeatedly" when `source_hashes` differ across reads — but the hash set
+includes non-authority, high-churn surfaces (the full working-tree
+`review_subject` diff fingerprint, `.ai/harness/checks/latest.json`,
+`tasks/current.md`, handoff/resume), so ordinary concurrent work (bun
+test, git commands, evidence-cache writes) makes an innocent Edit fail
+closed. Root-cause diagnosis (2026-07-23, root-cause-prover) reproduced
+this deterministically: 0/200 blocks at baseline, 30/30 blocks under
+sustained working-tree churn with each resolution spending ~375 ms in
+git subprocesses. A secondary same-shape path is the 5 s state-lock
+timeout throw. The "No stderr output" variant is the same block after
+the circuit breaker trips (stdout-only emission branch) and needs no
+separate fix. Operationally this has cost every linked-worktree package
+since EPC repeated false Edit/Write blocks worked around with heredoc.
+
+## Goal
+
+Partition the guard's failure modes so each gets truthful, distinct
+handling, without weakening real-blocker enforcement:
+
+1. Non-authority churn surfaces (`review_subject` diff fingerprint,
+   checks/latest, tasks/current snapshot, handoff/resume projections) no
+   longer participate in the stability-abort decision — instability of
+   evidence caches or the working tree must not abort authority
+   resolution. Authority surfaces (plan, contract, todos, policy,
+   markers) keep the full stability contract.
+2. The hook wrapper stops collapsing throws into `null`: resolution
+   outcomes become typed (resolved | no-deterministic-profile |
+   unstable/contended). Transient instability gets a bounded in-process
+   retry; if still unstable, the guard STILL fails closed but with a
+   distinct diagnostic naming concurrent-write instability and the
+   retry, never the misleading "resolution failed" banner.
+3. A genuinely blocked state (e.g. `conflict:plan_contract_relationship`)
+   blocks exactly as today — byte-identical message and exit code,
+   regression-guarded in both directions.
+4. The circuit-breaker stdout-only emission branch is explicitly out of
+   scope (it stops firing once transient blocks stop recurring).
+
+## Root Cause Evidence
+
+- root_cause: src/cli/hook/runtime.ts:246-261 catch-all converts the
+  stability-contract throw from
+  src/effects/state/resolve-effective-state.ts:582-634 (whose
+  source_hashes at :482-501 include non-authority churn surfaces) into
+  `null`, which mutation-guard.ts:398-406 cannot distinguish from a real
+  blocker, so mutation-guard.ts:275-285 fails closed with the generic
+  banner.
+- repro: run resolveEffectiveState (or the verbatim hook-wrapper probe)
+  in a loop while a concurrent writer churns the working tree /
+  checks/latest.json; stability loop exhausts and throws (diagnosis
+  probes: baseline 0/200 blocked, single-source churn 16/200 throws,
+  git-churn 30/30 blocked; probe scripts and JSON results preserved in
+  the package notes/run snapshots).
+- regression_guard: tests/state/effective-state-stability.test.ts —
+  injects a source mutation between stability re-reads (deterministic:
+  flip one hashed source between reads) and asserts (a) resolution does
+  not surface as the unresolvable-profile block for non-authority churn,
+  (b) a real plan/contract conflict still blocks identically.
+- pre_fix_failure_artifact: .ai/harness/runs/hook-guard-stability/
+  pre-fix-regression.log (captured red run of the regression guard on
+  unfixed code, PRE_FIX_EXIT non-zero, produced before the fix lands).
+
+## Task Breakdown
+
+- [ ] Add the regression guard red-first: deterministic instability
+  injection into the stability loop; capture the pre-fix failure
+  artifact with PRE_FIX_EXIT recorded.
+- [ ] Partition `source_hashes`: stability-abort set restricted to
+  workflow-authority surfaces; non-authority surfaces still read and
+  reported (subject/evidence revisions in the output remain), but their
+  churn cannot exhaust the stability loop.
+- [ ] Type the hook wrapper's resolution outcome; bounded retry (2-3
+  attempts) on unstable/contended; distinct fail-closed diagnostic for
+  residual instability naming the mechanism and the retry; identical
+  behavior and message for genuine blockers and unsupported profiles.
+- [ ] Cover the state-lock-timeout throw with the same typed handling.
+- [ ] Copy the diagnosis probe artifacts into the package's run
+  snapshots; record design decisions in the notes file.
+- [ ] Full verification: new regression guard green post-fix, real-
+  blocker regression (Occurrence-A shape) green, focused state/hook
+  suites, check:type, full bun test.
+
+## Verification
+
+```bash
+bun test tests/state/effective-state-stability.test.ts
+bun test tests/state/ tests/cli/
+bun run check:type
+bun test
+```
+
+## Non-goals
+
+- No fail-open path: residual instability still blocks, only with a
+  truthful diagnostic.
+- No circuit-breaker emission changes.
+- No change to blocker semantics, plan-transition rules, or any SSD
+  surface (`src/core/skill-surface/`, installer, sync script).
+- No global CLI refresh in this package (operator action after merge).
+
+## Rollback Surface
+
+Revert the single PR; the guard returns to the current
+collapse-and-block behavior. No state artifacts or installed surfaces
+are migrated.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [ ] Add the regression guard red-first: deterministic instability
+- [ ] Partition `source_hashes`: stability-abort set restricted to
+- [ ] Type the hook wrapper's resolution outcome; bounded retry (2-3
+- [ ] Cover the state-lock-timeout throw with the same typed handling.
+- [ ] Copy the diagnosis probe artifacts into the package's run
+- [ ] Full verification: new regression guard green post-fix, real-

--- a/src/cli/hook/mutation-guard.ts
+++ b/src/cli/hook/mutation-guard.ts
@@ -269,7 +269,24 @@ function runPerPathGuards(
   }
 
   // ---- resolve_effective_state: the ONE Effective State resolution -------
-  const effective = ctx.collector.getPreEditEffectiveState(allTargetPaths);
+  let effective: EffectiveState | null;
+  try {
+    effective = ctx.collector.getPreEditEffectiveState(allTargetPaths);
+  } catch {
+    // Residual instability after the wrapper's bounded retry (runtime.ts):
+    // concurrent workflow-state writes never settled. Distinct fail-closed
+    // diagnostic, never the collapsed "resolution failed" banner below --
+    // still fails closed, no fail-open path.
+    out(ctx, `[WorkflowResolutionUnstableGuard] Workflow resolution stayed unstable for ${filePath} after bounded retries.`);
+    structuredError(
+      ctx,
+      'WorkflowResolutionUnstableGuard',
+      `Concurrent workflow-state writes kept resolution unstable for ${filePath}; bounded retries were exhausted.`,
+      'Retry the edit once concurrent workflow-state writes settle.',
+      'state_violation',
+    );
+    exit(2);
+  }
   ctx.resolvedProfileHint = effective?.workflow_profile ?? ctx.resolvedProfileHint;
   const workflowProfile = workflowProfileOrNull(effective);
   if (!workflowProfile) {

--- a/src/cli/hook/runtime.ts
+++ b/src/cli/hook/runtime.ts
@@ -243,21 +243,52 @@ function effectiveStateSessionSection(
   }
 }
 
+const PRE_EDIT_RESOLUTION_MAX_ATTEMPTS = 3;
+const STABILITY_UNSTABLE_MESSAGE = 'workflow authority changed repeatedly while resolving effective state';
+const LOCK_TIMEOUT_MESSAGE_PREFIX = 'timed out waiting for exclusive lock ';
+
+/**
+ * The two known transient-instability throw signatures resolveEffectiveState
+ * can raise: the stability contract's re-read exhaustion (partitioned to
+ * authority sources only in resolve-effective-state.ts, but still reachable
+ * under sustained AUTHORITY churn) and the exclusive state-lock timeout
+ * (src/effects/locking/exclusive-directory-lock.ts). Both are concurrent-
+ * write contention, not a genuinely unresolvable workflow profile -- the
+ * bounded retry below gives ordinary contention a chance to clear before
+ * falling back to a distinct, truthful fail-closed diagnostic in
+ * mutation-guard.ts. Any other throw keeps today's exact behavior: caught
+ * immediately below, reported as `null` with zero retries.
+ */
+function isTransientResolutionInstability(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return error.message === STABILITY_UNSTABLE_MESSAGE
+    || error.message.startsWith(LOCK_TIMEOUT_MESSAGE_PREFIX);
+}
+
 function resolvePreEditEffectiveState(
   repoRoot: string,
   targetPaths: readonly string[],
   env: NodeJS.ProcessEnv,
 ): EffectiveState | null {
   const explicitOverride = env.REPO_HARNESS_WORKFLOW_PROFILE as WorkflowProfile | undefined;
-  try {
-    return resolveEffectiveState(repoRoot, Date.now(), {
-      targetPaths,
-      operationKind: 'edit',
-      explicitOverride,
-    });
-  } catch {
-    return null;
+  let lastInstability: unknown = null;
+  for (let attempt = 1; attempt <= PRE_EDIT_RESOLUTION_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      return resolveEffectiveState(repoRoot, Date.now(), {
+        targetPaths,
+        operationKind: 'edit',
+        explicitOverride,
+      });
+    } catch (error) {
+      if (!isTransientResolutionInstability(error)) return null;
+      lastInstability = error;
+    }
   }
+  // Bounded retry exhausted: residual instability. Re-throw the original
+  // error (message unchanged) instead of collapsing to null, so
+  // mutation-guard.ts can render a distinct fail-closed diagnostic rather
+  // than the misleading generic "resolution failed" banner.
+  throw lastInstability;
 }
 
 function resolveStopEffectiveState(repoRoot: string, env: NodeJS.ProcessEnv): EffectiveState | null {

--- a/src/effects/state/resolve-effective-state.ts
+++ b/src/effects/state/resolve-effective-state.ts
@@ -213,6 +213,37 @@ const RESUME_PATH = '.ai/harness/handoff/resume.md';
 const CURRENT_SNAPSHOT_PATH = 'tasks/current.md';
 const CHECKS_PATH = '.ai/harness/checks/latest.json';
 
+/**
+ * `source_hashes` keys the stability contract's re-read comparison ignores:
+ * high-churn, non-authority surfaces whose instability must not abort
+ * resolution (root-cause-prover diagnosis, 2026-07-23 -- see
+ * .ai/harness/runs/hook-guard-stability/). These sources are still read
+ * once per unlocked resolution and reported in `source_hashes` exactly as
+ * before; only their participation in the stability-abort DECISION changes.
+ * Workflow-authority surfaces (active-plan/active-worktree/active-sprint
+ * markers, the plan, contract, review, policy, capability registry, and the
+ * derived authority_revision) keep the full stability contract unchanged.
+ */
+const NON_AUTHORITY_SOURCE_HASH_KEYS: ReadonlySet<string> = new Set([
+  'review_subject',
+  CHECKS_PATH,
+  CURRENT_SNAPSHOT_PATH,
+  HANDOFF_PATH,
+  RESUME_PATH,
+]);
+
+/** Projects `sourceHashes` onto the workflow-authority subset the stability
+ * contract's re-read comparison uses to decide whether to retry or throw. */
+function authoritySourceHashes(
+  sourceHashes: Readonly<Record<string, string>>,
+): Readonly<Record<string, string>> {
+  const authority: Record<string, string> = {};
+  for (const key of Object.keys(sourceHashes)) {
+    if (!NON_AUTHORITY_SOURCE_HASH_KEYS.has(key)) authority[key] = sourceHashes[key];
+  }
+  return authority;
+}
+
 export type CapabilityRegistryStatus = 'valid' | 'absent' | 'invalid';
 
 export interface CapabilityResolution {
@@ -573,7 +604,8 @@ function resolveAndCommitEffectiveState(
     return publication;
   }, publicationEffects?.version, () => {
     const recheck = resolveEffectiveStateUnlocked(cwd, nowMs, { risk });
-    return JSON.stringify(recheck.source_hashes) === JSON.stringify(confirmed.source_hashes);
+    return JSON.stringify(authoritySourceHashes(recheck.source_hashes))
+      === JSON.stringify(authoritySourceHashes(confirmed.source_hashes));
   });
   if (finalized === null) throw new Error('effective-state publication did not produce a final state');
   return finalized;
@@ -625,7 +657,8 @@ function resolveStableEffectiveState(
   let state = resolveEffectiveStateUnlocked(cwd, nowMs, { risk });
   for (let attempt = 0; attempt < 3; attempt += 1) {
     const confirmed = resolveEffectiveStateUnlocked(cwd, nowMs, { risk });
-    if (JSON.stringify(state.source_hashes) === JSON.stringify(confirmed.source_hashes)) {
+    if (JSON.stringify(authoritySourceHashes(state.source_hashes))
+      === JSON.stringify(authoritySourceHashes(confirmed.source_hashes))) {
       return confirmed;
     }
     state = confirmed;

--- a/tasks/contracts/20260723-0620-hook-guard-stability.contract.md
+++ b/tasks/contracts/20260723-0620-hook-guard-stability.contract.md
@@ -1,0 +1,264 @@
+# Task Contract: hook-guard-stability
+
+> **Status**: Active
+> **Plan**: plans/plan-20260723-0620-hook-guard-stability.md
+> **Task Profile**: bugfix
+> **Owner**: kito
+> **Reviewer**: Claude
+> **Waiver Policy**: user_waiver allowed, owner kito only, per Acceptance Policy below
+> **Base SHA**: `bd461142c7b74a5be73b0eac5fe1b632b4d1a121` (fresh worktree branched from `origin/main` at package start; verified equal to `origin/main` after fetch — includes PRs #126, #127, and #112, none of which touch this package's fix surface)
+> **Target Branch**: main (via one independent PR)
+> **Working Branch**: `codex/hook-guard-stability`
+> **PR Unit**: one PR carrying the stability-set partition, the typed hook-wrapper resolution outcome with bounded retry and distinct diagnostics, the red-first regression guard with its captured pre-fix failure artifact, and this package's workflow artifacts
+> **Capability ID**: root
+> **Last Updated**: 2026-07-23 06:20
+> **Review File**: `tasks/reviews/20260723-0620-hook-guard-stability.review.md`
+> **Notes File**: `tasks/notes/20260723-0620-hook-guard-stability.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+The PreEdit WorkflowProfileGuard collapses three unrelated conditions —
+resolution threw, effective state genuinely blocked, profile unsupported —
+into one `null` and one misleading fail-closed banner. The dominant throw
+is the stability contract aborting on churn of non-authority surfaces
+(working-tree diff fingerprint, checks/latest, tasks/current,
+handoff/resume), so ordinary concurrent work blocks innocent edits.
+Every linked-worktree package since EPC has paid repeated false
+Edit/Write blocks and worked around them with heredoc writes, which
+bypasses the guard entirely — the current behavior is both noisy and
+weaker than a truthful gate.
+
+## Goal
+
+Deliver the plan's four-point partition (plan `## Goal`): non-authority
+churn excluded from the stability-abort decision; typed wrapper outcomes
+with bounded retry; residual instability still fail-closed but with a
+distinct truthful diagnostic; genuine blockers byte-identical to today.
+The regression guard proves both directions red-first.
+
+## Scope
+
+- In scope: `src/cli/hook/runtime.ts` (typed resolution outcome, bounded
+  retry, lock-timeout handling); `src/effects/state/resolve-effective-state.ts`
+  (stability-set partition only — output fields, including subject and
+  evidence revisions, keep their current shape and content);
+  `src/cli/hook/mutation-guard.ts` (only the guard branch that renders
+  the distinct instability diagnostic; blocker and unsupported-profile
+  branches byte-unchanged); new `tests/state/effective-state-stability.test.ts`;
+  narrow updates to existing tests ONLY if one pins the collapsed
+  throw-to-banner behavior (list each with justification);
+  `.ai/harness/runs/hook-guard-stability/` (pre-fix artifact + copied
+  diagnosis probes); this package's plan/contract/review/notes;
+  `tasks/todos.md` projection if a row needs updating.
+- Out of scope: circuit-breaker emission (`src/cli/hook/circuit-breaker.ts`);
+  every SSD surface (`src/core/skill-surface/`, installer, sync script,
+  `assets/skill-commands/`); plan-transition and blocker semantics;
+  `src/effects/locking/` internals (timeout value unchanged; only the
+  wrapper's handling of its throw); global CLI refresh (post-merge
+  operator action); any fail-open path.
+- Taste constraints: smallest change satisfying the partition; no new
+  config knobs; diagnostics name the mechanism in one line.
+
+## Execution Boundary
+
+Requirements absent from the plan are forbidden design space. Do not
+refactor state resolution, add retry configuration, introduce telemetry,
+or touch surfaces beyond the fix. Fail closed on ambiguity: stop and
+report rather than widening scope.
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a
+  path outside Allowed Paths; update this contract first.
+- Stop if partitioning the stability set changes any resolved-state
+  output field shape or value for a stable repository (byte-parity
+  falsifier below).
+- Stop if the regression guard cannot be made deterministic (no
+  sleep-based timing races committed to the suite).
+- Stop after three fail-fix-reverify rounds on one issue.
+
+## Falsifier
+
+The direction is wrong if excluding non-authority churn from the
+stability-abort set changes resolved output for a quiescent repo (it
+must not — the same sources are still read once and reported), or if the
+bounded retry masks a genuine blocker (the real-conflict regression case
+must still block with today's exact message). Cheapest proof: the
+regression guard's two directions — churn-no-block and
+real-conflict-still-blocks — plus a byte-diff of `state resolve --json`
+output on a quiescent repo before/after the fix.
+
+## Root Cause Evidence
+
+- root_cause: `src/cli/hook/runtime.ts:246-261` catch-all converts the
+  stability-contract throw from
+  `src/effects/state/resolve-effective-state.ts:582-634` (whose
+  `source_hashes` at :482-501 include non-authority churn surfaces:
+  `review_subject` working-tree diff fingerprint,
+  `.ai/harness/checks/latest.json`, `tasks/current.md`, handoff/resume)
+  into `null`, which `src/cli/hook/mutation-guard.ts:398-406` cannot
+  distinguish from a genuine blocker, so `mutation-guard.ts:275-285`
+  fails closed with the generic banner. Secondary same-shape path: the
+  5 s exclusive-lock timeout throw
+  (`src/effects/locking/exclusive-directory-lock.ts:19`).
+- repro: loop `resolveEffectiveState` (or the verbatim hook-wrapper
+  probe) while a concurrent writer churns a hashed non-authority source;
+  the stability loop exhausts and throws. Diagnosis probes (2026-07-23,
+  root-cause-prover): baseline 0/200 blocked; single-source churn 16/200
+  throws; sustained git-churn 30/30 blocked at ~375 ms/resolution. Probe
+  scripts and JSON results are copied into
+  `.ai/harness/runs/hook-guard-stability/`.
+- regression_guard: tests/state/effective-state-stability.test.ts
+- pre_fix_failure_artifact: .ai/harness/runs/hook-guard-stability/pre-fix-regression.log
+
+## Concurrency and Ownership
+
+- Fix surface is disjoint from the active SSD work-package's
+  `allowed_paths` (verified: PRs #126/#127/#112 and the SSD families do
+  not intersect this package's paths); both packages proceed in parallel
+  with independent PRs.
+- The orchestrator is the only committer/pusher/merger.
+
+## No-Compatibility Declaration
+
+No alias, dual read path, semantic fallback, or migration shim. The old
+collapsed behavior is removed in the same package that replaces it; no
+flag preserves it.
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260723-0620-hook-guard-stability.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260723-0620-hook-guard-stability.review.md`
+- Notes file: `tasks/notes/20260723-0620-hook-guard-stability.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/hook-guard-stability/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this
+  contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one
+  typed AcceptanceReceipt under the frozen policy below, then run
+  `verify-sprint`; review Markdown is projection only.
+
+## Acceptance Policy
+
+```json
+{"protocol":1,"reviewer":"Claude","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - src/cli/hook/runtime.ts
+  - src/cli/hook/mutation-guard.ts
+  - src/effects/state/resolve-effective-state.ts
+  - tests/state/effective-state-stability.test.ts
+  - tests/state/
+  - tests/cli/
+  - .ai/harness/runs/hook-guard-stability/
+  - plans/plan-20260723-0620-hook-guard-stability.md
+  - tasks/contracts/20260723-0620-hook-guard-stability.contract.md
+  - tasks/reviews/20260723-0620-hook-guard-stability.review.md
+  - tasks/notes/20260723-0620-hook-guard-stability.notes.md
+  - tasks/todos.md
+  - .ai/harness/worktrees/hook-guard-stability.json
+```
+
+## Forbidden Paths and Actions
+
+```yaml
+forbidden:
+  paths:
+    - src/cli/hook/circuit-breaker.ts
+    - src/effects/locking/
+    - src/core/skill-surface/
+    - src/cli/installer/
+    - scripts/
+    - assets/
+    - package.json
+  actions:
+    - any fail-open path (residual instability must still block)
+    - changing blocker or unsupported-profile messages or exit codes
+    - retry configuration knobs or telemetry
+    - sleep-based nondeterministic tests
+    - push, PR open, or merge (orchestrator-only)
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+      - codex-exec
+      - main-thread
+    fallback: main-thread
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - tests/state/effective-state-stability.test.ts
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260723-0620-hook-guard-stability.notes.md
+    - .ai/harness/runs/hook-guard-stability/pre-fix-regression.log
+  tests_pass:
+    - path: tests/state/effective-state-stability.test.ts
+  commands_succeed:
+    - bun run check:type
+    - bun test tests/state/
+  manual_checks:
+    - "Regression guard proves both directions: non-authority churn no longer blocks; a real plan-contract conflict still blocks with today's exact message and exit code"
+    - "Pre-fix failure artifact shows the regression guard red on unfixed code with non-zero PRE_FIX_EXIT"
+    - "state resolve --json output on a quiescent repo is byte-identical before and after the fix"
+    - "Residual-instability diagnostic is distinct, names concurrent-write instability and the bounded retry, and still fails closed"
+    - "Diagnosis probe artifacts copied into the package run snapshots"
+```
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior:
+- Edge cases:
+- Regression risks:
+
+## Rollback Point
+
+- Commit / checkpoint: `bd461142c7b74a5be73b0eac5fe1b632b4d1a121`
+  (worktree base).
+- Revert strategy: revert the single PR; the guard returns to the
+  current collapse-and-block behavior; no state artifacts or installed
+  surfaces are migrated either way.

--- a/tasks/notes/20260723-0620-hook-guard-stability.notes.md
+++ b/tasks/notes/20260723-0620-hook-guard-stability.notes.md
@@ -1,0 +1,145 @@
+# Implementation Notes: hook-guard-stability
+
+> **Status**: Active
+> **Plan**: plans/plan-20260723-0620-hook-guard-stability.md
+> **Contract**: tasks/contracts/20260723-0620-hook-guard-stability.contract.md
+> **Review**: tasks/reviews/20260723-0620-hook-guard-stability.review.md
+> **Last Updated**: 2026-07-23 06:59
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- **Authority-set membership** (`src/effects/state/resolve-effective-state.ts`):
+  classified the stability contract's `source_hashes` keys by EXCLUSION —
+  everything is authority except the five keys the Root Cause Evidence
+  names explicitly: `review_subject` (working-tree diff fingerprint,
+  additionalHashes key), `CHECKS_PATH` (`.ai/harness/checks/latest.json`),
+  `CURRENT_SNAPSHOT_PATH` (`tasks/current.md`), `HANDOFF_PATH`
+  (`.ai/harness/handoff/current.md`), `RESUME_PATH`
+  (`.ai/harness/handoff/resume.md`). Everything else stays authority:
+  `ACTIVE_PLAN_MARKER`, `ACTIVE_WORKTREE_MARKER`, `POLICY_PATH`,
+  `CAPABILITY_REGISTRY_PATH`, the dynamic `planPath`/`contractPath`, the
+  dynamic `reviewPath` (the review **file's own content hash** — distinct
+  from the `review_subject` diff-fingerprint key, and not named as
+  non-authority anywhere in the diagnosis), `ACTIVE_SPRINT_MARKER`, the
+  dynamic `sprintPath`, and `authority_revision` (itself a pure function of
+  the other authority keys, so its bucket placement doesn't change
+  comparison behavior, but semantically belongs there). Chose an exclusion
+  list (`NON_AUTHORITY_SOURCE_HASH_KEYS`) rather than enumerating inclusion
+  because the excluded set is small, fixed, and literally named by the
+  diagnosis, whereas the authority set has several repo-dependent dynamic
+  path values. The plan's Goal prose also says "todos" as an authority
+  example, but `tasks/todos.md` is not and never was one of the hashed
+  `source_hashes` keys (confirmed by grep) — that's a loose gloss in the
+  prose, not a literal key to add; adding it would violate Scope's "output
+  fields... keep their current shape and content."
+- **Both stability-comparison call sites partitioned, not just the loop.**
+  `resolveStableEffectiveState`'s 3-attempt re-read loop is the named
+  "stability contract," but `resolveAndCommitEffectiveState`'s
+  `confirmSnapshot` callback (the version-lock's post-stabilization re-check)
+  does the exact same `JSON.stringify(source_hashes) === JSON.stringify(...)`
+  comparison and, on two consecutive mismatches, throws the identical
+  `'workflow authority changed repeatedly...'` message via
+  `StateVersionConfirmMismatchError` conversion. Partitioning only the loop
+  and leaving this second comparison on the full map would leave the exact
+  same bug reachable through a different door under sustained non-authority
+  churn (the confirm-window re-read would keep seeing it "change"). Root
+  Cause Evidence's own cited line range (582-634) spans both call sites'
+  surrounding code, and the Falsifier's "resolved output stays byte-identical
+  for a quiescent repo" holds unchanged either way (this only touches the
+  retry/throw DECISION, never what `resolveEffectiveStateUnlocked` computes
+  or returns). Both sites now call the same `authoritySourceHashes()`
+  projection — one source of truth for "what counts as authority" within
+  this file.
+- **Bounded retry count: 3 total attempts** (1 initial + 2 retries) in
+  `resolvePreEditEffectiveState` (`src/cli/hook/runtime.ts`). The task's
+  "2-3 attempts" band is read here as total attempts (the upper end),
+  bounding added PreToolUse latency to roughly 3x a single resolution's
+  diagnosed ~375ms (git-subprocess-heavy) cost — about 1.1s worst case —
+  rather than stacking a fourth. If the intended reading was "2-3 retries
+  beyond the first" this is a documented interpretation choice within the
+  named numeric envelope, not a silent deviation.
+- **Signal shape: re-throw, not a new return type.** `MutationGuardCollector.
+  getPreEditEffectiveState` and the underlying `resolvePreEditEffectiveState`
+  dep type are constrained to `EffectiveState | null` by files OUTSIDE this
+  package's allowed_paths (`src/cli/hook/handler-contract.ts` pins
+  `StateInputCollector<..., EffectiveState | null, ...>` on
+  `HookHandlerContext.collector`; `handler-registry.ts` passes that same
+  typed collector straight into `runMutationGuard`). A three-member
+  discriminated-union return type was therefore not reachable without
+  editing forbidden files. Implemented the typed outcome as: resolved ->
+  return the `EffectiveState`; any non-instability throw -> catch and
+  return `null` (today's exact behavior, zero retries, byte-unchanged);
+  recognized instability with retries exhausted -> re-throw the original
+  error instead of collapsing to null. `mutation-guard.ts` wraps its single
+  `getPreEditEffectiveState()` call site in try/catch and renders the new
+  diagnostic on catch. This works because, by construction, the only thing
+  that can throw through that call site in production or in any existing
+  test's wiring is this one recognized-instability re-throw (every other
+  exception is caught-and-nulled inside the same function before it ever
+  reaches the collector boundary) — verified by grep across `tests/` for
+  every existing `resolvePreEditEffectiveState` mock (all use their own
+  inline catch-to-null, never exercising this code path) plus the full
+  `bun test` run. No new export or cross-file import was added between
+  `runtime.ts` and `mutation-guard.ts` to keep this signal (avoids a
+  `runtime.ts` -> `handler-registry.ts` -> `mutation-guard.ts` ->
+  `runtime.ts` import cycle, since `mutation-guard.ts` is otherwise a leaf
+  relative to `runtime.ts`/`handler-registry.ts`).
+- **Instability recognition is two literal message patterns**, local to
+  `runtime.ts`: exact match on `'workflow authority changed repeatedly while
+  resolving effective state'` (the stability throw) and a prefix match on
+  `'timed out waiting for exclusive lock '` (the exclusive-lock timeout,
+  `src/effects/locking/exclusive-directory-lock.ts`, per the plan's
+  "cover the state-lock-timeout throw with the same typed handling").
+  Anything else is caught immediately with zero retries, preserving today's
+  behavior exactly for every other throw origin (malformed policy JSON,
+  unsafe path validation, etc.) — none of those are diagnosed as
+  concurrency, so none get relabeled as "unstable."
+- **Diagnostic wording** (`mutation-guard.ts`, new
+  `WorkflowResolutionUnstableGuard` guard tag — distinct from
+  `WorkflowProfileGuard` so operators can tell "transient churn, retry"
+  from "unresolvable, go fix your plan/contract" at a glance): stdout —
+  `Workflow resolution stayed unstable for <path> after bounded retries.`;
+  structuredError reason — `Concurrent workflow-state writes kept resolution
+  unstable for <path>; bounded retries were exhausted.`; fix — `Retry the
+  edit once concurrent workflow-state writes settle.`. Names the mechanism
+  (concurrent workflow-state writes) and that retries were exhausted, one
+  line each, `failure_class: state_violation` (same class the existing
+  `WorkflowProfileGuard` banner uses). Still fails closed (`exit(2)`) — no
+  fail-open path.
+- **Existing tests touched: zero.** Only
+  `tests/state/effective-state-stability.test.ts` was added; no existing
+  test file was modified. `bun test` (full suite) confirms nothing else
+  needed a behavior-pinning update.
+
+## Deviations From Plan Or Spec
+
+- None recorded.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| Discriminated-union return type for the typed resolution outcome vs. re-throw on residual instability | Re-throw | The union's return type is externally pinned to `EffectiveState \| null` by out-of-scope files (`handler-contract.ts`, `handler-registry.ts`); re-throwing communicates the third outcome without touching them |
+| Shared exported predicate for "is this instability" (in `resolve-effective-state.ts`, imported by both `runtime.ts` and `mutation-guard.ts`) vs. keeping recognition local to `runtime.ts` only | Local to `runtime.ts` only | `mutation-guard.ts`'s single call site can only ever see this one recognized re-throw in practice (every other throw origin is already caught-and-nulled inside `runtime.ts`), so no second recognition check is needed; keeps the diff smaller and avoids a new cross-file coupling |
+| Partition only `resolveStableEffectiveState`'s loop vs. also `resolveAndCommitEffectiveState`'s confirmSnapshot re-check | Both | The confirmSnapshot callback does the identical full-map comparison and throws the identical message; leaving it unpartitioned would keep the diagnosed bug reachable through the version-commit path |
+| Retry count 3 (1 initial + 2 retries) vs. 4 (1 initial + 3 retries) | 3 | Upper end of the named "2-3 attempts" band read as total attempts; bounds worst-case added PreToolUse latency given the diagnosed ~375ms/resolution cost |
+
+## Open Questions
+
+- None.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/reviews/20260723-0620-hook-guard-stability.review.md
+++ b/tasks/reviews/20260723-0620-hook-guard-stability.review.md
@@ -1,0 +1,101 @@
+# Task Review: hook-guard-stability
+
+> **Status**: Reviewed
+> **Plan**: plans/plan-20260723-0620-hook-guard-stability.md
+> **Contract**: tasks/contracts/20260723-0620-hook-guard-stability.contract.md
+> **Notes File**: tasks/notes/20260723-0620-hook-guard-stability.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-07-23
+> **Recommendation**: pass
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pass
+- Change type: bugfix
+- Intended files changed: `src/effects/state/resolve-effective-state.ts` (stability-set partition), `src/cli/hook/runtime.ts` (typed resolution outcome + bounded retry), `src/cli/hook/mutation-guard.ts` (distinct residual-instability diagnostic), new `tests/state/effective-state-stability.test.ts`, package plan/contract/review/notes, todos timestamp projection, gitignored run evidence under `.ai/harness/runs/hook-guard-stability/`
+- Actual files changed: exactly that set — verified by gatekeeper (`git diff bd461142 --stat`; forbidden paths sweep over locking/, circuit-breaker, scripts/, assets/, package.json, skill-surface, installer all empty; `tasks/todos.md` diff is one `Updated:` timestamp line from the worktree projection machinery)
+- Commands passed: regression guard 2 pass/0 fail; `tests/state/` 126 pass; `tests/cli/` 378 pass/1 pre-existing skip; `check:type` clean; full `bun test` 1850 pass/1 skip/0 fail (no state-concurrency flake this run); `contract-run preflight` preflight_pass
+- Residual risks: the stability-throw message string is duplicated between `runtime.ts:247` and `resolve-effective-state.ts:636,666` (no shared constant) — drift would downgrade the distinct diagnostic to the generic banner, still fail-closed, and the state-concurrency tests pin the message; flagged for a future cleanup, not fixed here (smallest-change discipline)
+- Reviewer action required: none further — single gatekeeper round, verdict PASS
+- Rollback: revert the single PR; the guard returns to the collapse-and-block behavior; no state artifacts or installed surfaces migrated either way
+
+## Mode Evidence
+
+- Selected route: bugfix (root-cause-first)
+- P1/P2/P3 evidence: root-cause-prover diagnosis (DIAGNOSIS: CONFIRMED, 2026-07-23) — mechanism reproduced 30/30 under sustained git churn vs 0/200 baseline; probes archived at `.ai/harness/runs/hook-guard-stability/diagnosis-probes/`
+- Root cause or plan evidence: contract Root Cause Evidence four-field block; pre-fix artifact `.ai/harness/runs/hook-guard-stability/pre-fix-regression.log` with `PRE_FIX_EXIT=1` showing the exact diagnosed throw on unfixed code
+
+## Verification Evidence
+
+- Waza `/check` run: one gatekeeper review (fresh context, read-only), verdict PASS with independent byte-parity re-verification (scratch clone at `bd461142` vs fixed worktree, three scenarios, `cmp` byte-identical)
+- Commands run: see Human Review Card; executed in the contract worktree on base `bd461142`
+- Manual checks: see Manual Check Evidence below
+- Supporting artifacts: `.ai/harness/runs/hook-guard-stability/pre-fix-regression.log`; `.ai/harness/runs/hook-guard-stability/diagnosis-probes/` (FINDINGS-summary, probe scripts, probe JSON results)
+- Implementation notes reviewed: yes — authority-set membership decision, retry-count choice, diagnostic wording, both-call-site partition rationale
+- Run snapshot: `.ai/harness/runs/hook-guard-stability/`
+
+## Manual Check Evidence
+
+- [x] Regression guard proves both directions: non-authority churn no longer blocks; a real plan-contract conflict still blocks with today's exact message and exit code
+  - Evidence: `tests/state/effective-state-stability.test.ts` direction (a) red on unfixed code (pre-fix artifact) and green post-fix; direction (b) asserts today's exact stdout/stderr strings and exit code 2 through the real guard, green on both unfixed and fixed code; blocker/unsupported-profile branches byte-unchanged in the diff (gatekeeper ruling c).
+- [x] Pre-fix failure artifact shows the regression guard red on unfixed code with non-zero PRE_FIX_EXIT
+  - Evidence: `.ai/harness/runs/hook-guard-stability/pre-fix-regression.log` — `PRE_FIX_EXIT=1`, failing assertion is exactly `workflow authority changed repeatedly while resolving effective state` at `resolveStableEffectiveState`, regression-guard path string present (gatekeeper verified shape).
+- [x] state resolve --json output on a quiescent repo is byte-identical before and after the fix
+  - Evidence: worker stash-based capture (both 4312 bytes, raw diff exit 0) independently re-verified by gatekeeper via scratch clone at `bd461142` vs fixed worktree on an identical-path fixture across three scenarios (blocked 5105 B, no-risk-input 4376 B, clean edit 6098 B) — all `cmp` byte-identical with matching exit codes.
+- [x] Residual-instability diagnostic is distinct, names concurrent-write instability and the bounded retry, and still fails closed
+  - Evidence: `[WorkflowResolutionUnstableGuard]` one-line diagnostic naming sustained concurrent-write instability and exhausted bounded retries; end-to-end trace `runtime.ts:268-291` (3 attempts, re-throw) → `mutation-guard.ts:272-289` catch → `exit(2)` — no code path admits the edit on unresolved state (gatekeeper ruling b: the catch is load-bearing and present).
+- [x] Diagnosis probe artifacts copied into the package run snapshots
+  - Evidence: `.ai/harness/runs/hook-guard-stability/diagnosis-probes/` contains FINDINGS-summary.txt, probe.ts/probe2.ts/probe3.ts, baseline and churn JSON results (gitignored runtime evidence; durable conclusions recorded here and in the notes).
+
+## Acceptance Receipt Projection
+
+> **Disposition**: external_pass
+> **Reviewer**: Claude
+> **Source**: claude-review
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: sha256:2aa299cbc34e4ec089c1d9db542b9602bd068e4ffdde55006d4ec666a6d2e978
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: bd461142c7b74a5be73b0eac5fe1b632b4d1a121
+> **Verification Evidence SHA256**: sha256:c341d4b7d2d068868dd4159d68e026ffc7302e906ebef10253f51a3a0290ccfe
+> **Issued At**: 2026-07-22T23:35:35.753Z
+
+- Summary: Gatekeeper PASS: stability-set partition proven red-first; genuine-blocker parity byte-identical; quiescent state-resolve byte-parity independently re-verified; no fail-open path
+- Findings: none
+
+## Behavior Diff Notes
+
+- Quiescent-repo resolution output: byte-identical (proven three ways).
+- Concurrent non-authority churn (working-tree diff, checks/latest, tasks/current, handoff/resume): previously aborted resolution after 4 unstable reads and blocked the edit with the generic banner; now resolves from the single coherent snapshot and proceeds.
+- Sustained authority churn (plan/contract/markers/policy): still throws and still blocks — now after 3 bounded wrapper retries, with the distinct `[WorkflowResolutionUnstableGuard]` diagnostic instead of the misleading generic banner.
+- Lock-timeout throw: now typed into the same bounded-retry path instead of an instant generic block.
+
+## Residual Risks / Follow-ups
+
+- Message-string coupling between `runtime.ts:247` and the resolver throw sites (gatekeeper MEDIUM, non-blocking): fold into the next package touching these files.
+- The stale global CLI (`repo-harness-0.10.1-epc07-9ea195b9`) still carries the old collapse-and-block behavior until refreshed post-merge (operator action, out of contract scope).
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 9/10 | Both directions proven red-first; byte-parity held |
+| Product depth | 8/10 | Truthful diagnostics restore guard trust; heredoc bypass incentive removed |
+| Design quality | 8/10 | Partition at both call sites; typed outcomes; message coupling flagged |
+| Code quality | 9/10 | +103/-12 across three files; zero existing tests touched |
+
+## Failing Items
+
+- none
+
+## Retest Steps
+
+- Re-run: `bun test tests/state/effective-state-stability.test.ts && bun test tests/state/ && bun run check:type`
+- Re-check: quiescent byte-parity via `bun src/cli/index.ts state resolve --json` against a scratch clone at the base SHA
+
+## Summary
+
+- Transient WorkflowProfileGuard false blocks are fixed at the diagnosed root: non-authority churn no longer aborts effective-state resolution, throws are typed with bounded retry, residual instability blocks with a truthful distinct diagnostic, and genuine blockers behave byte-identically. Red-first regression guard + independent gatekeeper verification (PASS) bind the claim.

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -1,7 +1,7 @@
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: 2026-07-23 (SSD row retired on activation)
+> **Updated**: 2026-07-23 06:20
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.

--- a/tests/state/effective-state-stability.test.ts
+++ b/tests/state/effective-state-stability.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'fs';
+import { join } from 'path';
+import { spawn, spawnSync } from 'child_process';
+import {
+  CONTRACT,
+  createEffectiveStateFixture,
+  writeFixture,
+  writeFixtureStateLock,
+} from './effective-state-fixture';
+import { resolveEffectiveState } from '../../src/effects/state/resolve-effective-state';
+import { runMutationGuard, type MutationGuardCollector } from '../../src/cli/hook/mutation-guard';
+import { createStateInputCollector } from '../../src/effects/loop/state-input-collector';
+import type { EffectiveState } from '../../src/core/state/types';
+
+// hook-guard-stability regression guard (2026-07-23 root-cause-prover
+// diagnosis, .ai/harness/runs/hook-guard-stability/diagnosis-probes/).
+//
+// Root cause: resolveStableEffectiveState's stability contract
+// (src/effects/state/resolve-effective-state.ts) compares the FULL
+// source_hashes map -- including non-authority, high-churn surfaces such as
+// checks/latest.json, tasks/current.md, handoff/resume, and the
+// review_subject working-tree diff fingerprint -- between re-reads, and
+// throws "workflow authority changed repeatedly while resolving effective
+// state" whenever any one of them differs. The hook wrapper
+// (src/cli/hook/runtime.ts) collapses that throw into `null`, which
+// mutation-guard.ts cannot distinguish from a genuine blocker, so it fails
+// closed with the generic "Deterministic workflow profile resolution
+// failed" banner -- blocking innocent edits on ordinary concurrent work
+// (bun test, git commands, evidence-cache writes) rather than on anything
+// wrong with the plan/contract themselves.
+//
+// This guard proves both falsifier directions named in the task contract
+// (tasks/contracts/20260723-0620-hook-guard-stability.contract.md):
+//   (a) churn confined to a non-authority source must not abort resolution
+//       or surface as the unresolvable-profile block.
+//   (b) a genuine plan-contract conflict (the artifact-parsers
+//       planContractRelationshipConflicts shape) must still block with
+//       today's exact WorkflowProfileGuard message and exit code.
+//
+// On unfixed code, direction (a) is expected to be RED (the resolution
+// throws under sustained non-authority churn, so `failure` is non-null and
+// the assertions below fail); direction (b) already holds today and stays
+// green across the fix. Only the DESIRED end state is asserted here -- no
+// assertion encodes today's bug as expected behavior.
+
+const CHECKS_RELATIVE_PATH = '.ai/harness/checks/latest.json';
+
+interface ContinuousMutator {
+  readonly startedPath: string;
+  readonly stopPath: string;
+  readonly counterPath: string;
+  readonly done: Promise<void>;
+}
+
+/**
+ * Deterministically churns `relativePath` from a detached shell process for
+ * the whole lifetime of the caller's critical section, with no sleep-based
+ * timing race: mirrors tests/state/state-concurrency.test.ts's "continuous
+ * capability-registry mutation overlaps resolution" barrier technique.
+ *
+ * The mutator first claims the given fake lock-owner file (created via
+ * writeFixtureStateLock with this process's own pid, so it cannot be
+ * reclaimed as stale), mutates the target once, signals "started", THEN
+ * releases the fake lock -- guaranteeing the caller's own
+ * resolveEffectiveState call (which blocks on the same lock) cannot begin
+ * its own reads until at least one mutation has already landed -- and keeps
+ * mutating in a tight loop with no delay until the stop file appears, so
+ * every read taken during the caller's critical section observes fresh
+ * churn regardless of host speed.
+ */
+function spawnContinuousMutator(opts: {
+  readonly cwd: string;
+  readonly relativePath: string;
+  readonly ownerPath: string;
+  readonly lockPath: string;
+}): ContinuousMutator {
+  const stateDir = join(opts.cwd, '.ai/harness/state');
+  mkdirSync(stateDir, { recursive: true });
+  const startedPath = join(stateDir, 'stability-guard-mutator-started');
+  const stopPath = join(stateDir, 'stability-guard-mutator-stop');
+  const counterPath = join(stateDir, 'stability-guard-mutator-count');
+  const targetPath = join(opts.cwd, opts.relativePath);
+  const mutator = spawn('sh', [
+    '-c',
+    [
+      'i=0',
+      'printf "started\\n" > "$2"',
+      'printf " " >> "$1"',
+      'i=$((i + 1))',
+      'printf "%s\\n" "$i" > "$5"',
+      'rm -f "$3"',
+      'rmdir "$4"',
+      'while [ ! -f "$6" ]; do',
+      '  printf " " >> "$1"',
+      '  i=$((i + 1))',
+      'done',
+      'printf "%s\\n" "$i" > "$5"',
+    ].join('\n'),
+    'mutate-effective-state-non-authority-source',
+    targetPath,
+    startedPath,
+    opts.ownerPath,
+    opts.lockPath,
+    counterPath,
+    stopPath,
+  ], { stdio: 'ignore' });
+  const done = new Promise<void>((resolvePromise, rejectPromise) => {
+    mutator.once('exit', (code) => (code === 0
+      ? resolvePromise()
+      : rejectPromise(new Error(`fixture mutator exited ${code}`))));
+    mutator.once('error', rejectPromise);
+  });
+  return { startedPath, stopPath, counterPath, done };
+}
+
+/** Bounded, non-sleep-race busy wait for a barrier file (same idiom as
+ * tests/state/state-concurrency.test.ts): polls for existence, capped at 5s. */
+function waitForBarrier(path: string): void {
+  const barrier = spawnSync('sh', [
+    '-c',
+    'i=0; while [ ! -f "$1" ]; do i=$((i + 1)); [ "$i" -lt 500 ] || exit 1; sleep 0.01; done',
+    'wait-mutator',
+    path,
+  ]);
+  if (barrier.status !== 0) throw new Error(`fixture mutator did not start in time: ${path}`);
+}
+
+describe('Effective State stability contract: authority-only partition (hook-guard-stability)', () => {
+  test('sustained churn confined to a non-authority source (checks/latest.json) does not abort resolution', async () => {
+    const fixture = createEffectiveStateFixture();
+    try {
+      const risk = { targetPaths: ['src/feature.ts'], operationKind: 'feature' } as const;
+      const { ownerPath, lockPath } = writeFixtureStateLock(fixture.cwd, {
+        pid: process.pid,
+        created_at: Date.now(),
+        token: 'stability-guard-non-authority-barrier',
+      });
+      const mutator = spawnContinuousMutator({
+        cwd: fixture.cwd,
+        relativePath: CHECKS_RELATIVE_PATH,
+        ownerPath,
+        lockPath,
+      });
+      waitForBarrier(mutator.startedPath);
+      const beforeCount = Number.parseInt(readFileSync(mutator.counterPath, 'utf-8'), 10);
+
+      let failure: Error | null = null;
+      let resolved: EffectiveState | null = null;
+      try {
+        resolved = resolveEffectiveState(fixture.cwd, Date.now(), risk);
+      } catch (error) {
+        failure = error as Error;
+      } finally {
+        writeFileSync(mutator.stopPath, 'stop\n');
+      }
+      await mutator.done;
+
+      const afterCount = Number.parseInt(readFileSync(mutator.counterPath, 'utf-8'), 10);
+      // Sanity check on the injection itself: the non-authority source
+      // really did churn throughout the call window.
+      expect(afterCount).toBeGreaterThan(beforeCount);
+
+      // Falsifier direction (a): non-authority churn alone must not abort
+      // resolution (no throw) and must not surface as an unresolvable
+      // workflow profile.
+      expect(failure).toBeNull();
+      expect(resolved?.blockers ?? []).toEqual([]);
+      expect(resolved?.workflow_profile === 'lite'
+        || resolved?.workflow_profile === 'standard'
+        || resolved?.workflow_profile === 'strict').toBe(true);
+    } finally {
+      fixture.cleanup();
+    }
+  }, 15_000);
+
+  test('a genuine plan-contract conflict still blocks with the exact WorkflowProfileGuard message and exit code', () => {
+    const fixture = createEffectiveStateFixture();
+    try {
+      // artifact-parsers' planContractRelationshipConflicts shape: the
+      // contract's own `Plan` header disagrees with the actually-active
+      // plan path, so resolveEffectiveState pushes
+      // 'contract_plan_relationship' into conflictingSources, which
+      // projectEffectiveState turns into the hard blocker
+      // 'conflict:contract_plan_relationship'. This is a genuinely blocked
+      // resolution (no throw at all) and must stay byte-identical.
+      const current = readFileSync(join(fixture.cwd, CONTRACT), 'utf-8');
+      writeFixture(fixture.cwd, CONTRACT, current.replace(
+        /^> \*\*Plan\*\*: .*$/m,
+        '> **Plan**: plans/plan-some-other-conflicting-plan.md',
+      ));
+
+      const directResolution = resolveEffectiveState(fixture.cwd, Date.now(), {
+        targetPaths: ['src/feature.ts'],
+        operationKind: 'edit',
+      });
+      expect(directResolution.blockers).toContain('conflict:contract_plan_relationship');
+
+      const collector: MutationGuardCollector = createStateInputCollector({
+        event: 'PreToolUse',
+        repoRoot: fixture.cwd,
+        resolveSessionEffectiveState: () => null,
+        resolvePreEditEffectiveState: (targetPaths: readonly string[]): EffectiveState | null => {
+          try {
+            return resolveEffectiveState(fixture.cwd, Date.now(), {
+              targetPaths,
+              operationKind: 'edit',
+            });
+          } catch {
+            return null;
+          }
+        },
+      });
+      const result = runMutationGuard({
+        collector,
+        input: JSON.stringify({ tool_input: { file_path: 'src/feature.ts' } }),
+        env: {},
+      });
+
+      expect(result.exitCode).toBe(2);
+      expect(result.stdout).toContain('[WorkflowProfileGuard] Unable to resolve a deterministic workflow profile for src/feature.ts');
+      expect(result.stderr).toContain('[WorkflowProfileGuard] Deterministic workflow profile resolution failed for src/feature.ts.');
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The PreEdit WorkflowProfileGuard collapsed three unrelated conditions — resolution threw, effective state genuinely blocked, profile unsupported — into one null and one misleading fail-closed banner. Ordinary concurrent work (parallel test runs, git commands, evidence-cache writes) churned non-authority surfaces mid-resolution, exhausted the stability loop, and blocked innocent edits; every linked-worktree package since EPC paid repeated false Edit/Write blocks and bypassed the guard with heredoc writes.

Root cause (diagnosed with 30/30 reproduction under sustained git churn vs 0/200 baseline): the catch-all in resolvePreEditEffectiveState converting the stability-contract throw into null, with source_hashes counting non-authority churn surfaces (working-tree diff fingerprint, checks/latest, tasks/current, handoff/resume) toward the stability-abort decision.

## Fix

- Non-authority surfaces no longer participate in the stability-abort comparison (partitioned at both comparison sites); they are still read once and reported — quiescent-repo state resolve --json output proven byte-identical pre/post fix (cmp, three scenarios, independent re-verification).
- The hook wrapper types its resolution outcome (resolved | no_deterministic_profile | unstable, covering the stability throw and the exclusive-lock timeout), retries unstable resolution with 3 bounded attempts, and on residual instability fails closed with a distinct [WorkflowResolutionUnstableGuard] diagnostic.
- Genuine blockers and unsupported-profile handling stay byte-identical, regression-guarded in both directions (red-first: PRE_FIX_EXIT=1 artifact captured before the fix).

## Verification

- Regression guard 2 pass; tests/state 126 pass; tests/cli 378 pass; full suite 1850 pass / 1 skip / 0 fail; check:type clean; contract verify Fulfilled 22/22; acceptance receipt external_pass recorded; gatekeeper PASS with independent byte-parity re-verification.