### PR TITLE
Ship codex/reference-configs-projection

### DIFF
--- a/assets/reference-configs/harness-overview.md
+++ b/assets/reference-configs/harness-overview.md
@@ -62,7 +62,10 @@ with the project.
 - Externalized reference docs may be indexed by `.ai/harness/brain-manifest.json`. Validation and export through `repo-harness run check-brain-manifest` / `sync-brain-docs` are explicit operator actions and never part of hook or workflow correctness.
 - Contract-level execution should run in an isolated `codex/<task-slug>` worktree. Merge back only after the contract is fulfilled, `tasks/reviews/<plan-stem>.review.md` recommends pass, and the target worktree is clean.
 - Architecture-sensitive work also runs `repo-harness run check-architecture-sync`: the check keeps the request index derived from `docs/architecture/requests/` and, when policy is strict, blocks finish if the current diff touches a capability with a pending architecture request at or above `architecture.gate_min_severity`.
-- Migration cleans legacy root `scripts/<repo-harness-helper>` files only when content is identifiable as generated repo-harness runtime; ambiguous app-owned root scripts are reported and preserved.
+- Adoption retires legacy hook/runtime assets only inside the canonical
+  `FsTransaction`: declared paths require an exact SHA-256 match, while
+  mismatches, ambiguous app-owned files, and custom adapter siblings are
+  preserved and reported.
 
 ## Documentation Profile
 
@@ -100,18 +103,30 @@ Required v1 fields:
 
 Harness cost reports separate measured values from unavailable telemetry. A
 metric is authoritative only when its named source exposes that value directly;
-missing values stay `null` with an unavailable authority marker. Reports must
-not derive model calls from turns, subagents from tool-name text, billing tokens
-from byte counts, or live hook latency from host tool duration.
+missing or incomplete event metrics keep `runtime_evidence.available: false`.
+Reports must not derive model calls from turns, subagents from tool-name text,
+billing tokens from byte counts, or hidden legacy-script I/O from local
+heuristics.
 
 The two current evidence owners are:
 
-- `scripts/hook-dispatch-diet-report.ts` for static route topology and
-  synthetic subprocess probes. Probe distributions include sample count, total,
-  p50, p95, p99, and max latency. The SessionStart probe also records UTF-8
-  output/context bytes. Its context token value is an estimate labeled
-  `utf8_bytes_div_4`; it is a context-budget indicator, not provider billing
-  usage.
+- `.ai/harness/runs/hook-events.jsonl` is the sole hook runtime telemetry
+  authority. `src/cli/hook/runtime.ts` appends exactly one
+  `loop-engine-hook-event/v1` record per eligible handled host event. Typed
+  dispatch evidence contains one `in_process` handler step, direct
+  `child_processes: 0`, and no opaque steps. File/write metrics are only
+  authoritative at explicit observer boundaries; consumers inspect
+  `complete_metrics` and `incomplete_metrics` instead of treating zero as
+  proof of complete filesystem coverage. The telemetry append itself is
+  excluded from write amplification metrics and is non-authoritative: append
+  failure never changes hook safety.
+- `scripts/hook-dispatch-diet-report.ts` combines that event authority with
+  static route topology and synthetic subprocess probes. Runtime distributions
+  and route coverage include sample count, p50, and p95; missing, malformed,
+  mixed-protocol, duplicate, or target-incomplete records fail closed. Synthetic
+  probe distributions retain total, p50, p95, p99, and max latency. The
+  SessionStart token estimate remains labeled `utf8_bytes_div_4`; it is a
+  context-budget indicator, not provider billing usage.
 - `scripts/run-skill-evals.ts` for end-to-end benchmark duration, changed-file
   evidence, graders, and provider-structured usage. Claude single-result JSON
   and Codex JSONL are parsed independently. Raw output remains an artifact, and
@@ -120,6 +135,15 @@ The two current evidence owners are:
 
 Current SLOs:
 
+- Runtime entry: exactly one per eligible host event.
+- Direct runtime-dispatch child processes: at most one per event. This does not
+  claim to count internal `git`/`bun` plumbing or OS process syscalls.
+- Effective State resolution: exactly one for the measured PreEdit and Stop
+  target routes.
+- PreEdit event p95: target at most 150 ms, initial hard budget 250 ms.
+- PostEdit: zero full recovery-projection writes and at most one journal event
+  write.
+- Stop: at most one recovery-projection write transaction.
 - Synthetic hook phase p95: at most 250 ms per probe.
 - Estimated actionable SessionStart context: at most 1,500 tokens using the
   explicitly labeled byte heuristic.
@@ -170,7 +194,9 @@ rather than inferring those values from turns, tool names, or timestamps.
 - Declare capabilities in `.ai/context/capabilities.json`; each capability owns prefixes, paired contract files, an architecture module, a workstream directory, and local verification hints.
 - Add selected capabilities with `repo-harness-setup` (capability mode) or `repo-harness run capability-config add --prefix <path>` when the harness already exists and a full init/migrate/upgrade pass would be too broad.
 - Resolve edited paths through `repo-harness run capability-resolver match --path <path>`; longest prefix wins and equal-length ambiguity fails.
-- Treat `.ai/context/agent-context-blocks.txt`, `REPO_HARNESS_CONTEXT_BLOCKS`, and existing nested `CLAUDE.md`/`AGENTS.md` files as migration inputs or compatibility fallbacks only.
+- Treat `.ai/context/agent-context-blocks.txt`,
+  `REPO_HARNESS_CONTEXT_BLOCKS`, and existing nested `CLAUDE.md`/`AGENTS.md`
+  files as migration inputs only; the capability registry is runtime authority.
 - Selected capabilities receive paired `CLAUDE.md` and `AGENTS.md` files so Claude Code and Codex share the same local contract.
 - Use `repo-harness capability-context status|request|sync` to keep paired local context files aligned with the registry. The command writes only the controlled `CAPABILITY CONTEXT` block and preserves hand-authored content plus the separate architecture contract block.
 - `.ai/context/capability-source-map.json` is the optional human-edited source-map manifest for capability positioning and source pointers. Missing entries fall back to registry/architecture/workstream metadata; `--auto-fill-positioning` writes deterministic draft entries explicitly, not from hooks.
@@ -188,6 +214,10 @@ Maintainer-facing detail on how the initializer and runtime defaults are wired.
 - Question-pack source of truth: `assets/initializer-question-pack.v4.json`.
 - Generated repos default to the repo-local harness flow: `docs/spec.md -> plans/ -> tasks/contracts/ -> tasks/reviews/ -> .ai/context/context-map.json -> .ai/harness/*`.
 - Generated and self-hosted repos install `.ai/harness/workflow-contract.json` and `.ai/harness/policy.json`.
+- Host events use the user-level managed adapter projection, the 11-tuple
+  `route-registry.ts`, and exactly one typed in-process handler per tuple.
+  `.ai/hooks/lib/workflow-state.sh` is an operator helper projection, not a
+  second host-event runtime.
 - Generated and migrated repos keep discovery and complex/design planning in the parent agent: `geju` opens the pre-contract frame, then the parent completes P1/P2/P3 and freezes the accepted direction. Daily small/medium work uses Waza with Codex-first runtime copies in `~/.codex/skills`; durable knowledge stays in repo-authored research and lessons.
 - `repo-harness install` bootstraps the Codex/Claude runtime pieces for the default workflow: refreshes `repo-harness` skill aliases, installs global Codex/Claude hook adapters, installs Waza skills (`think`, `hunt`, `check`, `health`) and Mermaid through the skills CLI, persists the brain root in `~/.repo-harness/config.json`, and configures CodeGraph MCP for selected host agents. `repo-harness init` remains a compatibility alias for existing automation.
 - Other external tooling stays advisory-only: `repo-harness run check-agent-tooling --host both --check-updates`; Waza update checks compare upstream `tw93/Waza` `SKILL.md` hashes without running `npx skills check`; no automatic CodeGraph daemon or provider setup.

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "check:hooks": "bun scripts/sync-hook-sources.ts --check",
     "sync:helpers": "bun scripts/sync-helper-sources.ts --write",
     "check:helpers": "bun scripts/sync-helper-sources.ts --check",
+    "sync:reference-configs": "bun scripts/sync-reference-configs.ts --write",
+    "check:reference-configs": "bun scripts/sync-reference-configs.ts --check",
     "check:state-boundaries": "bun scripts/check-state-boundaries.ts",
     "check:ci": "bash scripts/check-ci.sh",
     "check:release": "bash scripts/check-npm-release.sh",

--- a/plans/plan-20260730-2149-reference-configs-projection.md
+++ b/plans/plan-20260730-2149-reference-configs-projection.md
@@ -1,0 +1,171 @@
+# Plan: Converge reference-configs projection and simplify low-risk tests
+
+> **Status**: Executing
+> **Created**: 20260730-2149
+> **Slug**: reference-configs-projection
+> **Planning Source**: codex-plan-or-waza-think
+> **Orchestration Kind**: host-plan
+> **Source Ref**: (none)
+> **Artifact Level**: work-package
+> **Promotion Reason**: merge_boundary
+> **Verification Boundary**: Commands named in the captured planning output plus `repo-harness run verify-contract --contract tasks/contracts/20260730-2149-reference-configs-projection.contract.md --strict`.
+> **Rollback Surface**: Before execution remove `plans/plan-20260730-2149-reference-configs-projection.md`; after execution revert branch `codex/reference-configs-projection` or the explicitly reviewed diff.
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260730-2149-reference-configs-projection.contract.md`
+> **Task Review**: `tasks/reviews/20260730-2149-reference-configs-projection.review.md`
+> **Implementation Notes**: `tasks/notes/20260730-2149-reference-configs-projection.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from codex-plan-or-waza-think planning output.
+- Source ref: (none)
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260730-2149-reference-configs-projection.md`
+- Sprint contract: `tasks/contracts/20260730-2149-reference-configs-projection.contract.md`
+- Sprint review: `tasks/reviews/20260730-2149-reference-configs-projection.review.md`
+- Implementation notes: `tasks/notes/20260730-2149-reference-configs-projection.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260730-2149-reference-configs-projection.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260730-2149-reference-configs-projection.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260730-2149-reference-configs-projection.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260730-2149-reference-configs-projection.contract.md`
+- Review file: `tasks/reviews/20260730-2149-reference-configs-projection.review.md`
+- Implementation notes file: `tasks/notes/20260730-2149-reference-configs-projection.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260730-2149-reference-configs-projection.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260730-2149-reference-configs-projection.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: Before execution remove `plans/plan-20260730-2149-reference-configs-projection.md`; after execution revert branch `codex/reference-configs-projection` or the explicitly reviewed diff.
+- **Verification boundary**: Commands named in the captured planning output plus `repo-harness run verify-contract --contract tasks/contracts/20260730-2149-reference-configs-projection.contract.md --strict`.
+- **Review/acceptance boundary**: `tasks/reviews/20260730-2149-reference-configs-projection.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: merge_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260730-2149-reference-configs-projection.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260730-2149-reference-configs-projection.contract.md`, `tasks/reviews/20260730-2149-reference-configs-projection.review.md`, and `tasks/notes/20260730-2149-reference-configs-projection.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260730-2149-reference-configs-projection.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: Before execution remove `plans/plan-20260730-2149-reference-configs-projection.md`; after execution revert branch `codex/reference-configs-projection` or the explicitly reviewed diff.
+
+## Captured Planning Output
+
+# 收斂 reference-configs 投影 + LOW 風險測試簡化
+
+## Context
+
+測試套件審計(2026-07-30,基於 main@095dcb06)證實:文檔逐字斷言層是純同步稅(readme-dx.test.ts 全歷史 20/20 commit 零攔截記錄),而鏡像等式守衛有真實攔截實證(commit 88a7b6a8 漂移 26 分鐘後被守衛逼回)。根因是投影面裸奔:docs/reference-configs 與 assets/reference-configs 23 對鏡像只有 6 對有散裝等式守衛,harness-overview.md 已分岔 shipped(docs 224 行 vs assets 194 行)。用戶批准:軸 A 投影收斂 + S1–S5 LOW 風險測試簡化,S6/S7(MEDIUM)明確不做。
+
+## 凍結決策
+
+1. **投影方向:assets/reference-configs/ = source,docs/reference-configs/ = byte-identical 生成投影。** 依據:近期實證(88a7b6a8)編輯入口在 assets 側;assets 是隨 `repo-harness init` 裝進下游 repo 的 shipped surface,真相跟著 shipped artifact 走保證下游與 self-host 讀到同一份。docs 側另有 7 個 docs-only 檔(chatgpt-coding-mcp.md、contract-brief-example.md、contract-brief-example-bugfix.md、general-repo-mcp.md、install-profiles.md、loop-engine-cutover-gate.md、loop-engine-nl-decision-table.md)——不屬投影範圍,sync 工具忽略、不刪。
+2. **harness-overview.md 裁決:時間性漂移,非刻意分歧。** 證據:docs 側含 canonical FsTransaction / SHA-256 精確匹配 / hook-events.jsonl 遙測 authority / route-registry 11-tuple 等新架構描述;assets 側停在舊語義且含 "compatibility fallbacks" 措辭(與 repo 現行禁令衝突)。處置:**內容取 docs 側現狀,住址歸 assets**——先把 docs 側整檔覆蓋到 assets 側,再由 sync 生成回 docs,兩側歸一。注意:stacked base 上兩側都已被 rename 任務改過 adopt→init 字串,以 base 上的 docs 側為準。
+3. **本包 stacked 在 `codex/cli-init-rename` 上**(檔案重疊:readme-dx.test.ts、check-ci.sh、5 對鏡像兩側)。merge 順序必須在 cli-init-rename 之後;merge 前 rebase 到該分支最新 tip。
+4. **審計中的行號全部基於 main@095dcb06,在 stacked base 上會漂移——一律以內容定位,行號僅供參考。**
+5. **散裝等式測試刪 6 條、補一條統一迴圈**:單一測試遍歷 assets/reference-configs/*.md 對 docs 對應檔做等式(同 tests/helper-scripts.test.ts 的 helper parity 迴圈同型)。理由:bun test 是第一必跑檢查,不能只靠 check-ci 的腳本層守衛;迴圈自動涵蓋 23 對與未來新增,散裝斷言才是稅。
+
+## Phase 1 — sync-reference-configs 工具與 harness-overview 歸一
+
+1. 先讀 `scripts/sync-helper-sources.ts`,新檔 `scripts/sync-reference-configs.ts` 照同一 idiom(--check / --write 兩模式、非零 exit、逐檔列差異)。規則:assets/reference-configs/ 每個 .md 必須在 docs/reference-configs/ 有 byte-identical 副本;--write 由 assets 覆寫 docs;--check 只報不寫;docs-only 檔忽略。
+2. `package.json` scripts 加 `check:reference-configs` / `sync:reference-configs`(對齊現有 check:helpers / sync:helpers 命名)。
+3. 掛進 `scripts/check-ci.sh` 現有 --check 段(sync-helper-sources --check 旁)。
+4. harness-overview 歸一:`cp docs/reference-configs/harness-overview.md assets/reference-configs/harness-overview.md`(決策 2),然後 `bun run check:reference-configs` 必須 23 對全綠。
+
+## Phase 2 — 等式守衛收斂(刪 6 補 1)
+
+新增統一迴圈測試(獨立小檔 `tests/reference-configs-projection.test.ts`),然後刪被取代的散裝等式(以內容定位):
+
+- `tests/readme-dx.test.ts` 兩條 `.toBe()` 鏡像等式(release-deploy.md、external-tooling.md)
+- `tests/ux-feature-guardrail.test.ts` 兩條鏡像等式
+- `tests/global-working-rules-distribution.test.ts` 的 global-working-rules.md 等式(只刪等式斷言,該檔其餘斷言保留)
+- `tests/sprint-backlog.test.ts` 的 sprint-contracts.md 等式(**注意**:同檔的 sprint/prd template 等式不屬 reference-configs,保留)
+
+## Phase 3 — README prose 斷言收斂(S1/S2)
+
+- `tests/readme-dx.test.ts` First-5-Minutes 區:砍 prose 逐字斷言——死斷言(被鄰行完全包含的)、精確出現次數鎖、行銷語逐字釘、以 README 反鎖 CLI stdout 字面值的那組、`not.toContain` 反向陷阱組。**保留**:章節順序結構斷言、localized README 版本號迴圈(從 package.json 推導,自維護)、red-flag scan 段。stacked base 上這些字串已是 init 動詞,以 base 內容決定具體刪哪些行。
+- `tests/install-scripts.test.ts`:刪與 readme-dx 字面重複的 README 斷言段;保留 install.sh / install.ps1 本體斷言與 `bash -n` 語法檢查。
+
+## Phase 4 — 機械簡化(S3/S4/S5)
+
+- **S3** `tests/bootstrap-files.test.ts` 去重:同 test 內連寫兩遍的 `operations.deploy_sql`;`create_contract_directories` ×4;`cat > tasks/todos.md`/`tasks/lessons.md`/`not.toContain("docs/TODO.md")` 整組 ×2;`pi_install_reference_configs` ×3;`policy.json`/`context-map.json` ×2。每組留一處。SKILL.md 2048 bytes 上限**保留**,只補一行 rationale 註解(router 常駐載入需精簡)。
+- **S4** `tests/skill-surface/retired-names-scan.test.ts`:decode 前跳過二進位(副檔名白名單或 NUL byte 探測,~5 行,砍掉 6 個 PNG 共 3.8s);`RETIRED_NAMES` 硬編清單改由 `assets/skill-commands/manifest.json` 的 `retiredPackages[]` 推導(減去檔內已文件化的例外),連帶刪硬編 `toBe(19)`;**保留** allowlist 防腐段(每條 allowlist 必須仍有命中)。
+- **S5** byte-parity 冗餘:先確認 `tests/helper-scripts.test.ts` 的 helper parity 迴圈確實涵蓋以下各條,再刪——`tests/evidence-residue-scan.test.ts`、`tests/evidence-checks-materializer.test.ts`、`tests/evidence-recovery-materializer.test.ts` 各自的單檔等式,以及 `tests/sprint-backlog.test.ts` 裡 sprint-backlog.sh / check-task-workflow.sh / refresh-current-status.sh 的等式。涵蓋不到的一律不刪。
+
+## 明確不做(EXECUTION_BOUNDARY)
+
+- S6(helper-scripts workspace 重構)、S7(CI per-file 隔離模式)——MEDIUM 風險,單獨包。
+- 不動 `tests/cli/adoption-plan.test.ts` 的 at-rest 協議鎖、`--help` 斷言、falsifier 測試等 load-bearing 項。
+- 不動 5 份 README 正文與任何 reference-configs 內容(harness-overview 歸一除外)。
+- 不做方案未列的任何「順手」改動;絕不新增 compatibility 路徑。
+
+## 驗證
+
+```bash
+bun run check:reference-configs            # 23 對全綠
+bun run check:helpers                      # 沒弄壞既有 sync
+bun run check:type
+bun test                                   # 全綠(用 > log 2>&1 形式跑,避免管道靜默)
+bun test tests/reference-configs-projection.test.ts
+bun test tests/skill-surface/retired-names-scan.test.ts   # 計時對比,預期 ~8.3s → ~4.5s
+bash scripts/check-ci.sh 的 --check 段(或全量)
+```
+
+負向驗證:臨時改壞一對鏡像(不 commit),`check:reference-configs` 與新迴圈測試都必須紅,改回後綠——證明守衛 fail-closed,結果記入 notes。
+
+## 交付
+
+- 分 Phase commit,conventional commits,**不加任何 AI attribution**;每 Phase 完成即 push(early-push 硬要求)。
+- notes 檔記 non-obvious 決策(harness-overview 裁決依據、S5 涵蓋關係核對結果、負向驗證輸出)。
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [ ] Execute captured plan: Converge reference-configs projection and simplify low-risk tests

--- a/scripts/check-ci.sh
+++ b/scripts/check-ci.sh
@@ -55,6 +55,9 @@ bun run check:hooks
 echo "[ci] helper projection"
 bun run check:helpers
 
+echo "[ci] reference-configs projection"
+bun run check:reference-configs
+
 echo "[ci] tests"
 run_bun_tests
 

--- a/scripts/sync-reference-configs.ts
+++ b/scripts/sync-reference-configs.ts
@@ -1,0 +1,136 @@
+#!/usr/bin/env bun
+import { existsSync, lstatSync, readdirSync, readFileSync } from "fs";
+import { dirname, join, resolve } from "path";
+import { fileURLToPath } from "url";
+import {
+  digestProjectionFiles,
+  readProjectionFile,
+  sameProjectionBytes,
+  writeProjectionFileAtomic,
+  type ProjectionFileRecord,
+} from "../src/core/source-projection";
+
+type Mode = "check" | "write";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(SCRIPT_DIR, "..");
+const CANONICAL_ROOT = join(REPO_ROOT, "assets", "reference-configs");
+const TARGET_ROOT = join(REPO_ROOT, "docs", "reference-configs");
+
+function usage(): never {
+  process.stderr.write("Usage: bun scripts/sync-reference-configs.ts [--check|--write]\n");
+  process.exit(2);
+}
+
+function parseMode(argv: string[]): Mode {
+  let mode: Mode = "check";
+  for (const arg of argv) {
+    if (arg === "--check") {
+      mode = "check";
+      continue;
+    }
+    if (arg === "--write") {
+      mode = "write";
+      continue;
+    }
+    usage();
+  }
+  return mode;
+}
+
+/**
+ * Canonical inventory: every `.md` directly under assets/reference-configs.
+ * docs/reference-configs may hold additional docs-only files (install profiles,
+ * MCP guides, contract brief examples); those are outside the projection and
+ * are neither checked nor removed.
+ */
+export function referenceConfigInventory(root: string = CANONICAL_ROOT): string[] {
+  return readdirSync(root, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".md"))
+    .map((entry) => entry.name)
+    .sort();
+}
+
+function main(): void {
+  const mode = parseMode(process.argv.slice(2));
+  const inventory = referenceConfigInventory();
+  if (inventory.length === 0) {
+    process.stderr.write("[reference-configs] canonical source has no markdown files\n");
+    process.exit(1);
+  }
+
+  const sourceFiles: ProjectionFileRecord[] = inventory.map((name) =>
+    readProjectionFile(CANONICAL_ROOT, name),
+  );
+
+  const drift: string[] = [];
+  const blockedDrift: string[] = [];
+
+  for (const sourceFile of sourceFiles) {
+    const targetPath = join(TARGET_ROOT, sourceFile.relPath);
+    if (!existsSync(targetPath)) {
+      drift.push(`missing projected doc: docs/reference-configs/${sourceFile.relPath}`);
+      if (mode === "write") {
+        writeProjectionFileAtomic(REPO_ROOT, targetPath, sourceFile.bytes, "100644");
+      }
+      continue;
+    }
+
+    const targetStat = lstatSync(targetPath);
+    if (targetStat.isSymbolicLink()) {
+      const message = `target symlink is not allowed: docs/reference-configs/${sourceFile.relPath}`;
+      drift.push(message);
+      blockedDrift.push(message);
+      continue;
+    }
+    if (!targetStat.isFile()) {
+      const message = `target is not a file: docs/reference-configs/${sourceFile.relPath}`;
+      drift.push(message);
+      blockedDrift.push(message);
+      continue;
+    }
+
+    const targetBytes = readFileSync(targetPath);
+    if (!sameProjectionBytes(targetBytes, sourceFile.bytes)) {
+      drift.push(`content drift: docs/reference-configs/${sourceFile.relPath}`);
+      if (mode === "write") {
+        writeProjectionFileAtomic(REPO_ROOT, targetPath, sourceFile.bytes, "100644");
+      }
+    }
+  }
+
+  if (mode === "check" && drift.length > 0) {
+    for (const item of drift) process.stderr.write(`[reference-configs] ${item}\n`);
+    process.stderr.write(
+      "[reference-configs] Edit assets/reference-configs/<doc>.md, then run bun run sync:reference-configs.\n",
+    );
+    process.exit(1);
+  }
+
+  if (mode === "write" && blockedDrift.length > 0) {
+    for (const item of blockedDrift) process.stderr.write(`[reference-configs] ${item}\n`);
+    process.exit(1);
+  }
+
+  const digest = digestProjectionFiles(sourceFiles);
+  if (mode === "write") {
+    process.stdout.write(
+      `[reference-configs] projected ${sourceFiles.length} docs from assets/reference-configs to docs/reference-configs (${digest})\n`,
+    );
+    return;
+  }
+
+  process.stdout.write(
+    `[reference-configs] projection OK: ${sourceFiles.length} docs (${digest})\n`,
+  );
+}
+
+if (import.meta.main) {
+  try {
+    main();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`[reference-configs] ${message}\n`);
+    process.exit(1);
+  }
+}

--- a/tasks/contracts/20260730-2149-reference-configs-projection.contract.md
+++ b/tasks/contracts/20260730-2149-reference-configs-projection.contract.md
@@ -1,0 +1,158 @@
+# Task Contract: reference-configs-projection
+
+> **Status**: Active
+> **Plan**: plans/plan-20260730-2149-reference-configs-projection.md
+> **Task Profile**: code-change
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: ancienttwo
+> **Capability ID**: root
+> **Last Updated**: 2026-07-30 21:49
+> **Review File**: `tasks/reviews/20260730-2149-reference-configs-projection.review.md`
+> **Notes File**: `tasks/notes/20260730-2149-reference-configs-projection.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+The docs/reference-configs and assets/reference-configs mirror (23 pairs) has only 6 scattered equality guards; harness-overview.md has already shipped divergent (docs newer than assets, including retired "compatibility fallbacks" wording on the assets side). Separately, a test-suite audit proved the README prose-assertion layer is pure sync tax (20/20 commits in readme-dx.test.ts history are same-commit updates, zero interceptions). Without convergence, every vocabulary or config change keeps fanning out across unguarded projections.
+
+## Goal
+
+`assets/reference-configs/` is the declared source and `docs/reference-configs/` its byte-identical generated projection, enforced by a new `scripts/sync-reference-configs.ts` (--check/--write, modeled on sync-helper-sources.ts) wired into check-ci and one loop test; harness-overview.md is re-unified taking the docs-side content as truth; the 6 scattered equality assertions are replaced by that loop; and the audited LOW-risk test simplifications (S1-S5: README prose cuts, duplicate assertions, binary-scan skip, manifest-derived retired names, byte-parity dedup) land per the source plan.
+
+## Scope
+
+- In scope: new scripts/sync-reference-configs.ts + package.json script entries + check-ci wiring; harness-overview.md assets-side re-unification (content from docs side); new tests/reference-configs-projection.test.ts loop guard; deletion of 6 scattered mirror-equality assertions; prose-assertion cuts in tests/readme-dx.test.ts and tests/install-scripts.test.ts; mechanical dedup in tests/bootstrap-files.test.ts; binary skip + manifest-derived RETIRED_NAMES in tests/skill-surface/retired-names-scan.test.ts; redundant byte-parity deletions covered by the helper-scripts parity loop.
+- Out of scope: S6 (helper-scripts workspace refactor) and S7 (CI per-file isolation) — separate package; any README body or reference-configs content change beyond harness-overview re-unification; load-bearing locks (adoption-plan at-rest protocol, --help assertions, falsifier tests, allowlist anti-rot section); anything not listed in the source plan.
+- Taste constraints: <!-- advisory only, no run gate; default style/taste lives in AGENTS.md and the minimal-change policy, use this to record a per-task override -->
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+
+## Falsifier
+
+If any of the 23 mirror pairs legitimately needs to diverge (audience-split content, not drift), forcing byte-equality would destroy intentional differences and the projection premise is wrong. Cheapest proof point: after harness-overview re-unification, `bun run check:reference-configs` must pass on all 23 pairs with zero content edits beyond that one file — if other pairs fail the check, they are undiagnosed divergences that must be reported (stop), not silently overwritten.
+
+## Root Cause Evidence
+
+Required when Task Profile is `bugfix`; leave as-is otherwise.
+
+- root_cause: one sentence naming file:line/condition (testable, not "a state issue").
+- repro: the command or UI path that reproduces the symptom.
+- regression_guard: path to a test that fails on the unfixed code and passes after the fix (must also appear under exit_criteria.tests_pass).
+- pre_fix_failure_artifact: path to a captured run of regression_guard on the UNFIXED code. Capture with `bun test <regression_guard> > <artifact> 2>&1; echo "PRE_FIX_EXIT=$?" >> <artifact>` (no pipes — pipes swallow the exit status). The gate requires a non-zero `PRE_FIX_EXIT=` line plus the regression_guard path string in the artifact (see the Root Cause Evidence Gate section in docs/reference-configs/sprint-contracts.md).
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260730-2149-reference-configs-projection.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260730-2149-reference-configs-projection.review.md`
+- Notes file: `tasks/notes/20260730-2149-reference-configs-projection.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Acceptance Policy
+
+```json
+{"protocol":1,"reviewer":"Claude","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - docs/spec.md
+  - plans/
+  - tasks/todos.md
+  - tasks/current.md
+  - tasks/contracts/20260730-2149-reference-configs-projection.contract.md
+  - tasks/reviews/20260730-2149-reference-configs-projection.review.md
+  - tasks/notes/20260730-2149-reference-configs-projection.notes.md
+  - .ai/context/capabilities.json
+  - .claude/templates/
+  - src/
+  - tests/
+  - scripts/
+  - package.json
+  - assets/reference-configs/harness-overview.md
+  - docs/reference-configs/
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+      - codex-exec
+      - main-thread
+    fallback: main-thread
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - docs/spec.md
+    - scripts/sync-reference-configs.ts
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260730-2149-reference-configs-projection.notes.md
+  tests_pass:
+    - path: tests/reference-configs-projection.test.ts
+    - path: tests/readme-dx.test.ts
+    - path: tests/skill-surface/retired-names-scan.test.ts
+    - path: tests/bootstrap-files.test.ts
+  commands_succeed:
+    - bun run check:type
+    - bun test
+    - bun run check:reference-configs
+    - bun run check:helpers
+```
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior:
+- Edge cases:
+- Regression risks:
+
+## Rollback Point
+
+- Commit / checkpoint: stacked on `codex/cli-init-rename` tip (`a43c4abe` at branch creation); this package must merge only after cli-init-rename merges, rebasing onto its final tip first.
+- Revert strategy: drop the `codex/reference-configs-projection` branch/worktree before merge; after merge, revert the merge commit — the sync tool and loop test disappear together, restoring the scattered-guard state with no data migration to unwind.

--- a/tasks/notes/20260730-2149-reference-configs-projection.notes.md
+++ b/tasks/notes/20260730-2149-reference-configs-projection.notes.md
@@ -98,6 +98,15 @@ never deletion candidates.
 
 ## Deviations From Plan Or Spec
 
+- **Phase 2 initially deleted 5 of the 6 scattered equalities, not 6.** The
+  `external-tooling.md` mirror equality in `tests/readme-dx.test.ts` was missed: that file holds
+  two of the six (release-deploy.md and external-tooling.md, read in two different tests), and
+  only the release-deploy one was cut. Found by the acceptance gate, not by the test suite —
+  the residual assertion still passed, so nothing failed to signal it. Removed afterwards in a
+  follow-up commit; the loop test covers external-tooling.md like every other pair, so the
+  residual was pure redundancy. The docs-side content assertions on `externalTooling` in the
+  same test were left untouched.
+
 - **S3 dedup narrowed to genuine within-test duplicates.** The plan counted
   `cat > tasks/todos.md` / `tasks/lessons.md` / `not.toContain("docs/TODO.md")` as a group
   appearing twice, and `.ai/harness/policy.json` / `.ai/context/context-map.json` as appearing

--- a/tasks/notes/20260730-2149-reference-configs-projection.notes.md
+++ b/tasks/notes/20260730-2149-reference-configs-projection.notes.md
@@ -15,6 +15,18 @@ Branch is stacked on `codex/cli-init-rename`. At execution start `origin/codex/c
 was still at `a43c4abe`, identical to the merge-base, so no rebase was needed. Plan line numbers
 come from `main@095dcb06`; every edit site was located by content instead.
 
+### Worktree `base_commit` accounting correction (ship time)
+
+`.ai/harness/worktrees/reference-configs-projection.json` recorded `base_commit` as `095dcb06`,
+which was never this worktree's real fork point. `contract-worktree start` records the source
+`HEAD` at creation, but this worktree was then manually reset onto the `cli-init-rename` tip to
+stack on it, and the metadata did not follow. The true fork point is `a43c4abe`, so the field was
+corrected to that commit at ship time. Without the correction `verify-sprint` diffs against
+`095dcb06` and charges all of `cli-init-rename`'s files to this contract's `allowed_paths` scope.
+The file is gitignored (`.gitignore:56`), so this is a local-only fix recorded here rather than a
+committed change. The general gap — `verify-sprint` silently trusting a `base_commit` that is no
+longer an ancestor of `HEAD` — is already logged as a deferred row in `tasks/todos.md`.
+
 ### harness-overview.md re-unification (plan decision 2)
 
 Divergence confirmed before the copy: docs side 224 lines, assets side 194. The decisive evidence

--- a/tasks/notes/20260730-2149-reference-configs-projection.notes.md
+++ b/tasks/notes/20260730-2149-reference-configs-projection.notes.md
@@ -68,9 +68,73 @@ $ bun test tests/reference-configs-projection.test.ts
 After restoring the file both went green and the projection digest returned to the pre-probe
 value `sha256:8953d34d...c714d1`, confirming the probe left no residue.
 
+### S5 byte-parity coverage check
+
+Every candidate was checked against the parity loop in `tests/helper-scripts.test.ts` before
+deletion. That loop walks all of `assets/templates/helpers/`, cross-checks the file list against
+`assets/workflow-contract.v1.json` `helpers.scripts`, skips `INTENTIONALLY_DIVERGENT`
+(`["capability-resolver.ts"]`), and asserts both content and exec-bit equality against
+`scripts/<name>` — the same pair and direction as each local assertion.
+
+| Candidate | In helpers inventory | Divergent-exempt | Verdict |
+|---|---|---|---|
+| `verify-sprint.sh` (evidence-residue-scan) | yes | no | deleted, covered |
+| `verify-sprint.sh` (evidence-checks-materializer) | yes | no | deleted, covered |
+| `recovery-view-cli.ts` (evidence-recovery-materializer) | yes | no | deleted, covered |
+| `sprint-backlog.sh` (sprint-backlog) | yes | no | deleted, covered |
+| `check-task-workflow.sh` (sprint-backlog) | yes | no | deleted, covered |
+| `refresh-current-status.sh` (sprint-backlog) | yes | no | deleted, covered |
+| `assets/hooks/lib/workflow-state.sh` | **no** | n/a | kept |
+| `.claude/templates/sprint.template.md` / `prd.template.md` | **no** | n/a | kept |
+
+`workflow-state.sh` is a hook asset under a different projection (`check:hooks` /
+`sync-hook-sources.ts`), not a contract helper, so the parity loop never sees it. The two
+`.claude/templates/` copies have no `assets/templates/helpers/` mirror at all, so the
+sprint-backlog assertion is their only guard and stays. Neither was deleted.
+
+Note the surviving `workflow-state.sh` assertions in evidence-residue-scan and
+evidence-checks-materializer are `not.toMatch` content checks, not byte-parity, so they were
+never deletion candidates.
+
 ## Deviations From Plan Or Spec
 
-- None recorded.
+- **S3 dedup narrowed to genuine within-test duplicates.** The plan counted
+  `cat > tasks/todos.md` / `tasks/lessons.md` / `not.toContain("docs/TODO.md")` as a group
+  appearing twice, and `.ai/harness/policy.json` / `.ai/context/context-map.json` as appearing
+  twice, with "keep one per group". Those pairs are split across two different tests reading two
+  different files — `scripts/create-project-dirs.sh` (274 lines) and `scripts/init-project.sh`
+  (499 lines) — which were verified to be independent scripts, each containing the string once,
+  with no sourcing relationship. Deleting either copy would drop coverage of one scaffolding
+  entrypoint rather than remove duplication, so both were kept. Only assertions repeated on the
+  *same* variable within the *same* test were deleted: `operations.deploy_sql` on `agents` (×2),
+  `create_contract_directories` (×2 in each of the two tests), and `pi_install_reference_configs`
+  (×2 within the init-project test). The `pi_install_reference_configs` copy in the
+  create-project-dirs test is a different file and was kept.
+
+- **`not.toContain("bun scripts/assemble-template.ts")` kept in the First 5 Minutes group.**
+  The plan groups the `not.toContain` reverse traps for deletion. This one is the negative half
+  of a placement invariant whose positive half (`maintainer` contains the same command) is
+  asserted three lines later, so deleting it alone would leave the positive assertion unable to
+  distinguish "documented in Maintainer Reference" from "documented anywhere". The retired-command
+  traps (`npm install -g`, `npx -y ... init`, `npx -y ... setup`, `install --dry-run`) had no such
+  pairing and were deleted.
+
+- **`not.toContain("npm install -g repo-harness")` relocated, not dropped.** Deleting the
+  First 5 Minutes copy would have removed the last README-level npm lock, so the whole-README
+  copy in `tests/install-scripts.test.ts` was kept instead of being cut as a duplicate.
+
+- **`toBe(19)` replaced rather than plainly deleted.** With `RETIRED_NAMES` derived from
+  `manifest.retiredPackages[]`, an emptied array would make the scan pass vacuously with no test
+  noticing. The hardcoded count is gone as the plan requires; a
+  `expect(RETIRED_NAMES.length).toBeGreaterThan(0)` sanity check took its place, mirroring the
+  existing `files.length > 100` non-vacuity guard on the file side.
+
+- **S4 binary skip implemented as a NUL-byte probe, not an extension allowlist.** The plan
+  allowed either. The probe is content-based, so it needs no maintenance list and cannot silently
+  skip a new text extension. Worth recording: the pre-existing `try/catch` around
+  `readFileSync(_, "utf-8")` never fired — that call does not throw on binary input, it produces
+  replacement characters, so every checked-in PNG was being fully decoded on each run. Measured
+  8.34s / 8.26s before, 3.32s / 3.16s after.
 
 ## Tradeoffs Considered
 

--- a/tasks/notes/20260730-2149-reference-configs-projection.notes.md
+++ b/tasks/notes/20260730-2149-reference-configs-projection.notes.md
@@ -23,9 +23,17 @@ which was never this worktree's real fork point. `contract-worktree start` recor
 stack on it, and the metadata did not follow. The true fork point is `a43c4abe`, so the field was
 corrected to that commit at ship time. Without the correction `verify-sprint` diffs against
 `095dcb06` and charges all of `cli-init-rename`'s files to this contract's `allowed_paths` scope.
-The file is gitignored (`.gitignore:56`), so this is a local-only fix recorded here rather than a
-committed change. The general gap — `verify-sprint` silently trusting a `base_commit` that is no
-longer an ancestor of `HEAD` — is already logged as a deferred row in `tasks/todos.md`.
+
+The parent package then merged into `main` as a squash commit, which rewrote its history and left
+this stacked branch with no common ancestor to three-way merge from; comparing it to `main`
+un-rebased reported three phantom conflicts that were an artifact of that missing ancestry, not
+real overlaps. Replaying this branch's own commits with
+`git rebase --onto origin/main a43c4abe` resolved them with zero conflicts, and `base_commit` was
+corrected a second time to the post-rebase fork point `8b506da4`.
+
+The metadata file is gitignored (`.gitignore:56`), so both corrections are local-only and recorded
+here rather than committed. The general gap — `verify-sprint` silently trusting a `base_commit`
+that is no longer an ancestor of `HEAD` — is already logged as a deferred row in `tasks/todos.md`.
 
 ### harness-overview.md re-unification (plan decision 2)
 

--- a/tasks/notes/20260730-2149-reference-configs-projection.notes.md
+++ b/tasks/notes/20260730-2149-reference-configs-projection.notes.md
@@ -1,0 +1,41 @@
+# Implementation Notes: reference-configs-projection
+
+> **Status**: Active
+> **Plan**: plans/plan-20260730-2149-reference-configs-projection.md
+> **Contract**: tasks/contracts/20260730-2149-reference-configs-projection.contract.md
+> **Review**: tasks/reviews/20260730-2149-reference-configs-projection.review.md
+> **Last Updated**: 2026-07-30 21:49
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- ...
+
+## Deviations From Plan Or Spec
+
+- None recorded.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| ... | ... | ... |
+
+## Open Questions
+
+- None.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/notes/20260730-2149-reference-configs-projection.notes.md
+++ b/tasks/notes/20260730-2149-reference-configs-projection.notes.md
@@ -9,7 +9,64 @@
 
 ## Design Decisions
 
-- ...
+### Stacked base
+
+Branch is stacked on `codex/cli-init-rename`. At execution start `origin/codex/cli-init-rename`
+was still at `a43c4abe`, identical to the merge-base, so no rebase was needed. Plan line numbers
+come from `main@095dcb06`; every edit site was located by content instead.
+
+### harness-overview.md re-unification (plan decision 2)
+
+Divergence confirmed before the copy: docs side 224 lines, assets side 194. The decisive evidence
+for calling this time drift rather than an intentional audience split was
+`assets/reference-configs/harness-overview.md:173`, which still described
+`agent-context-blocks.txt` / `REPO_HARNESS_CONTEXT_BLOCKS` / nested context files as "migration
+inputs or compatibility fallbacks only" — wording the repo's own no-fallback rule has since
+retired and the docs side had already dropped. An intentional split would not regress a retired
+term on the shipped side. Content therefore came from docs, address moved to assets.
+
+H1 and lead paragraph are identical on both sides, so `repo-harness docs show harness-overview`
+(resolves the assets path, title asserted in `tests/cli/docs.test.ts`) is unaffected.
+
+### Falsifier result
+
+The contract's falsifier asks whether any of the 23 pairs legitimately needs to diverge. Before
+any edit, a full `cmp` sweep over all 23 reported exactly one difference (`harness-overview.md`).
+After the single re-unification copy, `bun run check:reference-configs` passed on all 23 with
+zero further content edits. No undiagnosed divergence exists, so the projection premise holds.
+
+### Projection direction and docs-only files
+
+`assets/reference-configs/` is the source, `docs/reference-configs/` the generated projection.
+The projection is one-directional: docs additionally holds 7 docs-only files (chatgpt-coding-mcp,
+contract-brief-example, contract-brief-example-bugfix, general-repo-mcp, install-profiles,
+loop-engine-cutover-gate, loop-engine-nl-decision-table) that never ship in assets. The tool
+ignores them and must never delete them; the loop test asserts this docs-only set stays non-empty
+and disjoint from the source inventory, so a future "clean up extras" change to the tool fails a
+test instead of silently deleting docs.
+
+`tests/reference-configs-projection.test.ts` reads the filesystem directly rather than importing
+`scripts/sync-reference-configs.ts`. Importing the tool would make the test restate the tool's own
+logic; reading the tree keeps it an independent second guard, which matters because `bun test` is
+the first required check while the tool only runs under check-ci.
+
+### Negative verification (fail-closed proof)
+
+Appended a `<!-- drift probe -->` comment to `docs/reference-configs/git-strategy.md`, uncommitted:
+
+```
+$ bun run check:reference-configs
+[reference-configs] content drift: docs/reference-configs/git-strategy.md
+[reference-configs] Edit assets/reference-configs/<doc>.md, then run bun run sync:reference-configs.
+CHECK_EXIT=1
+
+$ bun test tests/reference-configs-projection.test.ts
+(fail) reference-configs projection > every assets/reference-configs doc has a byte-identical ...
+ 1 pass  1 fail
+```
+
+After restoring the file both went green and the projection digest returned to the pre-probe
+value `sha256:8953d34d...c714d1`, confirming the probe left no residue.
 
 ## Deviations From Plan Or Spec
 
@@ -19,7 +76,8 @@
 
 | Option | Decision | Reason |
 |--------|----------|--------|
-| ... | ... | ... |
+| Loop test imports the sync tool's inventory helper | Rejected | Would restate the tool's logic instead of guarding it independently |
+| Sync tool deletes unknown files in docs/reference-configs | Rejected | Would destroy the 7 legitimate docs-only files; projection stays one-directional |
 
 ## Open Questions
 

--- a/tasks/notes/20260730-2149-reference-configs-projection.notes.md
+++ b/tasks/notes/20260730-2149-reference-configs-projection.notes.md
@@ -31,6 +31,12 @@ real overlaps. Replaying this branch's own commits with
 `git rebase --onto origin/main a43c4abe` resolved them with zero conflicts, and `base_commit` was
 corrected a second time to the post-rebase fork point `8b506da4`.
 
+A third replay followed once the sibling `receipt-fingerprint-normalization` package landed as
+`3c991466`: this branch's original AcceptanceReceipt was recorded under the old key-order-sensitive
+fingerprint and was already unverifiable, so it had to be re-recorded under the fixed algorithm
+anyway. `git rebase origin/main` replayed all 8 commits with zero conflicts, and `base_commit` was
+corrected to `3c991466`.
+
 The metadata file is gitignored (`.gitignore:56`), so both corrections are local-only and recorded
 here rather than committed. The general gap — `verify-sprint` silently trusting a `base_commit`
 that is no longer an ancestor of `HEAD` — is already logged as a deferred row in `tasks/todos.md`.

--- a/tasks/reviews/20260730-2149-reference-configs-projection.review.md
+++ b/tasks/reviews/20260730-2149-reference-configs-projection.review.md
@@ -1,0 +1,84 @@
+# Task Review: reference-configs-projection
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260730-2149-reference-configs-projection.md
+> **Contract**: tasks/contracts/20260730-2149-reference-configs-projection.contract.md
+> **Notes File**: tasks/notes/20260730-2149-reference-configs-projection.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-07-30 21:49
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Commands passed:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+- Waza `/check` run:
+- Commands run:
+- Manual checks:
+- Supporting artifacts:
+- Implementation notes reviewed:
+- Run snapshot:
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...

--- a/tasks/reviews/20260730-2149-reference-configs-projection.review.md
+++ b/tasks/reviews/20260730-2149-reference-configs-projection.review.md
@@ -44,13 +44,13 @@
 > **Reviewer**: Claude
 > **Source**: claude-review
 > **Actor**: not-applicable
-> **Reviewed Subject SHA256**: sha256:afd10285a2799abf481c590c11d0c95671e2c4ad8ac3ee0b27b098b8df514369
+> **Reviewed Subject SHA256**: sha256:36dccfdb7f122ef2e897c312a93a04edb316b65272c07769829e7943fe3ff408
 > **Reviewed Subject Scope**: normalized-final-content
 > **Reviewed Target Revision**: 8b506da48fac02cb1a9e7134037cabd506636212
-> **Verification Evidence SHA256**: sha256:b17d614ce0b4668c78ba9cc39ef6e782fe94b947ab84e4729b6ac0fe67e09c9f
-> **Issued At**: 2026-07-30T21:22:07.045Z
+> **Verification Evidence SHA256**: sha256:0aeb8daa00caa1541154ab77ec939fb06fe3f29db33e570b400b7085be9a8ab3
+> **Issued At**: 2026-07-30T21:58:02.312Z
 
-- Summary: gatekeeper PASS after one repair round. assets/reference-configs/ is now the declared source and docs/reference-configs/ its byte-identical generated projection, enforced by scripts/sync-reference-configs.ts (--check/--write, modeled on sync-helper-sources.ts) wired into check-ci; the six scattered mirror-equality assertions are replaced by a single loop that covers all 23 projected pairs green, and negative verification confirmed the loop fails closed on an induced drift rather than silently passing. harness-overview.md was re-unified taking the docs side as truth, justified by the assets side still carrying retired compatibility-fallback wording. The audited LOW-risk test simplifications S1-S5 landed as specified. This run recorded 14/14 exit criteria green with allowed_paths clean at 19 files against the corrected fork point a43c4abe, plus full suite 2097 pass 0 fail and check:reference-configs green.
+- Summary: gatekeeper PASS after one repair round. assets/reference-configs/ is now the declared source and docs/reference-configs/ its byte-identical generated projection, enforced by scripts/sync-reference-configs.ts (--check/--write, modeled on sync-helper-sources.ts) wired into check-ci; the six scattered mirror-equality assertions are replaced by a single loop covering all 23 projected pairs green, and negative verification confirmed the loop fails closed on induced drift rather than silently passing. harness-overview.md was re-unified taking the docs side as truth, justified by the assets side still carrying retired compatibility-fallback wording. The audited LOW-risk test simplifications S1-S5 landed as specified. Verified after replaying this branch onto the squash-merged parent: 14/14 exit criteria green, allowed_paths clean at 19 files against fork point 8b506da4, full suite 2099 pass 0 fail, and check:reference-configs green.
 - Findings: none
 
 ## Behavior Diff Notes

--- a/tasks/reviews/20260730-2149-reference-configs-projection.review.md
+++ b/tasks/reviews/20260730-2149-reference-configs-projection.review.md
@@ -46,11 +46,11 @@
 > **Actor**: not-applicable
 > **Reviewed Subject SHA256**: sha256:36dccfdb7f122ef2e897c312a93a04edb316b65272c07769829e7943fe3ff408
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: 8b506da48fac02cb1a9e7134037cabd506636212
-> **Verification Evidence SHA256**: sha256:0aeb8daa00caa1541154ab77ec939fb06fe3f29db33e570b400b7085be9a8ab3
-> **Issued At**: 2026-07-30T21:58:02.312Z
+> **Reviewed Target Revision**: 3c991466b6bdddbcd606f2888d33f2660eb7df64
+> **Verification Evidence SHA256**: sha256:572cf40cdbeaf333f16de2ef086c2717d96ef28e5674f6c4db16b2557e876308
+> **Issued At**: 2026-07-31T01:22:09.163Z
 
-- Summary: gatekeeper PASS after one repair round. assets/reference-configs/ is now the declared source and docs/reference-configs/ its byte-identical generated projection, enforced by scripts/sync-reference-configs.ts (--check/--write, modeled on sync-helper-sources.ts) wired into check-ci; the six scattered mirror-equality assertions are replaced by a single loop covering all 23 projected pairs green, and negative verification confirmed the loop fails closed on induced drift rather than silently passing. harness-overview.md was re-unified taking the docs side as truth, justified by the assets side still carrying retired compatibility-fallback wording. The audited LOW-risk test simplifications S1-S5 landed as specified. Verified after replaying this branch onto the squash-merged parent: 14/14 exit criteria green, allowed_paths clean at 19 files against fork point 8b506da4, full suite 2099 pass 0 fail, and check:reference-configs green.
+- Summary: gatekeeper PASS after one repair round. assets/reference-configs/ is now the declared source and docs/reference-configs/ its byte-identical generated projection, enforced by scripts/sync-reference-configs.ts (--check/--write, modeled on sync-helper-sources.ts) wired into check-ci; the six scattered mirror-equality assertions are replaced by a single loop covering all 23 projected pairs green, and negative verification confirmed the loop fails closed on induced drift rather than silently passing. harness-overview.md was re-unified taking the docs side as truth, justified by the assets side still carrying retired compatibility-fallback wording. The audited LOW-risk test simplifications S1-S5 landed as specified. Verified after replaying onto the merged fingerprint fix 3c991466: 14/14 exit criteria green, allowed_paths clean at 19 files, full suite green, and check:reference-configs green. This receipt was re-recorded under the fixed key-order-invariant fingerprint; the original was unverifiable under the old algorithm.
 - Findings: none
 
 ## Behavior Diff Notes

--- a/tasks/reviews/20260730-2149-reference-configs-projection.review.md
+++ b/tasks/reviews/20260730-2149-reference-configs-projection.review.md
@@ -40,17 +40,17 @@
 
 ## Acceptance Receipt Projection
 
-> **Disposition**: unavailable
-> **Reviewer**: unavailable
-> **Source**: unavailable
+> **Disposition**: external_pass
+> **Reviewer**: Claude
+> **Source**: claude-review
 > **Actor**: not-applicable
-> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject SHA256**: sha256:afd10285a2799abf481c590c11d0c95671e2c4ad8ac3ee0b27b098b8df514369
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: pending
-> **Verification Evidence SHA256**: pending
-> **Issued At**: pending
+> **Reviewed Target Revision**: 8b506da48fac02cb1a9e7134037cabd506636212
+> **Verification Evidence SHA256**: sha256:b17d614ce0b4668c78ba9cc39ef6e782fe94b947ab84e4729b6ac0fe67e09c9f
+> **Issued At**: 2026-07-30T21:22:07.045Z
 
-- Summary: No AcceptanceReceipt has been recorded.
+- Summary: gatekeeper PASS after one repair round. assets/reference-configs/ is now the declared source and docs/reference-configs/ its byte-identical generated projection, enforced by scripts/sync-reference-configs.ts (--check/--write, modeled on sync-helper-sources.ts) wired into check-ci; the six scattered mirror-equality assertions are replaced by a single loop that covers all 23 projected pairs green, and negative verification confirmed the loop fails closed on an induced drift rather than silently passing. harness-overview.md was re-unified taking the docs side as truth, justified by the assets side still carrying retired compatibility-fallback wording. The audited LOW-risk test simplifications S1-S5 landed as specified. This run recorded 14/14 exit criteria green with allowed_paths clean at 19 files against the corrected fork point a43c4abe, plus full suite 2097 pass 0 fail and check:reference-configs green.
 - Findings: none
 
 ## Behavior Diff Notes

--- a/tests/bootstrap-files.test.ts
+++ b/tests/bootstrap-files.test.ts
@@ -45,6 +45,10 @@ describe("Bootstrap Script Contracts", () => {
   test("root SKILL stays a compact five-action router", () => {
     const skill = read("SKILL.md");
     const body = skill.replace(/^---\n[\s\S]*?\n---\n/u, "");
+    // The root SKILL.md is the router: every host loads it into context on every
+    // session, before any action is chosen. The 2048-byte ceiling is a standing
+    // budget on that always-resident cost, not an arbitrary style limit — content
+    // that grows past it belongs in a reference file the router points at.
     expect(Buffer.byteLength(body, "utf-8")).toBeLessThanOrEqual(2048);
     expect(skill.split("\n").length).toBeLessThanOrEqual(80);
   });
@@ -151,7 +155,6 @@ describe("Bootstrap Script Contracts", () => {
     expect(agents).toContain("tasks/todos.md");
     expect(agents).toContain("repo-harness run check-task-workflow --strict");
     expect(agents).toContain("check-agent-tooling.sh --host both --check-updates");
-    expect(agents).toContain("operations.deploy_sql");
     expect(agents).toContain("operations.deploy_sql");
   });
 
@@ -358,7 +361,6 @@ describe("Bootstrap Script Contracts", () => {
     expect(sharedLib).not.toContain(".memory-context.json");
     expect(sharedLib).not.toContain(".memory-snapshot.json");
     expect(content).not.toContain("install_skill_factory_files");
-    expect(content).toContain("create_contract_directories");
     expect(contract.artifacts.requiredDirectories).toContain("tasks/contracts");
     expect(contract.artifacts.requiredDirectories).toContain("tasks/reviews");
     expect(contract.artifacts.requiredDirectories).toContain("tasks/notes");
@@ -450,7 +452,6 @@ describe("Bootstrap Script Contracts", () => {
     expect(sharedLib).not.toContain(".skill-factory-state.json");
     expect(sharedLib).not.toContain(".memory-context.json");
     expect(sharedLib).not.toContain(".memory-snapshot.json");
-    expect(content).toContain("create_contract_directories");
     expect(contract.artifacts.requiredDirectories).toContain("tasks/contracts");
     expect(contract.artifacts.requiredDirectories).toContain("tasks/reviews");
     expect(contract.artifacts.requiredDirectories).toContain("tasks/notes");
@@ -460,7 +461,6 @@ describe("Bootstrap Script Contracts", () => {
     expect(content).toContain("install_hook_settings_template");
     expect(content).not.toContain("\"$TOOL_INPUT\"");
     expect(content).not.toContain("\"$PROMPT\"");
-    expect(content).toContain("pi_install_reference_configs");
     expect(content).not.toContain("cp \"$ASSETS_REF_DIR\"/*.md docs/reference-configs/");
     expect(content).toContain("pi_print_external_tooling_report");
   });

--- a/tests/evidence-checks-materializer.test.ts
+++ b/tests/evidence-checks-materializer.test.ts
@@ -743,9 +743,9 @@ describe("checks-materializer: no-independent-authoring", () => {
 
     const workflowState = readFileSync(join(REPO_ROOT, ".ai/hooks/lib/workflow-state.sh"), "utf-8");
     expect(workflowState).not.toMatch(/printf "\{\}\\n" > "\$\(workflow_checks_file\)"/);
-
-    const mirror = readFileSync(join(REPO_ROOT, "assets/templates/helpers/verify-sprint.sh"), "utf-8");
-    expect(mirror).toBe(verifySprint);
+    // verify-sprint.sh's packaged mirror is covered by the helper parity loop in
+    // tests/helper-scripts.test.ts (whole contract helper inventory, content plus
+    // exec bit), so the local byte-equality restatement is gone.
   });
 
   // Residual finding 2b (orchestrator ruling): mutation-observed.ts's own

--- a/tests/evidence-recovery-materializer.test.ts
+++ b/tests/evidence-recovery-materializer.test.ts
@@ -315,11 +315,9 @@ describe("no-independent-authoring: the retired writers carry zero content assem
     }
   });
 
-  test("scripts/recovery-view-cli.ts and its packaged mirror stay byte-identical", () => {
-    const canonical = readFileSync(join(REPO_ROOT, "scripts/recovery-view-cli.ts"), "utf-8");
-    const mirrored = readFileSync(join(REPO_ROOT, "assets/templates/helpers/recovery-view-cli.ts"), "utf-8");
-    expect(mirrored).toBe(canonical);
-  });
+  // recovery-view-cli.ts is in the contract helper inventory and outside
+  // INTENTIONALLY_DIVERGENT, so the helper parity loop in
+  // tests/helper-scripts.test.ts already asserts its byte-identical mirror.
 
   test("workflow_ensure_harness_surface no longer bootstraps handoff/resume placeholder content", () => {
     const text = readFileSync(join(REPO_ROOT, "assets/hooks/lib/workflow-state.sh"), "utf-8");

--- a/tests/evidence-residue-scan.test.ts
+++ b/tests/evidence-residue-scan.test.ts
@@ -126,8 +126,9 @@ describe("residue scan: direct re-assertion of each named retired surface", () =
     const text = readFileSync(join(REPO_ROOT, "scripts/verify-sprint.sh"), "utf-8");
     expect(text).not.toMatch(/cp\s+"\$checks_report"\s+"\$checks_file"/);
     expect(text).not.toMatch(/cp\s+"\$finalized_checks"\s+"\$checks_file"/);
-    const mirror = readFileSync(join(REPO_ROOT, "assets/templates/helpers/verify-sprint.sh"), "utf-8");
-    expect(mirror).toBe(text);
+    // The packaged assets/templates/helpers/verify-sprint.sh mirror is covered by
+    // the helper parity loop in tests/helper-scripts.test.ts, which walks the whole
+    // contract helper inventory; re-asserting it here only duplicated that loop.
   });
 
   test("workflow-state.sh no longer bootstraps checks/latest.json with {} (EPC-05)", () => {

--- a/tests/global-working-rules-distribution.test.ts
+++ b/tests/global-working-rules-distribution.test.ts
@@ -6,7 +6,6 @@ import { renderMinimalChangeSessionContext } from "../src/cli/hook/minimal-chang
 
 const ROOT = join(import.meta.dir, "..");
 const ASSETS_TEMPLATE = join(ROOT, "assets/reference-configs/global-working-rules.md");
-const DOCS_MIRROR = join(ROOT, "docs/reference-configs/global-working-rules.md");
 const PROJECT_INIT_LIB = join(ROOT, "scripts/lib/project-init-lib.sh");
 
 function countOccurrences(haystack: string, needle: string): number {
@@ -65,10 +64,6 @@ describe("global working rules distribution", () => {
         "It must be one concrete, bounded next slice derived from verified state: active plan, todo, handoff, failing checks, review gaps, deployment state, unresolved risk, or observed system behavior.",
       ),
     ).toBe(1);
-  });
-
-  test("docs/reference-configs mirror is byte-identical to the assets source", () => {
-    expect(readFileSync(DOCS_MIRROR, "utf-8")).toBe(readFileSync(ASSETS_TEMPLATE, "utf-8"));
   });
 
   test("renderMinimalChangeSessionContext carries the no-fallback rule within budget", () => {

--- a/tests/install-scripts.test.ts
+++ b/tests/install-scripts.test.ts
@@ -43,7 +43,10 @@ describe("install script contracts", () => {
     expect(script).not.toMatch(/\bnode\b/i);
   });
 
-  test("README front-loads the no-Node installer and Bun package-manager fallback", () => {
+  // Scope: the shell-installer surface only. The bunx / bun add -g / npx command
+  // pins live in tests/readme-dx.test.ts against the First 5 Minutes section;
+  // repeating them here at whole-README scope added no coverage.
+  test("README documents the no-Node installer and its Bun version floor", () => {
     const readme = read("README.md");
     const zhReadme = read("README.zh-CN.md");
     const pkg = JSON.parse(read("package.json"));
@@ -51,10 +54,6 @@ describe("install script contracts", () => {
     expect(readme).toContain("curl -fsSL https://raw.githubusercontent.com/Ancienttwo/repo-harness/main/install.sh | sh");
     expect(readme).toContain("irm https://raw.githubusercontent.com/Ancienttwo/repo-harness/main/install.ps1 | iex");
     expect(readme).toContain("If Bun >= 1.1.35 is already on PATH, you can skip the shell installer.");
-    expect(readme).toContain("Bun >= 1.1.35");
-    expect(readme).toContain("bunx repo-harness@latest install");
-    expect(readme).toContain("bun add -g repo-harness");
-    expect(readme).toContain("npx -y repo-harness@latest install");
     expect(readme).not.toContain("npm install -g repo-harness");
     expect(zhReadme).toContain("curl -fsSL https://raw.githubusercontent.com/Ancienttwo/repo-harness/main/install.sh | sh");
     expect(zhReadme).toContain("irm https://raw.githubusercontent.com/Ancienttwo/repo-harness/main/install.ps1 | iex");

--- a/tests/readme-dx.test.ts
+++ b/tests/readme-dx.test.ts
@@ -143,7 +143,6 @@ describe("README DX contract", () => {
     const spec = read("docs/spec.md");
     const flow = read("docs/reference-configs/agentic-development-flow.md");
     const externalTooling = read("docs/reference-configs/external-tooling.md");
-    const externalToolingAsset = read("assets/reference-configs/external-tooling.md");
 
     expect(spec).toContain("## Product Outcome");
     expect(spec).toContain("## Core Invariants");
@@ -163,7 +162,6 @@ describe("README DX contract", () => {
     expect(zhReadme).toContain("external verification manifest");
     expect(zhReadme).toContain("手动约定");
     expect(zhReadme).toContain("`repo-harness check` 已经会自动发现或 gate");
-    expect(externalToolingAsset).toBe(externalTooling);
     expect(externalTooling).toContain("## External Verification Evidence");
     expect(externalTooling).toContain("convention only");
     expect(externalTooling).toContain("does not automatically discover");

--- a/tests/readme-dx.test.ts
+++ b/tests/readme-dx.test.ts
@@ -54,32 +54,19 @@ describe("README DX contract", () => {
 
     expect(readme.indexOf("## First 5 Minutes")).toBeLessThan(readme.indexOf("## MCP Connector Quickstart"));
     expect(firstFive).toContain("docs/images/repo-harness-install-donkey-carrot.png");
-    expect(firstFive).toContain("No Node.js required for the default path");
-    expect(firstFive).toContain("# Bun one-shot bootstrap");
+    // Only the commands a first-run user copies are pinned here. Surrounding prose,
+    // code-comment text, occurrence counts, and CLI stdout literals quoted back
+    // through the README are not: they never caught a regression, they only forced
+    // a same-commit test edit whenever the README was reworded.
     expect(firstFive).toContain("bunx repo-harness@latest install");
-    expect(firstFive).toContain("# Or install the persistent CLI first");
     expect(firstFive).toContain("bun add -g repo-harness");
-    expect(firstFive).toContain("npx fallback");
     expect(firstFive).toContain("npx -y repo-harness@latest install");
     expect(firstFive).toContain("repo-harness install");
     expect(firstFive).toContain("repo-harness init --dry-run");
-    expect(firstFive).toContain("repo-harness init");
-    expect(firstFive).toContain("first-run global bootstrap path");
-    expect(firstFive.match(/repo-harness init --dry-run/g)?.length).toBe(1);
-    expect(firstFive).not.toContain("npm install -g repo-harness");
-    expect(firstFive).not.toContain("npx -y repo-harness init");
-    expect(firstFive).not.toContain("npx -y repo-harness setup");
-    expect(firstFive).not.toContain("npx -y repo-harness init");
-    expect(firstFive).not.toContain("repo-harness install --dry-run");
-    // Pre-rename this asserted the doc omits the (removed) duplicate global
-    // `init` bootstrap's dry-run form; post-rename `init --dry-run` IS the
-    // canonical repo-local command shown above, so the polarity flips to positive.
-    expect(firstFive).toContain("repo-harness init --dry-run");
+    // Kept as the negative half of a placement invariant: the template assembly
+    // command belongs in Maintainer Reference (asserted below), not in the
+    // first-run path.
     expect(firstFive).not.toContain("bun scripts/assemble-template.ts");
-    expect(firstFive).toContain("=== Migration Report ===");
-    expect(firstFive).toContain("Project hooks synced from:");
-    expect(firstFive).toContain("Host hook config target:");
-    expect(firstFive).toContain("Host hook adapters are user-level:");
     expect(hookAuthority).toContain("assets/hooks/");
     expect(hookAuthority).toContain("bun run sync:hooks");
     expect(hookAuthority).toContain("repo-harness-hook");

--- a/tests/readme-dx.test.ts
+++ b/tests/readme-dx.test.ts
@@ -120,10 +120,8 @@ describe("README DX contract", () => {
     const readme = read("README.md");
     const verification = section(readme, "Verification");
     const releaseDoc = read("docs/reference-configs/release-deploy.md");
-    const releaseAsset = read("assets/reference-configs/release-deploy.md");
     const evalArchitecture = read("docs/architecture/modules/verification/evals-checks.md");
 
-    expect(releaseAsset).toBe(releaseDoc);
     expect(releaseDoc).toContain("full_test_count");
     expect(releaseDoc).toContain("dry_run_ratio");
     expect(releaseDoc).toContain("grader_pass_rate");

--- a/tests/reference-configs-projection.test.ts
+++ b/tests/reference-configs-projection.test.ts
@@ -1,0 +1,54 @@
+import { describe, test, expect } from "bun:test";
+import { existsSync, readdirSync, readFileSync } from "fs";
+import { join } from "path";
+
+const ROOT = join(import.meta.dir, "..");
+const SOURCE_DIR = join(ROOT, "assets/reference-configs");
+const PROJECTION_DIR = join(ROOT, "docs/reference-configs");
+
+function markdownFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".md"))
+    .map((entry) => entry.name)
+    .sort();
+}
+
+describe("reference-configs projection", () => {
+  // This loop replaces the scattered per-file equality assertions that used to live in
+  // readme-dx / ux-feature-guardrail / global-working-rules-distribution / sprint-backlog.
+  // It reads the filesystem directly rather than importing scripts/sync-reference-configs.ts,
+  // so it stays an independent guard instead of restating the tool's own logic.
+  test("every assets/reference-configs doc has a byte-identical docs/reference-configs projection", () => {
+    const sources = markdownFiles(SOURCE_DIR);
+    expect(sources.length).toBeGreaterThan(0);
+
+    const drift: string[] = [];
+    for (const name of sources) {
+      const projectionPath = join(PROJECTION_DIR, name);
+      if (!existsSync(projectionPath)) {
+        drift.push(`missing projection: docs/reference-configs/${name}`);
+        continue;
+      }
+      if (!readFileSync(projectionPath).equals(readFileSync(join(SOURCE_DIR, name)))) {
+        drift.push(`content drift: docs/reference-configs/${name}`);
+      }
+    }
+
+    expect(
+      drift,
+      "assets/reference-configs is the source; run bun run sync:reference-configs after editing it",
+    ).toEqual([]);
+  });
+
+  // docs/reference-configs additionally carries docs-only material (install profiles, MCP
+  // guides, contract brief examples) that never ships in assets. Those are outside the
+  // mirror by design, so the projection is one-directional and must not delete them.
+  test("docs-only reference configs stay outside the mirror", () => {
+    const sources = new Set(markdownFiles(SOURCE_DIR));
+    const docsOnly = markdownFiles(PROJECTION_DIR).filter((name) => !sources.has(name));
+    expect(docsOnly.length).toBeGreaterThan(0);
+    for (const name of docsOnly) {
+      expect(existsSync(join(SOURCE_DIR, name))).toBe(false);
+    }
+  });
+});

--- a/tests/skill-surface/retired-names-scan.test.ts
+++ b/tests/skill-surface/retired-names-scan.test.ts
@@ -14,33 +14,30 @@ import { join, relative, sep } from "path";
 
 const ROOT = join(import.meta.dir, "..", "..");
 
-// The 19 retired names minus `repo-harness-chatgpt-bridge`: R2 rules that
-// name is the permanent, generated bridge.md-frontmatter-driven runtime
-// projection identity (setup.ts's CHATGPT_BRIDGE_FRONTMATTER_NAME, bridge.md
-// frontmatter, and every install-skill destination path), not a retired
-// name -- only the static self-hosted `.agents/skills/repo-harness-chatgpt-bridge/`
-// *directory* retired, and its non-existence is proven directly by
+const MANIFEST = JSON.parse(
+  readFileSync(join(ROOT, "assets/skill-commands/manifest.json"), "utf-8"),
+) as {
+  packages: Array<{ name: string }>;
+  retiredPackages: Array<{ name: string; replacement: string | null; note: string }>;
+};
+
+// R2: `repo-harness-chatgpt-bridge` is a retiredPackages[] entry but is NOT a
+// scannable retired name -- it is the permanent, generated
+// bridge.md-frontmatter-driven runtime projection identity (setup.ts's
+// CHATGPT_BRIDGE_FRONTMATTER_NAME, bridge.md frontmatter, and every
+// install-skill destination path). Only the static self-hosted
+// `.agents/skills/repo-harness-chatgpt-bridge/` *directory* retired, and its
+// non-existence is proven directly by
 // tests/skill-surface/chatgpt-package.test.ts instead of a name-string scan.
-const RETIRED_NAMES = [
-  "repo-harness-init",
-  "repo-harness-migrate",
-  "repo-harness-upgrade",
-  "repo-harness-repair",
-  "repo-harness-scaffold",
-  "repo-harness-capability",
-  "repo-harness-review",
-  "repo-harness-prd",
-  "repo-harness-sprint",
-  "repo-harness-goal",
-  "repo-harness-handoff",
-  "repo-harness-deploy",
-  "repo-harness-autoplan",
-  "repo-harness-gptpro-setup",
-  "repo-harness-gptpro",
-  "codex-review",
-  "claude-review",
-  "repo-harness-chatgpt-browser",
-] as const;
+const SCAN_EXEMPT_RETIRED_NAMES = new Set(["repo-harness-chatgpt-bridge"]);
+
+// Derived from the manifest rather than hand-listed: retiredPackages[] is
+// already the migration record of record, so a second hardcoded copy here
+// would be a competing authority that silently goes stale when a package
+// retires.
+const RETIRED_NAMES = MANIFEST.retiredPackages
+  .map((entry) => entry.name)
+  .filter((name) => !SCAN_EXEMPT_RETIRED_NAMES.has(name));
 
 // Plan C8: "src/, scripts/, assets/, .agents/, SKILL.md, README*,
 // docs/reference-configs/, docs/architecture/, evals/".
@@ -206,9 +203,16 @@ describe("retired Skill package names: live-reference scan", () => {
 
       let content: string;
       try {
-        content = readFileSync(absolute, "utf-8");
+        const bytes = readFileSync(absolute);
+        // Probe for a NUL byte before decoding. readFileSync(_, "utf-8") never
+        // throws on binary input -- it produces replacement characters -- so the
+        // catch below never fired for the checked-in PNGs and every one of them
+        // was fully UTF-8 decoded on each run. A retired name cannot live in a
+        // NUL-bearing file as a text reference, so skipping is not a coverage loss.
+        if (bytes.subarray(0, 8192).includes(0)) continue;
+        content = bytes.toString("utf-8");
       } catch {
-        continue; // binary or unreadable; not a text reference by construction
+        continue; // unreadable; not a text reference by construction
       }
 
       for (const name of RETIRED_NAMES) {
@@ -264,24 +268,19 @@ describe("retired Skill package names: live-reference scan", () => {
     expect(sawAtLeastOneProvenanceLine).toBe(true);
   });
 
-  test("retiredPackages[] in the manifest records all 19 retired names with a live-or-null replacement", () => {
-    const manifest = JSON.parse(readFileSync(join(ROOT, "assets/skill-commands/manifest.json"), "utf-8")) as {
-      packages: Array<{ name: string }>;
-      retiredPackages: Array<{ name: string; replacement: string | null; note: string }>;
-    };
-    const liveNames = new Set(manifest.packages.map((p) => p.name));
-    const recordedNames = new Set(manifest.retiredPackages.map((r) => r.name));
+  test("retiredPackages[] records every retired name with a live-or-null replacement", () => {
+    const liveNames = new Set(MANIFEST.packages.map((p) => p.name));
+    const recordedNames = new Set(MANIFEST.retiredPackages.map((r) => r.name));
 
-    // repo-harness-chatgpt-bridge is deliberately excluded from
-    // RETIRED_NAMES (R2) but IS one of the 19 retiredPackages[] entries
-    // (only its static directory retired, not its generated identity), so
-    // check the manifest's own 19-entry count directly here.
-    expect(manifest.retiredPackages.length).toBe(19);
-    for (const name of RETIRED_NAMES) {
+    // Sanity check against a vacuous scan: RETIRED_NAMES is derived from the
+    // manifest, so an emptied retiredPackages[] would make the scan above pass
+    // trivially. The exact count is deliberately not pinned here — the manifest
+    // is the single authority for it.
+    expect(RETIRED_NAMES.length).toBeGreaterThan(0);
+    for (const name of SCAN_EXEMPT_RETIRED_NAMES) {
       expect(recordedNames.has(name)).toBe(true);
     }
-    expect(recordedNames.has("repo-harness-chatgpt-bridge")).toBe(true);
-    for (const entry of manifest.retiredPackages) {
+    for (const entry of MANIFEST.retiredPackages) {
       if (entry.replacement !== null) expect(liveNames.has(entry.replacement)).toBe(true);
     }
   });

--- a/tests/sprint-backlog.test.ts
+++ b/tests/sprint-backlog.test.ts
@@ -679,21 +679,16 @@ describe("sprint projection", () => {
 });
 
 describe("sprint asset parity", () => {
-  test("self-host scripts match the distributed template helpers", () => {
-    expect(readFileSync(join(ROOT, "scripts/sprint-backlog.sh"), "utf-8")).toBe(
-      readFileSync(join(HELPER_DIR, "sprint-backlog.sh"), "utf-8")
-    );
+  // sprint-backlog.sh, check-task-workflow.sh, and refresh-current-status.sh are all
+  // in the contract helper inventory and outside INTENTIONALLY_DIVERGENT, so the
+  // helper parity loop in tests/helper-scripts.test.ts already covers them. The two
+  // template copies below have no helpers/ mirror, so this is their only guard.
+  test("self-host templates match the distributed template assets", () => {
     expect(readFileSync(join(ROOT, ".claude/templates/sprint.template.md"), "utf-8")).toBe(
       readFileSync(join(ROOT, "assets/templates/sprint.template.md"), "utf-8")
     );
     expect(readFileSync(join(ROOT, ".claude/templates/prd.template.md"), "utf-8")).toBe(
       readFileSync(join(ROOT, "assets/templates/prd.template.md"), "utf-8")
-    );
-    expect(readFileSync(join(ROOT, "scripts/check-task-workflow.sh"), "utf-8")).toBe(
-      readFileSync(join(HELPER_DIR, "check-task-workflow.sh"), "utf-8")
-    );
-    expect(readFileSync(join(ROOT, "scripts/refresh-current-status.sh"), "utf-8")).toBe(
-      readFileSync(join(HELPER_DIR, "refresh-current-status.sh"), "utf-8")
     );
   });
 });

--- a/tests/sprint-backlog.test.ts
+++ b/tests/sprint-backlog.test.ts
@@ -695,8 +695,5 @@ describe("sprint asset parity", () => {
     expect(readFileSync(join(ROOT, "scripts/refresh-current-status.sh"), "utf-8")).toBe(
       readFileSync(join(HELPER_DIR, "refresh-current-status.sh"), "utf-8")
     );
-    expect(readFileSync(join(ROOT, "docs/reference-configs/sprint-contracts.md"), "utf-8")).toBe(
-      readFileSync(join(ROOT, "assets/reference-configs/sprint-contracts.md"), "utf-8")
-    );
   });
 });

--- a/tests/ux-feature-guardrail.test.ts
+++ b/tests/ux-feature-guardrail.test.ts
@@ -20,11 +20,9 @@ function designBriefProjection(script: string): string {
 }
 
 describe("UX feature pre-implementation guard", () => {
-  test("ships one canonical runtime convention with a byte-identical self-host mirror", () => {
+  test("ships one canonical runtime convention", () => {
     const asset = read("assets/reference-configs/ux-feature-guard.md");
-    const mirror = read("docs/reference-configs/ux-feature-guard.md");
 
-    expect(mirror).toBe(asset);
     expect(asset).toContain("Instruction and payload are never interchangeable");
     expect(asset).toContain("design-brief template owns the exact Guard Card field schema");
     expect(asset).toContain("Do not change gameplay");
@@ -38,9 +36,7 @@ describe("UX feature pre-implementation guard", () => {
 
   test("routes UX feature creation through the guard before the existing brief and BDD flow", () => {
     const assetFlow = read("assets/reference-configs/agentic-development-flow.md");
-    const repoFlow = read("docs/reference-configs/agentic-development-flow.md");
 
-    expect(repoFlow).toBe(assetFlow);
     expect(assetFlow).toContain("repo-harness docs show ux-feature-guard");
     expect(assetFlow).toContain("then the existing design brief and BDD scenarios");
 


### PR DESCRIPTION
`docs/reference-configs/` and `assets/reference-configs/` were kept in sync by hand, guarded only by six scattered per-file equality assertions that covered a subset of the pairs and drifted from each other over time.

`assets/reference-configs/` is now the declared source and `docs/reference-configs/` its generated, byte-identical projection, enforced by a new `scripts/sync-reference-configs.ts` (`--check`/`--write`, modeled on the existing `sync-helper-sources.ts`) wired into `check-ci`. The six scattered assertions are replaced by a single loop that covers all 23 projected pairs, and negative verification confirmed the loop fails closed on induced drift rather than silently passing.

`harness-overview.md` is re-unified taking the docs side as truth: the assets side still described `agent-context-blocks.txt` and nested context files as compatibility fallbacks, wording this repo's no-fallback rule has since retired, so the divergence was time drift rather than an intentional audience split. The audited low-risk test simplifications land alongside it: dropped README prose-literal assertions that never caught a regression, deduplicated bootstrap assertions, and derived retired names from the manifest instead of restating them.

Acceptance: 14/14 contract exit criteria green, `allowed_paths` clean at 19 files, full suite green, and `check:reference-configs` green.