### PR TITLE
Ship codex/release-0-12-1

### DIFF
--- a/.claude/.skill-version
+++ b/.claude/.skill-version
@@ -1,3 +1,3 @@
-skill_version=0.12.0
-template_version=0.12.0
+skill_version=0.12.1
+template_version=0.12.1
 migrated_at=2026-07-18T22:31:36Z

--- a/README.es.md
+++ b/README.es.md
@@ -466,8 +466,8 @@ repositorio adopte la misma política.
 
 ## Versión actual
 
-- Paquete npm: `repo-harness@0.12.0`
-- Sello de workflow generado: `repo-harness@0.12.0+template@0.12.0`
+- Paquete npm: `repo-harness@0.12.1`
+- Sello de workflow generado: `repo-harness@0.12.1+template@0.12.1`
 - Repositorio de GitHub: `Ancienttwo/repo-harness`
 - Notas de versión e historial: [`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -461,8 +461,8 @@ adopte la même policy.
 
 ## Release actuelle
 
-- Package npm : `repo-harness@0.12.0`
-- Generated workflow stamp : `repo-harness@0.12.0+template@0.12.0`
+- Package npm : `repo-harness@0.12.1`
+- Generated workflow stamp : `repo-harness@0.12.1+template@0.12.1`
 - Dépôt GitHub : `Ancienttwo/repo-harness`
 - Notes et historique de release : [`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -469,8 +469,8 @@ commit script や hooks に組み込まないでください。
 
 ## 現在の Release
 
-- npm package：`repo-harness@0.12.0`
-- Generated workflow stamp：`repo-harness@0.12.0+template@0.12.0`
+- npm package：`repo-harness@0.12.1`
+- Generated workflow stamp：`repo-harness@0.12.1+template@0.12.1`
 - GitHub repository：`Ancienttwo/repo-harness`
 - Release notes and history：[`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -441,8 +441,8 @@ repo-harness commit scripts or hooks unless that repo adopts the same policy.
 
 ## Current Release
 
-- npm package: `repo-harness@0.12.0`
-- Generated workflow stamp: `repo-harness@0.12.0+template@0.12.0`
+- npm package: `repo-harness@0.12.1`
+- Generated workflow stamp: `repo-harness@0.12.1+template@0.12.1`
 - GitHub repository: `Ancienttwo/repo-harness`
 - Release notes and history: [`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -448,8 +448,8 @@ policy。
 
 ## 当前 Release
 
-- npm package：`repo-harness@0.12.0`
-- Generated workflow stamp：`repo-harness@0.12.0+template@0.12.0`
+- npm package：`repo-harness@0.12.1`
+- Generated workflow stamp：`repo-harness@0.12.1+template@0.12.1`
 - GitHub repository：`Ancienttwo/repo-harness`
 - Release notes 和 history：[`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/assets/skill-version.json
+++ b/assets/skill-version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.12.0",
-  "templateVersion": "0.12.0",
+  "version": "0.12.1",
+  "templateVersion": "0.12.1",
   "skillName": "repo-harness",
   "contractId": "tasks-first-harness-v1",
   "compatibility": {
@@ -227,6 +227,10 @@
     {
       "version": "0.12.0",
       "description": "Removes repo-harness adopt in favor of init as the sole repo-local adoption command, adds the deep-worker fleet agent, converges docs/reference-configs on a generated assets projection, and fixes MCP allowed-root canonicalization, an acceptance-receipt fingerprint defect, and contract-worktree squash-merge cleanup"
+    },
+    {
+      "version": "0.12.1",
+      "description": "Threads a single SessionStart-minted run identity through hook telemetry and evidence correlation, restructures the five-language README into a get-started-first layout, and refreshes the CodeGraph dev dependency line to latest"
     }
   ],
   "generatedProjectStamp": {

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "express": "^5.2.1",
       },
       "devDependencies": {
-        "@colbymchenry/codegraph": "1.4.1",
+        "@colbymchenry/codegraph": "1.5.0",
         "@types/bun": "latest",
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.0",
@@ -20,19 +20,19 @@
     },
   },
   "packages": {
-    "@colbymchenry/codegraph": ["@colbymchenry/codegraph@1.4.1", "", { "optionalDependencies": { "@colbymchenry/codegraph-darwin-arm64": "1.4.1", "@colbymchenry/codegraph-darwin-x64": "1.4.1", "@colbymchenry/codegraph-linux-arm64": "1.4.1", "@colbymchenry/codegraph-linux-x64": "1.4.1", "@colbymchenry/codegraph-win32-arm64": "1.4.1", "@colbymchenry/codegraph-win32-x64": "1.4.1" }, "bin": { "codegraph": "npm-shim.js" } }, "sha512-xZayboJt6T3QBzBsBsI0eJ3J/tN4vYs6LMuvrxJVdM71yQFjrFKFeV3KsbicAgkj6AHnTXxUNk26g9BYwkNMgg=="],
+    "@colbymchenry/codegraph": ["@colbymchenry/codegraph@1.5.0", "", { "optionalDependencies": { "@colbymchenry/codegraph-darwin-arm64": "1.5.0", "@colbymchenry/codegraph-darwin-x64": "1.5.0", "@colbymchenry/codegraph-linux-arm64": "1.5.0", "@colbymchenry/codegraph-linux-x64": "1.5.0", "@colbymchenry/codegraph-win32-arm64": "1.5.0", "@colbymchenry/codegraph-win32-x64": "1.5.0" }, "bin": { "codegraph": "npm-shim.js" } }, "sha512-/l1JMVOQ9WGQLrc/IIuAg7Igr944t79/oNCJTcnGkYtIeQx2XFIqI0ho+9Les/Yu4zKfmPU17hIUshD6yP1fKw=="],
 
-    "@colbymchenry/codegraph-darwin-arm64": ["@colbymchenry/codegraph-darwin-arm64@1.4.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-USSpExjuxZWN0OeNexZp2V5fCfOI4ZekqE79CJiBdGdPbqGTB+857ImIqzWGyF/rAyyED94Wc0Cd82t+uWD30w=="],
+    "@colbymchenry/codegraph-darwin-arm64": ["@colbymchenry/codegraph-darwin-arm64@1.5.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ptQV1WlEKCDDy0Wl2r/urVGwaczUn5ezjt/Rv22Gj7RnKHAc9pNdU1uvL3gQzvoWJ9q7kmCeo7q6866/ZohbjQ=="],
 
-    "@colbymchenry/codegraph-darwin-x64": ["@colbymchenry/codegraph-darwin-x64@1.4.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-syLC7QPsNui2hPrK58El0XQrjjdSYhsoKS5i26ieD8DVrb0adzFQrBRP8qId/wfGp078xdC54rdKvqgmbIL1WQ=="],
+    "@colbymchenry/codegraph-darwin-x64": ["@colbymchenry/codegraph-darwin-x64@1.5.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-7BUOOxMacLNXmXTQTrjDTZXhbo0o5R5Z19uKjICIau2KxO9oU+Zbk7Bnf4P/JT1T4M41xRuiCJVE1uqBi6cFWA=="],
 
-    "@colbymchenry/codegraph-linux-arm64": ["@colbymchenry/codegraph-linux-arm64@1.4.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-XC6GJ9/fTicW9CE3k2fOcUOcbtDU8mS53t+PUfzq3Py9+JiX3PtJgtBB8bmf6e45NZUF5foaLUwFXfxTTl961g=="],
+    "@colbymchenry/codegraph-linux-arm64": ["@colbymchenry/codegraph-linux-arm64@1.5.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Bq5Ggb7PoLF7mnOiGl/UxMrDgrPCAQUMsl7BpMkAxq8FulvVEp7E/GrIQih2YB32vWr18KpN2i2VoRLAHLIDUw=="],
 
-    "@colbymchenry/codegraph-linux-x64": ["@colbymchenry/codegraph-linux-x64@1.4.1", "", { "os": "linux", "cpu": "x64" }, "sha512-bjfa+0IyjbxpZz7ghznN4qMPoYVSiZafeZu/rXGdg3VI+kEPOPZrk2vmtWIU9tBPGVJbeU2Kwa/0Z2DkUGOJ9A=="],
+    "@colbymchenry/codegraph-linux-x64": ["@colbymchenry/codegraph-linux-x64@1.5.0", "", { "os": "linux", "cpu": "x64" }, "sha512-wT1O7NkQoV6zPiq36d1qBqoIHL2ZRnOkFMjQ7JJwWS7KHnP32qHCd/pPaSwl8cNRlGYkYSaX3WVDpz2BaV+Now=="],
 
-    "@colbymchenry/codegraph-win32-arm64": ["@colbymchenry/codegraph-win32-arm64@1.4.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-mb5bFDhwcP49U0P2IBRhH1O5ZmnlgE8lIXTlg2dqpfLeL+XfxzyeJ+i4I0KU0h1hlNWP/u3d2k+1EGem2swDBw=="],
+    "@colbymchenry/codegraph-win32-arm64": ["@colbymchenry/codegraph-win32-arm64@1.5.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-cWMJp8BeVLKR1mUVklI3opy9mJL/yrVkvjBqJFXRejM8CCU+UTpPDxDzQuPyywY0qyD0Ru2tjuWT4do7OUcNvg=="],
 
-    "@colbymchenry/codegraph-win32-x64": ["@colbymchenry/codegraph-win32-x64@1.4.1", "", { "os": "win32", "cpu": "x64" }, "sha512-ipN6WvTKa0cSXIL6DTdACq57WnNYTjVq2wtC5uPT8F22o6Ucbcu3/w3OzKkkfwP4mkXv2cDMbuvExbnYNULyuw=="],
+    "@colbymchenry/codegraph-win32-x64": ["@colbymchenry/codegraph-win32-x64@1.5.0", "", { "os": "win32", "cpu": "x64" }, "sha512-45gycJ+t153vpLEVkXChEySG1Ok5zqCgiBeonLe5V7Jxt1w+MF2vG00qexTC0pBWTmHSeMW4Q8d47nVMiC8ciQ=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 

--- a/deploy/release-checklists/260801-repo-harness-0.12.1.md
+++ b/deploy/release-checklists/260801-repo-harness-0.12.1.md
@@ -1,0 +1,71 @@
+# repo-harness 0.12.1 Release Filing
+
+- Date: 2026-08-01
+- Package: `repo-harness@0.12.1`
+- Base release: `v0.12.0`
+- Source range: `v0.12.0..candidate`
+- Release scope: thread a single SessionStart-minted run identity through
+  hook telemetry and evidence correlation via a new `run-identity.ts`
+  mint/resolution authority that replaces each writer's own self-minted
+  run id, restructure the five-language README suite into a
+  get-started-first layout (872 to 451 lines on the English README, with
+  deep-dive content relocated into `docs/reference-configs`), and refresh
+  the `@colbymchenry/codegraph` dev dependency line from `1.4.1` to
+  `1.5.0`.
+- Publish status: **pending publish**. This filing does not claim npm, Git
+  tag, or GitHub Release completion until the public readbacks below pass.
+
+## Candidate Evidence
+
+- `00a703e8` (PR #146) adds `run-identity.ts` as the single
+  SessionStart-only mint and resolution authority (payload ->
+  `HOOK_RUN_ID` -> `CODEX_RUN_ID` -> `CLAUDE_RUN_ID` -> session-state
+  lookup -> null), storing one bounded `session-run-identity.json` slot,
+  and wires `event-telemetry.ts` and `command-observed.ts` to the unified
+  resolver instead of independent chains or self-minted `run-${Date.now()}`
+  fallbacks, closing the gap where `hook-events.jsonl` `run_id` was always
+  empty and never joined to evidence `correlation_run_id`.
+- `629c9af6` (PR #145) rebuilds `README.md` as a codegraph-style layout
+  (centered header, TOC, Get Started at line 40, key-features table),
+  cutting it from 872 to 451 lines, relocates deep-dive content into
+  `docs/reference-configs` (install profiles, general-repo MCP, harness
+  overview, hook operations) before deletion so nothing is lost, rewrites
+  the four translations (zh-CN, ja, fr, es) against the new 14-section
+  structure with byte-identical code blocks and localized TOC anchors, and
+  updates the `readme-dx` and install-script characterization tests to pin
+  the new contract.
+- `17b8d57b` bumps the `@colbymchenry/codegraph` dev dependency from
+  `1.4.1` to `1.5.0` in `package.json` and `bun.lock`.
+- Version sources and localized README projections are `0.12.1`; the
+  generated stamp is `repo-harness@0.12.1+template@0.12.1`.
+
+## Required Release Sequence
+
+- [ ] Merge the release-candidate changes to `main` without unrelated files.
+- [ ] Confirm all GitHub CI jobs are green for the merged source commit.
+- [ ] Run `bun run check:release` on that exact merged commit.
+- [ ] Publish `repo-harness@0.12.1` to the official npm registry with `latest`.
+- [ ] Create and push annotated tag `v0.12.1` at the published source commit.
+- [ ] Create stable GitHub Release `repo-harness 0.12.1` from `v0.12.1` with no
+      attached asset, matching the established release convention.
+- [ ] Run `bash scripts/check-release-published.sh 0.12.1` and verify registry,
+      dist-tag, tarball integrity, source tag, GitHub Release, and clean-room CLI.
+
+## Candidate Verification Record
+
+- This release-prep pass has no separate `tasks/reviews/*.review.md`
+  artifact; the candidate's required checks (`bun test`,
+  `check-deploy-sql-order.sh`, `check-architecture-sync.sh`,
+  `check-task-sync.sh`, `check-task-workflow --strict`,
+  `inspect-project-state.ts`, `cli init --dry-run`, and the
+  `check:release` preflight) are run directly against this branch and
+  reported in the release-prep task execution record.
+- Hosted CI, exact-main release gate, npm publication, annotated tag, GitHub
+  Release, and published-package readbacks remain mandatory release operations;
+  no unchecked item above is represented as completed by this source filing.
+
+## Rollback
+
+- Before npm publication: revert or abandon the release-prep commits.
+- After npm publication: never move/reuse `v0.12.1`; correct forward with a new
+  patch release.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this skill are documented here.
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-08-01
+
+### Changed
+
+- Restructures the five-language README suite into a get-started-first
+  layout (centered header, TOC, Get Started section, key-features table),
+  cutting the English `README.md` from 872 to 451 lines; deep-dive content
+  (install profiles, General Repo MCP, harness overview, hook operations)
+  moves into `docs/reference-configs` before deletion so nothing is lost,
+  and the four translations (zh-CN, ja, fr, es) are rewritten against the
+  new section structure.
+- Bumps the `@colbymchenry/codegraph` dev dependency from `1.4.1` to
+  `1.5.0`.
+
+### Fixed
+
+- `hook-events.jsonl`'s `run_id` was always empty and each evidence writer
+  minted its own `run-${Date.now()}` on demand, so hook telemetry never
+  joined evidence `correlation_run_id`. A new `run-identity.ts` module is
+  now the single SessionStart-only mint and resolution authority (payload
+  -> `HOOK_RUN_ID` -> `CODEX_RUN_ID` -> `CLAUDE_RUN_ID` -> session-state
+  lookup -> null), storing one bounded `session-run-identity.json` slot;
+  `event-telemetry.ts` and `command-observed.ts` now wire to this unified
+  resolver instead of independent chains or self-minted fallbacks.
+
 ## [0.12.0] - 2026-07-31
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "sync:codex-installed": "bash scripts/sync-codex-installed-copies.sh"
   },
   "devDependencies": {
-    "@colbymchenry/codegraph": "1.4.1",
+    "@colbymchenry/codegraph": "1.5.0",
     "@types/bun": "latest",
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "repo-harness",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Installs, migrates, audits, and repairs repo-local agentic development harnesses",
   "license": "MIT",
   "repository": {

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,16 +1,16 @@
 # Current Status Snapshot
 
 <!-- generated-by: repo-harness refresh-current-status v1 -->
-<!-- updated_at: 2026-07-29T17:53:29+0800 -->
+<!-- updated_at: 2026-07-31T22:57:08+0800 -->
 <!-- stale_after: 24h -->
 
 > **Status**: Idle
-> **Updated At**: 2026-07-29T17:53:29+0800
-> **Source Branch**: codex/release-0-11-3
-> **Source Commit**: 8e38a667
+> **Updated At**: 2026-07-31T22:57:08+0800
+> **Source Branch**: main
+> **Source Commit**: 01c821d1
 > **Target Branch**: main
 > **Stale After**: 24h
-> **Reason**: archive-workflow
+> **Reason**: codegraph-update
 > **Derived From**: active-plan, active-sprint, workstreams, handoff, checks, git status
 
 This file is a tracked mainline snapshot derived from repo artifacts. It is not a live lock, not a kanban board, and not an implementation gate. If it is stale, read the source artifacts below.
@@ -46,27 +46,19 @@ This file is a tracked mainline snapshot derived from repo artifacts. It is not 
 - `tasks/workstreams/workflow-engine/inspection-migration/agent-fleet-specialists.md`: status=completed, current_slice=completed-20260713-policy-seed, source_plan=`plans/archive/plan-20260712-2215-agent-fleet-specialists.md`
 ## Handoff
 
-- Exact Next Step: If a major module was just completed, stage its coherent diff first; then continue the next Task Breakdown item: T1 版本升級：package.json → 0.11.3、`.claude/.skill-version`、`assets/skill-version.json`、五份 README 版本字串（照 142d4ccb 的 diff 形狀）
+- Exact Next Step: (none)
 
 ## Checks
 
-- status=pass, source=verify-sprint, exit_code=0, file=.ai/harness/checks/latest.json
+- status=(none), source=(none), exit_code=(none), file=.ai/harness/checks/latest.json
 
 ## Git Status
 
-- Summary: 10 changed/untracked path(s)
+- Summary: 2 changed/untracked path(s)
 
 ```
- D plans/plan-20260729-1707-release-0-11-3.md
- D tasks/contracts/20260729-1707-release-0-11-3.contract.md
- D tasks/notes/20260729-1707-release-0-11-3.notes.md
- D tasks/reviews/20260729-1707-release-0-11-3.review.md
- M tasks/todos.md
-?? plans/archive/plan-20260729-1707-release-0-11-3.md
-?? tasks/archive/contract-20260729-1753-release-0-11-3.md
-?? tasks/archive/notes-20260729-1753-release-0-11-3.md
-?? tasks/archive/review-20260729-1753-release-0-11-3.md
-?? tasks/archive/todo-20260729-1753-release-0-11-3.md
+ M bun.lock
+ M package.json
 ```
 
 ## Source Artifacts


### PR DESCRIPTION
Release candidate for repo-harness 0.12.1.

- `chore(deps): bump @colbymchenry/codegraph to 1.5.0` — dev dependency line refresh (package.json, bun.lock) plus the derived current-status snapshot.
- `release(0.12.1): bump version sources and add release filing` — version sources to 0.12.1 (package.json, .claude/.skill-version, assets/skill-version.json with the 0.12.1 breakingChanges entry, five README stamps), the release filing deploy/release-checklists/260801-repo-harness-0.12.1.md, and the docs/CHANGELOG.md [0.12.1] section covering #145 (README restructure), #146 (run-identity threading), and the CodeGraph bump.

Verification on this branch: bun test 2120 pass / 0 fail, check:release full gate green including tarball install smoke, task-sync / architecture-sync / check-task-workflow --strict / inspect-project-state all clean. Publish sequence (npm, v0.12.1 tag, GitHub Release, published readback) follows the filing after merge.