### PR TITLE
Ship codex/tooling-receipt-awareness

### DIFF
--- a/assets/templates/helpers/check-agent-tooling.sh
+++ b/assets/templates/helpers/check-agent-tooling.sh
@@ -105,6 +105,7 @@ const AGENT_FLEET_SOURCE_DIR = process.env.REPO_HARNESS_AGENT_FLEET_SOURCE_DIR;
 const AGENT_FLEET_SOURCE_LABEL = "package:agents/fleet";
 const AGENT_FLEET_DEFAULT_MANAGED = ["explorer", "deep-reasoner", "fast-worker", "deep-worker", "gatekeeper", "root-cause-prover", "harness-evaluator"];
 const AGENT_FLEET_INSTALL_COMMAND = "repo-harness run install-agent-fleet";
+const AGENT_FLEET_USER_MANAGED_RECEIPT_PATH = path.join(HOME, ".repo-harness", "agent-fleet-user-managed.json");
 const CODEGRAPH_PACKAGE = "@colbymchenry/codegraph";
 const CODEGRAPH_GLOBAL_INSTALL_COMMAND = `bun add -g ${CODEGRAPH_PACKAGE} && repo-harness tools configure codegraph --target codex --location global`;
 const CODEGRAPH_MCP_CONFIGURE_COMMAND = "repo-harness tools configure codegraph --target <codex|claude|both> --location global";
@@ -246,6 +247,10 @@ function sha1(text) {
 
 function sha1Buffer(buffer) {
   return crypto.createHash("sha1").update(buffer).digest("hex");
+}
+
+function sha256Buffer(buffer) {
+  return `sha256:${crypto.createHash("sha256").update(buffer).digest("hex")}`;
 }
 
 function parseSkillVersion(text) {
@@ -872,6 +877,37 @@ function readAgentFleetSource(agent) {
   return { status: "read", path: sourcePath, hash: source.hash };
 }
 
+// Read-only mirror of install-agent-fleet.sh's loadUserManagedReceipt(): this
+// checker never writes ~/.repo-harness/agent-fleet-user-managed.json, it only
+// consults it so an operator-accepted customized file is not misreported as
+// drift. Any malformation invalidates the whole receipt (fail-closed) rather
+// than exempting individual entries.
+function loadAgentFleetUserManagedReceipt() {
+  if (!fs.existsSync(AGENT_FLEET_USER_MANAGED_RECEIPT_PATH)) return { ok: true, hashes: new Map() };
+  try {
+    const parsed = JSON.parse(fs.readFileSync(AGENT_FLEET_USER_MANAGED_RECEIPT_PATH, "utf8"));
+    if (
+      parsed?.protocol !== 1
+      || parsed?.authority !== "user-managed-agent-fleet"
+      || !Array.isArray(parsed.files)
+    ) return { ok: false, hashes: new Map() };
+    const hashes = new Map();
+    for (const entry of parsed.files) {
+      if (
+        !entry
+        || typeof entry.path !== "string"
+        || typeof entry.sha256 !== "string"
+        || !/^sha256:[a-f0-9]{64}$/.test(entry.sha256)
+        || hashes.has(entry.path)
+      ) return { ok: false, hashes: new Map() };
+      hashes.set(entry.path, entry.sha256);
+    }
+    return { ok: true, hashes };
+  } catch (_error) {
+    return { ok: false, hashes: new Map() };
+  }
+}
+
 function detectAgentFleetHost(host, managedAgents) {
   const meta = HOSTS[host];
   const files = managedAgents.map((agent) => inspectAgentFleetFile(host, agent));
@@ -884,9 +920,11 @@ function detectAgentFleetHost(host, managedAgents) {
   const driftAgents = [];
   const syncedAgents = [];
   const sourceMissingAgents = [];
+  const userManagedAgents = [];
 
   if (checkUpdates) {
     if (host === "claude") {
+      const receipt = loadAgentFleetUserManagedReceipt();
       for (const entry of files) {
         if (!entry.present) continue;
         const source = readAgentFleetSource(entry.name);
@@ -896,9 +934,25 @@ function detectAgentFleetHost(host, managedAgents) {
         }
         if (source.hash === entry.hash) {
           syncedAgents.push(entry.name);
-        } else {
-          driftAgents.push(entry.name);
+          continue;
         }
+        // Differs from the packaged source: only a valid receipt entry whose
+        // sha256 matches the file's *current* installed content exempts it.
+        // A missing/invalid receipt, a path with no entry, or a hash mismatch
+        // (edited again after acceptance) all fall through to drift.
+        if (receipt.ok && receipt.hashes.get(entry.path) !== undefined) {
+          let installedHash = null;
+          try {
+            installedHash = sha256Buffer(fs.readFileSync(entry.path));
+          } catch (_error) {
+            installedHash = null;
+          }
+          if (installedHash === receipt.hashes.get(entry.path)) {
+            userManagedAgents.push(entry.name);
+            continue;
+          }
+        }
+        driftAgents.push(entry.name);
       }
 
       if (driftAgents.length > 0) {
@@ -907,9 +961,11 @@ function detectAgentFleetHost(host, managedAgents) {
       } else if (sourceMissingAgents.length > 0) {
         updateStatus = "unknown";
         updateReason = `Packaged repo-harness fleet source is missing files for: ${sourceMissingAgents.join(", ")}.`;
-      } else if (syncedAgents.length > 0) {
-        updateStatus = "synced";
-        updateReason = "Installed Claude agent definitions match the packaged repo-harness fleet source.";
+      } else if (syncedAgents.length > 0 || userManagedAgents.length > 0) {
+        updateStatus = "up-to-date";
+        updateReason = userManagedAgents.length > 0
+          ? `Installed Claude agent definitions match the packaged repo-harness fleet source, with user-managed exemptions accepted via receipt for: ${userManagedAgents.join(", ")}.`
+          : "Installed Claude agent definitions match the packaged repo-harness fleet source.";
       } else {
         updateStatus = "not-checked";
         updateReason = "No installed Claude agent definitions to compare.";
@@ -931,6 +987,7 @@ function detectAgentFleetHost(host, managedAgents) {
     drift_agents: driftAgents,
     synced_agents: syncedAgents,
     source_missing_agents: sourceMissingAgents,
+    user_managed_agents: userManagedAgents,
   };
 }
 
@@ -1630,6 +1687,9 @@ function printText(result) {
     }
     if (entry.update_status !== "not-checked") {
       console.log(`    updates: ${entry.update_status} (${entry.update_reason})`);
+    }
+    if (entry.user_managed_agents.length) {
+      console.log(`    user-managed (receipt): ${entry.user_managed_agents.join(", ")}`);
     }
   }
   console.log(`  - Install: ${agentFleet.install_command}`);

--- a/plans/plan-20260801-1255-tooling-receipt-awareness.md
+++ b/plans/plan-20260801-1255-tooling-receipt-awareness.md
@@ -1,0 +1,172 @@
+# Plan: check-agent-tooling receipt-aware agent fleet drift
+
+> **Status**: Approved
+> **Created**: 20260801-1255
+> **Slug**: tooling-receipt-awareness
+> **Planning Source**: repo-harness-plan
+> **Orchestration Kind**: host-plan
+> **Source Ref**: (none)
+> **Artifact Level**: work-package
+> **Promotion Reason**: human_decision_boundary
+> **Verification Boundary**: Commands named in the captured planning output plus `repo-harness run verify-contract --contract tasks/contracts/20260801-1255-tooling-receipt-awareness.contract.md --strict`.
+> **Rollback Surface**: Before execution remove `plans/plan-20260801-1255-tooling-receipt-awareness.md`; after execution revert branch `codex/tooling-receipt-awareness` or the explicitly reviewed diff.
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260801-1255-tooling-receipt-awareness.contract.md`
+> **Task Review**: `tasks/reviews/20260801-1255-tooling-receipt-awareness.review.md`
+> **Implementation Notes**: `tasks/notes/20260801-1255-tooling-receipt-awareness.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from repo-harness-plan planning output.
+- Source ref: (none)
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260801-1255-tooling-receipt-awareness.md`
+- Sprint contract: `tasks/contracts/20260801-1255-tooling-receipt-awareness.contract.md`
+- Sprint review: `tasks/reviews/20260801-1255-tooling-receipt-awareness.review.md`
+- Implementation notes: `tasks/notes/20260801-1255-tooling-receipt-awareness.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260801-1255-tooling-receipt-awareness.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260801-1255-tooling-receipt-awareness.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260801-1255-tooling-receipt-awareness.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260801-1255-tooling-receipt-awareness.contract.md`
+- Review file: `tasks/reviews/20260801-1255-tooling-receipt-awareness.review.md`
+- Implementation notes file: `tasks/notes/20260801-1255-tooling-receipt-awareness.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260801-1255-tooling-receipt-awareness.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260801-1255-tooling-receipt-awareness.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: Before execution remove `plans/plan-20260801-1255-tooling-receipt-awareness.md`; after execution revert branch `codex/tooling-receipt-awareness` or the explicitly reviewed diff.
+- **Verification boundary**: Commands named in the captured planning output plus `repo-harness run verify-contract --contract tasks/contracts/20260801-1255-tooling-receipt-awareness.contract.md --strict`.
+- **Review/acceptance boundary**: `tasks/reviews/20260801-1255-tooling-receipt-awareness.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: human_decision_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260801-1255-tooling-receipt-awareness.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260801-1255-tooling-receipt-awareness.contract.md`, `tasks/reviews/20260801-1255-tooling-receipt-awareness.review.md`, and `tasks/notes/20260801-1255-tooling-receipt-awareness.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260801-1255-tooling-receipt-awareness.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: Before execution remove `plans/plan-20260801-1255-tooling-receipt-awareness.md`; after execution revert branch `codex/tooling-receipt-awareness` or the explicitly reviewed diff.
+
+## Captured Planning Output
+
+## Goal
+
+Make `scripts/check-agent-tooling.sh`'s agent fleet drift detection aware of the
+user-managed receipt written by `scripts/install-agent-fleet.sh --accept-user-managed`,
+so an operator-accepted customized Claude agent file (e.g. `~/.claude/agents/deep-reasoner.md`,
+`~/.claude/agents/gatekeeper.md`) is reported as `user-managed`, not `drift`, while any
+receipt that is missing, malformed, path-less, or hash-mismatched still fails closed to `drift`.
+
+## Verified facts (from repo inspection)
+
+- Receipt path: `~/.repo-harness/agent-fleet-user-managed.json`, written by
+  `scripts/install-agent-fleet.sh --accept-user-managed`. Shape:
+  `{ protocol: 1, authority: "user-managed-agent-fleet", accepted_at, files: [{ path: <absolute target path>, sha256: "sha256:<64hex>" }] }`.
+  Reference implementation: `loadUserManagedReceipt()` in `scripts/install-agent-fleet.sh` (~L309-334).
+- `scripts/check-agent-tooling.sh`'s `detectAgentFleetHost()` (~L875-935 pre-change) compared
+  installed Claude `.md` files against the packaged `agents/fleet/<agent>.md` source using sha1
+  (`readFileHash`/`sha1Buffer`), with zero receipt awareness. Any byte difference was reported as
+  drift, producing a false positive for operator-accepted customized files.
+- The receipt stores sha256; the installed-file comparison for receipt purposes must use sha256 of
+  the *current* installed file content, not the existing sha1 comparison against packaged source.
+- `scripts/check-agent-tooling.sh` and `assets/templates/helpers/check-agent-tooling.sh` are a
+  synced pair; `scripts/` is canonical, `assets/templates/helpers/` is projected via
+  `bun scripts/sync-helper-sources.ts --write`, verified with `--check`.
+
+## Behavior spec
+
+1. When an installed agent file differs from the packaged source, consult the receipt first: if
+   the receipt is well-formed, contains an entry for that installed absolute path, and that
+   entry's sha256 matches the sha256 of the file's *current* installed content, classify the file
+   as `user-managed` and exclude it from drift.
+2. Every other case still resolves to drift: receipt file absent, receipt malformed (wrong
+   protocol/authority/shape, duplicate paths, malformed sha256 pattern), no entry for that path, or
+   sha256 mismatch (edited again after acceptance). Fail closed: an invalid receipt exempts nothing.
+3. Output: the drift message lists only real drift agents. When user-managed exemptions exist,
+   print a separate explicit line (e.g. `user-managed (receipt): deep-reasoner, gatekeeper`) so the
+   exemption is visible, not silently absorbed. When every agent is either synced or user-managed,
+   `update_status` becomes the new terminal value `up-to-date` (matching this script's existing
+   `up-to-date` vocabulary used elsewhere for CodeGraph project-index status), with a clear reason.
+   Extend the JSON shape with a new `user_managed_agents` array alongside the existing
+   `drift_agents`/`synced_agents`/`source_missing_agents`, following the script's existing shape;
+   no aliasing, no dual-track.
+4. Codex side `not-applicable` handling is untouched. `install-agent-fleet.sh` is untouched. No new
+   `~/.repo-harness` write path is added; the checker stays read-only.
+
+## Task Breakdown
+- [x] Add a read-only `loadAgentFleetUserManagedReceipt()` reader plus a `sha256Buffer()` helper in `scripts/check-agent-tooling.sh`, mirroring `install-agent-fleet.sh`'s validation shape without its installer-specific `allowedPaths` gate (this checker's per-invocation host scope is narrower than the installer's fixed 12-path target set).
+- [x] Rewire `detectAgentFleetHost()`'s claude branch so a hash mismatch first checks the receipt (sha256 of current installed bytes) before falling back to drift; add `userManagedAgents` alongside `driftAgents`/`syncedAgents`/`sourceMissingAgents`, and surface `user_managed_agents` in the returned object.
+- [x] Rename the "no drift" terminal `update_status` value from `synced` to `up-to-date` (covering pure-synced and mixed synced/user-managed cases), with a reason that names the user-managed subset when present.
+- [x] Add the `user-managed (receipt): <agents>` text-output line next to the existing `updates: ...` line.
+- [x] Project the change into `assets/templates/helpers/check-agent-tooling.sh` via `bun scripts/sync-helper-sources.ts --write` and confirm `--check` is clean.
+- [x] Add characterization tests in `tests/check-agent-tooling.test.ts` for: valid receipt exemption, receipt hash mismatch still drift, malformed receipt fails closed (exempts nothing even when a hash would otherwise match), and unchanged behavior with no receipt present.
+- [x] Run `bun test`, `bun scripts/sync-helper-sources.ts --check`, `bash scripts/check-task-sync.sh`, `repo-harness run check-task-workflow --strict`, and a real-machine `bash scripts/check-agent-tooling.sh --host both --check-updates` smoke check against this machine's actual `~/.claude/agents/{deep-reasoner,gatekeeper}.md` receipt.
+- [x] Commit as a single commit with no AI attribution; discard any side-effect `docs/architecture/requests/*` file the commit hook generates.
+
+## Execution boundary
+
+Implement exactly the behavior spec above. Do not modify `install-agent-fleet.sh` or any other
+helper, do not add config flags, do not add a receipt migration or a new write path, do not push,
+do not open a PR. Branch: `codex/tooling-receipt-awareness` (already created off a clean `main` at
+`4089376b`).
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [x] Add a read-only `loadAgentFleetUserManagedReceipt()` reader plus a `sha256Buffer()` helper in `scripts/check-agent-tooling.sh`, mirroring `install-agent-fleet.sh`'s validation shape without its installer-specific `allowedPaths` gate (this checker's per-invocation host scope is narrower than the installer's fixed 12-path target set).
+- [x] Rewire `detectAgentFleetHost()`'s claude branch so a hash mismatch first checks the receipt (sha256 of current installed bytes) before falling back to drift; add `userManagedAgents` alongside `driftAgents`/`syncedAgents`/`sourceMissingAgents`, and surface `user_managed_agents` in the returned object.
+- [x] Rename the "no drift" terminal `update_status` value from `synced` to `up-to-date` (covering pure-synced and mixed synced/user-managed cases), with a reason that names the user-managed subset when present.
+- [x] Add the `user-managed (receipt): <agents>` text-output line next to the existing `updates: ...` line.
+- [x] Project the change into `assets/templates/helpers/check-agent-tooling.sh` via `bun scripts/sync-helper-sources.ts --write` and confirm `--check` is clean.
+- [x] Add characterization tests in `tests/check-agent-tooling.test.ts` for: valid receipt exemption, receipt hash mismatch still drift, malformed receipt fails closed (exempts nothing even when a hash would otherwise match), and unchanged behavior with no receipt present.
+- [x] Run `bun test`, `bun scripts/sync-helper-sources.ts --check`, `bash scripts/check-task-sync.sh`, `repo-harness run check-task-workflow --strict`, and a real-machine `bash scripts/check-agent-tooling.sh --host both --check-updates` smoke check against this machine's actual `~/.claude/agents/{deep-reasoner,gatekeeper}.md` receipt.
+- [x] Commit as a single commit with no AI attribution; discard any side-effect `docs/architecture/requests/*` file the commit hook generates.

--- a/scripts/check-agent-tooling.sh
+++ b/scripts/check-agent-tooling.sh
@@ -105,6 +105,7 @@ const AGENT_FLEET_SOURCE_DIR = process.env.REPO_HARNESS_AGENT_FLEET_SOURCE_DIR;
 const AGENT_FLEET_SOURCE_LABEL = "package:agents/fleet";
 const AGENT_FLEET_DEFAULT_MANAGED = ["explorer", "deep-reasoner", "fast-worker", "deep-worker", "gatekeeper", "root-cause-prover", "harness-evaluator"];
 const AGENT_FLEET_INSTALL_COMMAND = "repo-harness run install-agent-fleet";
+const AGENT_FLEET_USER_MANAGED_RECEIPT_PATH = path.join(HOME, ".repo-harness", "agent-fleet-user-managed.json");
 const CODEGRAPH_PACKAGE = "@colbymchenry/codegraph";
 const CODEGRAPH_GLOBAL_INSTALL_COMMAND = `bun add -g ${CODEGRAPH_PACKAGE} && repo-harness tools configure codegraph --target codex --location global`;
 const CODEGRAPH_MCP_CONFIGURE_COMMAND = "repo-harness tools configure codegraph --target <codex|claude|both> --location global";
@@ -246,6 +247,10 @@ function sha1(text) {
 
 function sha1Buffer(buffer) {
   return crypto.createHash("sha1").update(buffer).digest("hex");
+}
+
+function sha256Buffer(buffer) {
+  return `sha256:${crypto.createHash("sha256").update(buffer).digest("hex")}`;
 }
 
 function parseSkillVersion(text) {
@@ -872,6 +877,37 @@ function readAgentFleetSource(agent) {
   return { status: "read", path: sourcePath, hash: source.hash };
 }
 
+// Read-only mirror of install-agent-fleet.sh's loadUserManagedReceipt(): this
+// checker never writes ~/.repo-harness/agent-fleet-user-managed.json, it only
+// consults it so an operator-accepted customized file is not misreported as
+// drift. Any malformation invalidates the whole receipt (fail-closed) rather
+// than exempting individual entries.
+function loadAgentFleetUserManagedReceipt() {
+  if (!fs.existsSync(AGENT_FLEET_USER_MANAGED_RECEIPT_PATH)) return { ok: true, hashes: new Map() };
+  try {
+    const parsed = JSON.parse(fs.readFileSync(AGENT_FLEET_USER_MANAGED_RECEIPT_PATH, "utf8"));
+    if (
+      parsed?.protocol !== 1
+      || parsed?.authority !== "user-managed-agent-fleet"
+      || !Array.isArray(parsed.files)
+    ) return { ok: false, hashes: new Map() };
+    const hashes = new Map();
+    for (const entry of parsed.files) {
+      if (
+        !entry
+        || typeof entry.path !== "string"
+        || typeof entry.sha256 !== "string"
+        || !/^sha256:[a-f0-9]{64}$/.test(entry.sha256)
+        || hashes.has(entry.path)
+      ) return { ok: false, hashes: new Map() };
+      hashes.set(entry.path, entry.sha256);
+    }
+    return { ok: true, hashes };
+  } catch (_error) {
+    return { ok: false, hashes: new Map() };
+  }
+}
+
 function detectAgentFleetHost(host, managedAgents) {
   const meta = HOSTS[host];
   const files = managedAgents.map((agent) => inspectAgentFleetFile(host, agent));
@@ -884,9 +920,11 @@ function detectAgentFleetHost(host, managedAgents) {
   const driftAgents = [];
   const syncedAgents = [];
   const sourceMissingAgents = [];
+  const userManagedAgents = [];
 
   if (checkUpdates) {
     if (host === "claude") {
+      const receipt = loadAgentFleetUserManagedReceipt();
       for (const entry of files) {
         if (!entry.present) continue;
         const source = readAgentFleetSource(entry.name);
@@ -896,9 +934,25 @@ function detectAgentFleetHost(host, managedAgents) {
         }
         if (source.hash === entry.hash) {
           syncedAgents.push(entry.name);
-        } else {
-          driftAgents.push(entry.name);
+          continue;
         }
+        // Differs from the packaged source: only a valid receipt entry whose
+        // sha256 matches the file's *current* installed content exempts it.
+        // A missing/invalid receipt, a path with no entry, or a hash mismatch
+        // (edited again after acceptance) all fall through to drift.
+        if (receipt.ok && receipt.hashes.get(entry.path) !== undefined) {
+          let installedHash = null;
+          try {
+            installedHash = sha256Buffer(fs.readFileSync(entry.path));
+          } catch (_error) {
+            installedHash = null;
+          }
+          if (installedHash === receipt.hashes.get(entry.path)) {
+            userManagedAgents.push(entry.name);
+            continue;
+          }
+        }
+        driftAgents.push(entry.name);
       }
 
       if (driftAgents.length > 0) {
@@ -907,9 +961,11 @@ function detectAgentFleetHost(host, managedAgents) {
       } else if (sourceMissingAgents.length > 0) {
         updateStatus = "unknown";
         updateReason = `Packaged repo-harness fleet source is missing files for: ${sourceMissingAgents.join(", ")}.`;
-      } else if (syncedAgents.length > 0) {
-        updateStatus = "synced";
-        updateReason = "Installed Claude agent definitions match the packaged repo-harness fleet source.";
+      } else if (syncedAgents.length > 0 || userManagedAgents.length > 0) {
+        updateStatus = "up-to-date";
+        updateReason = userManagedAgents.length > 0
+          ? `Installed Claude agent definitions match the packaged repo-harness fleet source, with user-managed exemptions accepted via receipt for: ${userManagedAgents.join(", ")}.`
+          : "Installed Claude agent definitions match the packaged repo-harness fleet source.";
       } else {
         updateStatus = "not-checked";
         updateReason = "No installed Claude agent definitions to compare.";
@@ -931,6 +987,7 @@ function detectAgentFleetHost(host, managedAgents) {
     drift_agents: driftAgents,
     synced_agents: syncedAgents,
     source_missing_agents: sourceMissingAgents,
+    user_managed_agents: userManagedAgents,
   };
 }
 
@@ -1630,6 +1687,9 @@ function printText(result) {
     }
     if (entry.update_status !== "not-checked") {
       console.log(`    updates: ${entry.update_status} (${entry.update_reason})`);
+    }
+    if (entry.user_managed_agents.length) {
+      console.log(`    user-managed (receipt): ${entry.user_managed_agents.join(", ")}`);
     }
   }
   console.log(`  - Install: ${agentFleet.install_command}`);

--- a/tasks/contracts/20260801-1255-tooling-receipt-awareness.contract.md
+++ b/tasks/contracts/20260801-1255-tooling-receipt-awareness.contract.md
@@ -1,0 +1,169 @@
+# Task Contract: tooling-receipt-awareness
+
+> **Status**: Active
+> **Plan**: plans/plan-20260801-1255-tooling-receipt-awareness.md
+> **Task Profile**: code-change
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: ancienttwo
+> **Capability ID**: verification-evals-checks
+> **Last Updated**: 2026-08-01 12:55
+> **Review File**: `tasks/reviews/20260801-1255-tooling-receipt-awareness.review.md`
+> **Notes File**: `tasks/notes/20260801-1255-tooling-receipt-awareness.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+`scripts/check-agent-tooling.sh --host both --check-updates` compares installed Claude agent
+`.md` files against the packaged `agents/fleet/` source with zero awareness of the
+`~/.repo-harness/agent-fleet-user-managed.json` receipt `install-agent-fleet.sh --accept-user-managed`
+writes. An operator who intentionally accepted a customized `deep-reasoner.md`/`gatekeeper.md`
+gets a permanent false-positive `drift` reading with no way to clear it short of reverting the
+customization or re-running `--force`.
+
+## Goal
+
+`detectAgentFleetHost()` consults the receipt before classifying a byte difference as drift: a
+well-formed receipt entry whose sha256 matches the file's current installed content reclassifies
+that file as `user-managed` and excludes it from `drift_agents`. Every other case (no receipt,
+malformed receipt, no entry for that path, hash mismatch) still resolves to `drift`, fail-closed.
+The per-host rollup `update_status` becomes `up-to-date` once nothing is left in drift, and the
+text output surfaces the exemption on its own line instead of absorbing it silently.
+
+## Scope
+
+- In scope: `scripts/check-agent-tooling.sh` (`loadAgentFleetUserManagedReceipt`, `sha256Buffer`,
+  `detectAgentFleetHost` drift/synced/user-managed classification, `update_status` vocabulary,
+  text-output line); its projected mirror `assets/templates/helpers/check-agent-tooling.sh` via
+  `bun scripts/sync-helper-sources.ts --write`; characterization tests in
+  `tests/check-agent-tooling.test.ts` for valid-receipt exemption, stale-hash-still-drift,
+  malformed-receipt-fail-closed, and no-receipt-unchanged; this contract's plan/notes pair.
+- Out of scope: `scripts/install-agent-fleet.sh` (receipt-writing side, untouched); any other
+  helper; new config flags; a receipt migration or new `~/.repo-harness` write path;
+  `docs/reference-configs/external-tooling.md` (flagged as stale in the notes file, not corrected
+  here); push or PR.
+- Taste constraints: <!-- advisory only, no run gate; default style/taste lives in AGENTS.md and the minimal-change policy, use this to record a per-task override -->
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+
+## Falsifier
+
+If a file whose receipt entry is stale (edited again after acceptance, or the receipt itself is
+malformed) still reports `user-managed` instead of `drift`, the fail-closed contract is broken and
+the direction is wrong. Cheapest proof point: the "keeps drift when a receipt entry's sha256 no
+longer matches" and "fails closed on a malformed receipt" tests in
+`tests/check-agent-tooling.test.ts` must both still report `drift`/`[]` for `user_managed_agents`.
+
+## Root Cause Evidence
+
+Required when Task Profile is `bugfix`; leave as-is otherwise.
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260801-1255-tooling-receipt-awareness.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260801-1255-tooling-receipt-awareness.review.md`
+- Notes file: `tasks/notes/20260801-1255-tooling-receipt-awareness.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Acceptance Policy
+
+```json
+{"protocol":1,"reviewer":"Claude","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - docs/spec.md
+  - plans/
+  - tasks/todos.md
+  - tasks/contracts/20260801-1255-tooling-receipt-awareness.contract.md
+  - tasks/reviews/20260801-1255-tooling-receipt-awareness.review.md
+  - tasks/notes/20260801-1255-tooling-receipt-awareness.notes.md
+  - .ai/context/capabilities.json
+  - .claude/templates/
+  - scripts/check-agent-tooling.sh
+  - assets/templates/helpers/check-agent-tooling.sh
+  - tests/
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+      - codex-exec
+      - main-thread
+    fallback: main-thread
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - docs/spec.md
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260801-1255-tooling-receipt-awareness.notes.md
+  tests_pass:
+    - path: tests/check-agent-tooling.test.ts
+  commands_succeed:
+    - bun test
+    - bun scripts/sync-helper-sources.ts --check
+    - bash scripts/check-task-sync.sh
+    - bash scripts/check-deploy-sql-order.sh
+    - bash scripts/check-architecture-sync.sh
+```
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior:
+- Edge cases:
+- Regression risks:
+
+## Rollback Point
+
+- Commit / checkpoint: `4089376b` (main at branch creation, branch `codex/tooling-receipt-awareness`)
+- Revert strategy: revert the commit — the drift check returns to plain sha1-vs-packaged-source
+  comparison with the receipt ignored (false positive returns, no worse than before this change).

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,27 +1,27 @@
 # Current Status Snapshot
 
 <!-- generated-by: repo-harness refresh-current-status v1 -->
-<!-- updated_at: 2026-07-31T22:57:08+0800 -->
+<!-- updated_at: 2026-08-01T13:05:41+0800 -->
 <!-- stale_after: 24h -->
 
-> **Status**: Idle
-> **Updated At**: 2026-07-31T22:57:08+0800
-> **Source Branch**: main
-> **Source Commit**: 01c821d1
+> **Status**: ManualClearedWithActiveWork
+> **Updated At**: 2026-08-01T13:05:41+0800
+> **Source Branch**: codex/tooling-receipt-awareness
+> **Source Commit**: 4089376b
 > **Target Branch**: main
 > **Stale After**: 24h
-> **Reason**: codegraph-update
+> **Reason**: ensure-task-workflow
 > **Derived From**: active-plan, active-sprint, workstreams, handoff, checks, git status
 
 This file is a tracked mainline snapshot derived from repo artifacts. It is not a live lock, not a kanban board, and not an implementation gate. If it is stale, read the source artifacts below.
 
 ## Current Focus
 
-- Status: Idle
-- Active Plan: (none)
-- Plan Status: (none)
-- Next Task: (none)
-- Clear Note: (none)
+- Status: ManualClearedWithActiveWork
+- Active Plan: plans/plan-20260801-1255-tooling-receipt-awareness.md
+- Plan Status: Approved
+- Next Task: Add characterization tests in `tests/check-agent-tooling.test.ts` for: valid receipt exemption, receipt hash mismatch still drift, malformed receipt fails closed (exempts nothing even when a hash would otherwise match), and unchanged behavior with no receipt present.
+- Clear Note: Manual clear requested, but active work markers still exist. Idle was not written.
 
 ## Mainline Snapshot Reading
 
@@ -31,7 +31,8 @@ This file is a tracked mainline snapshot derived from repo artifacts. It is not 
 
 ## Active Work
 
-- (none)
+- .: plans/plan-20260801-1255-tooling-receipt-awareness.md
+- .: active-worktree owner -> /Users/ancienttwo/Projects/repo-harness
 ## Active Sprint
 
 - Sprint: (none)
@@ -54,11 +55,14 @@ This file is a tracked mainline snapshot derived from repo artifacts. It is not 
 
 ## Git Status
 
-- Summary: 2 changed/untracked path(s)
+- Summary: 5 changed/untracked path(s)
 
 ```
- M bun.lock
- M package.json
+ M assets/templates/helpers/check-agent-tooling.sh
+ M scripts/check-agent-tooling.sh
+ M tests/check-agent-tooling.test.ts
+?? plans/plan-20260801-1255-tooling-receipt-awareness.md
+?? tasks/notes/20260801-1255-tooling-receipt-awareness.notes.md
 ```
 
 ## Source Artifacts

--- a/tasks/notes/20260801-1255-tooling-receipt-awareness.notes.md
+++ b/tasks/notes/20260801-1255-tooling-receipt-awareness.notes.md
@@ -1,0 +1,64 @@
+# Notes: tooling receipt awareness
+
+Plan: `plans/plan-20260801-1255-tooling-receipt-awareness.md`
+
+## Decisions and deviations
+
+- **`update_status` "synced" retired in favor of "up-to-date"**: the spec's
+  "全部檔案要嘛 synced 要嘛 user-managed 時,update_status 應為 up-to-date" reads as a
+  universal statement (true even when the user-managed subset is empty), and
+  `"up-to-date"` was already an established status-string spelling elsewhere in
+  this same script (`parseCodeGraphProjectStatus`). Implemented as a full
+  rename of the terminal "no drift" value for `hosts.claude.update_status`,
+  not a new value that only appears alongside user-managed exemptions. No
+  existing test pinned the literal `"synced"` value for this field (verified
+  via repo-wide grep before changing it), so this is not a breaking rename of
+  covered behavior.
+
+- **No `allowedPaths` gate in the checker's receipt loader**: unlike
+  `install-agent-fleet.sh`'s `loadUserManagedReceipt(allowedPaths)`, the new
+  `loadAgentFleetUserManagedReceipt()` in `check-agent-tooling.sh` does not
+  reject the whole receipt when it contains entries outside a fixed target
+  set. The installer always resolves all 12 target paths (both hosts) before
+  validating, so a foreign path is unambiguously wrong. This checker can be
+  invoked with `--host claude` alone, in which case a legitimately-written
+  full receipt (covering both hosts) would contain Codex `.toml` entries the
+  single-host run never looks up. Replicating the installer's strict
+  allow-list would have invalidated a valid receipt purely because of host
+  scope, which is a false negative the installer never has to worry about.
+  Well-formedness (protocol/authority/shape/regex/no duplicate paths) is
+  still fully enforced; only the "every entry must be in a pre-known allowed
+  set" clause was intentionally omitted, since lookups are by exact path via
+  `Map.get`, so an irrelevant entry is simply never consulted.
+
+- **`docs/reference-configs/external-tooling.md` left untouched**: its
+  "### Readiness" section still documents the pre-fix behavior ("compares...
+  and reports `drift`/`synced` per agent"), which is now stale after this
+  change (receipt-covered files report `user-managed`, and the per-host
+  rollup value is `up-to-date`, not `synced`). Left out of scope: the
+  dispatch's behavior spec and EXECUTION_BOUNDARY named `check-agent-tooling.sh`,
+  its `assets/templates/helpers/` mirror, and its tests; docs were not listed
+  and this repo's own EXECUTION_BOUNDARY convention treats "extra docs" as
+  forbidden unless explicitly requested. Flagged here as a residual
+  documentation-staleness item rather than fixed inline.
+
+- **Defensive try/catch around the extra sha256 read**: `detectAgentFleetHost`
+  already read each installed file once (via `inspectAgentFleetFile` ->
+  `readFileHash` -> sha1) before the new receipt-comparison step re-reads the
+  same path to compute sha256. The re-read is wrapped in try/catch, treating
+  a read failure as "cannot prove user-managed" (falls through to drift)
+  rather than letting an uncaught exception crash the whole check. This
+  mirrors the existing local pattern used by `readFileHash`/`readText`/
+  `readJson` in the same file (every fs read is wrapped and returns a
+  sentinel on failure), and keeps the fail-closed contract: an unreadable
+  file cannot be exempted either.
+
+- **Plan-capture detour**: `tests/check-agent-tooling.test.ts` is not a
+  workflow-surface path, so the repo's `PlanStatusGuard` (`.guards.edit_plan_gate:
+  enforce`) blocked the first edit attempt with no active plan. Captured the
+  dispatch's own already-decision-complete spec as this plan via
+  `repo-harness run capture-plan --status Approved` (no `--execute`, so
+  `plan-to-todo`/`contract-worktree start` automation never ran) to avoid
+  conflicting with the orchestrator's explicit instruction to work directly
+  on branch `codex/tooling-receipt-awareness` in the primary checkout rather
+  than a contract worktree.

--- a/tests/check-agent-tooling.test.ts
+++ b/tests/check-agent-tooling.test.ts
@@ -25,6 +25,27 @@ function sha256File(filePath: string) {
   return createHash("sha256").update(readFileSync(filePath)).digest("hex");
 }
 
+function sha256Text(content: string) {
+  return `sha256:${createHash("sha256").update(content).digest("hex")}`;
+}
+
+function writeAgentFleetReceipt(home: string, files: Array<{ path: string; sha256: string }>, authority = "user-managed-agent-fleet") {
+  mkdirSync(join(home, ".repo-harness"), { recursive: true });
+  writeFileSync(
+    join(home, ".repo-harness", "agent-fleet-user-managed.json"),
+    JSON.stringify(
+      {
+        protocol: 1,
+        authority,
+        accepted_at: "2026-07-30T00:00:00.000Z",
+        files,
+      },
+      null,
+      2
+    )
+  );
+}
+
 function writeExecutable(filePath: string, content: string) {
   writeFileSync(filePath, content);
   chmodSync(filePath, 0o755);
@@ -1020,13 +1041,202 @@ describe("check-agent-tooling", () => {
         "harness-evaluator",
       ]);
       expect(claude.source_missing_agents).toEqual([]);
+      expect(claude.user_managed_agents).toEqual([]);
       const codex = report.tools.agent_fleet.hosts.codex;
       expect(codex.update_status).toBe("not-applicable");
       expect(codex.drift_agents).toEqual([]);
       expect(codex.synced_agents).toEqual([]);
+      expect(codex.user_managed_agents).toEqual([]);
 
       expect(readFileSync(SCRIPT, "utf-8")).not.toContain("Fable-agents");
       expect(readFileSync(SCRIPT, "utf-8")).not.toContain("fetchAgentFleetUpstream");
+    } finally {
+      rmSync(envRoot.root, { recursive: true, force: true });
+    }
+  }, 15000);
+
+  test("exempts files covered by a valid user-managed receipt from drift and reports up-to-date", () => {
+    const envRoot = setupFakeEnvironment("check-agent-tooling-fleet-receipt-valid");
+    try {
+      const localContent: Record<string, string> = {};
+      for (const agent of MANAGED_AGENTS) {
+        localContent[agent] = readFileSync(join(FLEET_SOURCE_DIR, `${agent}.md`), "utf-8");
+      }
+      localContent["deep-reasoner"] += "\n# user-managed customization\n";
+      localContent["gatekeeper"] += "\n# user-managed customization\n";
+
+      mkdirSync(join(envRoot.home, ".claude", "agents"), { recursive: true });
+      mkdirSync(join(envRoot.home, ".codex", "agents"), { recursive: true });
+      for (const agent of MANAGED_AGENTS) {
+        writeFileSync(join(envRoot.home, ".claude", "agents", `${agent}.md`), localContent[agent]);
+        writeFileSync(join(envRoot.home, ".codex", "agents", `${agent}.toml`), `name = "${agent}"\n`);
+      }
+
+      writeAgentFleetReceipt(envRoot.home, [
+        {
+          path: join(envRoot.home, ".claude", "agents", "deep-reasoner.md"),
+          sha256: sha256Text(localContent["deep-reasoner"]),
+        },
+        {
+          path: join(envRoot.home, ".claude", "agents", "gatekeeper.md"),
+          sha256: sha256Text(localContent["gatekeeper"]),
+        },
+      ]);
+
+      writeFakeBunx(envRoot.fakeBin);
+      writeFakeCodeGraph(envRoot.fakeBin);
+      writeFakeNpm(envRoot.fakeBin, "0.9.6");
+
+      const res = spawnSync("bash", [SCRIPT, "--json", "--check-updates", "--host", "both"], {
+        cwd: ROOT,
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          HOME: envRoot.home,
+          PATH: `${envRoot.fakeBin}:${process.env.PATH ?? ""}`,
+          AGENTIC_DEV_CODEGRAPH_ALLOW_REPO_LOCAL: "0",
+        },
+      });
+
+      expect(res.status).toBe(0);
+      const report = JSON.parse(res.stdout);
+      const claude = report.tools.agent_fleet.hosts.claude;
+      expect(claude.update_status).toBe("up-to-date");
+      expect(claude.drift_agents).toEqual([]);
+      expect(claude.user_managed_agents).toEqual(["deep-reasoner", "gatekeeper"]);
+      expect(claude.synced_agents).toEqual([
+        "explorer",
+        "fast-worker",
+        "deep-worker",
+        "root-cause-prover",
+        "harness-evaluator",
+      ]);
+      expect(claude.source_missing_agents).toEqual([]);
+      expect(claude.update_reason).toContain("deep-reasoner, gatekeeper");
+      const codex = report.tools.agent_fleet.hosts.codex;
+      expect(codex.user_managed_agents).toEqual([]);
+
+      const textRes = spawnSync("bash", [SCRIPT, "--check-updates", "--host", "both"], {
+        cwd: ROOT,
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          HOME: envRoot.home,
+          PATH: `${envRoot.fakeBin}:${process.env.PATH ?? ""}`,
+          AGENTIC_DEV_CODEGRAPH_ALLOW_REPO_LOCAL: "0",
+        },
+      });
+      expect(textRes.status).toBe(0);
+      expect(textRes.stdout).toContain("user-managed (receipt): deep-reasoner, gatekeeper");
+      expect(textRes.stdout).not.toContain("updates: drift");
+    } finally {
+      rmSync(envRoot.root, { recursive: true, force: true });
+    }
+  }, 15000);
+
+  test("keeps drift when a receipt entry's sha256 no longer matches the installed file", () => {
+    const envRoot = setupFakeEnvironment("check-agent-tooling-fleet-receipt-stale-hash");
+    try {
+      const localContent: Record<string, string> = {};
+      for (const agent of MANAGED_AGENTS) {
+        localContent[agent] = readFileSync(join(FLEET_SOURCE_DIR, `${agent}.md`), "utf-8");
+      }
+      const acceptedContent = `${localContent["fast-worker"]}\n# accepted customization\n`;
+      localContent["fast-worker"] = `${acceptedContent}\n# edited again after acceptance\n`;
+
+      mkdirSync(join(envRoot.home, ".claude", "agents"), { recursive: true });
+      mkdirSync(join(envRoot.home, ".codex", "agents"), { recursive: true });
+      for (const agent of MANAGED_AGENTS) {
+        writeFileSync(join(envRoot.home, ".claude", "agents", `${agent}.md`), localContent[agent]);
+        writeFileSync(join(envRoot.home, ".codex", "agents", `${agent}.toml`), `name = "${agent}"\n`);
+      }
+
+      // The receipt records the hash of the previously accepted bytes, not the
+      // file's current (further-edited) content, so it must not exempt it.
+      writeAgentFleetReceipt(envRoot.home, [
+        {
+          path: join(envRoot.home, ".claude", "agents", "fast-worker.md"),
+          sha256: sha256Text(acceptedContent),
+        },
+      ]);
+
+      writeFakeBunx(envRoot.fakeBin);
+      writeFakeCodeGraph(envRoot.fakeBin);
+      writeFakeNpm(envRoot.fakeBin, "0.9.6");
+
+      const res = spawnSync("bash", [SCRIPT, "--json", "--check-updates", "--host", "both"], {
+        cwd: ROOT,
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          HOME: envRoot.home,
+          PATH: `${envRoot.fakeBin}:${process.env.PATH ?? ""}`,
+          AGENTIC_DEV_CODEGRAPH_ALLOW_REPO_LOCAL: "0",
+        },
+      });
+
+      expect(res.status).toBe(0);
+      const report = JSON.parse(res.stdout);
+      const claude = report.tools.agent_fleet.hosts.claude;
+      expect(claude.update_status).toBe("drift");
+      expect(claude.drift_agents).toEqual(["fast-worker"]);
+      expect(claude.user_managed_agents).toEqual([]);
+    } finally {
+      rmSync(envRoot.root, { recursive: true, force: true });
+    }
+  }, 15000);
+
+  test("fails closed on a malformed receipt and exempts nothing even if a hash would otherwise match", () => {
+    const envRoot = setupFakeEnvironment("check-agent-tooling-fleet-receipt-invalid");
+    try {
+      const localContent: Record<string, string> = {};
+      for (const agent of MANAGED_AGENTS) {
+        localContent[agent] = readFileSync(join(FLEET_SOURCE_DIR, `${agent}.md`), "utf-8");
+      }
+      localContent["deep-reasoner"] += "\n# user-managed customization\n";
+
+      mkdirSync(join(envRoot.home, ".claude", "agents"), { recursive: true });
+      mkdirSync(join(envRoot.home, ".codex", "agents"), { recursive: true });
+      for (const agent of MANAGED_AGENTS) {
+        writeFileSync(join(envRoot.home, ".claude", "agents", `${agent}.md`), localContent[agent]);
+        writeFileSync(join(envRoot.home, ".codex", "agents", `${agent}.toml`), `name = "${agent}"\n`);
+      }
+
+      // The hash entry matches the current file exactly, but the receipt's
+      // authority tag is wrong: the whole receipt must be rejected rather than
+      // exempting the one entry that "would" match.
+      writeAgentFleetReceipt(
+        envRoot.home,
+        [
+          {
+            path: join(envRoot.home, ".claude", "agents", "deep-reasoner.md"),
+            sha256: sha256Text(localContent["deep-reasoner"]),
+          },
+        ],
+        "not-the-expected-authority"
+      );
+
+      writeFakeBunx(envRoot.fakeBin);
+      writeFakeCodeGraph(envRoot.fakeBin);
+      writeFakeNpm(envRoot.fakeBin, "0.9.6");
+
+      const res = spawnSync("bash", [SCRIPT, "--json", "--check-updates", "--host", "both"], {
+        cwd: ROOT,
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          HOME: envRoot.home,
+          PATH: `${envRoot.fakeBin}:${process.env.PATH ?? ""}`,
+          AGENTIC_DEV_CODEGRAPH_ALLOW_REPO_LOCAL: "0",
+        },
+      });
+
+      expect(res.status).toBe(0);
+      const report = JSON.parse(res.stdout);
+      const claude = report.tools.agent_fleet.hosts.claude;
+      expect(claude.update_status).toBe("drift");
+      expect(claude.drift_agents).toEqual(["deep-reasoner"]);
+      expect(claude.user_managed_agents).toEqual([]);
     } finally {
       rmSync(envRoot.root, { recursive: true, force: true });
     }


### PR DESCRIPTION
Makes check-agent-tooling.sh agent-fleet drift detection receipt-aware: installed agent files whose content sha256 matches an accepted entry in ~/.repo-harness/agent-fleet-user-managed.json report as user-managed instead of drift, with an explicit exemption line in text output and user_managed_agents in JSON. Missing, malformed, or hash-mismatched receipts stay fail-closed as drift. The assets/templates/helpers mirror is synced byte-identical, and tests cover exemption, post-accept modification, invalid receipt, and no-receipt paths (18 pass in the target suite; init-hook consumer suite 20 pass; full bun test 2123 pass / 0 fail on the branch).

Closes the gap where install-agent-fleet.sh honored user-managed receipts but the health report still flagged the same files as permanent drift false positives.