### PR TITLE
fix(mcp): keep OAuth clients with active tokens past the dynamic client TTL

### DIFF
--- a/.ai/harness/checks/pre-fix-mcp-oauth-client-ttl.log
+++ b/.ai/harness/checks/pre-fix-mcp-oauth-client-ttl.log
@@ -1,0 +1,35 @@
+bun test v1.3.14 (0d9b296a)
+
+tests/cli/mcp-oauth.test.ts:
+256 |       const rotated = await provider.exchangeRefreshToken(client, tokens.refresh_token ?? '');
+257 | 
+258 |       // Day 31: the client is past its absolute registration TTL and the rotated
+259 |       // access token expired on day 20, but the refresh token is still valid.
+260 |       now += 11 * day;
+261 |       expect(store.getClient(client.client_id)).toBeTruthy();
+                                                      ^
+error: expect(received).toBeTruthy()
+
+Received: undefined
+
+      at <anonymous> (/Users/ancienttwo/Projects/repo-harness-wt-mcp-oauth-client-ttl-active-token/tests/cli/mcp-oauth.test.ts:261:49)
+(fail) mcp oauth provider > dynamic client past its absolute TTL survives while a refresh token keeps it active (issue #161) [3.02ms]
+329 |       });
+330 |       storeA.setRefreshToken('active-refresh', 'active-access', registeredAt + 50 * day);
+331 | 
+332 |       const storeB = new McpOAuthTokenStore(tokensPath, { nowSeconds: () => registeredAt + 31 * day });
+333 |       storeB.load();
+334 |       expect(storeB.getClient(active.client_id)).toBeTruthy();
+                                                       ^
+error: expect(received).toBeTruthy()
+
+Received: undefined
+
+      at <anonymous> (/Users/ancienttwo/Projects/repo-harness-wt-mcp-oauth-client-ttl-active-token/tests/cli/mcp-oauth.test.ts:334:50)
+(fail) mcp oauth provider > load() applies the same active-token exemption to expired dynamic clients [1.70ms]
+
+ 4 pass
+ 2 fail
+ 42 expect() calls
+Ran 6 tests across 1 file. [41.00ms]
+PRE_FIX_EXIT=1

--- a/plans/plan-20260807-0850-mcp-oauth-client-ttl-active-token.md
+++ b/plans/plan-20260807-0850-mcp-oauth-client-ttl-active-token.md
@@ -1,0 +1,147 @@
+# Plan: MCP OAuth: exempt clients with active tokens from TTL cleanup
+
+> **Status**: Executing
+> **Created**: 20260807-0850
+> **Slug**: mcp-oauth-client-ttl-active-token
+> **Planning Source**: repo-harness-plan
+> **Orchestration Kind**: host-plan
+> **Source Ref**: github-issue-161
+> **Artifact Level**: work-package
+> **Promotion Reason**: worktree_boundary
+> **Verification Boundary**: bun test full suite plus repo required checks
+> **Rollback Surface**: single commit on src/cli/mcp/oauth.ts + tests/cli/mcp-oauth.test.ts
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260807-0850-mcp-oauth-client-ttl-active-token.contract.md`
+> **Task Review**: `tasks/reviews/20260807-0850-mcp-oauth-client-ttl-active-token.review.md`
+> **Implementation Notes**: `tasks/notes/20260807-0850-mcp-oauth-client-ttl-active-token.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from repo-harness-plan planning output.
+- Source ref: github-issue-161
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260807-0850-mcp-oauth-client-ttl-active-token.md`
+- Sprint contract: `tasks/contracts/20260807-0850-mcp-oauth-client-ttl-active-token.contract.md`
+- Sprint review: `tasks/reviews/20260807-0850-mcp-oauth-client-ttl-active-token.review.md`
+- Implementation notes: `tasks/notes/20260807-0850-mcp-oauth-client-ttl-active-token.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260807-0850-mcp-oauth-client-ttl-active-token.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260807-0850-mcp-oauth-client-ttl-active-token.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260807-0850-mcp-oauth-client-ttl-active-token.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260807-0850-mcp-oauth-client-ttl-active-token.contract.md`
+- Review file: `tasks/reviews/20260807-0850-mcp-oauth-client-ttl-active-token.review.md`
+- Implementation notes file: `tasks/notes/20260807-0850-mcp-oauth-client-ttl-active-token.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260807-0850-mcp-oauth-client-ttl-active-token.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260807-0850-mcp-oauth-client-ttl-active-token.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: single commit on src/cli/mcp/oauth.ts + tests/cli/mcp-oauth.test.ts
+- **Verification boundary**: bun test full suite plus repo required checks
+- **Review/acceptance boundary**: `tasks/reviews/20260807-0850-mcp-oauth-client-ttl-active-token.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: worktree_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260807-0850-mcp-oauth-client-ttl-active-token.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260807-0850-mcp-oauth-client-ttl-active-token.contract.md`, `tasks/reviews/20260807-0850-mcp-oauth-client-ttl-active-token.review.md`, and `tasks/notes/20260807-0850-mcp-oauth-client-ttl-active-token.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260807-0850-mcp-oauth-client-ttl-active-token.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: single commit on src/cli/mcp/oauth.ts + tests/cli/mcp-oauth.test.ts
+
+## Captured Planning Output
+
+# MCP OAuth: exempt clients with active tokens from TTL cleanup
+
+## Problem (GitHub issue #161)
+
+MCP OAuth dynamic clients expire on an absolute 30-day TTL (`client_id_issued_at + dynamicClientTtlSeconds`, `src/cli/mcp/oauth.ts:67,86`), while refresh tokens slide (each `exchangeRefreshToken` rotation resets a fresh 30-day window, `src/cli/mcp/oauth.ts:354-387`). An actively used ChatGPT connector therefore hits day 30, the client record is cleaned up, the still-valid refresh token exchange fails with `invalid_client`, and the user is forced through periodic re-authorization. Reporter has downgraded to read-only url-token mode because of this.
+
+## Decision
+
+Do NOT enlarge the TTL number. Change the cleanup predicate instead: a client whose absolute TTL has elapsed is exempt from deletion while it still has active tokens. Client liveness is derived from existing token state (single source of truth; no new persisted field such as `last_used_at`).
+
+Active token definition (anti-zombie, security boundary):
+- an access token record with `info.clientId === clientId` that is unexpired (`!info.expiresAt || info.expiresAt > now`), OR
+- an unexpired refresh token (`record.expiresAt === undefined || record.expiresAt > now`) whose `accessToken` maps to an access-token record with `info.clientId === clientId`.
+
+Zombie state (expired access token + expired refresh token lingering only due to lazy cleanup) must NOT keep a client alive.
+
+Malformed `client_id_issued_at` (non-integer, `<= 0`, future) remains unconditionally deleted — that branch is data integrity, not TTL, and gets no exemption.
+
+Effects:
+- Spam registrations (never completed authorization) are still cleaned at 30 days; `maxDynamicClients` cap unchanged.
+- Active users never re-authorize: rotating refresh tokens keep the client alive.
+- Idle > 30 days: refresh token expires first, client follows — the whole chain uniformly means "30 days idle breaks the authorization".
+
+## Task Breakdown
+
+- [x] Add a single shared expiry predicate (private helper) in `McpOAuthTokenStore` and use it from both `cleanupExpiredClients()` (src/cli/mcp/oauth.ts:81-92) and the client filter loop in `load()` (src/cli/mcp/oauth.ts:107-120).
+- [x] Tests in `tests/cli/mcp-oauth.test.ts` (reuse existing clock-injection style): (1) client past 30 days with active refresh token is kept and `exchangeRefreshToken` succeeds; (2) client past 30 days with no tokens is deleted; (3) zombie tokens do not keep the client; (4) `load()` path applies the same exemption.
+- [x] Full `bun test` green plus repo required checks.
+
+## Out of scope
+
+TTL default values, `registerClient` capacity logic, `createMcpOAuthProvider` behavior, any persistence schema change, unrelated refactors.
+
+## Verification
+
+`bun test` (full suite) and the repo required checks (`check-task-sync`, `check-task-workflow --strict`, `init --repo . --dry-run`).
+
+## Rollback
+
+Single commit touching `src/cli/mcp/oauth.ts` + `tests/cli/mcp-oauth.test.ts`; revert restores the absolute-TTL behavior.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [x] Add a single shared expiry predicate (private helper) in `McpOAuthTokenStore` and use it from both `cleanupExpiredClients()` (src/cli/mcp/oauth.ts:81-92) and the client filter loop in `load()` (src/cli/mcp/oauth.ts:107-120).
+- [x] Tests in `tests/cli/mcp-oauth.test.ts` (reuse existing clock-injection style): (1) client past 30 days with active refresh token is kept and `exchangeRefreshToken` succeeds; (2) client past 30 days with no tokens is deleted; (3) zombie tokens do not keep the client; (4) `load()` path applies the same exemption.
+- [x] Full `bun test` green plus repo required checks.

--- a/src/cli/mcp/oauth.ts
+++ b/src/cli/mcp/oauth.ts
@@ -78,12 +78,30 @@ export class McpOAuthTokenStore implements OAuthRegisteredClientsStore {
     this.clock = clock;
   }
 
+  private hasActiveTokens(clientId: string, now: number): boolean {
+    for (const info of this.accessTokens.values()) {
+      if (info.clientId !== clientId) continue;
+      if (!info.expiresAt || info.expiresAt > now) return true;
+    }
+    for (const record of this.refreshTokens.values()) {
+      if (record.expiresAt !== undefined && record.expiresAt <= now) continue;
+      if (this.accessTokens.get(record.accessToken)?.clientId === clientId) return true;
+    }
+    return false;
+  }
+
+  private isRemovableClient(clientId: string, client: OAuthClientInformationFull, now: number): boolean {
+    const issuedAt = client.client_id_issued_at;
+    if (typeof issuedAt !== 'number' || !Number.isInteger(issuedAt) || issuedAt <= 0 || issuedAt > now) return true;
+    if (issuedAt + this.dynamicClientTtlSeconds > now) return false;
+    return !this.hasActiveTokens(clientId, now);
+  }
+
   private cleanupExpiredClients(flush = true): void {
     const now = this.clock();
     let changed = false;
     for (const [clientId, client] of this.clients) {
-      const issuedAt = client.client_id_issued_at;
-      if (typeof issuedAt !== 'number' || !Number.isInteger(issuedAt) || issuedAt <= 0 || issuedAt > now || issuedAt + this.dynamicClientTtlSeconds <= now) {
+      if (this.isRemovableClient(clientId, client, now)) {
         this.clients.delete(clientId);
         changed = true;
       }
@@ -108,8 +126,7 @@ export class McpOAuthTokenStore implements OAuthRegisteredClientsStore {
       const persistedClientCount = clients.size;
       const now = this.clock();
       for (const [clientId, client] of clients) {
-        const issuedAt = client.client_id_issued_at;
-        if (typeof issuedAt !== 'number' || !Number.isInteger(issuedAt) || issuedAt <= 0 || issuedAt > now || issuedAt + this.dynamicClientTtlSeconds <= now) {
+        if (this.isRemovableClient(clientId, client, now)) {
           clients.delete(clientId);
         }
       }

--- a/tasks/contracts/20260807-0850-mcp-oauth-client-ttl-active-token.contract.md
+++ b/tasks/contracts/20260807-0850-mcp-oauth-client-ttl-active-token.contract.md
@@ -1,0 +1,145 @@
+# Task Contract: mcp-oauth-client-ttl-active-token
+
+> **Status**: Active
+> **Plan**: plans/plan-20260807-0850-mcp-oauth-client-ttl-active-token.md
+> **Task Profile**: bugfix
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: ancienttwo
+> **Capability ID**: root
+> **Last Updated**: 2026-08-07 08:50
+> **Review File**: `tasks/reviews/20260807-0850-mcp-oauth-client-ttl-active-token.review.md`
+> **Notes File**: `tasks/notes/20260807-0850-mcp-oauth-client-ttl-active-token.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+GitHub issue #161: dynamic MCP OAuth clients expire on an absolute 30-day TTL while refresh tokens slide (rotation resets 30 days each use). Actively used ChatGPT connectors hit day 30, the client record is cleaned, refresh exchange fails with invalid_client, and the user is forced through periodic re-authorization. The reporter downgraded to read-only url-token mode because of this. If skipped, every OAuth connector breaks monthly regardless of activity.
+
+## Goal
+
+A client whose absolute TTL has elapsed is exempt from cleanup while it still holds active tokens, in both `cleanupExpiredClients()` and the `load()` client filter, using one shared predicate. Active means: an unexpired access token with `info.clientId === clientId`, or an unexpired refresh token whose `accessToken` maps to such a record. Zombie state (expired access + expired refresh lingering from lazy cleanup) must not keep a client alive. Malformed `client_id_issued_at` stays unconditionally deleted (data integrity, not TTL). Net effect: spam registrations still cleaned at 30 days, active users never re-authorize, idle >30 days breaks the whole chain uniformly.
+
+## Scope
+
+- In scope: `src/cli/mcp/oauth.ts` (`McpOAuthTokenStore` cleanup/load predicates only), `tests/cli/mcp-oauth.test.ts` regression cases.
+- Out of scope: TTL default values, `registerClient` capacity logic, `createMcpOAuthProvider` behavior, persistence schema changes (no `last_used_at`), unrelated refactors.
+- Taste constraints: <!-- advisory only, no run gate; default style/taste lives in AGENTS.md and the minimal-change policy, use this to record a per-task override -->
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+
+## Falsifier
+
+If a spam-registered client (never completed authorization) survives past 30 days under the new predicate, the exemption is too broad and the direction is wrong. Cheapest proof point: the "expired client with no tokens is deleted" test case.
+
+## Root Cause Evidence
+
+- root_cause: `src/cli/mcp/oauth.ts:86` — `cleanupExpiredClients()` deletes any client where `client_id_issued_at + dynamicClientTtlSeconds <= now`, ignoring live refresh-token state, so an actively refreshing client is removed at day 30 and subsequent refresh exchanges fail with invalid_client.
+- repro: register a client, complete authorization to obtain a refresh token, advance the injected clock past 30 days, call `getClient()` / `exchangeRefreshToken()` — the client is gone and the exchange throws although the refresh token is still valid.
+- regression_guard: tests/cli/mcp-oauth.test.ts
+- pre_fix_failure_artifact: .ai/harness/checks/pre-fix-mcp-oauth-client-ttl.log
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260807-0850-mcp-oauth-client-ttl-active-token.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260807-0850-mcp-oauth-client-ttl-active-token.review.md`
+- Notes file: `tasks/notes/20260807-0850-mcp-oauth-client-ttl-active-token.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Acceptance Policy
+
+```json
+{"protocol":1,"reviewer":"Claude","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - docs/spec.md
+  - plans/
+  - tasks/todos.md
+  - tasks/contracts/20260807-0850-mcp-oauth-client-ttl-active-token.contract.md
+  - tasks/reviews/20260807-0850-mcp-oauth-client-ttl-active-token.review.md
+  - tasks/notes/20260807-0850-mcp-oauth-client-ttl-active-token.notes.md
+  - .ai/context/capabilities.json
+  - .ai/harness/checks/
+  - src/cli/mcp/oauth.ts
+  - tests/cli/
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+      - codex-exec
+      - main-thread
+    fallback: main-thread
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - docs/spec.md
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260807-0850-mcp-oauth-client-ttl-active-token.notes.md
+  tests_pass:
+    - path: tests/cli/mcp-oauth.test.ts
+  commands_succeed:
+    - bun run check:type
+    - bun test
+```
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior:
+- Edge cases:
+- Regression risks:
+
+## Rollback Point
+
+- Commit / checkpoint:
+- Revert strategy:

--- a/tasks/notes/20260807-0850-mcp-oauth-client-ttl-active-token.notes.md
+++ b/tasks/notes/20260807-0850-mcp-oauth-client-ttl-active-token.notes.md
@@ -1,0 +1,49 @@
+# Implementation Notes: mcp-oauth-client-ttl-active-token
+
+> **Status**: Active
+> **Plan**: plans/plan-20260807-0850-mcp-oauth-client-ttl-active-token.md
+> **Contract**: tasks/contracts/20260807-0850-mcp-oauth-client-ttl-active-token.contract.md
+> **Review**: tasks/reviews/20260807-0850-mcp-oauth-client-ttl-active-token.review.md
+> **Last Updated**: 2026-08-07 08:50
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- Malformed `client_id_issued_at` (non-integer, `<= 0`, or in the future) stays an unconditional delete and is **not** eligible for the active-token exemption. It is a data-integrity check, not a TTL expiry, so an attacker-supplied or corrupt timestamp must never be kept alive by holding a token. Only the genuine `issuedAt + dynamicClientTtlSeconds <= now` branch consults token activity.
+- Both cleanup sites share one predicate, `McpOAuthTokenStore.isRemovableClient(clientId, client, now)`. `cleanupExpiredClients()` applies it to `this.clients`; `load()` applies it to the freshly parsed client map. `load()` populates `this.accessTokens` / `this.refreshTokens` before the client filter runs, so the helper reads consistent state in both paths and the two sites cannot drift apart.
+- Activity is derived from in-memory token state only. No new persisted field (no `last_used_at`): a valid refresh token already *is* the sliding proof of use, since `exchangeRefreshToken` rotates it to `now + refreshTokenTtlSeconds` on every call.
+- Zombie guard: a refresh token only counts when it is itself unexpired **and** resolves to an access-token record owned by that client. Expired access tokens linger in the map by design (`load()` deliberately keeps an expired access token when a refresh token targets it), so counting mere presence would make every dead client immortal.
+
+## Deviations From Plan Or Spec
+
+- The worktree had no `node_modules`; ran `bun install --frozen-lockfile` (local, lockfile-pinned) before the pre-fix capture. The first capture attempt failed on a missing module rather than on the assertion, so the artifact was re-captured after install and now records a real assertion failure.
+- No commit was made, per the dispatch.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| Persist `last_used_at` and slide the client TTL on use | Rejected | Adds a persisted field and a second source of truth for liveness; the refresh token already carries sliding expiry |
+| Exempt any client that appears in a refresh-token record | Rejected | Immortalizes dead clients, since expired access tokens are retained in the map on purpose |
+| Extend the client TTL default beyond 30 days | Rejected | Moves the cliff instead of removing it, and the TTL default is out of scope |
+| Derive liveness from unexpired access token OR unexpired refresh token resolving to a client-owned access token | Chosen | Keeps garbage-registration pressure intact while covering the real continuous-use path |
+
+## Open Questions
+
+- None.
+
+## Evidence Links
+
+- Pre-fix RED artifact: `.ai/harness/checks/pre-fix-mcp-oauth-client-ttl.log` (`PRE_FIX_EXIT=1`, 4 pass / 2 fail)
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/reviews/20260807-0850-mcp-oauth-client-ttl-active-token.review.md
+++ b/tasks/reviews/20260807-0850-mcp-oauth-client-ttl-active-token.review.md
@@ -1,0 +1,84 @@
+# Task Review: mcp-oauth-client-ttl-active-token
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260807-0850-mcp-oauth-client-ttl-active-token.md
+> **Contract**: tasks/contracts/20260807-0850-mcp-oauth-client-ttl-active-token.contract.md
+> **Notes File**: tasks/notes/20260807-0850-mcp-oauth-client-ttl-active-token.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-08-07 08:50
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Commands passed:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+- Waza `/check` run:
+- Commands run:
+- Manual checks:
+- Supporting artifacts:
+- Implementation notes reviewed:
+- Run snapshot:
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...

--- a/tasks/reviews/20260807-0850-mcp-oauth-client-ttl-active-token.review.md
+++ b/tasks/reviews/20260807-0850-mcp-oauth-client-ttl-active-token.review.md
@@ -40,17 +40,17 @@
 
 ## Acceptance Receipt Projection
 
-> **Disposition**: unavailable
-> **Reviewer**: unavailable
-> **Source**: unavailable
+> **Disposition**: external_pass
+> **Reviewer**: Claude
+> **Source**: claude-review
 > **Actor**: not-applicable
-> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject SHA256**: sha256:21ef5ff66c50f75ac83af337d17fb8415c6d60dae7f897ae48c563e935bc913e
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: pending
-> **Verification Evidence SHA256**: pending
-> **Issued At**: pending
+> **Reviewed Target Revision**: 7e9d6361aed4bd05b706241a75b4b5a4f8ea4784
+> **Verification Evidence SHA256**: sha256:7d6c962602516d147c2eb1c95cb73a0edcb309a5987de735fdf1f8a48aaf83db
+> **Issued At**: 2026-08-07T02:18:40.339Z
 
-- Summary: No AcceptanceReceipt has been recorded.
+- Summary: Gatekeeper acceptance for issue #161: cleanupExpiredClients() and load() share one isRemovableClient() predicate that exempts a past-TTL client only while it holds an unexpired access token, or an unexpired refresh token resolving to an access-token record it owns. Scope matches contract allowed_paths with no out-of-scope edits. Security boundary verified: /authorize is passphrase-gated (src/cli/mcp/transports/http.ts:680), so unauthenticated spam registrations never obtain tokens and are still cleaned at 30 days; zombie access+refresh pairs stay removable; malformed client_id_issued_at remains an unconditional delete. Pre-fix RED artifact shows PRE_FIX_EXIT=1 with only the two keep-alive cases failing. verify-sprint 16/16 Fulfilled, bun test 587922ms green, bun run check:type green.
 - Findings: none
 
 ## Behavior Diff Notes

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -1,7 +1,7 @@
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: (archive-workflow)
+> **Updated**: 2026-08-07 08:50
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.

--- a/tests/cli/mcp-oauth.test.ts
+++ b/tests/cli/mcp-oauth.test.ts
@@ -222,4 +222,124 @@ describe('mcp oauth provider', () => {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  test('dynamic client past its absolute TTL survives while a refresh token keeps it active (issue #161)', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'repo-harness-mcp-oauth-client-ttl-active-'));
+    try {
+      const day = 24 * 60 * 60;
+      let now = 1_000_000;
+      const store = new McpOAuthTokenStore(join(root, 'tokens.json'));
+      const provider = createMcpOAuthProvider(store, {
+        nowSeconds: () => now,
+        accessTokenTtlSeconds: 60 * 60,
+        refreshTokenTtlSeconds: 30 * day,
+      });
+      const client = store.registerClient({
+        redirect_uris: ['https://chatgpt.com/connector/callback'],
+        token_endpoint_auth_method: 'none',
+        grant_types: ['authorization_code', 'refresh_token'],
+        response_types: ['code'],
+        client_name: 'chatgpt-connector',
+      });
+
+      const redirect = redirectRecorder();
+      await provider.authorize(client, {
+        scopes: ['repo-harness', 'offline_access'],
+        redirectUri: client.redirect_uris[0]!,
+        codeChallenge: 'client-ttl-challenge',
+      }, redirect.response as never);
+      const code = new URL(redirect.state.url).searchParams.get('code') ?? '';
+      const tokens = await provider.exchangeAuthorizationCode(client, code, 'verifier', client.redirect_uris[0]);
+
+      // Day 20: continued use slides the refresh token out to day 50.
+      now += 20 * day;
+      const rotated = await provider.exchangeRefreshToken(client, tokens.refresh_token ?? '');
+
+      // Day 31: the client is past its absolute registration TTL and the rotated
+      // access token expired on day 20, but the refresh token is still valid.
+      now += 11 * day;
+      expect(store.getClient(client.client_id)).toBeTruthy();
+
+      const refreshedAfterTtl = await provider.exchangeRefreshToken(client, rotated.refresh_token ?? '');
+      expect(refreshedAfterTtl.access_token).not.toBe(rotated.access_token);
+      expect(await provider.verifyAccessToken(refreshedAfterTtl.access_token))
+        .toMatchObject({ clientId: client.client_id });
+      expect(store.getClient(client.client_id)).toBeTruthy();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('dynamic client past its absolute TTL is removed without tokens and with only zombie tokens', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'repo-harness-mcp-oauth-client-ttl-expired-'));
+    try {
+      const day = 24 * 60 * 60;
+      let now = 2_000_000;
+      const store = new McpOAuthTokenStore(join(root, 'tokens.json'), { nowSeconds: () => now });
+      const registration = {
+        redirect_uris: ['https://chatgpt.com/connector/callback'],
+        token_endpoint_auth_method: 'none',
+        grant_types: ['authorization_code', 'refresh_token'],
+        response_types: ['code'],
+      };
+      const idle = store.registerClient({ ...registration, client_name: 'never-used' });
+      const zombie = store.registerClient({ ...registration, client_name: 'zombie-tokens' });
+
+      // Zombie state: access token expired, and the refresh token pointing at it
+      // expired too; both linger only because cleanup is lazy.
+      store.setAccessToken('zombie-access', {
+        token: 'zombie-access',
+        clientId: zombie.client_id,
+        scopes: ['repo-harness', 'offline_access'],
+        expiresAt: now + 60 * 60,
+      });
+      store.setRefreshToken('zombie-refresh', 'zombie-access', now + 2 * 60 * 60);
+
+      expect(store.getClient(idle.client_id)).toBeTruthy();
+      expect(store.getClient(zombie.client_id)).toBeTruthy();
+
+      now += 31 * day;
+      expect(store.getClient(idle.client_id)).toBeUndefined();
+      expect(store.getClient(zombie.client_id)).toBeUndefined();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('load() applies the same active-token exemption to expired dynamic clients', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'repo-harness-mcp-oauth-client-ttl-load-'));
+    try {
+      const tokensPath = join(root, 'tokens.json');
+      const day = 24 * 60 * 60;
+      const registeredAt = 3_000_000;
+      const storeA = new McpOAuthTokenStore(tokensPath, { nowSeconds: () => registeredAt });
+      const registration = {
+        redirect_uris: ['https://chatgpt.com/connector/callback'],
+        token_endpoint_auth_method: 'none',
+        grant_types: ['authorization_code', 'refresh_token'],
+        response_types: ['code'],
+      };
+      const active = storeA.registerClient({ ...registration, client_name: 'active-client' });
+      const idle = storeA.registerClient({ ...registration, client_name: 'idle-client' });
+      storeA.setAccessToken('active-access', {
+        token: 'active-access',
+        clientId: active.client_id,
+        scopes: ['repo-harness', 'offline_access'],
+        expiresAt: registeredAt + 60 * 60,
+      });
+      storeA.setRefreshToken('active-refresh', 'active-access', registeredAt + 50 * day);
+
+      const storeB = new McpOAuthTokenStore(tokensPath, { nowSeconds: () => registeredAt + 31 * day });
+      storeB.load();
+      expect(storeB.getClient(active.client_id)).toBeTruthy();
+      expect(storeB.getClient(idle.client_id)).toBeUndefined();
+
+      const storeC = new McpOAuthTokenStore(tokensPath, { nowSeconds: () => registeredAt + 31 * day });
+      storeC.load();
+      expect(storeC.getClient(active.client_id)).toBeTruthy();
+      expect(storeC.getClient(idle.client_id)).toBeUndefined();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Problem

Dynamic MCP OAuth clients expire on an absolute 30-day TTL, but refresh tokens slide — rotation resets the refresh expiry by 30 days on every use. An actively used ChatGPT connector therefore reaches day 30 with a perfectly valid refresh token, has its client record cleaned by `cleanupExpiredClients()`, and the next refresh exchange fails with `invalid_client`. The user is pushed through re-authorization every month regardless of activity. The reporter of #161 downgraded to read-only url-token mode because of this.

Root cause: `src/cli/mcp/oauth.ts` deleted any client where `client_id_issued_at + dynamicClientTtlSeconds <= now`, ignoring live token state.

## Fix

`cleanupExpiredClients()` and the client filter in `load()` now share one predicate, `isRemovableClient(clientId, client, now)`:

1. Malformed `client_id_issued_at` (non-integer, `<= 0`, or in the future) — unconditional delete, unchanged. This is a data-integrity check, not TTL expiry, so it is deliberately not eligible for the exemption.
2. Absolute TTL not yet elapsed — keep, unchanged.
3. TTL elapsed — keep only while `hasActiveTokens()` holds.

`hasActiveTokens()` is true when the client owns an unexpired access token, or when an unexpired refresh token resolves to an access-token record owned by that client. Activity is derived entirely from existing token state; **no new persisted field** (no `last_used_at`) and no schema change. A valid refresh token already *is* the sliding proof of use, since `exchangeRefreshToken` rotates its expiry forward on every call.

Net effect: spam registrations are still cleaned at 30 days, active users never re-authorize, and a client idle for more than 30 days breaks the whole chain uniformly.

## Security argument

This cleanup is the garbage-collection defense for an **unauthenticated open registration endpoint**, so the exemption was reviewed for over-breadth:

- **Spam registrations are still cleaned at 30 days.** This is structural, not merely test-asserted. `/register` is open, but `/authorize` is passphrase-gated (`src/cli/mcp/transports/http.ts:680`, timing-safe compare at `:230-247` — without the passphrase the middleware renders the passphrase page and never calls `next()`). Access tokens are only ever minted by `exchangeAuthorizationCode` or `exchangeRefreshToken`, both of which require an authorization code. An unauthenticated attacker who floods `/register` obtains no tokens, so `hasActiveTokens()` is permanently false and the 30-day sweep still removes the client. The exemption path is unreachable without the operator passphrase.
- **Zombie tokens cannot keep a client alive.** An expired access token plus an expired refresh token lingering from lazy cleanup are both skipped, so the client stays removable. Counting mere presence would have made every dead client immortal, since `load()` deliberately retains an expired access token when a refresh token targets it.
- **The exemption is exactly as wide as real usability.** The refresh check uses the same expiry rule as `getRefreshToken()` and the same client-ownership rule as `exchangeRefreshToken()`. A refresh token that keeps a client alive is precisely a refresh token that would actually succeed; a dangling or expired one keeps nothing alive.

## Verification

- **Pre-fix RED artifact**: `.ai/harness/checks/pre-fix-mcp-oauth-client-ttl.log`, captured on the unfixed code after adding the new cases — `PRE_FIX_EXIT=1`, 4 pass / 2 fail. The two failures are exactly the "must be kept" cases; the "must be deleted" case is green both before and after, which is the falsifier guard.
- **Targeted**: `bun test tests/cli/mcp-oauth.test.ts tests/cli/mcp-http.test.ts` — 16 pass / 0 fail.
- **Types**: `bun run check:type` — clean.
- **Full suite**: `bun test` — 2212 pass, 587.9s. One earlier standalone run showed a single failure in `tests/unit/closeout-runner-guardrails.test.ts:594`, a leader-election race with zero overlap with this change; it passes 3/3 in isolation and belongs to the load-sensitive family addressed in a2381159. It did not recur in the verification run.
- **Contract gate**: `verify-sprint` — 16/16, status Fulfilled, acceptance receipt recorded.

Three new regression tests in `tests/cli/mcp-oauth.test.ts` cover four scenarios: past-TTL client with an active refresh token survives and can still refresh; past-TTL client with no tokens is deleted; zombie tokens do not keep a client; and `load()` applies the identical exemption across a restart.

## Commit structure

Two commits on the branch — the workflow contract is committed first so the acceptance receipt can bind to a committed authority, then the delivery. Squash on merge keeps main a single unit.

Fixes #161
