### PR TITLE
Ship codex/run-identity-threading

### DIFF
--- a/docs/researches/20260731-gated-semantic-qd-harness-evolution.md
+++ b/docs/researches/20260731-gated-semantic-qd-harness-evolution.md
@@ -1,0 +1,138 @@
+# Gated Semantic Quality-Diversity × repo-harness Implications
+
+> **Captured**: 2026-07-31; **revised 2026-08-01** after a dual-track adversarial review (independent GPT critique, every checkable claim verified verbatim against the full text and PDF)
+>
+> **Source**: [Self-Evolving Agent Harnesses via Gated Semantic Quality-Diversity](https://arxiv.org/abs/2607.13683) (arXiv 2607.13683v1, 2026-07-15; EverMind AI / Shanda Group). Full HTML text and PDF read end to end; all quotes below verified verbatim. No code, run ledger, or per-task-differences artifact released as of capture — the paper's only URL is a vendor model card.
+>
+> **Repo baseline**: `01c821d121577c461aea4fc9373ad5090ec3bdda` (`main`)
+>
+> **Status**: research synthesis only; no product code or policy change. Implications are proposals keyed to existing repo surfaces; each still needs a gap-check against current repo state before becoming a plan or contract row.
+
+## Conclusion
+
+The paper's central claim is that the hard part of self-evolving harnesses is not *producing* edits but *credibly crediting* them. Its answer is a strict role split — an LLM diagnoses failure pathologies and writes patches ("diagnosis proposes"), while deterministic code owns all sampling, gating, aggregation, and paired statistics ("measurement disposes") — plus a pathology-keyed quality-diversity archive (GSME) to resist overfitting. The role split is structurally the same bet repo-harness already makes (deterministic kernel, advisory prompts, gatekeeper reviews without deciding).
+
+**Adjudicated position after the dual-track review: absorb the credit architecture; do not adopt GSME, the automated evolution closed loop, or score borrowing.** The paper's strongest evidence supports its *gates* (sealed one-shot holdout, paired statistics, activation discipline, the ~60% single-run false-win measurement), not its *search* (the archive is never compared against flat history, beam search, or a task-keyed baseline). And the gates' own implementation has verified soundness gaps — documented below — that repo-harness must fix rather than copy:
+
+1. **No patch-level attribution.** Admission, promotion, and termination all compare against *vanilla*, never against the parent. A patch that degrades a strong parent can still enter the archive (cross-cell) and feed recombination.
+2. **Activation is candidate-level and self-reported.** Prose promises a per-trial activation ledger; Algorithm 1 only has a boolean `Fired(C_i)`, and the beacon is emitted by the patch being evaluated, not observed by the kernel. It catches never-fired mechanisms; it cannot catch fired-but-inert ones.
+3. **The denominator policy contradicts the paper's own Proposition 1.** Main text scores residual infra failures as 0 in the denominator and calls it unbiased; Prop 1 proves exactly that policy is missing-not-at-random bias that can flip rankings, and prescribes valid-receipt-only scoring plus coverage reporting. No coverage or infra-failure-rate numbers appear anywhere in the paper.
+
+One empirical result still deserves attention but is downgraded to a **hypothesis to test locally**: across seven benchmarks, every credited gain landed on the runtime lever (hooks, recovery, loop control), while prompt/knowledge injection fired without gaining (one task wrapper prompt triggered on 158/159 tasks with zero credited gain). The authors flag this as model-conditional; additionally, their vanilla is a deliberately minimal harness (~36% on TB2 vs the vendor's 59.3 with a heavily engineered harness), so the runtime lever may simply have had the most headroom.
+
+## Paper summary (distilled)
+
+### Problem
+
+For a frozen model, the harness (system prompt, injected knowledge, control loop/hooks/recovery, tools, config) is often the only movable lever. Prior self-evolving-harness work credits improvement by peak pass rate across rounds — taking a max over noise — usually on a single task set with no held-out split, so real gains, luck, and overfitting are indistinguishable.
+
+### Method
+
+- **Kernel vs mutable surface.** Measurement/evaluation code, the self-evolution machinery, and the product/interface contract are kernel; patches touching kernel are rejected at apply time. Everything else is the mutable surface. Accepted patches are env-gated, default off, so the un-evolved harness is byte-identical to vanilla. (Caveat: Table 5 lists `judge_prompt` — "evaluation-internal prompt" — among the 13 *editable* surfaces, in unexplained conflict with the kernel definition; see defect 6 below.)
+- **where × why coordinates.** `where` is a closed set of four levers (prompt / knowledge / runtime / config) refined into 13 operational edit surfaces, mechanically bound from which files the diff touches — never self-declared. `why` is an open, LLM-diagnosed failure-pathology label (thinking-runaway, premature finalization, careless wrong answer, repeated-call stall, engagement empty turn, method lock-in, turn-cap exhaustion, un-emitted deliverable — plus an explicit "model capability limit, no harness edit fixes this" exit).
+- **Loop.** Cold start scores vanilla K=3 on the full train set into a per-task ledger (baseline lock + sole variance source). Each round: evolver designs 3–4 env-gated candidates from train-only traces → zero-inference preflight (no declared activation beacon, or trigger never fires → discard) → anchor probe (15–30 high-variance tasks, K=1, cull only obvious losers at 1.5σ) → survivors get full-set K=3 → gates. Termination never looks at the test set.
+- **Three gates.** (1) *Validity*: environment health pre-check; infra failures retried ≤2×, then scored 0 but kept in the denominator (see defect 3). (2) *Activation*: only fired patches are credited (see defect 2 for the prose/algorithm mismatch). (3) *Significance*: navigation uses K=3 mean > vanilla; *credited* gain requires a paired 2σ test (z ≥ 1.96, σ from per-task paired differences). Final numbers come from a sealed test set scored exactly once.
+- **GSME archive.** MAP-Elites-style archive keyed by (where × why) — by *pathology attacked*, not by *tasks fixed*. One gated elite per cell; quality-biased selection expanding the global best, with cross-cell recombination. Physical substrate is a git tree: each candidate is a branch + commit with a per-node ledger (parent, status, activation spec, where/why, touched files).
+- **Role split.** The evolver (Claude Opus 4.8 driving Claude Code end to end) owns reading traces, assigning `why`, writing patches, launching scoring. Deterministic scripts own every quantitative judgment — "computed, not estimated". Note the framing correction from the dual-track review: the task model M is frozen and the diagnoser D is a *stronger, different* model, so this is stronger-model-driven automated harness optimization, not an agent improving itself from its own experience.
+
+### Results
+
+On frozen qwen3.6-27B across 7 domains: credited sealed-set gains of +9.2 to +15.5 pp on 6 domains (retention 86–147%); SWE-bench +5.1 pp held-out but n=26, z=0.78, reported as preliminary rather than lowering the bar. The gate also runs both ways — one significantly negative candidate (−6.4 pp) was flagged and culled. pass@3 rose everywhere credited, showing an enlarged solvable set, not variance compression.
+
+Most informative ablations:
+
+- **Precision beats brute force**: selective, sticky recovery (disable thinking only *after* detecting runaway) scored 79.4 on LiveCode vs 73.2 for globally-off, 71.1 for a 16× token budget, 64.6 vanilla.
+- **Single-run gates hallucinate**: a single-run gate calls a truly neutral mechanism a win ~60% of the time (~25% a ≥3 pp "big win"); a deterministic Δ>0 rule credited a `context-compact` mechanism whose beacon fired zero times.
+- **Pathology→patch match law**: verify-finalize fixed the 27B's empty-engagement failures (+15.5) but did ~nothing on the 397B (+0.2), whose careless-answer pathology was fixed by a submit-verify checklist (+13.6) — a pairing that replicated on Gemini 3 Flash. An evolved harness is "a corrective patch fitted to a model's failure distribution"; what transfers across models is the diagnose-and-credit loop, not any specific harness.
+- **Wrong diagnosis is cheap** (with a caveat): `why` steers which candidates get tried; credit is decided by paired stats, so a mislabel wastes candidates rather than crediting a bad harness. But Prop 2's formal version of this claim assumes a fixed candidate stream and does not cover the actual adaptive loop (defect 4).
+- **Tree-aware score borrowing** reproduced 14/14 offline and 7/7 online promote/prune decisions at ~1/3 trial cost — a sanity check on 21 decisions, not a production guarantee (defect 5).
+
+### Stated limitations
+
+Inherits all verifier gameability (gates prove gains on the *measured* metric, not that the metric is valid); optimizes a short-horizon proxy (per-task success, not robustness/maintainability); requires dense, frequent scored evaluation — the authors doubt transfer to open-ended settings with sparse, delayed signal; sealed-set withholding is enforced by discipline, not mechanism; frontier models out of scope — headroom is largest for cheaply deployable mid-capability models.
+
+## Verified defects (dual-track adversarial review)
+
+An independent GPT critique raised nine checkable claims; each was verified verbatim against the v1 full text and PDF by re-reading, not from summary memory. Verdicts: 8 confirmed, 1 partial, 0 refuted.
+
+1. **Attribution comparator (confirmed).** Algorithm 1: candidates are `Apply(parent, C_i)` but admission requires `pass@1 > v` where `v` is *vanilla* train score; parent selection and termination also compare to vanilla. The only additional check is "insert … if a better elite" — an incumbent test *within the candidate's own cell*, which blocks same-cell regression riders but not cross-cell ones, and cross-cell is exactly what recombination consumes. No child-vs-parent incremental credit exists anywhere in the paper (non-regression rules are mentioned only when describing prior work).
+2. **Activation gate granularity and ownership (confirmed).** Prose: "a ledger records, per trial, whether it triggered". Algorithm 1: only `if ¬Fired(C_i) then continue` — a candidate-level boolean applied after full scoring, with no per-trial filtering or weighting anywhere. Beacons are emitted/declared by the mechanism itself; no kernel-side observation is described. The gate catches never-fired mechanisms (the `context-compact` case) precisely because that patch emitted nothing; a patch that emits a beacon but changes nothing is indistinguishable.
+3. **Proposition 1 contradicts the main text (confirmed).** Prop 1: "admitting only trials with a valid verifier receipt yields an unbiased success estimate on the runnable subset … unrunnable tasks are reported as coverage, not scored 0", with an explicit MNAR argmax-flip counterexample. Main text: residual infra failures are "scored 0 but kept in the denominator … excluding infra-failed tasks inflates the score … re-running to a real measurement is the unbiased middle." Two incompatible estimators, both called "unbiased", no reconciling text; no coverage or infra-failure rates are reported anywhere, so the residual-zero mass is unauditable. (The rerun-≤2-then-zero policy is a third estimator with no formal guarantee; Prop 1's counterexample still applies to its residual.)
+4. **Proposition 2 assumes away adaptivity (confirmed).** Its proof ("each arrival is correctly archived with probability 1−ε … binomial thinning … label noise perturbs only the archive's bookkeeping") requires an exogenous candidate stream. In the actual loop, `why` labels drive next-round candidate generation (Diagnose → Design) and cell keys drive recombination — and four of six domains' final harnesses are recombinations. The main text's own weaker phrasing ("the label only steers exploration") concedes what the proposition denies.
+5. **Theorem 1's cap uses η̂ without a coverage condition (confirmed).** The bias-cap `α₀ ≤ Δk_c/(4η̂ − Δ)` is stated to hold "for any η", but that requires η̂ ≥ η and no condition on η̂ is ever given; underestimating η inflates the cap and breaks the Δ/4 bound. The displayed high-probability bound does include a Hoeffding noise term, but the "never mis-ranked" conclusion is derived from the bias constraint alone. The appendix promises "explicit assumptions" (A1–A3) that are never enumerated. Empirical validation covers 21 decisions total.
+6. **`judge_prompt` conflict (confirmed).** Table 5 lists `judge_prompt` / "evaluation-internal prompt" among the 13 editable surfaces, which Appendix D defines as "exactly the parts of the harness an edit is allowed to change" — while §3.1's kernel forbids touching "measurement and evaluation code". No reconciliation anywhere. Two of six credited domains use LLM judges as verifiers, so an editable judge prompt is the most direct path to the verifier gameability the limitations section worries about.
+7. **Reproducibility is promissory (confirmed).** "We publish the per-task differences so σ is auditable" — present tense, but no artifact, repo, or supplementary exists; the paper's only URL is the Qwen model card. All tables are aggregates. The paper's central auditability claim is currently unverifiable by outsiders.
+8. **SWE-bench wording (partial).** The crediting stance is genuinely hedged ("we report SWE-bench as preliminary rather than stretch the bar to fit"). The retention diagnosis is not: "its low apparent retention is noise at n=26, not overfitting" is an unhedged assertion; disjoint splits make overfitting *detectable*, they do not rule it out, and at n=26 noise and train-distribution overfitting are indistinguishable.
+9. **Affiliations (confirmed; corrects the first capture).** ¹ EverMind AI, ² Shanda Group — present on the PDF first page; lost in the LaTeXML HTML conversion.
+
+## Implications for repo-harness
+
+Revised after the dual-track review. Ordered by leverage; each item names the repo surface it lands on; none has been gap-checked against current code yet.
+
+### 1. Activation evidence: four layers, kernel-owned, on existing receipts
+
+The paper's activation idea is right and its implementation is the cautionary tale twice over (per-trial promise vs candidate-level boolean; self-reported beacons). The repo-harness version: extend the existing run/receipt evidence surface — no new ledger service, no second authority — with per-run, per-mechanism records distinguishing **eligible → triggered → action_taken → effect**, where the instrumentation is owned by the harness kernel (hook dispatcher / wrapper), never self-reported by the mechanism under evaluation. Effect estimation must respect that "fired" is post-treatment: overall deployment effect uses all assigned tasks (intention-to-treat); mechanism-level causal effect requires on/off comparison among pre-determined eligible trials; activation rate is observability only, never credit by itself. Immediate cheap payoff: a dead-mechanism audit (hooks or blocks that never fire in N days).
+
+### 2. Credit protocol: three credit types, two thresholds, sealed→spent
+
+Three distinct credits, never conflated: **local incremental** (child vs parent, paired), **global deployment** (champion vs vanilla/production baseline, sealed, scored once), **component causal** (mechanism on/off on the same parent). The paper only implements the second; the verified attribution gap shows why the first is mandatory before anything enters a durable corpus. Navigation may use cheap noisy scoring; any verdict that flows into lessons, policy, or a ship decision needs repeated sampling with per-task paired differences (K chosen from historical variance and minimum meaningful effect, not fixed at 3), effect size with interval rather than bare p, and cost/latency/regression guardrails.
+
+Sealed evaluation needs a state machine the paper admits it lacks: `frozen` (no longer edited) ≠ `sealed` (invisible to the developer/evolver before decision) ≠ `spent` (opened once, unusable as confirmatory holdout thereafter). Unseal events — who, when, commit, result digest — go into receipts. A spent suite may serve as a regression suite but never again as sealed evidence; a failed sealed comparison cannot be followed by patch edits and reuse of the same suite.
+
+### 3. Kernel manifest: apply-time enforcement, and split the two kinds of judge
+
+Make the measurement kernel a machine-readable manifest (checks, gates, scoring rules, evaluator code, receipt writers) that the edit guard rejects diffs against at apply time — extending the existing edit-guard / EXECUTION_BOUNDARY surface — with experiment manifests additionally pinning evaluator/suite/environment digests per experiment. The paper's `judge_prompt` defect fixes a boundary repo-harness should draw explicitly: **agent self-check prompts** (verify-finalize-style, part of the agent) are mutable surface; **evaluation judge prompts** (part of scoring) are kernel. Same word, opposite sides of the boundary.
+
+### 4. Behavior-changing harness patches ship env-gated, default off
+
+Unchanged from the first capture, and strengthened: the byte-identical vanilla is what made their baseline trustworthy and rollback free. Land behavior changes behind policy flags default-off; flip deliberately. The activation instrumentation for such flags is kernel-owned per item 1.
+
+### 5. Infra-failure taxonomy replaces the single `infra_fail` bucket
+
+The paper contains both the biased policy and its refutation (defect 3); adopt the resolution it proves but doesn't practice, with a three-way split: **platform/sandbox/verifier infrastructure failure** → mark missing, pair comparisons only over tasks with valid receipts on both arms, report coverage and differential missingness; **candidate-induced operational failure** (OOM, runaway tool loop, timeout, environment corruption caused by the candidate) → counts as candidate failure; **run-level environment health failure** → invalidate the batch, no score. This converges with the existing external-verification evidence contract direction (valid receipt as the unit of scoreable evidence).
+
+### 6. Three evaluation modes, matched to what repo-harness already has
+
+**Deterministic invariants** (schema parity, allowed paths, projection/byte parity, state-machine transitions): one exact run; paired statistics would be cargo cult. **Stochastic agent behavior** (recovery hooks, finalize checks, context changes affecting success rates): the full item-2 protocol — interleaved parent/candidate scheduling under one pinned model fingerprint, paired tasks, pre-declared minimum effect. The AppWorld vanilla drifting ~9 pp between reruns is the argument for interleaving and fingerprint pinning. **Human/long-horizon quality** (maintainability, operator burden, added complexity, usefulness weeks later): review, canary, rollback, delayed evidence, recurrence triggers — explicitly outside what paired pass rates can certify, as the paper's own limitations concede.
+
+### 7. Lessons and receipts: pathology as a facet, provenance retained, model-keyed expiry
+
+Tag lessons/receipts with `why` (pathology, always a hypothesis with confidence and evidence refs — advisory, never promotion authority) and `where` (mechanically derived from touched paths, multi-valued since patches often touch runtime *and* config), while keeping task provenance — pathology replaces nothing, it indexes. Keep the explicit "model capability limit — not a harness problem" exit. Model-conditional rules (routing, effort tiers, recovery patches) carry the model identity they were fitted to plus a revisit trigger; the cross-model dissociation result predicts they expire. The durable product is the evidence/credit loop — checks, receipts, gates, contracts, evaluator — not accumulated model-specific tweaks, and not automated self-modification itself.
+
+### 8. Runtime-lever-first: a hypothesis to test, not a conclusion to adopt
+
+All credited gains were runtime; injected prompt/knowledge fired without gaining. Model-conditional by the authors' own statement, and their minimal-harness vanilla means the runtime lever had the most headroom by construction. For repo-harness the actionable form is the measurement discipline, applied to our own workloads: the burden of proof for *growing* injected context is outcome evidence — which converges with the GPT-5.6 audit finding (`20260716-gpt-5-6-prompt-guidance-harness-audit.md`) that the ~8.7k-token static prompt stack has no owner or budget. Activation + paired credit per added/removed block is the missing measurement for that prompt-slimming program.
+
+### 9. First experiment before any archive
+
+Do not build a GSME archive, recombination, or score borrowing. First experiment: pick one existing mechanism with a clean trigger (repeat-break-style watchdog rule, a finalize-verification hook, or an existing advisory route), freeze an experiment manifest (parent commit, model fingerprint, task set, scoring rule), instrument eligible/triggered/action_taken via kernel wrapper, run interleaved child-vs-parent paired evaluation with guardrails, then champion-vs-baseline once on a genuinely sealed holdout. Only after accumulating tens of comparable interventions across several pathology/mechanism families does it become worth ablating `flat experiment history` vs `pathology-tagged retrieval` vs `task-keyed retrieval` vs `pathology archive + recombination` — producing our own evidence for whether GSME earns its complexity. Score borrowing stays a later cost optimization, never the credit system's foundation.
+
+## Gap-check: activation evidence surfaces (2026-08-01, verified against repo state)
+
+Read-only inventory of the five evidence surfaces named by implication 1, resolving the "audit vs build" question. Baseline `01c821d1`, local runtime caches included.
+
+**Repo state per surface:**
+
+- **Hook execution** — route registry is a typed `(event × route_id × matcher) → exactly one handler` contract (`src/cli/hook/route-registry.ts:66`, 8 route ids × 8 handler ids; `src/cli/hook/handler-registry.ts:16`). Every dispatch writes a `loop-engine-hook-event/v1` record to `.ai/harness/runs/hook-events.jsonl` via `src/cli/hook/event-telemetry.ts:214` — fields include `event_id`, `host`, `session_id`, `run_id`, `turn_id`, `event`, `route_id`, `exit_code`, `blocked`, `result_reason`, per-handler `steps[]` (name, execution mode, elapsed, exit code, output bytes), `metrics`, a `measurement.complete/incomplete_metrics` honesty block, and a fingerprint. The writer is the dispatcher, not the handler: **activation evidence here is already kernel-owned, which is precisely the paper's defect 2 done right.** Typed decline reasons exist in the handler vocabulary (`unknown-route`, `handler-unbound`, `handler-failed`, `non-opt-in`, `repair-circuit-tripped`, budget reasons…).
+- **Receipts** — `AttestedReceiptInput` (`src/effects/evidence/attested-import.ts:88`): disposition, reviewer, source, actor, findings, `subject_sha256`, `target_revision`, `contract_file`, `issued_at`, plus optional `correlationRunId`. Receipts attest acceptance outcomes on fingerprinted review subjects — this is the effect-layer authority.
+- **`.ai/harness/runs/`** — `run-*.json` are session-stop snapshots (run_id, reason, active-artifact pointers); mechanism data lives in `hook-events.jsonl` (9,453 records, cross-host: 7,101 claude / 2,289 codex) plus a 52-record legacy `hook-invocations.jsonl`.
+- **PostEditJournal** — qualifying edits write at-most-one coalesced pending event per (session, path) (`src/cli/hook/mutation-observed.ts:553-558`), consumed at Stop, surfaced at SessionStart. Non-qualifying edits deliberately write nothing (`mutation-observed.ts:87`) — the negative case leaves no trace.
+- **Checks cache** — `.ai/harness/checks/latest.json` is currently an empty object locally; outcome evidence is thin at rest.
+
+**Four-layer verdict (live derivation run over all 9,453 events):**
+
+| Layer | Status | Evidence |
+|---|---|---|
+| action_taken | **recorded, kernel-owned** | dispatcher-written per-execution records with per-handler steps; `result_reason` distribution: 9,439 `ok`, 14 `handler-failed` |
+| triggered | partially derivable | a dispatch record implies the route matcher held; handler-internal predicates visible only when they return typed reasons; most negative predicate outcomes unrecorded |
+| eligible | **absent** | host adapters filter before dispatch; non-qualifying cases write nothing; no denominators exist for "could have applied" |
+| effect | partially derivable | receipts/checks are real outcome authorities with fingerprints and an optional `correlationRunId`, but `run_id` is null on 9,453/9,453 hook events and `turn_id` filled on only 2,258 (24%) — no reliable join today |
+
+**Resolution: implication 1 is an audit plus a narrow build, not a rebuild.** The hard part the paper got wrong (kernel-owned action_taken observation) already exists here. The build gap is exactly two seams: (1) populate correlation keys end to end — `run_id` on hook events and `correlationRunId` on receipts — so activation joins to outcomes; (2) record decline/negative cases (or emit denominators) consistently so the eligible layer becomes countable, per the Prop-1 lesson that unrecorded missingness biases every downstream rate. The dead-mechanism audit is derivable today: registry routes `context` and `quality`, and all SubagentStart/SubagentStop events, have zero occurrences in the log — each is either genuinely dead, not installed into host adapters, or silently failing; distinguishing which is the audit. Implication 9's first experiment is blocked only by the effect-join seam.
+
+## What would change these conclusions
+
+- A v2 or camera-ready revising Prop 1/Prop 2/Theorem 1, enumerating the promised A1–A3 assumptions, or reconciling the denominator policy (v1 is the only version as of revision).
+- A code/artifact release: per-task differences would resolve defect 7; the real `Fired` implementation could soften defect 2; `judge_prompt` pointing at an agent-side judge would dissolve defect 6 (the printed text does not support that reading).
+- Gap-checks showing repo-harness already implements an item (e.g., activation layering may be partially derivable from existing receipts/journal events) — reducing that item to an audit.
+- Local experiments (item 9) contradicting the runtime-lever hypothesis or showing pathology-keyed retrieval beating flat history — that would be our evidence to revisit the no-archive stance.

--- a/src/cli/hook/command-observed.ts
+++ b/src/cli/hook/command-observed.ts
@@ -12,6 +12,7 @@ import { join, dirname } from 'path';
 import { recordCircuitAttempt, type CircuitDecision } from './circuit-breaker';
 import { parseHookInput, type HookInputFs } from './hook-input';
 import { importPostBashObservation } from '../../effects/evidence/post-bash-importer';
+import { resolveRunIdentity } from './run-identity';
 
 export interface CommandObservedFs extends HookInputFs {
   mkdirSync(path: string, options?: { readonly recursive?: boolean }): void;
@@ -237,12 +238,24 @@ export function runCommandObserved(opts: CommandObservedInput): CommandObservedR
     // same exitCode 1 / reason 'write-failed' envelope as any other
     // failure in this try block; no new fallback, no new severity.
     const durationMs = numberValue(parsed.get('.duration_ms', parsed.get('.tool_response.duration_ms', env.HOOK_DURATION_MS ?? '0')), 0);
+    // Unified run-identity resolution (payload -> HOOK_RUN_ID -> CODEX_RUN_ID
+    // -> CLAUDE_RUN_ID -> session-state lookup by session_id -> null). When a
+    // session-scoped run identity is resolvable, it is threaded through so
+    // this hook-path write never relies on the writer's own
+    // `run-${Date.now()}` self-mint; only a fully unresolvable case (no
+    // session ever started) reaches that pre-existing fallback.
+    const runIdentity = resolveRunIdentity(
+      opts.repoRoot,
+      { session_id: parsed.get('.session_id'), run_id: parsed.get('.run_id') },
+      env,
+    );
     const importResult = importPostBashObservation({
       repoRoot: opts.repoRoot,
       command,
       exitCode,
       durationMs,
       rawOutputPath: rawPath,
+      correlationRunId: runIdentity.runId ?? undefined,
     });
     if (!importResult.ok) {
       throw new Error(`ledger import failed (${importResult.reason}): ${importResult.message}`);

--- a/src/cli/hook/event-telemetry.ts
+++ b/src/cli/hook/event-telemetry.ts
@@ -8,6 +8,7 @@ import type {
   HookEventTelemetryStep,
 } from '../../core/loop/loop-event-protocol';
 import type { HookEvent, RouteHost, RouteId } from './route-registry';
+import { resolveRunIdentity } from './run-identity';
 
 export const HOOK_EVENT_TELEMETRY_PROTOCOL = 'loop-engine-hook-event/v1' as const;
 export const HOOK_EVENT_TELEMETRY_PATH = '.ai/harness/runs/hook-events.jsonl';
@@ -192,6 +193,12 @@ export function createHookEventTelemetry(
       const completedAt = new Date();
       const elapsedMs = roundMs(performance.now() - startedMonotonic);
       const incompleteMetrics = METRICS.filter((metric) => !completeMetrics.has(metric));
+      // Unified resolution order (payload.run_id -> HOOK_RUN_ID -> CODEX_RUN_ID
+      // -> CLAUDE_RUN_ID -> session-state lookup by session_id -> null) lives
+      // once in run-identity.ts; every consumption point calls it rather than
+      // maintaining its own copy of the chain. session_id's own chain is
+      // unchanged -- resolveRunIdentity computes it identically.
+      const runIdentity = resolveRunIdentity(options.repoRoot, payload, env);
       const unsigned = {
         protocol: HOOK_EVENT_TELEMETRY_PROTOCOL,
         kind: 'hook_event' as const,
@@ -199,13 +206,8 @@ export function createHookEventTelemetry(
         started_at: startedAt.toISOString(),
         completed_at: completedAt.toISOString(),
         host: hostFromEnv(env),
-        session_id: firstString(
-          payload.session_id,
-          env.HOOK_SESSION_ID,
-          env.CODEX_SESSION_ID,
-          env.CLAUDE_SESSION_ID,
-        ),
-        run_id: firstString(payload.run_id, env.HOOK_RUN_ID, env.CODEX_RUN_ID, env.CLAUDE_RUN_ID),
+        session_id: runIdentity.sessionId,
+        run_id: runIdentity.runId,
         turn_id: firstString(payload.turn_id, env.HOOK_TURN_ID, env.CODEX_TURN_ID, env.CLAUDE_TURN_ID),
         event: options.event,
         route_id: options.routeId,

--- a/src/cli/hook/handler-registry.ts
+++ b/src/cli/hook/handler-registry.ts
@@ -1,4 +1,4 @@
-import { buildSessionStartSections } from './session-context';
+import { buildSessionStartSections, ensureSessionRunIdentity } from './session-context';
 import { pendingPostEditJournalSection, runMutationObserved } from './mutation-observed';
 import { runMutationGuard } from './mutation-guard';
 import { runStopHandler } from './stop-handler';
@@ -17,6 +17,7 @@ const handlers: Readonly<Record<HookHandlerId, TypedHookHandler>> = Object.freez
   'session-context': {
     id: 'session-context',
     run(context: HookHandlerContext): HookHandlerResult {
+      ensureSessionRunIdentity(context.repoRoot, context.input, context.env, context.now);
       const sections = [];
       const stateSection = context.collector.getSessionEffectiveState();
       if (stateSection) sections.push(stateSection);

--- a/src/cli/hook/run-identity.ts
+++ b/src/cli/hook/run-identity.ts
@@ -1,0 +1,173 @@
+/**
+ * Single run-identity resolution + minting authority for the hook path
+ * (run-identity threading slice).
+ *
+ * Unified resolution order applied by every consumption point
+ * (`event-telemetry.ts`, `command-observed.ts`): `payload.run_id` ->
+ * `HOOK_RUN_ID` -> `CODEX_RUN_ID` -> `CLAUDE_RUN_ID` -> session-state lookup
+ * by `session_id` -> null. This mirrors the pre-existing chain in
+ * `event-telemetry.ts` (`firstString(payload.run_id, env.HOOK_RUN_ID,
+ * env.CODEX_RUN_ID, env.CLAUDE_RUN_ID)`), extended with one more fallback
+ * tier here rather than duplicated as a second, potentially divergent chain.
+ *
+ * Minting is SessionStart-only (`mintOrAdoptSessionRunIdentity`): when
+ * payload/env already carry an upstream run identity (loop-engine is the
+ * upstream authority), it is adopted verbatim and persisted, never minted
+ * over. Otherwise a fresh id is minted at most once per `session_id` --
+ * re-entry with the same `session_id` and no upstream override reuses the
+ * stored value instead of re-minting.
+ *
+ * Storage: `.ai/harness/state/session-run-identity.json`, a single-slot JSON
+ * object (pattern reference: `session-context-budget.ts`'s
+ * `session-context-budget.json` -- one current entry, overwritten on the
+ * next session rather than an ever-growing map keyed by every historical
+ * session_id). Bounded by construction: exactly one entry at all times.
+ *
+ * Hook processes are one-shot per invocation (`hook-entry.ts` spawns a fresh
+ * process per event and exits), so a bare module-level cache safely bounds
+ * the state-file read to at most once per invocation regardless of how many
+ * call sites in the same process ask for it -- mirrors
+ * `state-input-collector.ts`'s private `once()` memoization idiom without
+ * importing that unexported helper.
+ */
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
+
+const STATE_RELATIVE_PATH = '.ai/harness/state/session-run-identity.json';
+
+/** Structural subset of a hook's parsed JSON payload this module needs. */
+export interface RunIdentityPayload {
+  readonly session_id?: unknown;
+  readonly run_id?: unknown;
+}
+
+export interface ResolvedRunIdentity {
+  readonly sessionId: string | null;
+  readonly runId: string | null;
+}
+
+interface SessionRunIdentityState {
+  readonly protocol: 1;
+  readonly session_id: string;
+  readonly run_id: string;
+  readonly created_at: string;
+}
+
+function stringField(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+}
+
+function firstString(...values: readonly unknown[]): string | null {
+  for (const value of values) {
+    const resolved = stringField(value);
+    if (resolved !== null) return resolved;
+  }
+  return null;
+}
+
+function isSessionRunIdentityState(value: unknown): value is SessionRunIdentityState {
+  if (!value || typeof value !== 'object') return false;
+  const state = value as Partial<SessionRunIdentityState>;
+  return state.protocol === 1
+    && typeof state.session_id === 'string' && state.session_id.length > 0
+    && typeof state.run_id === 'string' && state.run_id.length > 0
+    && typeof state.created_at === 'string';
+}
+
+function readStateFile(repoRoot: string): SessionRunIdentityState | null {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(join(repoRoot, STATE_RELATIVE_PATH), 'utf-8'));
+    return isSessionRunIdentityState(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStateFile(repoRoot: string, state: SessionRunIdentityState): void {
+  const target = join(repoRoot, STATE_RELATIVE_PATH);
+  mkdirSync(dirname(target), { recursive: true });
+  const temp = `${target}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(temp, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 });
+  renameSync(temp, target);
+}
+
+// Module-level, one-shot-per-process memoization (see module doc). A fresh
+// hook process starts with both at UNCOMPUTED; `persist` below sets the
+// cache directly from the value it just wrote so a same-process re-read
+// (e.g. event-telemetry.ts's lookup right after SessionStart's own mint)
+// never re-touches disk. Keyed by repoRoot so distinct fixture repos within
+// one test process never see each other's cached state.
+const UNCOMPUTED = Symbol('run-identity-state-uncomputed');
+let cachedRepoRoot: string | typeof UNCOMPUTED = UNCOMPUTED;
+let cachedState: SessionRunIdentityState | null | typeof UNCOMPUTED = UNCOMPUTED;
+
+function readStateOnce(repoRoot: string): SessionRunIdentityState | null {
+  if (cachedState === UNCOMPUTED || cachedRepoRoot !== repoRoot) {
+    cachedRepoRoot = repoRoot;
+    cachedState = readStateFile(repoRoot);
+  }
+  return cachedState;
+}
+
+function persist(repoRoot: string, state: SessionRunIdentityState): void {
+  writeStateFile(repoRoot, state);
+  cachedRepoRoot = repoRoot;
+  cachedState = state;
+}
+
+/**
+ * The unified chain every consumption point applies: `payload.run_id` ->
+ * `HOOK_RUN_ID` -> `CODEX_RUN_ID` -> `CLAUDE_RUN_ID` -> session-state lookup
+ * by `session_id` -> null. Never mints -- SessionStart's
+ * `mintOrAdoptSessionRunIdentity` is the only place a new id is fabricated.
+ */
+export function resolveRunIdentity(
+  repoRoot: string,
+  payload: RunIdentityPayload,
+  env: NodeJS.ProcessEnv,
+): ResolvedRunIdentity {
+  const sessionId = firstString(payload.session_id, env.HOOK_SESSION_ID, env.CODEX_SESSION_ID, env.CLAUDE_SESSION_ID);
+  const directRunId = firstString(payload.run_id, env.HOOK_RUN_ID, env.CODEX_RUN_ID, env.CLAUDE_RUN_ID);
+  if (directRunId) return { sessionId, runId: directRunId };
+  if (!sessionId) return { sessionId, runId: null };
+  const state = readStateOnce(repoRoot);
+  return { sessionId, runId: state && state.session_id === sessionId ? state.run_id : null };
+}
+
+/** `run-<timestamp>-<pid>` (pattern reference: `scripts/verify-sprint.sh`'s `run_id="${HOOK_RUN_ID:-${CLAUDE_RUN_ID:-${CODEX_RUN_ID:-run-${run_stamp}-$$}}}"`). */
+function mintRunId(now: Date): string {
+  const pad = (value: number): string => String(value).padStart(2, '0');
+  const stamp = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}T${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
+  return `run-${stamp}-${process.pid}`;
+}
+
+/**
+ * SessionStart's single minting point. If payload/env already carry an
+ * upstream run identity, it is adopted (persisted verbatim, never minted
+ * over) -- loop-engine is the upstream authority. Otherwise, a prior stored
+ * entry for the SAME session_id is reused untouched (re-entry never changes
+ * the id); only a new/absent session_id triggers a fresh mint. Returns null
+ * only when no session_id is resolvable at all (nothing to key storage on).
+ */
+export function mintOrAdoptSessionRunIdentity(
+  repoRoot: string,
+  payload: RunIdentityPayload,
+  env: NodeJS.ProcessEnv,
+  now: Date = new Date(),
+): string | null {
+  const sessionId = firstString(payload.session_id, env.HOOK_SESSION_ID, env.CODEX_SESSION_ID, env.CLAUDE_SESSION_ID);
+  if (!sessionId) return null;
+
+  const upstream = firstString(payload.run_id, env.HOOK_RUN_ID, env.CODEX_RUN_ID, env.CLAUDE_RUN_ID);
+  if (upstream) {
+    persist(repoRoot, { protocol: 1, session_id: sessionId, run_id: upstream, created_at: now.toISOString() });
+    return upstream;
+  }
+
+  const existing = readStateOnce(repoRoot);
+  if (existing && existing.session_id === sessionId) return existing.run_id;
+
+  const minted = mintRunId(now);
+  persist(repoRoot, { protocol: 1, session_id: sessionId, run_id: minted, created_at: now.toISOString() });
+  return minted;
+}

--- a/src/cli/hook/session-context.ts
+++ b/src/cli/hook/session-context.ts
@@ -38,6 +38,38 @@ import { runSecurityScan, type SecurityScanReport } from '../commands/security';
 import { fileExists, readText } from '../../effects/state/collect-state-inputs';
 import type { WorktreeOwnership } from '../../effects/loop/state-input-collector';
 import { resolveRecoveryEvidence } from '../../effects/evidence/recovery-materializer';
+import { parseHookInput } from './hook-input';
+import { mintOrAdoptSessionRunIdentity } from './run-identity';
+
+// ---------------------------------------------------------------------------
+// run-identity threading -- SessionStart's single mint/adopt point
+// ---------------------------------------------------------------------------
+
+/**
+ * SessionStart's single run-identity mint/adopt point (design freeze: run
+ * identity threading slice). Parses `.session_id`/`.run_id` from the raw
+ * hook payload via the same `parseHookInput` every other typed handler uses,
+ * then delegates to `mintOrAdoptSessionRunIdentity` for the actual
+ * mint-vs-adopt-vs-reuse decision. The return value is intentionally
+ * unused by the caller -- later hook invocations (including this
+ * SessionStart event's own telemetry record) resolve it through
+ * `resolveRunIdentity`'s session-state fallback tier, not through this
+ * function's return.
+ */
+export function ensureSessionRunIdentity(
+  repoRoot: string,
+  input: string | Buffer | undefined,
+  env: NodeJS.ProcessEnv,
+  now: Date,
+): void {
+  const hookInput = parseHookInput(input, { env, repoRoot });
+  mintOrAdoptSessionRunIdentity(
+    repoRoot,
+    { session_id: hookInput.get('.session_id'), run_id: hookInput.get('.run_id') },
+    env,
+    now,
+  );
+}
 
 // ---------------------------------------------------------------------------
 // minimal-change-context.sh port (16 lines)

--- a/tasks/notes/run-identity-threading.notes.md
+++ b/tasks/notes/run-identity-threading.notes.md
@@ -1,0 +1,56 @@
+# Implementation Notes: run identity threading
+
+## Decision
+
+Add one small module, `src/cli/hook/run-identity.ts`, as the single resolution
+and minting authority for hook-path run identity. SessionStart's in-process
+handler is the only mint/adopt point; every other consumption point
+(`event-telemetry.ts`, `command-observed.ts`) only resolves through the same
+unified chain (`payload.run_id -> HOOK_RUN_ID -> CODEX_RUN_ID -> CLAUDE_RUN_ID
+-> session-state lookup by session_id -> null`) and never fabricates a value
+itself.
+
+## Rationale
+
+`.ai/harness/runs/hook-events.jsonl` events had an empty `run_id` because
+nothing ever populated one, and the three evidence writers
+(`verify-producer.ts`, `post-bash-importer.ts`, `attested-import.ts`) each
+minted their own `run-${Date.now()}` on demand when a caller omitted
+`correlationRunId`, so hook telemetry and evidence records never shared a
+joinable identity. Minting the identity once at SessionStart and threading it
+through the same resolution chain everywhere else closes that join without
+touching the evidence protocol/schema (both `run_id` and `correlation_run_id`
+already existed).
+
+## Scope
+
+- New: `src/cli/hook/run-identity.ts` — `resolveRunIdentity` (unified chain)
+  and `mintOrAdoptSessionRunIdentity` (SessionStart-only mint/adopt).
+- Storage: `.ai/harness/state/session-run-identity.json`, a single-slot JSON
+  object overwritten per session (pattern reference:
+  `session-context-budget.ts`'s `session-context-budget.json`), not a
+  growing map keyed by every historical `session_id`.
+- Wired consumption points: `event-telemetry.ts` (its `run_id`/`session_id`
+  fields now come from `resolveRunIdentity`), `session-context.ts` (new
+  `ensureSessionRunIdentity`, called from `handler-registry.ts`'s
+  `session-context` handler — the SessionStart in-process path), and
+  `command-observed.ts` (threads the resolved id into
+  `importPostBashObservation`'s `correlationRunId`).
+- Left untouched by design: `verify-producer.ts` and `attested-import.ts` —
+  neither is called from any hook-path handler today (only from the
+  standalone `scripts/emit-verify-evidence.ts` and
+  `scripts/acceptance-receipt.ts` CLIs, which carry no session context and
+  are explicitly out of scope). Their `?? run-${Date.now()}` fallback is
+  unmodified in all three writer files.
+
+## Tradeoff
+
+The state file is a single overwritten slot rather than a bounded map of
+recent sessions, so two genuinely concurrent sessions racing writes to the
+same worktree could overwrite each other's stored identity; a later lookup
+for the overwritten session degrades to `null` (fail-closed, never
+fabricated) rather than resolving. This mirrors the accepted concurrency
+model of the referenced `session-context-budget.json` precedent, which makes
+the same single-slot-overwrite tradeoff for the same reason: this repo's hook
+state files are per-worktree, and the common case is one active session per
+worktree at a time.

--- a/tests/command-observed.test.ts
+++ b/tests/command-observed.test.ts
@@ -11,6 +11,8 @@ import {
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { runCommandObserved, type CommandObservedFs } from '../src/cli/hook/command-observed';
+import { mintOrAdoptSessionRunIdentity } from '../src/cli/hook/run-identity';
+import { readAcceptedEvents } from '../src/effects/evidence/event-log';
 
 function workspace(prefix: string): string {
   return realpathSync(mkdtempSync(join(tmpdir(), `${prefix}-`)));
@@ -317,6 +319,62 @@ describe('runCommandObserved', () => {
       expect(result.exitCode).toBe(0);
       expect(result.stderr).toContain('[HookInput] WARN');
       expect(checks(repoRoot)).toMatchObject({ command: '', status: 'pass', exit_code: 0 });
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('threads an env-resolved run identity into the evidence ledger correlation_run_id instead of self-minting', () => {
+    const repoRoot = workspace('command-observed-run-identity-threaded');
+    try {
+      const result = runCommandObserved({
+        repoRoot,
+        input: commandInput('echo hello', 'hello\n', 0),
+        env: { PATH: '', HOOK_SESSION_ID: 'cmd-observed-session', HOOK_RUN_ID: 'cmd-observed-run-77' },
+        dependencies: { hasExecutable: () => false },
+      });
+      expect(result.exitCode).toBe(0);
+      const ledger = readAcceptedEvents(repoRoot);
+      const observed = ledger.accepted.find((event) => event.event_type === 'post_bash.command_observed');
+      expect(observed?.correlation_run_id).toBe('cmd-observed-run-77');
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('threads a session-state-derived run identity (minted during SessionStart) into the evidence ledger', () => {
+    const repoRoot = workspace('command-observed-run-identity-session-state');
+    try {
+      const minted = mintOrAdoptSessionRunIdentity(repoRoot, { session_id: 'cmd-observed-state-session' }, {});
+      expect(minted).not.toBeNull();
+      const result = runCommandObserved({
+        repoRoot,
+        input: commandInput('echo hello', 'hello\n', 0),
+        env: { PATH: '', HOOK_SESSION_ID: 'cmd-observed-state-session' },
+        dependencies: { hasExecutable: () => false },
+      });
+      expect(result.exitCode).toBe(0);
+      const ledger = readAcceptedEvents(repoRoot);
+      const observed = ledger.accepted.find((event) => event.event_type === 'post_bash.command_observed');
+      expect(observed?.correlation_run_id).toBe(minted as string);
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('falls back to the writer own self-minted id when no run identity is resolvable at all (unchanged fallback)', () => {
+    const repoRoot = workspace('command-observed-run-identity-unresolved');
+    try {
+      const result = runCommandObserved({
+        repoRoot,
+        input: commandInput('echo hello', 'hello\n', 0),
+        env: { PATH: '' },
+        dependencies: { hasExecutable: () => false },
+      });
+      expect(result.exitCode).toBe(0);
+      const ledger = readAcceptedEvents(repoRoot);
+      const observed = ledger.accepted.find((event) => event.event_type === 'post_bash.command_observed');
+      expect(observed?.correlation_run_id).toMatch(/^run-\d+$/);
     } finally {
       rmSync(repoRoot, { recursive: true, force: true });
     }

--- a/tests/run-identity.test.ts
+++ b/tests/run-identity.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, test } from 'bun:test';
+import { execFileSync } from 'child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { mintOrAdoptSessionRunIdentity, resolveRunIdentity } from '../src/cli/hook/run-identity';
+import { runHook } from '../src/cli/hook/runtime';
+import { readAcceptedEvents } from '../src/effects/evidence/event-log';
+
+const STATE_RELATIVE_PATH = '.ai/harness/state/session-run-identity.json';
+
+function workspace(prefix: string): string {
+  return mkdtempSync(join(tmpdir(), `${prefix}-`));
+}
+
+function readStateFileRaw(repoRoot: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(repoRoot, STATE_RELATIVE_PATH), 'utf-8')) as Record<string, unknown>;
+}
+
+describe('run-identity: resolveRunIdentity', () => {
+  test('prefers payload.run_id over every env var and session state', () => {
+    const repoRoot = workspace('run-identity-resolve-payload');
+    try {
+      const resolved = resolveRunIdentity(
+        repoRoot,
+        { session_id: 'sess-1', run_id: 'run-from-payload' },
+        { HOOK_RUN_ID: 'run-from-hook-env', CODEX_RUN_ID: 'run-from-codex-env', CLAUDE_RUN_ID: 'run-from-claude-env' },
+      );
+      expect(resolved).toEqual({ sessionId: 'sess-1', runId: 'run-from-payload' });
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('falls back HOOK_RUN_ID -> CODEX_RUN_ID -> CLAUDE_RUN_ID in order when payload carries nothing', () => {
+    const repoRoot = workspace('run-identity-resolve-env-order');
+    try {
+      expect(resolveRunIdentity(
+        repoRoot,
+        {},
+        { HOOK_RUN_ID: 'from-hook', CODEX_RUN_ID: 'from-codex', CLAUDE_RUN_ID: 'from-claude' },
+      ).runId).toBe('from-hook');
+      expect(resolveRunIdentity(
+        repoRoot,
+        {},
+        { CODEX_RUN_ID: 'from-codex', CLAUDE_RUN_ID: 'from-claude' },
+      ).runId).toBe('from-codex');
+      expect(resolveRunIdentity(repoRoot, {}, { CLAUDE_RUN_ID: 'from-claude' }).runId).toBe('from-claude');
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('falls back to session-state lookup by session_id when payload/env carry nothing', () => {
+    const repoRoot = workspace('run-identity-resolve-session-state');
+    try {
+      const minted = mintOrAdoptSessionRunIdentity(repoRoot, { session_id: 'sess-lookup' }, {});
+      expect(minted).not.toBeNull();
+      const resolved = resolveRunIdentity(repoRoot, { session_id: 'sess-lookup' }, {});
+      expect(resolved).toEqual({ sessionId: 'sess-lookup', runId: minted });
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('returns a null runId when session_id does not match the stored state entry', () => {
+    const repoRoot = workspace('run-identity-resolve-session-mismatch');
+    try {
+      mintOrAdoptSessionRunIdentity(repoRoot, { session_id: 'sess-a' }, {});
+      const resolved = resolveRunIdentity(repoRoot, { session_id: 'sess-b' }, {});
+      expect(resolved).toEqual({ sessionId: 'sess-b', runId: null });
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('returns null for both fields when nothing resolves at all', () => {
+    const repoRoot = workspace('run-identity-resolve-empty');
+    try {
+      expect(resolveRunIdentity(repoRoot, {}, {})).toEqual({ sessionId: null, runId: null });
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('run-identity: mintOrAdoptSessionRunIdentity', () => {
+  test('mints a run-<timestamp>-<pid> id when nothing upstream and no prior state', () => {
+    const repoRoot = workspace('run-identity-mint-fresh');
+    try {
+      const minted = mintOrAdoptSessionRunIdentity(repoRoot, { session_id: 'sess-fresh' }, {});
+      expect(minted).toMatch(/^run-\d{8}T\d{6}-\d+$/);
+      expect(readStateFileRaw(repoRoot)).toEqual({
+        protocol: 1,
+        session_id: 'sess-fresh',
+        run_id: minted,
+        created_at: expect.any(String),
+      });
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('re-entry with the same session_id and no upstream override reuses the previously minted id', () => {
+    const repoRoot = workspace('run-identity-mint-idempotent');
+    try {
+      const first = mintOrAdoptSessionRunIdentity(
+        repoRoot,
+        { session_id: 'sess-repeat' },
+        {},
+        new Date('2026-08-01T09:00:00.000Z'),
+      );
+      const second = mintOrAdoptSessionRunIdentity(
+        repoRoot,
+        { session_id: 'sess-repeat' },
+        {},
+        new Date('2026-08-01T09:05:00.000Z'),
+      );
+      expect(second).toBe(first);
+      expect(readStateFileRaw(repoRoot).run_id).toBe(first);
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('adopts an upstream-provided run_id verbatim instead of minting', () => {
+    const repoRoot = workspace('run-identity-mint-adopt');
+    try {
+      const adopted = mintOrAdoptSessionRunIdentity(
+        repoRoot,
+        { session_id: 'sess-upstream', run_id: 'loop-engine-run-77' },
+        {},
+      );
+      expect(adopted).toBe('loop-engine-run-77');
+      expect(readStateFileRaw(repoRoot).run_id).toBe('loop-engine-run-77');
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('a later upstream-provided value for the same session overwrites the stored id (upstream stays authoritative)', () => {
+    const repoRoot = workspace('run-identity-mint-upstream-override');
+    try {
+      mintOrAdoptSessionRunIdentity(repoRoot, { session_id: 'sess-loop', run_id: 'loop-run-1' }, {});
+      const second = mintOrAdoptSessionRunIdentity(repoRoot, { session_id: 'sess-loop', run_id: 'loop-run-2' }, {});
+      expect(second).toBe('loop-run-2');
+      expect(readStateFileRaw(repoRoot).run_id).toBe('loop-run-2');
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('returns null when no session_id is resolvable at all', () => {
+    const repoRoot = workspace('run-identity-mint-no-session');
+    try {
+      expect(mintOrAdoptSessionRunIdentity(repoRoot, {}, {})).toBeNull();
+      expect(existsSync(join(repoRoot, STATE_RELATIVE_PATH))).toBe(false);
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('storage stays a single bounded slot across distinct sessions, not a growing map', () => {
+    const repoRoot = workspace('run-identity-mint-bounded');
+    try {
+      mintOrAdoptSessionRunIdentity(repoRoot, { session_id: 'sess-first' }, {});
+      mintOrAdoptSessionRunIdentity(repoRoot, { session_id: 'sess-second' }, {});
+      mintOrAdoptSessionRunIdentity(repoRoot, { session_id: 'sess-third' }, {});
+      const state = readStateFileRaw(repoRoot);
+      expect(Object.keys(state).sort()).toEqual(['created_at', 'protocol', 'run_id', 'session_id']);
+      expect(state.session_id).toBe('sess-third');
+      // A prior session's identity must not be resolvable once overwritten --
+      // no cross-session history is retained (bounded growth).
+      expect(resolveRunIdentity(repoRoot, { session_id: 'sess-first' }, {}).runId).toBeNull();
+      expect(resolveRunIdentity(repoRoot, { session_id: 'sess-second' }, {}).runId).toBeNull();
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Acceptance probe: SessionStart -> PostToolUse.bash via the real runHook()
+// runtime, demonstrating the two required joins:
+//   (a) a newly produced hook event has a non-empty run_id
+//   (b) that same run_id appears as an evidence ledger correlation_run_id
+// ---------------------------------------------------------------------------
+
+function fixtureRepo(prefix: string): string {
+  const root = mkdtempSync(join(tmpdir(), `${prefix}-`));
+  execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: root });
+  execFileSync('git', ['config', 'user.name', 'Fixture'], { cwd: root });
+  execFileSync('git', ['config', 'user.email', 'fixture@example.com'], { cwd: root });
+  mkdirSync(join(root, '.ai/harness'), { recursive: true });
+  writeFileSync(join(root, '.ai/harness/workflow-contract.json'), '{}\n');
+  writeFileSync(join(root, '.ai/harness/policy.json'), '{}\n');
+  execFileSync('git', ['add', '.'], { cwd: root });
+  execFileSync('git', ['commit', '-q', '-m', 'fixture'], { cwd: root });
+  return root;
+}
+
+function hookEvents(root: string): Record<string, unknown>[] {
+  const file = join(root, '.ai/harness/runs/hook-events.jsonl');
+  if (!existsSync(file)) return [];
+  return readFileSync(file, 'utf8').trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+}
+
+describe('run-identity acceptance probe: SessionStart -> PostToolUse.bash', () => {
+  test('a fresh SessionStart mints a run identity that threads to hook telemetry and the evidence ledger correlation_run_id', () => {
+    const root = fixtureRepo('run-identity-acceptance');
+    try {
+      const env = {
+        ...process.env,
+        HOOK_REPO_ROOT: root,
+        HOOK_HOST: 'claude',
+        HOOK_SESSION_ID: 'run-identity-acceptance-session',
+        REPO_HARNESS_WORKFLOW_PROFILE: 'lite',
+        // Deliberately absent: HOOK_RUN_ID / CODEX_RUN_ID / CLAUDE_RUN_ID.
+        // Omitting every upstream run-identity source forces the mint path,
+        // so this probe actually exercises SessionStart's minting rather
+        // than an env-supplied passthrough.
+        HOOK_RUN_ID: undefined,
+        CODEX_RUN_ID: undefined,
+        CLAUDE_RUN_ID: undefined,
+      };
+
+      const sessionStartResult = runHook({ event: 'SessionStart', routeId: 'default', cwd: root, env });
+      expect(sessionStartResult.exitCode).toBe(0);
+
+      const bashResult = runHook({
+        event: 'PostToolUse',
+        routeId: 'bash',
+        cwd: root,
+        env,
+        input: JSON.stringify({ tool_input: { command: 'echo hello' }, tool_output: 'hello\n', exit_code: 0 }),
+      });
+      expect(bashResult.exitCode).toBe(0);
+
+      // (a) newly produced hook events carry a non-empty run_id.
+      const events = hookEvents(root);
+      const sessionStartEvent = events.find((event) => event.event === 'SessionStart');
+      const bashEvent = events.find((event) => event.event === 'PostToolUse' && event.route_id === 'bash');
+      expect(typeof sessionStartEvent?.run_id).toBe('string');
+      expect(sessionStartEvent?.run_id).not.toBe('');
+      expect(typeof bashEvent?.run_id).toBe('string');
+      expect(bashEvent?.run_id).not.toBe('');
+      // The same run identity threads across both hook invocations of one session.
+      expect(bashEvent?.run_id).toBe(sessionStartEvent?.run_id);
+
+      // (b) join instance: the identical run_id shows up as the evidence
+      // ledger's correlation_run_id for the PostBash-observed event.
+      const ledger = readAcceptedEvents(root);
+      const observed = ledger.accepted.find((event) => event.event_type === 'post_bash.command_observed');
+      expect(observed).toBeDefined();
+      expect(observed?.correlation_run_id).toBe(sessionStartEvent?.run_id as string);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, 30000);
+});


### PR DESCRIPTION
run 身分關聯鍵貫通：SessionStart 單一鑄造點（`.ai/harness/state/session-run-identity.json`，單槽有界），`event-telemetry` 與 `command-observed` 共用同一解析鏈（payload → HOOK_RUN_ID → CODEX_RUN_ID → CLAUDE_RUN_ID → session 狀態 → null），post-bash evidence 的 `correlation_run_id` 停止自鑄改為貫通。無 schema 變更。

驗收：新 hook 事件 `run_id` 非空且同 session 一致；hook 事件可 join 到 evidence ledger 同一 id，場景已固化為回歸測試（tests/run-identity.test.ts）。全量 bun test 2120 pass / 0 fail；required checks 全過（deploy-sql / architecture-sync / task-sync / init --dry-run / inspect-project-state）。

背景：docs/researches/20260731-gated-semantic-qd-harness-evolution.md 的 gap-check——9,453 條既有 hook 事件 run_id 全空、effect 層無 join 鍵，本 PR 補上這道縫。