### PR TITLE
Preserve user-managed agent fleet during strict installs

### DIFF
--- a/assets/reference-configs/external-tooling.md
+++ b/assets/reference-configs/external-tooling.md
@@ -582,8 +582,29 @@ stale managed target can be deactivated.
 
 The installer is **never-clobber by default**: an existing target file that
 differs from the newly resolved content is reported as `drift` and left
-untouched. Pass `--force` to overwrite drifted files. Re-running with no
-packaged-source changes reports every file as `up-to-date`.
+untouched. Pass `--force` to overwrite drifted files.
+
+An operator who intentionally owns a customized, complete fleet can acknowledge
+the current bytes once:
+
+```bash
+repo-harness run install-agent-fleet --accept-user-managed
+```
+
+The acknowledgement validates all twelve target files before writing
+`~/.repo-harness/agent-fleet-user-managed.json`. Claude files must have
+well-formed frontmatter with the target role identity, model, effort, and body;
+Codex files must be valid TOML with a pinned model, supported reasoning effort,
+and developer instructions. Symlinks, missing files, malformed files, or
+role-name mismatches fail closed without changing the receipt.
+
+Only customized files are recorded, by absolute path and SHA-256. Later
+installer and strict-profile runs report those exact bytes as `user-managed`
+and do not claim transaction ownership over them. Any subsequent byte change
+invalidates the acknowledgement and returns to `drift` until the operator
+reviews and accepts the new content. `--force` restores packaged content and
+removes the user-managed receipt. Re-running with no packaged-source changes
+reports packaged files as `up-to-date`.
 
 ### Readiness
 
@@ -596,7 +617,7 @@ the deterministic generation.
 
 ### Uninstall
 
-There is no uninstall command. Removing the fleet means deleting the eight
+There is no uninstall command. Removing the fleet means deleting the twelve
 managed files by hand:
 
 ```text
@@ -604,10 +625,14 @@ managed files by hand:
 ~/.claude/agents/deep-reasoner.md
 ~/.claude/agents/fast-worker.md
 ~/.claude/agents/gatekeeper.md
+~/.claude/agents/root-cause-prover.md
+~/.claude/agents/harness-evaluator.md
 ~/.codex/agents/explorer.toml
 ~/.codex/agents/deep-reasoner.toml
 ~/.codex/agents/fast-worker.toml
 ~/.codex/agents/gatekeeper.toml
+~/.codex/agents/root-cause-prover.toml
+~/.codex/agents/harness-evaluator.toml
 ```
 
 ## Manual Brain Vault Export

--- a/assets/templates/helpers/install-agent-fleet.sh
+++ b/assets/templates/helpers/install-agent-fleet.sh
@@ -63,18 +63,24 @@ exec "$RUNTIME_BIN" - "$@" <<'NODE_EOF'
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
+const crypto = require("crypto");
 
 const argv = process.argv.slice(2);
 let force = false;
+let acceptUserManaged = false;
 
 function usage() {
-  console.log("Usage: scripts/install-agent-fleet.sh [--force]");
+  console.log("Usage: scripts/install-agent-fleet.sh [--force|--accept-user-managed]");
 }
 
 for (let index = 0; index < argv.length; index += 1) {
   const arg = argv[index];
   if (arg === "--force") {
     force = true;
+    continue;
+  }
+  if (arg === "--accept-user-managed") {
+    acceptUserManaged = true;
     continue;
   }
   if (arg === "--help" || arg === "-h") {
@@ -85,12 +91,18 @@ for (let index = 0; index < argv.length; index += 1) {
   usage();
   process.exit(1);
 }
+if (force && acceptUserManaged) {
+  console.error("--force and --accept-user-managed are mutually exclusive");
+  usage();
+  process.exit(1);
+}
 
 const HOME = os.homedir();
 const MANAGED_AGENTS = ["explorer", "deep-reasoner", "fast-worker", "gatekeeper", "root-cause-prover", "harness-evaluator"];
 const WRITABLE_AGENTS = new Set(["fast-worker", "root-cause-prover", "harness-evaluator"]);
 const CLAUDE_TARGET_DIR = path.join(HOME, ".claude", "agents");
 const CODEX_TARGET_DIR = path.join(HOME, ".codex", "agents");
+const USER_MANAGED_RECEIPT_PATH = path.join(HOME, ".repo-harness", "agent-fleet-user-managed.json");
 const SOURCE_DIR = process.env.REPO_HARNESS_AGENT_FLEET_SOURCE_DIR;
 
 // Canonical anti-extras clause. Must stay byte-identical to the EXECUTION_BOUNDARY
@@ -236,7 +248,97 @@ function generateToml(agent, parsed, mapped) {
   return `${lines.join("\n")}\n`;
 }
 
-function compareAndWrite(targetPath, content) {
+function sha256(content) {
+  return `sha256:${crypto.createHash("sha256").update(content).digest("hex")}`;
+}
+
+function readRegularFile(targetPath) {
+  try {
+    const stat = fs.lstatSync(targetPath);
+    if (stat.isSymbolicLink() || !stat.isFile()) return { ok: false, text: "" };
+    return { ok: true, text: fs.readFileSync(targetPath, "utf8") };
+  } catch (_error) {
+    return { ok: false, text: "" };
+  }
+}
+
+function validateUserManagedClaude(agent, content) {
+  const parsed = parseFrontmatter(content);
+  const model = parseRoleNameScalar(parsed?.model);
+  const effort = parseRoleNameScalar(parsed?.effort);
+  return Boolean(
+    parsed
+    && parsed.name === agent
+    && parsed.description
+    && model
+    && effort
+    && EFFORT_LEVELS.includes(effort)
+    && parsed.body.trim(),
+  );
+}
+
+function validateUserManagedCodex(agent, content) {
+  try {
+    const parsed = Bun.TOML.parse(content);
+    if (parsed.name !== undefined && parsed.name !== agent) return false;
+    if (typeof parsed.model !== "string" || !parsed.model.trim()) return false;
+    if (
+      typeof parsed.model_reasoning_effort !== "string"
+      || !EFFORT_LEVELS.includes(parsed.model_reasoning_effort)
+    ) return false;
+    if (typeof parsed.developer_instructions !== "string" || !parsed.developer_instructions.trim()) return false;
+    if (
+      parsed.sandbox_mode !== undefined
+      && parsed.sandbox_mode !== "read-only"
+      && parsed.sandbox_mode !== "workspace-write"
+    ) return false;
+    return true;
+  } catch (_error) {
+    return false;
+  }
+}
+
+function loadUserManagedReceipt(allowedPaths) {
+  if (!fs.existsSync(USER_MANAGED_RECEIPT_PATH)) return { ok: true, hashes: new Map() };
+  try {
+    const parsed = JSON.parse(fs.readFileSync(USER_MANAGED_RECEIPT_PATH, "utf8"));
+    if (
+      parsed?.protocol !== 1
+      || parsed?.authority !== "user-managed-agent-fleet"
+      || !Array.isArray(parsed.files)
+    ) return { ok: false, hashes: new Map() };
+    const hashes = new Map();
+    for (const entry of parsed.files) {
+      if (
+        !entry
+        || typeof entry.path !== "string"
+        || !allowedPaths.has(entry.path)
+        || typeof entry.sha256 !== "string"
+        || !/^sha256:[a-f0-9]{64}$/.test(entry.sha256)
+        || hashes.has(entry.path)
+      ) return { ok: false, hashes: new Map() };
+      hashes.set(entry.path, entry.sha256);
+    }
+    return { ok: true, hashes };
+  } catch (_error) {
+    return { ok: false, hashes: new Map() };
+  }
+}
+
+function writeUserManagedReceipt(files) {
+  fs.mkdirSync(path.dirname(USER_MANAGED_RECEIPT_PATH), { recursive: true });
+  const receipt = {
+    protocol: 1,
+    authority: "user-managed-agent-fleet",
+    accepted_at: new Date().toISOString(),
+    files,
+  };
+  const temp = `${USER_MANAGED_RECEIPT_PATH}.tmp-${process.pid}-${Date.now()}`;
+  fs.writeFileSync(temp, `${JSON.stringify(receipt, null, 2)}\n`, { mode: 0o600 });
+  fs.renameSync(temp, USER_MANAGED_RECEIPT_PATH);
+}
+
+function compareAndWrite(targetPath, content, acceptedHash) {
   let existing = null;
   try {
     existing = fs.readFileSync(targetPath, "utf8");
@@ -256,6 +358,8 @@ function compareAndWrite(targetPath, content) {
     fs.writeFileSync(targetPath, content);
     return "installed";
   }
+
+  if (acceptedHash === sha256(existing)) return "user-managed";
 
   return "drift";
 }
@@ -287,16 +391,75 @@ if (prepared.length !== MANAGED_AGENTS.length) {
   process.exit(1);
 }
 
-for (const { agent, source, parsed, mapped } of prepared) {
-  const claudeTarget = path.join(CLAUDE_TARGET_DIR, `${agent}.md`);
-  const codexTarget = path.join(CODEX_TARGET_DIR, `${agent}.toml`);
-  const claudeStatus = compareAndWrite(claudeTarget, source);
-  results.push({ host: "claude", file: `${agent}.md`, status: claudeStatus });
-
+const targets = prepared.flatMap(({ agent, source, parsed, mapped }) => {
   const tomlContent = generateToml(agent, parsed, mapped);
   Bun.TOML.parse(tomlContent);
-  const codexStatus = compareAndWrite(codexTarget, tomlContent);
-  results.push({ host: "codex", file: `${agent}.toml`, status: codexStatus });
+  return [
+    {
+      agent,
+      host: "claude",
+      file: `${agent}.md`,
+      path: path.join(CLAUDE_TARGET_DIR, `${agent}.md`),
+      content: source,
+    },
+    {
+      agent,
+      host: "codex",
+      file: `${agent}.toml`,
+      path: path.join(CODEX_TARGET_DIR, `${agent}.toml`),
+      content: tomlContent,
+    },
+  ];
+});
+const allowedTargetPaths = new Set(targets.map((target) => target.path));
+
+if (acceptUserManaged) {
+  const acceptedFiles = [];
+  let invalid = false;
+  for (const target of targets) {
+    const existing = readRegularFile(target.path);
+    if (!existing.ok) {
+      results.push({ host: target.host, file: target.file, status: "user-managed-invalid" });
+      invalid = true;
+      continue;
+    }
+    if (existing.text === target.content) {
+      results.push({ host: target.host, file: target.file, status: "up-to-date" });
+      continue;
+    }
+    const valid = target.host === "claude"
+      ? validateUserManagedClaude(target.agent, existing.text)
+      : validateUserManagedCodex(target.agent, existing.text);
+    if (!valid) {
+      results.push({ host: target.host, file: target.file, status: "user-managed-invalid" });
+      invalid = true;
+      continue;
+    }
+    acceptedFiles.push({ path: target.path, sha256: sha256(existing.text) });
+    results.push({ host: target.host, file: target.file, status: "user-managed" });
+  }
+  for (const entry of results) console.log(`[fleet] ${entry.host}/${entry.file}: ${entry.status}`);
+  if (invalid) process.exit(1);
+  writeUserManagedReceipt(acceptedFiles);
+  console.log(`[fleet] user-managed receipt: accepted ${acceptedFiles.length} files`);
+  process.exit(0);
+}
+
+const receipt = force
+  ? { ok: true, hashes: new Map() }
+  : loadUserManagedReceipt(allowedTargetPaths);
+if (!receipt.ok) {
+  console.log("[fleet] user-managed receipt: invalid");
+  process.exit(1);
+}
+
+for (const target of targets) {
+  const status = compareAndWrite(target.path, target.content, receipt.hashes.get(target.path));
+  results.push({ host: target.host, file: target.file, status });
+}
+
+if (force && fs.existsSync(USER_MANAGED_RECEIPT_PATH)) {
+  fs.rmSync(USER_MANAGED_RECEIPT_PATH, { force: true });
 }
 
 for (const entry of results) {

--- a/docs/reference-configs/external-tooling.md
+++ b/docs/reference-configs/external-tooling.md
@@ -582,8 +582,29 @@ stale managed target can be deactivated.
 
 The installer is **never-clobber by default**: an existing target file that
 differs from the newly resolved content is reported as `drift` and left
-untouched. Pass `--force` to overwrite drifted files. Re-running with no
-packaged-source changes reports every file as `up-to-date`.
+untouched. Pass `--force` to overwrite drifted files.
+
+An operator who intentionally owns a customized, complete fleet can acknowledge
+the current bytes once:
+
+```bash
+repo-harness run install-agent-fleet --accept-user-managed
+```
+
+The acknowledgement validates all twelve target files before writing
+`~/.repo-harness/agent-fleet-user-managed.json`. Claude files must have
+well-formed frontmatter with the target role identity, model, effort, and body;
+Codex files must be valid TOML with a pinned model, supported reasoning effort,
+and developer instructions. Symlinks, missing files, malformed files, or
+role-name mismatches fail closed without changing the receipt.
+
+Only customized files are recorded, by absolute path and SHA-256. Later
+installer and strict-profile runs report those exact bytes as `user-managed`
+and do not claim transaction ownership over them. Any subsequent byte change
+invalidates the acknowledgement and returns to `drift` until the operator
+reviews and accepts the new content. `--force` restores packaged content and
+removes the user-managed receipt. Re-running with no packaged-source changes
+reports packaged files as `up-to-date`.
 
 ### Readiness
 
@@ -596,7 +617,7 @@ the deterministic generation.
 
 ### Uninstall
 
-There is no uninstall command. Removing the fleet means deleting the eight
+There is no uninstall command. Removing the fleet means deleting the twelve
 managed files by hand:
 
 ```text
@@ -604,10 +625,14 @@ managed files by hand:
 ~/.claude/agents/deep-reasoner.md
 ~/.claude/agents/fast-worker.md
 ~/.claude/agents/gatekeeper.md
+~/.claude/agents/root-cause-prover.md
+~/.claude/agents/harness-evaluator.md
 ~/.codex/agents/explorer.toml
 ~/.codex/agents/deep-reasoner.toml
 ~/.codex/agents/fast-worker.toml
 ~/.codex/agents/gatekeeper.toml
+~/.codex/agents/root-cause-prover.toml
+~/.codex/agents/harness-evaluator.toml
 ```
 
 ## Manual Brain Vault Export

--- a/scripts/install-agent-fleet.sh
+++ b/scripts/install-agent-fleet.sh
@@ -63,18 +63,24 @@ exec "$RUNTIME_BIN" - "$@" <<'NODE_EOF'
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
+const crypto = require("crypto");
 
 const argv = process.argv.slice(2);
 let force = false;
+let acceptUserManaged = false;
 
 function usage() {
-  console.log("Usage: scripts/install-agent-fleet.sh [--force]");
+  console.log("Usage: scripts/install-agent-fleet.sh [--force|--accept-user-managed]");
 }
 
 for (let index = 0; index < argv.length; index += 1) {
   const arg = argv[index];
   if (arg === "--force") {
     force = true;
+    continue;
+  }
+  if (arg === "--accept-user-managed") {
+    acceptUserManaged = true;
     continue;
   }
   if (arg === "--help" || arg === "-h") {
@@ -85,12 +91,18 @@ for (let index = 0; index < argv.length; index += 1) {
   usage();
   process.exit(1);
 }
+if (force && acceptUserManaged) {
+  console.error("--force and --accept-user-managed are mutually exclusive");
+  usage();
+  process.exit(1);
+}
 
 const HOME = os.homedir();
 const MANAGED_AGENTS = ["explorer", "deep-reasoner", "fast-worker", "gatekeeper", "root-cause-prover", "harness-evaluator"];
 const WRITABLE_AGENTS = new Set(["fast-worker", "root-cause-prover", "harness-evaluator"]);
 const CLAUDE_TARGET_DIR = path.join(HOME, ".claude", "agents");
 const CODEX_TARGET_DIR = path.join(HOME, ".codex", "agents");
+const USER_MANAGED_RECEIPT_PATH = path.join(HOME, ".repo-harness", "agent-fleet-user-managed.json");
 const SOURCE_DIR = process.env.REPO_HARNESS_AGENT_FLEET_SOURCE_DIR;
 
 // Canonical anti-extras clause. Must stay byte-identical to the EXECUTION_BOUNDARY
@@ -236,7 +248,97 @@ function generateToml(agent, parsed, mapped) {
   return `${lines.join("\n")}\n`;
 }
 
-function compareAndWrite(targetPath, content) {
+function sha256(content) {
+  return `sha256:${crypto.createHash("sha256").update(content).digest("hex")}`;
+}
+
+function readRegularFile(targetPath) {
+  try {
+    const stat = fs.lstatSync(targetPath);
+    if (stat.isSymbolicLink() || !stat.isFile()) return { ok: false, text: "" };
+    return { ok: true, text: fs.readFileSync(targetPath, "utf8") };
+  } catch (_error) {
+    return { ok: false, text: "" };
+  }
+}
+
+function validateUserManagedClaude(agent, content) {
+  const parsed = parseFrontmatter(content);
+  const model = parseRoleNameScalar(parsed?.model);
+  const effort = parseRoleNameScalar(parsed?.effort);
+  return Boolean(
+    parsed
+    && parsed.name === agent
+    && parsed.description
+    && model
+    && effort
+    && EFFORT_LEVELS.includes(effort)
+    && parsed.body.trim(),
+  );
+}
+
+function validateUserManagedCodex(agent, content) {
+  try {
+    const parsed = Bun.TOML.parse(content);
+    if (parsed.name !== undefined && parsed.name !== agent) return false;
+    if (typeof parsed.model !== "string" || !parsed.model.trim()) return false;
+    if (
+      typeof parsed.model_reasoning_effort !== "string"
+      || !EFFORT_LEVELS.includes(parsed.model_reasoning_effort)
+    ) return false;
+    if (typeof parsed.developer_instructions !== "string" || !parsed.developer_instructions.trim()) return false;
+    if (
+      parsed.sandbox_mode !== undefined
+      && parsed.sandbox_mode !== "read-only"
+      && parsed.sandbox_mode !== "workspace-write"
+    ) return false;
+    return true;
+  } catch (_error) {
+    return false;
+  }
+}
+
+function loadUserManagedReceipt(allowedPaths) {
+  if (!fs.existsSync(USER_MANAGED_RECEIPT_PATH)) return { ok: true, hashes: new Map() };
+  try {
+    const parsed = JSON.parse(fs.readFileSync(USER_MANAGED_RECEIPT_PATH, "utf8"));
+    if (
+      parsed?.protocol !== 1
+      || parsed?.authority !== "user-managed-agent-fleet"
+      || !Array.isArray(parsed.files)
+    ) return { ok: false, hashes: new Map() };
+    const hashes = new Map();
+    for (const entry of parsed.files) {
+      if (
+        !entry
+        || typeof entry.path !== "string"
+        || !allowedPaths.has(entry.path)
+        || typeof entry.sha256 !== "string"
+        || !/^sha256:[a-f0-9]{64}$/.test(entry.sha256)
+        || hashes.has(entry.path)
+      ) return { ok: false, hashes: new Map() };
+      hashes.set(entry.path, entry.sha256);
+    }
+    return { ok: true, hashes };
+  } catch (_error) {
+    return { ok: false, hashes: new Map() };
+  }
+}
+
+function writeUserManagedReceipt(files) {
+  fs.mkdirSync(path.dirname(USER_MANAGED_RECEIPT_PATH), { recursive: true });
+  const receipt = {
+    protocol: 1,
+    authority: "user-managed-agent-fleet",
+    accepted_at: new Date().toISOString(),
+    files,
+  };
+  const temp = `${USER_MANAGED_RECEIPT_PATH}.tmp-${process.pid}-${Date.now()}`;
+  fs.writeFileSync(temp, `${JSON.stringify(receipt, null, 2)}\n`, { mode: 0o600 });
+  fs.renameSync(temp, USER_MANAGED_RECEIPT_PATH);
+}
+
+function compareAndWrite(targetPath, content, acceptedHash) {
   let existing = null;
   try {
     existing = fs.readFileSync(targetPath, "utf8");
@@ -256,6 +358,8 @@ function compareAndWrite(targetPath, content) {
     fs.writeFileSync(targetPath, content);
     return "installed";
   }
+
+  if (acceptedHash === sha256(existing)) return "user-managed";
 
   return "drift";
 }
@@ -287,16 +391,75 @@ if (prepared.length !== MANAGED_AGENTS.length) {
   process.exit(1);
 }
 
-for (const { agent, source, parsed, mapped } of prepared) {
-  const claudeTarget = path.join(CLAUDE_TARGET_DIR, `${agent}.md`);
-  const codexTarget = path.join(CODEX_TARGET_DIR, `${agent}.toml`);
-  const claudeStatus = compareAndWrite(claudeTarget, source);
-  results.push({ host: "claude", file: `${agent}.md`, status: claudeStatus });
-
+const targets = prepared.flatMap(({ agent, source, parsed, mapped }) => {
   const tomlContent = generateToml(agent, parsed, mapped);
   Bun.TOML.parse(tomlContent);
-  const codexStatus = compareAndWrite(codexTarget, tomlContent);
-  results.push({ host: "codex", file: `${agent}.toml`, status: codexStatus });
+  return [
+    {
+      agent,
+      host: "claude",
+      file: `${agent}.md`,
+      path: path.join(CLAUDE_TARGET_DIR, `${agent}.md`),
+      content: source,
+    },
+    {
+      agent,
+      host: "codex",
+      file: `${agent}.toml`,
+      path: path.join(CODEX_TARGET_DIR, `${agent}.toml`),
+      content: tomlContent,
+    },
+  ];
+});
+const allowedTargetPaths = new Set(targets.map((target) => target.path));
+
+if (acceptUserManaged) {
+  const acceptedFiles = [];
+  let invalid = false;
+  for (const target of targets) {
+    const existing = readRegularFile(target.path);
+    if (!existing.ok) {
+      results.push({ host: target.host, file: target.file, status: "user-managed-invalid" });
+      invalid = true;
+      continue;
+    }
+    if (existing.text === target.content) {
+      results.push({ host: target.host, file: target.file, status: "up-to-date" });
+      continue;
+    }
+    const valid = target.host === "claude"
+      ? validateUserManagedClaude(target.agent, existing.text)
+      : validateUserManagedCodex(target.agent, existing.text);
+    if (!valid) {
+      results.push({ host: target.host, file: target.file, status: "user-managed-invalid" });
+      invalid = true;
+      continue;
+    }
+    acceptedFiles.push({ path: target.path, sha256: sha256(existing.text) });
+    results.push({ host: target.host, file: target.file, status: "user-managed" });
+  }
+  for (const entry of results) console.log(`[fleet] ${entry.host}/${entry.file}: ${entry.status}`);
+  if (invalid) process.exit(1);
+  writeUserManagedReceipt(acceptedFiles);
+  console.log(`[fleet] user-managed receipt: accepted ${acceptedFiles.length} files`);
+  process.exit(0);
+}
+
+const receipt = force
+  ? { ok: true, hashes: new Map() }
+  : loadUserManagedReceipt(allowedTargetPaths);
+if (!receipt.ok) {
+  console.log("[fleet] user-managed receipt: invalid");
+  process.exit(1);
+}
+
+for (const target of targets) {
+  const status = compareAndWrite(target.path, target.content, receipt.hashes.get(target.path));
+  results.push({ host: target.host, file: target.file, status });
+}
+
+if (force && fs.existsSync(USER_MANAGED_RECEIPT_PATH)) {
+  fs.rmSync(USER_MANAGED_RECEIPT_PATH, { force: true });
 }
 
 for (const entry of results) {

--- a/scripts/skill-surface-select.ts
+++ b/scripts/skill-surface-select.ts
@@ -68,6 +68,16 @@ function main(argv: readonly string[]): void {
     for (const name of facadesForProfile(catalog, profileFlag)) console.log(name);
     return;
   }
+  if (subcommand === "profile-projection") {
+    if (!isProfile(profileFlag)) {
+      fail(`profile-projection requires --profile <${SKILL_SURFACE_PROFILES.join("|")}>`);
+    }
+    for (const name of facadesForProfile(catalog, profileFlag)) console.log(`facade\t${name}`);
+    const placements = hostSkillPlacements(catalog, profileFlag);
+    for (const name of placements.claude) console.log(`host\tclaude ${name}`);
+    for (const name of placements.codex) console.log(`host\tcodex ${name}`);
+    return;
+  }
   if (subcommand === "facade-sources") {
     // Unconditional (no --profile): every facade-kind package's name/source
     // pair, regardless of which profile(s) select it. This is the single
@@ -99,7 +109,7 @@ function main(argv: readonly string[]): void {
     for (const name of placements.codex) console.log(`codex ${name}`);
     return;
   }
-  fail(`unknown or missing subcommand "${subcommand ?? ""}"; expected facades|facade-sources|external-skills|host-placements`);
+  fail(`unknown or missing subcommand "${subcommand ?? ""}"; expected facades|profile-projection|facade-sources|external-skills|host-placements`);
 }
 
 main(process.argv.slice(2));

--- a/scripts/sync-codex-installed-copies.sh
+++ b/scripts/sync-codex-installed-copies.sh
@@ -51,11 +51,21 @@ fi
 # Resolved once, eagerly, here in the main shell process (never inside a function
 # invoked as a pipeline's non-last stage -- bash forks a subshell for those, which
 # would silently swallow a failure here as "selects nothing" instead of aborting).
-# profile_facades() below just emits this precomputed value.
-if ! SELECTED_FACADES="$(bun "$SOURCE_ROOT/scripts/skill-surface-select.ts" facades --profile "$INSTALL_PROFILE")"; then
-  echo "[sync-installed] skill-surface-select facades failed for profile: $INSTALL_PROFILE" >&2
+# One adapter call returns both facade selection and separately-managed provider
+# placements so adding the ownership boundary does not add another Bun startup to
+# every sync.
+if ! PROFILE_PROJECTION="$(bun "$SOURCE_ROOT/scripts/skill-surface-select.ts" profile-projection --profile "$INSTALL_PROFILE")"; then
+  echo "[sync-installed] skill-surface-select profile-projection failed for profile: $INSTALL_PROFILE" >&2
   exit 1
 fi
+SELECTED_FACADES=""
+HOST_PLACEMENTS=""
+while IFS=$'\t' read -r projection_kind projection_value; do
+  case "$projection_kind" in
+    facade) SELECTED_FACADES+="${SELECTED_FACADES:+$'\n'}$projection_value" ;;
+    host) HOST_PLACEMENTS+="${HOST_PLACEMENTS:+$'\n'}$projection_value" ;;
+  esac
+done <<< "$PROFILE_PROJECTION"
 
 # Manifest-derived name -> source path for every facade-kind package,
 # regardless of profile. A facade's source directory is no longer guaranteed
@@ -67,7 +77,6 @@ if ! FACADE_SOURCES="$(bun "$SOURCE_ROOT/scripts/skill-surface-select.ts" facade
   echo "[sync-installed] skill-surface-select facade-sources failed" >&2
   exit 1
 fi
-
 common_excludes=(
   --exclude='.git/'
   --exclude='_ops/'
@@ -291,6 +300,18 @@ facade_selected() {
   profile_facades | grep -Fxq "$wanted"
 }
 
+provider_skill_selected_for_root() {
+  local root="$1"
+  local wanted="$2"
+  local host=""
+  if [[ "$root" == "$CODEX_SKILLS_ROOT" ]]; then
+    host="codex"
+  elif [[ -n "$CLAUDE_SKILLS_ROOT" && "$root" == "$CLAUDE_SKILLS_ROOT" ]]; then
+    host="claude"
+  fi
+  [[ -n "$host" ]] && grep -Fxq "$host $wanted" <<< "$HOST_PLACEMENTS"
+}
+
 preflight_skill_root() {
   local root="$1"
   [[ -n "$root" ]] || return 0
@@ -301,6 +322,11 @@ preflight_skill_root() {
   for dest in "$root"/repo-harness-*; do
     [[ -e "$dest" || -L "$dest" ]] || continue
     name="$(basename "$dest")"
+    # Provider Skills (for example repo-harness-cross-review) are installed by
+    # their own profile component after this facade sync. They are not command
+    # facades, so this loop must neither require a command-facade owner marker
+    # nor retire them while their host placement is selected.
+    provider_skill_selected_for_root "$root" "$name" && continue
     source_rel="$(facade_source_for "$name")"
     source=""
     [[ -n "$source_rel" ]] && source="$SOURCE_ROOT/$source_rel"
@@ -322,6 +348,7 @@ remove_retired_owned_facades() {
   for dest in "$root"/repo-harness-*; do
     [[ -e "$dest" || -L "$dest" ]] || continue
     name="$(basename "$dest")"
+    provider_skill_selected_for_root "$root" "$name" && continue
     facade_selected "$name" && continue
     source_rel="$(facade_source_for "$name")"
     source=""

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,16 +1,16 @@
 # Current Status Snapshot
 
 <!-- generated-by: repo-harness refresh-current-status v1 -->
-<!-- updated_at: 2026-07-23T17:38:47+0800 -->
+<!-- updated_at: 2026-07-23T19:42:27+0800 -->
 <!-- stale_after: 24h -->
 
 > **Status**: Idle
-> **Updated At**: 2026-07-23T17:38:47+0800
-> **Source Branch**: main
-> **Source Commit**: 7ef98272
+> **Updated At**: 2026-07-23T19:42:27+0800
+> **Source Branch**: codex/user-managed-agent-fleet
+> **Source Commit**: 8ab74bd0
 > **Target Branch**: main
 > **Stale After**: 24h
-> **Reason**: release-candidate
+> **Reason**: user-managed-agent-fleet-fix
 > **Derived From**: active-plan, active-sprint, workstreams, handoff, checks, git status
 
 This file is a tracked mainline snapshot derived from repo artifacts. It is not a live lock, not a kanban board, and not an implementation gate. If it is stale, read the source artifacts below.
@@ -54,10 +54,18 @@ This file is a tracked mainline snapshot derived from repo artifacts. It is not 
 
 ## Git Status
 
-- Summary: clean
+- Summary: 9 changed/untracked path(s)
 
 ```
-(none)
+ M assets/reference-configs/external-tooling.md
+ M assets/templates/helpers/install-agent-fleet.sh
+ M docs/reference-configs/external-tooling.md
+ M scripts/install-agent-fleet.sh
+ M scripts/skill-surface-select.ts
+ M scripts/sync-codex-installed-copies.sh
+ M tasks/current.md
+ M tests/install-agent-fleet.test.ts
+ M tests/installed-copy-sync.test.ts
 ```
 
 ## Source Artifacts

--- a/tests/install-agent-fleet.test.ts
+++ b/tests/install-agent-fleet.test.ts
@@ -209,6 +209,81 @@ describe("install-agent-fleet", () => {
     }
   });
 
+  test("an explicitly accepted user-managed fleet remains idempotent until an accepted file changes", () => {
+    const { root, home } = setupFakeHome("install-agent-fleet-user-managed");
+    try {
+      expect(runInstaller(home, FLEET_SOURCE_DIR).status).toBe(0);
+      const claudeTarget = join(home, ".claude/agents/deep-reasoner.md");
+      const codexTarget = join(home, ".codex/agents/explorer.toml");
+      const customClaude = readFileSync(claudeTarget, "utf-8")
+        .replaceAll("Opus at xhigh effort", "Opus at max effort")
+        .replace("effort: xhigh", "effort: max");
+      const customCodex = readFileSync(codexTarget, "utf-8")
+        .replace('model = "gpt-5.6-luna"', 'model = "gpt-5.6-terra"');
+      writeFileSync(claudeTarget, customClaude);
+      writeFileSync(codexTarget, customCodex);
+
+      const accepted = runInstaller(home, FLEET_SOURCE_DIR, ["--accept-user-managed"]);
+      expect(accepted.status).toBe(0);
+      expect(accepted.stdout).toContain("[fleet] user-managed receipt: accepted 2 files");
+      expect(readFileSync(claudeTarget, "utf-8")).toBe(customClaude);
+      expect(readFileSync(codexTarget, "utf-8")).toBe(customCodex);
+
+      const receiptPath = join(home, ".repo-harness/agent-fleet-user-managed.json");
+      const receipt = JSON.parse(readFileSync(receiptPath, "utf-8")) as {
+        protocol: number;
+        authority: string;
+        files: Array<{ path: string; sha256: string }>;
+      };
+      expect(receipt.protocol).toBe(1);
+      expect(receipt.authority).toBe("user-managed-agent-fleet");
+      expect(receipt.files.map((entry) => entry.path).sort()).toEqual([claudeTarget, codexTarget].sort());
+      expect(receipt.files.every((entry) => /^sha256:[a-f0-9]{64}$/.test(entry.sha256))).toBe(true);
+
+      const repeated = runInstaller(home, FLEET_SOURCE_DIR);
+      expect(repeated.status).toBe(0);
+      expect(repeated.stdout).toContain("[fleet] claude/deep-reasoner.md: user-managed");
+      expect(repeated.stdout).toContain("[fleet] codex/explorer.toml: user-managed");
+      expect(readFileSync(claudeTarget, "utf-8")).toBe(customClaude);
+      expect(readFileSync(codexTarget, "utf-8")).toBe(customCodex);
+
+      const changedAfterAcceptance = `${customCodex}# changed after acceptance\n`;
+      writeFileSync(codexTarget, changedAfterAcceptance);
+      const staleReceipt = runInstaller(home, FLEET_SOURCE_DIR);
+      expect(staleReceipt.status).not.toBe(0);
+      expect(staleReceipt.stdout).toContain("[fleet] codex/explorer.toml: drift");
+      expect(readFileSync(codexTarget, "utf-8")).toBe(changedAfterAcceptance);
+
+      const forced = runInstaller(home, FLEET_SOURCE_DIR, ["--force"]);
+      expect(forced.status).toBe(0);
+      expect(existsSync(receiptPath)).toBe(false);
+      expect(readFileSync(codexTarget, "utf-8")).toBe(
+        readFileSync(join(GOLDEN_CODEX_DIR, "explorer.toml"), "utf-8"),
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("--accept-user-managed rejects malformed or role-mismatched files without writing a receipt", () => {
+    const { root, home } = setupFakeHome("install-agent-fleet-user-managed-invalid");
+    try {
+      expect(runInstaller(home, FLEET_SOURCE_DIR).status).toBe(0);
+      const target = join(home, ".claude/agents/gatekeeper.md");
+      writeFileSync(
+        target,
+        readFileSync(target, "utf-8").replace("name: gatekeeper", "name: fast-worker"),
+      );
+
+      const accepted = runInstaller(home, FLEET_SOURCE_DIR, ["--accept-user-managed"]);
+      expect(accepted.status).not.toBe(0);
+      expect(accepted.stdout).toContain("[fleet] claude/gatekeeper.md: user-managed-invalid");
+      expect(existsSync(join(home, ".repo-harness/agent-fleet-user-managed.json"))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   test("--force overwrites a drifted target back to generated content", () => {
     const { root, home } = setupFakeHome("install-agent-fleet-force");
     try {

--- a/tests/installed-copy-sync.test.ts
+++ b/tests/installed-copy-sync.test.ts
@@ -149,6 +149,50 @@ describe("Codex installed copy sync", () => {
     }
   });
 
+  test("strict sync leaves separately managed provider skills untouched", () => {
+    const tmp = join(tmpdir(), `repo-harness-installed-provider-skill-${Date.now()}`);
+    const source = join(tmp, "source");
+    const codexSkills = join(tmp, "codex-skills");
+    const claudeSkills = join(tmp, "claude-skills");
+    const providerSkill = "repo-harness-cross-review";
+    const customContent = "---\nname: repo-harness-cross-review\n---\ntransaction-owned provider skill\n";
+
+    try {
+      seedSkillSurfaceRuntime(source);
+      mkdirSync(codexSkills, { recursive: true });
+      mkdirSync(claudeSkills, { recursive: true });
+      writeFileSync(join(source, "SKILL.md"), "---\nname: repo-harness\n---\n");
+      for (const root of [codexSkills, claudeSkills]) {
+        const installed = join(root, providerSkill);
+        mkdirSync(installed, { recursive: true });
+        writeFileSync(join(installed, "SKILL.md"), customContent);
+      }
+
+      const result = spawnSync("bash", [join(ROOT, "scripts", "sync-codex-installed-copies.sh")], {
+        cwd: ROOT,
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          AGENTIC_DEV_SOURCE_ROOT: source,
+          AGENTIC_DEV_LINK_INSTALLED_COPIES: "1",
+          REPO_HARNESS_INSTALL_PROFILE: "strict",
+          CODEX_SKILLS_ROOT: codexSkills,
+          CLAUDE_SKILLS_ROOT: claudeSkills,
+        },
+      });
+
+      expect(result.status).toBe(0);
+      for (const root of [codexSkills, claudeSkills]) {
+        const installed = join(root, providerSkill);
+        expect(readFileSync(join(installed, "SKILL.md"), "utf-8")).toBe(customContent);
+        expect(lstatSync(installed).isDirectory()).toBe(true);
+        expect(existsSync(join(installed, ".repo-harness-owner.json"))).toBe(false);
+      }
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   test("minimal profile removes an exact package-owned command facade", () => {
     const tmp = join(tmpdir(), `repo-harness-installed-minimal-${Date.now()}`);
     const source = join(tmp, "source");


### PR DESCRIPTION
## Summary

- add an explicit, hash-bound `--accept-user-managed` authority for customized Claude and Codex agent fleet files
- keep strict installs fail-closed when accepted bytes change, and let `--force` restore packaged content and clear the receipt
- distinguish command facades from separately managed provider skills so strict runtime sync no longer rejects `repo-harness-cross-review`
- document the operator workflow and add regression coverage for both ownership boundaries

## Root cause

Strict installation had only packaged/default and forced-overwrite states. Restoring reviewed user customizations therefore always appeared as drift and rolled back the all-or-nothing transaction. Separately, installed-copy sync globbed every `repo-harness-*` directory as a command facade, so it rejected the strict-only cross-review provider skill even though that directory was owned by its own transaction component.

## Impact

Reviewed custom agent routing remains byte-identical across repeated strict installs. Exact SHA-256 receipts make subsequent drift observable and fail closed. Strict installs also preserve provider skills that are selected by the manifest and managed by their dedicated installer.

## Validation

- real `install --profile strict --target both --json`: exit 0, installed state consistent
- 12 agent files byte-identical to the pre-strict backup; receipt mode 0600
- `bun test tests/install-agent-fleet.test.ts`: 21 passed
- `bun test tests/installed-copy-sync.test.ts`: 13 passed
- `bun run check:type`
- `bun run check:helpers`
- deploy SQL, architecture sync, task sync, strict workflow, project inspection, and adopt dry-run checks passed
- full suite: 2040 passed, 1 skipped; one unrelated retired-name scan exceeded the default 5-second timeout, then passed 5/5 standalone in 8.15 seconds