### PR TITLE
docs(delegation): App Thread live canary evidence and readback contract

### DIFF
--- a/assets/reference-configs/external-tooling.md
+++ b/assets/reference-configs/external-tooling.md
@@ -553,8 +553,27 @@ of the default thread path. Thread-path model evidence comes from official
 thread reads instead: the requested `model`/`thinking` passed to
 `codex_app__create_thread` and the model observed on the materialized thread are
 recorded separately, and a thread whose runtime model was never read back stays
-unverified. This slice ships the routing wording only; a live `create_thread`
-canary on the user's Codex host remains a runtime-readiness follow-up.
+unverified. A post-merge live canary on 2026-08-02 requested
+`gpt-5.6-luna`/`max`, materialized a worktree thread, and completed a bounded
+read-only task at the shipped main SHA. The host-owned rollout `turn_context`
+observed `model = gpt-5.6-luna` and `effort = max`, which proves the host-local
+execution matched the request. It does not close the orchestrator contract: the
+current `codex_app__read_thread` response omitted model and effort fields, so
+portable runtime readiness remains unverified and must not be inferred from
+create-call acceptance or private rollout parsing.
+
+The readback contract is version-bound and fail-closed. On Codex CLI
+`0.146.0-alpha.9.2`, `codex app-server generate-json-schema` shows that
+`ThreadReadResponse` contains only `thread`, while its `Thread` object exposes
+`modelProvider` but neither `model` nor `reasoningEffort`. The same generated
+schema exposes `model` and nullable `reasoningEffort` on `ThreadStartResponse`
+and `ThreadResumeResponse`, but the App Thread tools do not propagate those
+fields across the pending-worktree materialization path. Runtime readiness is
+closed only when a public App Thread response exposes the materialized thread's
+observed `model` and reasoning effort separately from the requested tuple. A
+missing or mismatched observed tuple keeps the role-routed result unverified and
+selects the declared fallback; repo-harness must not scrape rollout JSONL or
+SQLite as a compatibility path.
 
 `developer_instructions` is the packaged `.md` body plus the canonical
 EXECUTION_BOUNDARY anti-extras clause, kept byte-identical to the

--- a/docs/reference-configs/external-tooling.md
+++ b/docs/reference-configs/external-tooling.md
@@ -553,8 +553,27 @@ of the default thread path. Thread-path model evidence comes from official
 thread reads instead: the requested `model`/`thinking` passed to
 `codex_app__create_thread` and the model observed on the materialized thread are
 recorded separately, and a thread whose runtime model was never read back stays
-unverified. This slice ships the routing wording only; a live `create_thread`
-canary on the user's Codex host remains a runtime-readiness follow-up.
+unverified. A post-merge live canary on 2026-08-02 requested
+`gpt-5.6-luna`/`max`, materialized a worktree thread, and completed a bounded
+read-only task at the shipped main SHA. The host-owned rollout `turn_context`
+observed `model = gpt-5.6-luna` and `effort = max`, which proves the host-local
+execution matched the request. It does not close the orchestrator contract: the
+current `codex_app__read_thread` response omitted model and effort fields, so
+portable runtime readiness remains unverified and must not be inferred from
+create-call acceptance or private rollout parsing.
+
+The readback contract is version-bound and fail-closed. On Codex CLI
+`0.146.0-alpha.9.2`, `codex app-server generate-json-schema` shows that
+`ThreadReadResponse` contains only `thread`, while its `Thread` object exposes
+`modelProvider` but neither `model` nor `reasoningEffort`. The same generated
+schema exposes `model` and nullable `reasoningEffort` on `ThreadStartResponse`
+and `ThreadResumeResponse`, but the App Thread tools do not propagate those
+fields across the pending-worktree materialization path. Runtime readiness is
+closed only when a public App Thread response exposes the materialized thread's
+observed `model` and reasoning effort separately from the requested tuple. A
+missing or mismatched observed tuple keeps the role-routed result unverified and
+selects the declared fallback; repo-harness must not scrape rollout JSONL or
+SQLite as a compatibility path.
 
 `developer_instructions` is the packaged `.md` body plus the canonical
 EXECUTION_BOUNDARY anti-extras clause, kept byte-identical to the

--- a/tasks/notes/20260802-0309-codex-app-thread-dispatch.notes.md
+++ b/tasks/notes/20260802-0309-codex-app-thread-dispatch.notes.md
@@ -4,7 +4,7 @@
 > **Plan**: plans/plan-20260802-0309-codex-app-thread-dispatch.md
 > **Contract**: tasks/contracts/20260802-0309-codex-app-thread-dispatch.contract.md
 > **Review**: tasks/reviews/20260802-0309-codex-app-thread-dispatch.review.md
-> **Last Updated**: 2026-08-02 03:09
+> **Last Updated**: 2026-08-02 09:39
 > **Lifecycle**: notes
 
 ## Design Decisions
@@ -37,7 +37,60 @@
 
 ## Open Questions
 
-- None. Live `codex_app__create_thread` model acceptance stays a post-merge runtime canary per the plan's Out of scope.
+- Public readback observability remains incomplete: this Codex host's
+  `codex_app__read_thread` result did not expose model or effort even though the
+  host-owned rollout recorded both. Host-local execution matched the requested
+  tuple, but portable requested-vs-observed comparison through the public thread
+  tool is still unavailable and runtime readiness remains unverified at the
+  orchestrator contract.
+
+## Post-merge live App Thread canary
+
+- Requested role tuple from `~/.codex/agents/fast-worker.toml`:
+  `model = gpt-5.6-luna`, `model_reasoning_effort = max`; passed to
+  `codex_app__create_thread` as `model = gpt-5.6-luna`, `thinking = max`.
+- Creation first returned pending worktree id
+  `client-new-thread:1ca3d825-82b8-4263-9e15-9182e3a5b498`, then materialized
+  thread `019fc01e-05fa-7db1-a012-b4a499e4896f` in detached worktree
+  `/Users/ancienttwo/.codex/worktrees/f6db/repo-harness`.
+- The bounded read-only worker completed `RESULT: DONE`; its literal readback was
+  `git rev-parse HEAD` -> `1c64c507e5f535be6e800672dadd2db8fb90ac7d`
+  and `git status --short --branch` -> `## HEAD (no branch)`.
+- Official `codex_app__read_thread` confirmed the materialized thread and final
+  turn but returned no model/effort fields. The host-owned rollout
+  `/Users/ancienttwo/.codex/archived_sessions/rollout-2026-08-02T09-37-00-019fc01e-05fa-7db1-a012-b4a499e4896f.jsonl`
+  supplied the observed runtime tuple in its `turn_context`:
+  `model = gpt-5.6-luna`, `effort = max` (and the same values in collaboration
+  settings). Requested and observed tuples match.
+- Verdict: the live host accepts and honors per-thread model/thinking for the
+  fast-worker tuple, so the create/execute half of the plan's falsifier did not
+  fire. Public readback remains unverified; the completed canary thread was
+  archived through the App Thread lifecycle surface.
+
+## Public readback contract closure
+
+- Official Codex manual: `thread/read` returns the persisted `Thread` plus
+  runtime `status`; it does not document selected model or reasoning effort as
+  fields of that object. The manual also states generated schemas are specific
+  to the Codex version that produced them.
+- Versioned local proof on Codex CLI `0.146.0-alpha.9.2`:
+  `codex app-server generate-json-schema --out <temp-dir>` generated a
+  `ThreadReadResponse` whose only property is `thread`; the referenced `Thread`
+  has `modelProvider` but no `model` or `reasoningEffort`. In contrast,
+  `ThreadStartResponse` and `ThreadResumeResponse` require `model` and expose
+  nullable `reasoningEffort`.
+- Concrete pressure point: `codex_app__create_thread` returned only a pending
+  worktree id before materialization, and `codex_app__read_thread` later returned
+  the materialized thread/final turn without the start/resume model fields. The
+  public App Thread tool chain therefore loses the selected tuple exactly across
+  the async worktree boundary.
+- Closure criterion: after materialization, a public App Thread response must
+  expose observed `model` and reasoning effort separately from the requested
+  values. Missing or mismatched observed values keep the result unverified and
+  select the declared runner fallback.
+- Rejected compatibility path: repo-harness will not parse private rollout JSONL
+  or SQLite to synthesize public readback. Those files remain host-local
+  diagnostic evidence, not an orchestrator API contract.
 
 ## Evidence Links
 


### PR DESCRIPTION
Records the live App Thread canary run from 2026-08-02 in the delegation notes and the external-tooling reference (docs/ and assets/ copies kept byte-identical).

What it establishes:
- `create_thread` accepts and honors the fast-worker profile (gpt-5.6-luna / max): requested == observed via the host-owned rollout `turn_context`.
- Public `read_thread` omits model/effort on Codex CLI 0.146.0-alpha.9.2, so portable orchestrator readback stays unverified and the contract remains fail-closed and version-bound.

Why: closes the residual-risk follow-up declared in #155 — the dispatch path was documented as unverified pending a live canary, and this is that evidence.