### PR TITLE
Ship codex/readme-codegraph-restructure

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -1,200 +1,50 @@
+<div align="center">
+
 # repo-harness
 
-`repo-harness` convierte las sesiones de programación con Claude/Codex en un
-workflow repo-local repetible. Incluye un CLI y hooks de skill/runtime que
-escriben contexto, planes, handoffs, checks y evidencias de review dentro del
-proyecto, para que la siguiente sesión de agente continúe desde archivos y no
-desde el historial de chat.
+### Un flujo de trabajo repetible y basado en archivos para sesiones de programación con Claude y Codex
 
-Úsalo para:
+<img src="docs/images/repo-harness-hook-carrot.png" alt="hooks de repo-harness guiando a Codex y Claude hacia adelante con estado de workflow repo-local" width="900">
 
-- adoptar un repositorio existente con un contrato de agente tasks-first
-- mantener Claude y Codex alineados sobre los mismos planes, checks, handoffs y
-  límites de contexto
-- gastar menos tokens redescubriendo estructura gracias a CodeGraph y la carga
-  progresiva de contexto
-
-Entrega al agente un PRD o Sprint completo; después, tu bucle es solo review and
-`next`, o iniciar `/goal` y quedar AFK.
+[![npm version](https://img.shields.io/npm/v/repo-harness.svg)](https://www.npmjs.com/package/repo-harness)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Runtime: Bun](https://img.shields.io/badge/runtime-Bun%20%E2%89%A5%201.1.35-black.svg)](https://bun.sh)
 
 [English](README.md) | [简体中文](README.zh-CN.md) | [日本語](README.ja.md) | [Français](README.fr.md) | [Español](README.es.md)
 
-Dirección del repositorio: `https://github.com/Ancienttwo/repo-harness`
+**Dale al agente un PRD o Sprint completo; después, tu bucle es solo revisar y `next`, o inicia `/goal` y ponte AFK.**
 
-## Por qué usar repo-harness
+</div>
 
-- **El estado de la sesión vive en archivos, no en el historial de chat.** Las
-  distintas sesiones de agente —Claude, Codex, ahora o más tarde— se mantienen
-  sincronizadas a través del repositorio en lugar de un hilo de chat. Cuando
-  arranca una sesión nueva, el session-context builder in-process
-  (`src/cli/hook/session-context.ts`) inyecta el
-  resume packet de la sesión anterior (`.ai/harness/handoff/resume.md`,
-  `tasks/current.md`); al terminar la sesión y tras cada edición,
-  los typed handlers `session-context`, `stop` y `mutation-observed` escriben de vuelta el siguiente
-  handoff. Una tarea puede cortarse a mitad de camino y la siguiente sesión
-  retoma directamente el next step exacto, los puntos de bloqueo y los archivos
-  modificados sin tener que volver a inferirlos.
-- **Ahorra tokens por diseño.** En lugar de los bucles grep+read que reescanean
-  el repositorio en cada sesión, el harness usa el índice pre-construido de
-  CodeGraph para hacer consultas estructurales (quién llama, a qué llama, dónde
-  está definido) y, además, carga de contexto progresiva mediante
-  `.ai/context/context-map.json` y `capabilities.json`: un root context pequeño y
-  estable (~12KB), más bloques de capability que solo se cargan cuando los
-  archivos que tocas los necesitan. Un agente lee un contract de capability de
-  1KB o consulta el índice, en vez de gastar miles de tokens redescubriendo la
-  estructura.
+`repo-harness` distribuye un CLI junto con hooks de skill/runtime que escriben
+contexto, planes, handoffs, checks y evidencia de review de vuelta en el
+proyecto, de modo que la siguiente sesión de agente continúa desde archivos en
+lugar del historial de chat. Adopta un repositorio existente con un contract
+de agente tasks-first que mantiene alineados a Claude y Codex.
 
-En un repositorio adoptado, la superficie se mantiene pequeña:
+## Índice
 
-| Surface | Propósito |
-| --- | --- |
-| `docs/spec.md` y `docs/reference-configs/` | Estándares compartidos e intención de producto estable que cada sesión de agente puede leer. |
-| `plans/`, `plans/prds/` y `plans/sprints/` | Work packages decision-complete antes de empezar la implementación. |
-| `tasks/contracts/`, `tasks/reviews/` y `.ai/harness/checks/` | Scope, verificación y evidencia de review para probar que el trabajo terminó. |
-| `.ai/harness/handoff/` y `tasks/current.md` | Session journal y estado resumible, derivados de workflow artifacts en vez de chat memory. |
+- [Primeros pasos](#primeros-pasos)
+- [Por qué usar repo-harness](#por-qué-usar-repo-harness)
+- [Características clave](#características-clave)
+- [Cómo funciona](#cómo-funciona)
+- [Flujo de trabajo de tareas](#flujo-de-trabajo-de-tareas)
+- [Hooks](#hooks)
+- [Conector MCP](#conector-mcp)
+- [Revisión del trabajo](#revisión-del-trabajo)
+- [Skills](#skills)
+- [Referencia para mantenedores](#referencia-para-mantenedores)
+- [Agradecimientos](#agradecimientos)
+- [Versión actual](#versión-actual)
+- [Licencia](#licencia)
 
-## Human Review Path
+## Primeros pasos
 
-Empieza por `tasks/reviews/<task>.review.md`. La `## Human Review Card` es la
-superficie de decisión de una sola pantalla: verdict, change type, archivos
-previstos vs reales, comandos que pasaron, external acceptance, riesgo residual,
-acción del reviewer y rollback. Luego inspecciona el contract activo, el último
-trace en `.ai/harness/checks/latest.json` y los archivos modificados. Acepta solo
-cuando la review recomiende pass, el verdict de la card sea pass y el external
-acceptance sea pass, `not_required` o un manual override explícito.
+### 1. Instalar el CLI
 
-## Agent Tracking Path
-
-Los agentes leen los source artifacts antes que los resúmenes derivados:
-
-| Agent reads first | Human reviews first |
-| --- | --- |
-| Prompt actual del usuario y archivos referenciados | Human Review Card de `tasks/reviews/<task>.review.md` |
-| `AGENTS.md` / `CLAUDE.md` | Archivos modificados y diff |
-| Plan activo en `.ai/harness/active-plan` | Allowed paths y exit criteria del contract activo |
-| Contract activo en `tasks/contracts/` | `.ai/harness/checks/latest.json` y run trace |
-| Último handoff en `.ai/harness/handoff/` | Riesgos residuales y rollback |
-
-`tasks/current.md` es solo un snapshot de orientación. Si discrepa del plan
-activo, el contract, la review, los checks o el handoff, ganan los source
-artifacts.
-
-## Novedades
-
-Las notas de versión viven en [`docs/CHANGELOG.md`](docs/CHANGELOG.md). La línea
-actual es `0.12.0`.
-
-## Cómo funciona
-
-En conjunto hay tres capas y un único runtime typed para host events:
-
-1. **Capa del paquete fuente**: este repositorio mantiene la CLI, los command
-   skill facades, los templates, los hook assets, el workflow contract, los tests
-   y el release gate.
-2. **Capa del contract del repositorio objetivo**: `repo-harness init` o la
-   migración escribe `docs/spec.md`, `plans/`, `tasks/`, `.ai/context/`,
-   `.ai/harness/` y helper scripts. `.ai/hooks/lib/workflow-state.sh` es solo
-   una proyección de operator helper.
-3. **Capa del host adapter**: el `~/.claude/settings.json` y el
-   `~/.codex/hooks.json` a nivel de usuario enrutan los events de Claude/Codex
-   hacia `repo-harness-hook`. Tras validar `.ai/harness/workflow-contract.json`,
-   el route registry usa `event + routeId + matcher` para invocar exactamente un
-   typed handler.
-
-Todos los events siguen `host adapter -> repo-harness-hook -> route registry ->
-typed handler`. `UserPromptSubmit.default` usa `prompt`; edit/bash/stop usan
-`mutation-observed`, `command-observed` y `stop`. No existe un segundo shell
-dispatcher ni un runtime distinto por provider.
-
-El invariante central: los hechos persistentes viven en el repositorio, no en la
-ventana de chat. Los typed handlers son solo aceleradores y guardrails; la verdadera
-authority son los archivos de plan, contract, review, checks y handoff.
-
-## Task Workflow: de Plan a Closeout
-
-El diagrama de abajo asume que el harness ya está instalado en el repositorio
-objetivo. Muestra el ciclo cerrado normal de una sola tarea: primero se forma un
-plan, luego se proyecta al sprint contract, cuando hace falta se hace checkout de
-un worktree aislado, se implementa bajo la protección de los hooks, y después se
-verifica, se hace review, external acceptance y, por último, closeout.
-
-```mermaid
-flowchart TD
-  UserTask["Tarea de usuario o planning prompt"] --> Discovery["Investigación previa<br/>P1 map, P2 trace, P3 decision"]
-  Discovery --> PlanDraft["Draft plan<br/>plans/plan-*.md"]
-  PlanDraft --> PlanReview{"¿El plan es ejecutable?"}
-  PlanReview -->|no| Refine["Converger scope y evidence contract"]
-  Refine --> PlanDraft
-  PlanReview -->|sí| Approve["Approved plan<br/>Status: Approved"]
-
-  Approve --> Project["Proyectar a la superficie de ejecución<br/>capture-plan.sh --execute<br/>o plan-to-todo.sh --plan"]
-  Project --> Active["Active markers<br/>.ai/harness/active-plan<br/>.ai/harness/active-worktree"]
-  Project --> Contract["Sprint contract<br/>tasks/contracts/YYYYMMDD-HHMM-task-slug.contract.md"]
-  Project --> ReviewFile["Review file<br/>tasks/reviews/YYYYMMDD-HHMM-task-slug.review.md"]
-  Project --> Notes["Task notes<br/>tasks/notes/YYYYMMDD-HHMM-task-slug.notes.md"]
-
-  Contract --> WorktreePolicy{"¿Se necesita un contract worktree?"}
-  WorktreePolicy -->|sí| Checkout["Checkout de worktree aislado<br/>contract-worktree.sh start --plan<br/>branch codex/task-slug"]
-  WorktreePolicy -->|no| CurrentTree["Usar el worktree actual<br/>tarea pequeña o slice explícitamente permitido"]
-  Checkout --> Implement
-  CurrentTree --> Implement
-
-  Implement["Editar y ejecutar comandos"] --> PreHooks["Pre-edit guards<br/>PlanStatusGuard, ContractScopeGuard, WorktreeGuard"]
-  PreHooks -->|blocked| ScopeFix["Corregir plan, contract, worktree o scope"]
-  ScopeFix --> Implement
-  PreHooks -->|allowed| Changes["Cambios de código, docs, tests o configuración"]
-  Changes --> PostHooks["Post-edit / post-bash hooks<br/>trace, drift request, handoff, check evidence"]
-  PostHooks --> Verify["Ejecutar verificación<br/>tests plus repo workflow checks"]
-
-  Verify --> Checks["Evidence estructurada<br/>.ai/harness/checks/latest.json<br/>.ai/harness/runs/*.json"]
-  Checks --> CheckReview["Evaluator review<br/>Waza /check -> review file"]
-  CheckReview --> External["External acceptance advice<br/>o manual override explícito"]
-  External --> DoneGate{"¿Pasan contract, checks, review y acceptance?"}
-  DoneGate -->|no| Repair["Reparar la evidence fallida o la implementación"]
-  Repair --> Implement
-  DoneGate -->|sí| Closeout["Closeout<br/>scripts/contract-worktree.sh finish"]
-
-  Closeout --> Commit["Commit del contract branch"]
-  Commit --> Merge["Fast-forward del target branch"]
-  Merge --> Archive["Archivar plan/todo y refrescar el handoff"]
-  Archive --> Cleanup["Limpiar el worktree ya fusionado<br/>contract-worktree.sh cleanup"]
-  Cleanup --> Done["Tarea completada y auditable"]
-```
-
-## Bucles largos de producto
-
-Para trabajo Greenfield y Brownfield, adelanta la discovery y el juicio de
-engineering plan en el parent agent antes de pedirle a Codex que haga loops de
-ejecución:
-
-1. Antes de crear un contract, el parent agent invoca `geju` para abrir el marco y
-   después completa P1/P2/P3 con sus propias capacidades repo/runtime. Fija la
-   intención de producto, la arquitectura, los riesgos, el falsifier y el evidence
-   contract aceptados en los development documents.
-2. Convierte esos documentos en un PRD Sprint bajo `plans/prds/`, con un
-   backlog ordenado y sub-plans detallados para cada execution slice.
-3. Crea un Codex Goal que apunte a ese archivo de sprint. repo-harness puede
-   entonces proyectar cada sprint item por el flow normal plan -> contract ->
-   worktree -> verification.
-
-Ese handoff mantiene precisos los loops largos: el parent agent se ocupa del juicio
-amplio al inicio, el PRD Sprint es la durable source of truth, y Codex Goal mode
-retoma contra un sprint concreto en vez de reinterpretar el chat original.
-
-## Primeros 5 minutos
-
-Esta es la ruta más rápida para evaluar si un repositorio real es apto para
-adoptar este workflow.
-
-Prerrequisitos: un Git working tree, `bash` y `bun` (para la verificación
-posterior y el template assembly). `jq` es opcional para `--dry-run`, pero se
-recomienda al aplicar el settings merge.
-
-### Instalar el CLI
-
-La ruta por defecto no requiere Node.js: el instalador usa Bun >= 1.1.35 como
-runtime. Si Bun no existe o es anterior, lo instala o actualiza antes de
-instalar el CLI `repo-harness`.
+Prerrequisitos: un Git working tree, `bash` y `bun`; `jq` es opcional. No se
+necesita Node.js — el instalador usa Bun >= 1.1.35 como runtime, instalando o
+actualizando Bun primero si hace falta.
 
 ```bash
 # macOS / Linux
@@ -204,431 +54,423 @@ curl -fsSL https://raw.githubusercontent.com/Ancienttwo/repo-harness/main/instal
 irm https://raw.githubusercontent.com/Ancienttwo/repo-harness/main/install.ps1 | iex
 ```
 
-<details>
-<summary>¿Ya tienes Bun >= 1.1.35? Usa Bun primero, o npx como fallback</summary>
+Si ya tienes Bun >= 1.1.35 en el PATH, omite el instalador de shell. Las
+instalaciones de Bun gestionadas por un gestor de paquetes fallan de forma
+cerrada (fail closed) con el comando de actualización correspondiente
+(`brew upgrade bun`), en lugar de sobrescribir archivos que pertenecen a ese
+gestor.
 
 ```bash
-# Bun (recomendado)
-bun add -g repo-harness
+bunx repo-harness@latest install     # Bun one-shot bootstrap
+bun add -g repo-harness              # or install the persistent CLI first
 repo-harness install
-
-# Fallback con npx, con Bun ya en PATH porque el CLI corre sobre Bun
-npx -y repo-harness@latest install
+npx -y repo-harness@latest install   # npx fallback; the CLI still runs on Bun
 ```
 
-</details>
-
-### Bootstrap del runtime del host
+### 2. Bootstrap del runtime del host
 
 ```bash
 repo-harness install
 ```
 
-`repo-harness install` es el bootstrap global, `repo-harness update` es el refresco
-user-level y `repo-harness init` es el refresco repo-local. `repo-harness install`
-configura el CLI, los hook adapters de nivel usuario, Waza, Mermaid, el brain
-root y CodeGraph MCP; el viejo camino Claude plugin `scripts/setup-plugins.sh`
-queda retirado.
+El bootstrap global: instala el paquete npm como CLI global, refresca los
+alias de skill de repo-harness, instala los hook adapters a nivel de usuario,
+y registra un profile de instalación explícito. Es idempotente y no aplica
+archivos de workflow repo-local al directorio actual. `--dry-run --json` lista
+primero los componentes a instalar, omitir y eliminar. Profiles, modo de
+delegación, comandos de refresco, y la auditoría de solo lectura
+`setup check`: [`install-profiles.md`](docs/reference-configs/install-profiles.md).
 
-### Empieza por aquí
-
-En un repositorio existente, ejecuta desde el repo root:
+### 3. Vista previa del contract repo-local
 
 ```bash
 repo-harness init --dry-run
 ```
 
-Aplica solo después de que el reporte del dry-run sea correcto:
+Ejecuta esto desde la raíz del repositorio objetivo. Reporta las
+especificaciones, el estado de tareas, el helper runtime, el hook adapter de
+destino y los archivos de verificación que se crearían o refrescarían. Nunca
+crea un application stack; los proyectos y módulos nuevos usan en su lugar el
+scaffold mode de `repo-harness-setup`.
+
+### 4. Aplicar y verificar
 
 ```bash
 repo-harness init
-```
-
-Para un proyecto o módulo nuevo, usa el modo scaffold de `repo-harness-setup`.
-Para un repositorio existente, usa `repo-harness init`; este instala o refresca
-el harness y no crea el stack tecnológico de la aplicación.
-
-### Cómo se ve el éxito
-
-El comando debería terminar imprimiendo `=== Migration Report ===`, e incluir:
-
-- `Project hooks synced from:`: de dónde proviene el comportamiento de los hooks generados
-- `Host hook config target: user-level ~/.claude/settings.json and ~/.codex/hooks.json`: dónde está la capa del adapter
-- `Host hook adapters are user-level:`: recordatorio de instalar los global adapters y de confiar en `~/.codex/hooks.json`
-- `Workflow migration:`: el plan de creación o refresco de las repo-local harness surfaces
-- `Helper runtime:`: la cadena de herramientas operativa que obtendrás tras aplicar
-- `--- External Tooling ---`: la guía de planning parent/Geju, la readiness de Waza y CodeGraph y las advisory de instalación/actualización
-
-### Los dos comandos siguientes
-
-```bash
 bash scripts/check-task-workflow.sh --strict
 bun test
 ```
 
-Si la salida del dry-run no es correcta, detente aquí primero y lee
+### Así se ve el éxito
+
+Aplicar termina con `=== Migration Report ===`, indicando de dónde viene el
+comportamiento de hooks generado, el destino del adapter a nivel de usuario
+(`~/.claude/settings.json` y `~/.codex/hooks.json`), las superficies
+repo-local creadas o refrescadas, el helper runtime `.ai/harness/scripts/*`, y
+un bloque de readiness `--- External Tooling ---`. La intención estable vive
+entonces en `docs/spec.md`, el estado de ejecución en `plans/` y `tasks/`, y
+el estado de resume en `.ai/harness/handoff/`. Si el dry run se ve mal,
+detente y lee primero
+[`hook-operations.md`](docs/reference-configs/hook-operations.md).
+
+### Actualizar y desinstalar
+
+```bash
+repo-harness update          # refresh user-level CLI and runtime pieces
+repo-harness update --check  # read-only repair guidance, no writes
+repo-harness uninstall       # remove managed host adapters only
+```
+
+## Por qué usar repo-harness
+
+- **Sesiones respaldadas por archivos, no por historial de chat.** Las
+  sesiones separadas de Claude y Codex se mantienen coordinadas a través del
+  repositorio. `SessionStart` inyecta el resume packet de la sesión anterior,
+  `Stop` escribe el handoff, y cada edición registra un pequeño evento de
+  bitácora. Una sesión puede terminar a mitad de tarea, y la siguiente retoma
+  exactamente el próximo paso, los blockers y los archivos modificados, sin
+  tener que volver a inferirlos.
+- **Ahorro de tokens por diseño.** En lugar de bucles de grep-and-read que
+  reescanean el repositorio en cada sesión, el harness se apoya en un índice
+  de CodeGraph pre-construido para consultas estructurales y en carga de
+  contexto progresiva: un root context estable de ~12KB más bloques de
+  capability que solo se cargan cuando los archivos que tocas los necesitan.
+  Un agente lee un capability contract de ~1KB en vez de redescubrir la
+  estructura.
+- **Evidencia lista para review.** Cada tarea deja atrás un contract,
+  evidencia de check estructurada y una review card. La superficie de
+  decisión humana cabe en una sola pantalla — verdict, archivos previstos vs
+  reales, comandos que pasaron, riesgo residual, rollback — en lugar de una
+  reconstrucción de lo que el agente afirma haber hecho.
+
+En un repositorio adoptado, la superficie se mantiene intencionalmente
+pequeña:
+
+| Superficie | Propósito |
+| --- | --- |
+| `docs/spec.md` y `docs/reference-configs/` | Estándares compartidos e intención de producto estable que toda sesión de agente puede leer. |
+| `plans/`, `plans/prds/`, y `plans/sprints/` | Work packages decision-complete antes de empezar la implementación. |
+| `tasks/contracts/`, `tasks/reviews/`, y `.ai/harness/checks/` | Alcance, verificación y evidencia de review para demostrar que el trabajo está terminado. |
+| `.ai/harness/handoff/` y `tasks/current.md` | Bitácora de la sesión y estado resumible, derivados de artefactos de workflow en lugar de historial de chat. |
+
+## Características clave
+
+| | |
+| --- | --- |
+| **Sesiones respaldadas por archivos** | Plans, contracts, checks y handoffs viven en el repositorio, de modo que una sesión nueva retoma desde artefactos en vez de un hilo de chat |
+| **Typed hook runtime** | Ocho managed routes compartidas, más tres delegation routes exclusivas de Codex, cada una atada a exactamente un typed handler in-process, con guards fail-closed en el límite de edición |
+| **Plan → Contract → Review** | Un solo ciclo de vida desde el plan aprobado hasta el contract proyectado, el worktree aislado, la evidencia estructurada y un closeout revisable |
+| **Carga de contexto progresiva** | Un root context estable de ~12KB más capability contracts de ~1KB que solo se cargan para los archivos que realmente se están tocando |
+| **Integración con CodeGraph** | Consultas estructurales (callers, callees, definitions) respondidas desde un índice pre-construido en vez de pasadas repetidas de grep-and-read |
+| **MCP planner sidecar** | ChatGPT lee el estado real del repositorio y escribe artefactos de PRD/Sprint/Goal; Codex los ejecuta, sin acceso de escritura al código fuente por defecto |
+| **Alineación Claude + Codex** | Un solo adapter contract a nivel de usuario, un solo workflow contract, y un solo conjunto de artefactos repo-local compartidos por ambos hosts |
+
+## Cómo funciona
+
+1. **Paquete fuente**: este repositorio posee el CLI, los command facades,
+   los templates, los typed hook handlers, el operator-helper asset, el
+   workflow contract, los tests y el release gate.
+2. **Contract del repositorio objetivo**: `repo-harness init` o la migración
+   escribe archivos repo-local como `docs/spec.md`, `plans/`, `tasks/`,
+   `.ai/context/`, `.ai/harness/`, helper scripts y `.ai/hooks/`.
+3. **Adapters del host**: a nivel de usuario, `~/.claude/settings.json` y
+   `~/.codex/hooks.json` enrutan los events de Claude/Codex hacia
+   `repo-harness-hook`.
+
+El hook entrypoint termina en silencio para repos que no han hecho opt-in.
+Para repos con opt-in, el route registry ata el event tuple público a
+exactamente un typed handler empaquetado. `.ai/hooks/` solo contiene la
+proyección de operator-helper; nunca es un host-event dispatcher.
+
+El invariante central es que la verdad durable vive en el repositorio, no en
+un hilo de chat. Los hooks son aceleradores y guardrails; la autoridad sigue
+siendo los artefactos file-backed de plan, contract, review, checks y
+handoff. Los gates de plan/spec/contract en la capa de prompt son advisory
+routing; el enforcement estricto vive en el límite de edición. Los internals
+del handler, la superficie de minimal-change y los policy modes:
+[`hook-operations.md`](docs/reference-configs/hook-operations.md) y
+[`minimal-change-hooks.md`](docs/reference-configs/minimal-change-hooks.md).
+
+## Flujo de trabajo de tareas
+
+El diagrama asume que el harness ya está instalado. Muestra el ciclo de vida
+normal desde un sprint backlog de programa hasta una sola contract task:
+seleccionar la tarea, proyectarla en archivos de ejecución, hacer checkout
+del contract worktree cuando la política lo exige, implementar bajo los
+hooks, verificar, hacer review y cerrar (closeout).
+
+```mermaid
+flowchart TD
+  Program["Program goal or release theme"] --> Sprint{"Sprint layer needed?"}
+  Sprint -->|yes| PRD["Upper-layer PRD<br/>plans/prds/*.prd.md"]
+  PRD --> SprintDoc["Sprint backlog<br/>plans/sprints/*.sprint.md"]
+  SprintDoc --> NextTask["Select next sprint task<br/>sprint-backlog.sh next"]
+  Sprint -->|no| UserTask["User task or planning prompt"]
+  Heartbeat["Heartbeat triage<br/>scripts/heartbeat-triage.sh<br/>.ai/harness/triage/"] --> UserTask
+  NextTask --> UserTask
+
+  UserTask --> Discovery["Due diligence<br/>P1 map, P2 trace, P3 decision"]
+  Discovery --> LoopEvidence["Loop evidence when routing changes<br/>state-snapshot --json<br/>route-nl-vs-ts / cutover gate"]
+  LoopEvidence --> PlanDraft["Draft plan<br/>plans/plan-*.md"]
+  PlanDraft --> PlanReview{"Plan ready for execution?"}
+  PlanReview -->|no| Refine["Refine plan, scope, evidence contract"]
+  Refine --> PlanDraft
+  PlanReview -->|yes| Approve["Approved plan<br/>Status: Approved"]
+
+  Approve --> Project["Project plan into execution<br/>capture-plan.sh --execute<br/>or plan-to-todo.sh --plan"]
+  Project --> Active["Active markers<br/>.ai/harness/active-plan<br/>.ai/harness/active-worktree"]
+  Project --> SprintActive["Sprint projection<br/>active-sprint marker<br/>tasks/current.md"]
+  Project --> Contract["Sprint contract<br/>tasks/contracts/YYYYMMDD-HHMM-task-slug.contract.md"]
+  Project --> ReviewFile["Review file<br/>tasks/reviews/YYYYMMDD-HHMM-task-slug.review.md"]
+  Project --> Notes["Task notes<br/>tasks/notes/YYYYMMDD-HHMM-task-slug.notes.md"]
+
+  Contract --> Delegation["Delegation contract<br/>budget / permission_scope / roles"]
+  Delegation --> Delegate{"Use contract-run delegation?"}
+  Delegate -->|yes| ContractRun["Worker/verifier child run<br/>scripts/contract-run.ts"]
+  Delegate -->|no| WorktreePolicy{"Contract worktree required?"}
+  WorktreePolicy -->|yes| Checkout["Checkout isolated worktree<br/>contract-worktree.sh start --plan<br/>branch codex/task-slug"]
+  WorktreePolicy -->|no| CurrentTree["Use current worktree<br/>small or explicitly allowed slice"]
+  Checkout --> Implement
+  CurrentTree --> Implement
+  ContractRun --> Changes
+
+  Implement["Edit and run commands"] --> PreHooks["Pre-edit guards<br/>PlanStatusGuard, ContractScopeGuard, WorktreeGuard"]
+  PreHooks -->|blocked| ScopeFix["Fix plan, contract, worktree, or scope"]
+  ScopeFix --> Implement
+  PreHooks -->|allowed| Changes["Code, docs, tests, or config changes"]
+  Changes --> PostHooks["Post-edit and post-bash hooks<br/>trace, drift request, handoff, check evidence"]
+  PostHooks --> ArchQueue["Architecture queue<br/>architecture-queue.sh record/reindex<br/>check-architecture-sync.sh"]
+  ArchQueue --> Verify["Run verification<br/>tests plus repo workflow checks"]
+
+  Verify --> Checks["Structured evidence<br/>.ai/harness/checks/latest.json<br/>.ai/harness/runs/*.json"]
+  Checks --> CheckReview["Evaluator review<br/>Waza /check -> review file"]
+  CheckReview --> External["External acceptance advice<br/>or explicit manual override"]
+  External --> DoneGate{"Contract, checks, review, and acceptance pass?"}
+  DoneGate -->|no| Repair["Repair failing evidence or implementation"]
+  Repair --> Implement
+  DoneGate -->|yes| SprintComplete{"Sprint task active?"}
+  SprintComplete -->|yes| MarkSprint["Mark backlog item complete<br/>sprint-backlog.sh complete-task"]
+  SprintComplete -->|no| Closeout["Closeout<br/>scripts/contract-worktree.sh finish"]
+  MarkSprint --> Closeout
+
+  Closeout --> Commit["Commit contract branch"]
+  Commit --> Merge["Fast-forward target branch"]
+  Merge --> Archive["Archive plan/todo and refresh handoff"]
+  Archive --> Cleanup["Cleanup merged worktree<br/>contract-worktree.sh cleanup"]
+  Cleanup --> Done["Reviewable completed task"]
+```
+
+Para los loops de producto de larga duración, mantén el discovery y el
+juicio de engineering-plan con el agente padre antes de que Codex haga loops
+de ejecución: `geju` abre el pre-contract frame, el agente padre completa
+P1/P2/P3 y congela la dirección aceptada en un PRD de upper-layer bajo
+`plans/prds/` y un sprint backlog ordenado bajo `plans/sprints/`, luego un
+Codex Goal apunta a ese archivo de sprint. El PRD sigue siendo la fuente de
+verdad superior y el backlog es la cola de ejecución durable, de modo que una
+sesión de Goal reanudada nunca reinterpreta el chat original. Ver
+[`agentic-development-flow.md`](docs/reference-configs/agentic-development-flow.md)
+y [`workflow-orchestration.md`](docs/reference-configs/workflow-orchestration.md).
+
+## Hooks
+
+El adapter instalado posee ocho managed hook routes compartidas. El route
+tuple `event + routeId + matcher` es el contract estable; cada tuple ata
+exactamente un typed handler in-process.
+
+| Route | Matcher | Handler | Function |
+| --- | --- | --- | --- |
+| `SessionStart.default` | all sessions | `src/cli/hook/session-context.ts` (in-process builder) | Inyecta el handoff anterior, el estado del sprint, guía de minimal-change y hallazgos de config-security de solo lectura antes de que empiece el trabajo. |
+| `PreToolUse.edit` | `Edit\|Write` | `src/cli/hook/mutation-guard.ts` (in-process handler) | Aplica la worktree policy y la readiness de plan/contract antes de las ediciones de implementación. |
+| `PreToolUse.subagent` | `Task\|Agent\|SendUserMessage` | `src/cli/hook/subagent-handler.ts` | Mantiene el trabajo delegado retornando a través de la sesión padre, en lugar de dejar escapar afirmaciones de finalización. |
+| `PostToolUse.edit` | `Edit\|Write` | `src/cli/hook/mutation-observed.ts` (in-process handler) | Escribe como máximo un pequeño evento de bitácora con dirty bits por cada edición calificada; la verificación del contract, el sync de architecture/context/capability y la evidencia de minimal-change se difieren a Stop en vez de ejecutarse por cada edición. |
+| `PostToolUse.bash` | `Bash` | `src/cli/hook/command-observed.ts` | Observa los resultados de comandos y captura evidencia de verificación sin reemplazar el command runner. |
+| `PostToolUse.always` | all tools | `src/cli/hook/trace-observer.ts` | Provee trace y runtime observation de bajo ruido y siempre activo. |
+| `UserPromptSubmit.default` | all prompts | `src/cli/hook/prompt-handler.ts` | Clasifica la intención del prompt, enruta hints de planning/check y renderiza guía de workflow host-safe. |
+| `Stop.default` | session stop | `src/cli/hook/stop-handler.ts` (in-process handler) | Finaliza el handoff y protege contra terminar con draft-plans sin resolver o vacíos de evidencia de completion. |
+
+Codex también instala tres Codex-only bounded-delegation routes —
+`UserPromptSubmit.delegation`, `SubagentStart.context`, y
+`SubagentStop.quality`, todas atadas a `src/cli/hook/subagent-handler.ts`;
+Claude solo conserva la route compartida de return-channel,
+`PreToolUse.subagent`.
+
+`repo-harness-hook` y su typed handler registry son el host-event runtime;
+`~/.claude/settings.json` y `~/.codex/hooks.json` son los adapters a nivel de
+usuario, y Codex debe marcar su archivo como trusted en Settings antes de que
+esos hooks corran. `.claude/settings.json` y `.codex/hooks.json` repo-locales
+son config legacy a retirar. Depura en este orden: adapter config ->
+`repo-harness-hook` -> route registry -> typed handler.
+
+Cuando un hook bloquea el trabajo, lee primero el structured terminal
+output: `guard`, `reason`, `fix`, `failure_class`, y `run_id`. Los registros
+durables viven en `.ai/harness/failures/latest.jsonl`, con la actividad de
+tools circundante en `.claude/.trace.jsonl`. Los guards comunes son
+`PlanStatusGuard` (no hay plan activo o ejecutable), `ContractGuard` (falta
+el contract scaffold, o se afirma completion antes de que el contract
+pasara), y `WorktreeGuard` (escrituras desde el worktree equivocado).
+Playbook completo:
 [`docs/reference-configs/hook-operations.md`](docs/reference-configs/hook-operations.md).
 
-## MCP Connector Quickstart
+## Conector MCP
 
-Como sidecar opcional, `repo-harness mcp` expone solo workflow artifacts a los
-clientes MCP. ChatGPT actúa como planner/reviewer que lee el estado y mueve una
-idea a través de PRD, Sprint checklist y artifacts de handoff de goal de Codex —
-sin acceso de escritura al código fuente, ejecución de shell arbitraria ni un
-runner de Codex por defecto. Codex sigue siendo el ejecutor.
-
-Este sidecar asume que el CLI ya está instalado según «Primeros 5 minutos» de
-arriba. Úsalo cuando quieras que ChatGPT planifique contra el estado real del
-repositorio y que Codex ejecute el Sprint file-backed resultante.
+Como sidecar opcional, `repo-harness mcp` expone artefactos de workflow a
+clientes MCP a través del profile `planner` por defecto. ChatGPT lee el
+estado real del repositorio y mueve una idea a través de artefactos de PRD,
+checklist Sprint y Codex goal handoff — sin acceso de escritura al código
+fuente por defecto, sin ejecución arbitraria de shell, ni runner por
+defecto. Codex sigue siendo el ejecutor.
 
 ```bash
 repo-harness mcp setup chatgpt --repo .
 repo-harness mcp serve --repo . --transport http --host 127.0.0.1 --port 8765 --profile planner
 ```
 
-Expón ese server local a través de un túnel HTTPS y crea un Connector de ChatGPT
-con la URL `/mcp`. La guía generada se escribe en:
-
-```text
-docs/repo-harness-chatgpt-mcp-setup.md
-```
-
-El human workflow es:
+Expón ese servidor local a través de un túnel HTTPS, registra la URL `/mcp`,
+y el human workflow es:
 
 1. ChatGPT lee los archivos de workflow de repo-harness a través de MCP.
 2. ChatGPT escribe un PRD con `write_prd_from_idea`.
-3. ChatGPT escribe un Sprint checklist con `write_checklist_sprint`.
+3. ChatGPT escribe un checklist Sprint con `write_checklist_sprint`.
 4. ChatGPT prepara `.ai/harness/handoff/codex-goal.md` con `prepare_codex_goal_from_sprint`.
-5. Codex ejecuta el prompt host-native `/goal` y hace stage de cada Sprint phase completada.
+5. Codex ejecuta el prompt host-native `/goal` y hace stage de cada fase de Sprint completada.
 
-Alternativa local para el último paso de handoff:
+Herramientas generales de reader/writer del repositorio, consistencia de
+snapshot e índice, profiles de servidor y el dev runner opt-in:
+[`general-repo-mcp.md`](docs/reference-configs/general-repo-mcp.md). Profile
+de direct-coding:
+[`chatgpt-coding-mcp.md`](docs/reference-configs/chatgpt-coding-mcp.md).
+Operaciones de index-stale, CodeGraph caído y rollback:
+[`general-repo-mcp-codegraph.md`](deploy/runbooks/general-repo-mcp-codegraph.md).
 
-```bash
-repo-harness mcp prepare-goal --repo . --prd plans/prds/<feature>.prd.md --sprint plans/sprints/<feature>.sprint.md
-```
+## Revisión del trabajo
 
-El Skill orientado al agente se instala en:
+Empieza por `tasks/reviews/<task>.review.md`. Su `## Human Review Card` es
+la superficie de decisión de una sola pantalla: verdict, change type,
+archivos previstos vs reales, comandos que pasaron, external acceptance,
+riesgo residual, acción del reviewer y rollback. Luego inspecciona el
+contract activo, el último trace en `.ai/harness/checks/latest.json` y los
+archivos modificados. Acepta solo cuando la review recomiende pass, el
+verdict de la card sea pass, y el external acceptance sea pass,
+`not_required`, o un override explícito.
+
+Los agentes leen los artefactos fuente antes que los resúmenes derivados:
+
+| El agente lee primero | El humano revisa primero |
+| --- | --- |
+| El prompt actual del usuario y los archivos referenciados | Human Review Card de `tasks/reviews/<task>.review.md` |
+| `AGENTS.md` / `CLAUDE.md` | Archivos modificados y el diff |
+| Plan activo en `.ai/harness/active-plan` | Allowed paths y exit criteria del contract activo |
+| Contract activo en `tasks/contracts/` | `.ai/harness/checks/latest.json` y el run trace |
+| Último handoff en `.ai/harness/handoff/` | Riesgos residuales y rollback |
+
+`tasks/current.md` es solo un snapshot de orientación. Si discrepa del plan
+activo, el contract, la review, los checks o el handoff, ganan los
+artefactos fuente.
+
+Los validadores runtime-heavy (Unity, browser E2E, simuladores móviles,
+hardware rigs, staging smoke tests) pueden publicar manifiestos de external
+verification bajo la superficie ignorada de run-evidence — hoy una
+convención manual, no un gate automático de `repo-harness check`. Ver
+[external tooling](docs/reference-configs/external-tooling.md#external-verification-evidence).
+
+## Skills
+
+Los packages canónicos rule-owner viven bajo `assets/skills/` y
+`assets/skill-commands/`, manteniendo acotado el discovery de skills del
+host mientras el CLI y los hooks poseen la ejecución.
+
+| Skill | Propósito |
+| --- | --- |
+| `repo-harness` | Skill router raíz, sincronizado sin condición en todo profile |
+| `repo-harness-setup` | Modos init, migrate, upgrade, repair, scaffold y capability-configuration; router-only |
+| `repo-harness-plan` | Crea un plan decision-complete, o revisa uno existente |
+| `repo-harness-product` | Modos PRD, Sprint y Goal para el product planning de upper-layer |
+| `repo-harness-check` | Checks de workflow y release, más una referencia de deploy-readiness |
+| `repo-harness-ship` | Valida worktrees terminados, hace push de branches y abre PRs |
+| `repo-harness-architecture` | Docs de architecture, drift requests y diagramas sin un refresh completo del harness |
+| `repo-harness-cross-review` | Cross-model review independiente Claude/Codex, host-aware |
+| `claude-plan` | Provider skill del lado Codex: consulta independiente en Claude plan mode para un design fork o una decisión de alto riesgo; no es un entrypoint directo de usuario |
+| `repo-harness-chatgpt` | Consultas de Oracle browser/GPT Pro, setup del MCP Connector y bridge handoff; solo setup explícito |
+| `merge-gate` (externo) | Gate final de exact-candidate; repo-harness no distribuye ningún Skill de merge-gate — ver [external tooling](docs/reference-configs/external-tooling.md) |
+
+La cadena de planning está deliberadamente organizada en capas:
 
 ```text
-.agents/skills/repo-harness-chatgpt-bridge/SKILL.md
+idea -> PRD mode -> Sprint mode -> Goal mode
 ```
 
-Ese Skill le indica a Codex cómo consumir los artifacts PRD/Sprint/Goal
-producidos por ChatGPT sin concederle a ChatGPT escritura sobre el source-code
-ni ejecución de shell.
+`repo-harness init` es para un repositorio existente; el scaffold mode de
+`repo-harness-setup` crea un proyecto o módulo nuevo. `hooks-init`,
+`docs-init`, y `create-project-dirs` son pasos internos, no comandos
+públicos. Boundaries de routing por modo:
+[`agentic-development-flow.md`](docs/reference-configs/agentic-development-flow.md)
+y `repo-harness docs show harness-overview`.
 
-El Dev Mode puede optar por la ejecución local de agentes a través de MCP. Está
-desactivado por defecto. Cuando el usuario activa el profile `orchestrator` con
-el ajuste dev runner, ChatGPT puede llamar a `run_agent_goal`, que solo lee
-`.ai/harness/handoff/codex-goal.md` y ejecuta el handoff fijo a través de un CLI
-local permitido como `codex exec` o `claude -p`.
+## Referencia para mantenedores
+
+Editar el paquete en sí requiere un checkout del source:
 
 ```bash
-repo-harness mcp serve --repo . --transport http --profile orchestrator --enable-dev-runner --dev-runner-agents codex
+git clone https://github.com/Ancienttwo/repo-harness.git ~/Projects/repo-harness
+cd ~/Projects/repo-harness && bun src/cli/index.ts update
 ```
 
-Este ajuste es solo para el Developer Mode local. Tiene límite de timeout, está
-auditado, y no es un shell arbitrario.
+Ese checkout es la única fuente de verdad editable; las rutas locales de
+skill de Claude/Codex son runtime entrypoints respaldados por symlinks,
+reconstruidos por `scripts/sync-codex-installed-copies.sh`.
 
-## Hook Authority Map
+`bun run check:ci` es el único gate equivalente a CI; `bun run check:release`
+solo añade el preflight de unpublished-version de npm antes de delegar a ese
+mismo gate.
 
-`repo-harness-hook` es el único host-event runtime. El adapter a nivel de usuario
-solo entrega el event; route registry usa el tuple estable `event + routeId + matcher`
-para invocar exactamente un typed handler. `assets/hooks/lib/workflow-state.sh` y
-`.ai/hooks/lib/workflow-state.sh` son proyecciones de operator helper, no dispatchers.
-
-- `~/.claude/settings.json`: Claude adapter a nivel de usuario.
-- `~/.codex/hooks.json`: Codex adapter a nivel de usuario; requiere confianza en Settings.
-- `.claude/settings.json` / `.codex/hooks.json` repo-locales: inputs legacy que se retiran durante migration.
-- Los cambios de handler viven en `src/cli/hook/`; sincroniza la proyección con `bun run sync:hooks`.
-
-The installed adapter owns the managed hook routes. Each route invokes one typed
-handler; no existe un segundo runtime de shell ni un runtime específico por provider.
-
-| Route | Matcher | Typed handler | Function |
-| --- | --- | --- | --- |
-| `SessionStart.default` | all sessions | `src/cli/hook/session-context.ts` (in-process builder) | Injects prior handoff, sprint status, and read-only config-security findings before work starts. |
-| `PreToolUse.edit` | `Edit|Write` | `src/cli/hook/mutation-guard.ts` (in-process handler) | Enforces worktree policy and plan/contract readiness before implementation edits. |
-| `PreToolUse.subagent` | `Task|Agent|SendUserMessage` | `subagent` | Keeps delegated work returning through the parent session instead of leaking completion claims. |
-| `PostToolUse.edit` | `Edit|Write` | `mutation-observed` | Records the edit journal and controlled-file observations. |
-| `PostToolUse.bash` | `Bash` | `command-observed` | Observes command results and captures verification evidence without replacing the command runner. |
-| `PostToolUse.always` | all tools | `trace-observer` | Provides low-noise always-on trace and runtime observation. |
-| `UserPromptSubmit.default` | all prompts | `prompt` | Classifies prompt intent, routes planning/check/hunt hints, and renders host-safe workflow guidance. |
-| `Stop.default` | session stop | `src/cli/hook/stop-handler.ts` (in-process handler) | Finalizes handoff and guards against ending with unresolved draft-plan or completion evidence gaps. |
-
-`SessionStart` ejecuta el session-context builder in-process, que ensambla el contexto antes de empezar el trabajo:
-
-```mermaid
-flowchart LR
-  SessionStart["Claude/Codex SessionStart"] --> Ctx["session-context.ts<br/>in-process builder"]
-  Ctx --> Resume["contexto de resume + handoff"]
-  Ctx --> Sec["security scan<br/>escaneo de configuración de solo lectura, fingerprint-gated"]
-  Resume --> SSOut["SessionStart additionalContext<br/>estado de la sesión anterior + hallazgos de SecurityConfig"]
-  Sec --> SSOut
+```bash
+bun run check:ci                    # the whole gate
+repo-harness docs list              # runtime reference docs, resolved from the package
+repo-harness docs show harness-overview
+bun scripts/assemble-template.ts --plan C --name "MyProject"
 ```
 
-El prompt guard tiene un paso interno adicional:
-
-```mermaid
-flowchart LR
-  Host["Claude/Codex UserPromptSubmit"] --> Adapter["user-level adapter"]
-  Adapter --> CLI["repo-harness-hook UserPromptSubmit --route default"]
-  CLI --> Route["route registry"]
-  Route --> Handler["prompt handler<br/>typed decision table"]
-  Handler --> RouteHint["Waza route hint<br/>think/planning explícito coincide primero → /think"]
-  Handler --> HostOutput["host-safe allow, advice, block, or done gate output"]
-```
-
-El typed handler posee el parseo de entrada, el estado de archivos y los side effects
-declarados; el runtime solo unifica el host output. AcceptanceReceipt es la authority
-de closeout y review Markdown es una proyección.
-
-## Hook Failure Playbook
-
-Cuando un hook block está activo, mira primero la salida estructurada en el
-terminal. Los campos centrales son `guard`, `reason`, `fix`, `failure_class` y
-`run_id`.
-
-- Failure log: `.ai/harness/failures/latest.jsonl`
-- Trace log: `.claude/.trace.jsonl`
-- Guía detallada: [`docs/reference-configs/hook-operations.md`](docs/reference-configs/hook-operations.md)
-
-Guards habituales:
-
-- `PlanStatusGuard`: no hay active plan, o el plan todavía no puede ejecutarse
-- `ContractGuard`: la approved execution aún no ha generado el scaffold de contract/review/notes
-- `ContractGuard`: la tarea afirma estar completa sin haber pasado la contract verification
-- `WorktreeGuard`: se escribe desde el primary worktree bajo una política que fuerza linked worktrees
-
-## Repo Workflow
-
-- Root routing docs: `CLAUDE.md`, `AGENTS.md`
-- Typed hook runtime: `src/cli/hook/` (a través de `repo-harness-hook`)
-- Operator helper projection: `.ai/hooks/lib/workflow-state.sh`
-- User-level adapter layer: `~/.claude/settings.json`, `~/.codex/hooks.json`
-- Active execution surface: `tasks/`
-- Plan source of truth: `plans/`
-- Durable progress: `tasks/workstreams/`
-- Release history: `docs/CHANGELOG.md`
-
-## Release actual
-
-- npm package: `repo-harness@0.12.0`
-- Generated workflow stamp: `repo-harness@0.12.0+template@0.12.0`
-- GitHub repository: `Ancienttwo/repo-harness`
-- Release history: [`docs/CHANGELOG.md`](docs/CHANGELOG.md)
+Los cambios de hook actualizan `assets/hooks/` canónico una vez, y luego
+corren `bun run sync:hooks` con `bun run check:hooks` en la verificación. Los
+reference docs son canónicos bajo `assets/reference-configs/` y se proyectan
+en `docs/reference-configs/`; `bun run check:reference-configs` verifica esa
+proyección.
 
 ## Agradecimientos
 
-Gracias a [Hylarucoder](https://x.com/hylarucoder) por su contribución
-metodológica. El método P1/P2/P3 due-diligence de `repo-harness`, y la práctica
-Geju que disciplina el planning, el trace y el decision rationale, vienen de su
-contribución e influencia.
+`repo-harness` está construido alrededor de un pequeño conjunto de skills,
+repos y agent runtimes externos que dieron forma al workflow contract. No
+son dependencias empaquetadas ordinarias.
 
-Gracias a [TW93](https://x.com/HiTw93), autor de Waza. Los skills centrales
-`think`, `hunt`, `check` y `health` dan forma al ritmo diario de planning, bug
-hunt y verification de `repo-harness`.
-
-Gracias a [Peter Steinberger](https://x.com/steipete), autor de Oracle
-(`@steipete/oracle`, MIT). Es el motor de consult de navegador GPT Pro / ChatGPT
-Web por defecto de `chatgpt-browser`: el provider Oracle ejecuta el binario oracle
-externo para los consults `gptpro`, sin descarga automática, y un binario ausente
-es un fallo explícito.
-
+| Herramienta o repo | Usado para | Forma de la dependencia |
+| --- | --- | --- |
+| [Hylarucoder](https://x.com/hylarucoder) / Geju | El método de due diligence P1/P2/P3 y la práctica Geju que dieron forma a la disciplina de planning, tracing y decision-rationale de este workflow | Contribución metodológica y agradecimiento; no es una dependencia empaquetada |
+| Waza de [TW93](https://x.com/HiTw93), incluyendo `think`, `hunt`, `check` y `health` | Planning diario, bug hunts, verificación, health checks y sync de skill Codex-first | Instalado a través del skills CLI en los host skill roots |
+| `mermaid` | Diagramas de architecture y system-flow legibles por humanos cuando Mermaid no alcanza | Skill runtime-referenced, no vendored en los repos generados |
+| CodeGraph (`@colbymchenry/codegraph`) | Navegación symbol-aware, impact tracing y readiness checks para este repo self-host | Dev dependency en este repo; los repos generados se mantienen global-MCP-first salvo que la policy haga opt-in |
+| [Oracle](https://github.com/steipete/oracle) de [Peter Steinberger](https://x.com/steipete) (`@steipete/oracle`, MIT) | Motor de consulta de navegador GPT Pro / ChatGPT Web por defecto, al que el Oracle provider `chatgpt-browser` invoca externamente (shell out) para las consultas `gptpro` | Binario resuelto externamente (`--oracle-bin`, `REPO_HARNESS_ORACLE_BIN`, `node_modules/.bin`, o `PATH`); nunca se descarga automáticamente, y un binario ausente es un fallo duro de `ORACLE_NOT_INSTALLED` |
+| OpenAI Codex | Agente de ejecución primario para implementación repo-local, verificación y GitHub contributor attribution cuando un commit incluye materialmente trabajo escrito por Codex | Un runtime de agente externo; la atribución es un trailer de commit explícito, no automatización oculta de hooks |
 
 ### Atribución de contribuidor en GitHub
 
-Cuando Codex contribuya materialmente a un commit, usa el trailer co-author estándar de GitHub al final del commit message:
+Cuando Codex contribuye materialmente a un commit, usa el trailer estándar
+de co-author de GitHub al final del mensaje:
 
 ```text
 Co-authored-by: codex <codex@openai.com>
 ```
 
-Mantén esta atribución opt-in y visible por commit. No la incorpores en scripts de commit ni hooks downstream de repo-harness salvo que ese repo adopte explícitamente la misma política.
+Mantén esta atribución opt-in y visible por commit. No la incorpores en
+commit scripts o hooks downstream de repo-harness a menos que ese
+repositorio adopte la misma política.
 
-## Action Command Skills
+## Versión actual
 
-Los packages canónicos están en `assets/skills/` (packages canónicos
-activados) y en `assets/skill-commands/` (sobrevivientes que evolucionan en su
-sitio); preservan el alcance de discovery por skills, mientras el CLI y los
-hooks ejecutan:
+- Paquete npm: `repo-harness@0.12.0`
+- Sello de workflow generado: `repo-harness@0.12.0+template@0.12.0`
+- Repositorio de GitHub: `Ancienttwo/repo-harness`
+- Notas de versión e historial: [`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 
-- Router: `repo-harness` (Skill raíz, sincronizado sin condición en cada
-  profile)
-- Capa setup: `repo-harness-setup` (modos init, migrate, upgrade,
-  repair, scaffold, y capability-configuration; router-only, nunca
-  descubierto automáticamente por un profile)
-- Planning: `repo-harness-plan` (crea un plan decision-complete, o revisa uno
-  existente)
-- Capa product planning: `repo-harness-product` (modos PRD, Sprint, y Goal; el
-  modo PRD activa `$geju`, luego usa drafting Claude-first con `claude -p
-  --model opus`, Codex queda solo como fallback; el modo Sprint convierte un
-  PRD en un backlog ordenado bajo `plans/sprints/`, cada fila se expande con
-  `$think` antes del contract flow; el modo Goal prepara prompts `/goal` de
-  Codex/Claude desde un PRD o Sprint detallado y lo pide primero si falta)
-- Verificación: `repo-harness-check` (checks de workflow/release más una
-  referencia deploy-readiness)
-- Release: `repo-harness-ship`
-- Architecture: `repo-harness-architecture`
-- Cross-model review: `repo-harness-cross-review` (host-aware; se instala en
-  ambos hosts para el profile strict)
-- Integración ChatGPT: `repo-harness-chatgpt` (consult/continuation de Oracle
-  browser/GPT Pro, setup de MCP Connector, bridge handoff, y read-back
-  evidence; solo setup explícito, nunca implicado por product planning)
+## Licencia
 
-La cadena de planning está separada por capas:
-
-```text
-idea -> repo-harness-product (modo PRD) -> repo-harness-product (modo Sprint, from-prd) -> repo-harness-product (modo Goal)
-```
-
-Usa el modo PRD de `repo-harness-product` cuando la fuente todavía es una idea
-de producto: primero ejecuta un direction pass con `$geju`, luego pide a
-Claude vía `claude -p --model opus` que redacte el PRD, con Codex solo como
-fallback. Usa su modo Sprint (`from-prd <plans/prds/*.prd.md>`) para convertir
-un PRD aprobado en un Sprint backlog ordenado con acceptance lines
-verificables por máquina. Usa su modo Goal solo cuando ya exista un PRD o
-Sprint detallado; prepara un prompt `/goal` acotado para Codex/Claude y
-mantiene el PRD/Sprint como source of truth. Si falta ese documento, el modo
-Goal debe pedirlo antes de empezar implementación desde el chat.
-
-`repo-harness init` se usa para repositorios existentes; el modo scaffold de
-`repo-harness-setup` queda para crear proyectos o módulos nuevos. `hooks-init`,
-`docs-init` y `create-project-dirs` son pasos internos, no commands públicos.
-
-## Maintainer Reference
-
-Quienes editan el propio paquete necesitan un checkout del código fuente:
-
-```bash
-git clone https://github.com/Ancienttwo/repo-harness.git ~/Projects/repo-harness
-cd ~/Projects/repo-harness
-bun src/cli/index.ts update
-```
-
-`~/Projects/repo-harness` es la única source of truth editable; las rutas locales
-de Claude/Codex (`~/.claude/skills/repo-harness`, `~/.codex/skills/repo-harness`)
-son runtime entrypoints respaldados por symlinks. Solo
-`~/.codex/skills/repo-harness` expone `SKILL.md` y `assets/skill-commands/`;
-`scripts/sync-codex-installed-copies.sh` reconstruye estos alias y elimina los
-directorios retirados `repo-harness-skill` / `project-initializer`. El script
-enlaza las rutas al repo fuente por defecto; usa
-`AGENTIC_DEV_LINK_INSTALLED_COPIES=0` para staging por copia, o
-`CODEX_SKILLS_ROOT` / `CLAUDE_SKILLS_ROOT` para raíces alternativas.
-
-### Verificar el workflow contract de este repositorio
-
-Ejecuta el gate completo en [Verification](#verification); `bun run check:ci` es
-el único comando equivalente a CI.
-
-### Runtime reference docs
-
-Generic repo-harness runtime/reference docs live in the installed package under
-`assets/reference-configs/` and are resolved through the CLI:
-
-```bash
-repo-harness docs list
-repo-harness docs path harness-overview
-repo-harness docs show harness-overview
-```
-
-Los defaults del initializer y del runtime (question flow, plan menu, template
-vars, routing de external tooling) están documentados en `harness-overview.md`
-bajo **Initializer and Runtime Model**. Generated and migrated repos still keep
-`docs/reference-configs/*.md`, but those files are deterministic pointer stubs.
-Repo-local workflow state, policy, checks, runs, handoff packets, context maps,
-and helper snapshots stay under `.ai/`.
-
-### Template assembly
-
-```bash
-bun scripts/assemble-template.ts --plan C --name "MyProject"
-bun scripts/assemble-template.ts --target agents --plan C --name "MyProject"
-```
-
-### Verification
-
-```bash
-bun test
-bash scripts/check-task-sync.sh
-bash scripts/check-task-workflow.sh --strict
-bun scripts/inspect-project-state.ts --repo . --format text
-bun src/cli/index.ts init --repo . --dry-run
-bash scripts/check-agent-tooling.sh --host both --check-updates
-bun run benchmark:skills --eval route-workflow-check
-```
-
-
-### Local benchmark skeleton
-
-```bash
-bun run benchmark:skills --eval route-workflow-check
-```
-
-Eval output is the release/readiness evidence path; dry-run benchmark wiring is only a smoke and is not skill-effectiveness evidence.
-
-
-### Run one eval across both Claude and Codex
-
-```bash
-bun run benchmark:skills --eval repair-agents-task-sync
-```
-
-## Key Files
-
-- Skill spec: `SKILL.md`
-- Root routing docs: `CLAUDE.md`, `AGENTS.md`
-- Plan mapping: `assets/plan-map.json`
-- Question-pack: `assets/initializer-question-pack.v4.json`
-- Shared hooks: `assets/hooks/`
-- Runtime reference docs: `assets/reference-configs/` via `repo-harness docs`
-- Workflow contract: `assets/workflow-contract.v1.json`
-- Hook operations reference: `docs/reference-configs/hook-operations.md`
-- Template assembler: `scripts/assemble-template.ts`
-- State inspector: `scripts/inspect-project-state.ts`
-- External tooling detector: `scripts/check-agent-tooling.sh`
-- Scaffolding scripts:
-  - `scripts/init-project.sh`
-  - `scripts/create-project-dirs.sh`
-- Canonical adoption planner: `src/core/adoption/standard-plan.ts`
-
-## Generated vs Self-Hosted Hook Projection
-
-- El comportamiento downstream de hooks lo define la salida generada desde `assets/hooks/` y `assets/reference-configs/`.
-- Este repo dogfoodea el mismo contract, pero el comportamiento self-host no se sincroniza mágicamente con los generated repos; cada cambio debe actualizar explícitamente ambas superficies cuando aplique.
-- Todo cambio de hook debe indicar si afecta a `self-host`, `generated` o `both`.
-
-## Package Manager Defaults
-
-- Prioridad general por defecto: `bun > pnpm > npm`
-- **Plan G/H** (Python-centric) usa **`uv`** como primary package manager por defecto.
-
-## Runtime Profiles
-
-- `Plan-only (recommended)` (default)
-- `Plan + Permissionless`
-- `Standard (ask before each action)`
-
-Se configura en `assets/initializer-question-pack.v4.json` y lo consume `scripts/initializer-question-pack.ts`.
-
-## Verification
-
-Para release review usa el gate único equivalente a CI:
-
-```bash
-bun run check:ci
-```
-
-Ese gate se expande a los checks propios del repo; `bun run check:release` solo añade el preflight de npm unpublished-version antes de delegar al mismo gate.
-
-```bash
-bun test
-bash scripts/check-deploy-sql-order.sh
-bash scripts/check-architecture-sync.sh
-bash scripts/check-task-sync.sh
-bash scripts/check-task-workflow.sh --strict
-bun scripts/inspect-project-state.ts --repo . --format text
-bun src/cli/index.ts init --repo . --dry-run
-bash scripts/check-agent-tooling.sh --host both --check-updates
-bun run benchmark:skills --eval route-workflow-check
-```
+MIT — ver [`LICENSE`](LICENSE).

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,200 +1,50 @@
+<div align="center">
+
 # repo-harness
 
-`repo-harness` transforme les sessions de code Claude/Codex en workflow
-repo-local répétable. Il fournit un CLI et des hooks skill/runtime qui écrivent
-le contexte, les plans, les handoffs, les checks et les preuves de review dans le
-projet, afin que la session d'agent suivante reprenne depuis les fichiers plutôt
-que depuis l'historique de chat.
+### Un workflow file-backed et reproductible pour les sessions de code Claude et Codex
 
-Utilisez-le pour :
+<img src="docs/images/repo-harness-hook-carrot.png" alt="Les hooks repo-harness qui guident Codex et Claude vers l'avant grâce à l'état de workflow repo-local" width="900">
 
-- adopter un dépôt existant avec un contrat d'agent tasks-first
-- garder Claude et Codex alignés sur les mêmes plans, checks, handoffs et limites
-  de contexte
-- dépenser moins de tokens à redécouvrir la structure grâce à CodeGraph et au
-  chargement progressif du contexte
-
-Donnez à l'agent un PRD ou Sprint complet ; ensuite, votre boucle se limite à
-review and `next`, ou à lancer `/goal` puis passer AFK.
+[![npm version](https://img.shields.io/npm/v/repo-harness.svg)](https://www.npmjs.com/package/repo-harness)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Runtime: Bun](https://img.shields.io/badge/runtime-Bun%20%E2%89%A5%201.1.35-black.svg)](https://bun.sh)
 
 [English](README.md) | [简体中文](README.zh-CN.md) | [日本語](README.ja.md) | [Français](README.fr.md) | [Español](README.es.md)
 
-Adresse du dépôt : `https://github.com/Ancienttwo/repo-harness`
+**Donnez à l'agent un PRD ou un Sprint complet ; ensuite, votre boucle se résume à review et `next`, ou à lancer `/goal` et passer AFK.**
 
-## Pourquoi utiliser repo-harness
+</div>
 
-- **L'état de session vit dans les fichiers, pas dans l'historique de chat.** Des
-  sessions d'agent distinctes — Claude, Codex, maintenant ou plus tard — restent
-  synchronisées via le dépôt et non via un thread de conversation. Au démarrage
-  d'une nouvelle session, le session-context builder in-process
-  (`src/cli/hook/session-context.ts`) injecte le resume
-  packet de la session précédente (`.ai/harness/handoff/resume.md`,
-  `tasks/current.md`) ; à la fin de la session et après chaque édition,
-  les typed handlers `session-context`, `stop` et `mutation-observed` réécrivent le handoff suivant. Une
-  tâche peut s'interrompre en cours de route, et la session suivante reprend
-  directement avec l'étape suivante exacte, les points de blocage et les fichiers
-  modifiés, sans avoir à les redéduire.
-- **Économe en tokens par conception.** Au lieu de boucles grep+read qui
-  rescannent le dépôt à chaque session, le harness s'appuie sur un index CodeGraph
-  pré-construit pour les requêtes structurelles (qui appelle, qui est appelé, où
-  c'est défini), puis sur un chargement de contexte progressif via
-  `.ai/context/context-map.json` et `capabilities.json` : un root context petit et
-  stable (environ 12 Ko), plus des blocs capability chargés uniquement quand les
-  fichiers que vous touchez en ont besoin. Un agent lit un contrat capability de
-  1 Ko ou interroge l'index, au lieu de dépenser des milliers de tokens à
-  redécouvrir la structure.
+`repo-harness` fournit un CLI ainsi que des hooks skill/runtime qui réécrivent
+dans le projet le contexte, les plans, les handoffs, les checks et les preuves
+de review, afin que la session d'agent suivante reprenne à partir des fichiers
+plutôt que de la mémoire de chat. Il adopte un dépôt existant avec un contrat
+d'agent tasks-first qui maintient Claude et Codex alignés.
 
-Dans un dépôt adopté, la surface à comprendre reste volontairement réduite :
+## Sommaire
 
-| Surface | Rôle |
-| --- | --- |
-| `docs/spec.md` et `docs/reference-configs/` | Standards partagés et intention produit stable lisibles par chaque session d'agent. |
-| `plans/`, `plans/prds/` et `plans/sprints/` | Work packages decision-complete avant le début de l'implémentation. |
-| `tasks/contracts/`, `tasks/reviews/` et `.ai/harness/checks/` | Scope, vérification et preuves de review pour démontrer que le travail est terminé. |
-| `.ai/harness/handoff/` et `tasks/current.md` | Session journal et état resumable dérivés des workflow artifacts plutôt que de la chat memory. |
+- [Démarrage rapide](#démarrage-rapide)
+- [Pourquoi repo-harness](#pourquoi-repo-harness)
+- [Fonctionnalités clés](#fonctionnalités-clés)
+- [Comment ça marche](#comment-ça-marche)
+- [Workflow des tâches](#workflow-des-tâches)
+- [Hooks](#hooks)
+- [Connecteur MCP](#connecteur-mcp)
+- [Revue du travail](#revue-du-travail)
+- [Skills](#skills)
+- [Référence des mainteneurs](#référence-des-mainteneurs)
+- [Remerciements](#remerciements)
+- [Release actuelle](#release-actuelle)
+- [Licence](#licence)
 
-## Human Review Path
-
-Commencez par `tasks/reviews/<task>.review.md`. La `## Human Review Card` est la
-surface de décision sur un seul écran : verdict, change type, fichiers prévus vs
-réels, commandes passées, external acceptance, risque résiduel, action du
-reviewer et rollback. Inspectez ensuite le contract actif, le dernier trace dans
-`.ai/harness/checks/latest.json` et les fichiers modifiés. N'acceptez que lorsque
-la review recommande pass, que le verdict de la card est pass et que l'external
-acceptance est pass, `not_required` ou un manual override explicite.
-
-## Agent Tracking Path
-
-Les agents lisent les source artifacts avant les résumés dérivés :
-
-| Agent reads first | Human reviews first |
-| --- | --- |
-| Prompt utilisateur courant et fichiers référencés | Human Review Card de `tasks/reviews/<task>.review.md` |
-| `AGENTS.md` / `CLAUDE.md` | Fichiers modifiés et diff |
-| Plan actif dans `.ai/harness/active-plan` | Allowed paths et exit criteria du contract actif |
-| Contract actif dans `tasks/contracts/` | `.ai/harness/checks/latest.json` et run trace |
-| Dernier handoff dans `.ai/harness/handoff/` | Risques résiduels et rollback |
-
-`tasks/current.md` n'est qu'un snapshot d'orientation. S'il diverge du plan
-actif, du contract, de la review, des checks ou du handoff, les source artifacts
-l'emportent.
-
-## Nouveautés
-
-Les notes de version vivent dans [`docs/CHANGELOG.md`](docs/CHANGELOG.md). La
-ligne actuelle est `0.12.0`.
-
-## Comment ça marche
-
-L'ensemble se découpe en trois couches, avec un seul runtime typed pour les host events :
-
-1. **Couche package source** : ce dépôt maintient le CLI, les command skill
-   facades, les templates, les hook assets, le workflow contract, les tests et le
-   release gate.
-2. **Couche contrat du dépôt cible** : `repo-harness init` ou une migration écrit
-   `docs/spec.md`, `plans/`, `tasks/`, `.ai/context/`, `.ai/harness/` et les helper
-   scripts. `.ai/hooks/lib/workflow-state.sh` n'est qu'une projection d'operator helper.
-3. **Couche host adapter** : les `~/.claude/settings.json` et `~/.codex/hooks.json`
-   de niveau utilisateur routent les events Claude/Codex vers `repo-harness-hook`.
-   Après validation de `.ai/harness/workflow-contract.json`, le route registry
-   appelle exactement un typed handler pour le tuple `event + routeId + matcher`.
-
-Tous les events suivent `host adapter -> repo-harness-hook -> route registry ->
-typed handler`. `UserPromptSubmit.default` utilise `prompt`; edit/bash/stop utilisent
-`mutation-observed`, `command-observed` et `stop`. Il n'existe ni second dispatcher
-shell ni runtime différent selon le provider.
-
-Invariant central : les faits persistants vivent dans le dépôt, pas dans la
-fenêtre de chat. Les typed handlers ne sont que des accélérateurs et des guardrails ;
-l'authority réelle, ce sont les fichiers de plan, contract, review, checks et
-handoff.
-
-## Task Workflow : de Plan à Closeout
-
-Le diagramme ci-dessous suppose que le harness est déjà installé dans le dépôt
-cible. Il montre le cycle normal d'une tâche unique : d'abord former un plan,
-puis le projeter dans le sprint contract, faire un checkout d'un worktree isolé
-si nécessaire, implémenter sous la protection des hooks, puis vérifier, review,
-external acceptance, et enfin closeout.
-
-```mermaid
-flowchart TD
-  UserTask["Tâche utilisateur ou planning prompt"] --> Discovery["Due diligence préalable<br/>P1 map, P2 trace, P3 decision"]
-  Discovery --> PlanDraft["Draft plan<br/>plans/plan-*.md"]
-  PlanDraft --> PlanReview{"Le plan est-il exécutable ?"}
-  PlanReview -->|non| Refine["Resserrer le scope et l'evidence contract"]
-  Refine --> PlanDraft
-  PlanReview -->|oui| Approve["Approved plan<br/>Status: Approved"]
-
-  Approve --> Project["Projeter sur la surface d'exécution<br/>capture-plan.sh --execute<br/>ou plan-to-todo.sh --plan"]
-  Project --> Active["Active markers<br/>.ai/harness/active-plan<br/>.ai/harness/active-worktree"]
-  Project --> Contract["Sprint contract<br/>tasks/contracts/YYYYMMDD-HHMM-task-slug.contract.md"]
-  Project --> ReviewFile["Review file<br/>tasks/reviews/YYYYMMDD-HHMM-task-slug.review.md"]
-  Project --> Notes["Task notes<br/>tasks/notes/YYYYMMDD-HHMM-task-slug.notes.md"]
-
-  Contract --> WorktreePolicy{"Un contract worktree est-il requis ?"}
-  WorktreePolicy -->|oui| Checkout["Checkout d'un worktree isolé<br/>contract-worktree.sh start --plan<br/>branch codex/task-slug"]
-  WorktreePolicy -->|non| CurrentTree["Utiliser le worktree courant<br/>petite tâche ou slice explicitement autorisée"]
-  Checkout --> Implement
-  CurrentTree --> Implement
-
-  Implement["Éditer et exécuter des commandes"] --> PreHooks["Pre-edit guards<br/>PlanStatusGuard, ContractScopeGuard, WorktreeGuard"]
-  PreHooks -->|blocked| ScopeFix["Corriger plan, contract, worktree ou scope"]
-  ScopeFix --> Implement
-  PreHooks -->|allowed| Changes["Changements de code, docs, tests ou config"]
-  Changes --> PostHooks["Post-edit / post-bash hooks<br/>trace, drift request, handoff, check evidence"]
-  PostHooks --> Verify["Lancer la vérification<br/>tests plus repo workflow checks"]
-
-  Verify --> Checks["Evidence structurée<br/>.ai/harness/checks/latest.json<br/>.ai/harness/runs/*.json"]
-  Checks --> CheckReview["Evaluator review<br/>Waza /check -> review file"]
-  CheckReview --> External["External acceptance advice<br/>ou manual override explicite"]
-  External --> DoneGate{"Contract, checks, review, acceptance passent-ils ?"}
-  DoneGate -->|non| Repair["Réparer l'evidence ou l'implémentation en échec"]
-  Repair --> Implement
-  DoneGate -->|oui| Closeout["Closeout<br/>scripts/contract-worktree.sh finish"]
-
-  Closeout --> Commit["Commit de la contract branch"]
-  Commit --> Merge["Fast-forward de la target branch"]
-  Merge --> Archive["Archiver plan/todo et rafraîchir le handoff"]
-  Archive --> Cleanup["Nettoyer le worktree mergé<br/>contract-worktree.sh cleanup"]
-  Cleanup --> Done["Tâche terminée et auditable"]
-```
-
-## Longues boucles produit
-
-Pour le travail Greenfield comme Brownfield, avancez la discovery et le jugement
-d'engineering plan dans le parent agent avant de demander à Codex de boucler sur
-l'exécution :
-
-1. Avant la création d'un contract, le parent agent invoque `geju` pour ouvrir le
-   cadre, puis réalise P1/P2/P3 avec ses propres capacités repo/runtime. Il fige
-   l'intention produit, l'architecture, les risques, le falsifier et l'evidence
-   contract acceptés dans les development documents.
-2. Transformez ces documents en PRD Sprint sous `plans/prds/`, avec un backlog
-   ordonné et des sub-plans détaillés pour chaque execution slice.
-3. Créez un Codex Goal qui pointe vers ce fichier de sprint. repo-harness peut
-   ensuite projeter chaque sprint item dans le flow normal plan -> contract ->
-   worktree -> verification.
-
-Ce handoff rend les longues boucles plus précises : le parent agent porte le
-jugement large en amont, le PRD Sprint devient la durable source of truth, et
-Codex Goal mode reprend sur un sprint concret au lieu de réinterpréter le chat
-initial.
-
-## Les 5 premières minutes
-
-C'est le chemin le plus rapide pour évaluer si un dépôt réel se prête à l'adoption
-de ce workflow.
-
-Prérequis : un Git working tree, `bash` et `bun` (pour la vérification ultérieure
-et le template assembly). `jq` est optionnel pour `--dry-run`, mais recommandé
-lors de l'application d'un settings merge.
+## Démarrage rapide
 
 ### 1. Installer le CLI
 
-Le chemin par défaut ne demande pas Node.js : l'installateur utilise Bun >=
-1.1.35 comme runtime. Si Bun est absent ou plus ancien, il l'installe ou le met
-à niveau avant d'installer le CLI `repo-harness`.
+Prérequis : un working tree Git, `bash` et `bun` ; `jq` est optionnel. Node.js
+n'est pas nécessaire — l'installateur utilise Bun >= 1.1.35 comme runtime, en
+l'installant ou en le mettant à niveau d'abord si besoin.
 
 ```bash
 # macOS / Linux
@@ -204,19 +54,17 @@ curl -fsSL https://raw.githubusercontent.com/Ancienttwo/repo-harness/main/instal
 irm https://raw.githubusercontent.com/Ancienttwo/repo-harness/main/install.ps1 | iex
 ```
 
-<details>
-<summary>Vous avez déjà Bun >= 1.1.35 ? Utilisez Bun en priorité, ou npx en fallback</summary>
+Si Bun >= 1.1.35 est déjà sur le PATH, l'installateur shell peut être ignoré.
+Les installations de Bun gérées par un package manager échouent en mode
+fail-closed avec la commande de mise à niveau correspondante (`brew upgrade
+bun`), plutôt que d'écraser les fichiers appartenant au manager.
 
 ```bash
-# Bun (recommandé)
-bun add -g repo-harness
+bunx repo-harness@latest install     # Bun one-shot bootstrap
+bun add -g repo-harness              # or install the persistent CLI first
 repo-harness install
-
-# Fallback npx, avec Bun déjà sur PATH car le CLI s'exécute sur Bun
-npx -y repo-harness@latest install
+npx -y repo-harness@latest install   # npx fallback; the CLI still runs on Bun
 ```
-
-</details>
 
 ### 2. Bootstrap du runtime hôte
 
@@ -224,11 +72,13 @@ npx -y repo-harness@latest install
 repo-harness install
 ```
 
-`repo-harness install` sert au bootstrap global, `repo-harness update` au
-rafraîchissement user-level, et `repo-harness init` au rafraîchissement
-repo-local. `repo-harness install` configure le CLI, les hook adapters de niveau
-utilisateur, Waza, Mermaid, le brain root et CodeGraph MCP ; l'ancien chemin
-Claude plugin `scripts/setup-plugins.sh` est retiré.
+Le bootstrap global : installe le package npm comme CLI global, rafraîchit les
+alias de skill repo-harness, installe les hook adapters de niveau utilisateur,
+et enregistre un install profile explicite. Il est idempotent et n'applique
+aucun fichier de workflow repo-local au répertoire courant. `--dry-run --json`
+liste d'abord les composants à installer, ignorer et supprimer. Profiles,
+delegation mode, commandes de rafraîchissement, et l'audit read-only `setup
+check` : [`install-profiles.md`](docs/reference-configs/install-profiles.md).
 
 ### 3. Prévisualiser le contrat repo-local
 
@@ -236,13 +86,13 @@ Claude plugin `scripts/setup-plugins.sh` est retiré.
 repo-harness init --dry-run
 ```
 
-Lancez le dry-run depuis le repo root. Il rapporte les specs, l'état des tasks,
-le helper runtime, la cible des hook adapters et les fichiers de vérification qui
-seraient créés ou rafraîchis. Il ne doit pas créer de stack applicatif : un dépôt
-existant utilise `repo-harness init`, un nouveau projet ou module utilise le
-mode scaffold de `repo-harness-setup`.
+Lancez cette commande depuis la racine du repository cible. Elle rapporte les
+specs, l'état des tasks, le helper runtime, la cible des hook adapters, et les
+fichiers de vérification qui seraient créés ou rafraîchis. Elle ne crée jamais
+de stack applicatif ; les nouveaux projets et modules utilisent plutôt le
+scaffold mode de `repo-harness-setup`.
 
-### 4. Appliquer, puis prouver le workflow
+### 4. Appliquer et vérifier
 
 ```bash
 repo-harness init
@@ -250,390 +100,372 @@ bash scripts/check-task-workflow.sh --strict
 bun test
 ```
 
-Après application, le dépôt doit avoir un contract file-backed auditable plutôt
-qu'une configuration de chat propre à un outil. Pour un nouveau projet ou module,
-utilisez le mode scaffold de `repo-harness-setup` au lieu de `init`. Les maintainers éditant le
-package lui-même ont besoin d'un source checkout — voir
-[Maintainer Reference](#maintainer-reference).
-
 ### À quoi ressemble le succès
 
-La commande doit se terminer par `=== Migration Report ===` et inclure :
+L'apply se termine par `=== Migration Report ===`, qui indique la provenance
+du comportement des hooks générés, la cible des adapters de niveau utilisateur
+`~/.claude/settings.json` et `~/.codex/hooks.json`, les surfaces repo-local
+créées ou rafraîchies, le helper runtime `.ai/harness/scripts/*`, et un bloc de
+readiness `--- External Tooling ---`. L'intention stable vit ensuite dans
+`docs/spec.md`, l'état d'exécution dans `plans/` et `tasks/`, l'état de
+reprise dans `.ai/harness/handoff/`. Si le dry run semble incorrect,
+arrêtez-vous et lisez d'abord
+[`hook-operations.md`](docs/reference-configs/hook-operations.md).
 
-- `Project hooks synced from:` : d'où vient le comportement des hooks générés
-- `Host hook config target: user-level ~/.claude/settings.json and ~/.codex/hooks.json` : où se trouve la couche adapter
-- `Host hook adapters are user-level:` : rappel d'installer les global adapters, et de faire confiance à `~/.codex/hooks.json`
-- `Workflow migration:` : le plan de création ou de rafraîchissement des repo-local harness surfaces
-- `Helper runtime:` : la chaîne d'outils opérationnels obtenue après application
-- `--- External Tooling ---` : le guide de planning parent/Geju, la readiness Waza et CodeGraph et les conseils d'installation/mise à jour advisory
+### Mettre à jour et supprimer
 
-Si la sortie du dry-run est incorrecte, arrêtez-vous ici et lisez
+```bash
+repo-harness update          # refresh user-level CLI and runtime pieces
+repo-harness update --check  # read-only repair guidance, no writes
+repo-harness uninstall       # remove managed host adapters only
+```
+
+## Pourquoi repo-harness
+
+- **Des sessions file-backed, pas de mémoire de chat.** Les sessions Claude et
+  Codex séparées restent coordonnées via le dépôt. `SessionStart` injecte le
+  resume packet de la session précédente, `Stop` écrit le handoff, et chaque
+  édition enregistre un petit événement de journal. Une session peut
+  s'arrêter en plein milieu d'une tâche, et la suivante reprend directement à
+  l'étape suivante exacte, avec les blockers et les fichiers modifiés, sans
+  avoir à les redéduire.
+- **Économe en tokens par conception.** Au lieu de boucles grep-and-read qui
+  rescannent le dépôt à chaque session, le harness s'appuie sur un index
+  CodeGraph pré-construit pour les requêtes structurelles, et sur un
+  chargement de contexte progressif : un root context stable d'environ 12 Ko,
+  plus des capability blocks chargés uniquement quand les fichiers que vous
+  touchez en ont besoin. Les agents lisent un capability contract d'environ
+  1 Ko au lieu de redécouvrir la structure.
+- **Des preuves prêtes pour la review.** Chaque tâche laisse derrière elle un
+  contract, des check evidence structurées, et une review card. La surface de
+  décision humaine tient sur un seul écran — verdict, fichiers prévus vs
+  réels, commandes passées, risque résiduel, rollback — plutôt qu'une
+  reconstruction de ce que l'agent prétend avoir fait.
+
+Dans un dépôt adopté, la surface à comprendre reste volontairement réduite :
+
+| Surface | Rôle |
+| --- | --- |
+| `docs/spec.md` et `docs/reference-configs/` | Standards partagés et intention produit stable que chaque session d'agent peut lire. |
+| `plans/`, `plans/prds/` et `plans/sprints/` | Work packages decision-complete avant le début de l'implémentation. |
+| `tasks/contracts/`, `tasks/reviews/` et `.ai/harness/checks/` | Scope, vérification et preuves de review pour démontrer que le travail est terminé. |
+| `.ai/harness/handoff/` et `tasks/current.md` | Session journal et statut resumable, dérivés des workflow artifacts plutôt que de la mémoire de chat. |
+
+## Fonctionnalités clés
+
+| | |
+| --- | --- |
+| **Sessions file-backed** | Les plans, contracts, checks et handoffs vivent dans le dépôt, si bien qu'une nouvelle session reprend à partir des artifacts plutôt que d'un chat thread |
+| **Runtime de hooks typés** | Huit routes managées partagées, plus trois routes de delegation réservées à Codex, chacune liée à exactement un typed handler in-process, avec des guards fail-closed à la frontière d'édition |
+| **Plan → Contract → Review** | Un seul lifecycle, du plan approuvé au contract projeté, en passant par le worktree isolé et l'evidence structurée, jusqu'à un closeout prêt pour la review |
+| **Chargement de contexte progressif** | Un root context stable d'environ 12 Ko, plus des capability contracts d'environ 1 Ko chargés uniquement pour les fichiers réellement touchés |
+| **Intégration CodeGraph** | Requêtes structurelles (callers, callees, définitions) résolues depuis un index pré-construit, au lieu de passes grep-and-read répétées |
+| **MCP planner sidecar** | ChatGPT lit l'état réel du dépôt et écrit les artifacts PRD/Sprint/Goal ; Codex les exécute, sans accès en écriture par défaut au source-code |
+| **Alignement Claude + Codex** | Un seul adapter contract de niveau utilisateur, un seul workflow contract, et un seul ensemble d'artifacts repo-local partagés par les deux hosts |
+
+## Comment ça marche
+
+1. **Package source** : ce dépôt possède le CLI, les command facades, les
+   templates, les typed hook handlers, l'asset operator-helper, le workflow
+   contract, les tests et le release gate.
+2. **Contrat du dépôt cible** : `repo-harness init` ou une migration écrit des
+   fichiers repo-local tels que `docs/spec.md`, `plans/`, `tasks/`,
+   `.ai/context/`, `.ai/harness/`, des helper scripts et `.ai/hooks/`.
+3. **Host adapters** : les `~/.claude/settings.json` et `~/.codex/hooks.json`
+   de niveau utilisateur routent les events Claude/Codex vers
+   `repo-harness-hook`.
+
+Le hook entrypoint se termine silencieusement pour les dépôts non opt-in. Pour
+les dépôts opt-in, le route registry lie le tuple d'event public à exactement
+un typed handler packagé. `.ai/hooks/` ne contient qu'une projection
+operator-helper ; ce n'est jamais un host-event dispatcher.
+
+L'invariant central est que la vérité durable vit dans le dépôt, pas dans un
+chat thread. Les hooks sont des accélérateurs et des guardrails ; l'autorité
+reste dans les artifacts file-backed : le plan, le contract, la review, les
+checks et le handoff. Les gates plan/spec/contract de la prompt layer sont du
+routing advisory ; l'enforcement dur vit à la frontière d'édition. Les
+internals des handlers, la surface minimal-change et les policy modes :
+[`hook-operations.md`](docs/reference-configs/hook-operations.md) et
+[`minimal-change-hooks.md`](docs/reference-configs/minimal-change-hooks.md).
+
+## Workflow des tâches
+
+Le diagramme suppose que le harness est déjà installé. Il montre le cycle de
+vie normal, depuis le sprint backlog d'un programme jusqu'à une contract task
+unique : sélectionner la tâche, la projeter dans des fichiers d'exécution,
+checkout le contract worktree quand la policy l'exige, implémenter sous la
+protection des hooks, puis vérifier, review, et closeout.
+
+```mermaid
+flowchart TD
+  Program["Program goal or release theme"] --> Sprint{"Sprint layer needed?"}
+  Sprint -->|yes| PRD["Upper-layer PRD<br/>plans/prds/*.prd.md"]
+  PRD --> SprintDoc["Sprint backlog<br/>plans/sprints/*.sprint.md"]
+  SprintDoc --> NextTask["Select next sprint task<br/>sprint-backlog.sh next"]
+  Sprint -->|no| UserTask["User task or planning prompt"]
+  Heartbeat["Heartbeat triage<br/>scripts/heartbeat-triage.sh<br/>.ai/harness/triage/"] --> UserTask
+  NextTask --> UserTask
+
+  UserTask --> Discovery["Due diligence<br/>P1 map, P2 trace, P3 decision"]
+  Discovery --> LoopEvidence["Loop evidence when routing changes<br/>state-snapshot --json<br/>route-nl-vs-ts / cutover gate"]
+  LoopEvidence --> PlanDraft["Draft plan<br/>plans/plan-*.md"]
+  PlanDraft --> PlanReview{"Plan ready for execution?"}
+  PlanReview -->|no| Refine["Refine plan, scope, evidence contract"]
+  Refine --> PlanDraft
+  PlanReview -->|yes| Approve["Approved plan<br/>Status: Approved"]
+
+  Approve --> Project["Project plan into execution<br/>capture-plan.sh --execute<br/>or plan-to-todo.sh --plan"]
+  Project --> Active["Active markers<br/>.ai/harness/active-plan<br/>.ai/harness/active-worktree"]
+  Project --> SprintActive["Sprint projection<br/>active-sprint marker<br/>tasks/current.md"]
+  Project --> Contract["Sprint contract<br/>tasks/contracts/YYYYMMDD-HHMM-task-slug.contract.md"]
+  Project --> ReviewFile["Review file<br/>tasks/reviews/YYYYMMDD-HHMM-task-slug.review.md"]
+  Project --> Notes["Task notes<br/>tasks/notes/YYYYMMDD-HHMM-task-slug.notes.md"]
+
+  Contract --> Delegation["Delegation contract<br/>budget / permission_scope / roles"]
+  Delegation --> Delegate{"Use contract-run delegation?"}
+  Delegate -->|yes| ContractRun["Worker/verifier child run<br/>scripts/contract-run.ts"]
+  Delegate -->|no| WorktreePolicy{"Contract worktree required?"}
+  WorktreePolicy -->|yes| Checkout["Checkout isolated worktree<br/>contract-worktree.sh start --plan<br/>branch codex/task-slug"]
+  WorktreePolicy -->|no| CurrentTree["Use current worktree<br/>small or explicitly allowed slice"]
+  Checkout --> Implement
+  CurrentTree --> Implement
+  ContractRun --> Changes
+
+  Implement["Edit and run commands"] --> PreHooks["Pre-edit guards<br/>PlanStatusGuard, ContractScopeGuard, WorktreeGuard"]
+  PreHooks -->|blocked| ScopeFix["Fix plan, contract, worktree, or scope"]
+  ScopeFix --> Implement
+  PreHooks -->|allowed| Changes["Code, docs, tests, or config changes"]
+  Changes --> PostHooks["Post-edit and post-bash hooks<br/>trace, drift request, handoff, check evidence"]
+  PostHooks --> ArchQueue["Architecture queue<br/>architecture-queue.sh record/reindex<br/>check-architecture-sync.sh"]
+  ArchQueue --> Verify["Run verification<br/>tests plus repo workflow checks"]
+
+  Verify --> Checks["Structured evidence<br/>.ai/harness/checks/latest.json<br/>.ai/harness/runs/*.json"]
+  Checks --> CheckReview["Evaluator review<br/>Waza /check -> review file"]
+  CheckReview --> External["External acceptance advice<br/>or explicit manual override"]
+  External --> DoneGate{"Contract, checks, review, and acceptance pass?"}
+  DoneGate -->|no| Repair["Repair failing evidence or implementation"]
+  Repair --> Implement
+  DoneGate -->|yes| SprintComplete{"Sprint task active?"}
+  SprintComplete -->|yes| MarkSprint["Mark backlog item complete<br/>sprint-backlog.sh complete-task"]
+  SprintComplete -->|no| Closeout["Closeout<br/>scripts/contract-worktree.sh finish"]
+  MarkSprint --> Closeout
+
+  Closeout --> Commit["Commit contract branch"]
+  Commit --> Merge["Fast-forward target branch"]
+  Merge --> Archive["Archive plan/todo and refresh handoff"]
+  Archive --> Cleanup["Cleanup merged worktree<br/>contract-worktree.sh cleanup"]
+  Cleanup --> Done["Reviewable completed task"]
+```
+
+Pour les boucles produit de longue durée, gardez la discovery et le jugement
+d'engineering-plan du côté du parent agent avant que Codex ne boucle sur
+l'exécution : `geju` ouvre le pre-contract frame, le parent complète P1/P2/P3
+et fige la direction acceptée dans un PRD upper-layer sous `plans/prds/` et un
+sprint backlog ordonné sous `plans/sprints/`, puis un Codex Goal pointe vers ce
+fichier de sprint. Le PRD reste la source of truth supérieure, et le backlog
+est la file d'exécution durable, si bien qu'une session Goal reprise ne
+réinterprète jamais le chat d'origine. Voir
+[`agentic-development-flow.md`](docs/reference-configs/agentic-development-flow.md)
+et [`workflow-orchestration.md`](docs/reference-configs/workflow-orchestration.md).
+
+## Hooks
+
+L'adapter installé possède huit routes de hook managées et partagées. Le
+tuple de route `event + routeId + matcher` est le contrat stable ; chaque
+tuple lie exactement un typed handler in-process.
+
+| Route | Matcher | Handler | Fonction |
+| --- | --- | --- | --- |
+| `SessionStart.default` | all sessions | `src/cli/hook/session-context.ts` (in-process builder) | Injecte le handoff précédent, le statut sprint, la guidance minimal-change, et les findings config-security read-only avant le début du travail. |
+| `PreToolUse.edit` | `Edit\|Write` | `src/cli/hook/mutation-guard.ts` (in-process handler) | Impose la worktree policy et la readiness plan/contract avant les edits d'implémentation. |
+| `PreToolUse.subagent` | `Task\|Agent\|SendUserMessage` | `src/cli/hook/subagent-handler.ts` | Garde le travail délégué qui revient via la session parent, au lieu de laisser fuiter des complétions prétendues. |
+| `PostToolUse.edit` | `Edit\|Write` | `src/cli/hook/mutation-observed.ts` (in-process handler) | Écrit au plus un petit événement de journal avec des dirty bits par edit qualifiant ; la contract verification, la sync architecture/context/capability, et l'evidence minimal-change sont différées jusqu'au Stop plutôt qu'exécutées à chaque edit. |
+| `PostToolUse.bash` | `Bash` | `src/cli/hook/command-observed.ts` | Observe les résultats de commande et capture l'evidence de vérification sans remplacer le command runner. |
+| `PostToolUse.always` | all tools | `src/cli/hook/trace-observer.ts` | Fournit une trace toujours active et à faible bruit, ainsi que l'observation runtime. |
+| `UserPromptSubmit.default` | all prompts | `src/cli/hook/prompt-handler.ts` | Classifie l'intent du prompt, route les hints de planning/check, et rend une guidance de workflow host-safe. |
+| `Stop.default` | session stop | `src/cli/hook/stop-handler.ts` (in-process handler) | Finalise le handoff et empêche de terminer avec un draft-plan non résolu ou des gaps d'evidence de complétion. |
+
+Codex installe aussi trois routes de bounded-delegation réservées à Codex —
+`UserPromptSubmit.delegation`, `SubagentStart.context` et
+`SubagentStop.quality`, toutes liées à `src/cli/hook/subagent-handler.ts` ;
+Claude ne garde que la route partagée `PreToolUse.subagent` return-channel.
+
+`repo-harness-hook` et son typed handler registry constituent le host-event
+runtime ; `~/.claude/settings.json` et `~/.codex/hooks.json` sont les adapters
+de niveau utilisateur, et Codex doit marquer son fichier comme trusted dans
+Settings avant que ces hooks ne s'exécutent. Les `.claude/settings.json` et
+`.codex/hooks.json` repo-locales sont une config legacy à retirer. Debug dans
+l'ordre : adapter config -> `repo-harness-hook` -> route registry -> typed
+handler.
+
+Quand un hook bloque le travail, lisez d'abord la sortie terminal structurée :
+`guard`, `reason`, `fix`, `failure_class` et `run_id`. Les enregistrements
+durables vivent dans `.ai/harness/failures/latest.jsonl`, avec l'activité
+outil environnante dans `.claude/.trace.jsonl`. Les guards courants sont
+`PlanStatusGuard` (pas de plan actif ou exécutable), `ContractGuard` (contract
+scaffold manquant, ou complétion déclarée avant que le contract ne passe), et
+`WorktreeGuard` (écritures depuis le mauvais worktree). Guide complet :
 [`docs/reference-configs/hook-operations.md`](docs/reference-configs/hook-operations.md).
 
-## MCP Connector Quickstart
+## Connecteur MCP
 
-En sidecar optionnel, `repo-harness mcp` n'expose que les workflow artifacts aux
-clients MCP. ChatGPT agit comme planner/reviewer qui lit l'état et fait avancer
-une idée à travers les artifacts PRD, checklist Sprint et Codex goal handoff —
-sans accès en écriture au source-code, sans exécution shell arbitraire ni Codex
-runner par défaut. Codex reste l'exécuteur.
-
-Ce sidecar suppose que le CLI est déjà installé via « Les 5 premières minutes »
-ci-dessus. Utilisez-le quand vous voulez que ChatGPT planifie sur l'état réel du
-dépôt et que Codex exécute le Sprint file-backed qui en résulte.
+En tant que sidecar optionnel, `repo-harness mcp` expose les workflow
+artifacts aux clients MCP via le profile `planner` par défaut. ChatGPT lit
+l'état réel du dépôt et fait avancer une idée à travers les artifacts PRD,
+checklist Sprint et Codex goal handoff — sans accès en écriture au
+source-code par défaut, sans exécution shell arbitraire, ni runner par
+défaut. Codex reste l'exécuteur.
 
 ```bash
 repo-harness mcp setup chatgpt --repo .
 repo-harness mcp serve --repo . --transport http --host 127.0.0.1 --port 8765 --profile planner
 ```
 
-Exposez ce server local via un tunnel HTTPS et créez un Connector ChatGPT avec
-l'URL `/mcp`. Le guide généré est écrit dans :
-
-```text
-docs/repo-harness-chatgpt-mcp-setup.md
-```
-
-Le human workflow est le suivant :
+Exposez ce serveur local via un tunnel HTTPS, enregistrez l'URL `/mcp`, et le
+human workflow devient :
 
 1. ChatGPT lit les fichiers de workflow de repo-harness via MCP.
 2. ChatGPT écrit un PRD avec `write_prd_from_idea`.
-3. ChatGPT écrit un Sprint checklist avec `write_checklist_sprint`.
+3. ChatGPT écrit un checklist Sprint avec `write_checklist_sprint`.
 4. ChatGPT prépare `.ai/harness/handoff/codex-goal.md` avec `prepare_codex_goal_from_sprint`.
 5. Codex exécute le prompt host-native `/goal` et stage chaque Sprint phase terminée.
 
-Repli local pour la dernière étape de handoff :
+Outils génériques de lecture/écriture du dépôt, cohérence du snapshot et de
+l'index, server profiles, et le dev runner opt-in :
+[`general-repo-mcp.md`](docs/reference-configs/general-repo-mcp.md). Profile
+direct-coding : [`chatgpt-coding-mcp.md`](docs/reference-configs/chatgpt-coding-mcp.md).
+Opérations index-stale, CodeGraph-down et rollback :
+[`general-repo-mcp-codegraph.md`](deploy/runbooks/general-repo-mcp-codegraph.md).
 
-```bash
-repo-harness mcp prepare-goal --repo . --prd plans/prds/<feature>.prd.md --sprint plans/sprints/<feature>.sprint.md
-```
+## Revue du travail
 
-Le Skill destiné à l'agent est installé dans :
+Commencez par `tasks/reviews/<task>.review.md`. Sa `## Human Review Card` est
+la surface de décision sur un seul écran : verdict, change type, fichiers
+prévus vs réels, commandes passées, external acceptance, risque résiduel,
+action du reviewer et rollback. Inspectez ensuite le contract actif, le
+dernier trace dans `.ai/harness/checks/latest.json`, et les fichiers
+modifiés. N'acceptez que lorsque la review recommande pass, que le verdict de
+la card est pass, et que l'external acceptance est pass, `not_required`, ou un
+override explicite.
+
+Les agents lisent les source artifacts avant les résumés dérivés :
+
+| L'agent lit en premier | L'humain revoit en premier |
+| --- | --- |
+| Prompt utilisateur courant et fichiers référencés | Human Review Card de `tasks/reviews/<task>.review.md` |
+| `AGENTS.md` / `CLAUDE.md` | Fichiers modifiés et diff |
+| Plan actif dans `.ai/harness/active-plan` | Allowed paths et exit criteria du contract actif |
+| Contract actif dans `tasks/contracts/` | `.ai/harness/checks/latest.json` et run trace |
+| Dernier handoff dans `.ai/harness/handoff/` | Risques résiduels et rollback |
+
+`tasks/current.md` n'est qu'un snapshot d'orientation. S'il diverge du plan
+actif, du contract, de la review, des checks ou du handoff, les source
+artifacts l'emportent.
+
+Les validators runtime-heavy (Unity, browser E2E, mobile simulators, hardware
+rigs, staging smoke tests) peuvent publier des manifests de vérification
+externe sous la surface ignorée run-evidence — une convention manuelle
+aujourd'hui, pas un gate automatique `repo-harness check`. Voir
+[external tooling](docs/reference-configs/external-tooling.md#external-verification-evidence).
+
+## Skills
+
+Les packages canoniques propriétaires des règles vivent sous `assets/skills/`
+et `assets/skill-commands/`, ce qui garde la découverte de skill côté host
+bornée pendant que le CLI et les hooks possèdent l'exécution.
+
+| Skill | Rôle |
+| --- | --- |
+| `repo-harness` | Skill routeur racine, synchronisé sans condition sur chaque profile |
+| `repo-harness-setup` | Modes init, migrate, upgrade, repair, scaffold et capability-configuration ; router-only |
+| `repo-harness-plan` | Crée un plan decision-complete, ou revoit un plan existant |
+| `repo-harness-product` | Modes PRD, Sprint et Goal pour le product planning upper-layer |
+| `repo-harness-check` | Checks workflow et release, plus une référence deploy-readiness |
+| `repo-harness-ship` | Valide les worktrees terminés, push les branches et ouvre les PRs |
+| `repo-harness-architecture` | Docs d'architecture, drift requests et diagrammes sans rafraîchissement complet du harness |
+| `repo-harness-cross-review` | Cross-model review indépendante Claude/Codex, host-aware |
+| `claude-plan` | Provider skill côté Codex : consult indépendant en Claude plan mode pour un design fork ou une décision à enjeux élevés ; pas un point d'entrée utilisateur direct |
+| `repo-harness-chatgpt` | Consults Oracle browser/GPT Pro, setup du Connecteur MCP et bridge handoff ; setup explicite uniquement |
+| `merge-gate` (externe) | Gate final exact-candidate ; repo-harness ne fournit aucun Skill merge-gate — voir [external tooling](docs/reference-configs/external-tooling.md) |
+
+La chaîne de planning est volontairement découpée en couches :
 
 ```text
-.agents/skills/repo-harness-chatgpt-bridge/SKILL.md
+idea -> PRD mode -> Sprint mode -> Goal mode
 ```
 
-Ce Skill explique à Codex comment consommer les artifacts PRD/Sprint/Goal
-produits par ChatGPT sans accorder à ChatGPT d'écriture sur le source-code ni
-d'exécution shell.
+`repo-harness init` s'utilise sur un dépôt existant ; le scaffold mode de
+`repo-harness-setup` crée un nouveau projet ou module. `hooks-init`,
+`docs-init` et `create-project-dirs` sont des étapes internes, pas des
+commandes publiques. Limites de routing par mode :
+[`agentic-development-flow.md`](docs/reference-configs/agentic-development-flow.md)
+et `repo-harness docs show harness-overview`.
 
-Le Dev Mode peut opter pour l'exécution locale d'agents via MCP. C'est désactivé
-par défaut. Quand l'utilisateur active le profile `orchestrator` avec le réglage
-dev runner, ChatGPT peut appeler `run_agent_goal`, qui lit uniquement
-`.ai/harness/handoff/codex-goal.md` et exécute le handoff fixe via un CLI local
-autorisé tel que `codex exec` ou `claude -p`.
+## Référence des mainteneurs
+
+Éditer le package lui-même nécessite un source checkout :
 
 ```bash
-repo-harness mcp serve --repo . --transport http --profile orchestrator --enable-dev-runner --dev-runner-agents codex
+git clone https://github.com/Ancienttwo/repo-harness.git ~/Projects/repo-harness
+cd ~/Projects/repo-harness && bun src/cli/index.ts update
 ```
 
-Ce réglage est réservé au Developer Mode local. Il est borné par un timeout,
-audité, et ce n'est pas un shell arbitraire.
+Ce checkout est l'unique source of truth éditable ; les chemins de skill
+Claude/Codex locaux sont des runtime entrypoints adossés à des symlinks,
+reconstruits par `scripts/sync-codex-installed-copies.sh`.
 
-## Hook Authority Map
+`bun run check:ci` est le gate unique équivalent CI ; `bun run check:release`
+ajoute seulement le preflight npm unpublished-version avant de lui déléguer.
 
-`repo-harness-hook` est l'unique host-event runtime. L'adapter de niveau utilisateur
-transmet l'event, puis le route registry utilise le tuple stable `event + routeId + matcher`
-pour appeler exactement un typed handler. `assets/hooks/lib/workflow-state.sh` et
-`.ai/hooks/lib/workflow-state.sh` sont des projections d'operator helper, pas des dispatchers.
-
-- `~/.claude/settings.json` : adapter Claude de niveau utilisateur.
-- `~/.codex/hooks.json` : adapter Codex de niveau utilisateur ; confiance requise dans Settings.
-- `.claude/settings.json` / `.codex/hooks.json` repo-locales : inputs legacy à retirer pendant la migration.
-- Les changements de handler vivent dans `src/cli/hook/` ; synchronisez la projection avec `bun run sync:hooks`.
-
-The installed adapter owns the managed hook routes. Each route invokes one typed
-handler ; il n'existe ni second runtime shell ni runtime propre à un provider.
-
-| Route | Matcher | Typed handler | Function |
-| --- | --- | --- | --- |
-| `SessionStart.default` | all sessions | `src/cli/hook/session-context.ts` (in-process builder) | Injects prior handoff, sprint status, and read-only config-security findings before work starts. |
-| `PreToolUse.edit` | `Edit|Write` | `src/cli/hook/mutation-guard.ts` (in-process handler) | Enforces worktree policy and plan/contract readiness before implementation edits. |
-| `PreToolUse.subagent` | `Task|Agent|SendUserMessage` | `subagent` | Keeps delegated work returning through the parent session instead of leaking completion claims. |
-| `PostToolUse.edit` | `Edit|Write` | `mutation-observed` | Records the edit journal and controlled-file observations. |
-| `PostToolUse.bash` | `Bash` | `command-observed` | Observes command results and captures verification evidence without replacing the command runner. |
-| `PostToolUse.always` | all tools | `trace-observer` | Provides low-noise always-on trace and runtime observation. |
-| `UserPromptSubmit.default` | all prompts | `prompt` | Classifies prompt intent, routes planning/check/hunt hints, and renders host-safe workflow guidance. |
-| `Stop.default` | session stop | `src/cli/hook/stop-handler.ts` (in-process handler) | Finalizes handoff and guards against ending with unresolved draft-plan or completion evidence gaps. |
-
-`SessionStart` exécute le session-context builder in-process, qui assemble le contexte avant le début du travail :
-
-```mermaid
-flowchart LR
-  SessionStart["Claude/Codex SessionStart"] --> Ctx["session-context.ts<br/>in-process builder"]
-  Ctx --> Resume["resume + handoff context"]
-  Ctx --> Sec["security scan<br/>read-only config scan, fingerprint-gated"]
-  Resume --> SSOut["SessionStart additionalContext<br/>prior-session state + SecurityConfig findings"]
-  Sec --> SSOut
+```bash
+bun run check:ci                    # the whole gate
+repo-harness docs list              # runtime reference docs, resolved from the package
+repo-harness docs show harness-overview
+bun scripts/assemble-template.ts --plan C --name "MyProject"
 ```
 
-Le prompt guard ajoute une étape interne supplémentaire :
-
-```mermaid
-flowchart LR
-  Host["Claude/Codex UserPromptSubmit"] --> Adapter["user-level adapter"]
-  Adapter --> CLI["repo-harness-hook UserPromptSubmit --route default"]
-  CLI --> Route["route registry"]
-  Route --> Handler["prompt handler<br/>typed decision table"]
-  Handler --> RouteHint["Waza route hint<br/>explicit think/planning matched first → /think"]
-  Handler --> HostOutput["host-safe allow, advice, block, or done gate output"]
-```
-
-Le typed handler possède le parsing d'entrée, l'état des fichiers et les effets de bord
-déclarés ; le runtime uniformise uniquement la sortie host. AcceptanceReceipt est l'authority
-de closeout et le review Markdown n'est qu'une projection.
-
-## Hook Failure Playbook
-
-Quand un hook block fonctionne, regardez d'abord la sortie structurée dans le
-terminal. Les champs clés sont `guard`, `reason`, `fix`, `failure_class` et
-`run_id`.
-
-- Failure log : `.ai/harness/failures/latest.jsonl`
-- Trace log : `.claude/.trace.jsonl`
-- Guide approfondi : [`docs/reference-configs/hook-operations.md`](docs/reference-configs/hook-operations.md)
-
-Guards courants :
-
-- `PlanStatusGuard` : pas d'active plan, ou le plan n'est pas encore exécutable
-- `ContractGuard` : une approved execution n'a pas encore généré le scaffold contract/review/notes
-- `ContractGuard` : la tâche est déclarée terminée avant d'avoir passé la contract verification
-- `WorktreeGuard` : écriture depuis le primary worktree alors que la politique des linked worktrees est appliquée
-
-## Repo Workflow
-
-- Root routing docs : `CLAUDE.md`, `AGENTS.md`
-- Typed hook runtime : `src/cli/hook/` (via `repo-harness-hook`)
-- Projection d'operator helper : `.ai/hooks/lib/workflow-state.sh`
-- User-level adapter layer : `~/.claude/settings.json`, `~/.codex/hooks.json`
-- Active execution surface : `tasks/`
-- Plan source of truth : `plans/`
-- Durable progress : `tasks/workstreams/`
-- Release history : `docs/CHANGELOG.md`
-
-## Release actuelle
-
-- npm package : `repo-harness@0.12.0`
-- Generated workflow stamp : `repo-harness@0.12.0+template@0.12.0`
-- GitHub repository : `Ancienttwo/repo-harness`
-- Release history : [`docs/CHANGELOG.md`](docs/CHANGELOG.md)
+Les changements de hook mettent à jour `assets/hooks/` canonique une fois,
+puis lancent `bun run sync:hooks`, avec `bun run check:hooks` en
+vérification. Les reference docs sont canoniques sous
+`assets/reference-configs/` et projetées dans `docs/reference-configs/` ;
+`bun run check:reference-configs` vérifie cette projection.
 
 ## Remerciements
 
-Merci à [Hylarucoder](https://x.com/hylarucoder) pour sa contribution
-méthodologique. La méthode P1/P2/P3 due-diligence de `repo-harness`, ainsi que
-la pratique Geju qui structure le planning, le trace et le decision rationale,
-viennent de sa contribution et de son influence.
+`repo-harness` est construit autour d'un petit ensemble de skills externes, de
+dépôts et d'agent runtimes qui ont façonné le workflow contract. Ce ne sont
+pas des dépendances embarquées ordinaires.
 
-Merci à [TW93](https://x.com/HiTw93), auteur de Waza. Les skills centraux
-`think`, `hunt`, `check` et `health` structurent le rythme quotidien de planning,
-bug hunt et verification de `repo-harness`.
-
-Merci à [Peter Steinberger](https://x.com/steipete), auteur d'Oracle
-(`@steipete/oracle`, MIT). C'est le moteur de consult navigateur GPT Pro /
-ChatGPT Web par défaut de `chatgpt-browser` : le provider Oracle lance le binaire
-oracle externe pour les consults `gptpro`, sans téléchargement automatique, et un
-binaire manquant est une erreur franche.
-
+| Outil ou dépôt | Utilisé pour | Forme de dépendance |
+| --- | --- | --- |
+| [Hylarucoder](https://x.com/hylarucoder) / Geju | Méthode de due-diligence P1/P2/P3 et pratique Geju qui ont façonné la discipline de planning, de trace et de decision-rationale dans ce workflow | Contribution méthodologique et remerciement ; pas une dépendance embarquée |
+| Waza par [TW93](https://x.com/HiTw93), incluant `think`, `hunt`, `check` et `health` | Planning quotidien, bug hunts, vérification, health checks et skill sync Codex-first | Installé via le skills CLI dans les host skill roots |
+| `mermaid` | Diagrammes d'architecture et de system-flow lisibles par un humain quand Mermaid seul ne suffit pas | Skill référencé au runtime, non vendored dans les dépôts générés |
+| CodeGraph (`@colbymchenry/codegraph`) | Navigation symbol-aware, impact tracing et readiness checks pour ce dépôt self-host | Dev dependency dans ce dépôt ; les dépôts générés restent global-MCP-first sauf opt-in de la policy |
+| [Oracle](https://github.com/steipete/oracle) par [Peter Steinberger](https://x.com/steipete) (`@steipete/oracle`, MIT) | Moteur par défaut de consult navigateur GPT Pro / ChatGPT Web, que le provider Oracle `chatgpt-browser` invoque en shell out pour les consults `gptpro` | Binaire résolu en externe (`--oracle-bin`, `REPO_HARNESS_ORACLE_BIN`, `node_modules/.bin`, ou `PATH`) ; jamais téléchargé automatiquement, et un binaire manquant est une erreur franche `ORACLE_NOT_INSTALLED` |
+| OpenAI Codex | Agent d'exécution principal pour l'implémentation repo-local, la vérification, et l'attribution de contributeur GitHub quand un commit inclut matériellement du travail écrit par Codex | Agent runtime externe ; l'attribution est un commit trailer explicite, pas une automatisation cachée par hook |
 
 ### Attribution GitHub des contributeurs
 
-Lorsque Codex contribue matériellement à un commit, utilisez le trailer co-author standard de GitHub à la fin du commit message :
+Lorsque Codex contribue matériellement à un commit, utilisez le trailer
+co-author standard de GitHub à la fin du message :
 
 ```text
 Co-authored-by: codex <codex@openai.com>
 ```
 
-Gardez cette attribution opt-in et visible commit par commit. Ne l'intégrez pas aux scripts de commit ni aux hooks repo-harness downstream sauf si ce dépôt adopte explicitement la même politique.
+Gardez cette attribution opt-in et visible commit par commit. Ne l'intégrez
+pas dans les commit scripts ou hooks repo-harness en aval, sauf si ce dépôt
+adopte la même policy.
 
-## Action Command Skills
+## Release actuelle
 
-Les packages canoniques se trouvent dans `assets/skills/` (packages canoniques
-activés) et `assets/skill-commands/` (survivants qui évoluent sur place) ; ils
-préservent la portée de la découverte par skills, tandis que l'exécution
-appartient au CLI et aux hooks :
+- Package npm : `repo-harness@0.12.0`
+- Generated workflow stamp : `repo-harness@0.12.0+template@0.12.0`
+- Dépôt GitHub : `Ancienttwo/repo-harness`
+- Notes et historique de release : [`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 
-- Router : `repo-harness` (Skill racine, synchronisé sans condition sur chaque
-  profile)
-- Couche setup : `repo-harness-setup` (modes init, migrate, upgrade,
-  repair, scaffold, et capability-configuration ; router-only, jamais
-  découvert automatiquement par un profile)
-- Planning : `repo-harness-plan` (crée un plan decision-complete, ou revoit un
-  plan existant)
-- Couche product planning : `repo-harness-product` (modes PRD, Sprint, et
-  Goal ; le mode PRD active `$geju`, puis rédige en Claude-first avec
-  `claude -p --model opus`, Codex ne sert que de fallback ; le mode Sprint
-  transforme un PRD en backlog ordonné dans `plans/sprints/`, chaque ligne
-  étant développée avec `$think` avant le contract flow ; le mode Goal prépare
-  des prompts `/goal` Codex/Claude depuis un PRD ou Sprint détaillé et le
-  demande d'abord s'il manque)
-- Vérification : `repo-harness-check` (contrôles workflow/release plus une
-  référence deploy-readiness)
-- Release : `repo-harness-ship`
-- Architecture : `repo-harness-architecture`
-- Cross-model review : `repo-harness-cross-review` (host-aware ; installé sur
-  les deux hosts pour le profile strict)
-- Intégration ChatGPT : `repo-harness-chatgpt` (consult/continuation Oracle
-  browser/GPT Pro, setup MCP Connector, bridge handoff, et read-back
-  evidence ; setup explicite uniquement, jamais impliqué par le product
-  planning)
+## Licence
 
-La chaîne de planning est volontairement découpée en couches :
-
-```text
-idea -> repo-harness-product (mode PRD) -> repo-harness-product (mode Sprint, from-prd) -> repo-harness-product (mode Goal)
-```
-
-Utilisez le mode PRD de `repo-harness-product` quand la source est encore une
-idée produit : il lance d'abord un direction pass `$geju`, puis demande à
-Claude via `claude -p --model opus` de rédiger le PRD, avec Codex seulement en
-fallback. Utilisez son mode Sprint (`from-prd <plans/prds/*.prd.md>`) pour
-transformer un PRD approuvé en Sprint backlog ordonné avec des lignes
-d'acceptance vérifiables par machine. Utilisez son mode Goal seulement lorsqu'un
-PRD ou Sprint détaillé existe déjà ; il prépare un prompt `/goal` borné pour
-Codex/Claude et garde le PRD/Sprint comme source of truth. Si ce document
-manque, le mode Goal doit le demander avant de lancer une implémentation depuis
-le chat.
-
-`repo-harness init` sert aux dépôts existants ; le mode scaffold de
-`repo-harness-setup` sert à créer un nouveau projet ou module. `hooks-init`,
-`docs-init` et `create-project-dirs` sont des étapes internes, pas des
-commands publiques.
-
-## Maintainer Reference
-
-Les maintainers qui éditent le package lui-même ont besoin d'un source checkout :
-
-```bash
-git clone https://github.com/Ancienttwo/repo-harness.git ~/Projects/repo-harness
-cd ~/Projects/repo-harness
-bun src/cli/index.ts update
-```
-
-`~/Projects/repo-harness` est l'unique source of truth éditable ; les chemins
-Claude/Codex locaux (`~/.claude/skills/repo-harness`,
-`~/.codex/skills/repo-harness`) sont des runtime entrypoints adossés à des
-symlinks. Seul `~/.codex/skills/repo-harness` expose `SKILL.md` et
-`assets/skill-commands/` ; `scripts/sync-codex-installed-copies.sh` reconstruit
-ces alias et supprime les répertoires retirés `repo-harness-skill` /
-`project-initializer`. Le script lie par défaut les chemins runtime au dépôt
-source ; définissez `AGENTIC_DEV_LINK_INSTALLED_COPIES=0` pour un staging par
-copie, ou `CODEX_SKILLS_ROOT` / `CLAUDE_SKILLS_ROOT` pour des racines alternatives.
-
-### Vérifier le workflow contract de ce dépôt
-
-Lancez le gate complet dans [Verification](#verification) ; `bun run check:ci`
-est la commande unique équivalente CI.
-
-### Runtime reference docs
-
-Generic repo-harness runtime/reference docs live in the installed package under
-`assets/reference-configs/` and are resolved through the CLI:
-
-```bash
-repo-harness docs list
-repo-harness docs path harness-overview
-repo-harness docs show harness-overview
-```
-
-Les valeurs par défaut de l'initializer et du runtime (question flow, plan menu,
-template vars, routing external-tooling) sont documentées dans `harness-overview.md`
-sous **Initializer and Runtime Model**. Generated and migrated repos still keep
-`docs/reference-configs/*.md`, but those files are deterministic pointer stubs.
-Repo-local workflow state, policy, checks, runs, handoff packets, context maps,
-and helper snapshots stay under `.ai/`.
-
-### Template assembly
-
-```bash
-bun scripts/assemble-template.ts --plan C --name "MyProject"
-bun scripts/assemble-template.ts --target agents --plan C --name "MyProject"
-```
-
-### Verification
-
-```bash
-bun test
-bash scripts/check-task-sync.sh
-bash scripts/check-task-workflow.sh --strict
-bun scripts/inspect-project-state.ts --repo . --format text
-bun src/cli/index.ts init --repo . --dry-run
-bash scripts/check-agent-tooling.sh --host both --check-updates
-bun run benchmark:skills --eval route-workflow-check
-```
-
-
-### Local benchmark skeleton
-
-```bash
-bun run benchmark:skills --eval route-workflow-check
-```
-
-Eval output is the release/readiness evidence path; dry-run benchmark wiring is only a smoke and is not skill-effectiveness evidence.
-
-
-### Run one eval across both Claude and Codex
-
-```bash
-bun run benchmark:skills --eval repair-agents-task-sync
-```
-
-## Key Files
-
-- Skill spec : `SKILL.md`
-- Root routing docs : `CLAUDE.md`, `AGENTS.md`
-- Plan mapping : `assets/plan-map.json`
-- Question-pack : `assets/initializer-question-pack.v4.json`
-- Shared hooks : `assets/hooks/`
-- Runtime reference docs: `assets/reference-configs/` via `repo-harness docs`
-- Workflow contract : `assets/workflow-contract.v1.json`
-- Hook operations reference : `docs/reference-configs/hook-operations.md`
-- Template assembler : `scripts/assemble-template.ts`
-- State inspector : `scripts/inspect-project-state.ts`
-- External tooling detector: `scripts/check-agent-tooling.sh`
-- Scaffolding scripts:
-  - `scripts/init-project.sh`
-  - `scripts/create-project-dirs.sh`
-- Canonical adoption planner: `src/core/adoption/standard-plan.ts`
-
-## Generated vs Self-Hosted Hook Projection
-
-- Le comportement downstream des hooks est défini par la sortie générée depuis `assets/hooks/` et `assets/reference-configs/`.
-- Ce repo dogfoode le même contract, mais le comportement self-host ne se synchronise pas magiquement avec les generated repos ; un changement doit mettre à jour explicitement les deux surfaces lorsque nécessaire.
-- Chaque changement de hook doit dire s'il affecte `self-host`, `generated` ou `both`.
-
-## Package Manager Defaults
-
-- Priorité générale par défaut : `bun > pnpm > npm`
-- **Plan G/H** (Python-centric) utilise **`uv`** comme primary package manager par défaut.
-
-## Runtime Profiles
-
-- `Plan-only (recommended)` (default)
-- `Plan + Permissionless`
-- `Standard (ask before each action)`
-
-Configuré dans `assets/initializer-question-pack.v4.json` et consommé par `scripts/initializer-question-pack.ts`.
-
-## Verification
-
-Pour la release review, utilisez le gate unique équivalent CI :
-
-```bash
-bun run check:ci
-```
-
-Ce gate se développe vers les checks possédés par le repo ; `bun run check:release` ajoute seulement le preflight npm unpublished-version avant de déléguer au même gate.
-
-```bash
-bun test
-bash scripts/check-deploy-sql-order.sh
-bash scripts/check-architecture-sync.sh
-bash scripts/check-task-sync.sh
-bash scripts/check-task-workflow.sh --strict
-bun scripts/inspect-project-state.ts --repo . --format text
-bun src/cli/index.ts init --repo . --dry-run
-bash scripts/check-agent-tooling.sh --host both --check-updates
-bun run benchmark:skills --eval route-workflow-check
-```
+MIT — voir [`LICENSE`](LICENSE).

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,178 +1,49 @@
+<div align="center">
+
 # repo-harness
 
-`repo-harness` は、Claude/Codex のコーディング session を、繰り返し使える
-repo-local workflow に変えます。CLI と skill/runtime hooks によって、context、plan、
-handoff、check、review evidence をプロジェクト内のファイルへ書き戻し、次の agent session が
-chat memory ではなくファイルから続きに入れるようにします。
+### Claude と Codex のコーディングセッションのための、ファイルに基づく再現可能な workflow
 
-主な用途:
+<img src="docs/images/repo-harness-hook-carrot.png" alt="repo-harness の hooks が repo-local workflow state で Codex と Claude を前進させる様子" width="900">
 
-- 既存リポジトリへ tasks-first agent contract を導入する
-- Claude と Codex を同じ plan、check、handoff、context boundary に揃える
-- CodeGraph と段階的な context loading により、構造を再発見するための token 消費を減らす
-
-Agent に完全な PRD または Sprint を渡せば、あとは review and `next` だけで進めるか、
-`/goal` を開始して AFK できます。
+[![npm version](https://img.shields.io/npm/v/repo-harness.svg)](https://www.npmjs.com/package/repo-harness)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Runtime: Bun](https://img.shields.io/badge/runtime-Bun%20%E2%89%A5%201.1.35-black.svg)](https://bun.sh)
 
 [English](README.md) | [简体中文](README.zh-CN.md) | [日本語](README.ja.md) | [Français](README.fr.md) | [Español](README.es.md)
 
-リポジトリ：`https://github.com/Ancienttwo/repo-harness`
+**Agent に完全な PRD または Sprint を渡せば、その後のループはただ review して `next` を実行するだけ、もしくは `/goal` を起動して AFK するだけです。**
 
-## なぜ repo-harness を使うのか
+</div>
 
-- **セッションの状態はファイルに残り、チャット履歴には残らない。** 別々の agent
-  セッション（Claude、Codex、今のものも後のものも）は、チャットスレッドではなくリポジトリを通じて
-  同期を保ちます。新しいセッションが始まると in-process の session-context builder（`src/cli/hook/session-context.ts`）が前回セッションの
-  resume packet（`.ai/harness/handoff/resume.md`、`tasks/current.md`）を注入し、セッション終了時と
-  各編集後には `session-context`、`stop`、`mutation-observed` の typed handler が次の handoff を書き戻します。タスクは
-  途中で中断でき、次のセッションは正確な次の一手・ブロッカー・変更ファイルをそのまま引き継ぐので、
-  状況を推測し直す必要がありません。
-- **設計上 token を節約する。** セッションごとにリポジトリを grep+read で再スキャンするループに頼る
-  代わりに、harness は事前構築された CodeGraph index を使って構造的なクエリ（誰が呼ぶ・何を呼ぶ・
-  どこで定義されているか）を行い、さらに `.ai/context/context-map.json` と `capabilities.json` を使って
-  段階的な context 読み込みを行います。小さく安定した root context（約 12KB）に、対応するファイルを
-  触ったときだけ読み込まれる capability ブロックが加わる構成です。agent は構造を把握し直すために数千
-  token を費やすのではなく、1KB の capability contract を読むか index に問い合わせます。
+`repo-harness` は、context、plans、handoffs、checks、review evidence をプロジェクトへ
+書き戻す CLI と skill/runtime hooks を提供し、次の agent session が chat memory では
+なくファイルから続きに入れるようにします。既存のリポジトリに、Claude と Codex を
+揃える tasks-first な agent contract を導入します。
 
-導入後のリポジトリで意識する surface は小さく保たれます。
+## 目次
 
-| Surface | 目的 |
-| --- | --- |
-| `docs/spec.md` と `docs/reference-configs/` | すべての agent session が読める共有標準と安定した product intent。 |
-| `plans/`, `plans/prds/`, `plans/sprints/` | 実装前に固める decision-complete work packages。 |
-| `tasks/contracts/`, `tasks/reviews/`, `.ai/harness/checks/` | 作業完了を証明する scope、verification、review evidence。 |
-| `.ai/harness/handoff/` と `tasks/current.md` | chat memory ではなく workflow artifacts から派生する session journal と resumable status。 |
+- [セットアップ](#セットアップ)
+- [なぜ repo-harness を使うのか](#なぜ-repo-harness-を使うのか)
+- [主な機能](#主な機能)
+- [仕組み](#仕組み)
+- [タスク Workflow](#タスク-workflow)
+- [Hooks](#hooks)
+- [MCP Connector](#mcp-connector)
+- [レビューの進め方](#レビューの進め方)
+- [Skills](#skills)
+- [メンテナー向けリファレンス](#メンテナー向けリファレンス)
+- [謝辞](#謝辞)
+- [現在の Release](#現在の-release)
+- [ライセンス](#ライセンス)
 
-## Human Review Path
+## セットアップ
 
-まず `tasks/reviews/<task>.review.md` を読みます。`## Human Review Card` は
-1 画面の意思決定面で、verdict、change type、想定/実際の変更ファイル、通過した
-コマンド、external acceptance、残余リスク、reviewer action、rollback を載せます。
-続いて active contract、`.ai/harness/checks/latest.json` の latest trace、変更
-ファイルを確認します。review が pass を推奨し、card の verdict が pass で、
-external acceptance が pass・`not_required`・明示的な manual override のいずれ
-かのときだけ accept します。
+### 1. CLI をインストールする
 
-## Agent Tracking Path
-
-Agent は派生サマリーより先に source artifacts を読みます。
-
-| Agent reads first | Human reviews first |
-| --- | --- |
-| 現在のユーザー prompt と参照ファイル | `tasks/reviews/<task>.review.md` の Human Review Card |
-| `AGENTS.md` / `CLAUDE.md` | 変更ファイルと diff |
-| `.ai/harness/active-plan` の active plan | active contract の allowed paths と exit criteria |
-| `tasks/contracts/` の active contract | `.ai/harness/checks/latest.json` と run trace |
-| `.ai/harness/handoff/` の latest handoff | 残余リスクと rollback |
-
-`tasks/current.md` は orientation snapshot にすぎません。active plan、contract、
-review、checks、handoff と食い違う場合は、source artifacts を優先します。
-
-## What's New
-
-リリースノートは [`docs/CHANGELOG.md`](docs/CHANGELOG.md) にあります。現在の
-ラインは `0.12.0` です。
-
-## 仕組み
-
-設計は 3 層に分かれます。host event は 1 本の typed runtime を通ります。
-
-1. **ソースパッケージ層**：本リポジトリが CLI、CLI-backed command facades、templates、hook assets、
-   workflow contract、tests、release gate を所有します。
-2. **対象リポジトリ contract 層**：`repo-harness init` または migration が、`docs/spec.md`、
-   `plans/`、`tasks/`、`.ai/context/`、`.ai/harness/`、helper scripts を書き込みます。
-   `.ai/hooks/lib/workflow-state.sh` は operator helper projection だけです。
-3. **Host adapter 層**：user-level の `~/.claude/settings.json` と `~/.codex/hooks.json` が
-   Claude/Codex の events を `repo-harness-hook` へ route します。opt-in 契約を確認した後、
-   route registry が `event + routeId + matcher` に対応する exactly one typed handler を呼びます。
-
-すべての event は `host adapter -> repo-harness-hook -> route registry -> typed handler` を通ります。
-`UserPromptSubmit.default` は `prompt` handler、edit/bash/stop はそれぞれ `mutation-observed`、
-`command-observed`、`stop` が担当します。shell dispatcher や provider ごとの別 runtime はありません。
-
-中核となる不変条件は、持続的な真実がチャットスレッドではなくリポジトリに存在することです。Hooks は
-あくまで加速装置と guardrail であり、authority は plan、contract、review、checks、handoff といった
-ファイルベースの成果物にあります。
-
-## 任務 Workflow：Plan から Closeout まで
-
-下の図は、対象リポジトリに harness がすでにインストールされている前提です。単一タスクの通常の閉ループ
-を示しています。まず plan を形成し、sprint contract へ投射し、必要なら隔離された worktree を checkout し、
-hooks の保護下で実装し、検証・review・external acceptance を経て、最後に closeout します。
-
-```mermaid
-flowchart TD
-  UserTask["ユーザータスクまたは planning prompt"] --> Discovery["前置調査<br/>P1 map, P2 trace, P3 decision"]
-  Discovery --> PlanDraft["Draft plan<br/>plans/plan-*.md"]
-  PlanDraft --> PlanReview{"Plan は実行可能か?"}
-  PlanReview -->|いいえ| Refine["scope と evidence contract を収束させる"]
-  Refine --> PlanDraft
-  PlanReview -->|はい| Approve["Approved plan<br/>Status: Approved"]
-
-  Approve --> Project["実行面へ投射<br/>capture-plan.sh --execute<br/>または plan-to-todo.sh --plan"]
-  Project --> Active["Active markers<br/>.ai/harness/active-plan<br/>.ai/harness/active-worktree"]
-  Project --> Contract["Sprint contract<br/>tasks/contracts/YYYYMMDD-HHMM-task-slug.contract.md"]
-  Project --> ReviewFile["Review file<br/>tasks/reviews/YYYYMMDD-HHMM-task-slug.review.md"]
-  Project --> Notes["Task notes<br/>tasks/notes/YYYYMMDD-HHMM-task-slug.notes.md"]
-
-  Contract --> WorktreePolicy{"contract worktree が必要か?"}
-  WorktreePolicy -->|はい| Checkout["隔離 worktree を checkout<br/>contract-worktree.sh start --plan<br/>branch codex/task-slug"]
-  WorktreePolicy -->|いいえ| CurrentTree["現在の worktree を使う<br/>小タスクまたは明示的に許可された slice"]
-  Checkout --> Implement
-  CurrentTree --> Implement
-
-  Implement["編集とコマンド実行"] --> PreHooks["Pre-edit guards<br/>PlanStatusGuard, ContractScopeGuard, WorktreeGuard"]
-  PreHooks -->|blocked| ScopeFix["plan、contract、worktree、scope を修正"]
-  ScopeFix --> Implement
-  PreHooks -->|allowed| Changes["コード、ドキュメント、テスト、設定の変更"]
-  Changes --> PostHooks["Post-edit / post-bash hooks<br/>trace, drift request, handoff, check evidence"]
-  PostHooks --> Verify["検証を実行<br/>tests plus repo workflow checks"]
-
-  Verify --> Checks["構造化された evidence<br/>.ai/harness/checks/latest.json<br/>.ai/harness/runs/*.json"]
-  Checks --> CheckReview["Evaluator review<br/>Waza /check -> review file"]
-  CheckReview --> External["External acceptance advice<br/>または明示的な manual override"]
-  External --> DoneGate{"Contract、checks、review、acceptance は通ったか?"}
-  DoneGate -->|いいえ| Repair["失敗した evidence または実装を修復"]
-  Repair --> Implement
-  DoneGate -->|はい| Closeout["Closeout<br/>scripts/contract-worktree.sh finish"]
-
-  Closeout --> Commit["contract branch を commit"]
-  Commit --> Merge["target branch を fast-forward"]
-  Merge --> Archive["plan/todo を archive し handoff をリフレッシュ"]
-  Archive --> Cleanup["merge 済み worktree を cleanup<br/>contract-worktree.sh cleanup"]
-  Cleanup --> Done["レビュー可能な完了タスク"]
-```
-
-## 長期プロダクト Loop
-
-Greenfield と Brownfield の作業では、Codex に実行 loop を任せる前に、
-discovery と engineering-plan judgment を parent agent 側で前倒しします。
-
-1. contract を作る前に parent agent が `geju` で視野を広げ、その後、自身の
-   repo/runtime 能力で P1/P2/P3 を完了します。合意した product intent、
-   architecture、risks、falsifier、evidence contract を development documents
-   に固定します。
-2. それらの documents を `plans/prds/` 配下の PRD Sprint に変換し、
-   各 execution slice に ordered backlog と detailed sub-plans を持たせます。
-3. Codex Goal を作成し、その sprint file を指します。repo-harness はその後、
-   各 sprint item を通常の plan -> contract -> worktree -> verification flow
-   へ投射できます。
-
-この handoff により、長期 loop は精密になります。parent agent が広い前置判断を担い、
-PRD Sprint が durable source of truth となり、Codex Goal mode は元の chat を再解釈する
-のではなく、具体的な sprint に対して resume します。
-
-## 最初の 5 分
-
-実際のリポジトリがこの workflow を導入するのに適しているかを評価する、最速の経路です。
-
-前提条件：Git working tree、`bash`、`bun`（後続の検証と template assembly に使用）。
-`jq` は任意。`--dry-run` のときは導入を推奨し、settings merge を適用するときにより有用です。
-
-### CLI をインストールする
-
-既定の経路では Node.js は不要です。installer は Bun >= 1.1.35 を runtime として使います。
-Bun が見つからない場合や古い場合は、先に Bun をインストールまたは更新してから `repo-harness` CLI をインストールします。
+前提条件は Git working tree、`bash`、`bun` です。`jq` は任意です。Node.js は
+不要です — installer は runtime として Bun >= 1.1.35 を使用し、必要であれば
+先に Bun のインストールまたはアップグレードを行います。
 
 ```bash
 # macOS / Linux
@@ -182,425 +53,427 @@ curl -fsSL https://raw.githubusercontent.com/Ancienttwo/repo-harness/main/instal
 irm https://raw.githubusercontent.com/Ancienttwo/repo-harness/main/install.ps1 | iex
 ```
 
-<details>
-<summary>Bun >= 1.1.35 がすでにある場合は Bun を優先し、npx を fallback として使えます</summary>
+Bun >= 1.1.35 がすでに PATH 上にある場合は、shell installer をスキップできます。
+Package manager が所有する Bun のインストールでは、manager が管理するファイルを
+上書きする代わりに、対応する upgrade コマンド(`brew upgrade bun`)を伴って
+fail closed します。
 
 ```bash
-# Bun（推奨）
-bun add -g repo-harness
+bunx repo-harness@latest install     # Bun one-shot bootstrap
+bun add -g repo-harness              # or install the persistent CLI first
 repo-harness install
-
-# npx fallback。CLI runtime は Bun なので、Bun が PATH 上に必要です。
-npx -y repo-harness@latest install
+npx -y repo-harness@latest install   # npx fallback; the CLI still runs on Bun
 ```
 
-</details>
-
-### host runtime を bootstrap する
+### 2. host runtime を bootstrap する
 
 ```bash
 repo-harness install
 ```
 
-`repo-harness install` は global bootstrap、`repo-harness update` は
-user-level refresh、`repo-harness init` は repo-local refresh です。`repo-harness install` は CLI、user-level hook adapters、Waza、Mermaid、
-brain root、CodeGraph MCP を設定し、退役した `scripts/setup-plugins.sh` の Claude plugin path は使いません。
+この global bootstrap は、npm package を global CLI としてインストールし、
+repo-harness の skill alias を更新し、user-level の hook adapter をインストールし、
+明示的な install profile を記録します。冪等(idempotent)であり、repo-local な
+workflow ファイルをカレントディレクトリへ適用することはありません。
+`--dry-run --json` を使うと、インストール・skip・削除される component を
+先に一覧できます。profile、delegation mode、refresh コマンド、read-only な
+`setup check` audit については
+[`install-profiles.md`](docs/reference-configs/install-profiles.md)
+を参照してください。
 
-package 本体を編集する maintainer はソースの checkout が必要です
-—— [Maintainer Reference](#maintainer-reference) を参照してください。
-
-### ここから始める
-
-既存リポジトリでは repo root から実行します。
+### 3. repo-local contract をプレビューする
 
 ```bash
 repo-harness init --dry-run
 ```
 
-dry-run のレポートが正しいことを確認してから適用します。
+これは対象リポジトリの root から実行します。作成またはリフレッシュされる
+spec、task state、helper runtime、hook adapter の対象、verification ファイルを
+レポートします。application スタックを作成することは決してありません。新しい
+プロジェクトやモジュールには、代わりに `repo-harness-setup` の scaffold mode を
+使用してください。
+
+### 4. 適用して検証する
 
 ```bash
 repo-harness init
-```
-
-新しいプロジェクトやモジュールには `repo-harness-setup` の scaffold mode を使います。既存リポジトリには
-`repo-harness init` を使います。これは harness をインストールまたはリフレッシュするもので、アプリケーション
-スタックは作成しません。
-
-### 成功した状態
-
-コマンドの最後には `=== Migration Report ===` が出力され、次の内容を含むはずです。
-
-- `Project hooks synced from:`：生成された hook 行動がどこ由来かを示す
-- `Host hook config target: user-level ~/.claude/settings.json and ~/.codex/hooks.json`：adapter 層がどこにあるか
-- `Host hook adapters are user-level:`：global adapters のインストールを促し、`~/.codex/hooks.json` を信頼するよう注意する
-- `Workflow migration:`：repo-local harness surfaces の作成またはリフレッシュ計画
-- `Helper runtime:`：適用後に得られる操作ツールチェーン
-- `--- External Tooling ---`：parent/Geju planning の指針、Waza と CodeGraph の readiness、advisory なインストール/更新のヒント
-
-### 続けて実行する 2 つのコマンド
-
-```bash
 bash scripts/check-task-workflow.sh --strict
 bun test
 ```
 
-dry-run の出力がおかしい場合は、ここで一旦止め、
-[`docs/reference-configs/hook-operations.md`](docs/reference-configs/hook-operations.md) を読んでください。
+### 成功時の状態
 
-## MCP Connector Quickstart
+適用が終わると `=== Migration Report ===` が出力され、生成された hook の挙動が
+どこ由来かを示した上で、user-level の `~/.claude/settings.json` と
+`~/.codex/hooks.json` の adapter target、作成またはリフレッシュされた repo-local
+surface、`.ai/harness/scripts/*` の helper runtime、`--- External Tooling ---`
+readiness block を示します。安定した intent は `docs/spec.md` に、実行状態は
+`plans/` と `tasks/` に、resume state は `.ai/harness/handoff/` に置かれます。
+dry run の結果がおかしいと感じたら、まず立ち止まって
+[`hook-operations.md`](docs/reference-configs/hook-operations.md) を読んで
+ください。
 
-オプションの sidecar として、`repo-harness mcp` は workflow artifacts だけを MCP
-クライアントへ公開します。ChatGPT は状態を読み、アイデアを PRD、checklist Sprint、
-Codex goal handoff へと進める planner/reviewer として働きます。source-code への
-書き込み権限、任意の shell 実行、デフォルトの Codex runner はありません。Codex が
-実行者のままです。
+### 更新と削除
 
-この sidecar は、上記「最初の 5 分」で CLI が既にインストール済みであることを
-前提とします。ChatGPT に実際のリポジトリ状態へ対してプランニングさせ、生成された
-file-backed Sprint を Codex に実行させたいときに使います。
+```bash
+repo-harness update          # refresh user-level CLI and runtime pieces
+repo-harness update --check  # read-only repair guidance, no writes
+repo-harness uninstall       # remove managed host adapters only
+```
+
+## なぜ repo-harness を使うのか
+
+- **セッションの状態はファイルに残り、チャット履歴には残らない。** 別々の
+  Claude セッションと Codex セッションは、リポジトリを介して同期を保ちます。
+  `SessionStart` が前回セッションの resume packet を注入し、`Stop` が handoff
+  を書き出し、各編集は小さな journal event を記録します。セッションはタスクの
+  途中で終了でき、次のセッションは正確な次の一手・blocker・変更ファイルを、
+  推測し直すことなくそのまま引き継ぎます。
+- **設計上 token を節約する。** セッションのたびにリポジトリを grep-and-read
+  で再スキャンするループの代わりに、harness は構造的なクエリに事前構築された
+  CodeGraph index を用い、progressive context loading に頼ります。安定した
+  約 12KB の root context に、触れるファイルが必要とするときだけ読み込まれる
+  capability block が加わる構成です。Agent は構造を再発見する代わりに、約
+  1KB の capability contract を読むだけで済みます。
+- **Review 可能な evidence を残す。** すべての task は contract、構造化された
+  check evidence、review card を残します。人間が判断する surface は 1 画面に
+  収まります — verdict、想定/実際の変更ファイル、通過した commands、残余
+  リスク、rollback — agent が何をしたと主張しているかを再構築する必要は
+  ありません。
+
+導入済みのリポジトリでは、意識すべき surface area は意図的に小さく保たれて
+います。
+
+| Surface | 目的 |
+| --- | --- |
+| `docs/spec.md` と `docs/reference-configs/` | すべての agent session が読める共有標準と安定した product intent。 |
+| `plans/`、`plans/prds/`、`plans/sprints/` | 実装開始前に固める decision-complete な work package。 |
+| `tasks/contracts/`、`tasks/reviews/`、`.ai/harness/checks/` | 作業完了を証明する scope、verification、review evidence。 |
+| `.ai/harness/handoff/` と `tasks/current.md` | chat memory ではなく workflow artifacts から導かれる session journal と resumable status。 |
+
+## 主な機能
+
+| | |
+| --- | --- |
+| **File-backed sessions** | Plan、contract、check、handoff がリポジトリに残るので、新しいセッションはチャットスレッドではなく artifacts から再開します |
+| **Typed hook runtime** | 8 本の共有 managed route と 3 本の Codex 専用 delegation route があり、それぞれが exactly one の typed in-process handler に bind され、edit boundary で fail-closed な guard がかかります |
+| **Plan → Contract → Review** | approved plan から投射された contract、隔離された worktree、構造化された evidence、review 可能な closeout までの 1 本の lifecycle |
+| **Progressive context loading** | 安定した約 12KB の root context に、実際に触れるファイルにだけ読み込まれる約 1KB の capability contract が加わります |
+| **CodeGraph integration** | caller・callee・definition などの構造的なクエリに、grep-and-read を繰り返す代わりに事前構築された index が答えます |
+| **MCP planner sidecar** | ChatGPT が実際のリポジトリ状態を読み、PRD/Sprint/Goal artifacts を書きます。実行するのは Codex で、既定では source code への書き込み権限を持ちません |
+| **Claude + Codex alignment** | 両方の host が共有する、1 つの user-level adapter contract、1 つの workflow contract、1 組の repo-local artifacts |
+
+## 仕組み
+
+1. **Source package**: 本リポジトリが CLI、command facade、template、typed hook
+   handler、operator-helper asset、workflow contract、tests、release gate を
+   所有します。
+2. **Target repo contract**: `repo-harness init` または migration が、
+   `docs/spec.md`、`plans/`、`tasks/`、`.ai/context/`、`.ai/harness/`、helper
+   scripts、`.ai/hooks/` のような repo-local ファイルを書き込みます。
+3. **Host adapters**: user-level の `~/.claude/settings.json` と
+   `~/.codex/hooks.json` が、Claude/Codex の event を `repo-harness-hook` へ
+   route します。
+
+hook の entrypoint は、opt-in していないリポジトリに対しては何もせず静かに
+終了します。opt-in 済みのリポジトリでは、route registry が public な event
+tuple を exactly one の packaged typed handler に bind します。`.ai/hooks/` は
+operator-helper の projection だけを保持し、host-event の dispatcher には
+決してなりません。
+
+中核となる不変条件は、持続的な truth がチャットスレッドではなくリポジトリに
+存在することです。Hooks はあくまで accelerator と guardrail であり、authority
+は ファイルに基づく plan、contract、review、checks、handoff の artifacts に
+あります。Prompt 層の plan/spec/contract gate は advisory な routing に過ぎず、
+hard な enforcement は edit boundary にあります。Handler の内部実装、
+minimal-change surface、policy mode については
+[`hook-operations.md`](docs/reference-configs/hook-operations.md) と
+[`minimal-change-hooks.md`](docs/reference-configs/minimal-change-hooks.md)
+を参照してください。
+
+## タスク Workflow
+
+この図は harness が既にインストールされていることを前提としています。program
+の sprint backlog から 1 つの contract task に至るまでの通常の lifecycle を
+示しています。task を選び、実行ファイルへ投射し、policy が要求する場合は
+contract worktree を checkout し、hooks の下で実装し、検証・review を経て
+close out します。
+
+```mermaid
+flowchart TD
+  Program["Program goal or release theme"] --> Sprint{"Sprint layer needed?"}
+  Sprint -->|yes| PRD["Upper-layer PRD<br/>plans/prds/*.prd.md"]
+  PRD --> SprintDoc["Sprint backlog<br/>plans/sprints/*.sprint.md"]
+  SprintDoc --> NextTask["Select next sprint task<br/>sprint-backlog.sh next"]
+  Sprint -->|no| UserTask["User task or planning prompt"]
+  Heartbeat["Heartbeat triage<br/>scripts/heartbeat-triage.sh<br/>.ai/harness/triage/"] --> UserTask
+  NextTask --> UserTask
+
+  UserTask --> Discovery["Due diligence<br/>P1 map, P2 trace, P3 decision"]
+  Discovery --> LoopEvidence["Loop evidence when routing changes<br/>state-snapshot --json<br/>route-nl-vs-ts / cutover gate"]
+  LoopEvidence --> PlanDraft["Draft plan<br/>plans/plan-*.md"]
+  PlanDraft --> PlanReview{"Plan ready for execution?"}
+  PlanReview -->|no| Refine["Refine plan, scope, evidence contract"]
+  Refine --> PlanDraft
+  PlanReview -->|yes| Approve["Approved plan<br/>Status: Approved"]
+
+  Approve --> Project["Project plan into execution<br/>capture-plan.sh --execute<br/>or plan-to-todo.sh --plan"]
+  Project --> Active["Active markers<br/>.ai/harness/active-plan<br/>.ai/harness/active-worktree"]
+  Project --> SprintActive["Sprint projection<br/>active-sprint marker<br/>tasks/current.md"]
+  Project --> Contract["Sprint contract<br/>tasks/contracts/YYYYMMDD-HHMM-task-slug.contract.md"]
+  Project --> ReviewFile["Review file<br/>tasks/reviews/YYYYMMDD-HHMM-task-slug.review.md"]
+  Project --> Notes["Task notes<br/>tasks/notes/YYYYMMDD-HHMM-task-slug.notes.md"]
+
+  Contract --> Delegation["Delegation contract<br/>budget / permission_scope / roles"]
+  Delegation --> Delegate{"Use contract-run delegation?"}
+  Delegate -->|yes| ContractRun["Worker/verifier child run<br/>scripts/contract-run.ts"]
+  Delegate -->|no| WorktreePolicy{"Contract worktree required?"}
+  WorktreePolicy -->|yes| Checkout["Checkout isolated worktree<br/>contract-worktree.sh start --plan<br/>branch codex/task-slug"]
+  WorktreePolicy -->|no| CurrentTree["Use current worktree<br/>small or explicitly allowed slice"]
+  Checkout --> Implement
+  CurrentTree --> Implement
+  ContractRun --> Changes
+
+  Implement["Edit and run commands"] --> PreHooks["Pre-edit guards<br/>PlanStatusGuard, ContractScopeGuard, WorktreeGuard"]
+  PreHooks -->|blocked| ScopeFix["Fix plan, contract, worktree, or scope"]
+  ScopeFix --> Implement
+  PreHooks -->|allowed| Changes["Code, docs, tests, or config changes"]
+  Changes --> PostHooks["Post-edit and post-bash hooks<br/>trace, drift request, handoff, check evidence"]
+  PostHooks --> ArchQueue["Architecture queue<br/>architecture-queue.sh record/reindex<br/>check-architecture-sync.sh"]
+  ArchQueue --> Verify["Run verification<br/>tests plus repo workflow checks"]
+
+  Verify --> Checks["Structured evidence<br/>.ai/harness/checks/latest.json<br/>.ai/harness/runs/*.json"]
+  Checks --> CheckReview["Evaluator review<br/>Waza /check -> review file"]
+  CheckReview --> External["External acceptance advice<br/>or explicit manual override"]
+  External --> DoneGate{"Contract, checks, review, and acceptance pass?"}
+  DoneGate -->|no| Repair["Repair failing evidence or implementation"]
+  Repair --> Implement
+  DoneGate -->|yes| SprintComplete{"Sprint task active?"}
+  SprintComplete -->|yes| MarkSprint["Mark backlog item complete<br/>sprint-backlog.sh complete-task"]
+  SprintComplete -->|no| Closeout["Closeout<br/>scripts/contract-worktree.sh finish"]
+  MarkSprint --> Closeout
+
+  Closeout --> Commit["Commit contract branch"]
+  Commit --> Merge["Fast-forward target branch"]
+  Merge --> Archive["Archive plan/todo and refresh handoff"]
+  Archive --> Cleanup["Cleanup merged worktree<br/>contract-worktree.sh cleanup"]
+  Cleanup --> Done["Reviewable completed task"]
+```
+
+長期にわたる product loop では、Codex が実行を loop する前に、discovery と
+engineering-plan の judgment を parent agent 側に留めます。`geju` が
+pre-contract の frame を開き、parent が P1/P2/P3 を完了させて、合意した方向性
+を `plans/prds/` 配下の upper-layer PRD と `plans/sprints/` 配下の ordered
+sprint backlog に固定します。その後、Codex Goal がその sprint file を指し
+ます。PRD は上位の source of truth であり続け、backlog は durable な
+execution queue となるため、resume された Goal セッションが元のチャットを
+再解釈することはありません。詳細は
+[`agentic-development-flow.md`](docs/reference-configs/agentic-development-flow.md)
+と [`workflow-orchestration.md`](docs/reference-configs/workflow-orchestration.md)
+を参照してください。
+
+## Hooks
+
+インストールされた adapter は、8 本の共有 managed hook route を所有します。
+`event + routeId + matcher` の route tuple が安定した契約であり、各 tuple は
+exactly one の typed in-process handler に bind されます。
+
+| Route | Matcher | Handler | 機能 |
+| --- | --- | --- | --- |
+| `SessionStart.default` | all sessions | `src/cli/hook/session-context.ts` (in-process builder) | 作業開始前に、直前の handoff、sprint status、minimal-change guidance、read-only な config-security の findings を注入します。 |
+| `PreToolUse.edit` | `Edit\|Write` | `src/cli/hook/mutation-guard.ts` (in-process handler) | 実装編集の前に worktree policy と plan/contract の readiness を強制します。 |
+| `PreToolUse.subagent` | `Task\|Agent\|SendUserMessage` | `src/cli/hook/subagent-handler.ts` | delegate された作業が completion claim を漏らさず、parent session を経由して戻るようにします。 |
+| `PostToolUse.edit` | `Edit\|Write` | `src/cli/hook/mutation-observed.ts` (in-process handler) | 該当する編集ごとに、dirty bits を伴う小さな journal event を高々 1 件書き込みます。contract verification、architecture/context/capability sync、minimal-change evidence は編集ごとには実行されず、Stop まで遅延されます。 |
+| `PostToolUse.bash` | `Bash` | `src/cli/hook/command-observed.ts` | command runner を置き換えることなく、command の結果を観測し verification evidence を取得します。 |
+| `PostToolUse.always` | all tools | `src/cli/hook/trace-observer.ts` | low-noise で常時稼働する trace と runtime observation を提供します。 |
+| `UserPromptSubmit.default` | all prompts | `src/cli/hook/prompt-handler.ts` | prompt の intent を分類し、planning/check の hint を route し、host-safe な workflow guidance を描画します。 |
+| `Stop.default` | session stop | `src/cli/hook/stop-handler.ts` (in-process handler) | handoff を finalize し、未解決の draft-plan や completion evidence の gap を残したまま終了しないよう防ぎます。 |
+
+Codex はさらに、3 本の Codex 専用 bounded-delegation route —
+`UserPromptSubmit.delegation`、`SubagentStart.context`、`SubagentStop.quality`
+— をインストールし、すべて `src/cli/hook/subagent-handler.ts` に bind
+されます。Claude 側は共有の `PreToolUse.subagent` return-channel route だけを
+保持します。
+
+`repo-harness-hook` とその typed handler registry が host-event の runtime
+です。`~/.claude/settings.json` と `~/.codex/hooks.json` が user-level の
+adapter であり、Codex は hooks が動く前に Settings でそのファイルを trusted
+として明示する必要があります。Repo-local な `.claude/settings.json` と
+`.codex/hooks.json` は退役させるべき legacy config です。デバッグする際は
+adapter config -> `repo-harness-hook` -> route registry -> typed handler の
+順に確認してください。
+
+hook が作業を block したときは、まず構造化された terminal 出力 — `guard`、
+`reason`、`fix`、`failure_class`、`run_id` — を読んでください。持続的な記録は
+`.ai/harness/failures/latest.jsonl` にあり、周辺の tool activity は
+`.claude/.trace.jsonl` にあります。よくある guard は `PlanStatusGuard`(active
+または実行可能な plan がない)、`ContractGuard`(contract scaffold が存在
+しない、または contract が通る前に completion を主張した)、`WorktreeGuard`
+(誤った worktree からの書き込み)です。完全な playbook は
+[`docs/reference-configs/hook-operations.md`](docs/reference-configs/hook-operations.md)
+を参照してください。
+
+## MCP Connector
+
+オプションの sidecar として、`repo-harness mcp` は既定の `planner` profile
+を通じて workflow artifacts を MCP クライアントへ公開します。ChatGPT は実際の
+リポジトリ状態を読み、アイデアを PRD、checklist Sprint、Codex goal handoff の
+artifacts へと進めます — 既定では source-code への書き込み権限、任意の shell
+実行、既定の runner はありません。実行者は引き続き Codex です。
 
 ```bash
 repo-harness mcp setup chatgpt --repo .
 repo-harness mcp serve --repo . --transport http --host 127.0.0.1 --port 8765 --profile planner
 ```
 
-このローカル server を HTTPS tunnel 経由で公開し、`/mcp` URL で ChatGPT
-Connector を作成します。生成されるガイドの書き出し先は次のとおりです。
-
-```text
-docs/repo-harness-chatgpt-mcp-setup.md
-```
-
+そのローカル server を HTTPS tunnel 経由で公開し、`/mcp` URL を登録すると、
 human workflow は次のとおりです。
 
-1. ChatGPT が MCP 経由で repo-harness の workflow ファイルを読む。
-2. ChatGPT が `write_prd_from_idea` で PRD を書く。
-3. ChatGPT が `write_checklist_sprint` で checklist Sprint を書く。
-4. ChatGPT が `prepare_codex_goal_from_sprint` で `.ai/harness/handoff/codex-goal.md` を準備する。
-5. Codex が host-native `/goal` prompt を実行し、完了した Sprint phase を順に stage する。
+1. ChatGPT が MCP 経由で repo-harness の workflow ファイルを読みます。
+2. ChatGPT が `write_prd_from_idea` で PRD を書きます。
+3. ChatGPT が `write_checklist_sprint` で checklist Sprint を書きます。
+4. ChatGPT が `prepare_codex_goal_from_sprint` で `.ai/harness/handoff/codex-goal.md` を準備します。
+5. Codex が host-native な `/goal` prompt を実行し、完了した Sprint phase を順に stage します。
 
-最後の handoff ステップのローカルなフォールバック：
+汎用的な repo reader/writer tools、snapshot と index の整合性、server
+profile、opt-in の dev runner については
+[`general-repo-mcp.md`](docs/reference-configs/general-repo-mcp.md) を参照
+してください。Direct-coding profile は
+[`chatgpt-coding-mcp.md`](docs/reference-configs/chatgpt-coding-mcp.md)、
+index-stale・CodeGraph-down・rollback operation は
+[`general-repo-mcp-codegraph.md`](deploy/runbooks/general-repo-mcp-codegraph.md)
+を参照してください。
 
-```bash
-repo-harness mcp prepare-goal --repo . --prd plans/prds/<feature>.prd.md --sprint plans/sprints/<feature>.sprint.md
-```
+## レビューの進め方
 
-agent 向けの Skill のインストール先は次のとおりです。
+まず `tasks/reviews/<task>.review.md` から始めます。その
+`## Human Review Card` が 1 画面の意思決定 surface であり、verdict、change
+type、想定/実際の変更ファイル、通過した commands、external acceptance、残余
+リスク、reviewer action、rollback を載せています。続いて active contract、
+`.ai/harness/checks/latest.json` の最新 trace、変更ファイルを確認します。
+review が pass を推奨し、card の verdict が pass で、external acceptance が
+pass・`not_required`・明示的な override のいずれかのときだけ accept します。
+
+Agent は派生した summary より先に、source artifacts を読みます。
+
+| Agent reads first | Human reviews first |
+| --- | --- |
+| 現在のユーザー prompt と参照ファイル | `tasks/reviews/<task>.review.md` の Human Review Card |
+| `AGENTS.md` / `CLAUDE.md` | 変更ファイルと diff |
+| `.ai/harness/active-plan` の active plan | active contract の allowed paths と exit criteria |
+| `tasks/contracts/` の active contract | `.ai/harness/checks/latest.json` と run trace |
+| `.ai/harness/handoff/` の latest handoff | 残余リスクと rollback |
+
+`tasks/current.md` は orientation のための snapshot にすぎません。active
+plan、contract、review、checks、handoff と食い違う場合は、source artifacts
+を優先します。
+
+Unity、browser E2E、mobile simulator、hardware rig、staging smoke test の
+ような runtime-heavy な validator は、ignore されている run-evidence surface
+の下に external verification manifest を公開できます — これは現時点では
+手動の convention であり、自動の `repo-harness check` gate ではありません。
+詳細は
+[external tooling](docs/reference-configs/external-tooling.md#external-verification-evidence)
+を参照してください。
+
+## Skills
+
+Canonical な rule-owner package は `assets/skills/` と
+`assets/skill-commands/` 配下にあり、host の skill discovery の範囲を抑え
+つつ、実行は CLI と hooks が担います。
+
+| Skill | 役割 |
+| --- | --- |
+| `repo-harness` | root router Skill。すべての profile に無条件で同期されます |
+| `repo-harness-setup` | init、migrate、upgrade、repair、scaffold、capability-configuration の各 mode。router-only です |
+| `repo-harness-plan` | decision-complete な plan を作成する、または既存の plan を review します |
+| `repo-harness-product` | 上位層の product planning のための PRD・Sprint・Goal の各 mode |
+| `repo-harness-check` | workflow と release の checks、および deploy-readiness reference |
+| `repo-harness-ship` | 完了した worktree を検証し、branch を push し、PR を開きます |
+| `repo-harness-architecture` | harness 全体の refresh を伴わない architecture docs、drift request、diagram |
+| `repo-harness-cross-review` | host を意識した Claude/Codex 独立 cross-model review |
+| `claude-plan` | Codex 側の provider skill：設計上の分岐点や高リスクな意思決定のための、独立した Claude plan mode consult。ユーザーが直接呼び出す entrypoint ではない |
+| `repo-harness-chatgpt` | Oracle browser/GPT Pro consult、MCP Connector setup、bridge handoff。explicit setup 限定 |
+| `merge-gate`(external) | exact-candidate な final gate。repo-harness は merge-gate Skill を同梱しません — [external tooling](docs/reference-configs/external-tooling.md) を参照 |
+
+planning chain は意図的に層を分けています。
 
 ```text
-.agents/skills/repo-harness-chatgpt-bridge/SKILL.md
+idea -> PRD mode -> Sprint mode -> Goal mode
 ```
 
-この Skill は、ChatGPT に source-code への書き込みや shell 実行を与えることなく、
-ChatGPT が生成した PRD/Sprint/Goal artifacts を Codex がどう消費するかを伝えます。
+`repo-harness init` は既存リポジトリ向けであり、`repo-harness-setup` の
+scaffold mode が新しいプロジェクトやモジュールを作成します。`hooks-init`、
+`docs-init`、`create-project-dirs` は内部ステップであり、公開 command では
+ありません。mode ごとの routing 境界については
+[`agentic-development-flow.md`](docs/reference-configs/agentic-development-flow.md)
+と `repo-harness docs show harness-overview` を参照してください。
 
-Dev Mode は MCP 経由でローカル agent 実行を opt-in できます。デフォルトでは
-無効です。ユーザーが `orchestrator` profile と dev runner 設定を有効にすると、
-ChatGPT は `run_agent_goal` を呼べます。これは `.ai/harness/handoff/codex-goal.md`
-だけを読み、`codex exec` や `claude -p` などの許可されたローカル CLI を通じて
-固定された handoff を実行します。
+## メンテナー向けリファレンス
+
+package 本体を編集するには source checkout が必要です。
 
 ```bash
-repo-harness mcp serve --repo . --transport http --profile orchestrator --enable-dev-runner --dev-runner-agents codex
+git clone https://github.com/Ancienttwo/repo-harness.git ~/Projects/repo-harness
+cd ~/Projects/repo-harness && bun src/cli/index.ts update
 ```
 
-この設定はローカルの Developer Mode 専用です。タイムアウト上限があり、監査され、
-任意の shell ではありません。
+その checkout だけが編集可能な source of truth であり、ローカルの
+Claude/Codex skill path は `scripts/sync-codex-installed-copies.sh` によって
+再構築される、symlink に裏打ちされた runtime entrypoint です。
 
-## Hook Authority Map
+`bun run check:ci` が唯一の CI-equivalent gate であり、
+`bun run check:release` はそこへ委譲する前に npm の unpublished-version
+preflight を追加するだけです。
 
-`repo-harness-hook` が唯一の host-event runtime です。user-level adapter は event を渡すだけで、
-route registry が安定した `event + routeId + matcher` tuple に対して exactly one typed handler を
-呼びます。`assets/hooks/lib/workflow-state.sh` と `.ai/hooks/lib/workflow-state.sh` は workflow state
-を調べる operator helper projection であり、dispatcher ではありません。
-
-- `~/.claude/settings.json`：user-level Claude adapter。
-- `~/.codex/hooks.json`：user-level Codex adapter。Codex Settings で信頼が必要です。
-- Repo-local `.claude/settings.json` / `.codex/hooks.json`：migration 時に退役する legacy 入力。
-- handler の変更は `src/cli/hook/` で行い、asset projection は `bun run sync:hooks` で同期します。
-
-The installed adapter owns the managed hook routes. Each route invokes one typed
-handler; 2 本目の shell runtime や provider-specific runtime はありません。
-
-| Route | Matcher | Typed handler | Function |
-| --- | --- | --- | --- |
-| `SessionStart.default` | all sessions | `src/cli/hook/session-context.ts` (in-process builder) | Injects prior handoff, sprint status, and read-only config-security findings before work starts. |
-| `PreToolUse.edit` | `Edit|Write` | `src/cli/hook/mutation-guard.ts` (in-process handler) | Enforces worktree policy and plan/contract readiness before implementation edits. |
-| `PreToolUse.subagent` | `Task|Agent|SendUserMessage` | `subagent` | Keeps delegated work returning through the parent session instead of leaking completion claims. |
-| `PostToolUse.edit` | `Edit|Write` | `mutation-observed` | Records the edit journal and controlled-file observations. |
-| `PostToolUse.bash` | `Bash` | `command-observed` | Observes command results and captures verification evidence without replacing the command runner. |
-| `PostToolUse.always` | all tools | `trace-observer` | Provides low-noise always-on trace and runtime observation. |
-| `UserPromptSubmit.default` | all prompts | `prompt` | Classifies prompt intent, routes planning/check/hunt hints, and renders host-safe workflow guidance. |
-| `Stop.default` | session stop | `src/cli/hook/stop-handler.ts` (in-process handler) | Finalizes handoff and guards against ending with unresolved draft-plan or completion evidence gaps. |
-
-`SessionStart` は作業開始前に in-process の session-context builder を実行し、コンテキストを組み立てます。
-
-```mermaid
-flowchart LR
-  SessionStart["Claude/Codex SessionStart"] --> Ctx["session-context.ts<br/>in-process builder"]
-  Ctx --> Resume["resume + handoff context"]
-  Ctx --> Sec["security scan<br/>read-only config scan, fingerprint-gated"]
-  Resume --> SSOut["SessionStart additionalContext<br/>prior-session state + SecurityConfig findings"]
-  Sec --> SSOut
+```bash
+bun run check:ci                    # the whole gate
+repo-harness docs list              # runtime reference docs, resolved from the package
+repo-harness docs show harness-overview
+bun scripts/assemble-template.ts --plan C --name "MyProject"
 ```
 
-Prompt guard には内部ステップが 1 つ増えます。
+Hook の変更は、まず canonical な `assets/hooks/` を更新し、その後
+`bun run sync:hooks` を実行し、verification で `bun run check:hooks` を
+使います。Reference docs は `assets/reference-configs/` 配下が canonical であり、
+`docs/reference-configs/` へ投射されます。`bun run check:reference-configs`
+がその投射を検証します。
 
-```mermaid
-flowchart LR
-  Host["Claude/Codex UserPromptSubmit"] --> Adapter["user-level adapter"]
-  Adapter --> CLI["repo-harness-hook UserPromptSubmit --route default"]
-  CLI --> Route["route registry"]
-  Route --> Handler["prompt handler<br/>typed decision table"]
-  Handler --> RouteHint["Waza route hint<br/>explicit think/planning matched first → /think"]
-  Handler --> HostOutput["host-safe allow, advice, block, or done gate output"]
+## 謝辞
+
+`repo-harness` は、workflow contract の形を作った少数の外部 skill、repo、
+agent runtime を中心に構築されています。これらは通常の bundled dependency
+ではありません。
+
+| Tool or repo | 用途 | Dependency shape |
+| --- | --- | --- |
+| [Hylarucoder](https://x.com/hylarucoder) / Geju | この workflow における planning、tracing、decision-rationale の規律を形作った P1/P2/P3 due-diligence method と Geju の実践 | Methodology への貢献と謝辞であり、bundled dependency ではありません |
+| Waza by [TW93](https://x.com/HiTw93)(`think`、`hunt`、`check`、`health` を含む) | 日々の planning、bug hunt、verification、health check、Codex-first な skill sync | skills CLI を通じて host の skill root にインストールされます |
+| `mermaid` | Mermaid だけでは足りないときの、人間が読める architecture / system-flow diagram | Runtime で参照される skill であり、生成されたリポジトリには vendor されません |
+| CodeGraph(`@colbymchenry/codegraph`) | この self-host リポジトリのための symbol-aware navigation、impact tracing、readiness check | 本リポジトリでは dev dependency。生成されたリポジトリは、policy が opt-in しない限り global-MCP-first のままです |
+| [Oracle](https://github.com/steipete/oracle) by [Peter Steinberger](https://x.com/steipete)(`@steipete/oracle`、MIT) | `chatgpt-browser` の Oracle provider が `gptpro` consult のために shell out する、既定の GPT Pro / ChatGPT Web browser consult engine | 外部で解決される binary(`--oracle-bin`、`REPO_HARNESS_ORACLE_BIN`、`node_modules/.bin`、または `PATH`)。自動ダウンロードはされず、binary が見つからない場合は hard な `ORACLE_NOT_INSTALLED` failure になります |
+| OpenAI Codex | commit が実質的に Codex 作成の作業を含むときの、repo-local な実装・verification・GitHub contributor attribution を担う primary execution agent | 外部 agent runtime。attribution は隠れた hook automation ではなく、明示的な commit trailer です |
+
+### GitHub 貢献者クレジット表記
+
+commit に対して Codex が実質的に貢献した場合は、message の末尾に GitHub 標準
+の co-author trailer を使用します。
+
+```text
+Co-authored-by: codex <codex@openai.com>
 ```
 
-Typed handler が route の入力解析、ファイル状態、宣言された副作用を所有し、runtime は host 出力を
-統一して整形します。AcceptanceReceipt が closeout authority で、review Markdown は投影です。
-
-## Hook Failure Playbook
-
-hook がブロックしたときは、まず terminal の構造化された出力を見ます。中核となるフィールドは
-`guard`、`reason`、`fix`、`failure_class`、`run_id` です。
-
-- Failure log：`.ai/harness/failures/latest.jsonl`
-- Trace log：`.claude/.trace.jsonl`
-- 詳細ガイド：[`docs/reference-configs/hook-operations.md`](docs/reference-configs/hook-operations.md)
-
-よくある guards：
-
-- `PlanStatusGuard`：active plan がない、または plan がまだ実行できない
-- `ContractGuard`：approved execution がまだ contract/review/notes scaffold を生成していない
-- `ContractGuard`：タスクが contract verification を通る前に完了を主張した
-- `WorktreeGuard`：linked worktree を強制するポリシー下で、primary worktree から書き込もうとした
-
-## Repo Workflow
-
-- Root routing docs：`CLAUDE.md`、`AGENTS.md`
-- Typed hook runtime：`src/cli/hook/`（`repo-harness-hook` 経由）
-- Operator helper projection：`.ai/hooks/lib/workflow-state.sh`
-- User-level adapter layer：`~/.claude/settings.json`、`~/.codex/hooks.json`
-- Active execution surface：`tasks/`
-- Plan source of truth：`plans/`
-- Durable progress：`tasks/workstreams/`
-- Release history：`docs/CHANGELOG.md`
+これは commit ごとに opt-in で、可視化された状態を保ってください。対象の
+リポジトリが同じ policy を採用しない限り、これを downstream の repo-harness
+commit script や hooks に組み込まないでください。
 
 ## 現在の Release
 
 - npm package：`repo-harness@0.12.0`
 - Generated workflow stamp：`repo-harness@0.12.0+template@0.12.0`
 - GitHub repository：`Ancienttwo/repo-harness`
-- Release history：[`docs/CHANGELOG.md`](docs/CHANGELOG.md)
+- Release notes and history：[`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 
-## 謝辞
+## ライセンス
 
-[Hylarucoder](https://x.com/hylarucoder) の方法論への貢献に感謝します。
-`repo-harness` の P1/P2/P3 due-diligence メソッドと、planning、trace、
-decision rationale を重視する Geju の実践は、彼の貢献と示唆に基づいています。
-
-[TW93](https://x.com/HiTw93) による Waza にも感謝します。`think`、`hunt`、
-`check`、`health` という中核 skill は、`repo-harness` の日々の planning、
-bug hunt、verification のリズムを形作っています。
-
-[Peter Steinberger](https://x.com/steipete) による Oracle（`@steipete/oracle`、MIT）にも
-感謝します。これは `chatgpt-browser` の既定の GPT Pro / ChatGPT Web ブラウザ consult
-エンジンで、Oracle provider が外部の oracle バイナリを spawn して `gptpro` consult を
-実行します（自動ダウンロードはせず、見つからなければ hard failure）。
-
-
-### GitHub contributor attribution
-
-Codex が commit に実質的に貢献した場合は、GitHub 標準の co-author trailer を commit message の末尾に入れます。
-
-```text
-Co-authored-by: codex <codex@openai.com>
-```
-
-この署名は commit ごとに opt-in で明示します。対象 repo が同じ policy を明示的に採用しない限り、downstream の repo-harness commit scripts や hooks へ組み込まないでください。
-
-## Action Command Skills
-
-canonical rule-owner package は `assets/skills/`（activate 済みの canonical
-package）と `assets/skill-commands/`（その場で進化する survivor）にあります。
-host skill discovery の範囲を保ちつつ、実行は CLI と hooks が担います。
-
-- Router：`repo-harness`（root Skill。すべての profile に無条件で同期される）
-- Setup layer：`repo-harness-setup`（init、migrate、upgrade、repair、
-  scaffold、capability-configuration の各 mode。router-only で、どの profile
-  からも自動発見されない）
-- Planning：`repo-harness-plan`（decision-complete plan を作成、または既存
-  plan を review する）
-- Product planning layer：`repo-harness-product`（PRD / Sprint / Goal の
-  3 mode。PRD mode はまず `$geju` を有効化し、Claude-first の `claude -p
-  --model opus` で PRD を起草する。Codex は fallback のみ。Sprint mode は PRD
-  を `plans/sprints/` の順序付き backlog に分解し、各行を `$think` で展開して
-  から contract flow へ進む。Goal mode は詳細な PRD または Sprint artifact か
-  ら Codex/Claude の `/goal` prompt を準備し、文書がなければ先に要求する）
-- Verification：`repo-harness-check`（workflow/release チェックと
-  deploy-readiness reference）
-- Release：`repo-harness-ship`
-- Architecture：`repo-harness-architecture`
-- Cross-model review：`repo-harness-cross-review`（host-aware。strict profile
-  では両方の host にインストールされる）
-- ChatGPT 連携：`repo-harness-chatgpt`（Oracle browser / GPT Pro consult と
-  continuation、MCP Connector setup、bridge handoff、read-back evidence。
-  explicit setup 限定で、product planning から暗黙にインストールされることは
-  ない）
-
-planning chain は意図的に層を分けています。
-
-```text
-idea -> repo-harness-product（PRD mode） -> repo-harness-product（Sprint mode、from-prd） -> repo-harness-product（Goal mode）
-```
-
-入力がまだプロダクトアイデアなら `repo-harness-product` の PRD mode を使います。
-まず `$geju` の direction pass を行い、その後 Claude に `claude -p --model
-opus` で PRD を起草させます。Codex は Claude が使えない、または失敗した場合だ
-け fallback です。承認済み PRD を machine-checkable acceptance line 付きの順
-序付き Sprint backlog にするには、その Sprint mode（`from-prd
-<plans/prds/*.prd.md>`）を使います。Goal mode は詳細な PRD または Sprint
-artifact がある場合だけ使い、Codex/Claude 向けの bounded `/goal` prompt を準
-備し、PRD/Sprint を source of truth として維持します。その文書がない場合、
-Goal mode はチャット文脈から実装を始めず、先に文書を要求しなければなりません。
-
-`repo-harness init` は既存リポジトリ向け、`repo-harness-setup` の scaffold
-mode は新しいプロジェクトやモジュールを作成します。
-`hooks-init`、`docs-init`、`create-project-dirs` は内部ステップであり、公開 commands ではありません。
-
-## Maintainer Reference
-
-package 本体を編集する maintainer はソースの checkout が必要です：
-
-```bash
-git clone https://github.com/Ancienttwo/repo-harness.git ~/Projects/repo-harness
-cd ~/Projects/repo-harness
-bun src/cli/index.ts update
-```
-
-`~/Projects/repo-harness` が唯一の編集可能な source of truth です。ローカルの
-Claude/Codex パス（`~/.claude/skills/repo-harness`、`~/.codex/skills/repo-harness`）
-は symlink に裏打ちされた runtime entrypoint です。`SKILL.md` と
-`assets/skill-commands/` を公開するのは `~/.codex/skills/repo-harness` だけで、
-`scripts/sync-codex-installed-copies.sh` がこれらの alias を再構築し、退役した
-`repo-harness-skill` / `project-initializer` ディレクトリを削除します。スクリプトは
-既定で runtime パスをソースリポジトリにリンクします。`AGENTIC_DEV_LINK_INSTALLED_COPIES=0`
-で copy-based staging、`CODEX_SKILLS_ROOT` / `CLAUDE_SKILLS_ROOT` で別の root を指定できます。
-
-### 本リポジトリの workflow contract をセルフチェックする
-
-下の Verification にある完全な gate を実行します。`bun run check:ci` が単一の
-CI-equivalent コマンドです。
-
-### Runtime reference docs
-
-Generic repo-harness runtime/reference docs live in the installed package under
-`assets/reference-configs/` and are resolved through the CLI:
-
-```bash
-repo-harness docs list
-repo-harness docs path harness-overview
-repo-harness docs show harness-overview
-```
-
-Initializer と runtime のデフォルト（question flow、plan menu、template vars、
-external-tooling routing）は `harness-overview.md` の **Initializer and Runtime
-Model** に記載されています。Generated and migrated repos still keep
-`docs/reference-configs/*.md`, but those files are deterministic pointer stubs.
-Repo-local workflow state, policy, checks, runs, handoff packets, context maps,
-and helper snapshots stay under `.ai/`.
-
-### Template assembly
-
-```bash
-bun scripts/assemble-template.ts --plan C --name "MyProject"
-bun scripts/assemble-template.ts --target agents --plan C --name "MyProject"
-```
-
-### Verification
-
-```bash
-bun test
-bash scripts/check-task-sync.sh
-bash scripts/check-task-workflow.sh --strict
-bun scripts/inspect-project-state.ts --repo . --format text
-bun src/cli/index.ts init --repo . --dry-run
-bash scripts/check-agent-tooling.sh --host both --check-updates
-bun run benchmark:skills --eval route-workflow-check
-```
-
-
-### Local benchmark skeleton
-
-```bash
-bun run benchmark:skills --eval route-workflow-check
-```
-
-Eval output is the release/readiness evidence path; dry-run benchmark wiring is only a smoke and is not skill-effectiveness evidence.
-
-
-### Run one eval across both Claude and Codex
-
-```bash
-bun run benchmark:skills --eval repair-agents-task-sync
-```
-
-## Key Files
-
-- Skill spec：`SKILL.md`
-- Root routing docs：`CLAUDE.md`、`AGENTS.md`
-- Plan mapping：`assets/plan-map.json`
-- Question-pack：`assets/initializer-question-pack.v4.json`
-- Shared hooks：`assets/hooks/`
-- Runtime reference docs: `assets/reference-configs/` via `repo-harness docs`
-- Workflow contract：`assets/workflow-contract.v1.json`
-- Hook operations reference：`docs/reference-configs/hook-operations.md`
-- Template assembler：`scripts/assemble-template.ts`
-- State inspector：`scripts/inspect-project-state.ts`
-- External tooling detector: `scripts/check-agent-tooling.sh`
-- Scaffolding scripts:
-  - `scripts/init-project.sh`
-  - `scripts/create-project-dirs.sh`
-- Canonical adoption planner: `src/core/adoption/standard-plan.ts`
-
-## Generated vs Self-Hosted Hook Projection
-
-- Downstream hook behavior は `assets/hooks/` と `assets/reference-configs/` から生成される出力で定義されます。
-- この repo は同じ contract を dogfood しますが、self-host behavior は generated repos と自動同期されません。変更は両方の surface を明示的に更新する必要があります。
-- すべての hook 変更は、影響範囲が `self-host`、`generated`、または `both` のどれかを明記します。
-
-## Package Manager Defaults
-
-- 一般的な既定優先度：`bun > pnpm > npm`
-- **Plan G/H**（Python-centric）は **`uv`** を primary package manager として既定にします。
-
-## Runtime Profiles
-
-- `Plan-only (recommended)`（default）
-- `Plan + Permissionless`
-- `Standard (ask before each action)`
-
-これは `assets/initializer-question-pack.v4.json` で設定され、`scripts/initializer-question-pack.ts` が消費します。
-
-## Verification
-
-release review では単一の CI-equivalent gate を使います。
-
-```bash
-bun run check:ci
-```
-
-この gate は以下の repo-owned checks に展開されます。`bun run check:release` は npm unpublished-version preflight を追加してから同じ gate に委譲します。
-
-```bash
-bun test
-bash scripts/check-deploy-sql-order.sh
-bash scripts/check-architecture-sync.sh
-bash scripts/check-task-sync.sh
-bash scripts/check-task-workflow.sh --strict
-bun scripts/inspect-project-state.ts --repo . --format text
-bun src/cli/index.ts init --repo . --dry-run
-bash scripts/check-agent-tooling.sh --host both --check-updates
-bun run benchmark:skills --eval route-workflow-check
-```
+MIT — [`LICENSE`](LICENSE) を参照してください。

--- a/README.md
+++ b/README.md
@@ -1,49 +1,137 @@
+<div align="center">
+
 # repo-harness
 
-<p align="center">
-  <img src="docs/images/repo-harness-hook-carrot.png" alt="repo-harness hooks leading Codex and Claude forward with repo-local workflow state" width="900">
-</p>
+### A file-backed, repeatable workflow for Claude and Codex coding sessions
 
-`repo-harness` turns Claude/Codex coding sessions into a repeatable repo-local
-workflow. It ships a CLI plus skill/runtime hooks that write context, plans,
-handoffs, checks, and review evidence back into the project, so the next agent
-session can continue from files instead of chat memory.
+<img src="docs/images/repo-harness-hook-carrot.png" alt="repo-harness hooks leading Codex and Claude forward with repo-local workflow state" width="900">
 
-Use it to:
-
-- adopt an existing repo with a tasks-first agent contract
-- keep Claude and Codex aligned on the same plans, checks, handoffs, and context
-  boundaries
-- spend fewer tokens rediscovering structure by using CodeGraph and progressive
-  context loading
-
-Give the agent a complete PRD or Sprint; after that, your loop is just review
-and `next`, or start `/goal` and go AFK.
-
-Repository: `https://github.com/Ancienttwo/repo-harness`
+[![npm version](https://img.shields.io/npm/v/repo-harness.svg)](https://www.npmjs.com/package/repo-harness)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Runtime: Bun](https://img.shields.io/badge/runtime-Bun%20%E2%89%A5%201.1.35-black.svg)](https://bun.sh)
 
 [English](README.md) | [简体中文](README.zh-CN.md) | [日本語](README.ja.md) | [Français](README.fr.md) | [Español](README.es.md)
 
+**Give the agent a complete PRD or Sprint; after that, your loop is just review and `next`, or start `/goal` and go AFK.**
+
+</div>
+
+`repo-harness` ships a CLI plus skill/runtime hooks that write context, plans,
+handoffs, checks, and review evidence back into the project, so the next agent
+session continues from files instead of chat memory. It adopts an existing repo
+with a tasks-first agent contract that keeps Claude and Codex aligned.
+
+## Contents
+
+- [Get Started](#get-started)
+- [Why repo-harness](#why-repo-harness)
+- [Key Features](#key-features)
+- [How It Works](#how-it-works)
+- [Task Workflow](#task-workflow)
+- [Hooks](#hooks)
+- [MCP Connector](#mcp-connector)
+- [Reviewing Work](#reviewing-work)
+- [Skills](#skills)
+- [Maintainer Reference](#maintainer-reference)
+- [Acknowledgements](#acknowledgements)
+- [Current Release](#current-release)
+- [License](#license)
+
+## Get Started
+
+### 1. Install the CLI
+
+Prerequisites: a Git working tree, `bash`, and `bun`; `jq` is optional. No
+Node.js required — the installer uses Bun >= 1.1.35 as the runtime, installing or
+upgrading Bun first when needed.
+
+```bash
+# macOS / Linux
+curl -fsSL https://raw.githubusercontent.com/Ancienttwo/repo-harness/main/install.sh | sh
+
+# Windows (PowerShell)
+irm https://raw.githubusercontent.com/Ancienttwo/repo-harness/main/install.ps1 | iex
+```
+
+With Bun >= 1.1.35 already on PATH, skip the shell installer. Package-manager-owned
+Bun installs fail closed with the matching upgrade command (`brew upgrade bun`)
+instead of overwriting manager-owned files.
+
+```bash
+bunx repo-harness@latest install     # Bun one-shot bootstrap
+bun add -g repo-harness              # or install the persistent CLI first
+repo-harness install
+npx -y repo-harness@latest install   # npx fallback; the CLI still runs on Bun
+```
+
+### 2. Bootstrap the host runtime
+
+```bash
+repo-harness install
+```
+
+The global bootstrap: installs the npm package as the global CLI, refreshes
+repo-harness skill aliases, installs user-level hook adapters, and records an
+explicit install profile. It is idempotent and does not apply repo-local workflow
+files to the current directory. `--dry-run --json` lists components to install,
+skip, and remove first. Profiles, delegation mode, refresh commands, and the
+read-only `setup check` audit:
+[`install-profiles.md`](docs/reference-configs/install-profiles.md).
+
+### 3. Preview the repo-local contract
+
+```bash
+repo-harness init --dry-run
+```
+
+Run this from the target repository root. It reports the specs, task state,
+helper runtime, hook adapter target, and verification files that would be created
+or refreshed. It never creates an application stack; new projects and modules use
+`repo-harness-setup`'s scaffold mode instead.
+
+### 4. Apply and verify
+
+```bash
+repo-harness init
+bash scripts/check-task-workflow.sh --strict
+bun test
+```
+
+### Success looks like this
+
+Apply ends with `=== Migration Report ===`, naming where generated hook behavior
+comes from, the user-level `~/.claude/settings.json` and `~/.codex/hooks.json`
+adapter target, the repo-local surfaces created or refreshed, the
+`.ai/harness/scripts/*` helper runtime, and an `--- External Tooling ---`
+readiness block. Stable intent then lives in `docs/spec.md`, execution state in
+`plans/` and `tasks/`, resume state in `.ai/harness/handoff/`. If the dry run
+looks wrong, stop and read
+[`hook-operations.md`](docs/reference-configs/hook-operations.md) first.
+
+### Update and remove
+
+```bash
+repo-harness update          # refresh user-level CLI and runtime pieces
+repo-harness update --check  # read-only repair guidance, no writes
+repo-harness uninstall       # remove managed host adapters only
+```
+
 ## Why repo-harness
 
-- **File-backed sessions, not chat memory.** Separate agent sessions — Claude and
-  Codex, now and later — stay coordinated through the repo, not a thread.
-  The in-process session-context builder (`src/cli/hook/session-context.ts`)
-  injects the prior session's resume packet
-  (`.ai/harness/handoff/resume.md`, `tasks/current.md`) when a new session starts;
-  the in-process Stop handler (`src/cli/hook/stop-handler.ts`) writes the stop handoff, while the in-process
-  mutation-observed journal handler (`src/cli/hook/mutation-observed.ts`)
-  records a small dirty-bit event per edit and defers maintenance work (contract
-  verification, architecture/context/capability sync, minimal-change signals) to
-  Stop. A session can end mid-task and the next one resumes the exact next
-  step, blockers, and changed files without re-deriving them.
-- **Token-lean by design.** Instead of grep-and-read loops that re-scan the repo every
-  session, the harness leans on a pre-built CodeGraph index for structural queries
-  (callers, callees, definitions) and on progressive context loading via
-  `.ai/context/context-map.json` and `capabilities.json`: a small, stable root context
-  (~12KB) plus capability blocks loaded only when the files you touch need them. Agents
-  read a 1KB capability contract or query the index instead of spending thousands of
-  tokens rediscovering structure.
+- **File-backed sessions, not chat memory.** Separate Claude and Codex sessions
+  stay coordinated through the repo. `SessionStart` injects the prior session's
+  resume packet, `Stop` writes the handoff, and each edit records a small journal
+  event. A session can end mid-task and the next one resumes the exact next step,
+  blockers, and changed files without re-deriving them.
+- **Token-lean by design.** Instead of grep-and-read loops that re-scan the repo
+  every session, the harness leans on a pre-built CodeGraph index for structural
+  queries and on progressive context loading: a stable ~12KB root context plus
+  capability blocks loaded only when the files you touch need them. Agents read a
+  ~1KB capability contract instead of rediscovering structure.
+- **Review-ready evidence.** Every task leaves a contract, structured check
+  evidence, and a review card behind. The human decision surface is one screen —
+  verdict, intended vs actual files, commands passed, residual risk, rollback —
+  rather than a reconstruction of what the agent claims it did.
 
 In an adopted repo, the surface area is intentionally small:
 
@@ -54,98 +142,48 @@ In an adopted repo, the surface area is intentionally small:
 | `tasks/contracts/`, `tasks/reviews/`, and `.ai/harness/checks/` | Scope, verification, and review evidence for proving the work is done. |
 | `.ai/harness/handoff/` and `tasks/current.md` | Session journal and resumable status, derived from workflow artifacts instead of chat memory. |
 
-## Human Review Path
+## Key Features
 
-Start with `tasks/reviews/<task>.review.md`. The `## Human Review Card` is the
-one-screen decision surface: verdict, change type, intended vs actual files,
-commands passed, external acceptance, residual risk, reviewer action, and
-rollback. Then inspect the active contract, latest trace in
-`.ai/harness/checks/latest.json`, and the changed files. Accept only when the
-review recommends pass, the card verdict is pass, and external acceptance is
-pass, `not_required`, or an explicit manual override.
-
-Runtime-heavy validators such as Unity, browser E2E, mobile simulators, hardware
-rigs, or staging smoke tests can publish external verification manifests under
-the ignored run-evidence surface. This is a manual convention today, not an
-automatic `repo-harness check` discovery or gate. See
-[`docs/reference-configs/external-tooling.md`](docs/reference-configs/external-tooling.md#external-verification-evidence).
-
-## Agent Tracking Path
-
-Agents read source artifacts before derived summaries:
-
-| Agent reads first | Human reviews first |
+| | |
 | --- | --- |
-| Current user prompt and referenced files | `tasks/reviews/<task>.review.md` Human Review Card |
-| `AGENTS.md` / `CLAUDE.md` | Changed files and diff |
-| Active plan in `.ai/harness/active-plan` | Active contract allowed paths and exit criteria |
-| Active contract in `tasks/contracts/` | `.ai/harness/checks/latest.json` and run trace |
-| Latest handoff in `.ai/harness/handoff/` | Residual risks and rollback |
-
-`tasks/current.md` is only an orientation snapshot. If it disagrees with the
-active plan, contract, review, checks, or handoff, the source artifacts win.
-
-## What's New
-
-Release notes live in [`docs/CHANGELOG.md`](docs/CHANGELOG.md). The current line
-is `0.12.0`.
+| **File-backed sessions** | Plans, contracts, checks, and handoffs live in the repo, so a new session resumes from artifacts instead of a chat thread |
+| **Typed hook runtime** | Eight shared managed routes plus three Codex-only delegation routes, each bound to exactly one typed in-process handler, with fail-closed guards at the edit boundary |
+| **Plan → Contract → Review** | One lifecycle from approved plan to projected contract, isolated worktree, structured evidence, and a reviewable closeout |
+| **Progressive context loading** | A ~12KB stable root context plus ~1KB capability contracts loaded only for the files actually being touched |
+| **CodeGraph integration** | Structural queries (callers, callees, definitions) answered from a pre-built index instead of repeated grep-and-read passes |
+| **MCP planner sidecar** | ChatGPT reads real repo state and writes PRD/Sprint/Goal artifacts; Codex executes them, with no default source-code write access |
+| **Claude + Codex alignment** | One user-level adapter contract, one workflow contract, and one set of repo-local artifacts shared by both hosts |
 
 ## How It Works
 
-The design has three layers:
-
-1. **Source package**: this repository owns the CLI, CLI-backed command facades,
-   templates, typed hook handlers, the operator-helper asset, workflow contract,
-   tests, and release gate.
+1. **Source package**: this repository owns the CLI, command facades, templates,
+   typed hook handlers, the operator-helper asset, workflow contract, tests, and
+   release gate.
 2. **Target repo contract**: `repo-harness init` or migration writes repo-local
    files such as `docs/spec.md`, `plans/`, `tasks/`, `.ai/context/`,
    `.ai/harness/`, helper scripts, and `.ai/hooks/`.
 3. **Host adapters**: user-level `~/.claude/settings.json` and
    `~/.codex/hooks.json` route Claude/Codex events into `repo-harness-hook`.
 
-The hook entrypoint exits silently for non-opt-in repos. For opted-in repos,
-the route registry binds the public event tuple to exactly one packaged typed
-handler. `.ai/hooks/` contains operator-helper projection only; it is never a
+The hook entrypoint exits silently for non-opt-in repos. For opted-in repos, the
+route registry binds the public event tuple to exactly one packaged typed
+handler. `.ai/hooks/` holds operator-helper projection only; it is never a
 host-event dispatcher.
 
-Minimal-change hooks sit inside that same route surface without adding a public
-adapter route. `SessionStart` and allowed execution prompts print advisory
-context when policy opts in, `PostToolUse.edit` can write bounded change signals
-to `.ai/harness/checks/minimal-change.latest.json` when
-`post_edit_observer:true` is explicitly enabled, and `Stop` records the latest
-review summary in the handoff. Missing or malformed policy defaults to off; even
-`mode: "enforce"` is normalized to advisory behavior so tests, contracts, and
-human review stay the enforcement boundary.
+The core invariant is that durable truth lives in the repo, not a chat thread.
+Hooks are accelerators and guardrails; authority remains the file-backed plan,
+contract, review, checks, and handoff artifacts. Prompt-layer plan/spec/contract
+gates are advisory routing; hard enforcement lives at the edit boundary. Handler
+internals, the minimal-change surface, and policy modes:
+[`hook-operations.md`](docs/reference-configs/hook-operations.md) and
+[`minimal-change-hooks.md`](docs/reference-configs/minimal-change-hooks.md).
 
-For `UserPromptSubmit`, the public adapter contract stays
-`repo-harness-hook UserPromptSubmit --route default`. The CLI route registry
-dispatches that route to `src/cli/hook/prompt-handler.ts`. That handler parses
-host JSON once, reads workflow files, performs capture side effects, verifies
-the typed `AcceptanceReceipt`, and returns host-neutral output. Unicode-aware
-intent classification lives in `src/cli/hook/prompt-intents.ts`; there is no
-shell classifier, secondary dispatcher, or fallback decision table.
+## Task Workflow
 
-Prompt-layer plan/spec/contract gates are advisory routing. Hard enforcement
-lives at the edit boundary: the in-process mutation-guard handler
-(`src/cli/hook/mutation-guard.ts`) blocks implementation edits
-unless the active plan is Approved/Executing (policy
-`.guards.edit_plan_gate`: enforce | advice | off). Done-claim gates keep
-blocking because they verify file-backed completion evidence, not language.
-
-The core invariant is that durable truth lives in the repo, not in a chat
-thread. Hooks are accelerators and guardrails; the authority remains the
-file-backed plan, contract, review, checks, and handoff artifacts.
-
-## Task Workflow: Plan to Closeout
-
-The diagram below assumes the harness is already installed in the repo. It shows
-the normal lifecycle from a program sprint backlog down to one contract task:
-draft or select the task, project it into execution files, check out the
-contract worktree when policy requires it, implement under hooks, verify, review,
-complete the sprint task when applicable, and close out. The 0.4.x loop-system
-surfaces add scheduled heartbeat discovery, state-snapshot/eval evidence for
-routing changes, architecture queue freshness, and optional contract-run
-delegation without changing the file-backed authority model.
+The diagram assumes the harness is installed. It shows the normal lifecycle from
+a program sprint backlog down to one contract task: select the task, project it
+into execution files, check out the contract worktree when policy requires it,
+implement under hooks, verify, review, and close out.
 
 ```mermaid
 flowchart TD
@@ -208,304 +246,69 @@ flowchart TD
   Cleanup --> Done["Reviewable completed task"]
 ```
 
-## Long-Running Product Loops
+For long-running product loops, keep discovery and engineering-plan judgment with
+the parent agent before Codex loops on execution: `geju` opens the pre-contract
+frame, the parent completes P1/P2/P3 and freezes the accepted direction into an
+upper-layer PRD under `plans/prds/` and an ordered sprint backlog under
+`plans/sprints/`, then a Codex Goal points at that sprint file. The PRD stays the
+upper source of truth and the backlog is the durable execution queue, so a
+resumed Goal session never reinterprets the original chat. See
+[`agentic-development-flow.md`](docs/reference-configs/agentic-development-flow.md)
+and [`workflow-orchestration.md`](docs/reference-configs/workflow-orchestration.md).
 
-For Greenfield and Brownfield work, keep discovery and engineering-plan
-judgment with the parent agent before asking Codex to loop on execution:
+## Hooks
 
-1. Before a contract exists, the parent agent invokes `geju` to open the frame,
-   then completes P1/P2/P3 with its own repo/runtime capabilities. It freezes the
-   accepted product intent, architecture, risks, falsifier, and evidence contract
-   into the development documents.
-2. Turn those documents into an upper-layer PRD under `plans/prds/`, then into
-   an ordered sprint backlog under `plans/sprints/` with detailed sub-plans for
-   each execution slice.
-3. In Codex, create a Goal that points at that sprint file. The harness can then
-   project each sprint item through the normal plan -> contract -> worktree ->
-   verification flow.
+The installed adapter owns eight shared managed hook routes. The route tuple
+`event + routeId + matcher` is the stable contract; each tuple binds exactly
+one typed in-process handler.
 
-That handoff keeps long-running loops precise: the parent agent owns the broad
-front-loaded judgment, the PRD remains the upper source of truth, the sprint
-backlog is the durable execution queue, and Codex Goal mode resumes against a
-concrete sprint instead of reinterpreting the original chat.
+| Route | Matcher | Handler | Function |
+| --- | --- | --- | --- |
+| `SessionStart.default` | all sessions | `src/cli/hook/session-context.ts` (in-process builder) | Injects prior handoff, sprint status, minimal-change guidance, and read-only config-security findings before work starts. |
+| `PreToolUse.edit` | `Edit\|Write` | `src/cli/hook/mutation-guard.ts` (in-process handler) | Enforces worktree policy and plan/contract readiness before implementation edits. |
+| `PreToolUse.subagent` | `Task\|Agent\|SendUserMessage` | `src/cli/hook/subagent-handler.ts` | Keeps delegated work returning through the parent session instead of leaking completion claims. |
+| `PostToolUse.edit` | `Edit\|Write` | `src/cli/hook/mutation-observed.ts` (in-process handler) | Writes at most one small journal event with dirty bits per qualifying edit; contract verification, architecture/context/capability sync, and minimal-change evidence are deferred to Stop instead of run per edit. |
+| `PostToolUse.bash` | `Bash` | `src/cli/hook/command-observed.ts` | Observes command results and captures verification evidence without replacing the command runner. |
+| `PostToolUse.always` | all tools | `src/cli/hook/trace-observer.ts` | Provides low-noise always-on trace and runtime observation. |
+| `UserPromptSubmit.default` | all prompts | `src/cli/hook/prompt-handler.ts` | Classifies prompt intent, routes planning/check hints, and renders host-safe workflow guidance. |
+| `Stop.default` | session stop | `src/cli/hook/stop-handler.ts` (in-process handler) | Finalizes handoff and guards against ending with unresolved draft-plan or completion evidence gaps. |
 
-## First 5 Minutes
+Codex also installs three Codex-only bounded-delegation routes —
+`UserPromptSubmit.delegation`, `SubagentStart.context`, and `SubagentStop.quality`,
+all bound to `src/cli/hook/subagent-handler.ts`; Claude keeps only the shared
+`PreToolUse.subagent` return-channel route.
 
-<p align="center">
-  <img src="docs/images/repo-harness-install-donkey-carrot.png" alt="Pixel art donkey following a carrot for repo-harness installation" width="900">
-</p>
+`repo-harness-hook` and its typed handler registry are the host-event runtime;
+`~/.claude/settings.json` and `~/.codex/hooks.json` are the user-level adapters,
+and Codex must mark its file as trusted in Settings before those hooks run.
+Repo-local `.claude/settings.json` and `.codex/hooks.json` are legacy config to
+retire. Debug in order: adapter config -> `repo-harness-hook` -> route registry
+-> typed handler.
 
-This is the fastest path for an AI tooling owner evaluating whether the workflow is
-safe to adopt in a real repo. It separates the machine-level runtime bootstrap
-from the repo-local contract install, so a dry run can show exactly what will
-change before anything is applied.
+When a hook blocks work, read the structured terminal output first: `guard`,
+`reason`, `fix`, `failure_class`, and `run_id`. Durable records live in
+`.ai/harness/failures/latest.jsonl`, with surrounding tool activity in
+`.claude/.trace.jsonl`. The common guards are `PlanStatusGuard` (no active or
+executable plan), `ContractGuard` (missing contract scaffold, or completion
+claimed before the contract passed), and `WorktreeGuard` (writes from the wrong
+worktree). Full playbook:
+[`docs/reference-configs/hook-operations.md`](docs/reference-configs/hook-operations.md).
 
-Prerequisites: a Git working tree, `bash`, and `bun` (for follow-up verification
-and template assembly). `jq` is optional for `--dry-run`, but recommended when
-applying settings merges.
-
-### 1. Install the CLI
-
-No Node.js required for the default path: the installer uses Bun >= 1.1.35 as
-the runtime. If Bun is missing or older, it installs or upgrades Bun first, then
-installs the `repo-harness` CLI.
-
-```bash
-# macOS / Linux
-curl -fsSL https://raw.githubusercontent.com/Ancienttwo/repo-harness/main/install.sh | sh
-
-# Windows (PowerShell)
-irm https://raw.githubusercontent.com/Ancienttwo/repo-harness/main/install.ps1 | iex
-```
-
-If Bun >= 1.1.35 is already on PATH, you can skip the shell installer. When an
-older self-managed Bun launches one of these direct paths, `repo-harness install`
-upgrades that same binary before continuing. Package-manager-owned Bun installs
-fail closed with the matching upgrade command (for example, `brew upgrade bun`
-or `scoop update bun`) instead of overwriting manager-owned files:
-
-```bash
-# Bun one-shot bootstrap
-bunx repo-harness@latest install
-
-# Or install the persistent CLI first
-bun add -g repo-harness
-repo-harness install
-
-# npx fallback, with Bun already on PATH because the CLI runs on Bun
-npx -y repo-harness@latest install
-```
-
-### 2. Bootstrap the host runtime once
-
-```bash
-repo-harness install
-```
-
-`install` is the first-run global bootstrap path. It installs the current npm
-package as the global CLI, refreshes repo-harness skill aliases, installs
-user-level hook adapters, and records an explicit install profile. The profile
-vocabulary is exactly `minimal|full`: `full` is the default and projects all 11
-Codex routes plus planning, agent-fleet, verifier, cross-model, and release
-surfaces; explicit `--profile minimal` projects the bounded 7-route baseline.
-The retired 5-route tier is not available. The command is idempotent.
-`--dry-run --json` lists components to install, skip, and remove; `--state
---json` reads the effective installed state; `--rollback` restores the previous
-protocol-2 profile transaction. A protocol-1 state must be replaced explicitly
-with `--migrate-profile-state --profile minimal|full`; normal reads never
-reinterpret its old `minimal` meaning. See
-[`docs/reference-configs/install-profiles.md`](docs/reference-configs/install-profiles.md).
-
-It does not apply repo-local workflow files to the current directory.
-
-For an Agent-owned, read-only bootstrap audit, run `repo-harness setup check
---json` or add `--check-updates` for version and adopted-repo refresh
-advisories. `setup check` is not a runtime hook: it does not write user-level
-files, install updates, run `init`, or register adapters. It emits
-`agent_actions` with the reason, risk, target files, optional command, and
-verification surface for the Agent to execute deliberately.
-`repo-harness init-hook` remains a compatibility alias.
-
-### Install and refresh examples
-
-```bash
-# Refresh user-level CLI/runtime pieces after a package update.
-repo-harness update
-
-# Remove managed host adapters without touching sibling or third-party hooks.
-repo-harness uninstall
-
-# Install only the host hook adapters (older adapter-only surface).
-repo-harness install --target both --location global
-
-# Read-only repair guidance, no writes.
-repo-harness update --check
-
-# Refresh repo-local workflow files in an adopted repository.
-repo-harness init --repo /path/to/repo
-```
-
-`repo-harness install --target codex|both --location global` also resolves and
-persists the Codex delegation mode read by the delegation-advisor hook: pass
-`--delegation-mode auto|explicit` for non-interactive use, or answer the
-one-line interactive prompt shown in a TTY (Enter keeps the current choice,
-defaulting to `explicit` when nothing is configured yet). The chosen mode is
-written to `delegation.mode` in `~/.repo-harness/config.json`, merged with
-existing keys such as `brainRoot`; this global value takes precedence over a
-repo's `.ai/harness/policy.json` `delegation.mode`. At runtime, `auto` injects
-one standing bounded-delegation authorization block per session at
-`SessionStart`; the typed `subagent` handler injects on
-`UserPromptSubmit` only for explicit triggers (`/delegate`, `/parallel`, ...)
-in both `auto` and `explicit` modes. The step never fires for
-`--target claude`, and with no flag and no TTY it leaves the file untouched —
-it never writes a silent default.
-
-### 3. Preview the repo-local contract
-
-```bash
-repo-harness init --dry-run
-```
-
-Run the dry run from the target repository root. It reports the specs, task
-state, helper runtime, hook adapter target, and verification files that would be
-created or refreshed. It should not create an application stack; existing repos
-use `repo-harness init`, while new projects or modules use
-`repo-harness-setup`'s scaffold mode.
-
-### 4. Apply, then prove the workflow
-
-```bash
-repo-harness init
-bash scripts/check-task-workflow.sh --strict
-bun test
-```
-
-After apply, the repo should have a reviewable file-backed contract rather than
-tool-specific chat setup. Agents should be able to find the stable intent in
-`docs/spec.md`, execution state in `plans/` and `tasks/`, and resume state in
-`.ai/harness/handoff/`.
-
-For a new project or module, use `repo-harness-setup`'s scaffold mode instead
-of `init`; it installs or refreshes the harness without creating an
-application stack. Maintainers editing the package itself need a source checkout
-— see [Maintainer Reference](#maintainer-reference).
-
-### Success looks like this
-
-The command should end with `=== Migration Report ===` and summarize:
-
-- `Project hooks synced from:` to show where generated hook behavior comes from
-- `Host hook config target: user-level ~/.claude/settings.json and ~/.codex/hooks.json` to show the adapter layer
-- `Host hook adapters are user-level:` to remind the user to install global adapters and trust `~/.codex/hooks.json`
-- `Workflow migration:` to show the repo-local harness surfaces it will create or refresh
-- `Helper runtime:` to show `.ai/harness/scripts/*` implementations and `scripts/*` compatibility wrappers after apply
-- `--- External Tooling ---` to show parent/Geju planning guidance plus Waza and CodeGraph readiness and advisory install/update hints
-
-If the dry-run output looks wrong, stop there and inspect
-[`docs/reference-configs/hook-operations.md`](docs/reference-configs/hook-operations.md)
-before applying anything.
-
-## MCP Connector Quickstart
+## MCP Connector
 
 As an optional sidecar, `repo-harness mcp` exposes workflow artifacts to MCP
-clients through the default `planner` profile. ChatGPT acts as a
-planner/reviewer that reads state and moves an idea through PRD, checklist
-Sprint, and Codex goal handoff artifacts — with no default source-code write access,
-arbitrary shell execution, or default Codex runner. Codex remains the executor.
-
-The same `planner` Connector also exposes general repo tools for
-registered adopted repos. Use `discover_harness_repos` first, then call
-`list_allowed_roots` to get the stable `repo_id`. General repo reads use
-`repo_manifest`, `list_tree`, `stat_file`, `read_file`, `read_files`, and
-`search_text`. The write surface currently exposes `write_file`, `apply_patch`,
-`move_path`, `delete_path`, and `refresh_repo_index`, all rejected unless that
-registered repo is explicitly configured as `read_write`.
-`write_file` creates only with `must_not_exist: true`, replaces only with
-`expected_sha256`, and reports `before`, `after`, `diff`, `mutation_id`, and
-`index_state` after an atomic same-directory rename. `apply_patch` operates only
-on existing text files, requires `expected_sha256`, and accepts either structured
-`old_text`/`new_text` edits or guarded unified diff hunks. Patch precondition
-misses and stale hashes return `REVISION_CONFLICT` without writing. Successful
-file moves require a source `expected_sha256` plus `must_not_exist: true` for the
-target. Deletes require `expected_sha256`; v1 deletes regular files only and
-rejects directory or recursive deletes. Successful writes leave the index
-pending and append an index invalidation event under
-`.ai/harness/mcp/index-events.jsonl`; `refresh_repo_index` runs CodeGraph sync
-for the repo, invalidates reader snapshots, records refresh success or
-dead-letter failure in that same event log, and returns the new `snapshot_id`,
-`index_revision`, `index_state`, refresh strategy, and optional mutation lag when
-called with `mutation_id`. The CLI adapter reports `path_refresh_supported:false`
-when it must use repo-level sync for requested paths. The MCP audit log records
-actor/profile, repo id, operation, relative paths, hash summary, result, error
-code, duration, and mutation/index event ids without storing file bodies or
-patch text. The repo whitelist is the authorization boundary, `.ignore` is the
-only content exclusion source, paths are repo-relative, and authorized file
-content is not implicitly redacted. External non-repo local roots require
-explicit `--allow-root` authorization.
-
-When CodeGraph is initialized for a registered repo, the general reader merges
-CodeGraph indexed-file metadata into manifest/stat/read/search responses while
-keeping the filesystem walker as the complete manifest source of truth. Responses
-carry `snapshot_id`, `index_revision`, `ignore_digest`, and `indexed` metadata;
-stale client snapshots return `SNAPSHOT_STALE` instead of silently mixing
-versions. Responses also expose `snapshot_state`, snapshot TTL/expiry, and a
-bounded in-process snapshot cache marker. The public `snapshot_cache.key` is
-scoped by tool and repo-relative path set, while `snapshot_cache.snapshot_key`
-identifies the underlying repo snapshot. Entry metadata is cached separately by
-repo, registry revision, `.ignore` digest, relative path, and current stat
-signature, so unchanged warm manifest/stat/read calls avoid repeated file hash
-and binary probes without hiding file, registry, or `.ignore` changes. Explicit
-`snapshot_id` stat/read calls can reuse the cached snapshot and validate the
-requested file hash instead of rebuilding the full repo snapshot. If CodeGraph
-reports a now-missing indexed path or metadata that no longer matches the
-filesystem, the snapshot becomes `index_lagging` while authorized read/stat
-fallback stays available. Full-text search still falls back to the guarded
-filesystem path when CodeGraph cannot provide complete repo-text search.
-For large manifests, `repo_manifest` streams the visible tree and keeps only the
-requested page of entries in memory. Returned page entries include exact content
-hashes; non-page file content metadata is deferred and reported as
-`counts.content_deferred` until a later manifest page, `stat_file`, `read_file`,
-or `search_text` actually returns that content.
-
-For large-repo reader baselines, run:
-
-```bash
-bun run benchmark:mcp-reader -- --entries 10000 --json
-```
-
-Use `--entries all` for the full 10k/100k/500k fixture sequence when the local
-machine can spend the filesystem time.
-
-For the full tool reference, JSON examples, repo administrator guidance,
-privacy notes, migration guide, rollout flags, and known limits, see
-[`docs/reference-configs/general-repo-mcp.md`](docs/reference-configs/general-repo-mcp.md).
-For index stale, CodeGraph down, manifest incomplete, mutation conflict,
-reindex dead-letter, and rollback operations, see
-[`deploy/runbooks/general-repo-mcp-codegraph.md`](deploy/runbooks/general-repo-mcp-codegraph.md).
-
-This sidecar assumes the CLI is already installed from
-[First 5 Minutes](#first-5-minutes). Use it when you want ChatGPT to plan
-against the real repo state and Codex to execute the resulting file-backed
-Sprint.
-
-The ChatGPT Connector registers one endpoint URL, not one repository per URL.
-Adopted repos are discovered from `~/.repo-harness/registered-repos.json`, which
-is updated by `repo-harness init` and user-scope ChatGPT
-setup. Stale registry entries are ignored unless the live repo still has
-repo-harness adoption markers.
+clients through the default `planner` profile. ChatGPT reads real repo state and
+moves an idea through PRD, checklist Sprint, and Codex goal handoff artifacts —
+with no default source-code write access, arbitrary shell execution, or default
+runner. Codex remains the executor.
 
 ```bash
 repo-harness mcp setup chatgpt --repo .
 repo-harness mcp serve --repo . --transport http --host 127.0.0.1 --port 8765 --profile planner
 ```
 
-User-scope global Connector setup:
-
-```bash
-repo-harness mcp setup chatgpt --scope user --repo . --endpoint <https-url>/mcp
-repo-harness mcp serve --repo . --transport http --host 127.0.0.1 --port 8765 --profile planner
-```
-
-Optional external reader roots:
-
-```bash
-repo-harness mcp setup chatgpt \
-  --scope user \
-  --repo . \
-  --enable-reader \
-  --allow-root "$HOME/Documents" \
-  --allow-root "$HOME/Projects" \
-  --endpoint <https-url>/mcp
-```
-
-Expose that local server through an HTTPS tunnel and create a ChatGPT Connector
-with the `/mcp` URL. The generated guide is written to:
-
-```text
-docs/repo-harness-chatgpt-mcp-setup.md
-```
-
-The human workflow is:
+Expose that local server through an HTTPS tunnel, register the `/mcp` URL, and
+the human workflow is:
 
 1. ChatGPT reads repo-harness workflow files through MCP.
 2. ChatGPT writes a PRD with `write_prd_from_idea`.
@@ -513,143 +316,107 @@ The human workflow is:
 4. ChatGPT prepares `.ai/harness/handoff/codex-goal.md` with `prepare_codex_goal_from_sprint`.
 5. Codex runs the host-native `/goal` prompt and stages each completed Sprint phase.
 
-Local fallback for the last handoff step:
+General repo reader/writer tools, snapshot and index consistency, server
+profiles, and the opt-in dev runner:
+[`general-repo-mcp.md`](docs/reference-configs/general-repo-mcp.md). Direct-coding
+profile: [`chatgpt-coding-mcp.md`](docs/reference-configs/chatgpt-coding-mcp.md).
+Index-stale, CodeGraph-down, and rollback operations:
+[`general-repo-mcp-codegraph.md`](deploy/runbooks/general-repo-mcp-codegraph.md).
 
-```bash
-repo-harness mcp prepare-goal --repo . --prd plans/prds/<feature>.prd.md --sprint plans/sprints/<feature>.sprint.md
-```
+## Reviewing Work
 
-The agent-facing Skill is installed at:
+Start with `tasks/reviews/<task>.review.md`. Its `## Human Review Card` is the
+one-screen decision surface: verdict, change type, intended vs actual files,
+commands passed, external acceptance, residual risk, reviewer action, and
+rollback. Then inspect the active contract, the latest trace in
+`.ai/harness/checks/latest.json`, and the changed files. Accept only when the
+review recommends pass, the card verdict is pass, and external acceptance is
+pass, `not_required`, or an explicit override.
+
+Agents read source artifacts before derived summaries:
+
+| Agent reads first | Human reviews first |
+| --- | --- |
+| Current user prompt and referenced files | `tasks/reviews/<task>.review.md` Human Review Card |
+| `AGENTS.md` / `CLAUDE.md` | Changed files and diff |
+| Active plan in `.ai/harness/active-plan` | Active contract allowed paths and exit criteria |
+| Active contract in `tasks/contracts/` | `.ai/harness/checks/latest.json` and run trace |
+| Latest handoff in `.ai/harness/handoff/` | Residual risks and rollback |
+
+`tasks/current.md` is only an orientation snapshot. If it disagrees with the
+active plan, contract, review, checks, or handoff, the source artifacts win.
+
+Runtime-heavy validators (Unity, browser E2E, mobile simulators, hardware rigs,
+staging smoke tests) can publish external verification manifests under the
+ignored run-evidence surface — a manual convention today, not an automatic
+`repo-harness check` gate. See
+[external tooling](docs/reference-configs/external-tooling.md#external-verification-evidence).
+
+## Skills
+
+Canonical rule-owner packages live under `assets/skills/` and
+`assets/skill-commands/`, keeping host skill discovery bounded while the CLI and
+hooks own execution.
+
+| Skill | Purpose |
+| --- | --- |
+| `repo-harness` | Root router Skill, synced unconditionally to every profile |
+| `repo-harness-setup` | Init, migrate, upgrade, repair, scaffold, and capability-configuration modes; router-only |
+| `repo-harness-plan` | Create a decision-complete plan, or review an existing one |
+| `repo-harness-product` | PRD, Sprint, and Goal modes for upper-layer product planning |
+| `repo-harness-check` | Workflow and release checks plus a deploy-readiness reference |
+| `repo-harness-ship` | Validate finished worktrees, push branches, and open PRs |
+| `repo-harness-architecture` | Architecture docs, drift requests, and diagrams without a full harness refresh |
+| `repo-harness-cross-review` | Host-aware Claude/Codex independent cross-model review |
+| `claude-plan` | Codex-side provider skill: independent Claude plan-mode consult for a design fork or high-stakes decision; not a direct user entrypoint |
+| `repo-harness-chatgpt` | Oracle browser/GPT Pro consults, MCP Connector setup, and bridge handoff; explicit setup only |
+| `merge-gate` (external) | Exact-candidate final gate; repo-harness ships no merge-gate Skill — see [external tooling](docs/reference-configs/external-tooling.md) |
+
+The planning chain is intentionally layered:
 
 ```text
-.agents/skills/repo-harness-chatgpt-bridge/SKILL.md
+idea -> PRD mode -> Sprint mode -> Goal mode
 ```
 
-That Skill tells Codex how to consume ChatGPT-produced PRD/Sprint/Goal artifacts
-without granting ChatGPT source-code writes or shell execution.
+`repo-harness init` is for an existing repo; `repo-harness-setup`'s scaffold mode
+creates a new project or module. `hooks-init`, `docs-init`, and
+`create-project-dirs` are internal steps, not public commands. Per-mode routing
+boundaries: [`agentic-development-flow.md`](docs/reference-configs/agentic-development-flow.md)
+and `repo-harness docs show harness-overview`.
 
-Dev Mode can opt into local agent execution through MCP. This is off by default.
-When the user enables the `orchestrator` profile with the dev runner setting,
-ChatGPT can call `run_agent_goal`, which reads only
-`.ai/harness/handoff/codex-goal.md` and runs the fixed handoff through an
-allowed local CLI such as `codex exec` or `claude -p`.
+## Maintainer Reference
+
+Editing the package itself needs a source checkout:
 
 ```bash
-repo-harness mcp serve --repo . --transport http --profile orchestrator --enable-dev-runner --dev-runner-agents codex
+git clone https://github.com/Ancienttwo/repo-harness.git ~/Projects/repo-harness
+cd ~/Projects/repo-harness && bun src/cli/index.ts update
 ```
 
-This setting is for local Developer Mode only. It is timeout-bounded, audited,
-and not arbitrary shell.
+That checkout is the only editable source of truth; local Claude/Codex skill
+paths are symlink-backed runtime entrypoints rebuilt by
+`scripts/sync-codex-installed-copies.sh`.
 
-## Hook Authority Map
+`bun run check:ci` is the single CI-equivalent gate; `bun run check:release` only
+adds the npm unpublished-version preflight before delegating to it.
 
-- `repo-harness-hook` and its typed handler registry are the host-event runtime. `assets/hooks/lib/workflow-state.sh` is retained only for operator helpers; `.ai/hooks/` is a checked-in helper projection, not a dispatcher.
-- `~/.claude/settings.json` is the user-level Claude adapter that dispatches into opted-in repos.
-- `~/.codex/hooks.json` is the user-level Codex adapter that dispatches into the same runner.
-- Repo-local `.claude/settings.json` and `.codex/hooks.json` hook adapters are legacy project-level config and should be retired during migration.
-- Codex must mark `~/.codex/hooks.json` as trusted in Codex Settings before those hooks run.
-- Debug in this order: user-level adapter config -> `repo-harness-hook` -> route registry -> typed handler.
-- For host-event behavior, edit `src/cli/hook/` and its focused tests. `assets/hooks/lib/workflow-state.sh` is an operator-helper source; `bun run sync:hooks` verifies its helper projection.
-
-The installed adapter owns eight shared managed hook routes. Codex also installs
-three Codex-only bounded-delegation routes. The route tuple
-`event + routeId + matcher` is the stable contract; each tuple binds exactly
-one typed in-process handler.
-
-| Route | Matcher | Handler | Function |
-| --- | --- | --- | --- |
-| `SessionStart.default` | all sessions | `src/cli/hook/session-context.ts` (in-process builder) | Injects prior handoff, sprint status, minimal-change guidance, and read-only config-security findings before work starts. |
-| `PreToolUse.edit` | `Edit|Write` | `src/cli/hook/mutation-guard.ts` (in-process handler) | Enforces worktree policy and plan/contract readiness before implementation edits. |
-| `PreToolUse.subagent` | `Task|Agent|SendUserMessage` | `src/cli/hook/subagent-handler.ts` | Keeps delegated work returning through the parent session instead of leaking completion claims. |
-| `PostToolUse.edit` | `Edit|Write` | `src/cli/hook/mutation-observed.ts` (in-process handler) | Writes at most one small journal event with dirty bits per qualifying edit; contract verification, architecture/context/capability sync, and minimal-change evidence are deferred to Stop instead of run per edit. |
-| `PostToolUse.bash` | `Bash` | `src/cli/hook/command-observed.ts` | Observes command results and captures verification evidence without replacing the command runner. |
-| `PostToolUse.always` | all tools | `src/cli/hook/trace-observer.ts` | Provides low-noise always-on trace and runtime observation. |
-| `UserPromptSubmit.default` | all prompts | `src/cli/hook/prompt-handler.ts` | Classifies prompt intent, routes planning/check hints, and renders host-safe workflow guidance. |
-| `Stop.default` | session stop | `src/cli/hook/stop-handler.ts` (in-process handler) | Finalizes handoff and guards against ending with unresolved draft-plan or completion evidence gaps. |
-
-Codex-only routes are `UserPromptSubmit.delegation`,
-`SubagentStart.context`, and `SubagentStop.quality`. Claude keeps the shared
-`PreToolUse.subagent` return-channel route and does not install those Codex
-delegation lifecycle entries.
-
-`SessionStart` resolves the in-process session-context builder, which
-assembles resume, sprint, minimal-change, and security-scan sections into one
-context before work begins:
-
-```mermaid
-flowchart LR
-  SessionStart["Claude/Codex SessionStart"] --> Adapter["user-level adapter"]
-  Adapter --> Entry["repo-harness-hook SessionStart --route default"]
-  Entry --> Ctx["session-context.ts<br/>in-process builder"]
-  Ctx --> Resume["resume + sprint + handoff context"]
-  Ctx --> Min["minimal-change guidance<br/>advice-only scope pressure"]
-  Ctx --> Sec["security scan<br/>read-only config scan, fingerprint-gated"]
-  Resume --> SSOut["SessionStart additionalContext<br/>prior-session state + SecurityConfig findings"]
-  Min --> SSOut
-  Sec --> SSOut
+```bash
+bun run check:ci                    # the whole gate
+repo-harness docs list              # runtime reference docs, resolved from the package
+repo-harness docs show harness-overview
+bun scripts/assemble-template.ts --plan C --name "MyProject"
 ```
 
-No host route resolves repo-local scripts. A missing typed handler binding is a
-runtime contract failure; guard routes remain fail closed.
+Hook changes update canonical `assets/hooks/` once, then run `bun run sync:hooks`
+with `bun run check:hooks` in verification. Reference docs are canonical under
+`assets/reference-configs/` and projected into `docs/reference-configs/`;
+`bun run check:reference-configs` verifies that projection.
 
-Prompt guard has one extra internal step:
-
-```mermaid
-flowchart LR
-  Host["Claude/Codex UserPromptSubmit"] --> Adapter["user-level adapter"]
-  Adapter --> CLI["repo-harness-hook UserPromptSubmit --route default"]
-  CLI --> Route["route registry"]
-  Route --> Handler["prompt-handler.ts<br/>single typed authority"]
-  Handler --> Decision["Unicode intent classifiers<br/>+ state decision table"]
-  Decision --> RouteHint["Waza route hint<br/>explicit think/planning matched first → /think"]
-  Handler --> Receipt["contract + checks + AcceptanceReceipt"]
-  Handler --> HostOutput["host-safe advice, done gate, or capture output"]
-```
-
-The typed handler owns filesystem authority, side effects, classification, and
-the `intent x plan state` decision table. Plan-state hard blocks still render at
-the PreToolUse edit layer.
-
-## Hook Failure Playbook
-
-When a hook blocks work, start with the structured output in the terminal. The core
-fields are `guard`, `reason`, `fix`, `failure_class`, and `run_id`.
-
-- Failure log: `.ai/harness/failures/latest.jsonl`
-- Trace log: `.claude/.trace.jsonl`
-- Deep guide: [`docs/reference-configs/hook-operations.md`](docs/reference-configs/hook-operations.md)
-
-Most common guards:
-
-- `PlanStatusGuard` (edit layer): an implementation edit was attempted with no active plan, or the plan is not ready to execute; the prompt layer emits the same guard name as advisory guidance
-- `ContractGuard`: approved execution has not yet produced the contract/review/notes scaffold
-- `ContractGuard`: completion was claimed before the task contract passed
-- `WorktreeGuard`: writes were attempted in the primary worktree while linked worktrees are enforced
-
-## Repo Workflow
-
-- Root routing docs: `CLAUDE.md`, `AGENTS.md`
-- Shared hook layer: `.ai/hooks/`
-- User-level adapter layer: `~/.claude/settings.json`, `~/.codex/hooks.json`
-- Active execution surface: `tasks/`
-- Plan source of truth: `plans/`
-- Durable progress: `tasks/workstreams/`
-- Release history: `docs/CHANGELOG.md`
-
-## Current Release
-
-- npm package: `repo-harness@0.12.0`
-- Generated workflow stamp: `repo-harness@0.12.0+template@0.12.0`
-- GitHub repository: `Ancienttwo/repo-harness`
-- Release history: [`docs/CHANGELOG.md`](docs/CHANGELOG.md)
-
-## Acknowledgements and Workflow Influences
+## Acknowledgements
 
 `repo-harness` is built around a small set of external skills, repos, and agent
-runtimes that
-proved useful while this project was being designed, debugged, and released.
-They are acknowledged here because they shaped the workflow contract, but they
-are not ordinary bundled product dependencies.
+runtimes that shaped the workflow contract. They are not ordinary bundled
+dependencies.
 
 | Tool or repo | Used for | Dependency shape |
 | --- | --- | --- |
@@ -663,210 +430,22 @@ are not ordinary bundled product dependencies.
 ### GitHub Contributor Attribution
 
 When Codex materially contributes to a commit, use GitHub's standard co-author
-trailer format at the end of the commit message:
+trailer at the end of the message:
 
 ```text
 Co-authored-by: codex <codex@openai.com>
 ```
 
 Keep this opt-in and visible per commit. Do not bake it into downstream
-repo-harness commit scripts or hooks unless that repo explicitly adopts the same
-policy.
+repo-harness commit scripts or hooks unless that repo adopts the same policy.
 
-## Action Command Skills
+## Current Release
 
-Canonical rule-owner packages live under `assets/skills/` (activated
-canonical packages) and `assets/skill-commands/` (survivors evolving in
-place). They keep host skill discovery bounded while the CLI and hooks own
-execution:
+- npm package: `repo-harness@0.12.0`
+- Generated workflow stamp: `repo-harness@0.12.0+template@0.12.0`
+- GitHub repository: `Ancienttwo/repo-harness`
+- Release notes and history: [`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 
-- Router: `repo-harness` (root Skill, synced unconditionally to every profile)
-- Setup layer: `repo-harness-setup` (init, migrate, upgrade, repair,
-  scaffold, and capability-configuration modes; router-only, never
-  auto-discovered by a profile)
-- Planning: `repo-harness-plan` (create a decision-complete plan, or review an
-  existing one)
-- Product planning layer: `repo-harness-product` (PRD, Sprint, and Goal
-  modes; PRD activates `$geju`, then uses Claude-first `claude -p --model
-  opus` drafting with Codex fallback to write upper-layer PRDs in
-  `plans/prds/`; Sprint plans ordered backlogs in `plans/sprints/`, each row
-  expanded with `$think` before the contract flow; Goal prepares Codex/Claude
-  `/goal` prompts from detailed PRD or Sprint artifacts and asks for those
-  docs when missing)
-- Verification: `repo-harness-check` (workflow/release checks plus a
-  deploy-readiness reference)
-- Release: `repo-harness-ship`
-- Architecture: `repo-harness-architecture`
-- Cross-model review: `repo-harness-cross-review` (host-aware Claude/Codex
-  provider modes; installed on both hosts for the full profile)
-- Exact-candidate final gate: `merge-gate` (classification-only row in the
-  full-profile discovery matrix; repo-harness ships no merge-gate Skill —
-  see [external tooling](docs/reference-configs/external-tooling.md))
-- ChatGPT integration: `repo-harness-chatgpt` (Oracle browser/GPT Pro consult
-  and continuation, MCP Connector setup, bridge handoff, and read-back
-  evidence; explicit setup only, never implied by either install profile)
+## License
 
-The planning chain is intentionally layered:
-
-```text
-idea -> repo-harness-product (PRD mode) -> repo-harness-product (Sprint mode, from-prd) -> repo-harness-product (Goal mode)
-```
-
-Use `repo-harness-product`'s PRD mode when the source is still a product idea;
-it first runs a `$geju` direction pass, then asks Claude via `claude -p
---model opus` to draft the PRD, with Codex only as fallback. Use its Sprint
-mode (`from-prd <plans/prds/*.prd.md>`) to turn an approved PRD into an
-ordered Sprint backlog with machine-checkable acceptance lines. Use its Goal
-mode only after a detailed PRD or Sprint artifact exists; it prepares a
-bounded Codex/Claude `/goal` prompt and keeps the PRD/Sprint as the source of
-truth. If that document is missing, Goal mode must ask for it instead of
-starting implementation from chat context.
-
-`repo-harness init` is for an existing repo; `repo-harness-setup`'s scaffold
-mode creates a new project or module scaffold as a side mode. `hooks-init`,
-`docs-init`, and `create-project-dirs` are internal steps, not public
-commands.
-
-`repo-harness-setup`'s scaffold mode keeps the A-K plan catalog as the
-project-type authority and layers optional overlays on top: an
-`ai_native_profile` overlay (default `none`) for AI-native app structure, and
-a separate webapp-rendering overlay (client-only Vite as Plan B, or TanStack
-Start + Vite on a Cloudflare Worker as Plan C). Overlays never install model
-providers or force a language default.
-
-Use `repo-harness-setup`'s capability mode when the harness already exists
-and only selected capability boundaries should be added. It updates
-`.ai/context/capabilities.json`, syncs the requested local `AGENTS.md` /
-`CLAUDE.md` contract files, and validates the registry without running a full
-init, migrate, or upgrade pass.
-
-Use `repo-harness-architecture`, the root Skill's handoff action, and
-`repo-harness-check`'s deploy-readiness reference for focused architecture
-documentation, rollover, and deploy/ops readiness passes. These call existing
-repo-local helpers and keep their scope narrow instead of refreshing the full
-harness.
-
-## Maintainer Reference
-
-Maintainers editing the package itself need a source checkout:
-
-```bash
-git clone https://github.com/Ancienttwo/repo-harness.git ~/Projects/repo-harness
-cd ~/Projects/repo-harness
-bun src/cli/index.ts update
-```
-
-The `~/Projects/repo-harness` repo is the only editable source of truth; local
-Claude/Codex paths (`~/.claude/skills/repo-harness`,
-`~/.codex/skills/repo-harness`) are symlink-backed runtime entrypoints. Only
-`~/.codex/skills/repo-harness` exposes `SKILL.md` and `assets/skill-commands/`;
-`scripts/sync-codex-installed-copies.sh` rebuilds these aliases and removes the
-retired `repo-harness-skill` / `project-initializer` directories. The script
-links runtime paths back to the source repo by default; set
-`AGENTIC_DEV_LINK_INSTALLED_COPIES=0` for copy-based staging, or
-`CODEX_SKILLS_ROOT` / `CLAUDE_SKILLS_ROOT` to stage under alternate roots.
-
-### Self-check this repository's workflow contract
-
-Run the full gate in [Verification](#verification); `bun run check:ci` is the
-single CI-equivalent command.
-
-### Runtime reference docs
-
-Generic repo-harness runtime/reference docs live in the installed package under
-`assets/reference-configs/` and are resolved through the CLI:
-
-```bash
-repo-harness docs list
-repo-harness docs path harness-overview
-repo-harness docs show harness-overview
-```
-
-Initializer and runtime defaults (question flow, plan menu, template vars,
-external-tooling routing) are documented in `harness-overview.md` under
-**Initializer and Runtime Model**. Generated and migrated repos still keep
-`docs/reference-configs/*.md`, but those files are deterministic pointer stubs.
-Repo-local workflow state, policy, checks, runs, handoff packets, context maps,
-and helper snapshots stay under `.ai/`.
-
-### Explicit template assembly
-
-```bash
-bun scripts/assemble-template.ts --plan C --name "MyProject"
-bun scripts/assemble-template.ts --target agents --plan C --name "MyProject"
-```
-
-### Local benchmark skeleton
-
-```bash
-bun run benchmark:skills --dry-run
-```
-
-Dry-run benchmark output is a wiring smoke only. Release or readiness evidence
-needs a non-dry-run eval with grader output.
-
-### Run one eval across both Claude and Codex
-
-```bash
-bun run benchmark:skills --eval repair-agents-task-sync
-```
-
-## Key Files
-
-- Skill spec: `SKILL.md`
-- Root routing docs: `CLAUDE.md`, `AGENTS.md`
-- Plan mapping: `assets/plan-map.json`
-- Question-pack: `assets/initializer-question-pack.v4.json`
-- Shared hooks: `assets/hooks/`
-- Runtime reference docs: `assets/reference-configs/` via `repo-harness docs`
-- Workflow contract: `assets/workflow-contract.v1.json`
-- Source repo reference docs: `docs/reference-configs/*.md`
-- Template assembler: `scripts/assemble-template.ts`
-- Question inference helper: `scripts/initializer-question-pack.ts`
-- State inspector: `scripts/inspect-project-state.ts`
-- Canonical adoption planner: `src/core/adoption/standard-plan.ts`
-- External tooling detector: `scripts/check-agent-tooling.sh`
-- Scaffolding scripts:
-  - `scripts/init-project.sh`
-  - `scripts/create-project-dirs.sh`
-
-## Generated vs Self-Hosted Hook Projection
-
-- Downstream hook behavior is defined by `assets/hooks/` plus `assets/reference-configs/`.
-- This repo dogfoods the same hook runtime through `.ai/hooks/`, but that tree is generated from `assets/hooks/projection.json`.
-- Every hook change should update canonical `assets/hooks/` once, run `bun run sync:hooks`, and include `bun run check:hooks` in verification.
-
-## Package Manager Defaults
-
-- General default priority: `bun > pnpm > npm`
-- **Plan G/H** (Python-centric) default to **`uv`** as primary package manager.
-
-## Runtime Profiles
-
-- `Plan-only (recommended)` (default)
-- `Plan + Permissionless`
-- `Standard (ask before each action)`
-
-Configured in `assets/initializer-question-pack.v4.json` and consumed by `scripts/initializer-question-pack.ts`.
-
-## Verification
-
-Use the single CI-equivalent gate for release review:
-
-```bash
-bun run check:ci
-```
-
-The gate expands to the owned checks below; `bun run check:release` adds only the npm unpublished-version preflight before delegating to the same gate.
-
-```bash
-bun test
-bash scripts/check-deploy-sql-order.sh
-bash scripts/check-architecture-sync.sh
-bash scripts/check-task-sync.sh
-bash scripts/check-task-workflow.sh --strict
-bun scripts/inspect-project-state.ts --repo . --format text
-bun src/cli/index.ts init --repo . --dry-run
-bash scripts/check-agent-tooling.sh --host both --check-updates
-bun run benchmark:skills --eval route-workflow-check
-```
+MIT — see [`LICENSE`](LICENSE).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,210 +1,49 @@
+<div align="center">
+
 # repo-harness
 
-`repo-harness` 把 Claude/Codex 的 AI 编程会话变成可复用、可恢复、可检查的
-repo-local workflow。它提供 CLI 和 skill/runtime hooks，把上下文、计划、
-handoff、检查结果和 review evidence 写回项目文件，让下一个 agent 会话可以从文件继续，
-而不是依赖聊天记录。
+### 面向 Claude 与 Codex 编程会话的 file-backed 可复现 workflow
 
-它主要解决三件事：
+<img src="docs/images/repo-harness-hook-carrot.png" alt="repo-harness hooks 借助 repo-local workflow state，引导 Codex 与 Claude 向前推进" width="900">
 
-- 用 tasks-first agent contract 快速接入已有仓库。
-- 让 Claude 和 Codex 共享同一套计划、检查、handoff 和上下文边界。
-- 用 CodeGraph 和渐进式 context loading 减少重复摸仓库结构的 token 消耗。
-
-你只需要把完整 PRD/Sprint 发给 Agent；之后的工作就是 review and `next`，
-或者启动 `/goal` 后 AFK。
+[![npm version](https://img.shields.io/npm/v/repo-harness.svg)](https://www.npmjs.com/package/repo-harness)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Runtime: Bun](https://img.shields.io/badge/runtime-Bun%20%E2%89%A5%201.1.35-black.svg)](https://bun.sh)
 
 [English](README.md) | [简体中文](README.zh-CN.md) | [日本語](README.ja.md) | [Français](README.fr.md) | [Español](README.es.md)
 
-仓库地址：`https://github.com/Ancienttwo/repo-harness`
+**把完整的 PRD 或 Sprint 交给 agent；之后你的循环只剩 review 和 `next`，或者启动 `/goal` 然后 AFK。**
 
-## 为什么用 repo-harness
+</div>
 
-- **会话状态落在文件里，不在聊天记录里。** 不同 agent 会话——Claude、Codex、现在或之后——
-  靠仓库而不是聊天线程保持同步。新会话启动时进程内的 session-context builder（`src/cli/hook/session-context.ts`）注入上一会话的
-  resume packet（`.ai/harness/handoff/resume.md`、`tasks/current.md`）；会话结束和每次编辑后，
-  `session-context`、`stop` 和 `mutation-observed` typed handlers 把下一份 handoff 写回。任务可以中途断开，下一个会话
-  直接接上准确的下一步、阻塞点和改动文件，不用重新推断。
-- **天生省 token。** 不靠每个会话重扫一遍仓库的 grep+read 循环，harness 用预建的 CodeGraph 索引做
-  结构化查询（谁调用、调用谁、定义在哪），再用 `.ai/context/context-map.json` 和 `capabilities.json`
-  做渐进式上下文加载：一份小而稳定的 root context（约 12KB），加上只在改到对应文件时才加载的
-  capability 块。agent 读一份 1KB 的 capability 合约或查索引，而不是花上千 token 重新摸清结构。
+`repo-harness` 提供一套 CLI 加 skill/runtime hooks，把 context、plan、handoff、
+checks 和 review evidence 写回项目文件，让下一个 agent 会话从文件而不是聊天
+记忆里继续。它用 tasks-first agent contract 接入已有仓库，让 Claude 和 Codex
+保持一致。
 
-接入后的仓库只需要理解几个 surface：
+## 目录
 
-| Surface | 作用 |
-| --- | --- |
-| `docs/spec.md` 和 `docs/reference-configs/` | 共享标准和稳定产品意图，每个 agent 会话都能读取。 |
-| `plans/`、`plans/prds/`、`plans/sprints/` | 实现前先沉淀 decision-complete work package。 |
-| `tasks/contracts/`、`tasks/reviews/`、`.ai/harness/checks/` | 证明完成所需的 scope、verification 和 review evidence。 |
-| `.ai/harness/handoff/` 和 `tasks/current.md` | session journal 与可恢复状态，从 workflow artifacts 派生，而不是依赖聊天记忆。 |
+- [快速开始](#快速开始)
+- [为什么用 repo-harness](#为什么用-repo-harness)
+- [核心特性](#核心特性)
+- [工作原理](#工作原理)
+- [任务 Workflow](#任务-workflow)
+- [Hooks](#hooks)
+- [MCP Connector](#mcp-connector)
+- [审查产出](#审查产出)
+- [Skills](#skills)
+- [Maintainer Reference](#maintainer-reference)
+- [致谢](#致谢)
+- [当前 Release](#当前-release)
+- [许可证](#许可证)
 
-## Human Review Path
-
-先读 `tasks/reviews/<task>.review.md`。`## Human Review Card` 是一屏决策面：
-verdict、change type、预期/实际改动文件、已通过命令、external acceptance、
-残余风险、reviewer action 和 rollback。然后检查 active contract、
-`.ai/harness/checks/latest.json` 里的 latest trace，以及实际 diff。只有当 review
-recommend pass、card verdict 为 pass，且 external acceptance 为 pass、not_required
-或明确 manual override 时，才进入 closeout。
-
-Unity、浏览器 E2E、mobile simulator、硬件测试和 staging smoke test 这类
-运行时重验证器，可以把 external verification manifest 写到被忽略的 run-evidence
-surface。当前这只是手动约定，不是 `repo-harness check` 已经会自动发现或 gate
-的能力。详见
-[`docs/reference-configs/external-tooling.md`](docs/reference-configs/external-tooling.md#external-verification-evidence)。
-
-## Agent Tracking Path
-
-Agent 先读 source artifacts，再读派生摘要：
-
-| Agent reads first | Human reviews first |
-| --- | --- |
-| 当前用户 prompt 和引用文件 | `tasks/reviews/<task>.review.md` 的 Human Review Card |
-| `AGENTS.md` / `CLAUDE.md` | changed files 和 diff |
-| `.ai/harness/active-plan` 指向的 active plan | active contract 的 allowed paths 和 exit criteria |
-| `tasks/contracts/` 下的 active contract | `.ai/harness/checks/latest.json` 和 run trace |
-| `.ai/harness/handoff/` 下的 latest handoff | 残余风险和 rollback |
-
-`tasks/current.md` 只是 orientation snapshot。如果它和 active plan、contract、
-review、checks 或 handoff 冲突，以 source artifacts 为准。
-
-## What's New
-
-Release notes 见 [`docs/CHANGELOG.md`](docs/CHANGELOG.md)，当前版本线是 `0.12.0`。
-
-## 工作原理
-
-整体分三层，host-event 只有一条 typed runtime 路径：
-
-1. **源码包层**：本仓库维护 CLI、CLI-backed command facades、templates、hook assets、
-   workflow contract、tests 和 release gate。
-2. **目标仓库合约层**：`repo-harness init` 或 migration 会写入 `docs/spec.md`、
-   `plans/`、`tasks/`、`.ai/context/`、`.ai/harness/` 和 helper scripts；
-   `.ai/hooks/lib/workflow-state.sh` 只作为 operator helper projection。
-3. **Host adapter 层**：user-level `~/.claude/settings.json` 和 `~/.codex/hooks.json`
-   把 Claude/Codex events 路由到 `repo-harness-hook`。runtime 先检查当前 repo 是否存在
-   `.ai/harness/workflow-contract.json`；opt in 后由 route registry 按
-   `event + routeId + matcher` 调用 exactly one typed handler。
-
-minimal-change hooks 复用同一套路由 surface，不新增公开 adapter route。`SessionStart`
-和允许执行的 prompt 只在 policy opt in 时打印 advisory context；只有显式启用
-`post_edit_observer:true` 时，`PostToolUse.edit` 才会把有界改动信号写到
-`.ai/harness/checks/minimal-change.latest.json`，`Stop` 把最新 review 摘要写进 handoff。
-缺失或损坏的 policy 默认 off；即使配置 `mode: "enforce"` 也会归一化为 advisory 行为，
-真正的 enforcement boundary 仍然是 tests、contracts 和 human review。
-
-所有事件都通过同一条 `host adapter -> repo-harness-hook -> route registry ->
-typed handler` 路径。`UserPromptSubmit.default` 由 `prompt` handler 负责 intent、
-workflow state、quality gate 和 host-safe 输出；`PostToolUse.edit`、`PostToolUse.bash`
-和 `Stop` 分别由 `mutation-observed`、`command-observed` 和 `stop` 处理。没有第二个
-shell dispatcher，也不根据 host provider 选择另一套语义实现。
-
-核心不变量：持久事实在仓库里，不在聊天窗口里。Typed handlers 只是加速器和 guardrail；
-真正的 authority 是 plan、contract、review、checks 和 handoff 这些文件。
-
-## 任务 Workflow：从 Plan 到 Closeout
-
-下面这张图假设目标仓库已经安装 harness。它展示的是从 program sprint backlog
-到单个 contract task 的正常闭环：先选择或形成任务，再投射到执行文件，需要时
-checkout 隔离 worktree，在 hooks 保护下实现，然后验证、review、external acceptance，
-必要时标记 sprint task 完成，最后 closeout。0.4.x 的 loop-system surface
-新增 heartbeat 定时发现、state-snapshot/eval 证据、architecture queue freshness，
-以及可选的 contract-run 委派，但 source of truth 仍然是 repo 内文件合约。
-
-```mermaid
-flowchart TD
-  Program["Program goal 或 release theme"] --> Sprint{"需要 sprint layer?"}
-  Sprint -->|是| SprintDoc["Sprint PRD + backlog<br/>plans/prds/*.prd.md"]
-  SprintDoc --> NextTask["选择下一个 sprint task<br/>sprint-backlog.sh next"]
-  Sprint -->|否| UserTask["用户任务或 planning prompt"]
-  Heartbeat["Heartbeat triage<br/>scripts/heartbeat-triage.sh<br/>.ai/harness/triage/"] --> UserTask
-  NextTask --> UserTask
-
-  UserTask --> Discovery["前置调查<br/>P1 map, P2 trace, P3 decision"]
-  Discovery --> LoopEvidence["路由变更时的 loop evidence<br/>state-snapshot --json<br/>route-nl-vs-ts / cutover gate"]
-  LoopEvidence --> PlanDraft["Draft plan<br/>plans/plan-*.md"]
-  PlanDraft --> PlanReview{"Plan 是否可执行?"}
-  PlanReview -->|否| Refine["收敛 scope 和 evidence contract"]
-  Refine --> PlanDraft
-  PlanReview -->|是| Approve["Approved plan<br/>Status: Approved"]
-
-  Approve --> Project["投射到执行面<br/>capture-plan.sh --execute<br/>或 plan-to-todo.sh --plan"]
-  Project --> Active["Active markers<br/>.ai/harness/active-plan<br/>.ai/harness/active-worktree"]
-  Project --> SprintActive["Sprint projection<br/>active-sprint marker<br/>tasks/current.md"]
-  Project --> Contract["Sprint contract<br/>tasks/contracts/YYYYMMDD-HHMM-task-slug.contract.md"]
-  Project --> ReviewFile["Review file<br/>tasks/reviews/YYYYMMDD-HHMM-task-slug.review.md"]
-  Project --> Notes["Task notes<br/>tasks/notes/YYYYMMDD-HHMM-task-slug.notes.md"]
-
-  Contract --> Delegation["Delegation contract<br/>budget / permission_scope / roles"]
-  Delegation --> Delegate{"是否使用 contract-run 委派?"}
-  Delegate -->|是| ContractRun["Worker/verifier child run<br/>scripts/contract-run.ts"]
-  Delegate -->|否| WorktreePolicy{"是否需要 contract worktree?"}
-  WorktreePolicy -->|是| Checkout["Checkout 隔离 worktree<br/>contract-worktree.sh start --plan<br/>branch codex/task-slug"]
-  WorktreePolicy -->|否| CurrentTree["使用当前 worktree<br/>小任务或明确允许的 slice"]
-  Checkout --> Implement
-  CurrentTree --> Implement
-  ContractRun --> Changes
-
-  Implement["编辑和运行命令"] --> PreHooks["Pre-edit guards<br/>PlanStatusGuard, ContractScopeGuard, WorktreeGuard"]
-  PreHooks -->|blocked| ScopeFix["修正 plan、contract、worktree 或 scope"]
-  ScopeFix --> Implement
-  PreHooks -->|allowed| Changes["代码、文档、测试或配置改动"]
-  Changes --> PostHooks["Post-edit / post-bash hooks<br/>trace, drift request, handoff, check evidence"]
-  PostHooks --> ArchQueue["Architecture queue<br/>architecture-queue.sh record/reindex<br/>check-architecture-sync.sh"]
-  ArchQueue --> Verify["运行验证<br/>tests plus repo workflow checks"]
-
-  Verify --> Checks["结构化 evidence<br/>.ai/harness/checks/latest.json<br/>.ai/harness/runs/*.json"]
-  Checks --> CheckReview["Evaluator review<br/>Waza /check -> review file"]
-  CheckReview --> External["External acceptance advice<br/>或明确 manual override"]
-  External --> DoneGate{"Contract、checks、review、acceptance 是否通过?"}
-  DoneGate -->|否| Repair["修复失败 evidence 或实现"]
-  Repair --> Implement
-  DoneGate -->|是| SprintComplete{"存在 active sprint task?"}
-  SprintComplete -->|是| MarkSprint["标记 backlog item 完成<br/>sprint-backlog.sh complete-task"]
-  SprintComplete -->|否| Closeout["Closeout<br/>scripts/contract-worktree.sh finish"]
-  MarkSprint --> Closeout
-
-  Closeout --> Commit["提交 contract branch"]
-  Commit --> Merge["Fast-forward target branch"]
-  Merge --> Archive["归档 plan/todo 并刷新 handoff"]
-  Archive --> Cleanup["清理已合并 worktree<br/>contract-worktree.sh cleanup"]
-  Cleanup --> Done["可审查的已完成任务"]
-```
-
-## 长周期产品 Loop
-
-Greenfield 和 Brownfield 工作先由 parent agent 完成 discovery 和工程计划判断，
-不要直接让 Codex 从原始聊天长期滚动：
-
-1. contract 产生前，parent agent 先调用 `geju` 打开格局，再用自身的 repo/runtime
-   能力完成 P1/P2/P3，并把确认后的产品意图、架构、风险、falsifier 和 evidence
-   contract 冻结进开发文档。
-2. 把这些文档转成 `plans/prds/` 下的 PRD Sprint，并为每个 execution
-   slice 写清有序 backlog 和详细 sub-plan。
-3. 创建 Codex Goal，目标指向该 sprint 文件。repo-harness 之后就可以按既有
-   plan -> contract -> worktree -> verification flow 逐项投射和执行。
-
-这个交接让长周期 loop 更精准：parent agent 负责前置判断，PRD Sprint 是 durable
-source of truth，Codex Goal mode 只围绕具体 sprint 恢复和推进，而不是反复重新解释原始聊天。
-
-## 前 5 分钟
-
-<p align="center">
-  <img src="docs/images/repo-harness-install-donkey-carrot.png" alt="repo-harness 安装引导的 pixel art 驴和萝卜 banner" width="900">
-</p>
-
-这是评估一个真实仓库是否适合接入该 workflow 的最快路径。它把机器级 runtime
-bootstrap 和 repo-local contract install 分开，所以 dry-run 能先展示会改什么，
-再决定是否应用。
-
-前置条件：Git working tree、`bash`、`bun`（用于后续验证和 template assembly）。
-`jq` 可选；做 `--dry-run` 时推荐，应用 settings merge 时更有用。
+## 快速开始
 
 ### 1. 安装 CLI
 
-默认路径不需要 Node.js：installer 使用 Bun >= 1.1.35 作为 runtime。如果机器上
-没有 Bun 或版本更旧，它会先安装或升级 Bun，再安装 `repo-harness` CLI。
+前置条件：一个 Git working tree、`bash` 和 `bun`；`jq` 可选。不需要
+Node.js——installer 使用 Bun >= 1.1.35 作为 runtime，需要时会先安装或升级
+Bun。
 
 ```bash
 # macOS / Linux
@@ -214,60 +53,29 @@ curl -fsSL https://raw.githubusercontent.com/Ancienttwo/repo-harness/main/instal
 irm https://raw.githubusercontent.com/Ancienttwo/repo-harness/main/install.ps1 | iex
 ```
 
-如果 Bun >= 1.1.35 已经在 `PATH` 上，可以跳过 shell installer。旧的 self-managed
-Bun 从这些 direct path 启动时，`repo-harness install` 会先升级同一个 binary 再继续；
-如果 Bun 由 package manager 管理，则 fail closed 并提示对应的升级命令（例如
-`brew upgrade bun` 或 `scoop update bun`），不会覆盖 package-manager-owned 文件：
+如果 Bun >= 1.1.35 已经在 PATH 上，可以跳过 shell installer。由包管理器
+安装的 Bun 会 fail closed，并提示对应的升级命令（如 `brew upgrade bun`），
+而不是覆盖包管理器管理的文件。
 
 ```bash
-# Bun 一步 bootstrap
-bunx repo-harness@latest install
-
-# 或者先安装持久化 CLI
-bun add -g repo-harness
+bunx repo-harness@latest install     # Bun one-shot bootstrap
+bun add -g repo-harness              # or install the persistent CLI first
 repo-harness install
-
-# npx 备选；仍要求 Bun 已在 PATH 上，因为 CLI runtime 是 Bun
-npx -y repo-harness@latest install
+npx -y repo-harness@latest install   # npx fallback; the CLI still runs on Bun
 ```
 
-### 2. 先做一次 host runtime bootstrap
+### 2. 引导 host runtime
 
 ```bash
 repo-harness install
 ```
 
-`install` 是首次全局引导入口。它把当前 npm 包安装成全局 CLI，刷新 repo-harness
-skill aliases，安装 user-level hook adapters，配置 Waza runtime skills，把 brain
-root 持久化到 `~/.repo-harness/config.json`，并配置 CodeGraph MCP。这个命令是
-幂等的：如果 CLI 已经来自 Bun global package source，它会跳过 CLI 重装，但仍继续
-刷新 host runtime pieces。它不会把当前目录默认迁移成 repo-local workflow。
-
-如果要让 Agent 做只读 bootstrap audit，运行 `repo-harness setup check
---json`；需要版本和已接入仓库刷新提示时加 `--check-updates`。`setup check`
-不是 runtime hook：它不会写 user-level files、安装更新、执行 `init` 或注册
-adapters，只输出带 reason、risk、targets、可选 command 和 verification 的
-`agent_actions`，由 Agent 再显式执行。
-`repo-harness init-hook` 保留为兼容 alias。
-
-### 安装和刷新例子
-
-```bash
-# 包更新后刷新 user-level CLI/runtime。
-repo-harness update
-
-# 移除管理的 host adapters，不动 sibling 或第三方 hooks。
-repo-harness uninstall
-
-# 只安装 host hook adapters（旧版 adapter-only surface）。
-repo-harness install --target both --location global
-
-# 只读修复建议，不写文件。
-repo-harness update --check
-
-# 刷新已接入仓库里的 repo-local workflow 文件。
-repo-harness init --repo /path/to/repo
-```
+这个全局 bootstrap 会把 npm 包安装成全局 CLI，刷新 repo-harness 的 skill
+aliases，安装 user-level hook adapters，并记录一份明确的 install profile。
+它是幂等的，不会把 repo-local workflow 文件应用到当前目录。`--dry-run
+--json` 会先列出将要安装、跳过和移除的组件。Profile、delegation mode、
+刷新命令，以及只读的 `setup check` audit，见
+[`install-profiles.md`](docs/reference-configs/install-profiles.md)。
 
 ### 3. 预览 repo-local contract
 
@@ -275,11 +83,12 @@ repo-harness init --repo /path/to/repo
 repo-harness init --dry-run
 ```
 
-在目标仓库根目录运行 dry-run。它会报告将要创建或刷新的 spec、task state、
-helper runtime、hook adapter target 和 verification files。它不会创建应用技术栈；
-已有仓库走 `repo-harness init`，新项目或新模块走 `repo-harness-setup` 的 scaffold mode。
+在目标仓库根目录运行这条命令。它会报告将要创建或刷新的 specs、task
+state、helper runtime、hook adapter target 和 verification files。它从不
+创建 application stack；新项目和新模块改用 `repo-harness-setup` 的
+scaffold mode。
 
-### 4. 应用后验证 workflow
+### 4. 应用并验证
 
 ```bash
 repo-harness init
@@ -287,384 +96,363 @@ bash scripts/check-task-workflow.sh --strict
 bun test
 ```
 
-应用后，目标仓库应该得到一套可审查的 file-backed contract，而不是 tool-specific
-聊天配置。agent 应该能在 `docs/spec.md` 找到稳定意图，在 `plans/` 和 `tasks/`
-找到执行状态，在 `.ai/harness/handoff/` 找到可恢复状态。
+### 成功之后是这样
 
-新项目或新模块用 `repo-harness-setup` 的 scaffold mode 代替 `init`；它会安装或
-刷新 harness，不会创建应用技术栈。维护者编辑 package 源码需要 source checkout
-—— 见 [Maintainer Reference](#maintainer-reference)。
+应用命令最后会输出 `=== Migration Report ===`，说明生成的 hook 行为来自
+哪里、user-level `~/.claude/settings.json` 与 `~/.codex/hooks.json` 的
+adapter target、被创建或刷新的 repo-local surfaces、
+`.ai/harness/scripts/*` helper runtime，以及一段 `--- External Tooling
+---` readiness block。此后，稳定意图落在 `docs/spec.md`，执行状态落在
+`plans/` 和 `tasks/`，resume 状态落在 `.ai/harness/handoff/`。如果 dry
+run 结果看起来不对，先停下来读
+[`hook-operations.md`](docs/reference-configs/hook-operations.md)。
 
-### 成功长什么样
+### 更新与移除
 
-命令最后应该输出 `=== Migration Report ===`，并包含：
+```bash
+repo-harness update          # refresh user-level CLI and runtime pieces
+repo-harness update --check  # read-only repair guidance, no writes
+repo-harness uninstall       # remove managed host adapters only
+```
 
-- `Project hooks synced from:`：生成的 hook 行为来自哪里
-- `Host hook config target: user-level ~/.claude/settings.json and ~/.codex/hooks.json`：adapter 层在哪里
-- `Host hook adapters are user-level:`：提醒安装 global adapters，并信任 `~/.codex/hooks.json`
-- `Workflow migration:`：repo-local harness surfaces 的创建或刷新计划
-- `Helper runtime:`：应用后会得到的操作工具链
-- `--- External Tooling ---`：parent/Geju planning 指引，以及 Waza 和 CodeGraph readiness 与 advisory 安装/更新提示
+## 为什么用 repo-harness
 
-如果 dry-run 输出不对，先停在这里，阅读
+- **会话状态落在文件里，而不是聊天记忆里。** 不同的 Claude 和 Codex 会话
+  靠仓库保持协调。`SessionStart` 注入上一个会话的 resume packet，`Stop`
+  写下 handoff，每次 edit 都记一条小的 journal event。一个会话可以在任务
+  中途结束，下一个会话直接接上准确的下一步、blocker 和改动过的文件，不
+  需要重新推导。
+- **天生省 token。** Harness 不靠每个会话重新扫一遍仓库的 grep-and-read
+  循环，而是靠预建的 CodeGraph 索引做结构化查询，配合渐进式 context
+  loading：一份稳定的约 12KB root context，加上只在你改到的文件需要时才
+  加载的 capability 块。Agent 读一份约 1KB 的 capability contract，而
+  不是重新摸索结构。
+- **自带 review-ready 的证据。** 每个任务都会留下一份 contract、结构化的
+  check 证据和一张 review card。人工决策面就是一屏——verdict、intended
+  vs actual files、commands passed、residual risk、rollback——而不是
+  靠还原 agent 自称做过什么来判断。
+
+在接入后的仓库里，surface 刻意保持精简：
+
+| Surface | 作用 |
+| --- | --- |
+| `docs/spec.md` 和 `docs/reference-configs/` | 每个 agent 会话都能读到的共享标准和稳定产品意图。 |
+| `plans/`、`plans/prds/`、`plans/sprints/` | 开工前就已 decision-complete 的 work package。 |
+| `tasks/contracts/`、`tasks/reviews/`、`.ai/harness/checks/` | 证明工作完成所需的 scope、verification 和 review evidence。 |
+| `.ai/harness/handoff/` 和 `tasks/current.md` | session journal 和可恢复状态，从 workflow artifact 派生，而不是依赖聊天记忆。 |
+
+## 核心特性
+
+| | |
+| --- | --- |
+| **会话状态落在文件里** | Plan、contract、check 和 handoff 都留在仓库里，新会话从 artifact 而不是聊天线程恢复 |
+| **Typed hook runtime** | 八条共享 managed route 加三条 Codex-only delegation route，每条都绑定唯一一个 typed in-process handler，在 edit boundary 上做 fail-closed guard |
+| **Plan → Contract → Review** | 从 approved plan 到 projected contract、隔离 worktree、结构化证据，再到可审查 closeout 的完整生命周期 |
+| **渐进式 context loading** | 约 12KB 的稳定 root context，加上只为实际改动文件加载的约 1KB capability contract |
+| **CodeGraph 集成** | 用预建索引回答调用者、被调用者、定义位置这类结构化查询，取代反复的 grep-and-read |
+| **MCP planner sidecar** | ChatGPT 读取真实仓库状态并写出 PRD/Sprint/Goal artifact；Codex 负责执行，默认没有源码写入权限 |
+| **Claude + Codex 对齐** | 一份 user-level adapter contract、一份 workflow contract，以及两个 host 共用的一套 repo-local artifact |
+
+## 工作原理
+
+1. **源码包层**：本仓库负责 CLI、command facade、template、typed hook
+   handler、operator-helper asset、workflow contract、test 和 release
+   gate。
+2. **目标仓库 contract 层**：`repo-harness init` 或 migration 会写入
+   repo-local 文件，例如 `docs/spec.md`、`plans/`、`tasks/`、
+   `.ai/context/`、`.ai/harness/`、helper script 和 `.ai/hooks/`。
+3. **Host adapter 层**：user-level 的 `~/.claude/settings.json` 和
+   `~/.codex/hooks.json` 把 Claude/Codex 的事件路由进 `repo-harness-hook`。
+
+对于没有 opt-in 的仓库，hook entrypoint 会静默退出。对于已经 opt-in 的
+仓库，route registry 会把公开的 event tuple 绑定到唯一一个打包好的
+typed handler。`.ai/hooks/` 只保存 operator-helper projection，从来不是
+host-event dispatcher。
+
+核心不变量是：持久事实活在仓库里，而不是聊天线程里。Hook 只是
+accelerator 和 guardrail；真正的 authority 是 file-backed 的 plan、
+contract、review、checks 和 handoff artifact。Prompt 层面的
+plan/spec/contract gate 只是 advisory routing；硬性 enforcement 落在
+edit boundary 上。Handler 内部实现、minimal-change surface 和 policy
+mode，见 [`hook-operations.md`](docs/reference-configs/hook-operations.md)
+和
+[`minimal-change-hooks.md`](docs/reference-configs/minimal-change-hooks.md)。
+
+## 任务 Workflow
+
+这张图假设 harness 已经安装好。它展示的是从 program sprint backlog 到
+单个 contract task 的正常生命周期：选择任务，把它投射成执行文件，在
+policy 要求时 checkout contract worktree，在 hook 保护下实现，然后
+验证、review、closeout。
+
+```mermaid
+flowchart TD
+  Program["Program goal or release theme"] --> Sprint{"Sprint layer needed?"}
+  Sprint -->|yes| PRD["Upper-layer PRD<br/>plans/prds/*.prd.md"]
+  PRD --> SprintDoc["Sprint backlog<br/>plans/sprints/*.sprint.md"]
+  SprintDoc --> NextTask["Select next sprint task<br/>sprint-backlog.sh next"]
+  Sprint -->|no| UserTask["User task or planning prompt"]
+  Heartbeat["Heartbeat triage<br/>scripts/heartbeat-triage.sh<br/>.ai/harness/triage/"] --> UserTask
+  NextTask --> UserTask
+
+  UserTask --> Discovery["Due diligence<br/>P1 map, P2 trace, P3 decision"]
+  Discovery --> LoopEvidence["Loop evidence when routing changes<br/>state-snapshot --json<br/>route-nl-vs-ts / cutover gate"]
+  LoopEvidence --> PlanDraft["Draft plan<br/>plans/plan-*.md"]
+  PlanDraft --> PlanReview{"Plan ready for execution?"}
+  PlanReview -->|no| Refine["Refine plan, scope, evidence contract"]
+  Refine --> PlanDraft
+  PlanReview -->|yes| Approve["Approved plan<br/>Status: Approved"]
+
+  Approve --> Project["Project plan into execution<br/>capture-plan.sh --execute<br/>or plan-to-todo.sh --plan"]
+  Project --> Active["Active markers<br/>.ai/harness/active-plan<br/>.ai/harness/active-worktree"]
+  Project --> SprintActive["Sprint projection<br/>active-sprint marker<br/>tasks/current.md"]
+  Project --> Contract["Sprint contract<br/>tasks/contracts/YYYYMMDD-HHMM-task-slug.contract.md"]
+  Project --> ReviewFile["Review file<br/>tasks/reviews/YYYYMMDD-HHMM-task-slug.review.md"]
+  Project --> Notes["Task notes<br/>tasks/notes/YYYYMMDD-HHMM-task-slug.notes.md"]
+
+  Contract --> Delegation["Delegation contract<br/>budget / permission_scope / roles"]
+  Delegation --> Delegate{"Use contract-run delegation?"}
+  Delegate -->|yes| ContractRun["Worker/verifier child run<br/>scripts/contract-run.ts"]
+  Delegate -->|no| WorktreePolicy{"Contract worktree required?"}
+  WorktreePolicy -->|yes| Checkout["Checkout isolated worktree<br/>contract-worktree.sh start --plan<br/>branch codex/task-slug"]
+  WorktreePolicy -->|no| CurrentTree["Use current worktree<br/>small or explicitly allowed slice"]
+  Checkout --> Implement
+  CurrentTree --> Implement
+  ContractRun --> Changes
+
+  Implement["Edit and run commands"] --> PreHooks["Pre-edit guards<br/>PlanStatusGuard, ContractScopeGuard, WorktreeGuard"]
+  PreHooks -->|blocked| ScopeFix["Fix plan, contract, worktree, or scope"]
+  ScopeFix --> Implement
+  PreHooks -->|allowed| Changes["Code, docs, tests, or config changes"]
+  Changes --> PostHooks["Post-edit and post-bash hooks<br/>trace, drift request, handoff, check evidence"]
+  PostHooks --> ArchQueue["Architecture queue<br/>architecture-queue.sh record/reindex<br/>check-architecture-sync.sh"]
+  ArchQueue --> Verify["Run verification<br/>tests plus repo workflow checks"]
+
+  Verify --> Checks["Structured evidence<br/>.ai/harness/checks/latest.json<br/>.ai/harness/runs/*.json"]
+  Checks --> CheckReview["Evaluator review<br/>Waza /check -> review file"]
+  CheckReview --> External["External acceptance advice<br/>or explicit manual override"]
+  External --> DoneGate{"Contract, checks, review, and acceptance pass?"}
+  DoneGate -->|no| Repair["Repair failing evidence or implementation"]
+  Repair --> Implement
+  DoneGate -->|yes| SprintComplete{"Sprint task active?"}
+  SprintComplete -->|yes| MarkSprint["Mark backlog item complete<br/>sprint-backlog.sh complete-task"]
+  SprintComplete -->|no| Closeout["Closeout<br/>scripts/contract-worktree.sh finish"]
+  MarkSprint --> Closeout
+
+  Closeout --> Commit["Commit contract branch"]
+  Commit --> Merge["Fast-forward target branch"]
+  Merge --> Archive["Archive plan/todo and refresh handoff"]
+  Archive --> Cleanup["Cleanup merged worktree<br/>contract-worktree.sh cleanup"]
+  Cleanup --> Done["Reviewable completed task"]
+```
+
+面向长周期的产品 loop，在 Codex 开始循环执行之前，先把 discovery 和
+工程 plan 判断留给 parent agent：`geju` 打开 pre-contract frame，parent
+agent 完成 P1/P2/P3，把确认的方向冻结进 `plans/prds/` 下的上层 PRD，
+以及 `plans/sprints/` 下的有序 sprint backlog，然后用 Codex Goal 指向
+那份 sprint 文件。PRD 保持为上层 source of truth，backlog 是持久的
+执行队列，这样 resume 之后的 Goal 会话就不需要重新解释原始聊天。见
+[`agentic-development-flow.md`](docs/reference-configs/agentic-development-flow.md)
+和
+[`workflow-orchestration.md`](docs/reference-configs/workflow-orchestration.md)。
+
+## Hooks
+
+安装好的 adapter 拥有八条共享的 managed hook route。Route tuple
+`event + routeId + matcher` 是稳定的 contract；每个 tuple 绑定唯一一个
+typed in-process handler。
+
+| Route | Matcher | Handler | Function |
+| --- | --- | --- | --- |
+| `SessionStart.default` | all sessions | `src/cli/hook/session-context.ts` (in-process builder) | 在开工前注入之前的 handoff、sprint 状态、minimal-change 指引，以及只读的 config-security 发现项。 |
+| `PreToolUse.edit` | `Edit\|Write` | `src/cli/hook/mutation-guard.ts` (in-process handler) | 在实现性 edit 之前，强制执行 worktree policy 和 plan/contract 就绪检查。 |
+| `PreToolUse.subagent` | `Task\|Agent\|SendUserMessage` | `src/cli/hook/subagent-handler.ts` | 让 delegated 工作始终经由 parent session 回流，避免泄漏未经确认的 completion 声明。 |
+| `PostToolUse.edit` | `Edit\|Write` | `src/cli/hook/mutation-observed.ts` (in-process handler) | 每次符合条件的 edit 最多写一条带 dirty bits 的小 journal event；contract verification、architecture/context/capability sync 和 minimal-change 证据都延后到 Stop 才跑，而不是每次 edit 都跑。 |
+| `PostToolUse.bash` | `Bash` | `src/cli/hook/command-observed.ts` | 观察命令结果并捕获 verification 证据，不替代命令本身的 runner。 |
+| `PostToolUse.always` | all tools | `src/cli/hook/trace-observer.ts` | 提供低噪音、常驻的 trace 和 runtime observation。 |
+| `UserPromptSubmit.default` | all prompts | `src/cli/hook/prompt-handler.ts` | 对 prompt intent 分类，路由 planning/check 提示，并渲染 host-safe 的 workflow 指引。 |
+| `Stop.default` | session stop | `src/cli/hook/stop-handler.ts` (in-process handler) | 收尾 handoff，并防止在 draft-plan 未解决或 completion 证据有缺口时结束会话。 |
+
+Codex 还会额外安装三条 Codex-only 的 bounded-delegation route——
+`UserPromptSubmit.delegation`、`SubagentStart.context` 和
+`SubagentStop.quality`，全部绑定到 `src/cli/hook/subagent-handler.ts`；
+Claude 只保留共享的 `PreToolUse.subagent` return-channel route。
+
+`repo-harness-hook` 和它的 typed handler registry 是 host-event
+runtime；`~/.claude/settings.json` 和 `~/.codex/hooks.json` 是
+user-level adapter，Codex 必须先在 Settings 里把这个文件标记为
+trusted，这些 hook 才会运行。Repo-local 的 `.claude/settings.json` 和
+`.codex/hooks.json` 是需要退休的 legacy config。按顺序 debug：adapter
+config -> `repo-harness-hook` -> route registry -> typed handler。
+
+当某个 hook 挡住工作时，先读 terminal 里结构化输出的 `guard`、
+`reason`、`fix`、`failure_class` 和 `run_id`。持久记录在
+`.ai/harness/failures/latest.jsonl`，相关 tool activity 在
+`.claude/.trace.jsonl`。常见的 guard 有 `PlanStatusGuard`（没有 active
+或可执行的 plan）、`ContractGuard`（缺少 contract scaffold，或者在
+contract 通过之前就声称完成）和 `WorktreeGuard`（从错误的 worktree
+写入）。完整 playbook 见
 [`docs/reference-configs/hook-operations.md`](docs/reference-configs/hook-operations.md)。
 
-## MCP Connector Quickstart
+## MCP Connector
 
-作为可选 sidecar，`repo-harness mcp` 只把 workflow artifacts 暴露给 MCP 客户端。
-ChatGPT 充当读取状态、把想法推过 PRD、checklist Sprint 和 Codex goal handoff 的
-planner/reviewer —— 没有源码写入权限、没有任意 shell 执行、也没有默认 Codex
-runner。Codex 仍然是执行者。
-
-这个 sidecar 假设 CLI 已经按上面「前 5 分钟」装好。当你想让 ChatGPT
-对着真实仓库状态做规划、由 Codex 执行生成的 file-backed Sprint 时用它。
+作为可选 sidecar，`repo-harness mcp` 通过默认的 `planner` profile 把
+workflow artifact 暴露给 MCP client。ChatGPT 读取真实仓库状态，把一个
+想法推进过 PRD、checklist Sprint 和 Codex goal handoff artifact——默认
+没有源码写入权限、没有任意 shell 执行，也没有默认 runner。Codex 仍然是
+执行者。
 
 ```bash
 repo-harness mcp setup chatgpt --repo .
 repo-harness mcp serve --repo . --transport http --host 127.0.0.1 --port 8765 --profile planner
 ```
 
-把这个本地 server 通过 HTTPS tunnel 暴露出去，再用 `/mcp` URL 创建一个
-ChatGPT Connector。生成的指南写到：
+把这个本地 server 通过 HTTPS tunnel 暴露出去，注册 `/mcp` URL，human
+workflow 就是：
+
+1. ChatGPT 通过 MCP 读取 repo-harness 的 workflow 文件。
+2. ChatGPT 用 `write_prd_from_idea` 写一份 PRD。
+3. ChatGPT 用 `write_checklist_sprint` 写一份 checklist Sprint。
+4. ChatGPT 用 `prepare_codex_goal_from_sprint` 准备好
+   `.ai/harness/handoff/codex-goal.md`。
+5. Codex 运行 host-native 的 `/goal` prompt，逐个 stage 已完成的 Sprint
+   phase。
+
+通用的 repo reader/writer 工具、snapshot 与 index 一致性、server
+profile，以及 opt-in 的 dev runner，见
+[`general-repo-mcp.md`](docs/reference-configs/general-repo-mcp.md)。
+Direct-coding profile 见
+[`chatgpt-coding-mcp.md`](docs/reference-configs/chatgpt-coding-mcp.md)。
+Index-stale、CodeGraph-down 和 rollback 操作见
+[`general-repo-mcp-codegraph.md`](deploy/runbooks/general-repo-mcp-codegraph.md)。
+
+## 审查产出
+
+先看 `tasks/reviews/<task>.review.md`。它的 `## Human Review Card` 是
+一屏决策面：verdict、change type、intended vs actual files、commands
+passed、external acceptance、residual risk、reviewer action、
+rollback。然后再检查 active contract、`.ai/harness/checks/latest.json`
+里的最新 trace，以及实际改动的文件。只有当 review 建议 pass、card 的
+verdict 是 pass，且 external acceptance 是 pass、`not_required` 或
+明确的 override 时，才能接受这次交付。
+
+Agent 会先读 source artifact，再读派生出来的摘要：
+
+| Agent 先读 | Human 先看 |
+| --- | --- |
+| 当前用户 prompt 和引用的文件 | `tasks/reviews/<task>.review.md` 的 Human Review Card |
+| `AGENTS.md` / `CLAUDE.md` | 改动的文件和 diff |
+| `.ai/harness/active-plan` 里的 active plan | Active contract 的 allowed paths 和 exit criteria |
+| `tasks/contracts/` 里的 active contract | `.ai/harness/checks/latest.json` 和 run trace |
+| `.ai/harness/handoff/` 里的最新 handoff | 残余风险和 rollback |
+
+`tasks/current.md` 只是一份 orientation snapshot。如果它和 active
+plan、contract、review、checks 或 handoff 有分歧，以 source artifact
+为准。
+
+Runtime 较重的 validator（Unity、浏览器 E2E、mobile simulator、硬件
+rig、staging smoke test）可以把 external verification manifest 发布到
+被忽略的 run-evidence surface——目前这只是人工约定，还不是
+`repo-harness check` 会自动执行的 gate。见
+[external tooling](docs/reference-configs/external-tooling.md#external-verification-evidence)。
+
+## Skills
+
+Canonical 的 rule-owner package 放在 `assets/skills/` 和
+`assets/skill-commands/` 下，让 host skill discovery 保持在有限范围
+内，真正的 execution 仍由 CLI 和 hooks 负责。
+
+| Skill | 作用 |
+| --- | --- |
+| `repo-harness` | 根路由 Skill，无条件同步到每个 profile |
+| `repo-harness-setup` | Init、migrate、upgrade、repair、scaffold 和 capability-configuration 各 mode；仅 router-only |
+| `repo-harness-plan` | 创建一份 decision-complete plan，或者 review 已有的 plan |
+| `repo-harness-product` | 面向上层产品规划的 PRD、Sprint 和 Goal mode |
+| `repo-harness-check` | Workflow 和 release check，附带 deploy-readiness reference |
+| `repo-harness-ship` | 校验完成的 worktree，push 分支并开 PR |
+| `repo-harness-architecture` | Architecture 文档、drift request 和图表，不需要完整刷新 harness |
+| `repo-harness-cross-review` | Host-aware 的 Claude/Codex 独立 cross-model review |
+| `claude-plan` | Codex 端 provider skill：面向设计分叉或高风险决策的独立 Claude plan mode consult；不是用户直呼入口 |
+| `repo-harness-chatgpt` | Oracle browser/GPT Pro consult、MCP Connector setup 和 bridge handoff；仅限显式 setup |
+| `merge-gate`（外部） | Exact-candidate 的 final gate；repo-harness 本身不附带 merge-gate Skill——见 [external tooling](docs/reference-configs/external-tooling.md) |
+
+规划链路刻意分层：
 
 ```text
-docs/repo-harness-chatgpt-mcp-setup.md
+idea -> PRD mode -> Sprint mode -> Goal mode
 ```
 
-human workflow 是：
+`repo-harness init` 面向已有仓库；`repo-harness-setup` 的 scaffold
+mode 创建新项目或新模块。`hooks-init`、`docs-init` 和
+`create-project-dirs` 是内部步骤，不是公开命令。各 mode 的路由边界见
+[`agentic-development-flow.md`](docs/reference-configs/agentic-development-flow.md)
+和 `repo-harness docs show harness-overview`。
 
-1. ChatGPT 通过 MCP 读取 repo-harness workflow 文件。
-2. ChatGPT 用 `write_prd_from_idea` 写 PRD。
-3. ChatGPT 用 `write_checklist_sprint` 写 checklist Sprint。
-4. ChatGPT 用 `prepare_codex_goal_from_sprint` 准备 `.ai/harness/handoff/codex-goal.md`。
-5. Codex 运行 host-native `/goal` prompt，逐个 stage 完成的 Sprint phase。
+## Maintainer Reference
 
-最后一步 handoff 的本地兜底：
+修改 package 本身需要一份 source checkout：
 
 ```bash
-repo-harness mcp prepare-goal --repo . --prd plans/prds/<feature>.prd.md --sprint plans/sprints/<feature>.sprint.md
+git clone https://github.com/Ancienttwo/repo-harness.git ~/Projects/repo-harness
+cd ~/Projects/repo-harness && bun src/cli/index.ts update
 ```
 
-面向 agent 的 Skill 安装在：
+这份 checkout 是唯一可编辑的 source of truth；本地 Claude/Codex 的
+skill 路径是 symlink-backed 的 runtime entrypoint，由
+`scripts/sync-codex-installed-copies.sh` 重建。
+
+`bun run check:ci` 是唯一的 CI-equivalent gate；`bun run
+check:release` 只是在委托给它之前，多加一步 npm unpublished-version
+preflight。
+
+```bash
+bun run check:ci                    # the whole gate
+repo-harness docs list              # runtime reference docs, resolved from the package
+repo-harness docs show harness-overview
+bun scripts/assemble-template.ts --plan C --name "MyProject"
+```
+
+Hook 变更只更新一次 canonical 的 `assets/hooks/`，然后跑 `bun run
+sync:hooks`，并在验证里包含 `bun run check:hooks`。Reference doc 的
+canonical 版本在 `assets/reference-configs/` 下，并投射到
+`docs/reference-configs/`；`bun run check:reference-configs` 用来
+验证这次投射。
+
+## 致谢
+
+`repo-harness` 是围绕一小组外部 skill、仓库和 agent runtime 搭建起来
+的，它们塑造了这套 workflow contract。它们不是普通的 bundled
+dependency。
+
+| 工具或仓库 | 用途 | 依赖形态 |
+| --- | --- | --- |
+| [Hylarucoder](https://x.com/hylarucoder) / Geju | P1/P2/P3 due-diligence 方法和 Geju 实践，塑造了这套 workflow 里 planning、tracing 和 decision-rationale 的纪律 | 方法论贡献和致谢；不是 bundled dependency |
+| [TW93](https://x.com/HiTw93) 的 Waza，包括 `think`、`hunt`、`check` 和 `health` | 日常 planning、bug hunt、verification、health check，以及 Codex-first 的 skill sync | 通过 skills CLI 安装进 host skill root |
+| `mermaid` | 当 Mermaid 不够用时，提供人类可读的 architecture 和 system-flow 图 | Runtime-referenced 的 skill，不会 vendor 进生成的仓库 |
+| CodeGraph（`@colbymchenry/codegraph`） | 为这个 self-host 仓库提供 symbol-aware 导航、impact tracing 和 readiness check | 本仓库的 dev dependency；生成的仓库默认保持 global-MCP-first，除非 policy 显式开启 |
+| [Peter Steinberger](https://x.com/steipete) 的 [Oracle](https://github.com/steipete/oracle)（`@steipete/oracle`，MIT） | `chatgpt-browser` 的 Oracle provider 为 `gptpro` consult 默认 shell 出去调用的 GPT Pro / ChatGPT Web 浏览器 consult 引擎 | 外部解析的 binary（`--oracle-bin`、`REPO_HARNESS_ORACLE_BIN`、`node_modules/.bin` 或 `PATH`）；从不自动下载，缺失 binary 会硬失败 `ORACLE_NOT_INSTALLED` |
+| OpenAI Codex | repo-local 实现和验证的主要执行 agent；commit 实质包含 Codex 产出内容时，也承担 GitHub contributor attribution | 外部 agent runtime；attribution 是显式的 commit trailer，不是隐藏的 hook automation |
+
+### GitHub 贡献者署名
+
+当 Codex 对某次 commit 有实质贡献时，在 message 末尾用 GitHub 标准的
+co-author trailer：
 
 ```text
-.agents/skills/repo-harness-chatgpt-bridge/SKILL.md
+Co-authored-by: codex <codex@openai.com>
 ```
 
-这个 Skill 告诉 Codex 如何消费 ChatGPT 产出的 PRD/Sprint/Goal artifacts，
-而不给 ChatGPT 源码写入或 shell 执行权限。
-
-Dev Mode 可以选择通过 MCP 开启本地 agent 执行，默认关闭。当用户启用
-`orchestrator` profile 并打开 dev runner 设置后，ChatGPT 可以调用
-`run_agent_goal`，它只读取 `.ai/harness/handoff/codex-goal.md`，并通过
-`codex exec` 或 `claude -p` 这类被允许的本地 CLI 运行这段固定 handoff。
-
-```bash
-repo-harness mcp serve --repo . --transport http --profile orchestrator --enable-dev-runner --dev-runner-agents codex
-```
-
-这个设置只面向本地 Developer Mode，有超时上限、有审计，不是任意 shell。
-
-## Hook Authority Map
-
-`repo-harness-hook` 是唯一 host-event runtime。user-level adapter 只负责送入事件，
-route registry 按稳定的 `event + routeId + matcher` tuple 调用 exactly one typed handler。
-`assets/hooks/lib/workflow-state.sh` 与 `.ai/hooks/lib/workflow-state.sh` 仅供 operator
-helpers 检查 workflow state，不是 dispatcher。
-
-- `~/.claude/settings.json`：user-level Claude adapter。
-- `~/.codex/hooks.json`：user-level Codex adapter；必须在 Codex Settings 中信任。
-- Repo-local `.claude/settings.json` / `.codex/hooks.json`：迁移时退休的 legacy 输入。
-- 产品 handler 变更在 `src/cli/hook/`；asset projection 用 `bun run sync:hooks` 同步。
-
-The installed adapter owns the managed hook routes. Each route invokes one typed
-handler; 不存在第二套 shell runtime，也不存在 provider-specific runtime。
-
-| Route | Matcher | Typed handler | Function |
-| --- | --- | --- | --- |
-| `SessionStart.default` | all sessions | `src/cli/hook/session-context.ts` (in-process builder) | Injects prior handoff, sprint status, and read-only config-security findings before work starts. |
-| `PreToolUse.edit` | `Edit|Write` | `src/cli/hook/mutation-guard.ts` (in-process handler) | Enforces worktree policy and plan/contract readiness before implementation edits. |
-| `PreToolUse.subagent` | `Task|Agent|SendUserMessage` | `subagent` | Keeps delegated work returning through the parent session instead of leaking completion claims. |
-| `PostToolUse.edit` | `Edit|Write` | `mutation-observed` | Records the edit journal and controlled-file observations. |
-| `PostToolUse.bash` | `Bash` | `command-observed` | Observes command results and captures verification evidence without replacing the command runner. |
-| `PostToolUse.always` | all tools | `trace-observer` | Provides low-noise always-on trace and runtime observation. |
-| `UserPromptSubmit.default` | all prompts | `prompt` | Classifies prompt intent, routes planning/check/hunt hints, and renders host-safe workflow guidance. |
-| `Stop.default` | session stop | `src/cli/hook/stop-handler.ts` (in-process handler) | Finalizes handoff and guards against ending with unresolved draft-plan or completion evidence gaps. |
-
-`SessionStart` 运行进程内的 session-context builder，一次性组装出上下文：
-
-```mermaid
-flowchart LR
-  SessionStart["Claude/Codex SessionStart"] --> Adapter["user-level adapter"]
-  Adapter --> Entry["repo-harness-hook SessionStart --route default"]
-  Entry --> Ctx["session-context.ts<br/>in-process builder"]
-  Ctx --> Resume["恢复 + sprint + handoff 上下文"]
-  Ctx --> Sec["security scan<br/>只读配置扫描，按指纹门控"]
-  Resume --> SSOut["SessionStart additionalContext<br/>上次会话状态 + SecurityConfig 发现项"]
-  Sec --> SSOut
-```
-
-Prompt guard 多一个内部步骤：
-
-```mermaid
-flowchart LR
-  Host["Claude/Codex UserPromptSubmit"] --> Adapter["user-level adapter"]
-  Adapter --> CLI["repo-harness-hook UserPromptSubmit --route default"]
-  CLI --> Route["route registry"]
-  Route --> Handler["prompt handler<br/>typed decision table"]
-  Handler --> RouteHint["Waza 路由提示<br/>显式 think/规划优先匹配 → /think"]
-  Handler --> HostOutput["host-safe allow, advice, block, or done gate output"]
-```
-
-Typed handler 拥有该 route 的输入解析、文件状态读取和声明的副作用；runtime 只负责
-统一 host 输出 shaping。AcceptanceReceipt 是 closeout authority，review Markdown 只是投影。
-
-## Hook Failure Playbook
-
-hook block 工作时，先看 terminal 里的结构化输出。核心字段是
-`guard`、`reason`、`fix`、`failure_class` 和 `run_id`。
-
-- Failure log：`.ai/harness/failures/latest.jsonl`
-- Trace log：`.claude/.trace.jsonl`
-- 深入指南：[`docs/reference-configs/hook-operations.md`](docs/reference-configs/hook-operations.md)
-
-常见 guards：
-
-- `PlanStatusGuard`：没有 active plan，或 plan 还不能执行
-- `ContractGuard`：approved execution 还没有生成 contract/review/notes scaffold
-- `ContractGuard`：任务还没通过 contract verification 就声称完成
-- `WorktreeGuard`：在强制 linked worktree 策略下，从 primary worktree 写入
-
-## Repo Workflow
-
-- Root routing docs：`CLAUDE.md`、`AGENTS.md`
-- Typed hook runtime：`src/cli/hook/`（通过 `repo-harness-hook` 运行）
-- Operator helper projection：`.ai/hooks/lib/workflow-state.sh`
-- User-level adapter layer：`~/.claude/settings.json`、`~/.codex/hooks.json`
-- Active execution surface：`tasks/`
-- Plan source of truth：`plans/`
-- Durable progress：`tasks/workstreams/`
-- Release history：`docs/CHANGELOG.md`
+保持这条 trailer 逐 commit 显式添加、可见；不要把它固化进下游
+repo-harness 的 commit script 或 hook，除非目标仓库采用同样的
+policy。
 
 ## 当前 Release
 
 - npm package：`repo-harness@0.12.0`
 - Generated workflow stamp：`repo-harness@0.12.0+template@0.12.0`
 - GitHub repository：`Ancienttwo/repo-harness`
-- Release history：[`docs/CHANGELOG.md`](docs/CHANGELOG.md)
+- Release notes 和 history：[`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 
-## 致谢
+## 许可证
 
-感谢 [Hylarucoder](https://x.com/hylarucoder) 的方法论贡献。`repo-harness`
-里的 P1/P2/P3 due-diligence 方法，以及 Geju 实践对 planning、trace 和
-decision rationale 的要求，来自他的贡献与启发。
-
-感谢 [TW93](https://x.com/HiTw93) 创作 Waza；`think`、`hunt`、`check`
-和 `health` 这些核心 skill 构成了 `repo-harness` 的日常 planning、bug hunt
-和 verification 节奏。
-
-感谢 [Peter Steinberger](https://x.com/steipete) 创作 Oracle（`@steipete/oracle`，MIT）；它是
-`chatgpt-browser` 默认的 GPT Pro / ChatGPT Web 浏览器 consult 引擎，Oracle provider
-通过 spawn 外部 oracle 二进制完成 `gptpro` consult，从不自动下载，缺失即硬失败。
-
-感谢 OpenAI Codex 作为本仓库主要执行 agent 参与实现、验证和收口。
-
-### GitHub Contributor Attribution
-
-Codex 对某个 commit 有实质贡献时，GitHub contributor 署名使用显式 trailer：
-
-```text
-Co-authored-by: codex <codex@openai.com>
-```
-
-这条署名保持逐 commit 显式添加，不把它藏进下游 `repo-harness` commit 脚本或 hook
-里，除非目标仓库自己采用同样策略。
-
-## Action Command Skills
-
-canonical rule-owner package 分布在 `assets/skills/`（已激活的 canonical package）
-和 `assets/skill-commands/`（原地演进的幸存者）；它们保留 host skill discovery
-的边界，真正执行由 CLI 和 hooks 负责：
-
-- Router：`repo-harness`（root Skill，无条件同步到每个 profile）
-- Setup layer：`repo-harness-setup`（init、migrate、upgrade、repair、
-  scaffold、capability-configuration 各 mode；仅 router-only，不被任何 profile
-  自动发现）
-- Planning：`repo-harness-plan`（创建 decision-complete plan，或 review 已有 plan）
-- Product planning layer：`repo-harness-product`（PRD / Sprint / Goal 三种
-  mode；PRD mode 先激活 `$geju` 做格局判断，再优先用 Claude `claude -p --model
-  opus` 起草 PRD，Codex 只做 fallback；Sprint mode 把 PRD 拆成 `plans/sprints/`
-  里的有序 backlog，每行先用 `$think` 展开再进 contract 流程；Goal mode 从详细
-  PRD 或 Sprint 文档准备 Codex/Claude `/goal` prompt，缺文档时先要求补文档）
-- Verification：`repo-harness-check`（workflow/release 检查，附带
-  deploy-readiness reference）
-- Release：`repo-harness-ship`
-- Architecture：`repo-harness-architecture`
-- Cross-model review：`repo-harness-cross-review`（host-aware，strict profile
-  下两个 host 都会安装）
-- ChatGPT 集成：`repo-harness-chatgpt`（Oracle browser / GPT Pro consult 与
-  continuation、MCP Connector setup、bridge handoff、read-back evidence；仅限
-  explicit setup，product planning 从不隐式安装）
-
-规划链路按层推进：
-
-```text
-idea -> repo-harness-product（PRD mode） -> repo-harness-product（Sprint mode，from-prd） -> repo-harness-product（Goal mode）
-```
-
-`repo-harness-product` 的 PRD mode 处理产品想法：先跑 `$geju` direction pass，
-再用 Claude `claude -p --model opus` 起草 PRD，Codex 只在 Claude 不可用或失败时
-fallback。用它的 Sprint mode（`from-prd <plans/prds/*.prd.md>`）把已批准 PRD 拆成
-带 machine-checkable acceptance 的 Sprint backlog；Goal mode 只在已有详细 PRD 或
-Sprint artifact 后使用，用它生成有边界的 Codex/Claude `/goal` prompt，并把
-PRD/Sprint 保持为 source of truth。缺少这份文档时，Goal mode 必须先要求补文档，
-而不是从聊天上下文直接开工。
-
-`repo-harness init` 用于已有仓库；`repo-harness-setup` 的 scaffold mode 创建新
-项目或模块。`hooks-init`、`docs-init` 和 `create-project-dirs` 是内部步骤，不是
-公共 commands。
-
-## Maintainer Reference
-
-维护者编辑 package 源码需要 source checkout：
-
-```bash
-git clone https://github.com/Ancienttwo/repo-harness.git ~/Projects/repo-harness
-cd ~/Projects/repo-harness
-bun src/cli/index.ts update
-```
-
-`~/Projects/repo-harness` 是唯一可编辑 source of truth；本地 Claude/Codex 路径
-（`~/.claude/skills/repo-harness`、`~/.codex/skills/repo-harness`）是 symlink-backed
-runtime entrypoints。只有 `~/.codex/skills/repo-harness` 暴露 `SKILL.md` 和
-`assets/skill-commands/`；`scripts/sync-codex-installed-copies.sh` 重建这些 alias
-并清理退休的 `repo-harness-skill` / `project-initializer` 目录。脚本默认把 runtime
-路径链回源码仓库；设 `AGENTIC_DEV_LINK_INSTALLED_COPIES=0` 走 copy-based staging，
-或用 `CODEX_SKILLS_ROOT` / `CLAUDE_SKILLS_ROOT` 指定其他 root。
-
-### 检查本仓库 workflow contract
-
-跑 [Verification](#verification) 里的完整 gate；`bun run check:ci` 是单条
-CI-equivalent 命令。
-
-### Runtime reference docs
-
-Generic repo-harness runtime/reference docs live in the installed package under
-`assets/reference-configs/` and are resolved through the CLI:
-
-```bash
-repo-harness docs list
-repo-harness docs path harness-overview
-repo-harness docs show harness-overview
-```
-
-Initializer 和 runtime 默认（question flow、plan menu、template vars、外部工具
-路由）记录在 `harness-overview.md` 的 **Initializer and Runtime Model** 一节。
-Generated and migrated repos still keep `docs/reference-configs/*.md`, but
-those files are deterministic pointer stubs. Repo-local workflow state,
-policy, checks, runs, handoff packets, context maps, and helper snapshots stay
-under `.ai/`.
-
-### Template assembly
-
-```bash
-bun scripts/assemble-template.ts --plan C --name "MyProject"
-bun scripts/assemble-template.ts --target agents --plan C --name "MyProject"
-```
-
-### Verification
-
-发布前 review 使用唯一 CI-equivalent gate：
-
-```bash
-bun run check:ci
-```
-
-这个 gate 展开为下面这些 repo-owned checks；`bun run check:release` 只是在委托同一个 gate 前增加 npm 版本未发布检查。
-
-```bash
-bun test
-bash scripts/check-deploy-sql-order.sh
-bash scripts/check-architecture-sync.sh
-bash scripts/check-task-sync.sh
-bash scripts/check-task-workflow.sh --strict
-bun scripts/inspect-project-state.ts --repo . --format text
-bun src/cli/index.ts init --repo . --dry-run
-bash scripts/check-agent-tooling.sh --host both --check-updates
-bun run benchmark:skills --eval route-workflow-check
-```
-
-
-### Local benchmark skeleton
-
-```bash
-bun run benchmark:skills --eval route-workflow-check
-```
-
-Eval output is the release/readiness evidence path; dry-run benchmark wiring is only a smoke and is not skill-effectiveness evidence.
-
-
-### Run one eval across both Claude and Codex
-
-```bash
-bun run benchmark:skills --eval repair-agents-task-sync
-```
-
-## Key Files
-
-- Skill spec：`SKILL.md`
-- Root routing docs：`CLAUDE.md`、`AGENTS.md`
-- Plan mapping：`assets/plan-map.json`
-- Question-pack：`assets/initializer-question-pack.v4.json`
-- Shared hooks：`assets/hooks/`
-- Runtime reference docs: `assets/reference-configs/` via `repo-harness docs`
-- Workflow contract：`assets/workflow-contract.v1.json`
-- Hook operations reference：`docs/reference-configs/hook-operations.md`
-- Template assembler：`scripts/assemble-template.ts`
-- State inspector：`scripts/inspect-project-state.ts`
-- External tooling detector: `scripts/check-agent-tooling.sh`
-- Scaffolding scripts:
-  - `scripts/init-project.sh`
-  - `scripts/create-project-dirs.sh`
-- Canonical adoption planner: `src/core/adoption/standard-plan.ts`
-
-## Generated vs Self-Hosted Hook Projection
-
-- 下游 hook 行为由 `assets/hooks/` 和 `assets/reference-configs/` 定义。
-- 本仓库通过 `.ai/hooks/` dogfood 同一套 hook runtime，但这棵树由 `assets/hooks/projection.json` 生成。
-- 每个 hook 变更只应更新 canonical `assets/hooks/`，运行 `bun run sync:hooks`，并在验证里包含 `bun run check:hooks`。
-
-## Package Manager Defaults
-
-- 通用默认优先级：`bun > pnpm > npm`
-- **Plan G/H**（Python-centric）默认以 **`uv`** 作为 primary package manager。
-
-## Runtime Profiles
-
-- `Plan-only (recommended)`（默认）
-- `Plan + Permissionless`
-- `Standard (ask before each action)`
-
-配置在 `assets/initializer-question-pack.v4.json`，由 `scripts/initializer-question-pack.ts` 消费。
-
-## Verification
-
-发布 review 使用唯一 CI-equivalent gate：
-
-```bash
-bun run check:ci
-```
-
-这个 gate 展开为下面这些 repo-owned checks；`bun run check:release` 只是在委托同一个 gate 前增加 npm unpublished-version preflight。
-
-```bash
-bun test
-bash scripts/check-deploy-sql-order.sh
-bash scripts/check-architecture-sync.sh
-bash scripts/check-task-sync.sh
-bash scripts/check-task-workflow.sh --strict
-bun scripts/inspect-project-state.ts --repo . --format text
-bun src/cli/index.ts init --repo . --dry-run
-bash scripts/check-agent-tooling.sh --host both --check-updates
-bun run benchmark:skills --eval route-workflow-check
-```
+MIT——见 [`LICENSE`](LICENSE)。

--- a/assets/reference-configs/harness-overview.md
+++ b/assets/reference-configs/harness-overview.md
@@ -222,3 +222,40 @@ Maintainer-facing detail on how the initializer and runtime defaults are wired.
 - `repo-harness install` bootstraps the Codex/Claude runtime pieces for the default workflow: refreshes `repo-harness` skill aliases, installs global Codex/Claude hook adapters, installs Waza skills (`think`, `hunt`, `check`, `health`) and Mermaid through the skills CLI, persists the brain root in `~/.repo-harness/config.json`, and configures CodeGraph MCP for selected host agents. `repo-harness init` remains a compatibility alias for existing automation.
 - Other external tooling stays advisory-only: `repo-harness run check-agent-tooling --host both --check-updates`; Waza update checks compare upstream `tw93/Waza` `SKILL.md` hashes without running `npx skills check`; no automatic CodeGraph daemon or provider setup.
 - Manual distillation stays repo-local: repeated corrections -> `tasks/lessons.md`; deep findings and hidden contracts -> topic-scoped `docs/researches/*.md`; sprint verification evidence -> `tasks/reviews/*.review.md`; durable capability progress -> `tasks/workstreams/`; release history -> `docs/CHANGELOG.md`.
+
+### Package Manager Defaults
+
+- General default priority: `bun > pnpm > npm`.
+- **Plan G/H** (Python-centric) default to **`uv`** as the primary package manager.
+
+### Runtime Profiles
+
+The initializer offers exactly three runtime profiles:
+
+- `Plan-only (recommended)` (default)
+- `Plan + Permissionless`
+- `Standard (ask before each action)`
+
+They are configured in `assets/initializer-question-pack.v4.json` and consumed by
+`scripts/initializer-question-pack.ts`.
+
+### Package Authority Files
+
+Maintainer-facing map of which package file owns which contract:
+
+| File | Owns |
+|---|---|
+| `SKILL.md` | Root Skill spec |
+| `CLAUDE.md`, `AGENTS.md` | Root routing docs |
+| `assets/plan-map.json` | Plan catalog mapping |
+| `assets/initializer-question-pack.v4.json` | Question pack |
+| `assets/hooks/` | Canonical hook asset source |
+| `assets/reference-configs/` | Runtime reference docs, resolved through `repo-harness docs` |
+| `assets/workflow-contract.v1.json` | Workflow contract manifest |
+| `docs/reference-configs/*.md` | Source-repo projection of the runtime reference docs |
+| `scripts/assemble-template.ts` | Explicit template assembly |
+| `scripts/initializer-question-pack.ts` | Question inference helper |
+| `scripts/inspect-project-state.ts` | State inspector |
+| `src/core/adoption/standard-plan.ts` | Canonical adoption planner |
+| `scripts/check-agent-tooling.sh` | External tooling detector |
+| `scripts/init-project.sh`, `scripts/create-project-dirs.sh` | Scaffolding steps |

--- a/assets/reference-configs/hook-operations.md
+++ b/assets/reference-configs/hook-operations.md
@@ -48,6 +48,17 @@ for done/review prompts. Markdown review cards are deterministic projections and
 are never parsed as a second authority. A missing or malformed receipt blocks
 closeout; the runtime does not guess or downgrade the contract.
 
+Unicode-aware intent classification lives in `src/cli/hook/prompt-intents.ts`.
+There is no shell classifier, secondary dispatcher, or fallback decision table.
+The handler owns filesystem authority, side effects, classification, and the
+`intent x plan state` table; it also renders the Waza route hint, where an
+explicit think/planning intent is matched first and routed to `/think`.
+
+The `SessionStart` builder assembles one bounded context from four sources
+before work begins: the prior handoff/resume packet, sprint status, advice-only
+minimal-change guidance, and a read-only fingerprint-gated security config scan.
+They are emitted together as `additionalContext`.
+
 Plan/spec/contract hints in `UserPromptSubmit` are advisory. Hard edit enforcement
 lives in `PreToolUse.edit` and the `mutation-guard` handler. The policy can select
 `enforce`, `advice`, or `off` for that guard. Stop and observer handlers remain

--- a/docs/reference-configs/general-repo-mcp.md
+++ b/docs/reference-configs/general-repo-mcp.md
@@ -35,6 +35,12 @@ Use `discover_harness_repos` from the Connector to discover the registered
 `repo_id` before calling general repo tools. `list_allowed_roots` is only for
 the separate session-local workspace capability.
 
+The ChatGPT Connector registers one endpoint URL, not one repository per URL.
+Stale registry entries are ignored unless the live repo still carries
+repo-harness adoption markers. External non-repo local roots are outside the
+adopted-repo boundary and require explicit `--allow-root` authorization at setup
+time.
+
 Read/write access is an operator decision in the registry. Do not grant
 `read_write` for routine planning. Mutation calls retain revision preconditions
 and are denied for every `read_only` repo.
@@ -224,6 +230,69 @@ flow:
 6. Use write tools only after explicit operator approval and only with revision
    preconditions.
 7. Call `refresh_repo_index` after successful writes.
+
+## Snapshot Consistency and Cache
+
+Reader responses carry `snapshot_id`, `index_revision`, `ignore_digest`, and
+`indexed` metadata. A stale client snapshot returns `SNAPSHOT_STALE` instead of
+silently mixing versions. Responses also expose `snapshot_state`, the snapshot
+TTL/expiry, and a bounded in-process snapshot cache marker.
+
+- `snapshot_cache.key` is scoped by tool and repo-relative path set;
+  `snapshot_cache.snapshot_key` identifies the underlying repo snapshot.
+- Entry metadata is cached separately by repo, registry revision, `.ignore`
+  digest, relative path, and current stat signature, so warm unchanged
+  manifest/stat/read calls skip repeated hash and binary probes without hiding
+  file, registry, or `.ignore` changes.
+- An explicit `snapshot_id` on `stat_file`/`read_file` reuses the cached snapshot
+  and validates only the requested file hash instead of rebuilding the full repo
+  snapshot.
+- When CodeGraph reports a now-missing indexed path, or metadata that no longer
+  matches the filesystem, the snapshot becomes `index_lagging` while authorized
+  read/stat fallback stays available.
+- For large manifests, `repo_manifest` streams the visible tree and keeps only
+  the requested page in memory. Page entries carry exact content hashes;
+  off-page content metadata is deferred and reported as
+  `counts.content_deferred` until a later manifest page, `stat_file`,
+  `read_file`, or `search_text` returns it.
+
+Successful writes leave the index pending and append an invalidation event to
+`.ai/harness/mcp/index-events.jsonl`. `refresh_repo_index` runs CodeGraph sync
+for the repo, invalidates reader snapshots, records refresh success or
+dead-letter failure in that same event log, and returns the new `snapshot_id`,
+`index_revision`, `index_state`, refresh strategy, and optional mutation lag when
+called with `mutation_id`.
+
+For large-repo reader baselines:
+
+```bash
+bun run benchmark:mcp-reader -- --entries 10000 --json
+```
+
+Use `--entries all` for the full 10k/100k/500k fixture sequence when the local
+machine can spend the filesystem time. Recorded results live in
+`docs/researches/20260623-general-repo-reader-performance-baseline.md`.
+
+## Server Profiles and Dev Runner
+
+`repo-harness mcp serve --profile <profile>` selects the tool surface. The
+default `planner` profile is read-and-plan only: ChatGPT reads workflow and repo
+state, writes PRD/Sprint/Goal handoff artifacts, and holds no source-code write
+access, arbitrary shell execution, or agent runner. Codex remains the executor.
+
+Dev Mode can opt into local agent execution through MCP. This is off by default.
+When the operator enables the `orchestrator` profile with the dev runner
+setting, ChatGPT can call `run_agent_goal`, which reads only
+`.ai/harness/handoff/codex-goal.md` and runs that fixed handoff through an
+allowed local CLI such as `codex exec` or `claude -p`:
+
+```bash
+repo-harness mcp serve --repo . --transport http --profile orchestrator --enable-dev-runner --dev-runner-agents codex
+```
+
+This setting is for local Developer Mode only. It is timeout-bounded, audited,
+and not arbitrary shell. The direct-coding `coding` profile is a separate opt-in
+surface documented in [`chatgpt-coding-mcp.md`](chatgpt-coding-mcp.md).
 
 ## Known Limits
 

--- a/docs/reference-configs/harness-overview.md
+++ b/docs/reference-configs/harness-overview.md
@@ -222,3 +222,40 @@ Maintainer-facing detail on how the initializer and runtime defaults are wired.
 - `repo-harness install` bootstraps the Codex/Claude runtime pieces for the default workflow: refreshes `repo-harness` skill aliases, installs global Codex/Claude hook adapters, installs Waza skills (`think`, `hunt`, `check`, `health`) and Mermaid through the skills CLI, persists the brain root in `~/.repo-harness/config.json`, and configures CodeGraph MCP for selected host agents. `repo-harness init` remains a compatibility alias for existing automation.
 - Other external tooling stays advisory-only: `repo-harness run check-agent-tooling --host both --check-updates`; Waza update checks compare upstream `tw93/Waza` `SKILL.md` hashes without running `npx skills check`; no automatic CodeGraph daemon or provider setup.
 - Manual distillation stays repo-local: repeated corrections -> `tasks/lessons.md`; deep findings and hidden contracts -> topic-scoped `docs/researches/*.md`; sprint verification evidence -> `tasks/reviews/*.review.md`; durable capability progress -> `tasks/workstreams/`; release history -> `docs/CHANGELOG.md`.
+
+### Package Manager Defaults
+
+- General default priority: `bun > pnpm > npm`.
+- **Plan G/H** (Python-centric) default to **`uv`** as the primary package manager.
+
+### Runtime Profiles
+
+The initializer offers exactly three runtime profiles:
+
+- `Plan-only (recommended)` (default)
+- `Plan + Permissionless`
+- `Standard (ask before each action)`
+
+They are configured in `assets/initializer-question-pack.v4.json` and consumed by
+`scripts/initializer-question-pack.ts`.
+
+### Package Authority Files
+
+Maintainer-facing map of which package file owns which contract:
+
+| File | Owns |
+|---|---|
+| `SKILL.md` | Root Skill spec |
+| `CLAUDE.md`, `AGENTS.md` | Root routing docs |
+| `assets/plan-map.json` | Plan catalog mapping |
+| `assets/initializer-question-pack.v4.json` | Question pack |
+| `assets/hooks/` | Canonical hook asset source |
+| `assets/reference-configs/` | Runtime reference docs, resolved through `repo-harness docs` |
+| `assets/workflow-contract.v1.json` | Workflow contract manifest |
+| `docs/reference-configs/*.md` | Source-repo projection of the runtime reference docs |
+| `scripts/assemble-template.ts` | Explicit template assembly |
+| `scripts/initializer-question-pack.ts` | Question inference helper |
+| `scripts/inspect-project-state.ts` | State inspector |
+| `src/core/adoption/standard-plan.ts` | Canonical adoption planner |
+| `scripts/check-agent-tooling.sh` | External tooling detector |
+| `scripts/init-project.sh`, `scripts/create-project-dirs.sh` | Scaffolding steps |

--- a/docs/reference-configs/hook-operations.md
+++ b/docs/reference-configs/hook-operations.md
@@ -48,6 +48,17 @@ for done/review prompts. Markdown review cards are deterministic projections and
 are never parsed as a second authority. A missing or malformed receipt blocks
 closeout; the runtime does not guess or downgrade the contract.
 
+Unicode-aware intent classification lives in `src/cli/hook/prompt-intents.ts`.
+There is no shell classifier, secondary dispatcher, or fallback decision table.
+The handler owns filesystem authority, side effects, classification, and the
+`intent x plan state` table; it also renders the Waza route hint, where an
+explicit think/planning intent is matched first and routed to `/think`.
+
+The `SessionStart` builder assembles one bounded context from four sources
+before work begins: the prior handoff/resume packet, sprint status, advice-only
+minimal-change guidance, and a read-only fingerprint-gated security config scan.
+They are emitted together as `additionalContext`.
+
 Plan/spec/contract hints in `UserPromptSubmit` are advisory. Hard edit enforcement
 lives in `PreToolUse.edit` and the `mutation-guard` handler. The policy can select
 `enforce`, `advice`, or `off` for that guard. Stop and observer handlers remain

--- a/docs/reference-configs/install-profiles.md
+++ b/docs/reference-configs/install-profiles.md
@@ -80,3 +80,61 @@ Install and benchmark transactions must also bind `BUN_INSTALL` to the selected
 host home. Setting `HOME` alone does not isolate Bun global installation when a
 caller already exports `BUN_INSTALL`; an inherited real path would mutate the
 operator's global package instead of the disposable profile runtime.
+
+## Install Surfaces and Refresh Commands
+
+`repo-harness install` is the first-run global bootstrap: it installs the current
+npm package as the global CLI, refreshes repo-harness Skill aliases, installs the
+user-level hook adapters, and records the explicit install profile. It never
+applies repo-local workflow files to the current directory; that stays on
+`repo-harness init`.
+
+```bash
+# Refresh the user-level CLI and runtime pieces after a package update.
+repo-harness update
+
+# Read-only repair guidance, no writes.
+repo-harness update --check
+
+# Remove managed host adapters without touching sibling or third-party hooks.
+repo-harness uninstall
+
+# Install only the host hook adapters (adapter-only surface).
+repo-harness install --target both --location global
+
+# Refresh repo-local workflow files in an adopted repository.
+repo-harness init --repo /path/to/repo
+```
+
+## Read-Only Bootstrap Audit
+
+`repo-harness setup check --json` is the Agent-owned, read-only bootstrap audit;
+add `--check-updates` for version and adopted-repo refresh advisories. It is not
+a runtime hook: it does not write user-level files, install updates, run `init`,
+or register adapters. It emits `agent_actions` entries carrying the reason, risk,
+target files, an optional command, and the verification surface, so the Agent
+executes each one deliberately. `repo-harness init-hook` remains a compatibility
+alias for the adapter-only install path.
+
+## Codex Delegation Mode
+
+`repo-harness install --target codex|both --location global` also resolves and
+persists the Codex delegation mode read by the delegation-advisor hook. Pass
+`--delegation-mode auto|explicit` for non-interactive use, or answer the one-line
+interactive prompt shown in a TTY; Enter keeps the current choice and defaults to
+`explicit` when nothing is configured yet.
+
+The chosen mode is written to `delegation.mode` in
+`~/.repo-harness/config.json`, merged with existing keys such as `brainRoot`.
+This global value takes precedence over a repo's `.ai/harness/policy.json`
+`delegation.mode`.
+
+At runtime:
+
+- `auto` injects one standing bounded-delegation authorization block per session
+  at `SessionStart`.
+- The typed `subagent` handler injects on `UserPromptSubmit` only for explicit
+  triggers (`/delegate`, `/parallel`, ...), in both `auto` and `explicit` modes.
+
+The step never fires for `--target claude`. With no flag and no TTY it leaves the
+file untouched; it never writes a silent default.

--- a/tests/install-scripts.test.ts
+++ b/tests/install-scripts.test.ts
@@ -53,7 +53,12 @@ describe("install script contracts", () => {
 
     expect(readme).toContain("curl -fsSL https://raw.githubusercontent.com/Ancienttwo/repo-harness/main/install.sh | sh");
     expect(readme).toContain("irm https://raw.githubusercontent.com/Ancienttwo/repo-harness/main/install.ps1 | iex");
-    expect(readme).toContain("If Bun >= 1.1.35 is already on PATH, you can skip the shell installer.");
+    // SSD-xx: the README's Bun-floor sentence reworded from "If Bun >= 1.1.35
+    // is already on PATH, you can skip the shell installer." to "With Bun >=
+    // 1.1.35 already on PATH, skip the shell installer." Pin the version
+    // string shared with install.sh's MIN_BUN_VERSION invariant, not the
+    // exact prose.
+    expect(readme).toContain("1.1.35");
     expect(readme).not.toContain("npm install -g repo-harness");
     expect(zhReadme).toContain("curl -fsSL https://raw.githubusercontent.com/Ancienttwo/repo-harness/main/install.sh | sh");
     expect(zhReadme).toContain("irm https://raw.githubusercontent.com/Ancienttwo/repo-harness/main/install.ps1 | iex");

--- a/tests/readme-dx.test.ts
+++ b/tests/readme-dx.test.ts
@@ -48,36 +48,40 @@ function isAllowedRuntimeReference(file: string, line: string): boolean {
 describe("README DX contract", () => {
   test("front-loads a single first-run path and hook authority guidance", () => {
     const readme = read("README.md");
-    const firstFive = section(readme, "First 5 Minutes");
-    const hookAuthority = section(readme, "Hook Authority Map");
+    const getStarted = section(readme, "Get Started");
+    const hooksSection = section(readme, "Hooks");
     const maintainer = section(readme, "Maintainer Reference");
 
-    expect(readme.indexOf("## First 5 Minutes")).toBeLessThan(readme.indexOf("## MCP Connector Quickstart"));
-    expect(firstFive).toContain("docs/images/repo-harness-install-donkey-carrot.png");
+    expect(readme.indexOf("## Get Started")).toBeLessThan(readme.indexOf("## MCP Connector"));
+    expect(readme).toContain("docs/images/repo-harness-hook-carrot.png");
     // Only the commands a first-run user copies are pinned here. Surrounding prose,
     // code-comment text, occurrence counts, and CLI stdout literals quoted back
     // through the README are not: they never caught a regression, they only forced
     // a same-commit test edit whenever the README was reworded.
-    expect(firstFive).toContain("bunx repo-harness@latest install");
-    expect(firstFive).toContain("bun add -g repo-harness");
-    expect(firstFive).toContain("npx -y repo-harness@latest install");
-    expect(firstFive).toContain("repo-harness install");
-    expect(firstFive).toContain("repo-harness init --dry-run");
+    expect(getStarted).toContain("bunx repo-harness@latest install");
+    expect(getStarted).toContain("bun add -g repo-harness");
+    expect(getStarted).toContain("npx -y repo-harness@latest install");
+    expect(getStarted).toContain("repo-harness install");
+    expect(getStarted).toContain("repo-harness init --dry-run");
     // Kept as the negative half of a placement invariant: the template assembly
     // command belongs in Maintainer Reference (asserted below), not in the
     // first-run path.
-    expect(firstFive).not.toContain("bun scripts/assemble-template.ts");
-    expect(hookAuthority).toContain("assets/hooks/");
-    expect(hookAuthority).toContain("bun run sync:hooks");
-    expect(hookAuthority).toContain("repo-harness-hook");
-    expect(hookAuthority).toContain("route registry");
+    expect(getStarted).not.toContain("bun scripts/assemble-template.ts");
+    expect(maintainer).toContain("assets/hooks/");
+    expect(maintainer).toContain("bun run sync:hooks");
+    expect(hooksSection).toContain("repo-harness-hook");
+    expect(hooksSection).toContain("route registry");
     // HRD-04 retired minimal-change-context.sh (folded into the in-process
     // session-context builder). HRD-05 retired post-edit-guard.sh and
     // minimal-change-observer.sh (folded into the in-process
-    // mutation-observed journal handler).
-    expect(hookAuthority).toContain("session-context.ts");
-    expect(hookAuthority).toContain("mutation-observed.ts");
-    expect(hookAuthority).toContain("stop-handler.ts");
+    // mutation-observed journal handler). The 14-section rewrite folded the
+    // former "Hook Authority Map" section into "Hooks" and "Maintainer
+    // Reference"; the handler filenames are the placement invariant that
+    // replaces it.
+    expect(hooksSection).toContain("session-context.ts");
+    expect(hooksSection).toContain("mutation-guard.ts");
+    expect(hooksSection).toContain("mutation-observed.ts");
+    expect(hooksSection).toContain("stop-handler.ts");
     expect(readme).not.toContain("finalize-handoff.sh");
     expect(readme).not.toContain("session-start-context.sh");
     expect(readme).not.toContain("post-edit-guard.sh");
@@ -90,7 +94,11 @@ describe("README DX contract", () => {
     const hookOps = read("docs/reference-configs/hook-operations.md");
 
     expect(readme).toContain("docs/reference-configs/hook-operations.md");
-    expect(readme).toContain("Generated vs Self-Hosted Hook Projection");
+    // SSD-xx: the README's own "Generated vs Self-Hosted Hook Projection"
+    // heading retired in the 14-section rewrite; the projection contract now
+    // lives solely in hook-operations.md, so pin its phrasing there instead
+    // of duplicating it back into the README.
+    expect(hookOps).toContain("generated operator-helper projection");
     expect(hookOps).toContain("## Hook Authority Map");
     expect(hookOps).toContain("## Hook Failure Playbook");
     expect(hookOps).toContain("PlanStatusGuard");
@@ -105,7 +113,7 @@ describe("README DX contract", () => {
 
   test("release and verification docs require authoritative skill eval evidence", () => {
     const readme = read("README.md");
-    const verification = section(readme, "Verification");
+    const maintainer = section(readme, "Maintainer Reference");
     const releaseDoc = read("docs/reference-configs/release-deploy.md");
     const evalArchitecture = read("docs/architecture/modules/verification/evals-checks.md");
 
@@ -122,8 +130,11 @@ describe("README DX contract", () => {
     expect(evalArchitecture).toContain("full_test_count");
     expect(evalArchitecture).toContain("effectiveness_authority");
 
-    expect(verification).toContain("bun run benchmark:skills --eval route-workflow-check");
-    expect(verification).not.toContain("bun run benchmark:skills --dry-run");
+    // SSD-xx: the README's dedicated "## Verification" section folded into
+    // Maintainer Reference; the authoritative non-dry-run eval-evidence
+    // requirement now lives solely in evals-checks.md (asserted above)
+    // instead of a copy-pasted eval command example in the README.
+    expect(maintainer).toContain("bun run check:ci");
   });
 
   test("documents explicit Codex GitHub contributor attribution", () => {
@@ -148,20 +159,21 @@ describe("README DX contract", () => {
     expect(spec).toContain("## Core Invariants");
     expect(spec).toContain("## Human Review Expectations");
     expect(spec).toContain("## Acceptance Scenarios");
-    expect(readme).toContain("## Human Review Path");
-    expect(readme).toContain("## Agent Tracking Path");
+    // SSD-xx: Human Review Path and Agent Tracking Path merged into one
+    // Reviewing Work section; the agent-reads-first/human-reviews-first
+    // table header is the structural invariant that survives the merge.
+    expect(readme).toContain("## Reviewing Work");
     expect(readme).toContain("Agent reads first");
     expect(readme).toContain("Human reviews first");
-    expect(zhReadme).toContain("## Human Review Path");
-    expect(zhReadme).toContain("## Agent Tracking Path");
+    expect(zhReadme).toContain("## 审查产出");
     expect(flow).toContain("Agent reads first");
     expect(flow).toContain("Human reviews first");
     expect(readme).toContain("external verification manifests");
     expect(readme).toContain("manual convention today");
-    expect(readme).toContain("automatic `repo-harness check` discovery or gate");
+    expect(readme).toMatch(/not an automatic\s+`repo-harness check` gate/);
     expect(zhReadme).toContain("external verification manifest");
-    expect(zhReadme).toContain("手动约定");
-    expect(zhReadme).toContain("`repo-harness check` 已经会自动发现或 gate");
+    expect(zhReadme).toContain("人工约定");
+    expect(zhReadme).toContain("`repo-harness check` 会自动执行的 gate");
     expect(externalTooling).toContain("## External Verification Evidence");
     expect(externalTooling).toContain("convention only");
     expect(externalTooling).toContain("does not automatically discover");
@@ -172,6 +184,9 @@ describe("README DX contract", () => {
   });
 
   test("localized READMEs track the current English release surface", () => {
+    const languageSwitcher =
+      "[English](README.md) | [简体中文](README.zh-CN.md) | [日本語](README.ja.md) | [Français](README.fr.md) | [Español](README.es.md)";
+
     for (const file of LOCALIZED_READMES) {
       const localized = read(file);
 
@@ -187,13 +202,19 @@ describe("README DX contract", () => {
       expect(localized).toContain("repo-harness docs list");
       expect(localized).toContain("SessionStart.default");
       expect(localized).toContain("PostToolUse.always");
-      expect(localized).toContain("Generated vs Self-Hosted Hook Projection");
-      expect(localized).toContain("Package Manager Defaults");
-      expect(localized).toContain("Runtime Profiles");
-      expect(localized).toContain("bun run benchmark:skills --eval route-workflow-check");
+      // SSD-xx: "Generated vs Self-Hosted Hook Projection", "Package Manager
+      // Defaults", "Runtime Profiles", and the benchmark:skills eval command
+      // example all moved into docs/reference-configs (harness-overview.md,
+      // evals-checks.md) per the approved README slim-down; they are no
+      // longer README content to pin. Pin the install commands and the
+      // five-language switcher instead, since every locale must keep them.
+      expect(localized).toContain(languageSwitcher);
+      expect(localized).toContain(
+        "curl -fsSL https://raw.githubusercontent.com/Ancienttwo/repo-harness/main/install.sh | sh",
+      );
+      expect(localized).toContain("bunx repo-harness@latest install");
       expect(localized).not.toContain("0.5.0");
       expect(localized).not.toContain("0.2.1");
-      expect(localized).not.toContain("bun run benchmark:skills --dry-run");
       expect(localized.toLowerCase()).not.toContain("gstack");
     }
   });


### PR DESCRIPTION
## Summary

- Rebuild `README.md` as a codegraph-style, get-started-first layout: centered header + badges + TOC, `## Get Started` at line 40 (was line 232), 872 → 451 lines, 14 sections.
- Zero information loss: deep-dive content (install variants, delegation mode, MCP reader/writer spec, hook internals, package-manager defaults, runtime profiles, key files) moved into `docs/reference-configs/{install-profiles,general-repo-mcp}.md` and canonical `assets/reference-configs/{harness-overview,hook-operations}.md` (projection check passes) before deletion.
- Rewrite all four translations (zh-CN 457 / ja 478 / fr 470 / es 476 lines) against the new 14-section structure: all fenced code blocks incl. the task-workflow mermaid are byte-identical to English; TOC anchors verified per-language with GitHub slugger rules.
- Update `tests/readme-dx.test.ts` and `tests/install-scripts.test.ts` to pin the new contract — commands and invariants, not prose.
- Fix pre-existing GFM defect: raw `|` inside table-cell code spans (`Edit\|Write`, `Task\|Agent\|SendUserMessage`) now escaped in all five files; add missing `claude-plan` row to the skills table.

## Verification

- `bun run check:ci`: 2102 pass / 3 fail — the 3 remaining failures are pre-attributed environmental issues unrelated to this change (workflow-state-lock month-boundary TZ bug, self-heals after 08:00 +0800; two suite timeouts in check-agent-tooling and benchmark-authority).
- Round-1 gate had 9 failures; the 6 caused by the old README-pinning tests are gone after the test-contract update.
- mermaid main diagram byte-identical to pre-rewrite HEAD; all relative links resolve in all five files.