### PR TITLE
release(0.12.2): prepare npm and GitHub release

### DIFF
--- a/.claude/.skill-version
+++ b/.claude/.skill-version
@@ -1,3 +1,3 @@
-skill_version=0.12.1
-template_version=0.12.1
+skill_version=0.12.2
+template_version=0.12.2
 migrated_at=2026-07-18T22:31:36Z

--- a/README.es.md
+++ b/README.es.md
@@ -466,8 +466,8 @@ repositorio adopte la misma política.
 
 ## Versión actual
 
-- Paquete npm: `repo-harness@0.12.1`
-- Sello de workflow generado: `repo-harness@0.12.1+template@0.12.1`
+- Paquete npm: `repo-harness@0.12.2`
+- Sello de workflow generado: `repo-harness@0.12.2+template@0.12.2`
 - Repositorio de GitHub: `Ancienttwo/repo-harness`
 - Notas de versión e historial: [`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -461,8 +461,8 @@ adopte la même policy.
 
 ## Release actuelle
 
-- Package npm : `repo-harness@0.12.1`
-- Generated workflow stamp : `repo-harness@0.12.1+template@0.12.1`
+- Package npm : `repo-harness@0.12.2`
+- Generated workflow stamp : `repo-harness@0.12.2+template@0.12.2`
 - Dépôt GitHub : `Ancienttwo/repo-harness`
 - Notes et historique de release : [`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -469,8 +469,8 @@ commit script や hooks に組み込まないでください。
 
 ## 現在の Release
 
-- npm package：`repo-harness@0.12.1`
-- Generated workflow stamp：`repo-harness@0.12.1+template@0.12.1`
+- npm package：`repo-harness@0.12.2`
+- Generated workflow stamp：`repo-harness@0.12.2+template@0.12.2`
 - GitHub repository：`Ancienttwo/repo-harness`
 - Release notes and history：[`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -441,8 +441,8 @@ repo-harness commit scripts or hooks unless that repo adopts the same policy.
 
 ## Current Release
 
-- npm package: `repo-harness@0.12.1`
-- Generated workflow stamp: `repo-harness@0.12.1+template@0.12.1`
+- npm package: `repo-harness@0.12.2`
+- Generated workflow stamp: `repo-harness@0.12.2+template@0.12.2`
 - GitHub repository: `Ancienttwo/repo-harness`
 - Release notes and history: [`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -448,8 +448,8 @@ policy。
 
 ## 当前 Release
 
-- npm package：`repo-harness@0.12.1`
-- Generated workflow stamp：`repo-harness@0.12.1+template@0.12.1`
+- npm package：`repo-harness@0.12.2`
+- Generated workflow stamp：`repo-harness@0.12.2+template@0.12.2`
 - GitHub repository：`Ancienttwo/repo-harness`
 - Release notes 和 history：[`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/assets/skill-version.json
+++ b/assets/skill-version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.12.1",
-  "templateVersion": "0.12.1",
+  "version": "0.12.2",
+  "templateVersion": "0.12.2",
   "skillName": "repo-harness",
   "contractId": "tasks-first-harness-v1",
   "compatibility": {
@@ -231,6 +231,10 @@
     {
       "version": "0.12.1",
       "description": "Threads a single SessionStart-minted run identity through hook telemetry and evidence correlation, restructures the five-language README into a get-started-first layout, and refreshes the CodeGraph dev dependency line to latest"
+    },
+    {
+      "version": "0.12.2",
+      "description": "Makes agent-fleet drift checks receipt-aware, hardens verifier environment and provenance boundaries, and routes Codex delegation through model-pinned App Threads with fail-closed fallbacks"
     }
   ],
   "generatedProjectStamp": {

--- a/deploy/release-checklists/260802-repo-harness-0.12.2.md
+++ b/deploy/release-checklists/260802-repo-harness-0.12.2.md
@@ -1,0 +1,65 @@
+# repo-harness 0.12.2 Release Filing
+
+- Date: 2026-08-02
+- Package: `repo-harness@0.12.2`
+- Base release: `v0.12.1`
+- Source range: `v0.12.1..candidate`
+- Release scope: make agent-fleet health receipt-aware, converge packaged fleet
+  authorship, isolate verification from helper-injected environment and stale
+  provenance, and move Codex delegation to exact role-mapped App Threads with
+  fail-closed native-spawn eligibility plus codex-exec/main-thread degradation.
+- Publish status: **pending publish**. This filing does not claim npm, Git tag,
+  or GitHub Release completion until the public readbacks below pass.
+
+## Candidate Evidence
+
+- `e5498b86` / PR #148 makes `check-agent-tooling.sh` honor hash-bound
+  user-managed receipts and keeps absent, invalid, or mismatched receipts on the
+  drift path; `048ced89` / PR #149 documents the contract, makes
+  `agents/fleet/` the single authored role authority, and regenerates the
+  gatekeeper Codex fixture through the installer mapping.
+- `27c42d77` / PR #150 removes real upstream network calls from the four receipt
+  update-check tests by using the suite's existing fake-curl boundary.
+- `62daea2e` / PR #152 scrubs the whole `REPO_HARNESS_*` prefix at the bounded
+  verifier spawn boundary; `5e89f6c8` / PR #153 strips materializer-owned
+  provenance from the acceptance finalize overlay so the resulting projection
+  re-verifies from its own bytes.
+- `143e36b0`, `5e89f6c8`, and `876725fe` close the fulfilled workflow packages
+  through typed acceptance and archive surfaces without adding product
+  compatibility paths.
+- `1c64c507` / PR #155 changes the canonical policy, advisor, standing
+  authorization, downstream initializer seeds, helper mirror, and tests to
+  prefer App Threads with role-TOML model/effort and fail closed when either
+  thread or native schema cannot carry the exact tuple.
+- `7c93c914` / PR #156 records the live fast-worker canary: requested and
+  host-observed `gpt-5.6-luna`/`max` matched, while public `read_thread` omitted
+  model/effort on Codex CLI `0.146.0-alpha.9.2`; portable runtime readiness
+  therefore remains unverified rather than inferred from rollout JSONL.
+- Version sources and localized README projections are `0.12.2`; the generated
+  stamp is `repo-harness@0.12.2+template@0.12.2`.
+
+## Required Release Sequence
+
+- [ ] Merge the release-candidate changes to `main` without unrelated files.
+- [ ] Confirm all GitHub CI jobs are green for the merged source commit.
+- [ ] Run `bun run check:release` on that exact merged commit.
+- [ ] Publish `repo-harness@0.12.2` to the official npm registry with `latest`.
+- [ ] Create and push annotated tag `v0.12.2` at the published source commit.
+- [ ] Create stable GitHub Release `repo-harness 0.12.2` from `v0.12.2` with no
+      attached asset, matching the established release convention.
+- [ ] Run `bash scripts/check-release-published.sh 0.12.2` and verify registry,
+      dist-tag, tarball integrity, source tag, GitHub Release, and clean-room CLI.
+
+## Candidate Verification Record
+
+- The release gate is run on the release-prep branch before merge and again on
+  the exact merged `main` commit before publication.
+- Hosted CI, exact-main release gate, npm publication, annotated tag, GitHub
+  Release, and published-package readbacks remain mandatory release operations;
+  no unchecked item above is represented as completed by this source filing.
+
+## Rollback
+
+- Before npm publication: revert or abandon the release-prep commit.
+- After npm publication: never move or reuse `v0.12.2`; correct forward with a
+  new patch release.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to this skill are documented here.
 
 ## [Unreleased]
 
+## [0.12.2] - 2026-08-02
+
+### Changed
+
+- Makes Codex App Threads the preferred delegation runner. The orchestrator
+  reads each role's exact model and reasoning effort from the installed
+  `~/.codex/agents/<role>.toml`; native `spawn_agent` is now a fail-closed
+  fallback only when its live schema can carry the same tuple. The canonical
+  policy, hook advice, standing authorization, downstream initializer seeds,
+  and helper mirror all carry the same routing contract.
+- Converges packaged fleet authorship on `agents/fleet/`: tracked repo-level
+  Claude agent copies are removed, Codex TOMLs remain generated installer
+  fixtures, and gatekeeper maps to the Terra/xhigh Codex profile through the
+  existing role mapping authority.
+- Records the live App Thread canary and its version-bound readiness limit:
+  Codex CLI `0.146.0-alpha.9.2` honored the requested fast-worker tuple, while
+  the public materialized-thread readback still omits model and effort. That
+  result remains unverified at the portable orchestrator contract and selects
+  the declared fallback instead of inferring readiness from private host data.
+
+### Fixed
+
+- Agent-fleet health checks now honor hash-bound user-managed receipts, so an
+  accepted local role override reports as user-managed instead of permanent
+  drift; absent, malformed, or stale receipts still fail closed.
+- Receipt update-check tests now stub their upstream fetches, removing eight
+  real network calls per affected path and the resulting deterministic timeout
+  on slower networks.
+- Bounded verifier children now remove every inherited
+  `REPO_HARNESS_*` variable at the spawn boundary, preventing helper routing
+  metadata from overriding fixture isolation inside nested test commands.
+- Acceptance finalization strips materializer-owned `provenance` before
+  re-emitting its run trace, so the published checks projection's recorded
+  content hash is self-consistent with its own bytes.
+
 ## [0.12.1] - 2026-08-01
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "repo-harness",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Installs, migrates, audits, and repairs repo-local agentic development harnesses",
   "license": "MIT",
   "repository": {

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,16 +1,16 @@
 # Current Status Snapshot
 
 <!-- generated-by: repo-harness refresh-current-status v1 -->
-<!-- updated_at: 2026-08-02T03:06:37+0800 -->
+<!-- updated_at: 2026-08-02T16:33:15+0800 -->
 <!-- stale_after: 24h -->
 
 > **Status**: Idle
-> **Updated At**: 2026-08-02T03:06:37+0800
-> **Source Branch**: codex/final-closeout
-> **Source Commit**: 823e6186
+> **Updated At**: 2026-08-02T16:33:15+0800
+> **Source Branch**: codex/release-0-12-2
+> **Source Commit**: 7c93c914
 > **Target Branch**: main
 > **Stale After**: 24h
-> **Reason**: archive-workflow
+> **Reason**: release-0.12.2-prep
 > **Derived From**: active-plan, active-sprint, workstreams, handoff, checks, git status
 
 This file is a tracked mainline snapshot derived from repo artifacts. It is not a live lock, not a kanban board, and not an implementation gate. If it is stale, read the source artifacts below.
@@ -46,7 +46,7 @@ This file is a tracked mainline snapshot derived from repo artifacts. It is not 
 - `tasks/workstreams/workflow-engine/inspection-migration/agent-fleet-specialists.md`: status=completed, current_slice=completed-20260713-policy-seed, source_plan=`plans/archive/plan-20260712-2215-agent-fleet-specialists.md`
 ## Handoff
 
-- Exact Next Step: If a major module was just completed, stage its coherent diff first; then continue the next Task Breakdown item: Strip `.provenance` from the finalize overlay in `scripts/verify-sprint.sh` and mirror to `assets/templates/helpers/verify-sprint.sh`.
+- Exact Next Step: (none)
 
 ## Checks
 
@@ -57,16 +57,16 @@ This file is a tracked mainline snapshot derived from repo artifacts. It is not 
 - Summary: 10 changed/untracked path(s)
 
 ```
- D plans/plan-20260801-2124-verify-provenance-overlay.md
- D tasks/contracts/20260801-2124-verify-provenance-overlay.contract.md
- D tasks/notes/20260801-2124-verify-provenance-overlay.notes.md
- D tasks/reviews/20260801-2124-verify-provenance-overlay.review.md
- M tasks/todos.md
-?? plans/archive/plan-20260801-2124-verify-provenance-overlay.md
-?? tasks/archive/contract-20260802-0306-verify-provenance-overlay.md
-?? tasks/archive/notes-20260802-0306-verify-provenance-overlay.md
-?? tasks/archive/review-20260802-0306-verify-provenance-overlay.md
-?? tasks/archive/todo-20260802-0306-verify-provenance-overlay.md
+ M .claude/.skill-version
+ M README.es.md
+ M README.fr.md
+ M README.ja.md
+ M README.md
+ M README.zh-CN.md
+ M assets/skill-version.json
+ M docs/CHANGELOG.md
+ M package.json
+?? deploy/release-checklists/260802-repo-harness-0.12.2.md
 ```
 
 ## Source Artifacts


### PR DESCRIPTION
## Summary

- bump package, skill, template, and five localized release surfaces to `0.12.2`
- add the `v0.12.1..candidate` changelog and release filing
- preserve the established publish order: merge -> exact-main release gate -> npm -> annotated tag -> GitHub Release -> public readback

## Release scope

- receipt-aware user-managed agent-fleet health and single authored fleet authority
- bounded verifier environment isolation and self-consistent acceptance provenance
- exact role-TOML App Thread delegation with fail-closed runner degradation and version-bound live canary evidence

## Verification

- `BUN_TEST_TIMEOUT_MS=180000 BUN_TEST_MAX_CONCURRENCY=1 bun run check:release`
- 2127 pass / 1 skip / 0 fail
- package tarball install smoke passed for `repo-harness-0.12.2.tgz`
- `repo-harness@0.12.2` is E404 on the official npm registry before publication

Publication remains intentionally pending until this candidate is merged and the exact merged `main` commit passes the release gate.
