### PR TITLE
chore(release): prepare repo-harness 0.13.2

### DIFF
--- a/.claude/.skill-version
+++ b/.claude/.skill-version
@@ -1,3 +1,3 @@
-skill_version=0.13.1
-template_version=0.13.1
+skill_version=0.13.2
+template_version=0.13.2
 migrated_at=2026-07-18T22:31:36Z

--- a/README.es.md
+++ b/README.es.md
@@ -466,8 +466,8 @@ repositorio adopte la misma política.
 
 ## Versión actual
 
-- Paquete npm: `repo-harness@0.13.1`
-- Sello de workflow generado: `repo-harness@0.13.1+template@0.13.1`
+- Paquete npm: `repo-harness@0.13.2`
+- Sello de workflow generado: `repo-harness@0.13.2+template@0.13.2`
 - Repositorio de GitHub: `Ancienttwo/repo-harness`
 - Notas de versión e historial: [`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -461,8 +461,8 @@ adopte la même policy.
 
 ## Release actuelle
 
-- Package npm : `repo-harness@0.13.1`
-- Generated workflow stamp : `repo-harness@0.13.1+template@0.13.1`
+- Package npm : `repo-harness@0.13.2`
+- Generated workflow stamp : `repo-harness@0.13.2+template@0.13.2`
 - Dépôt GitHub : `Ancienttwo/repo-harness`
 - Notes et historique de release : [`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -469,8 +469,8 @@ commit script や hooks に組み込まないでください。
 
 ## 現在の Release
 
-- npm package：`repo-harness@0.13.1`
-- Generated workflow stamp：`repo-harness@0.13.1+template@0.13.1`
+- npm package：`repo-harness@0.13.2`
+- Generated workflow stamp：`repo-harness@0.13.2+template@0.13.2`
 - GitHub repository：`Ancienttwo/repo-harness`
 - Release notes and history：[`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -441,8 +441,8 @@ repo-harness commit scripts or hooks unless that repo adopts the same policy.
 
 ## Current Release
 
-- npm package: `repo-harness@0.13.1`
-- Generated workflow stamp: `repo-harness@0.13.1+template@0.13.1`
+- npm package: `repo-harness@0.13.2`
+- Generated workflow stamp: `repo-harness@0.13.2+template@0.13.2`
 - GitHub repository: `Ancienttwo/repo-harness`
 - Release notes and history: [`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -448,8 +448,8 @@ policy。
 
 ## 当前 Release
 
-- npm package：`repo-harness@0.13.1`
-- Generated workflow stamp：`repo-harness@0.13.1+template@0.13.1`
+- npm package：`repo-harness@0.13.2`
+- Generated workflow stamp：`repo-harness@0.13.2+template@0.13.2`
 - GitHub repository：`Ancienttwo/repo-harness`
 - Release notes 和 history：[`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/assets/skill-version.json
+++ b/assets/skill-version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.13.1",
-  "templateVersion": "0.13.1",
+  "version": "0.13.2",
+  "templateVersion": "0.13.2",
   "skillName": "repo-harness",
   "contractId": "tasks-first-harness-v1",
   "compatibility": {

--- a/deploy/release-checklists/260807-repo-harness-0.13.2.md
+++ b/deploy/release-checklists/260807-repo-harness-0.13.2.md
@@ -1,0 +1,50 @@
+# repo-harness 0.13.2 Release Filing
+
+- Date: 2026-08-07
+- Package: `repo-harness@0.13.2`
+- Base release: `v0.13.1`
+- Source range: `v0.13.1..candidate`
+- Release scope: security hardening — collapse every authored `.repo-harness/`
+  gitignore projection (adoption managed block, shell scaffold heredoc, this
+  repo's own `.gitignore`) to a single directory-level rule so MCP credentials
+  written under `<repo>/.repo-harness/` (notably `mcp.oauth-tokens.json`) can
+  never sit NOT-IGNORED in a downstream working tree. Zero behavior change
+  elsewhere; repo-scope retirement is deferred to a separate slice.
+- Publish status: **pending publish**. This filing does not claim npm, Git tag,
+  or GitHub Release completion until the public readbacks below pass.
+
+## Candidate Evidence
+
+- `0c8247a2` (PR #164, squash of `8d4de56b` + acceptance `daa344a2`) lands the
+  directory-level rule in `src/core/adoption/gitignore-plan.ts`,
+  `scripts/lib/project-init-lib.sh`, and this repo's `.gitignore`, with
+  `tests/unit/gitignore-plan.test.ts` asserting exact-line presence plus an
+  empty residual per-file set, and three existing scaffold/contract tests
+  updated with `not.toContain` guards. `assets/templates/gitignore.template`
+  carries no `.repo-harness` entries and was verified unchanged.
+- Acceptance: verify-sprint `total=10 failed=0 status=Fulfilled`
+  (run `run-20260807T140032-32208`), AcceptanceReceipt `external_pass` bound to
+  `subject_sha256 f8ebd00e` against `467a6d26`; PR CI 4/4 green on `daa344a2`.
+- Non-injury evidence: `git ls-files .repo-harness/` empty, no negation rules
+  depend on the directory, `.repo-harness-owner.json` is not matched by the
+  new rule, and all three `git check-ignore` probes resolve to the single
+  `.gitignore:74` rule.
+
+## Required Release Sequence
+
+- [x] Merge the candidate work-package to `main` (PR #164 squash `0c8247a2`)
+      with its AcceptanceReceipt recorded on the branch.
+- [x] Bump `package.json`, `assets/skill-version.json`, `.claude/.skill-version`,
+      and the five README `Current Release` blocks to `0.13.2`.
+- [ ] Run `bash scripts/check-npm-release.sh --prepublish` on the exact release
+      commit and publish to npm.
+- [ ] Create the annotated tag `v0.13.2` on the published commit.
+- [ ] Create the stable GitHub Release `repo-harness 0.13.2` from `v0.13.2`
+      with no attached asset, matching the established release convention.
+- [ ] Run `bash scripts/check-release-published.sh 0.13.2`.
+
+## Rollback
+
+- Before npm publication: revert or abandon the release-prep commit.
+- After npm publication: never move or reuse `v0.13.2`; correct forward with a
+  new patch release.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this skill are documented here.
 
 ## [Unreleased]
 
+## [0.13.2] - 2026-08-07
+
+### Security
+
+- Collapses every authored `.repo-harness/` gitignore projection to a single
+  directory-level rule (#164). The generated managed block
+  (`src/core/adoption/gitignore-plan.ts`) and the shell scaffold heredoc
+  (`scripts/lib/project-init-lib.sh`) previously listed only two dead
+  per-file entries, so the four files the MCP server actually writes under
+  `<repo>/.repo-harness/` — including `mcp.oauth-tokens.json` holding OAuth
+  access and refresh tokens — stayed NOT-IGNORED for any user who started
+  `repo-harness mcp serve --transport http` without first running
+  `mcp setup chatgpt` with repo scope. Nothing under `.repo-harness/` is
+  intentionally tracked and `.repo-harness-owner.json` is not caught by the
+  new rule. Retiring the repo config scope and the setup-time per-file
+  compensation stays a separate slice.
+
 ## [0.13.1] - 2026-08-07
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "repo-harness",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Installs, migrates, audits, and repairs repo-local agentic development harnesses",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Release preparation for 0.13.2

Version bump (`package.json`, `assets/skill-version.json`, `.claude/.skill-version`, five README Current Release blocks), the 0.13.2 changelog, and the release filing under `deploy/release-checklists/260807-repo-harness-0.13.2.md`.

### Release scope

Security hardening (#164): every authored `.repo-harness/` gitignore projection — adoption managed block, shell scaffold heredoc, and this repo's own `.gitignore` — collapses to a single directory-level rule, so MCP credentials written under `<repo>/.repo-harness/` (notably `mcp.oauth-tokens.json` holding OAuth access/refresh tokens) can never sit NOT-IGNORED in a downstream working tree. Zero behavior change elsewhere; repo-scope retirement is a separate slice.

### After merge

Publish sequence per the release filing: `check-npm-release.sh --prepublish` on the release commit → npm publish → annotated tag `v0.13.2` → GitHub Release → `check-release-published.sh 0.13.2`.