### PR TITLE
fix: drop per-call [ChecksFile] stdout noise; out-of-repo paths no longer invalidate the capability registry

### DIFF
--- a/assets/templates/helpers/capability-resolver.ts
+++ b/assets/templates/helpers/capability-resolver.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env bun
-// @generated-from src/core/capabilities/registry.ts sha256:c9d580a3eff168b763f309dc0cbec15b1c6c478aa7bdf7bcd17015044a02830d
+// @generated-from src/core/capabilities/registry.ts sha256:2d0a2e802983d792e988db7e5ad8b1cd1b67353fbfc91db924d921bfb26cb3fe
 // Standalone typed Bun projection. Regenerate from scripts/capability-resolver.ts; do not edit by hand.
 export const CAPABILITY_REGISTRY_VERSION = 1 as const;
 
@@ -143,6 +143,22 @@ export function normalizeCapabilityPath(value: string, repoRoot = ""): string {
     throw new Error(`path must not contain traversal: ${value}`);
   }
   return parts.join("/");
+}
+
+/**
+ * True when the path is absolute and not under repoRoot. Such paths can never
+ * be governed by the repo-relative capability registry (prefixes are
+ * repo-relative), so callers keep them out of prefix matching -- where
+ * normalizeCapabilityPath would otherwise fail the whole resolution -- and
+ * account for them separately. Mirrors normalizeCapabilityPath's
+ * outside-repo branch exactly.
+ */
+export function isCapabilityPathOutsideRepo(value: string, repoRoot = ""): boolean {
+  if (typeof value !== "string") return false;
+  const next = value.trim().replace(/^file:\/\//, "").replaceAll("\\", "/");
+  const normalizedRoot = repoRoot.trim().replaceAll("\\", "/").replace(/\/+$/, "");
+  if (normalizedRoot && next.startsWith(`${normalizedRoot}/`)) return false;
+  return next.startsWith("/") || /^[A-Za-z]:\//.test(next);
 }
 
 function validatePathField(

--- a/assets/templates/helpers/capability-resolver.ts
+++ b/assets/templates/helpers/capability-resolver.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env bun
-// @generated-from src/core/capabilities/registry.ts sha256:2d0a2e802983d792e988db7e5ad8b1cd1b67353fbfc91db924d921bfb26cb3fe
+// @generated-from src/core/capabilities/registry.ts sha256:015424e6b1e0edd98719b353d7e5ab7745948d38fc3de27ceaec63f093b51004
 // Standalone typed Bun projection. Regenerate from scripts/capability-resolver.ts; do not edit by hand.
 export const CAPABILITY_REGISTRY_VERSION = 1 as const;
 
@@ -150,12 +150,13 @@ export function normalizeCapabilityPath(value: string, repoRoot = ""): string {
  * be governed by the repo-relative capability registry (prefixes are
  * repo-relative), so callers keep them out of prefix matching -- where
  * normalizeCapabilityPath would otherwise fail the whole resolution -- and
- * account for them separately. Mirrors normalizeCapabilityPath's
- * outside-repo branch exactly.
+ * account for them separately. Invalid values stay in the canonical
+ * normalization path so validation still fails closed.
  */
 export function isCapabilityPathOutsideRepo(value: string, repoRoot = ""): boolean {
   if (typeof value !== "string") return false;
   const next = value.trim().replace(/^file:\/\//, "").replaceAll("\\", "/");
+  if (next.includes("\0")) return false;
   const normalizedRoot = repoRoot.trim().replaceAll("\\", "/").replace(/\/+$/, "");
   if (normalizedRoot && next.startsWith(`${normalizedRoot}/`)) return false;
   return next.startsWith("/") || /^[A-Za-z]:\//.test(next);

--- a/src/cli/hook/command-observed.ts
+++ b/src/cli/hook/command-observed.ts
@@ -205,9 +205,7 @@ export function runCommandObserved(opts: CommandObservedInput): CommandObservedR
       stdout += '[PostBash] Tests failed. Reminder: failure = rewrite module, not patching.\n';
     }
 
-    const checksRelative = '.ai/harness/checks/latest.json';
     const postBashRelative = '.ai/harness/checks/post-bash-latest.json';
-    const checksPath = join(opts.repoRoot, checksRelative);
     fsApi.mkdirSync(dirname(join(opts.repoRoot, postBashRelative)), { recursive: true });
     const record = {
       source: 'post-bash',
@@ -227,11 +225,10 @@ export function runCommandObserved(opts: CommandObservedInput): CommandObservedR
       generated_at: offsetTimestamp(now),
     };
     fsApi.writeFileSync(join(opts.repoRoot, postBashRelative), `${JSON.stringify(record, null, 2)}\n`);
-    if (fsApi.existsSync(checksPath)) {
-      stdout += `[ChecksFile] Preserved ${checksRelative}; updated ${postBashRelative}.\n`;
-    } else {
-      stdout += `[ChecksFile] Updated ${postBashRelative}; ${checksRelative} remains reserved for repo-harness-run-trace.v1.\n`;
-    }
+    // No [ChecksFile] stdout notice here: hosts forward hook stdout into agent
+    // context, so a fixed per-command status line is pure token noise. The
+    // checks files are contract-documented state; consumers read the paths
+    // from .ai/harness/policy.json, not from per-call output.
 
     // Additive ledger import (EPC-03): one `observed` EvidenceEvent per
     // observation, after the post-bash-latest.json write above. Failure

--- a/src/cli/hook/mutation-guard.ts
+++ b/src/cli/hook/mutation-guard.ts
@@ -380,6 +380,12 @@ function runPerPathGuards(
   }
 
   // ---- TDD/BDD reminder ------------------------------------------------------
+  // Out-of-repo absolute paths (normalizeFilePath's documented fallthrough)
+  // are exempt like every other repo-scoped gate above: their test siblings
+  // would be read through collect-state-inputs' repoPath sandbox, which
+  // throws "unsafe state source path escapes repository" and crashed the
+  // whole hook for a mere advisory reminder.
+  if (!isRepoScopedPath(filePath)) return;
   if (!/\.(ts|tsx|js|jsx|py)$/.test(filePath)) return;
   if (TDD_EXCLUSION_PATTERNS.some((pattern) => pattern.test(filePath))) return;
   if (/(^|\/)index\.(ts|tsx|js|jsx)$/.test(filePath) && isPureBarrelFile(ctx.repoRoot, filePath)) return;

--- a/src/cli/hook/mutation-guard.ts
+++ b/src/cli/hook/mutation-guard.ts
@@ -19,7 +19,7 @@
 
 import { execFileSync } from 'child_process';
 import { appendFileSync, mkdirSync, realpathSync } from 'fs';
-import { basename, dirname, join } from 'path';
+import { basename, dirname, isAbsolute, join, posix, win32 } from 'path';
 import type { EffectiveState } from '../../core/state/types';
 import type { WorkflowProfile } from '../../core/workflow/profile';
 import { recordCircuitAttempt, type CircuitAttempt } from './circuit-breaker';
@@ -754,7 +754,35 @@ function tddCandidateExists(repoRoot: string, filePath: string): boolean {
 // ---------------------------------------------------------------------------
 
 function isRepoScopedPath(filePath: string): boolean {
-  return filePath.length > 0 && !filePath.startsWith('/');
+  return filePath.length > 0 && !isAbsolutePathInAnyGrammar(filePath);
+}
+
+function isAbsolutePathInAnyGrammar(filePath: string): boolean {
+  return posix.isAbsolute(filePath)
+    || win32.isAbsolute(filePath)
+    || /^[A-Za-z]:/.test(filePath);
+}
+
+function normalizePathSeparators(filePath: string): string {
+  const normalized = filePath.replaceAll('\\', '/');
+  if (normalized === '/' || /^[A-Za-z]:\/$/.test(normalized)) return normalized;
+  return normalized.replace(/\/+$/, '');
+}
+
+function pathComparisonKey(filePath: string): string {
+  return /^[A-Za-z]:\//.test(filePath) || filePath.startsWith('//')
+    ? filePath.toLowerCase()
+    : filePath;
+}
+
+function stripRepoPrefix(repoRoot: string, candidate: string): string | null {
+  const normalizedRoot = normalizePathSeparators(repoRoot);
+  const normalizedCandidate = normalizePathSeparators(candidate);
+  const rootKey = pathComparisonKey(normalizedRoot);
+  const candidateKey = pathComparisonKey(normalizedCandidate);
+  if (candidateKey === rootKey) return '';
+  if (!candidateKey.startsWith(`${rootKey}/`)) return null;
+  return normalizedCandidate.slice(normalizedRoot.length + 1);
 }
 
 /**
@@ -768,12 +796,19 @@ function isRepoScopedPath(filePath: string): boolean {
  * symlink to `/private/var/...`.
  */
 function normalizeFilePath(repoRoot: string, raw: string): string {
-  if (!raw || !raw.startsWith('/')) return raw;
-  if (raw === repoRoot || raw.startsWith(`${repoRoot}/`)) return raw.slice(repoRoot.length + 1);
+  if (!raw || !isAbsolutePathInAnyGrammar(raw)) return raw;
+  const direct = stripRepoPrefix(repoRoot, raw);
+  if (direct !== null) return direct;
+
+  // A path expressed in another platform's grammar is still absolute and
+  // outside this repo, but native realpath/dirname must not reinterpret it as
+  // a relative local path (for example C:\\... on a POSIX host).
+  if (!isAbsolute(raw)) return raw;
 
   const repoReal = tryRealpath(repoRoot);
-  if (repoReal && (raw === repoReal || raw.startsWith(`${repoReal}/`))) {
-    return raw.slice(repoReal.length + 1);
+  if (repoReal) {
+    const canonical = stripRepoPrefix(repoReal, raw);
+    if (canonical !== null) return canonical;
   }
 
   // Last resort: resolve the raw path's own parent directory (the file
@@ -781,13 +816,13 @@ function normalizeFilePath(repoRoot: string, raw: string): string {
   // roots.
   const rawParentReal = tryRealpath(dirname(raw));
   if (rawParentReal) {
-    const rawReal = `${rawParentReal}/${basename(raw)}`;
-    if (repoReal && (rawReal === repoReal || rawReal.startsWith(`${repoReal}/`))) {
-      return rawReal.slice(repoReal.length + 1);
+    const rawReal = join(rawParentReal, basename(raw));
+    if (repoReal) {
+      const canonical = stripRepoPrefix(repoReal, rawReal);
+      if (canonical !== null) return canonical;
     }
-    if (rawReal === repoRoot || rawReal.startsWith(`${repoRoot}/`)) {
-      return rawReal.slice(repoRoot.length + 1);
-    }
+    const lexical = stripRepoPrefix(repoRoot, rawReal);
+    if (lexical !== null) return lexical;
   }
 
   return raw;

--- a/src/core/capabilities/registry.ts
+++ b/src/core/capabilities/registry.ts
@@ -142,6 +142,22 @@ export function normalizeCapabilityPath(value: string, repoRoot = ""): string {
   return parts.join("/");
 }
 
+/**
+ * True when the path is absolute and not under repoRoot. Such paths can never
+ * be governed by the repo-relative capability registry (prefixes are
+ * repo-relative), so callers keep them out of prefix matching -- where
+ * normalizeCapabilityPath would otherwise fail the whole resolution -- and
+ * account for them separately. Mirrors normalizeCapabilityPath's
+ * outside-repo branch exactly.
+ */
+export function isCapabilityPathOutsideRepo(value: string, repoRoot = ""): boolean {
+  if (typeof value !== "string") return false;
+  const next = value.trim().replace(/^file:\/\//, "").replaceAll("\\", "/");
+  const normalizedRoot = repoRoot.trim().replaceAll("\\", "/").replace(/\/+$/, "");
+  if (normalizedRoot && next.startsWith(`${normalizedRoot}/`)) return false;
+  return next.startsWith("/") || /^[A-Za-z]:\//.test(next);
+}
+
 function validatePathField(
   value: unknown,
   path: string,

--- a/src/core/capabilities/registry.ts
+++ b/src/core/capabilities/registry.ts
@@ -147,12 +147,13 @@ export function normalizeCapabilityPath(value: string, repoRoot = ""): string {
  * be governed by the repo-relative capability registry (prefixes are
  * repo-relative), so callers keep them out of prefix matching -- where
  * normalizeCapabilityPath would otherwise fail the whole resolution -- and
- * account for them separately. Mirrors normalizeCapabilityPath's
- * outside-repo branch exactly.
+ * account for them separately. Invalid values stay in the canonical
+ * normalization path so validation still fails closed.
  */
 export function isCapabilityPathOutsideRepo(value: string, repoRoot = ""): boolean {
   if (typeof value !== "string") return false;
   const next = value.trim().replace(/^file:\/\//, "").replaceAll("\\", "/");
+  if (next.includes("\0")) return false;
   const normalizedRoot = repoRoot.trim().replaceAll("\\", "/").replace(/\/+$/, "");
   if (normalizedRoot && next.startsWith(`${normalizedRoot}/`)) return false;
   return next.startsWith("/") || /^[A-Za-z]:\//.test(next);

--- a/src/effects/state/resolve-effective-state.ts
+++ b/src/effects/state/resolve-effective-state.ts
@@ -3,6 +3,7 @@ import { posix, win32 } from 'path';
 import { buildReviewSubject, isImplementationSurfacePath } from '../review/diff-fingerprint';
 import { resolveWorkflowProfile, type WorkflowProfile } from '../../core/workflow/profile';
 import {
+  isCapabilityPathOutsideRepo,
   parseCapabilityRegistry,
   resolveCapabilityPaths,
 } from '../../core/capabilities/registry';
@@ -251,6 +252,7 @@ export interface CapabilityResolution {
   readonly registryStatus: CapabilityRegistryStatus;
   readonly unmappedPaths: readonly string[];
   readonly malformedEntryCount: number;
+  readonly outOfRepoPathCount: number;
 }
 
 // Deterministic "declared" signal for a missing registry file: a repo commits
@@ -279,13 +281,21 @@ function capabilityIdsForPaths(
   paths: readonly string[],
   policy: WorkflowPolicy,
 ): CapabilityResolution {
+  // Absolute paths outside the repo (user-level config such as ~/.pi/agent/*)
+  // are outside the registry's jurisdiction: prefixes are repo-relative, so
+  // they can never match, and feeding them into prefix matching used to fail
+  // the ENTIRE resolution as capability_registry:invalid even though the
+  // registry itself was valid. Partition them out and report them via their
+  // own capability:out-of-repo:<n> reason instead.
+  const inRepoPaths = paths.filter((path) => !isCapabilityPathOutsideRepo(path, cwd));
+  const outOfRepoPathCount = paths.length - inRepoPaths.length;
   const text = readText(cwd, CAPABILITY_REGISTRY_PATH);
   const registry = parseCapabilityRegistry(text && text.length > 0 ? text : null, {
     declared: policyDeclaresCapabilityRegistry(policy),
     repoRoot: cwd,
   });
   if (registry.status === 'absent') {
-    return { ids: [], registryStatus: 'absent', unmappedPaths: [], malformedEntryCount: 0 };
+    return { ids: [], registryStatus: 'absent', unmappedPaths: [], malformedEntryCount: 0, outOfRepoPathCount };
   }
   if (registry.status === 'invalid') {
     const malformedEntries = new Set(
@@ -298,14 +308,16 @@ function capabilityIdsForPaths(
       registryStatus: 'invalid',
       unmappedPaths: [...paths],
       malformedEntryCount: malformedEntries.size,
+      outOfRepoPathCount,
     };
   }
-  const resolution = resolveCapabilityPaths(registry.registry, paths, { repoRoot: cwd });
+  const resolution = resolveCapabilityPaths(registry.registry, inRepoPaths, { repoRoot: cwd });
   return {
     ids: resolution.capabilityIds,
     registryStatus: resolution.status,
     unmappedPaths: resolution.unmappedPaths,
     malformedEntryCount: 0,
+    outOfRepoPathCount,
   };
 }
 
@@ -410,12 +422,13 @@ function resolveEffectiveStateUnlocked(
   // from the implementation-surface path set (capabilityIdsForPaths' contract
   // is stated in terms of "implementation paths").
   const capabilityResolution: CapabilityResolution | null = options.risk?.capabilityIds
-    ? { ids: options.risk.capabilityIds, registryStatus: 'valid', unmappedPaths: [], malformedEntryCount: 0 }
+    ? { ids: options.risk.capabilityIds, registryStatus: 'valid', unmappedPaths: [], malformedEntryCount: 0, outOfRepoPathCount: 0 }
     : hasRawTargetPaths
       ? capabilityIdsForPaths(cwd, implementationTargetPaths, policy)
       : null;
   const observedCapabilityIds = capabilityResolution?.ids;
   const unmappedCapabilityCount = capabilityResolution?.unmappedPaths.length ?? 0;
+  const outOfRepoPathCount = capabilityResolution?.outOfRepoPathCount ?? 0;
   // capabilityCount is always an explicit number (never left undefined) once
   // there are any raw target paths, so an all-workflow-surface batch (whose
   // implementationTargetPaths is empty) resolves the deterministic "known,
@@ -425,7 +438,9 @@ function resolveEffectiveStateUnlocked(
   // which stays untouched below.
   const declaredCapabilityCount = options.risk?.capabilityCount ?? (
     hasRawTargetPaths
-      ? (observedCapabilityIds?.length ?? 0) + (unmappedCapabilityCount > 0 ? 1 : 0)
+      ? (observedCapabilityIds?.length ?? 0)
+        + (unmappedCapabilityCount > 0 ? 1 : 0)
+        + (outOfRepoPathCount > 0 ? 1 : 0)
       : undefined
   );
 
@@ -462,6 +477,9 @@ function resolveEffectiveStateUnlocked(
   }
   if (unmappedCapabilityCount > 0) {
     capabilityReasons.push(`capability:unmapped:${unmappedCapabilityCount}`);
+  }
+  if (outOfRepoPathCount > 0) {
+    capabilityReasons.push(`capability:out-of-repo:${outOfRepoPathCount}`);
   }
 
   const reviewPath = planPath ? deriveReviewPath(planPath, planText, contractText) : null;

--- a/src/effects/state/resolve-effective-state.ts
+++ b/src/effects/state/resolve-effective-state.ts
@@ -306,7 +306,7 @@ function capabilityIdsForPaths(
     return {
       ids: [],
       registryStatus: 'invalid',
-      unmappedPaths: [...paths],
+      unmappedPaths: [...inRepoPaths],
       malformedEntryCount: malformedEntries.size,
       outOfRepoPathCount,
     };
@@ -436,11 +436,12 @@ function resolveEffectiveStateUnlocked(
   // resolveWorkflowProfile's signals-unavailable fail-closed branch -- that
   // branch exists for the genuinely unknown case (no target paths at all),
   // which stays untouched below.
+  // Out-of-repo paths remain diagnostic-only: they are not capabilities
+  // governed by this repo and therefore never contribute to capabilityCount.
   const declaredCapabilityCount = options.risk?.capabilityCount ?? (
     hasRawTargetPaths
       ? (observedCapabilityIds?.length ?? 0)
         + (unmappedCapabilityCount > 0 ? 1 : 0)
-        + (outOfRepoPathCount > 0 ? 1 : 0)
       : undefined
   );
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -12,6 +12,12 @@
 
 ## Active Lessons
 
+- Date: 2026-07-26
+- Triggered by correction: PR #132 review found that a repo-external target was reported correctly but also counted as an anonymous capability, while NUL-bearing paths and Win32 absolute hook paths diverged from the intended fail-closed and repo-scope boundaries.
+- Mistake pattern: using one partition predicate as both reporting classification and validation authority, then treating every non-POSIX-absolute path as repo-relative.
+- Prevention rule: partition valid repo-external paths out of capability matching without adding them to `capabilityCount`; leave malformed paths for canonical validation; classify hook paths with both POSIX and Win32 grammars before any repo-scoped filesystem probe.
+- Where to apply next time: Effective State target-risk resolution, capability registry adapters, mutation hooks, and cross-platform path tests.
+
 - Date: 2026-07-23
 - Triggered by correction: a scope-runaway incident (a branch-cleanup task self-expanded into fixing every CI fault on `main`) exposed that the live `~/.codex/AGENTS.md` had gained a whole `## Sufficiency and Stop Boundaries` section through direct edits while `assets/reference-configs/global-working-rules.md` — the source `repo-harness init` actually distributes — never received it, so freshly initialized machines shipped without any stop-boundary discipline.
 - Mistake pattern: patching the installed copy of a distributed artifact and never back-porting to the template that init ships, leaving the authoring surface and the distribution surface with divergent authority.

--- a/tests/capabilities/registry.test.ts
+++ b/tests/capabilities/registry.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  isCapabilityPathOutsideRepo,
   matchCapabilityPath,
   normalizeCapabilityPath,
   parseCapabilityRegistry,
@@ -8,6 +9,26 @@ import {
   type Capability,
   type CapabilityRegistry,
 } from "../../src/core/capabilities/registry";
+
+describe("isCapabilityPathOutsideRepo", () => {
+  const repoRoot = "/repo/root";
+
+  test("flags absolute paths outside the repo root", () => {
+    expect(isCapabilityPathOutsideRepo("/home/user/.pi/agent/bridge.ts", repoRoot)).toBe(true);
+    expect(isCapabilityPathOutsideRepo("C:/Users/user/config.ts", repoRoot)).toBe(true);
+  });
+
+  test("keeps repo-internal and relative paths inside jurisdiction", () => {
+    expect(isCapabilityPathOutsideRepo("/repo/root/src/a.ts", repoRoot)).toBe(false);
+    expect(isCapabilityPathOutsideRepo("src/a.ts", repoRoot)).toBe(false);
+    expect(isCapabilityPathOutsideRepo("../escape.ts", repoRoot)).toBe(false);
+  });
+
+  test("mirrors normalizeCapabilityPath's outside-repo branch exactly", () => {
+    expect(() => normalizeCapabilityPath("/home/user/.pi/agent/bridge.ts", repoRoot)).toThrow(/outside repo/);
+    expect(normalizeCapabilityPath("/repo/root/src/a.ts", repoRoot)).toBe("src/a.ts");
+  });
+});
 
 const web: Capability = {
   id: "apps-web",

--- a/tests/capabilities/registry.test.ts
+++ b/tests/capabilities/registry.test.ts
@@ -24,9 +24,12 @@ describe("isCapabilityPathOutsideRepo", () => {
     expect(isCapabilityPathOutsideRepo("../escape.ts", repoRoot)).toBe(false);
   });
 
-  test("mirrors normalizeCapabilityPath's outside-repo branch exactly", () => {
+  test("partitions only validation-safe paths outside the repo", () => {
     expect(() => normalizeCapabilityPath("/home/user/.pi/agent/bridge.ts", repoRoot)).toThrow(/outside repo/);
     expect(normalizeCapabilityPath("/repo/root/src/a.ts", repoRoot)).toBe("src/a.ts");
+    const invalid = "/home/user/.pi/agent/bri\0dge.ts";
+    expect(isCapabilityPathOutsideRepo(invalid, repoRoot)).toBe(false);
+    expect(() => normalizeCapabilityPath(invalid, repoRoot)).toThrow(/NUL/);
   });
 });
 

--- a/tests/command-observed.test.ts
+++ b/tests/command-observed.test.ts
@@ -40,7 +40,7 @@ describe('runCommandObserved', () => {
       });
       expect(result.exitCode).toBe(0);
       expect(result.reason).toBe('ok');
-      expect(result.stdout).toContain('[ChecksFile] Updated .ai/harness/checks/post-bash-latest.json');
+      expect(result.stdout).toBe('');
       const checks = JSON.parse(readFileSync(join(repoRoot, '.ai/harness/checks/post-bash-latest.json'), 'utf8')) as Record<string, unknown>;
       expect(checks).toMatchObject({
         source: 'post-bash',
@@ -98,7 +98,7 @@ describe('runCommandObserved', () => {
       });
 
       expect(result).toMatchObject({ exitCode: 0, reason: 'ok' });
-      expect(result.stdout).toBe('[ChecksFile] Preserved .ai/harness/checks/latest.json; updated .ai/harness/checks/post-bash-latest.json.\n');
+      expect(result.stdout).toBe('');
       expect(JSON.parse(readFileSync(join(repoRoot, '.ai/harness/checks/latest.json'), 'utf8'))).toEqual(existing);
       expect(checks(repoRoot)).toMatchObject({
         source: 'post-bash',

--- a/tests/effective-state.test.ts
+++ b/tests/effective-state.test.ts
@@ -329,6 +329,44 @@ describe('effective state resolver', () => {
       });
     });
 
+    test('absolute target paths outside the repo do not invalidate a valid registry', () => {
+      withRepo((cwd) => {
+        write(cwd, '.ai/context/capabilities.json', JSON.stringify({ version: 1, capabilities: [] }));
+        const state = resolveFixtureState(cwd, Date.now(), {
+          targetPaths: ['/home/user/.pi/agent/extensions/bridge.ts'],
+          operationKind: 'edit',
+        });
+        expect(state.blockers).not.toContain('capability_registry:invalid');
+        expect(state.profile_reasons).not.toContain('capability:registry:invalid');
+        expect(state.profile_reasons).toContain('capability:out-of-repo:1');
+        expect(state.phase).not.toBe('blocked');
+      });
+    });
+
+    test('a mixed batch keeps in-repo unmapped accounting alongside out-of-repo paths', () => {
+      withRepo((cwd) => {
+        write(cwd, '.ai/context/capabilities.json', JSON.stringify({ version: 1, capabilities: [] }));
+        const state = resolveFixtureState(cwd, Date.now(), {
+          targetPaths: ['src/feature.ts', '/home/user/.pi/agent/extensions/bridge.ts'],
+          operationKind: 'edit',
+        });
+        expect(state.blockers).not.toContain('capability_registry:invalid');
+        expect(state.profile_reasons).toContain('capability:unmapped:1');
+        expect(state.profile_reasons).toContain('capability:out-of-repo:1');
+      });
+    });
+
+    test('in-repo traversal paths still fail closed as invalid', () => {
+      withRepo((cwd) => {
+        write(cwd, '.ai/context/capabilities.json', JSON.stringify({ version: 1, capabilities: [] }));
+        const state = resolveFixtureState(cwd, Date.now(), {
+          targetPaths: ['../escape.ts'],
+          operationKind: 'edit',
+        });
+        expect(state.blockers).toContain('capability_registry:invalid');
+      });
+    });
+
     test('malformed entries inside an otherwise-parseable registry are counted and fail closed instead of silently dropped', () => {
       withRepo((cwd) => {
         write(cwd, '.ai/context/capabilities.json', JSON.stringify({

--- a/tests/effective-state.test.ts
+++ b/tests/effective-state.test.ts
@@ -353,6 +353,53 @@ describe('effective state resolver', () => {
         expect(state.blockers).not.toContain('capability_registry:invalid');
         expect(state.profile_reasons).toContain('capability:unmapped:1');
         expect(state.profile_reasons).toContain('capability:out-of-repo:1');
+        expect(state.profile_signals?.capabilityCount).toBe(1);
+        expect(state.profile_signals?.crossCapability).toBe(false);
+        expect(state.risk_floor).toBe('lite');
+      });
+    });
+
+    test('a mapped repo capability plus an out-of-repo path stays one capability', () => {
+      withRepo((cwd) => {
+        write(cwd, '.ai/context/capabilities.json', JSON.stringify({
+          version: 1,
+          capabilities: [capability('feature-cap', ['src/feature'])],
+        }));
+        const state = resolveFixtureState(cwd, Date.now(), {
+          targetPaths: ['src/feature/index.ts', '/home/user/.pi/agent/extensions/bridge.ts'],
+          operationKind: 'edit',
+        });
+        expect(state.profile_reasons).toContain('capability:out-of-repo:1');
+        expect(state.profile_reasons).not.toContain('capability:unmapped:1');
+        expect(state.profile_signals?.capabilityCount).toBe(1);
+        expect(state.profile_signals?.crossCapability).toBe(false);
+        expect(state.risk_floor).toBe('lite');
+      });
+    });
+
+    test('a NUL-bearing absolute path fails canonical validation instead of bypassing it', () => {
+      withRepo((cwd) => {
+        write(cwd, '.ai/context/capabilities.json', JSON.stringify({ version: 1, capabilities: [] }));
+        const state = resolveFixtureState(cwd, Date.now(), {
+          targetPaths: ['/home/user/.pi/agent/bri\0dge.ts'],
+          operationKind: 'edit',
+        });
+        expect(state.blockers).toContain('capability_registry:invalid');
+        expect(state.profile_reasons).toContain('capability:registry:invalid');
+        expect(state.profile_reasons).not.toContain('capability:out-of-repo:1');
+      });
+    });
+
+    test('an invalid registry does not also count out-of-repo paths as unmapped', () => {
+      withRepo((cwd) => {
+        write(cwd, '.ai/context/capabilities.json', '{not json');
+        const state = resolveFixtureState(cwd, Date.now(), {
+          targetPaths: ['/home/user/.pi/agent/extensions/bridge.ts'],
+          operationKind: 'edit',
+        });
+        expect(state.blockers).toContain('capability_registry:invalid');
+        expect(state.profile_reasons).toContain('capability:out-of-repo:1');
+        expect(state.profile_reasons).not.toContain('capability:unmapped:1');
       });
     });
 

--- a/tests/runtime-profile-enforcement.test.ts
+++ b/tests/runtime-profile-enforcement.test.ts
@@ -112,6 +112,24 @@ describe('risk-based runtime profile enforcement', () => {
     } finally { rmSync(cwd, { recursive: true, force: true }); }
   });
 
+  test('editing a .ts file outside the repo skips the TDD reminder instead of crashing the sandbox', () => {
+    const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'profile-oor-')));
+    const outside = realpathSync(mkdtempSync(join(tmpdir(), 'profile-oor-home-')));
+    try {
+      initRepo(cwd);
+      mkdirSync(join(outside, 'extensions'), { recursive: true });
+      const target = join(outside, 'extensions', 'bridge.ts');
+      writeFileSync(target, 'export const x = 1;\n');
+      const result = preEdit(cwd, target);
+      expect(result.status).toBe(0);
+      expect(`${result.stdout}${result.stderr}`).not.toContain('unsafe state source path');
+      expect(result.stdout).not.toContain('TDD Guard');
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
   test('Standard requires a plan but not the Strict contract/worktree chain', () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'profile-standard-')));
     try {

--- a/tests/runtime-profile-enforcement.test.ts
+++ b/tests/runtime-profile-enforcement.test.ts
@@ -130,6 +130,22 @@ describe('risk-based runtime profile enforcement', () => {
     }
   });
 
+  test('Win32 absolute .ts paths outside the repo skip repo-scoped TDD probes', () => {
+    const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'profile-oor-win32-')));
+    try {
+      initRepo(cwd);
+      for (const target of [
+        'C:/Users/user/.pi/agent/extensions/bridge.ts',
+        'C:\\Users\\user\\.pi\\agent\\extensions\\bridge.ts',
+      ]) {
+        const result = preEdit(cwd, target);
+        expect(result.status).toBe(0);
+        expect(`${result.stdout}${result.stderr}`).not.toContain('unsafe state source path');
+        expect(result.stdout).not.toContain('TDD Guard');
+      }
+    } finally { rmSync(cwd, { recursive: true, force: true }); }
+  });
+
   test('Standard requires a plan but not the Strict contract/worktree chain', () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'profile-standard-')));
     try {


### PR DESCRIPTION
## Summary

This PR now closes the full out-of-repo edit path while preserving the original stdout-noise cleanup:

1. Removes the unconditional `[ChecksFile]` PostToolUse stdout notice without changing checks-file writes or the actionable failure reminder.
2. Partitions valid repo-external target paths out of capability prefix matching and reports `capability:out-of-repo:<n>`.
3. Skips repo-scoped TDD/BDD sibling probes for external POSIX and Win32 paths.
4. Applies the review follow-up in `f8316a9e`:
   - repo-external paths are diagnostic-only and do not contribute to `capabilityCount`;
   - NUL-bearing paths stay on canonical validation and fail closed;
   - an invalid registry no longer counts one external path as both unmapped and out-of-repo;
   - hook path classification recognizes both POSIX and Win32 absolute grammars while preserving repo-internal absolute/symlink normalization.

The capability registry remains the authority only for repo-relative prefixes. External paths neither match nor invent a synthetic repository capability.

`assets/templates/helpers/capability-resolver.ts` was regenerated from the canonical registry source, and the correction-derived prevention rule was recorded in `tasks/lessons.md`.

## Evidence

- [Hosted CI run 30187353689](https://github.com/Ancienttwo/repo-harness/actions/runs/30187353689): Test plus macOS, Ubuntu, and Windows MCP path matrix all passed.
- Focused regression suite: 68 passed, 0 failed.
- Mutation-guard characterization suite: 15 passed, 0 failed.
- `check:type`, helper/hook projection checks, state-boundary check, deploy SQL order, architecture sync, task sync, strict workflow check, project inspection, adopt dry-run, and diff hygiene all passed.
- One loaded local full-suite run reached 2076 passed / 1 skipped with two unrelated timing/timeout failures; both failing cases passed immediately in isolated reruns. Hosted CI's clean Test job is the final environment readback.
