### PR TITLE
Ship codex/release-0-12-0

### DIFF
--- a/.claude/.skill-version
+++ b/.claude/.skill-version
@@ -1,3 +1,3 @@
-skill_version=0.11.3
-template_version=0.11.3
+skill_version=0.12.0
+template_version=0.12.0
 migrated_at=2026-07-18T22:31:36Z

--- a/README.es.md
+++ b/README.es.md
@@ -82,7 +82,7 @@ artifacts.
 ## Novedades
 
 Las notas de versión viven en [`docs/CHANGELOG.md`](docs/CHANGELOG.md). La línea
-actual es `0.11.3`.
+actual es `0.12.0`.
 
 ## Cómo funciona
 
@@ -413,8 +413,8 @@ Guards habituales:
 
 ## Release actual
 
-- npm package: `repo-harness@0.11.3`
-- Generated workflow stamp: `repo-harness@0.11.3+template@0.11.3`
+- npm package: `repo-harness@0.12.0`
+- Generated workflow stamp: `repo-harness@0.12.0+template@0.12.0`
 - GitHub repository: `Ancienttwo/repo-harness`
 - Release history: [`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -82,7 +82,7 @@ l'emportent.
 ## Nouveautés
 
 Les notes de version vivent dans [`docs/CHANGELOG.md`](docs/CHANGELOG.md). La
-ligne actuelle est `0.11.3`.
+ligne actuelle est `0.12.0`.
 
 ## Comment ça marche
 
@@ -414,8 +414,8 @@ Guards courants :
 
 ## Release actuelle
 
-- npm package : `repo-harness@0.11.3`
-- Generated workflow stamp : `repo-harness@0.11.3+template@0.11.3`
+- npm package : `repo-harness@0.12.0`
+- Generated workflow stamp : `repo-harness@0.12.0+template@0.12.0`
 - GitHub repository : `Ancienttwo/repo-harness`
 - Release history : [`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -71,7 +71,7 @@ review、checks、handoff と食い違う場合は、source artifacts を優先�
 ## What's New
 
 リリースノートは [`docs/CHANGELOG.md`](docs/CHANGELOG.md) にあります。現在の
-ラインは `0.11.3` です。
+ラインは `0.12.0` です。
 
 ## 仕組み
 
@@ -389,8 +389,8 @@ hook がブロックしたときは、まず terminal の構造化された出�
 
 ## 現在の Release
 
-- npm package：`repo-harness@0.11.3`
-- Generated workflow stamp：`repo-harness@0.11.3+template@0.11.3`
+- npm package：`repo-harness@0.12.0`
+- Generated workflow stamp：`repo-harness@0.12.0+template@0.12.0`
 - GitHub repository：`Ancienttwo/repo-harness`
 - Release history：[`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ active plan, contract, review, checks, or handoff, the source artifacts win.
 ## What's New
 
 Release notes live in [`docs/CHANGELOG.md`](docs/CHANGELOG.md). The current line
-is `0.11.3`.
+is `0.12.0`.
 
 ## How It Works
 
@@ -638,8 +638,8 @@ Most common guards:
 
 ## Current Release
 
-- npm package: `repo-harness@0.11.3`
-- Generated workflow stamp: `repo-harness@0.11.3+template@0.11.3`
+- npm package: `repo-harness@0.12.0`
+- Generated workflow stamp: `repo-harness@0.12.0+template@0.12.0`
 - GitHub repository: `Ancienttwo/repo-harness`
 - Release history: [`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -71,7 +71,7 @@ review、checks 或 handoff 冲突，以 source artifacts 为准。
 
 ## What's New
 
-Release notes 见 [`docs/CHANGELOG.md`](docs/CHANGELOG.md)，当前版本线是 `0.11.3`。
+Release notes 见 [`docs/CHANGELOG.md`](docs/CHANGELOG.md)，当前版本线是 `0.12.0`。
 
 ## 工作原理
 
@@ -448,8 +448,8 @@ hook block 工作时，先看 terminal 里的结构化输出。核心字段是
 
 ## 当前 Release
 
-- npm package：`repo-harness@0.11.3`
-- Generated workflow stamp：`repo-harness@0.11.3+template@0.11.3`
+- npm package：`repo-harness@0.12.0`
+- Generated workflow stamp：`repo-harness@0.12.0+template@0.12.0`
 - GitHub repository：`Ancienttwo/repo-harness`
 - Release history：[`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/assets/skill-version.json
+++ b/assets/skill-version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.11.3",
-  "templateVersion": "0.11.3",
+  "version": "0.12.0",
+  "templateVersion": "0.12.0",
   "skillName": "repo-harness",
   "contractId": "tasks-first-harness-v1",
   "compatibility": {
@@ -223,6 +223,10 @@
     {
       "version": "0.11.3",
       "description": "Adds ChatGPT delegate mode with a repo-owned dual-agent GPT Pro protocol and Claude/Codex host transports, enforces a mandatory pre-spawn Gitleaks scan over the rendered PromptBundle, and adds explicit host skill projection commands for the repo-harness-chatgpt package"
+    },
+    {
+      "version": "0.12.0",
+      "description": "Removes repo-harness adopt in favor of init as the sole repo-local adoption command, adds the deep-worker fleet agent, converges docs/reference-configs on a generated assets projection, and fixes MCP allowed-root canonicalization, an acceptance-receipt fingerprint defect, and contract-worktree squash-merge cleanup"
     }
   ],
   "generatedProjectStamp": {

--- a/deploy/release-checklists/260731-repo-harness-0.12.0.md
+++ b/deploy/release-checklists/260731-repo-harness-0.12.0.md
@@ -1,0 +1,82 @@
+# repo-harness 0.12.0 Release Filing
+
+- Date: 2026-07-31
+- Package: `repo-harness@0.12.0`
+- Base release: `v0.11.3`
+- Source range: `v0.11.3..candidate`
+- Release scope: land the previously-announced breaking `adopt`-to-`init`
+  cutover, add the `deep-worker` managed fleet agent with a Codex model
+  projection respec, converge `docs/reference-configs` on a generated
+  projection of `assets/reference-configs`, and fix four production defects —
+  an MCP allowed-root realpath-canonicalization false denial, an
+  `ensure-task-workflow` bootstrap write-order race, an `acceptance-receipt`
+  evidence-fingerprint key-order defect, and a `contract-worktree` cleanup gap
+  that left squash-absorbed branches undeleted.
+- Publish status: **pending publish**. This filing does not claim npm, Git tag,
+  or GitHub Release completion until the public readbacks below pass.
+
+## Candidate Evidence
+
+- `bd2155da` (PR #137) adds `deep-worker` to the managed agent fleet
+  (Opus/high effort, workspace-write) across `.claude/agents/`,
+  `.codex/agents/`, and `agents/fleet/`, moves `fast-worker` from Sonnet/max
+  to Opus/medium with an explicit max-target override, and respecs the
+  default Codex model projection for the `opus` family.
+- `4a795875` (PR #138) fixes two production defects: an MCP allowed-root
+  policy false denial on realpath-canonicalized prefixes such as
+  `/private/tmp` on macOS, and an `ensure-task-workflow` bootstrap
+  write-order race where the resume packet could be written before the
+  current-status snapshot, failing `check-task-workflow --strict`'s
+  whole-second mtime comparison nondeterministically.
+- `8b506da4` (PR #139) lands the breaking `repo-harness adopt` removal:
+  `init` takes over repo-local adoption byte-for-byte, the former duplicate
+  global-bootstrap `init` block is removed, and `install` becomes the sole
+  global/host-level bootstrap entrypoint; this is the Breaking entry already
+  carried in the Unreleased changelog before this prep started.
+- `3c991466` (PR #140) fixes `acceptance-receipt`'s verification-evidence
+  fingerprint so it hashes through the existing `stableJson()` canonicalizer
+  instead of raw `JSON.stringify`, closing a key-order-sensitivity defect
+  between the evidence ledger's inline and blob storage paths that could
+  fail acceptance closed as stale with no semantic change.
+- `83792a81` (PR #141) makes `docs/reference-configs/` a generated
+  projection of the shipped `assets/reference-configs/` source, adds
+  `scripts/sync-reference-configs.ts --check/--write` wired into `check-ci`,
+  and replaces scattered duplicate test assertions with one inventory-driven
+  projection guard.
+- `a37c16e4` (PR #142) fixes `contract-worktree` cleanup so a squash-merged
+  branch is recognized as absorbed via an exact `git merge-tree`
+  tree-equality fallback instead of ancestry alone, closing a false-refusal
+  gap on this repo's own squash-merge ship flow.
+- `eb6c001c` (PR #143) extends #142: absorbed branches now delete with
+  `git branch -D` while plain ancestor merges still use `-d`, closing the
+  half-completed cleanup (worktree removed, branch left behind) that
+  unconditional `-d` caused on every squash-absorbed package.
+- Version sources and localized README projections are `0.12.0`; the
+  generated stamp is `repo-harness@0.12.0+template@0.12.0`.
+
+## Required Release Sequence
+
+- [ ] Merge the release-candidate changes to `main` without unrelated files.
+- [ ] Confirm all GitHub CI jobs are green for the merged source commit.
+- [ ] Run `bun run check:release` on that exact merged commit.
+- [ ] Publish `repo-harness@0.12.0` to the official npm registry with `latest`.
+- [ ] Create and push annotated tag `v0.12.0` at the published source commit.
+- [ ] Create stable GitHub Release `repo-harness 0.12.0` from `v0.12.0` with no
+      attached asset, matching the established release convention.
+- [ ] Run `bash scripts/check-release-published.sh 0.12.0` and verify registry,
+      dist-tag, tarball integrity, source tag, GitHub Release, and clean-room CLI.
+
+## Candidate Verification Record
+
+- Version consistency, strict workflow, contract, and full release gates are
+  recorded in `tasks/reviews/20260731-1626-release-0-12-0.review.md` before
+  the release candidate is merged.
+- Hosted CI, exact-main release gate, npm publication, annotated tag, GitHub
+  Release, and published-package readbacks remain mandatory release operations;
+  no unchecked item above is represented as completed by this source filing.
+
+## Rollback
+
+- Before npm publication: revert or abandon the single release-prep commit.
+- After npm publication: never move/reuse `v0.12.0`; correct forward with a new
+  patch release.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this skill are documented here.
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-07-31
+
+### Added
+
+- Adds `deep-worker` to the managed agent fleet (`.claude/agents/`,
+  `.codex/agents/`, `agents/fleet/`): an Opus/high-effort heavy execution
+  worker for cross-module refactors, tricky concurrency or state fixes, and
+  other hard changes that must land right in one pass.
+
 ### Changed
 
 - Breaking: `repo-harness adopt` is removed with no alias or compatibility
@@ -16,6 +25,41 @@ All notable changes to this skill are documented here.
   manifests keep rolling back unmodified: their frozen protocol-1
   `"command": "adopt"` literal is unchanged on disk, so
   `repo-harness init rollback --transaction <path>` still accepts them.
+- `fast-worker` moves from Sonnet at max effort to Opus at medium effort
+  with an explicit max-target override; the default Codex model projection
+  for the `opus` family is respecified accordingly, and pinned model
+  versions are dropped in favor of the effort-tier projection.
+- `docs/reference-configs/` is now a generated projection of the shipped
+  `assets/reference-configs/` source. `scripts/sync-reference-configs.ts
+  --check/--write` keeps all 23 mirrored pairs in sync and is wired into
+  `check-ci`; the README and reference-config test suites also drop
+  scattered duplicate assertions that never caught a regression, in favor
+  of one inventory-driven projection guard.
+
+### Fixed
+
+- MCP allowed-root policy no longer denies roots under an OS realpath
+  canonicalization prefix such as `/private/tmp` on macOS; only that
+  prefix is stripped before the `private/**` deny glob runs, so a genuine
+  `private`/`secrets`/`node_modules` segment elsewhere in the path still
+  denies.
+- `ensure-task-workflow`'s bootstrap now writes the resume packet after the
+  current-status snapshot instead of before, closing a same-second
+  write-order race that made `check-task-workflow --strict`'s whole-second
+  mtime comparison fail nondeterministically (1 of 12 idle runs before the
+  fix).
+- `acceptance-receipt`'s verification-evidence fingerprint now hashes
+  through the existing `stableJson()` canonicalizer instead of raw
+  `JSON.stringify`, so a semantics-preserving key-order difference between
+  the evidence ledger's inline (under the 8192-byte cap) and blob storage
+  paths for `checks/latest.json` no longer flips
+  `verification_evidence_sha256` and fails acceptance closed as stale.
+- `contract-worktree` cleanup now recognizes a squash-merged branch as
+  absorbed via an exact `git merge-tree` tree-equality fallback instead of
+  ancestry alone, and deletes absorbed branches with `git branch -D` while
+  still using `-d` for plain ancestor merges — closing the half-completed
+  cleanup (worktree removed, branch left behind) that unconditional `-d`
+  caused on every squash-absorbed package.
 
 ## [0.11.3] - 2026-07-29
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "repo-harness",
-  "version": "0.11.3",
+  "version": "0.12.0",
   "description": "Installs, migrates, audits, and repairs repo-local agentic development harnesses",
   "license": "MIT",
   "repository": {

--- a/plans/plan-20260731-1626-release-0-12-0.md
+++ b/plans/plan-20260731-1626-release-0-12-0.md
@@ -1,0 +1,147 @@
+# Plan: Release repo-harness 0.12.0
+
+> **Status**: Executing
+> **Created**: 20260731-1626
+> **Slug**: release-0-12-0
+> **Planning Source**: codex-plan-or-waza-think
+> **Orchestration Kind**: host-plan
+> **Source Ref**: (none)
+> **Artifact Level**: work-package
+> **Promotion Reason**: merge_boundary
+> **Verification Boundary**: Commands named in the captured planning output plus `repo-harness run verify-contract --contract tasks/contracts/20260731-1626-release-0-12-0.contract.md --strict`.
+> **Rollback Surface**: Before execution remove `plans/plan-20260731-1626-release-0-12-0.md`; after execution revert branch `codex/release-0-12-0` or the explicitly reviewed diff.
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260731-1626-release-0-12-0.contract.md`
+> **Task Review**: `tasks/reviews/20260731-1626-release-0-12-0.review.md`
+> **Implementation Notes**: `tasks/notes/20260731-1626-release-0-12-0.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from codex-plan-or-waza-think planning output.
+- Source ref: (none)
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260731-1626-release-0-12-0.md`
+- Sprint contract: `tasks/contracts/20260731-1626-release-0-12-0.contract.md`
+- Sprint review: `tasks/reviews/20260731-1626-release-0-12-0.review.md`
+- Implementation notes: `tasks/notes/20260731-1626-release-0-12-0.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260731-1626-release-0-12-0.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260731-1626-release-0-12-0.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260731-1626-release-0-12-0.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260731-1626-release-0-12-0.contract.md`
+- Review file: `tasks/reviews/20260731-1626-release-0-12-0.review.md`
+- Implementation notes file: `tasks/notes/20260731-1626-release-0-12-0.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260731-1626-release-0-12-0.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260731-1626-release-0-12-0.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: Before execution remove `plans/plan-20260731-1626-release-0-12-0.md`; after execution revert branch `codex/release-0-12-0` or the explicitly reviewed diff.
+- **Verification boundary**: Commands named in the captured planning output plus `repo-harness run verify-contract --contract tasks/contracts/20260731-1626-release-0-12-0.contract.md --strict`.
+- **Review/acceptance boundary**: `tasks/reviews/20260731-1626-release-0-12-0.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: merge_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260731-1626-release-0-12-0.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260731-1626-release-0-12-0.contract.md`, `tasks/reviews/20260731-1626-release-0-12-0.review.md`, and `tasks/notes/20260731-1626-release-0-12-0.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260731-1626-release-0-12-0.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: Before execution remove `plans/plan-20260731-1626-release-0-12-0.md`; after execution revert branch `codex/release-0-12-0` or the explicitly reviewed diff.
+
+## Captured Planning Output
+
+# Release repo-harness 0.12.0
+
+## Context
+
+v0.11.3(`095dcb06`)之後 main 累積了 #137(fleet deep-worker respec)與本輪六包(#138–#143):兩顆生產缺陷修復、adopt→init 破壞性語義對齊、receipt 指紋修復、投影收斂+測試簡化、cleanup 雙修。這些修復目前只在 main 和本機手裝 pre-release 上,下游 repo 與全局 runtime 都拿不到。用戶批准發正式 release。
+
+**版本決策:0.12.0**(非 0.11.4)。依據:CHANGELOG Unreleased 含明確標注 Breaking 的 CLI 指令移除(`adopt` 無 alias 移除),semver 0.x 慣例破壞性變更進 minor 位;patch 位裝 breaking 會誤導下游升級判斷。
+
+## 流程分工
+
+- **Phase A(本包 worker)**:release-prep——版本源、CHANGELOG、release filing,不跑長命令。
+- **Phase B(調度執行)**:merge 後的 release operations(CI 確認 → check:release → npm publish → tag → GitHub Release → published 讀回 → 全局 runtime 對齊)。照 0.11.3 filing 的 Required Release Sequence 逐項走。
+
+## Phase A — release-prep(worker 範圍)
+
+1. **版本源盤點與更新**:先跑 `bun src/cli/index.ts run check-skill-version` 找出全部版本源(已知至少:package.json、`.claude/.skill-version`、5 份 README 的版本戳、模板 stamp `repo-harness@X+template@X`;以檢查器輸出為準),全部 0.11.3 → 0.12.0。改完重跑檢查器須綠。
+2. **CHANGELOG**(`docs/CHANGELOG.md`):Unreleased → `## [0.12.0] - 2026-07-31`。既有 Breaking 條目保留;**補寫本輪未記帳的條目**(從 `git log v0.11.3..main --oneline` 派生,每個 squash PR 一條,按 Added/Changed/Fixed 歸類):
+   - #137 fleet:新增 deep-worker agent、Codex model projection respec
+   - #138 Fixed:MCP allowed-root 對 `/private/tmp` 等 realpath 前綴的誤殺;ensure-task-workflow 的 resume/current 寫入順序競態(strict check ~9% 假陽性)
+   - #140 Fixed:AcceptanceReceipt 證據指紋的 key-order 敏感性(8192B inline/blob 分岔)
+   - #141 Changed:docs/reference-configs 成為 assets 側的生成投影(sync-reference-configs --check/--write);測試套件冗餘清理
+   - #142/#143 Fixed:contract-worktree cleanup 認得 squash 吸收(merge 閘 + 分支刪除 `-D, absorbed`)
+   措辭精煉、事實準確,禁止誇飾;新 Unreleased 空段補回。
+3. **Release filing**:`deploy/release-checklists/260731-repo-harness-0.12.0.md`,照 260729-0.11.3 檔的結構——header(Package/Base release `v0.11.3`/Source range/Release scope 一段)、Candidate Evidence(六包各一短條,引 PR 號與 merge SHA)、Required Release Sequence(照抄 0.11.3 的七項,版本改 0.12.0,全部 unchecked)、Candidate Verification Record、Rollback(publish 前棄 prep commit;publish 後永不移 tag、只向前修)。
+4. **驗證(worker 只跑輕量)**:`bun run check:type`、`bun src/cli/index.ts run check-skill-version`、`bun test tests/readme-dx.test.ts`(localized 版本迴圈會驗 README 戳)。**不跑全量 bun test / check:release**——完成閘與 release gate 由調度統一跑(watchdog 教訓)。
+5. 單一 prep commit(`chore(release): prepare 0.12.0`),push。notes 記版本決策依據。
+
+## Phase B — release operations(調度,merge 後逐項)
+
+1. 完成閘(inline background)→ receipt → seal → PR `Ship codex/release-0-12-0` → CI 綠(**gate 在 CI 結果上,不搶跑**)→ squash merge → main CI 綠確認。
+2. `bun run check:release`(merged main 上,background)。
+3. `npm publish`(latest tag;先 `npm whoami` 驗證登入,未登入即停上報)。
+4. 註 annotated tag `v0.12.0` 於 published source commit,push tag。
+5. `gh release create v0.12.0`(stable,無附件,照慣例)。
+6. `bash scripts/check-release-published.sh 0.12.0` 全項讀回。
+7. 全局 runtime 對齊:`bun add -g repo-harness@0.12.0`(取代手裝 pre-release),驗證 `stableJson` 與 cleanup 修復都在;更新 filing 勾選項與 acceptance 記錄(照 0.11.3 的 `record acceptance` 後續 commit 模式);刪除記憶中的 pre-release 狀態條目。
+
+## 明確不做(EXECUTION_BOUNDARY)
+
+- 不動任何生產代碼/測試(純 release-prep;版本戳與文檔除外)。
+- 不在 worker 階段跑任何 >5 分鐘命令。
+- publish 前發現任何紅燈即停,絕不帶病發版;publish 後只向前修,永不動已發 tag。
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [ ] Execute captured plan: Release repo-harness 0.12.0

--- a/tasks/contracts/20260731-1626-release-0-12-0.contract.md
+++ b/tasks/contracts/20260731-1626-release-0-12-0.contract.md
@@ -1,0 +1,156 @@
+# Task Contract: release-0-12-0
+
+> **Status**: Active
+> **Plan**: plans/plan-20260731-1626-release-0-12-0.md
+> **Task Profile**: code-change
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: ancienttwo
+> **Capability ID**: root
+> **Last Updated**: 2026-07-31 16:26
+> **Review File**: `tasks/reviews/20260731-1626-release-0-12-0.review.md`
+> **Notes File**: `tasks/notes/20260731-1626-release-0-12-0.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+Everything since v0.11.3 — #137 plus this round's six packages (two production defect fixes, the breaking adopt→init cutover, the receipt fingerprint fix, projection convergence, cleanup repairs) — exists only on main and in a hand-built pre-release global install. Downstream repos cannot receive the fixes and the machine's global runtime is off-registry until an official release ships.
+
+## Goal
+
+A single release-prep commit that moves every version source to 0.12.0 (minor bump: the Unreleased changelog carries a Breaking CLI removal, which must not ship in a patch position), promotes Unreleased to `[0.12.0] - 2026-07-31` with accurate entries for all seven merged PRs (#137–#143), and files `deploy/release-checklists/260731-repo-harness-0.12.0.md` following the 0.11.3 filing structure with an unchecked Required Release Sequence. Publish/tag/GitHub-Release operations happen post-merge per that sequence and are NOT claimed by this prep.
+
+## Scope
+
+- In scope: version sources per `check-skill-version` (package.json, .claude/.skill-version, README x5 stamps, template stamp, and whatever else the checker names); docs/CHANGELOG.md promotion + missing entries; the release filing; notes.
+- Out of scope: any production code or test changes; running full `bun test` or `check:release` in the worker phase (coordinator runs the gates); npm publish, tag, GitHub Release (post-merge release operations).
+- Taste constraints: <!-- advisory only, no run gate; default style/taste lives in AGENTS.md and the minimal-change policy, use this to record a per-task override -->
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+
+## Falsifier
+
+If `check-skill-version` still reports any 0.11.3 source after the bump, or the changelog claims anything not derivable from `git log v0.11.3..main`, the prep is inconsistent or overstated. Cheapest proof point: re-run `bun src/cli/index.ts run check-skill-version` (must be green) and cross-check each changelog entry against its PR's squash commit message.
+
+## Root Cause Evidence
+
+Required when Task Profile is `bugfix`; leave as-is otherwise.
+
+- root_cause: one sentence naming file:line/condition (testable, not "a state issue").
+- repro: the command or UI path that reproduces the symptom.
+- regression_guard: path to a test that fails on the unfixed code and passes after the fix (must also appear under exit_criteria.tests_pass).
+- pre_fix_failure_artifact: path to a captured run of regression_guard on the UNFIXED code. Capture with `bun test <regression_guard> > <artifact> 2>&1; echo "PRE_FIX_EXIT=$?" >> <artifact>` (no pipes — pipes swallow the exit status). The gate requires a non-zero `PRE_FIX_EXIT=` line plus the regression_guard path string in the artifact (see the Root Cause Evidence Gate section in docs/reference-configs/sprint-contracts.md).
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260731-1626-release-0-12-0.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260731-1626-release-0-12-0.review.md`
+- Notes file: `tasks/notes/20260731-1626-release-0-12-0.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Acceptance Policy
+
+```json
+{"protocol":1,"reviewer":"Claude","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - docs/spec.md
+  - plans/
+  - tasks/todos.md
+  - tasks/contracts/20260731-1626-release-0-12-0.contract.md
+  - tasks/reviews/20260731-1626-release-0-12-0.review.md
+  - tasks/notes/20260731-1626-release-0-12-0.notes.md
+  - .ai/context/capabilities.json
+  - .claude/templates/
+  - .claude/.skill-version
+  - docs/CHANGELOG.md
+  - deploy/release-checklists/
+  - package.json
+  - README.md
+  - README.zh-CN.md
+  - README.fr.md
+  - README.ja.md
+  - README.es.md
+  - assets/
+  - tests/
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+      - codex-exec
+      - main-thread
+    fallback: main-thread
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - docs/spec.md
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260731-1626-release-0-12-0.notes.md
+  tests_pass:
+    - path: tests/readme-dx.test.ts
+  commands_succeed:
+    - bun run check:type
+    - bun src/cli/index.ts run check-skill-version
+```
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior:
+- Edge cases:
+- Regression risks:
+
+## Rollback Point
+
+- Commit / checkpoint: `eb6c001c` (main at worktree creation, branch `codex/release-0-12-0`)
+- Revert strategy: before npm publication, drop/revert the single prep commit; after publication, never move `v0.12.0` — correct forward with a new patch release (per filing rollback policy).

--- a/tasks/notes/20260731-1626-release-0-12-0.notes.md
+++ b/tasks/notes/20260731-1626-release-0-12-0.notes.md
@@ -9,17 +9,62 @@
 
 ## Design Decisions
 
-- ...
+- Version target is `0.12.0`, not `0.11.4`. Unreleased already carried an
+  explicit `Breaking:` entry (`repo-harness adopt` removed with no alias,
+  landed in PR #139) before this prep started. This repo's 0.x convention
+  moves a breaking change into the minor position rather than the patch
+  position — the same pattern `0.11.0` (skill-surface convergence) and
+  `0.11.1` (install-profile collapse) followed — so a patch bump here would
+  misrepresent the compatibility break to any downstream tooling that reads
+  semver to decide whether an upgrade is safe to auto-apply.
+- PR #137 (fleet respec) reads as internal agent-routing config, but it
+  ships through `assets/AGENTS.md`, `assets/CLAUDE.md`, and
+  `agents/fleet/*.md`, all of which project into downstream repos via
+  `repo-harness init`. It is therefore in-scope for the CHANGELOG like any
+  other shipped-surface change, not filtered out as "meta" tooling.
+- `assets/skill-version.json`'s `breakingChanges` array (despite the field
+  name, used as a one-line-per-version running history) got a new `0.12.0`
+  entry in addition to the `version`/`templateVersion` bump the plan's step
+  1 named explicitly. Every prior release back through `0.9.1` added an
+  entry here with no exception, so this follows established local
+  convention rather than widening scope; confirmed `check-skill-version`
+  does not itself validate this array, so the addition is additive, not
+  required for the checker to pass.
+- The `ensure-task-workflow` Fixed entry uses "1 of 12 idle runs" (the
+  exact figure in the PR #138 squash commit body and its notes file's
+  `IDLE inversions: 1 / 12` measurement) instead of the plan's own "~9%"
+  shorthand, to keep the entry literally traceable to the source commit
+  text per the contract's Falsifier rather than a rounded derivation.
 
 ## Deviations From Plan Or Spec
 
-- None recorded.
+- None beyond the two additive/wording notes above (skill-version.json
+  history entry; "1 of 12" vs "~9%" phrasing) — both stay inside the
+  plan's intent and the contract's allowed_paths.
 
 ## Tradeoffs Considered
 
 | Option | Decision | Reason |
 |--------|----------|--------|
-| ... | ... | ... |
+| Ship as `0.11.4` (patch) | Rejected | Unreleased already contains a `Breaking:` entry; a breaking CLI removal at a patch position misleads semver-based upgrade tooling downstream |
+| Ship as `0.12.0` (minor) | Chosen | Matches this repo's established 0.x convention for breaking changes (see `0.11.0`, `0.11.1` precedent) |
+| One CHANGELOG bullet per PR | Rejected | PR #137 adds a new agent (Added) and re-specs an existing one (Changed); PR #138 fixes two unrelated defects (both Fixed). Folding either into a single bullet would hide a distinct fact a downstream reader needs |
+| Split multi-fact PRs across bullets/sections | Chosen | Matches the `0.11.3`/PR #135 precedent, which split one PR across an Added bullet and three Fixed bullets |
+| Separate bullets for #142 and #143 | Rejected | #143 is a direct, same-day extension of #142's absorption predicate (branch-delete mode built on the same merge-tree check); one combined Fixed bullet avoids describing the same defect twice |
+
+## CHANGELOG Entry Derivation (PR -> Entry)
+
+| PR | Merge SHA | Section | Entry summary |
+|----|-----------|---------|----------------|
+| #137 | `bd2155da` | Added | `deep-worker` joins the managed agent fleet |
+| #137 | `bd2155da` | Changed | `fast-worker` Sonnet/max -> Opus/medium; `opus` family Codex projection respec |
+| #138 | `4a795875` | Fixed | MCP allowed-root realpath-canonicalization false denial (`/private/tmp`) |
+| #138 | `4a795875` | Fixed | `ensure-task-workflow` resume/current write-order race (strict check false positive) |
+| #139 | `8b506da4` | Changed | Covered by the pre-existing `Breaking:` Unreleased entry, carried forward verbatim (no new bullet) |
+| #140 | `3c991466` | Fixed | `acceptance-receipt` verification-evidence fingerprint key-order normalization |
+| #141 | `83792a81` | Changed | `docs/reference-configs` generated projection of `assets/reference-configs` + test-suite dedup |
+| #142 | `a37c16e4` | Fixed | `contract-worktree` cleanup squash-merge absorption detection (`git merge-tree` fallback) |
+| #143 | `eb6c001c` | Fixed | `contract-worktree` absorbed-branch deletion mode (`-D` vs `-d`) — same bullet as #142 |
 
 ## Open Questions
 

--- a/tasks/notes/20260731-1626-release-0-12-0.notes.md
+++ b/tasks/notes/20260731-1626-release-0-12-0.notes.md
@@ -1,0 +1,41 @@
+# Implementation Notes: release-0-12-0
+
+> **Status**: Active
+> **Plan**: plans/plan-20260731-1626-release-0-12-0.md
+> **Contract**: tasks/contracts/20260731-1626-release-0-12-0.contract.md
+> **Review**: tasks/reviews/20260731-1626-release-0-12-0.review.md
+> **Last Updated**: 2026-07-31 16:26
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- ...
+
+## Deviations From Plan Or Spec
+
+- None recorded.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| ... | ... | ... |
+
+## Open Questions
+
+- None.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/reviews/20260731-1626-release-0-12-0.review.md
+++ b/tasks/reviews/20260731-1626-release-0-12-0.review.md
@@ -1,0 +1,84 @@
+# Task Review: release-0-12-0
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260731-1626-release-0-12-0.md
+> **Contract**: tasks/contracts/20260731-1626-release-0-12-0.contract.md
+> **Notes File**: tasks/notes/20260731-1626-release-0-12-0.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-07-31 16:26
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Commands passed:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+- Waza `/check` run:
+- Commands run:
+- Manual checks:
+- Supporting artifacts:
+- Implementation notes reviewed:
+- Run snapshot:
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...

--- a/tasks/reviews/20260731-1626-release-0-12-0.review.md
+++ b/tasks/reviews/20260731-1626-release-0-12-0.review.md
@@ -40,17 +40,17 @@
 
 ## Acceptance Receipt Projection
 
-> **Disposition**: unavailable
-> **Reviewer**: unavailable
-> **Source**: unavailable
+> **Disposition**: external_pass
+> **Reviewer**: Claude
+> **Source**: claude-review
 > **Actor**: not-applicable
-> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject SHA256**: sha256:56f67e57717d1e02f646e0d84a49190e88a182d2a23466ebdaadb0e05c540b25
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: pending
-> **Verification Evidence SHA256**: pending
-> **Issued At**: pending
+> **Reviewed Target Revision**: eb6c001c86512ad2d164a92b3b5fa02fa80581da
+> **Verification Evidence SHA256**: sha256:ff736a699239f6a701ad9c0d8edc90c94d5f6b9839cf39a6432952ce55a0f796
+> **Issued At**: 2026-07-31T09:02:22.226Z
 
-- Summary: No AcceptanceReceipt has been recorded.
+- Summary: Gatekeeper PASS: version sources complete, changelog entries verified against squash commits, filing per 0.11.3 template with all release-sequence items unchecked
 - Findings: none
 
 ## Behavior Diff Notes

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -1,7 +1,7 @@
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: 2026-07-31 10:56
+> **Updated**: 2026-07-31 16:26
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.


### PR DESCRIPTION
Release prep for repo-harness 0.12.0 (minor bump: the changelog carries the breaking adopt-to-init CLI cutover).

Scope v0.11.3..main: fleet deep-worker respec (#137), MCP allowed-root canonicalization + bootstrap write-order fixes (#138), adopt-to-init semantic alignment (#139), acceptance-receipt fingerprint normalization (#140), reference-configs projection convergence (#141), contract-worktree squash-aware cleanup (#142/#143).

All version sources at 0.12.0, changelog entries verified against squash commits, release filing with unchecked publish sequence. Publish/tag/GitHub Release follow the filing after merge.