### PR TITLE
Ship codex/contract-worktree-branch-delete

### DIFF
--- a/assets/templates/helpers/contract-worktree.sh
+++ b/assets/templates/helpers/contract-worktree.sh
@@ -1001,7 +1001,7 @@ cleanup_worktree() {
   fi
 
   local target_worktree current_root branch_prefix branch_name worktree_path metadata_file
-  local worktree_status repair_needed=0
+  local worktree_status repair_needed=0 merge_mode=""
   branch_prefix="$(policy_get '.worktree_strategy.branch_prefix' 'codex/')"
   branch_name="${branch_prefix}${slug}"
   metadata_file=".ai/harness/worktrees/${slug}.json"
@@ -1029,6 +1029,7 @@ cleanup_worktree() {
   if git show-ref --verify --quiet "refs/heads/$branch_name"; then
     if git merge-base --is-ancestor "$branch_name" "$target_branch" >/dev/null 2>&1; then
       echo "[ContractWorktree] Merge check for $branch_name: ancestor of $target_branch"
+      merge_mode="ancestor"
     else
       # Squash-merge (this repo's house ship flow) never makes the branch
       # tip an ancestor of the target. Fall back to an absorption check:
@@ -1043,6 +1044,7 @@ cleanup_worktree() {
       fi
       if [[ "$absorbed" -eq 1 ]]; then
         echo "[ContractWorktree] Merge check for $branch_name: absorbed into $target_branch (squash-equivalent tree)"
+        merge_mode="absorbed"
       else
         echo "contract-worktree: branch $branch_name is not fully merged into $target_branch; refusing cleanup" >&2
         exit 1
@@ -1088,8 +1090,21 @@ cleanup_worktree() {
   fi
 
   if git show-ref --verify --quiet "refs/heads/$branch_name"; then
-    git branch -d "$branch_name"
-    echo "[ContractWorktree] Deleted branch: $branch_name"
+    if [[ "$merge_mode" == "absorbed" ]]; then
+      # The absorption check above already proved this branch's tree is
+      # identical to target's -- git's own ancestry-based `-d` safety check
+      # is a guaranteed false positive here (squash-merge never makes the
+      # branch tip an ancestor of target), so force delete on this
+      # predicate only. Every other path (ancestor, or merge_mode unset
+      # because the branch was already absent at gate time -- which can't
+      # reach here since show-ref above would then be false) keeps the
+      # safer `-d`.
+      git branch -D "$branch_name"
+      echo "[ContractWorktree] Deleted branch: $branch_name (-D, absorbed)"
+    else
+      git branch -d "$branch_name"
+      echo "[ContractWorktree] Deleted branch: $branch_name (-d, ancestor)"
+    fi
   fi
 
   if [[ -e "$metadata_file" ]]; then

--- a/plans/plan-20260731-1056-contract-worktree-branch-delete.md
+++ b/plans/plan-20260731-1056-contract-worktree-branch-delete.md
@@ -1,0 +1,140 @@
+# Plan: Align cleanup branch deletion with the absorption predicate
+
+> **Status**: Executing
+> **Created**: 20260731-1056
+> **Slug**: contract-worktree-branch-delete
+> **Planning Source**: codex-plan-or-waza-think
+> **Orchestration Kind**: host-plan
+> **Source Ref**: (none)
+> **Artifact Level**: work-package
+> **Promotion Reason**: merge_boundary
+> **Verification Boundary**: Commands named in the captured planning output plus `repo-harness run verify-contract --contract tasks/contracts/20260731-1056-contract-worktree-branch-delete.contract.md --strict`.
+> **Rollback Surface**: Before execution remove `plans/plan-20260731-1056-contract-worktree-branch-delete.md`; after execution revert branch `codex/contract-worktree-branch-delete` or the explicitly reviewed diff.
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260731-1056-contract-worktree-branch-delete.contract.md`
+> **Task Review**: `tasks/reviews/20260731-1056-contract-worktree-branch-delete.review.md`
+> **Implementation Notes**: `tasks/notes/20260731-1056-contract-worktree-branch-delete.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from codex-plan-or-waza-think planning output.
+- Source ref: (none)
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260731-1056-contract-worktree-branch-delete.md`
+- Sprint contract: `tasks/contracts/20260731-1056-contract-worktree-branch-delete.contract.md`
+- Sprint review: `tasks/reviews/20260731-1056-contract-worktree-branch-delete.review.md`
+- Implementation notes: `tasks/notes/20260731-1056-contract-worktree-branch-delete.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260731-1056-contract-worktree-branch-delete.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260731-1056-contract-worktree-branch-delete.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260731-1056-contract-worktree-branch-delete.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260731-1056-contract-worktree-branch-delete.contract.md`
+- Review file: `tasks/reviews/20260731-1056-contract-worktree-branch-delete.review.md`
+- Implementation notes file: `tasks/notes/20260731-1056-contract-worktree-branch-delete.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260731-1056-contract-worktree-branch-delete.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260731-1056-contract-worktree-branch-delete.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: Before execution remove `plans/plan-20260731-1056-contract-worktree-branch-delete.md`; after execution revert branch `codex/contract-worktree-branch-delete` or the explicitly reviewed diff.
+- **Verification boundary**: Commands named in the captured planning output plus `repo-harness run verify-contract --contract tasks/contracts/20260731-1056-contract-worktree-branch-delete.contract.md --strict`.
+- **Review/acceptance boundary**: `tasks/reviews/20260731-1056-contract-worktree-branch-delete.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: merge_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260731-1056-contract-worktree-branch-delete.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260731-1056-contract-worktree-branch-delete.contract.md`, `tasks/reviews/20260731-1056-contract-worktree-branch-delete.review.md`, and `tasks/notes/20260731-1056-contract-worktree-branch-delete.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260731-1056-contract-worktree-branch-delete.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: Before execution remove `plans/plan-20260731-1056-contract-worktree-branch-delete.md`; after execution revert branch `codex/contract-worktree-branch-delete` or the explicitly reviewed diff.
+
+## Captured Planning Output
+
+# contract-worktree cleanup 的分支刪除與吸收判定對齊(contract-worktree.sh:1091)
+
+## Context
+
+#142 讓 cleanup 的 merge 閘認得 squash 吸收(`absorbed`),但後續刪分支仍是 `git branch -d`——git 自己的 ancestry 安全刪除,對 squash 吸收的分支照樣拒絕。2026-07-31 closeout 實證:三個 absorbed 的包(receipt-fingerprint-normalization、reference-configs-projection、contract-worktree-squash-cleanup)cleanup 都半途而廢——worktree 與 metadata 刪了、分支報 `error: the branch '…' is not fully merged` 留下,退出碼非零,要人工 `git branch -D` 收尾。每個 squash 包都會重演,`-D` 變習慣動作反而蛀空安全閘。
+
+## 凍結設計
+
+merge 閘(#142 加入的雙判定段,`scripts/contract-worktree.sh:1029-1053`)已經知道命中哪個判定。把該結果(如 `absorbed=1` 旗標)傳遞到 `:1091` 的刪除步:
+
+- 命中 `absorbed` → `git branch -D`(安全依據:吸收判定剛證明該分支對 main 零增量,git 的 ancestry 檢查在此必然誤報)。
+- 命中 `ancestor` → 照舊 `git branch -d`(git 自身檢查有效,保留雙保險)。
+- 分支不存在本地 → 照舊跳過。
+- 閘拒絕的分支根本到不了刪除步,fail-closed 語意不變。
+
+刪除成功訊息可註明用了哪個模式(對齊 #142 的判定日誌風格)。
+
+## 修復面
+
+- `scripts/contract-worktree.sh`:merge 閘旗標傳遞 + `:1091` 刪除分支(唯一生產改動)。
+- 鏡像 `assets/templates/helpers/contract-worktree.sh`:`bun run sync:helpers` 重生,不手改。
+
+## 步驟(TDD:RED → GREEN)
+
+1. **RED**:擴充 #142 的 guard `tests/contract-worktree-squash-cleanup.test.ts`——正向 case 從「dry-run 通過」升級為「**實跑 cleanup 一次清淨**」:squash 合入的分支跑 `cleanup --slug <slug>`(非 dry-run),斷言 worktree 目錄消失 + metadata 消失 + **分支消失** + 退出碼 0。未修碼上此斷言組必紅(分支殘留、exit 非 0)。既有負向對照(未合併分支在閘就被拒)保留不動。另加一個 ancestor case:普通 merge(非 squash)合入的分支,cleanup 後分支同樣消失(走 `-d` 路徑,證明未破壞既有雙保險)。
+   capture:`bun test tests/contract-worktree-squash-cleanup.test.ts > tasks/notes/20260731-branch-delete.pre-fix.log 2>&1; s=$?; echo "PRE_FIX_EXIT=$s" >> 同檔`,確認 `PRE_FIX_EXIT=1`。commit。
+2. **GREEN**:實作旗標傳遞與條件刪除;guard 全綠;`bun run sync:helpers` + `bun run check:helpers`。
+3. **驗證**:guard 單檔、`bun test` 全量(log 檔形式)、`bun run check:type`、`bun run check:helpers`。
+4. notes 記:`-D` 的安全論證(吸收判定為前置)、ancestor 路徑保留 `-d` 的理由(雙保險)。RED/GREEN 分 commit,push。
+
+## 明確不做(EXECUTION_BOUNDARY)
+
+- 不動 merge 閘判定邏輯本身(#142 的段落只加旗標導出,不改判定)。
+- 不動 start/finish/status、其他安全檢查、其他 helper。
+- 不清理任何真實 worktree(本輪 closeout 已完成,無現存對象)。
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [ ] Execute captured plan: Align cleanup branch deletion with the absorption predicate

--- a/scripts/contract-worktree.sh
+++ b/scripts/contract-worktree.sh
@@ -1001,7 +1001,7 @@ cleanup_worktree() {
   fi
 
   local target_worktree current_root branch_prefix branch_name worktree_path metadata_file
-  local worktree_status repair_needed=0
+  local worktree_status repair_needed=0 merge_mode=""
   branch_prefix="$(policy_get '.worktree_strategy.branch_prefix' 'codex/')"
   branch_name="${branch_prefix}${slug}"
   metadata_file=".ai/harness/worktrees/${slug}.json"
@@ -1029,6 +1029,7 @@ cleanup_worktree() {
   if git show-ref --verify --quiet "refs/heads/$branch_name"; then
     if git merge-base --is-ancestor "$branch_name" "$target_branch" >/dev/null 2>&1; then
       echo "[ContractWorktree] Merge check for $branch_name: ancestor of $target_branch"
+      merge_mode="ancestor"
     else
       # Squash-merge (this repo's house ship flow) never makes the branch
       # tip an ancestor of the target. Fall back to an absorption check:
@@ -1043,6 +1044,7 @@ cleanup_worktree() {
       fi
       if [[ "$absorbed" -eq 1 ]]; then
         echo "[ContractWorktree] Merge check for $branch_name: absorbed into $target_branch (squash-equivalent tree)"
+        merge_mode="absorbed"
       else
         echo "contract-worktree: branch $branch_name is not fully merged into $target_branch; refusing cleanup" >&2
         exit 1
@@ -1088,8 +1090,21 @@ cleanup_worktree() {
   fi
 
   if git show-ref --verify --quiet "refs/heads/$branch_name"; then
-    git branch -d "$branch_name"
-    echo "[ContractWorktree] Deleted branch: $branch_name"
+    if [[ "$merge_mode" == "absorbed" ]]; then
+      # The absorption check above already proved this branch's tree is
+      # identical to target's -- git's own ancestry-based `-d` safety check
+      # is a guaranteed false positive here (squash-merge never makes the
+      # branch tip an ancestor of target), so force delete on this
+      # predicate only. Every other path (ancestor, or merge_mode unset
+      # because the branch was already absent at gate time -- which can't
+      # reach here since show-ref above would then be false) keeps the
+      # safer `-d`.
+      git branch -D "$branch_name"
+      echo "[ContractWorktree] Deleted branch: $branch_name (-D, absorbed)"
+    else
+      git branch -d "$branch_name"
+      echo "[ContractWorktree] Deleted branch: $branch_name (-d, ancestor)"
+    fi
   fi
 
   if [[ -e "$metadata_file" ]]; then

--- a/tasks/contracts/20260731-1056-contract-worktree-branch-delete.contract.md
+++ b/tasks/contracts/20260731-1056-contract-worktree-branch-delete.contract.md
@@ -1,0 +1,148 @@
+# Task Contract: contract-worktree-branch-delete
+
+> **Status**: Active
+> **Plan**: plans/plan-20260731-1056-contract-worktree-branch-delete.md
+> **Task Profile**: bugfix
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: ancienttwo
+> **Capability ID**: root
+> **Last Updated**: 2026-07-31 10:56
+> **Review File**: `tasks/reviews/20260731-1056-contract-worktree-branch-delete.review.md`
+> **Notes File**: `tasks/notes/20260731-1056-contract-worktree-branch-delete.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+#142 taught cleanup's merge gate to recognize squash absorption, but the subsequent branch deletion still uses `git branch -d` — git's own ancestry-based safety — which refuses every squash-absorbed branch. Verified 2026-07-31 on all three absorbed cleanups: worktree and metadata removed, branch left behind with `error: the branch '…' is not fully merged`, non-zero exit. Every future squash package repeats this, forcing manual `-D` as a habit and hollowing out the safety gate #142 just fixed.
+
+## Goal
+
+The merge gate's matched predicate flows into the deletion step: `absorbed` branches delete via `git branch -D` (the absorption check just proved zero delta against main — git's ancestry check is a guaranteed false positive there), `ancestor` branches keep `-d` (double insurance intact), gate-refused branches never reach deletion. A squash-merged branch's real `cleanup --slug <slug>` removes worktree, metadata, and branch in one pass with exit 0; a merge-commit branch still deletes via `-d`.
+
+## Scope
+
+- In scope: predicate-flag plumbing + conditional deletion in `scripts/contract-worktree.sh` (around :1091); mirror via `bun run sync:helpers`; extend `tests/contract-worktree-squash-cleanup.test.ts` (real-cleanup positive case + ancestor `-d` case; existing negative control untouched); notes file.
+- Out of scope: the #142 gate logic itself (flag export only, no predicate change); start/finish/status branches; other safety checks; other helpers; any real worktree cleanup (closeout already done, none exist).
+- Taste constraints: <!-- advisory only, no run gate; default style/taste lives in AGENTS.md and the minimal-change policy, use this to record a per-task override -->
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+
+## Falsifier
+
+If `-D` ever fires on a branch the gate did NOT judge absorbed (or the flag leaks across invocations), the change converts a guaranteed-false-positive bypass into an unconditional force-delete and the direction is wrong. Cheapest proof point: the gate-refused negative control must still exit 1 before any deletion, and the ancestor case must still log/delete via `-d`.
+
+## Root Cause Evidence
+
+- root_cause: `scripts/contract-worktree.sh:1091` deletes with `git branch -d`, whose built-in ancestry check independently re-judges "merged" and refuses every squash-absorbed branch that the #142 gate (same script, :1029-1053) has already proven tree-identical to main, so cleanup half-completes (worktree+metadata removed, branch left, non-zero exit).
+- repro: on a squash-merged branch, `bash scripts/contract-worktree.sh cleanup --slug <slug>` → gate logs `absorbed into main (squash-equivalent tree)`, worktree removed, then `error: the branch 'codex/<slug>' is not fully merged` (observed 2026-07-31 on all three absorbed cleanups: receipt-fingerprint-normalization, reference-configs-projection, contract-worktree-squash-cleanup).
+- regression_guard: tests/contract-worktree-squash-cleanup.test.ts
+- pre_fix_failure_artifact: tasks/notes/20260731-branch-delete.pre-fix.log
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260731-1056-contract-worktree-branch-delete.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260731-1056-contract-worktree-branch-delete.review.md`
+- Notes file: `tasks/notes/20260731-1056-contract-worktree-branch-delete.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Acceptance Policy
+
+```json
+{"protocol":1,"reviewer":"Claude","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - docs/spec.md
+  - plans/
+  - tasks/todos.md
+  - tasks/contracts/20260731-1056-contract-worktree-branch-delete.contract.md
+  - tasks/reviews/20260731-1056-contract-worktree-branch-delete.review.md
+  - tasks/notes/20260731-1056-contract-worktree-branch-delete.notes.md
+  - tasks/notes/20260731-branch-delete.pre-fix.log
+  - .ai/context/capabilities.json
+  - .claude/templates/
+  - scripts/contract-worktree.sh
+  - assets/templates/helpers/contract-worktree.sh
+  - tests/
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+      - codex-exec
+      - main-thread
+    fallback: main-thread
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - docs/spec.md
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260731-1056-contract-worktree-branch-delete.notes.md
+  tests_pass:
+    - path: tests/contract-worktree-squash-cleanup.test.ts
+  commands_succeed:
+    - bun run check:type
+    - bun run check:helpers
+    - bun test
+```
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior:
+- Edge cases:
+- Regression risks:
+
+## Rollback Point
+
+- Commit / checkpoint: `a37c16e4` (main at worktree creation, branch `codex/contract-worktree-branch-delete`)
+- Revert strategy: revert the merge commit — deletion returns to unconditional `-d` (safe direction: half-completed cleanups with orphan branches, never over-deletion); the real-cleanup guard case fails again by design.

--- a/tasks/notes/20260731-1056-contract-worktree-branch-delete.notes.md
+++ b/tasks/notes/20260731-1056-contract-worktree-branch-delete.notes.md
@@ -1,0 +1,41 @@
+# Implementation Notes: contract-worktree-branch-delete
+
+> **Status**: Active
+> **Plan**: plans/plan-20260731-1056-contract-worktree-branch-delete.md
+> **Contract**: tasks/contracts/20260731-1056-contract-worktree-branch-delete.contract.md
+> **Review**: tasks/reviews/20260731-1056-contract-worktree-branch-delete.review.md
+> **Last Updated**: 2026-07-31 10:56
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- ...
+
+## Deviations From Plan Or Spec
+
+- None recorded.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| ... | ... | ... |
+
+## Open Questions
+
+- None.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/notes/20260731-1056-contract-worktree-branch-delete.notes.md
+++ b/tasks/notes/20260731-1056-contract-worktree-branch-delete.notes.md
@@ -9,17 +9,21 @@
 
 ## Design Decisions
 
-- ...
+- **`-D` safety argument**: the merge gate (`scripts/contract-worktree.sh:1029-1053`) already runs two independent predicates before any deletion happens — `git merge-base --is-ancestor` (ancestor case) or, on a fresh conflict-free `git merge-tree --write-tree`, an exact tree-equality check against `$target_branch^{tree}` (absorbed case). The absorbed branch is only reached when that tree-equality proof already holds, i.e. the branch's full content is a strict subset of target's — there is no code path to `merge_mode="absorbed"` without that proof running first. Given that, `git branch -d`'s own ancestry re-check at deletion time is a *guaranteed* false positive for every absorbed branch: squash-merge (this repo's house ship flow) rewrites history, so the branch tip is structurally never an ancestor of `main`, regardless of content. `-d` refusing here is not a second opinion, it is git re-asking a question the gate already answered with a stronger proof (full tree equality, not just ancestry). Using `-D` on this predicate only converts a redundant, always-wrong safety check into the intended force-delete, without weakening the gate itself (the gate's `exit 1` refusal path is untouched — see Deviations).
+- **Ancestor keeps `-d` (double insurance)**: the ancestor branch never rewrites history relative to target, so `git branch -d`'s ancestry check is not redundant there — it is a real, cheap, independently-computed second confirmation that riding on `merge_mode="ancestor"` alone would give up. Keeping `-d` on that path costs nothing (it always succeeds when the gate's own `--is-ancestor` check already passed) and preserves the pre-#142 safety property for the common (non-squash) case. The deletion step's `else` branch (i.e. anything that is not exactly `merge_mode == "absorbed"`) uses `-d`, so this is the safe default, not a second literal check of `merge_mode == "ancestor"`.
+- **Flag scope verification**: `merge_mode` is declared with the rest of `cleanup_worktree`'s `local` variables (`scripts/contract-worktree.sh:1004`) and assigned inside the nested `if/else` at :1029-1053. Bash `local` is function-scoped, not block-scoped, and there is no subshell (`( … )`, pipeline stage, or `$(...)` around the assignment itself — the surrounding `if` bodies run in the current shell) between that assignment and the deletion step at :1090-1093, so the value set by the gate is visible unchanged at the deletion site within the same `cleanup_worktree` invocation. Verified empirically, not just by reading: the new ancestor-path regression test asserts the exact log annotation `(-d, ancestor)` and the absorbed-path test asserts `(-D, absorbed)` — if scope leaked or defaulted wrong, the wrong annotation (or the wrong git flag) would fire and the corresponding assertion would fail. Both pass post-fix (see Evidence Links). `cleanup_worktree` is invoked once per script execution (no loop reuses the function across multiple branches in one process), so there is no cross-invocation leak surface to test.
 
 ## Deviations From Plan Or Spec
 
-- None recorded.
+- None recorded. Implementation matches the frozen design exactly: flag export only in the gate (`merge_mode="ancestor"` / `merge_mode="absorbed"`, two one-line additions, no predicate logic touched), conditional deletion at the single named site (:1090-1093), mirror regenerated via `bun run sync:helpers` (not hand-edited).
 
 ## Tradeoffs Considered
 
 | Option | Decision | Reason |
 |--------|----------|--------|
-| ... | ... | ... |
+| Pass predicate via explicit function return value / global associative array keyed by branch | Rejected | `cleanup_worktree` is a single straight-line function processing one branch per invocation; a `local` flag already crosses the gate-to-deletion distance with correct scope (verified, see Design Decisions) — a return-value or global-map plumbing would be a wider change for no added safety, and would touch more of the function than the frozen design allows |
+| Re-run the `merge-tree` absorption check again at deletion time instead of reusing the gate's result | Rejected | Re-deriving the same proof a second time is exactly the anti-pattern this fix removes (git's `-d` ancestry re-check is already a redundant, wrong re-derivation); trusting the gate's result once it has already fail-closed on every other outcome is the smallest coherent change |
+| Default the deletion `if` on `merge_mode == "ancestor"` explicitly, treat unset as a third error case | Rejected | The gate's `exit 1` refusal already makes "reached deletion with `merge_mode` unset and branch still present" an unreachable state (unset only happens on the "branch already absent" path, which fails the deletion step's own `git show-ref` guard); adding a third branch for an unreachable state is complexity the invariant doesn't need, and `else -> -d` is the safe default if that invariant is ever violated by a future edit |
 
 ## Open Questions
 
@@ -29,6 +33,11 @@
 
 - Checks: `.ai/harness/checks/latest.json`
 - Run snapshots: `.ai/harness/runs/`
+- Pre-fix RED capture: `tasks/notes/20260731-branch-delete.pre-fix.log` (`PRE_FIX_EXIT=1`; absorbed real-cleanup case fails on exit code, ancestor real-cleanup case fails only on the new log annotation — proving the pre-existing `-d` path already worked and only the mode-annotation/`-D` behavior was missing)
+- Post-fix guard: `bun test tests/contract-worktree-squash-cleanup.test.ts` — 4 pass, 0 fail
+- Full suite: `bun test` — 2105 pass, 1 skip (pre-existing, unrelated), 0 fail
+- `bun run check:type` — clean
+- `bun run check:helpers` — projection OK (mirror regenerated via `bun run sync:helpers`, identical diff to `scripts/contract-worktree.sh`)
 
 ## Promotion Filter
 

--- a/tasks/notes/20260731-branch-delete.pre-fix.log
+++ b/tasks/notes/20260731-branch-delete.pre-fix.log
@@ -1,0 +1,37 @@
+bun test v1.3.14 (0d9b296a)
+
+tests/contract-worktree-squash-cleanup.test.ts:
+219 |       const result = run(
+220 |         "bash",
+221 |         ["scripts/contract-worktree.sh", "cleanup", "--slug", "squash-real"],
+222 |         cwd,
+223 |       );
+224 |       expect(result.status).toBe(0);
+                                  ^
+error: expect(received).toBe(expected)
+
+Expected: 0
+Received: 1
+
+      at <anonymous> (/Users/ancienttwo/Projects/repo-harness-wt-contract-worktree-branch-delete/tests/contract-worktree-squash-cleanup.test.ts:224:29)
+(fail) contract-worktree cleanup squash-merge absorption > cleanup deletes a squash-merged branch end to end on a real (non-dry-run) run [370.28ms]
+281 |         ["scripts/contract-worktree.sh", "cleanup", "--slug", "ancestor-real"],
+282 |         cwd,
+283 |       );
+284 |       expect(result.status).toBe(0);
+285 |       expect(result.stdout).toContain("ancestor of main");
+286 |       expect(result.stdout).toContain("Deleted branch: codex/ancestor-real (-d, ancestor)");
+                                  ^
+error: expect(received).toContain(expected)
+
+Expected to contain: "Deleted branch: codex/ancestor-real (-d, ancestor)"
+Received: "[ContractWorktree] Merge check for codex/ancestor-real: ancestor of main\n[ContractWorktree] Removed worktree: /private/var/folders/_6/dkz7p7251y1gqntnk0ll5n380000gn/T/helper-cleanup-ancestor-real-3i1n0A-wt-ancestor-real\nDeleted branch codex/ancestor-real (was c831a78).\n[ContractWorktree] Deleted branch: codex/ancestor-real\n[ContractWorktree] Removed metadata: .ai/harness/worktrees/ancestor-real.json\n"
+
+      at <anonymous> (/Users/ancienttwo/Projects/repo-harness-wt-contract-worktree-branch-delete/tests/contract-worktree-squash-cleanup.test.ts:286:29)
+(fail) contract-worktree cleanup squash-merge absorption > cleanup deletes a plain-merged (ancestor) branch via -d on a real run [413.34ms]
+
+ 2 pass
+ 2 fail
+ 78 expect() calls
+Ran 4 tests across 1 file. [1.56s]
+PRE_FIX_EXIT=1

--- a/tasks/reviews/20260731-1056-contract-worktree-branch-delete.review.md
+++ b/tasks/reviews/20260731-1056-contract-worktree-branch-delete.review.md
@@ -48,9 +48,9 @@
 > **Reviewed Subject Scope**: normalized-final-content
 > **Reviewed Target Revision**: a37c16e4393c374877b9472bd3d771c0862fab12
 > **Verification Evidence SHA256**: sha256:06f5d71d65690f15b38b1ecdaf09b12f8fc743fbf099fd5c2bb920699ce48524
-> **Issued At**: 2026-07-31T08:08:07.426Z
+> **Issued At**: 2026-07-31T08:12:14.356Z
 
-- Summary: Gatekeeper PASS: force-boundary verified (merge_mode flag scope + unreachable-state analysis), adversarial cases green, full suite 2105/0
+- Summary: gatekeeper PASS. The sibling squash-cleanup package taught the merge check to accept absorbed branches, but the deletion step still called git branch -d, which is itself ancestry-based, so cleanup half-completed on every squash-merged worktree: the worktree and metadata were removed and the branch was left orphaned, forcing a manual git branch -D that trains the operator to bypass the safety gate. The fix keeps -d for genuine ancestors and uses -D only on the branches the merge check already proved absorbed, so force is scoped to the case where safety was independently established rather than applied blanket. Force-boundary verified: an unmerged branch still takes -d and is still refused. Two adversarial cases were exercised, and the flag-unreachable analysis confirms no path reaches -D without a prior absorbed determination. This run recorded 17/17 exit criteria green including the full Root Cause Evidence gate, allowed_paths clean at 9 files, and full suite green.
 - Findings: none
 
 ## Behavior Diff Notes

--- a/tasks/reviews/20260731-1056-contract-worktree-branch-delete.review.md
+++ b/tasks/reviews/20260731-1056-contract-worktree-branch-delete.review.md
@@ -40,17 +40,17 @@
 
 ## Acceptance Receipt Projection
 
-> **Disposition**: unavailable
-> **Reviewer**: unavailable
-> **Source**: unavailable
+> **Disposition**: external_pass
+> **Reviewer**: Claude
+> **Source**: claude-review
 > **Actor**: not-applicable
-> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject SHA256**: sha256:80bc2f28eaba1dde5b268d28c8ed86a0a61e14cac20d7fe170ac51f8b82f4b90
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: pending
-> **Verification Evidence SHA256**: pending
-> **Issued At**: pending
+> **Reviewed Target Revision**: a37c16e4393c374877b9472bd3d771c0862fab12
+> **Verification Evidence SHA256**: sha256:06f5d71d65690f15b38b1ecdaf09b12f8fc743fbf099fd5c2bb920699ce48524
+> **Issued At**: 2026-07-31T08:08:07.426Z
 
-- Summary: No AcceptanceReceipt has been recorded.
+- Summary: Gatekeeper PASS: force-boundary verified (merge_mode flag scope + unreachable-state analysis), adversarial cases green, full suite 2105/0
 - Findings: none
 
 ## Behavior Diff Notes

--- a/tasks/reviews/20260731-1056-contract-worktree-branch-delete.review.md
+++ b/tasks/reviews/20260731-1056-contract-worktree-branch-delete.review.md
@@ -1,0 +1,84 @@
+# Task Review: contract-worktree-branch-delete
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260731-1056-contract-worktree-branch-delete.md
+> **Contract**: tasks/contracts/20260731-1056-contract-worktree-branch-delete.contract.md
+> **Notes File**: tasks/notes/20260731-1056-contract-worktree-branch-delete.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-07-31 10:56
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Commands passed:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+- Waza `/check` run:
+- Commands run:
+- Manual checks:
+- Supporting artifacts:
+- Implementation notes reviewed:
+- Run snapshot:
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -1,7 +1,7 @@
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: 2026-07-31 09:52
+> **Updated**: 2026-07-31 10:56
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.

--- a/tests/contract-worktree-squash-cleanup.test.ts
+++ b/tests/contract-worktree-squash-cleanup.test.ts
@@ -186,4 +186,114 @@ describe("contract-worktree cleanup squash-merge absorption", () => {
       rmSync(cwd, { recursive: true, force: true });
     }
   }, 15000);
+
+  // Regression guard for the branch-deletion half of the fix: the merge
+  // gate above already proves absorption/ancestry -- the deletion step must
+  // consume that predicate instead of re-deriving it via git's own
+  // ancestry-based `-d` safety check, which is a guaranteed false positive
+  // for every squash-absorbed branch. See:
+  //   plans/plan-20260731-1056-contract-worktree-branch-delete.md
+  //   tasks/contracts/20260731-1056-contract-worktree-branch-delete.contract.md
+  test("cleanup deletes a squash-merged branch end to end on a real (non-dry-run) run", () => {
+    const cwd = tmpWorkspace("helper-cleanup-squash-real");
+    const worktreePath = `${cwd}-wt-squash-real`;
+    try {
+      copyHelpers(cwd);
+      initGitRepo(cwd);
+      writeFileSync(join(cwd, "README.md"), "# demo\n");
+      commitAll(cwd, "init squash real cleanup");
+
+      expect(run("git", ["worktree", "add", worktreePath, "-b", "codex/squash-real"], cwd).status).toBe(0);
+      writeFileSync(join(worktreePath, "feature.txt"), "squash feature\n");
+      commitAll(worktreePath, "add squash feature");
+
+      expect(run("git", ["merge", "--squash", "codex/squash-real"], cwd).status).toBe(0);
+      commitAll(cwd, "squash-merge codex/squash-real");
+      expect(
+        run("git", ["merge-base", "--is-ancestor", "codex/squash-real", "main"], cwd).status,
+      ).not.toBe(0);
+
+      mkdirSync(join(cwd, ".ai/harness/worktrees"), { recursive: true });
+      writeFileSync(join(cwd, ".ai/harness/worktrees/squash-real.json"), '{"slug":"squash-real"}\n');
+
+      const result = run(
+        "bash",
+        ["scripts/contract-worktree.sh", "cleanup", "--slug", "squash-real"],
+        cwd,
+      );
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("absorbed into main (squash-equivalent tree)");
+      expect(result.stdout).toContain("Deleted branch: codex/squash-real (-D, absorbed)");
+
+      // The real assertion this test exists for: cleanup must finish in one
+      // pass -- worktree, branch, AND metadata all gone, exit 0. Pre-fix,
+      // `git branch -d` refuses (not fully merged) and `set -euo pipefail`
+      // kills the script before metadata removal, leaving the branch (and
+      // possibly the metadata) behind with a non-zero exit.
+      expect(existsSync(worktreePath)).toBe(false);
+      expect(
+        run("git", ["show-ref", "--verify", "--quiet", "refs/heads/codex/squash-real"], cwd).status,
+      ).not.toBe(0);
+      expect(existsSync(join(cwd, ".ai/harness/worktrees/squash-real.json"))).toBe(false);
+    } finally {
+      run("git", ["worktree", "remove", "--force", worktreePath], cwd);
+      rmSync(worktreePath, { recursive: true, force: true });
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  }, 15000);
+
+  test("cleanup deletes a plain-merged (ancestor) branch via -d on a real run", () => {
+    const cwd = tmpWorkspace("helper-cleanup-ancestor-real");
+    const worktreePath = `${cwd}-wt-ancestor-real`;
+    try {
+      copyHelpers(cwd);
+      initGitRepo(cwd);
+      writeFileSync(join(cwd, "README.md"), "# demo\n");
+      commitAll(cwd, "init ancestor real cleanup");
+
+      expect(run("git", ["worktree", "add", worktreePath, "-b", "codex/ancestor-real"], cwd).status).toBe(0);
+      writeFileSync(join(worktreePath, "feature.txt"), "ancestor feature\n");
+      commitAll(worktreePath, "add ancestor feature");
+
+      // Diverge main so the merge cannot fast-forward -- forces a real merge
+      // commit, proving the ancestor predicate (not the absorption
+      // fallback) is what fires here, and that the double-insurance -d path
+      // still works after the deletion step starts branching on merge_mode.
+      writeFileSync(join(cwd, "main-only.txt"), "main-only change\n");
+      commitAll(cwd, "diverge main");
+
+      expect(
+        run(
+          "git",
+          ["merge", "--no-ff", "-m", "merge codex/ancestor-real", "codex/ancestor-real"],
+          cwd,
+        ).status,
+      ).toBe(0);
+      expect(
+        run("git", ["merge-base", "--is-ancestor", "codex/ancestor-real", "main"], cwd).status,
+      ).toBe(0);
+
+      mkdirSync(join(cwd, ".ai/harness/worktrees"), { recursive: true });
+      writeFileSync(join(cwd, ".ai/harness/worktrees/ancestor-real.json"), '{"slug":"ancestor-real"}\n');
+
+      const result = run(
+        "bash",
+        ["scripts/contract-worktree.sh", "cleanup", "--slug", "ancestor-real"],
+        cwd,
+      );
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("ancestor of main");
+      expect(result.stdout).toContain("Deleted branch: codex/ancestor-real (-d, ancestor)");
+
+      expect(existsSync(worktreePath)).toBe(false);
+      expect(
+        run("git", ["show-ref", "--verify", "--quiet", "refs/heads/codex/ancestor-real"], cwd).status,
+      ).not.toBe(0);
+      expect(existsSync(join(cwd, ".ai/harness/worktrees/ancestor-real.json"))).toBe(false);
+    } finally {
+      run("git", ["worktree", "remove", "--force", worktreePath], cwd);
+      rmSync(worktreePath, { recursive: true, force: true });
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  }, 15000);
 });


### PR DESCRIPTION
Cleanup's branch deletion now follows the merge gate's verdict: absorbed (squash-equivalent tree) branches delete via -D, ancestor branches keep git's own -d double-check, gate-refused branches never reach deletion.

Force boundary: -D fires only after the absorption predicate proves the branch adds zero delta to main; unreachable-state analysis and adversarial cases verified by review.

Verification: RED/GREEN guard (4 tests incl. real-run cleanup and ancestor path), full suite 2105 pass / 0 fail, helper mirror byte-identical, completion gate 17/17.