### PR TITLE
test: complete the subprocess-timeout sibling sweep a2381159 started

### DIFF
--- a/plans/plan-20260807-1930-test-timeout-sibling-sweep.md
+++ b/plans/plan-20260807-1930-test-timeout-sibling-sweep.md
@@ -1,0 +1,130 @@
+# Plan: Tests: complete the subprocess-timeout sibling sweep
+
+> **Status**: Executing
+> **Created**: 20260807-1930
+> **Slug**: test-timeout-sibling-sweep
+> **Planning Source**: repo-harness-plan
+> **Orchestration Kind**: host-plan
+> **Source Ref**: a2381159-sibling-class
+> **Artifact Level**: work-package
+> **Promotion Reason**: verification_boundary
+> **Verification Boundary**: bun test full suite; downstream verify-sprint green
+> **Rollback Surface**: single commit, test files only
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260807-1930-test-timeout-sibling-sweep.contract.md`
+> **Task Review**: `tasks/reviews/20260807-1930-test-timeout-sibling-sweep.review.md`
+> **Implementation Notes**: `tasks/notes/20260807-1930-test-timeout-sibling-sweep.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from repo-harness-plan planning output.
+- Source ref: a2381159-sibling-class
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260807-1930-test-timeout-sibling-sweep.md`
+- Sprint contract: `tasks/contracts/20260807-1930-test-timeout-sibling-sweep.contract.md`
+- Sprint review: `tasks/reviews/20260807-1930-test-timeout-sibling-sweep.review.md`
+- Implementation notes: `tasks/notes/20260807-1930-test-timeout-sibling-sweep.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260807-1930-test-timeout-sibling-sweep.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260807-1930-test-timeout-sibling-sweep.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260807-1930-test-timeout-sibling-sweep.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260807-1930-test-timeout-sibling-sweep.contract.md`
+- Review file: `tasks/reviews/20260807-1930-test-timeout-sibling-sweep.review.md`
+- Implementation notes file: `tasks/notes/20260807-1930-test-timeout-sibling-sweep.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260807-1930-test-timeout-sibling-sweep.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260807-1930-test-timeout-sibling-sweep.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: single commit, test files only
+- **Verification boundary**: bun test full suite; downstream verify-sprint green
+- **Review/acceptance boundary**: `tasks/reviews/20260807-1930-test-timeout-sibling-sweep.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: verification_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260807-1930-test-timeout-sibling-sweep.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260807-1930-test-timeout-sibling-sweep.contract.md`, `tasks/reviews/20260807-1930-test-timeout-sibling-sweep.review.md`, and `tasks/notes/20260807-1930-test-timeout-sibling-sweep.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260807-1930-test-timeout-sibling-sweep.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: single commit, test files only
+
+## Captured Planning Output
+
+# Tests: complete the subprocess-timeout sibling sweep a2381159 started
+
+## Problem
+
+`a2381159` ("make five load-sensitive tests robust under machine load") established the convention — subprocess-spawning tests carry an explicit generous per-test timeout (30000ms) because bun's 5000ms default measures machine load, not correctness — but fixed only the five instances that had failed by then. The sibling class was left unswept. Consequence, empirically demonstrated across two consecutive shipments (gitignore-dir-level, mcp-scope-retirement): verify-sprint's `bun test` (harness process contending with its own child) repeatedly trips *different* threshold-marginal tests — `capability-config` (fixed ad hoc mid-slice), `session-context-packet-panel` fixture builder (5163ms/5000), `factor-factory` lifecycle (29323ms/15000), `continuation-attempt` breaker siblings (5036ms, 5073ms/5000) — each passing 3/3 standalone. Every future contract on this repo blocks on this class until it is closed.
+
+## Decision
+
+One sweep, one convention: every test that spawns CLI subprocesses (`spawnSync`/`spawn` of `bun`/CLI entrypoints, directly or through fixture helpers like `record()`/`envelopeFrom()`/`commitFixture()`) declares an explicit timeout in the `a2381159` shape (positional `30_000`; larger only where an explicit bound already exists and has proven insufficient — factor-factory's 15000 becomes 45_000 given the observed 29.3s under contention). Assertion-only tests keep the default. No production code, no test-logic changes, no timeout removal.
+
+## Task Breakdown
+
+- [x] Sweep `tests/` for subprocess-spawning tests lacking explicit timeouts (minimum confirmed set: remaining `continuation-attempt.test.ts` no-progress-breaker siblings, `session-context-packet-panel.test.ts` fixture builder, `factor-factory.test.ts` lifecycle; sweep the rest of the suite for the same class).
+- [x] Apply the `a2381159` positional-timeout shape to each.
+- [x] Full `bun test` green; spot-check the previously failing tests individually.
+
+## Verification
+
+`bun test` (full), `bun run check:type`. The real acceptance signal arrives downstream: mcp-scope-retirement's verify-sprint re-run going green.
+
+## Rollback
+
+Single commit, test files only; revert restores defaults.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [x] Sweep `tests/` for subprocess-spawning tests lacking explicit timeouts (minimum confirmed set: remaining `continuation-attempt.test.ts` no-progress-breaker siblings, `session-context-packet-panel.test.ts` fixture builder, `factor-factory.test.ts` lifecycle; sweep the rest of the suite for the same class).
+- [x] Apply the `a2381159` positional-timeout shape to each.
+- [x] Full `bun test` green; spot-check the previously failing tests individually.

--- a/tasks/contracts/20260807-1930-test-timeout-sibling-sweep.contract.md
+++ b/tasks/contracts/20260807-1930-test-timeout-sibling-sweep.contract.md
@@ -1,0 +1,145 @@
+# Task Contract: test-timeout-sibling-sweep
+
+> **Status**: Active
+> **Plan**: plans/plan-20260807-1930-test-timeout-sibling-sweep.md
+> **Task Profile**: code-change
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: ancienttwo
+> **Capability ID**: root
+> **Last Updated**: 2026-08-07 19:30
+> **Review File**: `tasks/reviews/20260807-1930-test-timeout-sibling-sweep.review.md`
+> **Notes File**: `tasks/notes/20260807-1930-test-timeout-sibling-sweep.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+The a2381159 convention (subprocess-spawning tests carry explicit generous timeouts) was applied to five instances, not the class. Threshold-marginal siblings keep tripping verify-sprint's contended `bun test` — three consecutive blocked acceptance runs on mcp-scope-retirement, each a different test, each passing standalone. Every future contract on this repo blocks on this until the class is closed.
+
+## Goal
+
+Every test in `tests/` that spawns CLI subprocesses (directly via spawnSync/spawn or through fixture helpers) declares an explicit positional timeout in the a2381159 shape (`30_000`; `45_000` for factor-factory lifecycle whose existing 15000 was observed insufficient at 29.3s). Assertion-only tests keep the default. Full `bun test` green. Minimum confirmed set covered: remaining continuation-attempt no-progress-breaker siblings, session-context-packet-panel fixture builder, factor-factory lifecycle.
+
+## Scope
+
+- In scope: timeout declarations in `tests/**` files only.
+- Out of scope: production code, test-logic changes, timeout removals, verify-sprint/harness runner changes.
+- Taste constraints: <!-- advisory only, no run gate; default style/taste lives in AGENTS.md and the minimal-change policy, use this to record a per-task override -->
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+
+## Falsifier
+
+If a swept test still times out under normal load (~<4) with its explicit 30s bound, the problem is a hang, not load sensitivity — the timeout sweep direction is wrong for that test and it needs investigation instead. Cheapest proof point: each previously failing test passes standalone 3/3 before the sweep.
+
+## Root Cause Evidence
+
+Required when Task Profile is `bugfix`; leave as-is otherwise.
+
+- root_cause: one sentence naming file:line/condition (testable, not "a state issue").
+- repro: the command or UI path that reproduces the symptom.
+- regression_guard: path to a test that fails on the unfixed code and passes after the fix (must also appear under exit_criteria.tests_pass).
+- pre_fix_failure_artifact: path to a captured run of regression_guard on the UNFIXED code. Capture with `bun test <regression_guard> > <artifact> 2>&1; echo "PRE_FIX_EXIT=$?" >> <artifact>` (no pipes — pipes swallow the exit status). The gate requires a non-zero `PRE_FIX_EXIT=` line plus the regression_guard path string in the artifact (see the Root Cause Evidence Gate section in docs/reference-configs/sprint-contracts.md).
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260807-1930-test-timeout-sibling-sweep.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260807-1930-test-timeout-sibling-sweep.review.md`
+- Notes file: `tasks/notes/20260807-1930-test-timeout-sibling-sweep.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Acceptance Policy
+
+```json
+{"protocol":1,"reviewer":"Claude","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - docs/spec.md
+  - plans/
+  - tasks/todos.md
+  - tasks/contracts/20260807-1930-test-timeout-sibling-sweep.contract.md
+  - tasks/reviews/20260807-1930-test-timeout-sibling-sweep.review.md
+  - tasks/notes/20260807-1930-test-timeout-sibling-sweep.notes.md
+  - .ai/context/capabilities.json
+  - tests/
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+      - codex-exec
+      - main-thread
+    fallback: main-thread
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - docs/spec.md
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260807-1930-test-timeout-sibling-sweep.notes.md
+  tests_pass:
+    - path: tests/continuation-attempt.test.ts
+  commands_succeed:
+    - bun run check:type
+    - bun test
+```
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior:
+- Edge cases:
+- Regression risks:
+
+## Rollback Point
+
+- Commit / checkpoint:
+- Revert strategy:

--- a/tasks/notes/20260807-1930-test-timeout-sibling-sweep.notes.md
+++ b/tasks/notes/20260807-1930-test-timeout-sibling-sweep.notes.md
@@ -1,0 +1,111 @@
+# Implementation Notes: test-timeout-sibling-sweep
+
+> **Status**: Active
+> **Plan**: plans/plan-20260807-1930-test-timeout-sibling-sweep.md
+> **Contract**: tasks/contracts/20260807-1930-test-timeout-sibling-sweep.contract.md
+> **Review**: tasks/reviews/20260807-1930-test-timeout-sibling-sweep.review.md
+> **Last Updated**: 2026-08-07 19:30
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- The class was closed by static analysis, not by eyeballing: a throwaway scanner
+  (`/tmp/sweep/scan.ts`, not committed) parsed every file under `tests/`, computed
+  per-file transitive "spawning helper" sets, matched each `test(...)`/`it(...)` call
+  by paren balancing, and reported which spawning tests carry no positional timeout.
+  Membership rule: a test is in-class if its body textually reaches `spawnSync`,
+  `spawn(`, `execSync`, `execFileSync`, or `Bun.spawn` either directly or through a
+  helper declared in the same file / imported from another `tests/**` or `scripts/**`
+  module (fixture builders live in both).
+- Value shape follows a2381159: positional `30_000` appended after the callback's
+  closing brace. Chosen over a global `bunfig` default because the default 5000ms
+  still guards the assertion-only majority, and an explicit per-test bound keeps
+  hang detection at 30s rather than removing it.
+- `tests/factor-factory.test.ts` already had an explicit bound expressed as a named
+  constant `FACTOR_FACTORY_SMOKE_TIMEOUT_MS = 15000`; observed lifecycle cost was
+  29.3s, so the constant moved to `45_000` rather than adding a second, conflicting
+  literal on the test.
+- Propagation was deliberately **not** extended into `src/`. A test calling a product
+  function that internally spawns is arguably in the same class, but the name-based
+  transitive closure over `src/` cascaded into obvious non-spawning helpers
+  (`profileEnablesCodegraph`, `currentStateVersion`, `readLatestPackageVersion`,
+  `jsonTool`), which would have widened 149 more tests on unsound evidence. Scope
+  stops at test-side and `scripts/` fixture helpers, matching the contract wording.
+- Existing explicit bounds were left alone even where they are tighter than 30s
+  (`SCAFFOLD_PARITY_TIMEOUT_MS = 15000`, `DOCTOR_CHECK_TIMEOUT_MS = 15000`,
+  `tests/state/state-concurrency.test.ts` 8s-20s, `closeout-runner-guardrails` 6s-10s).
+  Only `factor-factory` was named as observed-insufficient; widening the others would
+  be unrequested design space.
+
+## Sweep Result
+
+- Files under `tests/` scanned: 122 (all `.ts`).
+- In-class (subprocess-spawning) tests found: 863.
+- Already carrying an explicit timeout before the sweep: 114
+  (93 numeric literals + 21 named-constant declarations such as
+  `DOCTOR_CHECK_TIMEOUT_MS`, `SCAFFOLD_PARITY_TIMEOUT_MS`).
+- Timeout declarations added this slice: **749** across **96** files, all `30_000`.
+- Existing bound raised: **1** (`tests/factor-factory.test.ts:16`, `15000` -> `45_000`).
+- Total diff: 97 test files, 750 changed lines.
+- Assertion-only tests touched: 0. No test logic changed, no timeout removed, nothing
+  outside `tests/**` edited.
+
+### Minimum confirmed set (contract-named)
+
+| Test | Spawns | Before | After |
+|---|---|---|---|
+| `tests/continuation-attempt.test.ts:310` `real material progress clears a tripped breaker` | `withLedgerRepo` -> `withRepo`/`commitFixture` -> `git`; `record`/`envelopeFrom` -> `runStateCli` -> `bun src/cli/index.ts` (multiple CLI invocations) | default 5000 | `30_000` |
+| `tests/continuation-attempt.test.ts:327` `an explicit resumed receipt resets the count, which then restarts at one` | same fixture chain | default 5000 | `30_000` |
+| `tests/continuation-attempt.test.ts` remaining breaker/authority-fence siblings (142, 175, 185, 200, 228, 292, 301, 344, 354, 369, 383, 398, 409, 425, 438) | same fixture chain | default 5000 | `30_000` |
+| `tests/session-context-packet-panel.test.ts:43` `every authority state's fixture is git-initialized with the opt-in marker present` | `buildPanelFixture` from `scripts/session-context-packet-panel.ts`, 9 authority states x git init/commit | default 5000 (measured 5163ms) | `30_000` |
+| `tests/factor-factory.test.ts:49` `factor lifecycle commands create, promote, reject, and check registry state` | `bootstrapRepo` -> `create-project-dirs.sh` plus repeated `bun src/cli/index.ts` factor commands | `15000` (measured 29323ms) | `45_000` |
+
+### Largest per-file additions
+
+`helper-scripts.test.ts` 99, `effective-state.test.ts` 30, `cli/chatgpt-browser.test.ts` 26,
+`contract-run.test.ts` 24, `mutation-guard.test.ts` 22, `sprint-backlog.test.ts` 21,
+`runtime-profile-enforcement.test.ts` 21, `install-agent-fleet.test.ts` 21,
+`skill-routing-eval.test.ts` 18, `mutation-observed.test.ts` 17,
+`continuation-attempt.test.ts` 17.
+
+### Deliberately not patched
+
+- `tests/state/loop-semantics-characterization.test.ts:808` — scanner false positive.
+  The match is the substring `it (` inside a prose comment (`...stopped calling it (while
+  leaving the marker string in place)...`), not a test declaration. Verified by reading
+  the source; no edit made.
+
+## Deviations From Plan Or Spec
+
+- None. Scope stayed inside `tests/**`.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| Global default timeout in `bunfig.toml` | Rejected | Would relax the 5000ms fence for the assertion-only majority, hiding real regressions there; the load sensitivity is specific to subprocess spawning |
+| Patch only the three observed-failing tests | Rejected | That is exactly what a2381159 did, and it left the class open — three further acceptance rounds each blocked on a different sibling |
+| Extend helper propagation into `src/` (149 more tests) | Rejected | Transitive closure over `src/` produced demonstrable false positives; unsound basis for widening assertion-only tests |
+| Raise every existing sub-30s bound to 30s | Rejected | Only `factor-factory` was observed insufficient; the rest are deliberate tighter fences |
+
+## Open Questions
+
+- None.
+
+## Evidence Links
+
+- Falsifier (pre-sweep, standalone): `bun test tests/session-context-packet-panel.test.ts tests/factor-factory.test.ts tests/continuation-attempt.test.ts` -> 35 pass / 0 fail, 53.98s. Confirms load sensitivity rather than hangs, so widening the bound is the right direction.
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Candidate for `tasks/lessons.md`: when a fix is applied to named failing instances of a
+  class, close the class in the same slice or file the sweep as a deferred goal. a2381159
+  fixed five instances; the unswept remainder blocked three later acceptance rounds.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/reviews/20260807-1930-test-timeout-sibling-sweep.review.md
+++ b/tasks/reviews/20260807-1930-test-timeout-sibling-sweep.review.md
@@ -1,84 +1,104 @@
 # Task Review: test-timeout-sibling-sweep
 
-> **Status**: Pending
+> **Status**: Complete
 > **Plan**: plans/plan-20260807-1930-test-timeout-sibling-sweep.md
 > **Contract**: tasks/contracts/20260807-1930-test-timeout-sibling-sweep.contract.md
 > **Notes File**: tasks/notes/20260807-1930-test-timeout-sibling-sweep.notes.md
 > **Checks File**: .ai/harness/checks/latest.json
-> **Last Updated**: 2026-08-07 19:30
-> **Recommendation**: fail
+> **Last Updated**: 2026-08-07 22:05
+> **Recommendation**: pass
 > **Review Rubric Version**: 2
 > **Reviewed Subject SHA256**: pending
 > **Reviewed Subject Scope**: normalized-final-content
 > **Reviewed Target Revision**: pending
 
+The two `pending` header fields above are rubric metadata only. The
+authoritative reviewed-subject hash and target revision for this review are
+the ones recorded in the Acceptance Receipt Projection below, which the
+receipt tooling writes from the receipt itself; they are deliberately not
+hand-copied here, because editing this file after the receipt is recorded
+would invalidate the recorded subject hash.
+
 ## Human Review Card
 
-- Verdict: pending
-- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
-- Intended files changed:
-- Actual files changed:
-- Commands passed:
-- Residual risks:
-- Reviewer action required: inspect diff and card
-- Rollback:
+- Verdict: pass
+- Change type: code-change
+- Intended files changed: timeout declarations in `tests/**` only, per contract Goal — the a2381159 positional `30_000` shape on every subprocess-spawning test lacking an explicit bound, plus `tests/factor-factory.test.ts` raising its existing `FACTOR_FACTORY_SMOKE_TIMEOUT_MS` from `15000` to `45_000`.
+- Actual files changed: 97 files under `tests/` (750 changed lines, +751 -751 including the ledger header), plus `tasks/todos.md` (`Updated` header timestamp only) and the four new plan/contract/review/notes workflow artifacts. Nothing outside the contract `allowed_paths`; no `src/` file appears in the diff.
+- Commands passed: `bun test` standalone (2217 pass / 1 skip / 0 fail, 177 files, 502.57s, exit 0); `bun run check:type` (exit 0); `repo-harness run verify-sprint --prepare-acceptance` (`[ContractVerify] total=8 failed=0 status=Fulfilled`, including its own contended `bun test` at 518810ms and `tests/continuation-attempt.test.ts` at 27038ms); `repo-harness run verify-sprint` (exit 0, acceptance finalized).
+- Residual risks: see Residual Risks / Follow-ups
+- Reviewer action required: none
+- Rollback: revert the single sweep commit; every test returns to bun's 5000ms default (or its prior explicit bound). No production code, no runner config, no adapter surface involved.
 
 ## Mode Evidence
 
-- Selected route:
-- P1/P2/P3 evidence:
-- Root cause or plan evidence:
+- Selected route: acceptance gate review of the full working-tree diff against contract Goal / Scope / Allowed Paths / Exit Criteria, weighted toward mechanical change purity because the slice is test-only and mass-applied.
+- P1/P2/P3 evidence: P1 — the surface is `tests/**` per-test timeout arguments only; the timeout authority is bun's third positional argument to `test()`/`it()`, and the pressure surface is verify-sprint's `bun test`, which runs the suite while the harness process itself contends for the same machine. P2 — traced the failure mode end to end: `repo-harness run verify-sprint` invokes `bun test` as a child of the already-running harness, so wall-clock per test inflates; a test whose real cost is 4.5s of `spawnSync` fixture work crosses bun's 5000ms default and is reported as a timeout, not an assertion failure. That is why every blocked round named a different test and every named test passed 3/3 standalone. P3 — a positional per-test bound was the right instrument over a global `bunfig` default: the 5000ms fence still guards the assertion-only majority (where a 5s test really is a regression), while the subprocess class gets a bound generous enough for contention but still short enough to catch a genuine hang at 30s instead of removing hang detection entirely.
+- Root cause or plan evidence: contract Task Profile is `code-change`, so the Root Cause Evidence block is not required and was left as-is. The class evidence is in the plan Problem section and the notes `Sweep Result` table.
 
 ## Verification Evidence
 
-- Waza `/check` run:
+- Waza `/check` run: not run as a separate skill; the contract's exit-criteria commands were run directly and are listed below.
 - Commands run:
-- Manual checks:
-- Supporting artifacts:
-- Implementation notes reviewed:
-- Run snapshot:
+
+| Command | Result |
+|---|---|
+| `bun test` (standalone) | 2217 pass / 1 skip / 0 fail, 177 files, 502.57s, exit 0 |
+| `bun run check:type` | exit 0 |
+| `repo-harness run verify-sprint --prepare-acceptance` | `[ContractVerify] total=8 failed=0 status=Fulfilled`, exit 0; contended `bun test` green at 518810ms |
+| `repo-harness run verify-sprint` | exit 0, `Sprint acceptance finalized` |
+
+- Manual checks: mechanical purity was proved rather than sampled. All 750 diff hunks are single-line-for-single-line replacements (`git diff -U0 -- tests/` hunk headers are uniformly `-n +n` with no line counts). Normalizing each added line by deleting one `, 30_000` reproduces its removed line byte-for-byte in 749 of 750 cases; the one remainder is `tests/factor-factory.test.ts:16` `15000` -> `45_000`. Insertion-point correctness was checked structurally, not by eye: for every insertion the enclosing block opener at the same indentation is a `test(`/`it(` call — 744 close `});` -> `}, 30_000);` and 5 close the wrapped-callback form `}));` -> `}), 30_000);` in `tests/install-profiles.test.ts` (the `test(name, () => withHome(...), 30_000)` shape, timeout still the third argument of `test`). The single case the indentation heuristic could not resolve, `tests/run-skill-evals.test.ts:703`, was read by hand and closes the `test(` opened at line 631 (the heuristic tripped on a zero-indent line inside a shell template literal). The notes' claimed scanner false positive at `tests/state/loop-semantics-characterization.test.ts:808` was confirmed to be prose inside a comment, correctly left unpatched. Selectivity confirmed on both sides: `tests/ux-feature-guardrail.test.ts` had its `spawnSync` test swept while the adjacent assertion-only test was left at the default, and `tests/continuation-attempt.test.ts:238` was left alone because it already carries a more generous explicit `120_000` — no existing bound was removed or tightened.
+- Supporting artifacts: `.ai/harness/checks/latest.json` (status pass, 2 source events); run snapshot below.
+- Implementation notes reviewed: yes — `tasks/notes/20260807-1930-test-timeout-sibling-sweep.notes.md`. Counts independently reproduced from the diff: 749 added declarations across 96 files plus 1 widened constant = 97 files, 750 changed lines.
+- Run snapshot: `.ai/harness/runs/run-20260807T215257-27977-20260807-1930-test-timeout-sibling-sweep.json`
 
 ## Acceptance Receipt Projection
 
-> **Disposition**: unavailable
-> **Reviewer**: unavailable
-> **Source**: unavailable
+> **Disposition**: external_pass
+> **Reviewer**: Claude
+> **Source**: claude-review
 > **Actor**: not-applicable
-> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject SHA256**: sha256:f6013e3b40410b1cb24d0a783c825279aabce50bcc4d796ba9ebb6aaa866674c
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: pending
-> **Verification Evidence SHA256**: pending
-> **Issued At**: pending
+> **Reviewed Target Revision**: 222efa1287b2792bb333795466bc5ae6d5c9a4e1
+> **Verification Evidence SHA256**: sha256:e31ebde2a4ed583d1f3cefcbc0827403001102406ad3fc6b5839a595c98320e9
+> **Issued At**: 2026-08-07T14:03:23.282Z
 
-- Summary: No AcceptanceReceipt has been recorded.
+- Summary: Mechanical purity verified: all 750 diff hunks are 1-for-1 line replacements; 749 are pure ', 30_000' insertions at test/it declaration closers and 1 widens factor-factory's FACTOR_FACTORY_SMOKE_TIMEOUT_MS from 15000 to 45_000. No test logic changed, no timeout removed, nothing outside tests/ except the tasks/todos.md timestamp. Full bun test 2217 pass / 1 skip / 0 fail (502.6s standalone), bun run check:type clean, and verify-sprint's own contended bun test green at 518.8s - the downstream signal that was 0-for-3 before this sweep.
 - Findings: none
 
 ## Behavior Diff Notes
 
-- ...
+- No behavior change in any product path. The only observable difference is the per-test deadline bun enforces: 749 tests move from the implicit 5000ms default to an explicit 30000ms, and `tests/factor-factory.test.ts` lifecycle moves from 15000ms to 45000ms.
+- Hang detection is preserved, not removed: a swept test that genuinely deadlocks still fails, at 30s instead of 5s.
+- Assertion-only tests are unchanged and keep the 5000ms fence, so a real performance regression in that majority still surfaces.
 
 ## Residual Risks / Follow-ups
 
-- ...
+- A regression that makes a swept test 6x slower now hides inside the 30s bound. Accepted deliberately: for subprocess-spawning tests the default measured machine load rather than correctness, which is what produced three consecutive false-negative acceptance rounds.
+- Class membership came from a throwaway static scanner (transitive spawning-helper closure across `tests/**` and `scripts/**`). It is deliberately conservative — over-application to a few assertion-heavy tests in a file that also has spawning helpers is possible, and is harmless. Under-application is the risk that matters, and the falsifier for it is the next contended verify-sprint round.
+- Helper propagation was deliberately not extended into `src/` (149 further tests). The notes record the reason: the name-based closure over `src/` produced demonstrable false positives (`profileEnablesCodegraph`, `currentStateVersion`), so widening on that basis would be unsound. If a future round trips on a test whose spawn happens inside a product function, that is the sweep's known boundary and the follow-up slice.
+- Existing sub-30s bounds elsewhere (`SCAFFOLD_PARITY_TIMEOUT_MS`, `DOCTOR_CHECK_TIMEOUT_MS`, `state-concurrency`, `closeout-runner-guardrails`) were left as deliberate tighter fences. Only `factor-factory` had observed evidence of insufficiency.
 
 ## Scorecard
 
 | Dimension | Score | Notes |
 |-----------|-------|-------|
-| Functionality | 0/10 | |
-| Product depth | 0/10 | |
-| Design quality | 0/10 | |
-| Code quality | 0/10 | |
+| Functionality | 9/10 | Full suite green standalone and under verify-sprint contention; the downstream signal that was 0-for-3 is now green |
+| Product depth | 9/10 | Closes the class a2381159 left open instead of patching the three newly observed instances, which is the failure mode being fixed |
+| Design quality | 9/10 | Per-test positional bound over a global default keeps the 5000ms fence on the assertion-only majority and keeps hang detection at 30s |
+| Code quality | 10/10 | Mechanically pure: 749 identical insertions plus 1 constant widening, proved by normalization rather than sampling; no logic change, no timeout removal, nothing outside `tests/` |
 
 ## Failing Items
 
-- ...
+- None.
 
 ## Retest Steps
 
-- Re-run:
-- Re-check:
+- Re-run: `bun test` and `repo-harness run verify-sprint --prepare-acceptance`.
+- Re-check: if a future contended round still trips a timeout, record which test and by how much before widening anything — per the contract Falsifier, a swept test exceeding 30s under normal load is a hang, not load sensitivity, and needs investigation rather than a larger bound.
 
 ## Summary
 
-- ...
+- Gatekeeper PASS. The slice closes the class `a2381159` opened: subprocess-spawning tests now carry an explicit generous per-test timeout, 749 new positional `30_000` declarations across 96 files plus one existing bound widened where it was observed insufficient (`tests/factor-factory.test.ts` lifecycle, 29.3s against 15000, now `45_000`). Purity was proved mechanically rather than sampled: all 750 hunks are 1-for-1 line replacements, normalizing away one `, 30_000` reproduces the removed line in 749 of them, and every insertion closes a `test(`/`it(` declaration — 744 in the plain `});` form and 5 in `install-profiles.test.ts`'s wrapped-callback `}), 30_000);` form where the timeout is still `test`'s third argument. The one indentation-ambiguous site, `run-skill-evals.test.ts:703`, was read by hand and closes the `test(` at line 631. Selectivity holds in both directions: the adjacent assertion-only test in `ux-feature-guardrail.test.ts` was left at the default, and `continuation-attempt.test.ts:238` kept its pre-existing, more generous `120_000` — no bound was removed or tightened. Nothing outside `tests/` changed except the `tasks/todos.md` header timestamp. Verification: standalone `bun test` 2217 pass / 1 skip / 0 fail in 502.57s, `bun run check:type` clean, and `verify-sprint --prepare-acceptance` at `total=8 failed=0 Fulfilled` with its own contended `bun test` green at 518810ms — that contended run is the acceptance signal this class had blocked three times running, each on a different threshold-marginal test, each green standalone.

--- a/tasks/reviews/20260807-1930-test-timeout-sibling-sweep.review.md
+++ b/tasks/reviews/20260807-1930-test-timeout-sibling-sweep.review.md
@@ -1,0 +1,84 @@
+# Task Review: test-timeout-sibling-sweep
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260807-1930-test-timeout-sibling-sweep.md
+> **Contract**: tasks/contracts/20260807-1930-test-timeout-sibling-sweep.contract.md
+> **Notes File**: tasks/notes/20260807-1930-test-timeout-sibling-sweep.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-08-07 19:30
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Commands passed:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+- Waza `/check` run:
+- Commands run:
+- Manual checks:
+- Supporting artifacts:
+- Implementation notes reviewed:
+- Run snapshot:
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -1,7 +1,7 @@
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: 2026-08-07 11:28
+> **Updated**: 2026-08-07 19:30
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.

--- a/tests/acceptance-receipt-evidence-fingerprint.test.ts
+++ b/tests/acceptance-receipt-evidence-fingerprint.test.ts
@@ -118,7 +118,7 @@ describe('AcceptanceReceipt verification-evidence fingerprint', () => {
     const verified = await verifyAcceptance({ root, authorityHome: home });
     expect(verified.verification_evidence_sha256).toBe(receipt.verification_evidence_sha256);
     expect(verified.disposition).toBe('external_pass');
-  });
+  }, 30_000);
 
   test('still fails closed when the verification evidence changes semantically', async () => {
     const { root, home } = makeFixture();
@@ -139,5 +139,5 @@ describe('AcceptanceReceipt verification-evidence fingerprint', () => {
       ],
     });
     await expect(verifyAcceptance({ root, authorityHome: home })).rejects.toThrow('verification evidence is stale');
-  });
+  }, 30_000);
 });

--- a/tests/acceptance-receipt.test.ts
+++ b/tests/acceptance-receipt.test.ts
@@ -147,7 +147,7 @@ describe('AcceptanceReceipt', () => {
 
     writeFileSync(join(root, 'feature.txt'), 'semantic change\n');
     await expect(verifyAcceptance({ root, authorityHome: home })).rejects.toThrow('semantic subject is stale');
-  });
+  }, 30_000);
 
   test('typed user waiver stays distinct from external pass and obeys the contract', async () => {
     const allowed = makeFixture('allowed');
@@ -190,7 +190,7 @@ describe('AcceptanceReceipt', () => {
       actor: 'kito',
       summary: 'attempted waiver',
     })).toThrow('forbids user waiver');
-  });
+  }, 30_000);
 
   test('reuses one owner grant after semantic correction while every receipt stays exact', async () => {
     const { root, home } = makeFixture();
@@ -228,7 +228,7 @@ describe('AcceptanceReceipt', () => {
     expect(second.waiver_grant_sha256).toBe(first.waiver_grant_sha256);
     expect((verifyUserWaiverGrant({ root, authorityHome: home }))).toEqual(grant);
     expect((await verifyAcceptance({ root, authorityHome: home })).subject_sha256).toBe(second.subject_sha256);
-  });
+  }, 30_000);
 
   test('contract or goal authority changes invalidate the owner grant', async () => {
     const contractChanged = makeFixture();
@@ -263,7 +263,7 @@ describe('AcceptanceReceipt', () => {
       authorityHome: goalChanged.home,
       contract: 'tasks/contracts/demo.contract.md',
     })).toThrow('goal authority is stale');
-  });
+  }, 30_000);
 
   test('revocation invalidates a user-waiver receipt and external pass never binds a grant', async () => {
     const waived = makeFixture();
@@ -286,7 +286,7 @@ describe('AcceptanceReceipt', () => {
     const external = makeFixture();
     const externalReceipt = await externalPass(external.root, external.home);
     expect(externalReceipt.waiver_grant_sha256).toBeNull();
-  });
+  }, 30_000);
 
   test('non-overlapping target movement preserves acceptance; overlap invalidates it', async () => {
     const { root, home } = makeFixture();
@@ -302,7 +302,7 @@ describe('AcceptanceReceipt', () => {
     commit(root, 'advance target with overlap');
     git(root, 'checkout', 'codex/demo');
     await expect(verifyAcceptance({ root, authorityHome: home })).rejects.toThrow('overlaps 1 reviewed path');
-  });
+  }, 30_000);
 
   test('strict archive envelopes preserve plan and contract receipt authority', async () => {
     const { root, home } = makeFixture();
@@ -329,7 +329,7 @@ describe('AcceptanceReceipt', () => {
     commit(root, 'archive accepted workflow');
 
     expect((await verifyAcceptance({ root, authorityHome: home })).disposition).toBe('external_pass');
-  });
+  }, 30_000);
 
   test('strict archive envelopes preserve the waiver grant and its exact receipt', async () => {
     const { root, home } = makeFixture();
@@ -369,5 +369,5 @@ describe('AcceptanceReceipt', () => {
 
     expect(verifyUserWaiverGrant({ root, authorityHome: home }).actor).toBe('kito');
     expect((await verifyAcceptance({ root, authorityHome: home })).disposition).toBe('user_waiver');
-  });
+  }, 30_000);
 });

--- a/tests/architecture-event.test.ts
+++ b/tests/architecture-event.test.ts
@@ -41,7 +41,7 @@ describe("architecture-event helper", () => {
       "docs/architecture/modules/apps-web/account.md",
       "tasks/workstreams/apps-web/account",
     ]);
-  });
+  }, 30_000);
 
   test("builds architecture event JSON without shell string escaping", () => {
     const res = runArchitectureEvent([
@@ -85,7 +85,7 @@ describe("architecture-event helper", () => {
     expect(event.file_path).toBe('apps/web/src/routes/account/"page".tsx');
     expect(event.spawn_recommended).toBe(false);
     expect(event.contract_sync_required).toBe(true);
-  });
+  }, 30_000);
 
   test("updates context-map discoverable contexts idempotently", () => {
     const cwd = mkdtempSync(join(tmpdir(), "architecture-event-context-map-"));
@@ -122,7 +122,7 @@ describe("architecture-event helper", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("syncs architecture contract blocks without shell rendering", () => {
     const cwd = mkdtempSync(join(tmpdir(), "architecture-event-contract-files-"));
@@ -210,7 +210,7 @@ describe("architecture-event helper", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("syncs pending architecture request only when the card is active and pending", () => {
     const cwd = mkdtempSync(join(tmpdir(), "architecture-event-pending-request-"));
@@ -279,5 +279,5 @@ describe("architecture-event helper", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 });

--- a/tests/architecture-queue.test.ts
+++ b/tests/architecture-queue.test.ts
@@ -137,7 +137,7 @@ describe("architecture queue", () => {
       expect(index).toContain("Human-owned backlog note.");
       expect(queue(cwd, ["reindex", "--check"]).status).toBe(0);
     });
-  });
+  }, 30_000);
 
   test("reindex self-heals stale loose pending lines and is idempotent", () => {
     tmpRepo((cwd) => {
@@ -153,7 +153,7 @@ describe("architecture queue", () => {
       const index = readFileSync(indexPath, "utf-8");
       expect(index).not.toContain("duplicate.md");
     });
-  });
+  }, 30_000);
 
   test("triage collapses cutoff legacy requests into capability cards and archives the originals", () => {
     tmpRepo((cwd) => {
@@ -173,7 +173,7 @@ describe("architecture queue", () => {
       expect(archived).toContain("20260528-120100-runtime-a.md");
       expect(queue(cwd, ["reindex", "--check"]).status).toBe(0);
     });
-  });
+  }, 30_000);
 
   test("gate modes are advisory by default and strict blocks pending requests", () => {
     tmpRepo((cwd) => {
@@ -190,7 +190,7 @@ describe("architecture queue", () => {
       );
       expect(queue(cwd, ["status", "--gate", "--format", "summary"]).status).toBe(1);
     });
-  });
+  }, 30_000);
 
   test("archive roundtrip leaves an empty derived pending block", () => {
     tmpRepo((cwd) => {
@@ -207,5 +207,5 @@ describe("architecture queue", () => {
       expect(index).toContain("<!-- BEGIN ARCHITECTURE PENDING REQUESTS -->\n- (none)\n<!-- END ARCHITECTURE PENDING REQUESTS -->");
       expect(queue(cwd, ["reindex", "--check"]).status).toBe(0);
     });
-  });
+  }, 30_000);
 });

--- a/tests/architecture-sync.test.ts
+++ b/tests/architecture-sync.test.ts
@@ -114,7 +114,7 @@ describe("architecture sync gate", () => {
       expect(parsed[0].capability_id).toBe("apps-web");
       expect(parsed[1].capability_id).toBe("root");
     });
-  });
+  }, 30_000);
 
   test("strict blocks when a changed capability has a pending request at the threshold", () => {
     tmpRepo((cwd) => {
@@ -127,7 +127,7 @@ describe("architecture sync gate", () => {
       expect(res.stdout).toContain("blocking=1");
       expect(res.stderr).toContain("strict gate failed");
     });
-  });
+  }, 30_000);
 
   test("advisory warns but exits zero for matching pending requests", () => {
     tmpRepo((cwd) => {
@@ -140,7 +140,7 @@ describe("architecture sync gate", () => {
       expect(res.stdout).toContain("blocking=1");
       expect(res.stderr).toContain("WARN");
     });
-  });
+  }, 30_000);
 
   test("off mode still checks index integrity but ignores freshness blocking", () => {
     tmpRepo((cwd) => {
@@ -152,7 +152,7 @@ describe("architecture sync gate", () => {
       expect(res.status).toBe(0);
       expect(res.stdout).toContain("mode=off");
     });
-  });
+  }, 30_000);
 
   test("stale architecture index fails in every mode", () => {
     tmpRepo((cwd) => {
@@ -168,7 +168,7 @@ describe("architecture sync gate", () => {
       expect(res.status).toBe(1);
       expect(res.stderr).toContain("architecture request index is stale");
     });
-  });
+  }, 30_000);
 
   test("missing resolver is advisory in advisory mode and fail-closed in strict mode", () => {
     tmpRepo((cwd) => {
@@ -186,5 +186,5 @@ describe("architecture sync gate", () => {
       expect(strict.status).toBe(1);
       expect(strict.stderr).toContain("strict gate failed");
     });
-  });
+  }, 30_000);
 });

--- a/tests/archive-evidence-gates.test.ts
+++ b/tests/archive-evidence-gates.test.ts
@@ -565,7 +565,7 @@ describe("archive evidence gates", () => {
       expect(existsSync(join(cwd, "tasks/contracts/20260711-1200-demo.contract.md"))).toBe(false);
       expect(existsSync(join(cwd, "tasks/reviews/20260711-1200-demo.review.md"))).toBe(false);
     });
-  });
+  }, 30_000);
 
   test("sealed-terminal mode accepts only a Fulfilled contract, pass review, and typed receipt projection", () => {
     withTempRepo("sealed-terminal-archive", (cwd) => {
@@ -610,7 +610,7 @@ describe("archive evidence gates", () => {
         expect(existsSync(join(cwd, "plans/plan-20260711-1200-demo.md"))).toBe(true);
       });
     }
-  });
+  }, 30_000);
 
   test("predict-manifest merges live checks evidence into the scratch clone instead of nesting it", () => {
     withTempRepo("archive-workflow-predict-manifest", (cwd) => {
@@ -656,7 +656,7 @@ describe("archive evidence gates", () => {
       expect(manifest).toContain("tasks/archive/contract-20260721-2256-demo.md");
       expect(manifest).toContain("tasks/archive/review-20260721-2256-demo.md");
     });
-  });
+  }, 30_000);
 
   test("ordinary Completed archive cannot reuse a same-HEAD local origin receipt", () => {
     withTempRepo("archive-workflow-root-bound-receipt", (container) => {
@@ -697,7 +697,7 @@ describe("archive evidence gates", () => {
       expect(result.stderr).toContain("AcceptanceReceipt gate failed");
       expect(existsSync(join(clone, "plans/plan-20260711-1200-demo.md"))).toBe(true);
     });
-  });
+  }, 30_000);
 
   test("current-status refresh failures are returned instead of being ignored", () => {
     withTempRepo("archive-workflow-refresh", (cwd) => {
@@ -725,7 +725,7 @@ describe("archive evidence gates", () => {
       expect(retry.status).toBe(0);
       expect(existsSync(join(cwd, "plans/archive/plan-20260711-1200-demo.md"))).toBe(true);
     });
-  });
+  }, 30_000);
 
   test("Abandoned and Superseded archives preserve the full plan body without completion evidence", () => {
     for (const outcome of ["Abandoned", "Superseded"]) {
@@ -738,7 +738,7 @@ describe("archive evidence gates", () => {
         expect(archived).toContain("Keep this content.");
       });
     }
-  });
+  }, 30_000);
 
   test("Resolved architecture archive requires a live Pending request and its existing module artifact", () => {
     withTempRepo("archive-architecture-gates", (cwd) => {
@@ -775,7 +775,7 @@ describe("archive evidence gates", () => {
       expect(archived).toContain("- `docs/architecture/modules/runtime/demo.md`");
       expect(readFileSync(join(cwd, ".queue-calls"), "utf-8")).toContain("reindex --check");
     });
-  });
+  }, 30_000);
 
   test("unsafe artifact symlinks and post-archive reindex failures fail visibly", () => {
     withTempRepo("archive-architecture-failure", (cwd) => {
@@ -816,5 +816,5 @@ describe("archive evidence gates", () => {
       expect(retry.status).toBe(0);
       expect(existsSync(requestPath)).toBe(false);
     });
-  });
+  }, 30_000);
 });

--- a/tests/bdd2-evals-contract.test.ts
+++ b/tests/bdd2-evals-contract.test.ts
@@ -8,33 +8,33 @@ describe("BDD2 Phase E3 evaluation contract", () => {
     const evaluation = validateEvaluation();
     expect(evaluation.manifest.historical_reports.length).toBeGreaterThanOrEqual(13);
     for (const ref of evaluation.manifest.historical_reports) expect(sha256File(join(REPO_ROOT, ref.path))).toBe(ref.sha256);
-  });
+  }, 30_000);
 
   test("Browser and ImageGen appendices remain first-class tracked evidence", () => {
     const evaluation = validateEvaluation();
     expect(Object.keys(evaluation.manifest.experiments.EB3.appendices ?? {})).toHaveLength(6);
     expect(Object.keys(evaluation.manifest.experiments.EI3.appendices ?? {})).toHaveLength(6);
-  });
+  }, 30_000);
 
   test("current Behavior Audit and Phase P surfaces are absent", () => {
     const evaluation = validateEvaluation();
     expect(JSON.stringify(evaluation.manifest)).not.toContain('"A3"');
     const changedProductSurface = ["assets/skill-commands/repo-harness-bdd", "src/cli/commands/bdd.ts", "src/cli/mcp/behavior-tools.ts"];
     for (const path of changedProductSurface) expect(() => readFileSync(join(REPO_ROOT, path))).toThrow();
-  });
+  }, 30_000);
 
   test("I3 gate is frozen but does not encode a post-reveal outcome", () => {
     const evaluation = validateEvaluation();
     expect(evaluation.manifest.i3.prerequisite).toEqual({ shape: "Pass", any_adapter: "Pass" });
     expect(JSON.stringify(evaluation.manifest.i3)).not.toContain("S3_decision");
-  });
+  }, 30_000);
 
   test("tracked E3 evidence reproduces every terminal decision", () => {
     const evaluation = validateEvaluation();
     expect(verifyEvidenceProjection(evaluation, evaluation.manifest.experiments.S3.result.evidence.path)).toEqual({ experiment: "S3", decision: "Kill" });
     expect(verifyEvidenceProjection(evaluation, evaluation.manifest.experiments.EB3.result.evidence.path)).toEqual({ experiment: "EB3", decision: "Kill" });
     expect(verifyEvidenceProjection(evaluation, evaluation.manifest.experiments.EI3.result.evidence.path)).toEqual({ experiment: "EI3", decision: "Kill" });
-  });
+  }, 30_000);
 
   test("authoritative evaluation CI checks out the historical source commit", () => {
     const workflow = readFileSync(join(REPO_ROOT, ".github/workflows/ci.yml"), "utf8");

--- a/tests/capability-archcontext-export.test.ts
+++ b/tests/capability-archcontext-export.test.ts
@@ -278,5 +278,5 @@ describe("capability-resolver archcontext-boundaries-v1 export", () => {
       expect(result.issues).toEqual([]);
       expect(result.valid).toBe(true);
     }
-  });
+  }, 30_000);
 });

--- a/tests/capability-config.test.ts
+++ b/tests/capability-config.test.ts
@@ -81,7 +81,7 @@ describe("capability-config helper", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("refuses to create missing capability prefixes unless explicitly requested", () => {
     const cwd = tmpWorkspace("capability-config-missing-prefix");
@@ -94,7 +94,7 @@ describe("capability-config helper", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("reuses existing registry entries instead of re-deriving custom fields", () => {
     const cwd = tmpWorkspace("capability-config-existing");
@@ -127,5 +127,5 @@ describe("capability-config helper", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 });

--- a/tests/capability-resolver.test.ts
+++ b/tests/capability-resolver.test.ts
@@ -129,7 +129,7 @@ describe("capability resolver", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("contract file pairs are required for every capability", () => {
     const cwd = tmpWorkspace("capability-contract-pair");
@@ -150,7 +150,7 @@ describe("capability resolver", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("missing registry fails closed instead of deriving legacy context blocks", () => {
     const cwd = tmpWorkspace("capability-missing-registry");
@@ -167,7 +167,7 @@ describe("capability resolver", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("environment context blocks cannot replace the capability registry", () => {
     const cwd = tmpWorkspace("capability-env-blocks");
@@ -190,7 +190,7 @@ describe("capability resolver", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("malformed registry JSON fails with an authority-specific error", () => {
     const cwd = tmpWorkspace("capability-malformed-registry");
@@ -204,7 +204,7 @@ describe("capability resolver", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("registered prefixes must exist", () => {
     const cwd = tmpWorkspace("capability-missing-prefix");
@@ -217,5 +217,5 @@ describe("capability resolver", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 });

--- a/tests/check-state-boundaries.test.ts
+++ b/tests/check-state-boundaries.test.ts
@@ -186,7 +186,7 @@ describe('state architecture boundary checker', () => {
       );
     });
     expect(messages(result, 'CORE_PROCESS_EXECUTION')).toHaveLength(5);
-  });
+  }, 30_000);
 
   test('keeps canonical symbols in their core owners and catches renamed CLI authority', async () => {
     const { result } = await checkWith((root) => {
@@ -338,5 +338,5 @@ describe('state architecture boundary checker', () => {
     expect(run.stdout).toBe('');
     expect(run.stderr).toContain('CORE_FORBIDDEN_IMPORT src/core/state/forbidden.ts:1:1');
     expect(run.stderr).toContain('[state-boundaries] failed: 1 violation(s)');
-  });
+  }, 30_000);
 });

--- a/tests/check-task-sync.test.ts
+++ b/tests/check-task-sync.test.ts
@@ -55,7 +55,7 @@ describe("check-task-sync helper", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("fails when only an untracked source file is added", () => {
     const cwd = setupRepo();
@@ -67,7 +67,7 @@ describe("check-task-sync helper", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("passes when code changes include tasks/todos.md updates", () => {
     const cwd = setupRepo();
@@ -79,7 +79,7 @@ describe("check-task-sync helper", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("passes when untracked repo changes include an untracked tasks file", () => {
     const cwd = setupRepo();
@@ -93,7 +93,7 @@ describe("check-task-sync helper", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("passes when code changes include tasks/lessons.md updates", () => {
     const cwd = setupRepo();
@@ -105,7 +105,7 @@ describe("check-task-sync helper", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("passes when only tasks files changed", () => {
     const cwd = setupRepo();
@@ -117,7 +117,7 @@ describe("check-task-sync helper", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("passes when code changes include docs/researches updates", () => {
     const cwd = setupRepo();
@@ -130,7 +130,7 @@ describe("check-task-sync helper", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("ignores regenerated harness benchmark evidence as operational output", () => {
     const cwd = setupRepo();
@@ -143,7 +143,7 @@ describe("check-task-sync helper", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("does not let regenerated harness evidence hide an unsynchronized source change", () => {
     const cwd = setupRepo();
@@ -156,7 +156,7 @@ describe("check-task-sync helper", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("does not broaden the operational exclusion to sibling report files", () => {
     const cwd = setupRepo();
@@ -168,7 +168,7 @@ describe("check-task-sync helper", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("fails when only legacy docs/PROGRESS.md changed", () => {
     const cwd = setupRepo();
@@ -180,7 +180,7 @@ describe("check-task-sync helper", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("fails when code changes only update docs/PROGRESS.md", () => {
     const cwd = setupRepo();
@@ -193,7 +193,7 @@ describe("check-task-sync helper", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("prefers staged changes over working tree changes", () => {
     const cwd = setupRepo();
@@ -208,5 +208,5 @@ describe("check-task-sync helper", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 });

--- a/tests/cli/adoption-plan.test.ts
+++ b/tests/cli/adoption-plan.test.ts
@@ -163,7 +163,7 @@ describe("canonical adoption plan", () => {
     } finally {
       cleanup(repo);
     }
-  });
+  }, 30_000);
 
   test("standard adoption directly replaces managed planning routes", () => {
     const repo = tempRepo();
@@ -480,7 +480,7 @@ describe("canonical adoption plan", () => {
     } finally {
       cleanup(repo);
     }
-  });
+  }, 30_000);
 });
 
 describe("init command cutover", () => {
@@ -496,7 +496,7 @@ describe("init command cutover", () => {
     } finally {
       cleanup(repo);
     }
-  });
+  }, 30_000);
 
   test("ordinary minimal apply uses the TypeScript transaction and retired experimental flag is absent", () => {
     const repo = tempRepo();
@@ -516,7 +516,7 @@ describe("init command cutover", () => {
       cleanup(repo);
       cleanup(home);
     }
-  });
+  }, 30_000);
 
   test("retired reclaim and compact flags have no compatibility CLI surface", () => {
     const repo = tempRepo();
@@ -531,7 +531,7 @@ describe("init command cutover", () => {
     } finally {
       cleanup(repo);
     }
-  });
+  }, 30_000);
 
   test("retired adopt command is fail-closed with no alias or stub", () => {
     const repo = tempRepo();
@@ -543,7 +543,7 @@ describe("init command cutover", () => {
     } finally {
       cleanup(repo);
     }
-  });
+  }, 30_000);
 
   test("interactive init is rejected before it can configure user-level runtime state", () => {
     const repo = tempRepo();
@@ -555,5 +555,5 @@ describe("init command cutover", () => {
     } finally {
       cleanup(repo);
     }
-  });
+  }, 30_000);
 });

--- a/tests/cli/capability-context.test.ts
+++ b/tests/cli/capability-context.test.ts
@@ -251,5 +251,5 @@ describe('capability-context command', () => {
     } finally {
       fs.rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 });

--- a/tests/cli/chatgpt-browser.test.ts
+++ b/tests/cli/chatgpt-browser.test.ts
@@ -99,7 +99,7 @@ describe('chatgpt browser command', () => {
     expect(consult.stdout).toContain('--chatgpt-app');
     expect(consult.stdout).toContain('--secret-scan');
     expect(consult.stdout).toContain('--gitleaks-bin');
-  });
+  }, 30_000);
 
   test('secret scan covers the exact prompt bundle and follow-ups fail closed before a new session', () => {
     withRepo((repoRoot) => {
@@ -163,7 +163,7 @@ describe('chatgpt browser command', () => {
         rmSync(binDir, { recursive: true, force: true });
       }
     });
-  });
+  }, 30_000);
 
   test('a scan-bound source session cannot disable inherited scanning programmatically', async () => {
     await withAsyncRepo(async (repoRoot) => {
@@ -266,7 +266,7 @@ describe('chatgpt browser command', () => {
         rmSync(binDir, { recursive: true, force: true });
       }
     });
-  });
+  }, 30_000);
 
   test('scan-bound Oracle sends immutable captured file bytes instead of a post-scan source mutation', () => {
     withRepo((repoRoot) => {
@@ -321,7 +321,7 @@ describe('chatgpt browser command', () => {
         rmSync(binDir, { recursive: true, force: true });
       }
     });
-  });
+  }, 30_000);
 
   test('explicit skill projection is canonical, idempotent, reversible, and refuses unowned destinations', () => {
     const testHome = mkdtempSync(join(tmpdir(), 'repo-harness-chatgpt-skill-home-'));
@@ -356,7 +356,7 @@ describe('chatgpt browser command', () => {
     } finally {
       rmSync(testHome, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('dry-run consult writes a repo-local session with inline files', () => {
     withRepo((repoRoot) => {
@@ -425,7 +425,7 @@ describe('chatgpt browser command', () => {
       expect(cleanupPlan.status).toBe(0);
       expect(JSON.parse(cleanupPlan.stdout).dryRun).toBe(true);
     });
-  });
+  }, 30_000);
 
   test('denies secret files before writing a session', () => {
     withRepo((repoRoot) => {
@@ -443,7 +443,7 @@ describe('chatgpt browser command', () => {
       expect(result.stderr).toContain('path is denied by ChatGPT browser policy');
       expect(existsSync(join(repoRoot, '.ai/harness/chatgpt/sessions'))).toBe(false);
     });
-  });
+  }, 30_000);
 
   test('denies allowed-path symlink escapes before writing a session', () => {
     withRepo((repoRoot) => {
@@ -468,7 +468,7 @@ describe('chatgpt browser command', () => {
         rmSync(outside, { recursive: true, force: true });
       }
     });
-  });
+  }, 30_000);
 
   test('validates write-output path and overwrite policy before writing a session', () => {
     withRepo((repoRoot) => {
@@ -516,7 +516,7 @@ describe('chatgpt browser command', () => {
       expect(noOverwrite.stderr).toContain('write output already exists');
       expect(readFileSync(join(repoRoot, 'tasks/reviews/existing.md'), 'utf-8')).toBe('old\n');
     });
-  });
+  }, 30_000);
 
   test('native provider readiness and dry-run are wired without opening a browser', () => {
     withRepo((repoRoot) => {
@@ -597,7 +597,7 @@ describe('chatgpt browser command', () => {
       expect(unboundPayload.status).toBe('failed');
       expect(unboundPayload.error.code).toBe('NATIVE_PROFILE_NOT_BOUND');
     });
-  });
+  }, 30_000);
 
   test('rejects removed bridge provider and browser-bind command surfaces', () => {
     withRepo((repoRoot) => {
@@ -613,7 +613,7 @@ describe('chatgpt browser command', () => {
       expect(bind.status).not.toBe(0);
       expect(bind.stderr).toContain("unknown command 'browser-bind'");
     });
-  });
+  }, 30_000);
 
   test('browser setup binds a user-selected ChatGPT profile and native dry-run uses it', () => {
     withRepo((repoRoot) => {
@@ -685,7 +685,7 @@ describe('chatgpt browser command', () => {
       expect(meta.browser.selectedProfilePath).toBe(profileDir);
       expect(meta.browser.channel).toBe('chrome');
     });
-  });
+  }, 30_000);
 
   test('native provider blocks the default Chrome profile before CDP launch', () => {
     if (process.platform !== 'darwin') {
@@ -735,7 +735,7 @@ describe('chatgpt browser command', () => {
       expect(payload.error.recovery).toContain('Chrome 136+ requires a non-standard --user-data-dir');
       expect(readFileSync(payload.paths.output, 'utf-8')).toContain('Chrome 136+ requires a non-standard --user-data-dir');
     });
-  });
+  }, 30_000);
 
   test('oracle provider reads the --write-output answer file and treats stdout as logs', () => {
     withRepo((repoRoot) => {
@@ -822,7 +822,7 @@ describe('chatgpt browser command', () => {
         rmSync(binDir, { recursive: true, force: true });
       }
     });
-  });
+  }, 30_000);
 
   test('oracle provider uses the bound ChatGPT profile cookie database', () => {
     withRepo((repoRoot) => {
@@ -888,7 +888,7 @@ describe('chatgpt browser command', () => {
         rmSync(binDir, { recursive: true, force: true });
       }
     });
-  });
+  }, 30_000);
 
   test('oracle provider prefers modern Network/Cookies over legacy Cookies', () => {
     withRepo((repoRoot) => {
@@ -948,7 +948,7 @@ describe('chatgpt browser command', () => {
         rmSync(binDir, { recursive: true, force: true });
       }
     });
-  });
+  }, 30_000);
 
   test('oracle provider fails closed when the bound profile has no regular cookie database', () => {
     withRepo((repoRoot) => {
@@ -1001,7 +1001,7 @@ describe('chatgpt browser command', () => {
         rmSync(binDir, { recursive: true, force: true });
       }
     });
-  });
+  }, 30_000);
 
   test('oracle provider downgrades an empty answer file to recoverable, not completed', () => {
     withRepo((repoRoot) => {
@@ -1038,7 +1038,7 @@ describe('chatgpt browser command', () => {
         rmSync(binDir, { recursive: true, force: true });
       }
     });
-  });
+  }, 30_000);
 
   test('oracle provider maps thinking to Oracle browser thinking time', () => {
     withRepo((repoRoot) => {
@@ -1085,7 +1085,7 @@ describe('chatgpt browser command', () => {
         rmSync(binDir, { recursive: true, force: true });
       }
     });
-  });
+  }, 30_000);
 
   test('oracle app preselection fails closed when the binary lacks browser-app support', () => {
     withRepo((repoRoot) => {
@@ -1130,7 +1130,7 @@ describe('chatgpt browser command', () => {
         rmSync(binDir, { recursive: true, force: true });
       }
     });
-  });
+  }, 30_000);
 
   test('oracle provider passes ChatGPT app preselection to Oracle when supported', () => {
     withRepo((repoRoot) => {
@@ -1178,7 +1178,7 @@ describe('chatgpt browser command', () => {
         rmSync(binDir, { recursive: true, force: true });
       }
     });
-  });
+  }, 30_000);
 
   test('oracle doctor probes binary capabilities and reports ready', () => {
     withRepo((repoRoot) => {
@@ -1247,7 +1247,7 @@ describe('chatgpt browser command', () => {
         rmSync(binDir, { recursive: true, force: true });
       }
     });
-  });
+  }, 30_000);
 
   test('oracle doctor requires every runtime flag before reporting ready', () => {
     withRepo((repoRoot) => {
@@ -1300,7 +1300,7 @@ describe('chatgpt browser command', () => {
         rmSync(binDir, { recursive: true, force: true });
       }
     });
-  });
+  }, 30_000);
 
   test('oracle doctor repairs repo-local and env-selected binaries through source-aware actions', () => {
     withRepo((repoRoot) => {
@@ -1342,7 +1342,7 @@ describe('chatgpt browser command', () => {
         command: 'REPO_HARNESS_ORACLE_BIN=<path-to-pinned-oracle> repo-harness chatgpt browser-doctor --repo <repo> --provider oracle --json',
       });
     });
-  });
+  }, 30_000);
 
   test('oracle follow-up uses providerSessionId instead of local sessionId', () => {
     withRepo((repoRoot) => {
@@ -1422,7 +1422,7 @@ describe('chatgpt browser command', () => {
         rmSync(binDir, { recursive: true, force: true });
       }
     });
-  });
+  }, 30_000);
 
   test('rejects invalid session ids for read/open surfaces', () => {
     withRepo((repoRoot) => {
@@ -1430,7 +1430,7 @@ describe('chatgpt browser command', () => {
       expect(read.status).toBe(2);
       expect(read.stderr).toContain('invalid ChatGPT browser session id');
     });
-  });
+  }, 30_000);
 
   test('ships browser engine docs', () => {
     // SSD-06 migration: docs/repo-harness-chatgpt-browser-engine.md documents

--- a/tests/cli/cross-review.test.ts
+++ b/tests/cli/cross-review.test.ts
@@ -120,7 +120,7 @@ describe("captureCrossReviewScope (scope capture, no provider invoked)", () => {
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("staged-only change appears in scope.paths", () => {
     const repo = initRepo();
@@ -133,7 +133,7 @@ describe("captureCrossReviewScope (scope capture, no provider invoked)", () => {
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("unstaged tracked modification appears in scope.paths", () => {
     const repo = initRepo();
@@ -145,7 +145,7 @@ describe("captureCrossReviewScope (scope capture, no provider invoked)", () => {
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("untracked file appears in scope.paths", () => {
     const repo = initRepo();
@@ -157,7 +157,7 @@ describe("captureCrossReviewScope (scope capture, no provider invoked)", () => {
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("degraded_scope: an unresolvable base revision fails closed", () => {
     const repo = initRepo();
@@ -167,7 +167,7 @@ describe("captureCrossReviewScope (scope capture, no provider invoked)", () => {
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("exact-base binding: scope binds to the resolved SHA of the declared base even after HEAD moves later", () => {
     const repo = initRepo();
@@ -200,7 +200,7 @@ describe("captureCrossReviewScope (scope capture, no provider invoked)", () => {
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 });
 
 describe("runCrossReview (codex mode, fixture provider process)", () => {
@@ -221,7 +221,7 @@ describe("runCrossReview (codex mode, fixture provider process)", () => {
         expect(result.scope).toBeNull();
       }
     });
-  });
+  }, 30_000);
 
   test("empty_output: clean exit with no stdout and no recovery attempted", () => {
     withFixture((repo, provider) => {
@@ -235,7 +235,7 @@ describe("runCrossReview (codex mode, fixture provider process)", () => {
       expect(result.status).toBe("failed");
       if (result.status === "failed") expect(result.code).toBe("empty_output");
     });
-  });
+  }, 30_000);
 
   test("timeout: a provider that outlives the budget is killed and reported explicitly", () => {
     withFixture((repo, provider) => {
@@ -263,7 +263,7 @@ describe("runCrossReview (codex mode, fixture provider process)", () => {
       expect(result.status).toBe("failed");
       if (result.status === "failed") expect(result.code).toBe("auth_failure");
     });
-  });
+  }, 30_000);
 
   test("provider_nonzero: a nonzero exit without an auth signal stays the generic code", () => {
     withFixture((repo, provider) => {
@@ -277,7 +277,7 @@ describe("runCrossReview (codex mode, fixture provider process)", () => {
       expect(result.status).toBe("failed");
       if (result.status === "failed") expect(result.code).toBe("provider_nonzero");
     });
-  });
+  }, 30_000);
 
   test("success: a P2-only transcript parses to a PASS recommendation", () => {
     withFixture((repo, provider) => {
@@ -295,7 +295,7 @@ describe("runCrossReview (codex mode, fixture provider process)", () => {
         expect(result.recommendation).toContain("PASS");
       }
     });
-  });
+  }, 30_000);
 
   test("success-p1: a P1 finding drives a FAIL recommendation and a nonzero CLI exit code", () => {
     withFixture((repo, provider) => {
@@ -311,7 +311,7 @@ describe("runCrossReview (codex mode, fixture provider process)", () => {
       if (command.result.status === "ok") expect(command.result.recommendation).toContain("FAIL");
       expect(command.output).toContain("[P1]");
     });
-  });
+  }, 30_000);
 
   test("json output round-trips the structured result", () => {
     withFixture((repo, provider) => {
@@ -327,7 +327,7 @@ describe("runCrossReview (codex mode, fixture provider process)", () => {
       expect(parsed.status).toBe("ok");
       expect(parsed.provider).toBe("codex");
     });
-  });
+  }, 30_000);
 });
 
 describe("runCrossReview (claude mode: transcript recovery)", () => {
@@ -356,7 +356,7 @@ describe("runCrossReview (claude mode: transcript recovery)", () => {
         rmSync(claudeConfigDir, { recursive: true, force: true });
       }
     });
-  });
+  }, 30_000);
 
   test("empty_output: claude mode with no recoverable session file at all", () => {
     withFixture((repo, provider) => {
@@ -376,7 +376,7 @@ describe("runCrossReview (claude mode: transcript recovery)", () => {
         rmSync(claudeConfigDir, { recursive: true, force: true });
       }
     });
-  });
+  }, 30_000);
 
   test("claude mode success embeds diff text without crashing on a populated scope", () => {
     withFixture((repo, provider) => {
@@ -390,7 +390,7 @@ describe("runCrossReview (claude mode: transcript recovery)", () => {
       });
       expect(result.status).toBe("ok");
     });
-  });
+  }, 30_000);
 });
 
 describe("pure classification and parsing helpers (src/core/review/cross-review.ts)", () => {

--- a/tests/cli/docs.test.ts
+++ b/tests/cli/docs.test.ts
@@ -31,7 +31,7 @@ describe('docs command', () => {
     expect(parsed.docs.find((entry: { id: string }) => entry.id === 'harness-overview').path).toContain(
       'assets/reference-configs/harness-overview.md',
     );
-  });
+  }, 30_000);
 
   test('resolves and prints bundled runtime docs', () => {
     const pathResult = runDocs(['path', 'harness-overview']);
@@ -44,13 +44,13 @@ describe('docs command', () => {
     const showResult = runDocs(['show', 'harness-overview']);
     expect(showResult.status).toBe(0);
     expect(showResult.stdout).toContain('# Harness Overview');
-  });
+  }, 30_000);
 
   test('returns exit code 2 for unknown docs', () => {
     const result = runDocs(['path', 'missing-doc']);
     expect(result.status).toBe(2);
     expect(result.stderr).toContain('unknown doc "missing-doc"');
-  });
+  }, 30_000);
 
   test('exports reusable doc resolution helpers', () => {
     expect(listRuntimeDocs().map((entry) => entry.id)).toContain('harness-overview');

--- a/tests/cli/global-runtime-init.test.ts
+++ b/tests/cli/global-runtime-init.test.ts
@@ -206,7 +206,7 @@ describe('install command global runtime bootstrap', () => {
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('installs CLI, hooks, Waza, brain root, and CodeGraph without setup-plugins.sh', () => {
     const tmp = mkdtempSync(join(tmpdir(), 'repo-harness-global-init-'));
@@ -726,7 +726,7 @@ exit 0
     expect(res.stdout).not.toContain('--with-optional');
     expect(res.stdout).not.toContain('--project-type');
     expect(res.stdout).not.toContain('setup-plugins');
-  });
+  }, 30_000);
 
   test('CLI update refreshes user-level runtime without touching the current repo', () => {
     const tmp = mkdtempSync(join(tmpdir(), 'repo-harness-cli-update-'));
@@ -789,7 +789,7 @@ exit 0
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('CLI update --version installs the requested package version', () => {
     const tmp = mkdtempSync(join(tmpdir(), 'repo-harness-cli-update-version-'));
@@ -836,7 +836,7 @@ exit 0
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('CLI update rejects protocol-1 state until explicit migration', () => {
     const tmp = mkdtempSync(join(tmpdir(), 'repo-harness-cli-update-legacy-profile-'));
@@ -887,7 +887,7 @@ exit 0
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('CLI top-level --version still prints the CLI version', () => {
     const res = spawnSync(process.execPath, [CLI, '--version'], {
@@ -897,7 +897,7 @@ exit 0
 
     expect(res.status).toBe(0);
     expect(res.stdout.trim()).toMatch(/^\d+\.\d+\.\d+$/);
-  });
+  }, 30_000);
 
   test('CLI update --check is read-only setup readiness output', () => {
     const tmp = mkdtempSync(join(tmpdir(), 'repo-harness-cli-update-check-'));
@@ -942,7 +942,7 @@ exit 0
     expect(res.stdout).toContain('--configure-codegraph');
     expect(res.stdout).toContain('--no-cli');
     expect(res.stdout).toContain('Deprecated: use repo-harness init --repo <path>');
-  });
+  }, 30_000);
 
   test('CLI install defaults non-interactively to full with its selected optional ecosystems', () => {
     const tmp = mkdtempSync(join(tmpdir(), 'repo-harness-cli-install-non-tty-'));

--- a/tests/cli/hook.test.ts
+++ b/tests/cli/hook.test.ts
@@ -50,7 +50,7 @@ describe('typed hook runtime', () => {
       expect(result.reason).toBe('non-opt-in');
       expect(result.handler).toBeUndefined();
     } finally { clean(root); }
-  });
+  }, 30_000);
 
   test('rejects an explicit repo-root mismatch before route dispatch', () => {
     const root = repo();
@@ -64,7 +64,7 @@ describe('typed hook runtime', () => {
       });
       expect(result).toEqual({ exitCode: 0, reason: 'repo-root-mismatch' });
     } finally { clean(root); clean(other); }
-  });
+  }, 30_000);
 
   test('unknown routes do not create a handler or telemetry record', () => {
     const root = repo();
@@ -74,7 +74,7 @@ describe('typed hook runtime', () => {
       expect(result.handler).toBeUndefined();
       expect(existsSync(join(root, '.ai/harness/runs/hook-events.jsonl'))).toBe(false);
     } finally { clean(root); }
-  });
+  }, 30_000);
 
   test('dispatches each route through its typed handler identity', () => {
     const root = repo();
@@ -111,7 +111,7 @@ describe('typed hook runtime', () => {
       expect(result.status).toBe(0);
       expect(result.stdout).toBe('');
     } finally { clean(root); }
-  });
+  }, 30_000);
 
   test('one telemetry record stays opaque-free without fabricating file-metric completeness', () => {
     const root = repo();
@@ -125,5 +125,5 @@ describe('typed hook runtime', () => {
       expect(record.measurement).toMatchObject({ complete: false, opaque_steps: [] });
       expect(record.measurement.incomplete_metrics).toContain('files_read');
     } finally { clean(root); }
-  });
+  }, 30_000);
 });

--- a/tests/cli/init-hook.test.ts
+++ b/tests/cli/init-hook.test.ts
@@ -616,7 +616,7 @@ describe('init-hook command', () => {
     expect(res.stdout).toContain('Usage: repo-harness init-hook');
     expect(res.stdout).toContain('--target <target>');
     expect(res.stdout).toContain('--check-updates');
-  });
+  }, 30_000);
 
   test('CLI exposes setup check help', () => {
     const res = spawnSync('bun', [CLI, 'setup', 'check', '--help'], {
@@ -627,5 +627,5 @@ describe('init-hook command', () => {
     expect(res.stdout).toContain('Usage: repo-harness setup check');
     expect(res.stdout).toContain('--target <target>');
     expect(res.stdout).toContain('--check-updates');
-  });
+  }, 30_000);
 });

--- a/tests/cli/init.test.ts
+++ b/tests/cli/init.test.ts
@@ -377,7 +377,7 @@ describe("init command", () => {
     expect(res.stdout).toContain("--dry-run");
     expect(res.stdout).not.toContain("--experimental-ts-apply");
     expect(res.stdout).toContain("--no-codegraph");
-  });
+  }, 30_000);
 
   test("CLI update rejects repo refresh flags with an init hint", () => {
     const res = spawnSync("bun", [CLI, "update", "--repo", ".", "--json"], {
@@ -388,7 +388,7 @@ describe("init command", () => {
     expect(res.status).toBe(2);
     expect(res.stderr).toContain("repo-harness update no longer refreshes repositories");
     expect(res.stderr).toContain("repo-harness init --repo <path>");
-  });
+  }, 30_000);
 
   test("CLI init rejects user-level brain configuration flags", () => {
     const tmp = join(tmpdir(), `repo-harness-init-brain-${Date.now()}`);
@@ -405,7 +405,7 @@ describe("init command", () => {
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("init refuses HOME before running migration or host bootstrap", () => {
     const tmp = join(tmpdir(), `repo-harness-init-home-${Date.now()}`);

--- a/tests/cli/install.test.ts
+++ b/tests/cli/install.test.ts
@@ -91,7 +91,7 @@ describe('install command (Phase 1B)', () => {
       expect(fs.readFileSync(statePath)).toEqual(stateBefore);
       expect(fs.readFileSync(hooksPath)).toEqual(hooksBefore);
     });
-  });
+  }, 30_000);
 
   test('codex --location local errors with exit 2 (no project-local hook concept)', () => {
     withTempHome(() => {
@@ -368,7 +368,7 @@ describe('install command (Phase 1B)', () => {
       expect(uninstall.status).toBe(0);
       expect(uninstall.stdout).toContain('[codex] removed');
     });
-  });
+  }, 30_000);
 
   test('CLI install without required profile components fails closed and compensates adapters', () => {
     withTempHome((home) => {
@@ -395,7 +395,7 @@ describe('install command (Phase 1B)', () => {
       expect(fs.existsSync(path.join(home, '.codex/hooks.json'))).toBe(false);
       expect(fs.existsSync(path.join(home, '.repo-harness/install-state.json'))).toBe(false);
     });
-  });
+  }, 30_000);
 });
 
 describe('install --delegation-mode (global delegation config write)', () => {
@@ -418,7 +418,7 @@ describe('install --delegation-mode (global delegation config write)', () => {
       const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
       expect(config.delegation.mode).toBe('auto');
     });
-  });
+  }, 30_000);
 
   test('merges delegation.mode with existing brainRoot and unknown nested delegation keys', () => {
     withTempHome((home) => {
@@ -462,7 +462,7 @@ describe('install --delegation-mode (global delegation config write)', () => {
       expect(install.stderr).toContain('invalid --delegation-mode "bogus"');
       expect(fs.existsSync(path.join(home, '.repo-harness', 'config.json'))).toBe(false);
     });
-  });
+  }, 30_000);
 
   test('no --delegation-mode flag over non-TTY stdio leaves ~/.repo-harness/config.json untouched', () => {
     withTempHome((home) => {
@@ -481,7 +481,7 @@ describe('install --delegation-mode (global delegation config write)', () => {
       expect(fs.existsSync(path.join(home, '.codex/hooks.json'))).toBe(true);
       expect(fs.existsSync(path.join(home, '.repo-harness', 'config.json'))).toBe(false);
     });
-  });
+  }, 30_000);
 
   test('re-running with the same mode is idempotent and reports unchanged', () => {
     withTempHome(() => {

--- a/tests/cli/mcp-coding-tools.test.ts
+++ b/tests/cli/mcp-coding-tools.test.ts
@@ -173,7 +173,7 @@ describe('coding MCP workspace and file tools', () => {
     } finally {
       await state.processManager.shutdown();
     }
-  });
+  }, 30_000);
 
   test('fails closed for traversal, ignored and secret paths, symlinks, stale revisions, and cross-session workspaces', async () => {
     const state = fixture();
@@ -223,7 +223,7 @@ describe('coding MCP workspace and file tools', () => {
     } finally {
       await state.processManager.shutdown();
     }
-  });
+  }, 30_000);
 
   test('fails closed when repository ignore policy is not a regular file', async () => {
     const state = fixture();
@@ -257,7 +257,7 @@ describe('coding MCP workspace and file tools', () => {
     } finally {
       await state.processManager.shutdown();
     }
-  });
+  }, 30_000);
 
   test('does not follow root instruction symlinks or execute a granted repo local CodeGraph binary', async () => {
     const state = fixture();
@@ -289,7 +289,7 @@ describe('coding MCP workspace and file tools', () => {
     } finally {
       await state.processManager.shutdown();
     }
-  });
+  }, 30_000);
 
   test('records process completion after a live repo grant is revoked', async () => {
     const state = fixture();
@@ -319,7 +319,7 @@ describe('coding MCP workspace and file tools', () => {
     } finally {
       await state.processManager.shutdown();
     }
-  });
+  }, 30_000);
 
   test('rolls back all files on commit failure and cleanup refuses dirty or unmerged worktrees', async () => {
     const state = fixture();
@@ -378,7 +378,7 @@ describe('coding MCP workspace and file tools', () => {
     } finally {
       await state.processManager.shutdown();
     }
-  });
+  }, 30_000);
 
   test('does not persist raw unexpected failure text in the coding audit log', async () => {
     const state = fixture();
@@ -426,5 +426,5 @@ describe('coding MCP workspace and file tools', () => {
     } finally {
       await state.processManager.shutdown();
     }
-  });
+  }, 30_000);
 });

--- a/tests/cli/mcp-http.test.ts
+++ b/tests/cli/mcp-http.test.ts
@@ -381,7 +381,7 @@ describe('mcp http transport', () => {
       restoreRegistryHome();
       rmSync(repoRoot, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('supports URL token compatibility mode for single-user clients', async () => {
     const repoRoot = mkdtempSync(join(tmpdir(), 'repo-harness-mcp-url-token-'));
@@ -442,7 +442,7 @@ describe('mcp http transport', () => {
       restoreRegistryHome();
       rmSync(repoRoot, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('supports ChatGPT-compatible OAuth authorization flow', async () => {
     const repoRoot = mkdtempSync(join(tmpdir(), 'repo-harness-mcp-oauth-'));
@@ -601,7 +601,7 @@ describe('mcp http transport', () => {
       restoreRegistryHome();
       rmSync(repoRoot, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('coding OAuth E2E enforces Host/CORS/redirect boundaries and exposes the exact direct-coding schema', async () => {
     const repoRoot = mkdtempSync(join(tmpdir(), 'repo-harness-mcp-coding-e2e-'));

--- a/tests/cli/mcp-reader-tools.test.ts
+++ b/tests/cli/mcp-reader-tools.test.ts
@@ -1103,7 +1103,7 @@ describe('MCP reader tools', () => {
 	      expect(readFileSync(join(repoRoot, relativePath), 'utf-8')).toBe('recovered\n');
 	      expect(existsSync(lockPath)).toBe(false);
 	    }, { accessMode: 'read_write' });
-	  });
+	  }, 30_000);
 
 	  test('write mutation does not reclaim dead owner locks for a different path', async () => {
 	    await withReaderRepo(async (repoRoot, ctx) => {
@@ -1130,7 +1130,7 @@ describe('MCP reader tools', () => {
 	      expect(existsSync(lockPath)).toBe(true);
 	      rmSync(lockPath, { recursive: true, force: true });
 	    }, { accessMode: 'read_write' });
-	  });
+	  }, 30_000);
 
 	  test('write mutation keeps live owner directory locks fail-closed', async () => {
 	    await withReaderRepo(async (repoRoot, ctx) => {

--- a/tests/cli/mcp-setup.test.ts
+++ b/tests/cli/mcp-setup.test.ts
@@ -597,7 +597,7 @@ describe('mcp setup', () => {
         endpoint: 'https://repo-harness-mcp.example.com/mcp',
       });
     });
-  });
+  }, 30_000);
 
   test('stores a stable ChatGPT endpoint in ignored local config and keeps the tracked guide generic', () => {
     withTmpRepo((repoRoot) => {

--- a/tests/cli/mcp.test.ts
+++ b/tests/cli/mcp.test.ts
@@ -43,13 +43,13 @@ describe('mcp command', () => {
     expect(setup.stdout).toContain('chatgpt');
     expect(setup.stdout).toContain('codex');
     expect(root.stdout).toContain('prepare-goal');
-  });
+  }, 30_000);
 
   test('rejects invalid subcommands with a useful error', () => {
     const result = runMcp(['missing']);
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("unknown command 'missing'");
-  });
+  }, 30_000);
 
   test('prepare-goal writes Codex handoff and prints host-native /goal prompt', () => {
     const repoRoot = mkdtempSync(join(tmpdir(), 'repo-harness-mcp-goal-'));
@@ -88,5 +88,5 @@ describe('mcp command', () => {
       rmSync(repoRoot, { recursive: true, force: true });
       rmSync(repoHarnessHome, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 });

--- a/tests/cli/prompt-guard-decision.test.ts
+++ b/tests/cli/prompt-guard-decision.test.ts
@@ -204,7 +204,7 @@ describe('prompt-guard decision engine', () => {
 
     expect(res.status).toBe(0);
     expect(res.stdout.trim()).toBe('plan_capture_draft_advice');
-  });
+  }, 30_000);
 
   test('hook entry exposes the lightweight prompt-guard decision command', () => {
     const res = spawnSync(
@@ -230,5 +230,5 @@ describe('prompt-guard decision engine', () => {
 
     expect(res.status).toBe(0);
     expect(res.stdout.trim()).toBe('plan_capture_missing_active_advice');
-  });
+  }, 30_000);
 });

--- a/tests/cli/registry.test.ts
+++ b/tests/cli/registry.test.ts
@@ -172,7 +172,7 @@ describe('repo registration persistence', () => {
     } finally {
       rmSync(fixtureRoot, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('removes its newly created lock when owner metadata persistence fails', async () => {
     const fixtureRoot = mkdtempSync(join(tmpdir(), 'repo-harness-registry-lock-failure-'));
@@ -235,7 +235,7 @@ describe('repo registration persistence', () => {
     } finally {
       rmSync(fixtureRoot, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('serializes concurrent registrations, access updates, and authorization revision bumps', async () => {
     const fixtureRoot = mkdtempSync(join(tmpdir(), 'repo-harness-registry-concurrency-'));

--- a/tests/cli/run.test.ts
+++ b/tests/cli/run.test.ts
@@ -74,7 +74,7 @@ describe("run command", () => {
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("resolves bundled helpers from the package by default", () => {
     const tmp = mkdtempSync(join(tmpdir(), "repo-harness-run-package-"));
@@ -174,7 +174,7 @@ describe("run command", () => {
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("source checkout override fails closed for missing and malformed authority", () => {
     const tmp = mkdtempSync(join(tmpdir(), "repo-harness-run-source-invalid-"));
@@ -255,7 +255,7 @@ describe("run command", () => {
     expect(res.stdout).toMatch(
       /check-task-workflow\s+Check workflow contract and policy compliance for the current repo/,
     );
-  });
+  }, 30_000);
 
   test("package sprint-backlog helper resolves the target repo root from runHelper", () => {
     const tmp = mkdtempSync(join(tmpdir(), "repo-harness-run-sprint-root-"));
@@ -283,7 +283,7 @@ describe("run command", () => {
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("ignores repo-local helper runtime when helper_source is repo pinned", () => {
     const tmp = mkdtempSync(join(tmpdir(), "repo-harness-run-repo-pin-"));

--- a/tests/cli/security.test.ts
+++ b/tests/cli/security.test.ts
@@ -166,7 +166,7 @@ describe('security scan command', () => {
       expect(report.findings.map((finding) => finding.ruleId)).toContain('vscode-folder-open-suspicious');
       expect(report.findings.find((finding) => finding.ruleId === 'vscode-folder-open-suspicious')?.severity).toBe('high');
     });
-  });
+  }, 30_000);
 
   test('legacy project hook adapter is reported as a warning', () => {
     withTempHomeAndRepo(({ home, repo }) => {
@@ -225,5 +225,5 @@ describe('security scan command', () => {
       });
       expect(strict.status).toBe(1);
     });
-  });
+  }, 30_000);
 });

--- a/tests/cli/state-snapshot.test.ts
+++ b/tests/cli/state-snapshot.test.ts
@@ -59,7 +59,7 @@ describe('state-snapshot hook command', () => {
       expect(existsSync(join(cwd, '.ai/harness/active-plan'))).toBe(false);
       expect(existsSync(join(cwd, '.ai/harness/state/effective.json'))).toBe(false);
     });
-  });
+  }, 30_000);
 
   test('rejects unsupported output flags', () => {
     withTempRepo((cwd) => {
@@ -71,5 +71,5 @@ describe('state-snapshot hook command', () => {
       expect(result.stdout).toBe('');
       expect(result.stderr).toContain('state-snapshot --json');
     });
-  });
+  }, 30_000);
 });

--- a/tests/cli/status.test.ts
+++ b/tests/cli/status.test.ts
@@ -116,7 +116,7 @@ describe('status command (Phase 1C)', () => {
         fs.rmSync(repo, { recursive: true, force: true });
       }
     });
-  });
+  }, 30_000);
 
   test('non-git-repo cwd reports inGitRepo=false and optIn=false', () => {
     withTempHome(() => {

--- a/tests/continuation-attempt.test.ts
+++ b/tests/continuation-attempt.test.ts
@@ -170,7 +170,7 @@ describe('attempt receipt recorder', () => {
       expect(JSON.parse(lines[0])).toEqual(first as unknown as Record<string, unknown>);
       expect(JSON.parse(lines[1])).toEqual(second as unknown as Record<string, unknown>);
     });
-  });
+  }, 30_000);
 
   test('--outcome resumed may omit both tokens', () => {
     withLedgerRepo((cwd) => {
@@ -180,7 +180,7 @@ describe('attempt receipt recorder', () => {
       expect(receipt.after_progress_token).toBeNull();
       expect(ledgerLines(cwd)).toHaveLength(1);
     });
-  });
+  }, 30_000);
 
   test('rejects an unknown outcome and a token-bearing outcome without tokens', () => {
     withLedgerRepo((cwd) => {
@@ -195,7 +195,7 @@ describe('attempt receipt recorder', () => {
 
       expect(existsSync(join(cwd, LEDGER))).toBe(false);
     });
-  });
+  }, 30_000);
 
   test('a unit_ref containing a space is legal; a NUL byte is rejected', () => {
     withLedgerRepo((cwd) => {
@@ -223,7 +223,7 @@ describe('attempt receipt recorder', () => {
         recordedAt: '2026-08-03T00:00:00.000Z',
       })).toEqual({ ok: false, error: '--unit-ref must be a non-empty single-line value' });
     });
-  });
+  }, 30_000);
 
   test('the recorder touches no tracked file', () => {
     withLedgerRepo((cwd) => {
@@ -233,7 +233,7 @@ describe('attempt receipt recorder', () => {
       expect(spawnSync('git', ['status', '--porcelain'], { cwd, encoding: 'utf-8' }).stdout).toBe(before);
       expect(existsSync(join(cwd, LEDGER))).toBe(true);
     });
-  });
+  }, 30_000);
 
   test('eight parallel recorders append eight intact lines', async () => {
     const fixture = createEffectiveStateFixture();
@@ -296,7 +296,7 @@ describe('no-progress circuit breaker', () => {
       record(cwd, { outcome: 'completed', before: `${token}-moved`, after: token });
       expect(envelopeFrom(cwd).route).toBe('continue_active_plan');
     });
-  });
+  }, 30_000);
 
   test('receipts recorded against a superseded token do not halt the current one', () => {
     withLedgerRepo((cwd) => {
@@ -305,7 +305,7 @@ describe('no-progress circuit breaker', () => {
       recordStalled(cwd, stale);
       expect(envelopeFrom(cwd).route).toBe('continue_active_plan');
     });
-  });
+  }, 30_000);
 
   test('real material progress clears a tripped breaker', () => {
     withLedgerRepo((cwd) => {
@@ -322,7 +322,7 @@ describe('no-progress circuit breaker', () => {
       expect(moved.progress_token).not.toBe(token);
       expect(moved.route).toBe('verify_or_finish');
     });
-  });
+  }, 30_000);
 
   test('an explicit resumed receipt resets the count, which then restarts at one', () => {
     withLedgerRepo((cwd) => {
@@ -339,7 +339,7 @@ describe('no-progress circuit breaker', () => {
       recordStalled(cwd, token);
       expect(envelopeFrom(cwd).reason).toBe('no_progress');
     });
-  });
+  }, 30_000);
 
   test('a halted receipt also breaks the trailing run', () => {
     withLedgerRepo((cwd) => {
@@ -349,7 +349,7 @@ describe('no-progress circuit breaker', () => {
       recordStalled(cwd, token);
       expect(envelopeFrom(cwd).route).toBe('continue_active_plan');
     });
-  });
+  }, 30_000);
 
   test("another unit's receipts neither trigger nor clear this unit's stall", () => {
     withLedgerRepo((cwd) => {
@@ -364,7 +364,7 @@ describe('no-progress circuit breaker', () => {
       recordStalled(cwd, token);
       expect(envelopeFrom(cwd).reason).toBe('no_progress');
     });
-  });
+  }, 30_000);
 
   test('a corrupt ledger line fails closed with its own halt reason', () => {
     withLedgerRepo((cwd) => {
@@ -378,7 +378,7 @@ describe('no-progress circuit breaker', () => {
       expect(halted.unit_ref).toBe(PLAN);
       expect(halted.command).toBeNull();
     });
-  });
+  }, 30_000);
 
   test('a structurally invalid receipt is unreadable, not silently skipped', () => {
     withLedgerRepo((cwd) => {
@@ -393,7 +393,7 @@ describe('no-progress circuit breaker', () => {
       })}\n`);
       expect(envelopeFrom(cwd).reason).toBe('attempt_ledger_unreadable');
     });
-  });
+  }, 30_000);
 
   test('an absent or empty ledger leaves every route exactly as it was', () => {
     withLedgerRepo((cwd) => {
@@ -402,7 +402,7 @@ describe('no-progress circuit breaker', () => {
       write(cwd, LEDGER, '');
       expect(envelopeFrom(cwd)).toEqual(untouched);
     });
-  });
+  }, 30_000);
 });
 
 describe('circuit breaker scope', () => {
@@ -420,7 +420,7 @@ describe('circuit breaker scope', () => {
       writeFileSync(join(cwd, LEDGER), '{not json\n');
       expect(envelopeFrom(cwd)).toEqual(complete);
     });
-  });
+  }, 30_000);
 
   test('an unreadable ledger never rewrites an existing halt reason', () => {
     withLedgerRepo((cwd) => {
@@ -431,7 +431,7 @@ describe('circuit breaker scope', () => {
       write(cwd, LEDGER, '{not json\n');
       expect(envelopeFrom(cwd)).toEqual(blocked);
     });
-  });
+  }, 30_000);
 });
 
 describe('attempt ledger authority fences', () => {
@@ -463,7 +463,7 @@ describe('attempt ledger authority fences', () => {
       expect(envelopeAfter.progress_token).toBe(envelopeBefore.progress_token);
       expect(envelopeAfter.authority_revision).toBe(envelopeBefore.authority_revision);
     });
-  });
+  }, 30_000);
 
   test('`state next` still performs no writes while reading the ledger', () => {
     withLedgerRepo((cwd) => {

--- a/tests/continuation-conformance.test.ts
+++ b/tests/continuation-conformance.test.ts
@@ -105,7 +105,7 @@ describe('attempt receipts are invisible to progress_token by two independent me
   test('the shipped .gitignore covers the attempt ledger path', () => {
     const ignored = git(ROOT, ['check-ignore', '-q', LEDGER]);
     expect(ignored.status, `git check-ignore did not cover ${LEDGER}`).toBe(0);
-  });
+  }, 30_000);
 
   // Arm 2, in a repository with no ignore rule at all: the review-subject
   // classifier alone excludes the ledger. `isOperationalReviewPath` is module
@@ -131,7 +131,7 @@ describe('attempt receipts are invisible to progress_token by two independent me
       expect(subject.excluded_paths).toContain(LEDGER);
       expect(subject.paths).not.toContain(LEDGER);
     });
-  });
+  }, 30_000);
 });
 
 /**
@@ -772,5 +772,5 @@ describe('host Goal conformance: the full tick over a disposable repository', ()
       expect(existsSync(join(worktreeTwo, LEDGER))).toBe(true);
       expect(git(worktreeTwo, ['status', '--porcelain', '--untracked-files=all']).stdout).toBe('');
     });
-  });
+  }, 30_000);
 });

--- a/tests/continuation-envelope.test.ts
+++ b/tests/continuation-envelope.test.ts
@@ -198,7 +198,7 @@ describe('continuation envelope routes', () => {
         expect(envelope.authority_revision).toMatch(/^sha256:[0-9a-f]{64}$/);
         expect(envelope.progress_token).toMatch(/^sha256:[0-9a-f]{64}$/);
       });
-    });
+    }, 30_000);
   }
 
   test('every route stays inside the frozen route vocabulary with one unit or one halt', () => {
@@ -263,7 +263,7 @@ describe('continuation envelope halts on unusable sprint authority', () => {
         expect(envelope.unit_ref).toBe(scenario.unit_ref);
         expect(envelope.command).toBeNull();
       });
-    });
+    }, 30_000);
   }
 
   test('halts when the active-plan marker points at a deleted plan', () => {
@@ -275,7 +275,7 @@ describe('continuation envelope halts on unusable sprint authority', () => {
       expect(envelope.reason).toBe('stale:active_plan_marker');
       expect(envelope.command).toBeNull();
     });
-  });
+  }, 30_000);
 });
 
 describe('continuation envelope determinism and read-only contract', () => {
@@ -299,7 +299,7 @@ describe('continuation envelope determinism and read-only contract', () => {
       expect(halted.status).toBe(0);
       expect((JSON.parse(halted.stdout) as ContinuationEnvelopeV1).route).toBe('halt');
     });
-  });
+  }, 30_000);
 
   test('key order is stable and matches the declared envelope shape', () => {
     withRepo((cwd) => {
@@ -314,7 +314,7 @@ describe('continuation envelope determinism and read-only contract', () => {
         'reason',
       ]);
     });
-  });
+  }, 30_000);
 
   test('performs no writes: repo tree, .ai/harness, and the state cache are untouched', () => {
     withRepo((cwd) => {
@@ -331,5 +331,5 @@ describe('continuation envelope determinism and read-only contract', () => {
       expect(spawnSync('git', ['status', '--porcelain'], { cwd, encoding: 'utf-8' }).stdout).toBe(beforeStatus);
       expect(existsSync(join(cwd, '.ai/harness/state/effective.json'))).toBe(false);
     });
-  });
+  }, 30_000);
 });

--- a/tests/contract-block-rewrite.test.ts
+++ b/tests/contract-block-rewrite.test.ts
@@ -130,7 +130,7 @@ describe("contract block rewrite hardening", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("TS sync refuses duplicate contract blocks", () => {
     const original = [
@@ -151,7 +151,7 @@ describe("contract block rewrite hardening", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("TS sync tolerates trailing whitespace on markers without duplicating the block", () => {
     const cwd = makeFixture(
@@ -176,7 +176,7 @@ describe("contract block rewrite hardening", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("shell replace_contract_block aborts on missing END marker instead of eating content to EOF", () => {
     const res = runShellReplace(
@@ -184,14 +184,14 @@ describe("contract block rewrite hardening", () => {
     );
     expect(res.status).not.toBe(0);
     expect(res.stderr).toContain("unbalanced ARCHITECTURE CONTRACT markers");
-  });
+  }, 30_000);
 
   test("shell replace_contract_block aborts when END precedes BEGIN", () => {
     const res = runShellReplace(
       ["<!-- END ARCHITECTURE CONTRACT -->", "x", "<!-- BEGIN ARCHITECTURE CONTRACT -->", ""].join("\n"),
     );
     expect(res.status).not.toBe(0);
-  });
+  }, 30_000);
 
   test("shell replace_contract_block replaces balanced block and keeps surrounding content", () => {
     const res = runShellReplace(
@@ -210,7 +210,7 @@ describe("contract block rewrite hardening", () => {
     expect(res.output).toContain("outro");
     expect(res.output).not.toContain("old\n");
     expect(res.output?.match(/<!-- BEGIN ARCHITECTURE CONTRACT -->/g)?.length).toBe(1);
-  });
+  }, 30_000);
 
   test("shell fallback renders no pending request when the event request has been archived", () => {
     const cwd = mkdtempSync(join(tmpdir(), "context-sync-shell-fallback-"));
@@ -237,5 +237,5 @@ describe("contract block rewrite hardening", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 });

--- a/tests/contract-run.test.ts
+++ b/tests/contract-run.test.ts
@@ -327,7 +327,7 @@ describe("contract-run helper", () => {
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("dry-run propagates contract Why/Goal/Scope/Exemplar/Stop Conditions content into prompts", () => {
     const repo = makeRepo("contract-run-propagation-");
@@ -370,7 +370,7 @@ describe("contract-run helper", () => {
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("run executes worker then verifier and leaves a contract-verifiable review", () => {
     const repo = makeRepo();
@@ -492,7 +492,7 @@ describe("contract-run helper", () => {
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("budget overrun stops before the next child command", () => {
     const repo = makeRepo("contract-run-budget-");
@@ -556,13 +556,13 @@ describe("contract-run helper", () => {
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("unknown flags exit with usage error", () => {
     const res = runContractRun(ROOT, ["dry-run", "--bogus"]);
     expect(res.status).toBe(2);
     expect(res.stderr).toContain("unknown argument --bogus");
-  });
+  }, 30_000);
 
   test("preflight passes for a self-sufficient brief", () => {
     const repo = makeRepo("contract-run-preflight-ok-");
@@ -583,7 +583,7 @@ describe("contract-run helper", () => {
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("golden example contract brief passes its own preflight gate", () => {
     const repo = makeRepo("contract-run-golden-example-");
@@ -608,7 +608,7 @@ describe("contract-run helper", () => {
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   describe("bugfix root-cause evidence gate", () => {
     // Runs contract-run.ts directly against the real repo (not a synthetic temp repo):
@@ -677,7 +677,7 @@ describe("contract-run helper", () => {
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("preflight fails closed on a placeholder brief", () => {
     const repo = makeRepo("contract-run-preflight-fail-");
@@ -729,7 +729,7 @@ describe("contract-run helper", () => {
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("run refuses an incomplete brief before dispatching the worker", () => {
     const repo = makeRepo("contract-run-incomplete-");
@@ -819,7 +819,7 @@ describe("contract-run helper", () => {
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("runner metadata from the contract flows into the manifest", () => {
     const repo = makeRepo("contract-run-runner-");
@@ -977,7 +977,7 @@ describe("contract-run helper", () => {
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   // Worker identity must key off the literal --runner value alone, never off whether it
   // happens to match the contract's declared worker fallback. That "did we land on the
@@ -1014,7 +1014,7 @@ describe("contract-run helper", () => {
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("a Codex runner label passes through unchanged even when it is the contract's declared fallback", () => {
     const repo = makeRepo("contract-run-runner-codexfallback-");
@@ -1049,13 +1049,13 @@ describe("contract-run helper", () => {
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("invalid --effort value exits with usage error", () => {
     const res = runContractRun(ROOT, ["dry-run", "--effort", "nonsense"]);
     expect(res.status).toBe(2);
     expect(res.stderr).toContain("contract-run: --effort must be one of low, medium, high, xhigh, max");
-  });
+  }, 30_000);
 
   test("run fails closed on a blank Out of scope even though In scope is populated", () => {
     const repo = makeRepo("contract-run-outscope-run-");
@@ -1101,7 +1101,7 @@ describe("contract-run helper", () => {
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("dry-run stays advisory on a blank Out of scope", () => {
     const repo = makeRepo("contract-run-outscope-dryrun-");
@@ -1127,7 +1127,7 @@ describe("contract-run helper", () => {
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("worker prompt carries the execution boundary clause", () => {
     const repo = makeRepo("contract-run-boundary-");
@@ -1152,7 +1152,7 @@ describe("contract-run helper", () => {
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   describe("delegation budget enforce-or-reject", () => {
     test("preflight rejects a non-null tokens budget with a named-constraint message", () => {
@@ -1185,7 +1185,7 @@ describe("contract-run helper", () => {
       } finally {
         rmSync(repo, { recursive: true, force: true });
       }
-    });
+    }, 30_000);
 
     test("preflight rejects a non-inherited network value with a named-constraint message", () => {
       const repo = makeRepo("contract-run-network-reject-");
@@ -1219,7 +1219,7 @@ describe("contract-run helper", () => {
       } finally {
         rmSync(repo, { recursive: true, force: true });
       }
-    });
+    }, 30_000);
 
     test("preflight rejects a non-empty writable_paths narrowing with a named-constraint message", () => {
       const repo = makeRepo("contract-run-writable-paths-reject-");
@@ -1256,7 +1256,7 @@ describe("contract-run helper", () => {
       } finally {
         rmSync(repo, { recursive: true, force: true });
       }
-    });
+    }, 30_000);
 
     test("preflight reports every unenforceable constraint together, not just the first", () => {
       const repo = makeRepo("contract-run-multi-reject-");
@@ -1288,7 +1288,7 @@ describe("contract-run helper", () => {
       } finally {
         rmSync(repo, { recursive: true, force: true });
       }
-    });
+    }, 30_000);
 
     test("preflight passes when tokens is null, network is inherited, and writable_paths is empty", () => {
       const repo = makeRepo("contract-run-enforceable-ok-");
@@ -1318,7 +1318,7 @@ describe("contract-run helper", () => {
       } finally {
         rmSync(repo, { recursive: true, force: true });
       }
-    });
+    }, 30_000);
 
     test("preflight fails closed on the retired tool_calls field name instead of silently dropping the budget", () => {
       const repo = makeRepo("contract-run-legacy-field-");
@@ -1352,7 +1352,7 @@ describe("contract-run helper", () => {
       } finally {
         rmSync(repo, { recursive: true, force: true });
       }
-    });
+    }, 30_000);
 
     test("run enforces wall_time_minutes via the bounded process runner deadline and kills an overrunning worker", () => {
       const repo = makeRepo("contract-run-walltime-");
@@ -1408,6 +1408,6 @@ describe("contract-run helper", () => {
       } finally {
         rmSync(repo, { recursive: true, force: true });
       }
-    });
+    }, 30_000);
   });
 });

--- a/tests/contract-worktree-closeout-journal.test.ts
+++ b/tests/contract-worktree-closeout-journal.test.ts
@@ -428,7 +428,7 @@ describe("contract-worktree finish closeout journal", () => {
       expect(journalDirs(fixture, "finish")).toHaveLength(1);
       expect(readJournal(onlyJournal(fixture, "finish")).status).toBe("complete");
     });
-  });
+  }, 30_000);
 
   test("explicit recover abort clears a dead owner claimed before journal preparation", () => {
     withTempRepo("closeout-journal-orphan-claim", (container) => {
@@ -482,7 +482,7 @@ describe("contract-worktree finish closeout journal", () => {
       expect(existsSync(claim)).toBe(false);
       expect(journalDirs(fixture, "finish")).toHaveLength(0);
     });
-  });
+  }, 30_000);
 
   test("an uninterrupted finish journals every phase and clears its snapshot on completion", () => {
     withTempRepo("closeout-journal-happy", (container) => {
@@ -517,7 +517,7 @@ describe("contract-worktree finish closeout journal", () => {
       expect(meta.contract).toBe(CONTRACT);
       expect(meta.original_head).toMatch(/^[0-9a-f]{40}$/);
     });
-  });
+  }, 30_000);
 
   test("a completed transaction is never re-run as a second closeout", () => {
     withTempRepo("closeout-journal-replay", (container) => {
@@ -543,7 +543,7 @@ describe("contract-worktree finish closeout journal", () => {
       expect(inspect.status).toBe(0);
       expect(inspect.stdout).toContain("No unfinished closeout journal for this worktree.");
     });
-  });
+  }, 30_000);
 
   // The core acceptance requirement: per-phase SIGKILL injection. Each case
   // crashes the helper immediately after the named phase is durably recorded,
@@ -614,7 +614,7 @@ describe("contract-worktree finish closeout journal", () => {
         expect(existsSync(join(fixture.linked, ARCHIVED_PLAN))).toBe(true);
         expect(readJournal(onlyJournal(fixture, "finish")).status).toBe("complete");
       });
-    });
+    }, 30_000);
   }
 
   test("SIGKILL after gate_sealed still rolls back, and SIGKILL after merged reconciles without a second merge", () => {
@@ -680,7 +680,7 @@ describe("contract-worktree finish closeout journal", () => {
       expect(runProcess("git", ["rev-parse", "main"], fixture.primary).stdout.trim()).toBe(mergedSha);
       expect(existsSync(join(dir, "snapshot"))).toBe(false);
     });
-  });
+  }, 30_000);
 
   test("an unfinished journal owned by another worktree does not block this one", () => {
     withTempRepo("closeout-journal-other-worktree", (container) => {
@@ -703,7 +703,7 @@ describe("contract-worktree finish closeout journal", () => {
       expect(inspect.status).toBe(0);
       expect(inspect.stdout).toContain("No unfinished closeout journal for this worktree.");
     });
-  });
+  }, 30_000);
 });
 
 describe("ship-worktrees closeout journal", () => {
@@ -779,7 +779,7 @@ describe("ship-worktrees closeout journal", () => {
       expect(prCreates).toHaveLength(1);
       expect(runProcess("git", ["rev-parse", "refs/heads/codex/demo"], fixture.remote).status).toBe(0);
     });
-  });
+  }, 30_000);
 
   test("SIGKILL right after the prepared phase rolls back with nothing pushed", () => {
     withTempRepo("closeout-journal-ship-prepared", (container) => {
@@ -855,7 +855,7 @@ describe("ship-worktrees closeout journal", () => {
       expect(readJournal(dir).status).toBe("aborted");
       expect(runProcess("git", ["rev-parse", "refs/heads/codex/demo"], fixture.remote).status).not.toBe(0);
     });
-  });
+  }, 30_000);
 
   test("SIGKILL between the PR record and complete reconciles without a second push or PR", () => {
     withTempRepo("closeout-journal-ship-pr-observed", (container) => {
@@ -935,7 +935,7 @@ describe("ship-worktrees closeout journal", () => {
       expect(done.phases).toEqual(["prepared", "gate_sealed", "pushed", "pr_observed", "complete"]);
       expect(existsSync(join(dir, "snapshot"))).toBe(false);
     });
-  });
+  }, 30_000);
 
   test("SIGKILL between push and PR creation reconciles to PR creation only", () => {
     withTempRepo("closeout-journal-ship", (container) => {
@@ -1000,7 +1000,7 @@ describe("ship-worktrees closeout journal", () => {
       expect(done.status).toBe("complete");
       expect(done.phases).toEqual(["prepared", "gate_sealed", "pushed", "pr_observed", "complete"]);
     });
-  });
+  }, 30_000);
 
   test("SIGKILL after the push but before its phase record still reconciles from the remote", () => {
     withTempRepo("closeout-journal-ship-window", (container) => {
@@ -1052,7 +1052,7 @@ describe("ship-worktrees closeout journal", () => {
       expect(readJournal(dir).phases).toEqual(["prepared", "gate_sealed", "pushed", "pr_observed", "complete"]);
       expect(runProcess("git", ["rev-parse", "refs/heads/codex/demo"], fixture.remote).stdout.trim()).toBe(remoteSha);
     });
-  });
+  }, 30_000);
 });
 
 describe("closeout journal no-read guard", () => {
@@ -1079,5 +1079,5 @@ describe("closeout journal no-read guard", () => {
       const after = JSON.stringify(resolveFixtureState(cwd, nowMs), null, 2);
       expect(after).toBe(before);
     });
-  });
+  }, 30_000);
 });

--- a/tests/effective-state.test.ts
+++ b/tests/effective-state.test.ts
@@ -101,7 +101,7 @@ describe('effective state resolver', () => {
       failedClosed: true,
       published: false,
     })));
-  });
+  }, 30_000);
 
   test('fails closed when an in-repo authority path symlinks outside the repository', () => {
     if (process.platform === 'win32') return;
@@ -119,7 +119,7 @@ describe('effective state resolver', () => {
       rmSync(outsidePath, { force: true });
       fixture.cleanup();
     }
-  });
+  }, 30_000);
 
   test('fails closed when a missing authority path has an external symlink ancestor', () => {
     if (process.platform === 'win32') return;
@@ -136,7 +136,7 @@ describe('effective state resolver', () => {
       rmSync(outsideDirectory, { recursive: true, force: true });
       fixture.cleanup();
     }
-  });
+  }, 30_000);
 
   test('fails closed when no actual changed or target paths are authoritative', () => {
     withRepo((cwd) => {
@@ -148,7 +148,7 @@ describe('effective state resolver', () => {
       expect(state.blockers).toContain('workflow_profile:invalid_risk_input');
       expect(state.phase).toBe('blocked');
     });
-  });
+  }, 30_000);
 
   test('steady-state resolution ignores the retired legacy marker', () => {
     withRepo((cwd) => {
@@ -158,7 +158,7 @@ describe('effective state resolver', () => {
       expect(state.conflicting_sources).not.toContain('active_plan_markers');
       expect(state.source_hashes['.claude/.active-plan']).toBeUndefined();
     });
-  });
+  }, 30_000);
 
   test('performs legacy migration only through the explicit one-shot command', () => {
     withRepo((cwd) => {
@@ -171,14 +171,14 @@ describe('effective state resolver', () => {
       expect(() => readFileSync(join(cwd, '.claude/.active-plan'), 'utf-8')).toThrow();
       expect(resolveFixtureState(cwd).authoritative_plan?.path).toBe(PLAN);
     });
-  });
+  }, 30_000);
 
   test('explicit legacy migration fails closed on a real authority conflict', () => {
     withRepo((cwd) => {
       write(cwd, '.claude/.active-plan', 'plans/plan-other.md\n');
       expect(() => migrateLegacyActivePlan(cwd)).toThrow('conflicts with canonical');
     });
-  });
+  }, 30_000);
 
   test('explicit legacy migration fails closed when a canonical marker is unreadable', () => {
     withRepo((cwd) => {
@@ -189,7 +189,7 @@ describe('effective state resolver', () => {
       expect(() => migrateLegacyActivePlan(cwd)).toThrow();
       expect(readFileSync(join(cwd, '.claude/.active-plan'), 'utf-8')).toContain(PLAN);
     });
-  });
+  }, 30_000);
 
   test('blocks approved or executing work under Strict when its contract is missing', () => {
     withRepo((cwd) => {
@@ -207,7 +207,7 @@ describe('effective state resolver', () => {
       expect(state.blockers).toContain('missing_contract');
       expect(state.next_action).toBe('resolve blockers');
     });
-  });
+  }, 30_000);
 
   test('allows approved or executing work under Standard when its contract is missing', () => {
     withRepo((cwd) => {
@@ -221,7 +221,7 @@ describe('effective state resolver', () => {
       expect(state.blockers).not.toContain('missing_contract');
       expect(state.phase).not.toBe('blocked');
     });
-  });
+  }, 30_000);
 
   test('allows approved or executing work under Lite when its contract is missing', () => {
     withRepo((cwd) => {
@@ -237,7 +237,7 @@ describe('effective state resolver', () => {
       expect(state.blockers).not.toContain('missing_contract');
       expect(state.phase).not.toBe('blocked');
     });
-  });
+  }, 30_000);
 
   test('fails closed with missing_contract when the workflow profile cannot be resolved', () => {
     withRepo((cwd) => {
@@ -256,7 +256,7 @@ describe('effective state resolver', () => {
       expect(state.blockers).toContain('missing_contract');
       expect(state.phase).toBe('blocked');
     });
-  });
+  }, 30_000);
 
   test('rewriting handoff and resume advances only projection and state revision, never authority, subject, evidence, or the progress token', () => {
     withRepo((cwd) => {
@@ -280,7 +280,7 @@ describe('effective state resolver', () => {
       expect(second.evidence_revision).toBe(first.evidence_revision);
       expect(second.progress_token).toBe(first.progress_token);
     });
-  });
+  }, 30_000);
 
   describe('capability registry resolution (Phase C1)', () => {
     function capability(id: string, prefixes: readonly string[]) {
@@ -307,7 +307,7 @@ describe('effective state resolver', () => {
         expect(state.profile_reasons).not.toContain('capability:registry:invalid');
         expect(state.profile_reasons).toContain('capability:registry:absent');
       });
-    });
+    }, 30_000);
 
     test('a declared-but-missing registry fails closed with a structured blocker', () => {
       withRepo((cwd) => {
@@ -319,7 +319,7 @@ describe('effective state resolver', () => {
         expect(state.profile_reasons).toContain('capability:registry:invalid');
         expect(state.phase).toBe('blocked');
       });
-    });
+    }, 30_000);
 
     test('corrupt registry JSON fails closed with a structured blocker instead of a silent capabilityCount=0', () => {
       withRepo((cwd) => {
@@ -327,7 +327,7 @@ describe('effective state resolver', () => {
         const state = resolveFixtureState(cwd);
         expect(state.blockers).toContain('capability_registry:invalid');
       });
-    });
+    }, 30_000);
 
     test('absolute target paths outside the repo do not invalidate a valid registry', () => {
       withRepo((cwd) => {
@@ -341,7 +341,7 @@ describe('effective state resolver', () => {
         expect(state.profile_reasons).toContain('capability:out-of-repo:1');
         expect(state.phase).not.toBe('blocked');
       });
-    });
+    }, 30_000);
 
     test('a mixed batch keeps in-repo unmapped accounting alongside out-of-repo paths', () => {
       withRepo((cwd) => {
@@ -357,7 +357,7 @@ describe('effective state resolver', () => {
         expect(state.profile_signals?.crossCapability).toBe(false);
         expect(state.risk_floor).toBe('lite');
       });
-    });
+    }, 30_000);
 
     test('a mapped repo capability plus an out-of-repo path stays one capability', () => {
       withRepo((cwd) => {
@@ -375,7 +375,7 @@ describe('effective state resolver', () => {
         expect(state.profile_signals?.crossCapability).toBe(false);
         expect(state.risk_floor).toBe('lite');
       });
-    });
+    }, 30_000);
 
     test('a NUL-bearing absolute path fails canonical validation instead of bypassing it', () => {
       withRepo((cwd) => {
@@ -388,7 +388,7 @@ describe('effective state resolver', () => {
         expect(state.profile_reasons).toContain('capability:registry:invalid');
         expect(state.profile_reasons).not.toContain('capability:out-of-repo:1');
       });
-    });
+    }, 30_000);
 
     test('an invalid registry does not also count out-of-repo paths as unmapped', () => {
       withRepo((cwd) => {
@@ -401,7 +401,7 @@ describe('effective state resolver', () => {
         expect(state.profile_reasons).toContain('capability:out-of-repo:1');
         expect(state.profile_reasons).not.toContain('capability:unmapped:1');
       });
-    });
+    }, 30_000);
 
     test('in-repo traversal paths still fail closed as invalid', () => {
       withRepo((cwd) => {
@@ -412,7 +412,7 @@ describe('effective state resolver', () => {
         });
         expect(state.blockers).toContain('capability_registry:invalid');
       });
-    });
+    }, 30_000);
 
     test('malformed entries inside an otherwise-parseable registry are counted and fail closed instead of silently dropped', () => {
       withRepo((cwd) => {
@@ -440,7 +440,7 @@ describe('effective state resolver', () => {
         expect(state.blockers).toContain('capability_registry:invalid');
         expect(state.phase).toBe('blocked');
       });
-    });
+    }, 30_000);
 
     test('a corrupt policy.json fails closed before cache/version publication', () => {
       withRepo((cwd) => {
@@ -449,7 +449,7 @@ describe('effective state resolver', () => {
         expect(existsSync(join(cwd, '.ai/harness/state/effective.json'))).toBe(false);
         expect(existsSync(stateVersionOwnerPath(cwd))).toBe(false);
       });
-    });
+    }, 30_000);
 
     for (const malformed of [
       {
@@ -485,7 +485,7 @@ describe('effective state resolver', () => {
           expect(existsSync(join(cwd, '.ai/harness/state/effective.json'))).toBe(false);
           expect(existsSync(stateVersionOwnerPath(cwd))).toBe(false);
         });
-      });
+      }, 30_000);
     }
 
     for (const malformed of [
@@ -503,7 +503,7 @@ describe('effective state resolver', () => {
           expect(existsSync(join(cwd, '.ai/harness/state/effective.json'))).toBe(false);
           expect(existsSync(stateVersionOwnerPath(cwd))).toBe(false);
         });
-      });
+      }, 30_000);
     }
 
     test('a valid registry with no matching prefix produces no blocker but records the unmapped reason', () => {
@@ -520,7 +520,7 @@ describe('effective state resolver', () => {
         expect(state.blockers).not.toContain('capability_registry:invalid');
         expect(state.profile_reasons).toContain('capability:unmapped:1');
       });
-    });
+    }, 30_000);
 
     test('registry and policy changes advance the state revision, durable version, and authority revision', () => {
       withRepo((cwd) => {
@@ -571,7 +571,7 @@ describe('effective state resolver', () => {
         expect(third.authority_revision).not.toBe(second.authority_revision);
         expect(third.blockers).toEqual(second.blockers);
       });
-    });
+    }, 30_000);
 
     test('an unmapped implementation path contributes one cross-capability bucket without lowering the floor', () => {
       withRepo((cwd) => {
@@ -588,7 +588,7 @@ describe('effective state resolver', () => {
         expect(state.risk_floor).toBe('standard');
         expect(state.blockers).not.toContain('capability_registry:invalid');
       });
-    });
+    }, 30_000);
 
     test('workflow-surface-only target paths never reach capability resolution as implementation paths (Phase C2)', () => {
       withRepo((cwd) => {
@@ -604,7 +604,7 @@ describe('effective state resolver', () => {
         expect(state.profile_reasons).not.toContain('capability:unmapped:1');
         expect(state.profile_signals?.capabilityCount).toBe(0);
       });
-    });
+    }, 30_000);
   });
 
 });

--- a/tests/evidence-attested-import.test.ts
+++ b/tests/evidence-attested-import.test.ts
@@ -99,7 +99,7 @@ describe("importAttestedEvidence: trust mapping", () => {
       expect(accepted.length).toBe(1);
       expect(accepted[0]!.event_id).toBe(result.event.event_id);
     });
-  });
+  }, 30_000);
 
   test("user_waiver maps to human_acceptance", () => {
     withTempRepo("attested-import-user-waiver", (repoRoot) => {
@@ -117,7 +117,7 @@ describe("importAttestedEvidence: trust mapping", () => {
       if (!result.ok) return;
       expect(result.event.trust_class).toBe("human_acceptance");
     });
-  });
+  }, 30_000);
 
   test("emits the complete D3 field set and a redaction-safe short payload", () => {
     withTempRepo("attested-import-d3-fields", (repoRoot) => {
@@ -151,7 +151,7 @@ describe("importAttestedEvidence: trust mapping", () => {
       expect((payload.receipt_ref as string).length).toBeLessThan(32);
       expect(payload.receipt_ref).not.toContain("sha256:");
     });
-  });
+  }, 30_000);
 });
 
 describe("importAttestedEvidence: fail-closed paths", () => {
@@ -168,7 +168,7 @@ describe("importAttestedEvidence: fail-closed paths", () => {
       const { accepted } = readAcceptedEvents(repoRoot);
       expect(accepted.length).toBe(0);
     });
-  });
+  }, 30_000);
 
   test("a completely bogus disposition also fails closed", () => {
     withTempRepo("attested-import-bogus-disposition", (repoRoot) => {
@@ -182,7 +182,7 @@ describe("importAttestedEvidence: fail-closed paths", () => {
       const { accepted } = readAcceptedEvents(repoRoot);
       expect(accepted.length).toBe(0);
     });
-  });
+  }, 30_000);
 
   test("missing actor (empty reviewer) fails closed and appends nothing", () => {
     withTempRepo("attested-import-missing-actor", (repoRoot) => {
@@ -197,7 +197,7 @@ describe("importAttestedEvidence: fail-closed paths", () => {
       const { accepted } = readAcceptedEvents(repoRoot);
       expect(accepted.length).toBe(0);
     });
-  });
+  }, 30_000);
 
   test("missing reason (blank summary) fails closed and appends nothing", () => {
     withTempRepo("attested-import-missing-reason", (repoRoot) => {
@@ -211,7 +211,7 @@ describe("importAttestedEvidence: fail-closed paths", () => {
       const { accepted } = readAcceptedEvents(repoRoot);
       expect(accepted.length).toBe(0);
     });
-  });
+  }, 30_000);
 
   test("missing subject (empty subject_sha256) fails closed and appends nothing", () => {
     withTempRepo("attested-import-missing-subject-hash", (repoRoot) => {
@@ -225,7 +225,7 @@ describe("importAttestedEvidence: fail-closed paths", () => {
       const { accepted } = readAcceptedEvents(repoRoot);
       expect(accepted.length).toBe(0);
     });
-  });
+  }, 30_000);
 
   test("missing subject (empty target_revision) fails closed and appends nothing", () => {
     withTempRepo("attested-import-missing-target-revision", (repoRoot) => {
@@ -239,7 +239,7 @@ describe("importAttestedEvidence: fail-closed paths", () => {
       const { accepted } = readAcceptedEvents(repoRoot);
       expect(accepted.length).toBe(0);
     });
-  });
+  }, 30_000);
 
   test("an uncommitted contract file fails closed (no authority commit) and appends nothing", () => {
     withTempRepo("attested-import-uncommitted-contract", (repoRoot) => {
@@ -250,7 +250,7 @@ describe("importAttestedEvidence: fail-closed paths", () => {
       const { accepted } = readAcceptedEvents(repoRoot);
       expect(accepted.length).toBe(0);
     });
-  });
+  }, 30_000);
 });
 
 describe("importAttestedEvidence: default-deny at trust level", () => {
@@ -282,7 +282,7 @@ describe("importAttestedEvidence: default-deny at trust level", () => {
       const authoritative = accepted.filter((event) => event.trust_class === "authoritative_machine");
       expect(authoritative.length).toBe(0);
     });
-  });
+  }, 30_000);
 });
 
 describe("importAttestedEvidence: idempotency and genesis", () => {
@@ -310,7 +310,7 @@ describe("importAttestedEvidence: idempotency and genesis", () => {
       expect(accepted.length).toBe(1);
       expect(accepted[0]!.event_id).toBe(first.event.event_id);
     });
-  });
+  }, 30_000);
 
   test("re-importing a receipt with a different subject is not deduped", () => {
     withTempRepo("attested-import-distinct-subject", (repoRoot) => {
@@ -328,7 +328,7 @@ describe("importAttestedEvidence: idempotency and genesis", () => {
       const { accepted } = readAcceptedEvents(repoRoot);
       expect(accepted.length).toBe(2);
     });
-  });
+  }, 30_000);
 
   test("genesis is written once with LEDGER_EPOCH_START_SHA across repeated imports", () => {
     withTempRepo("attested-import-genesis-once", (repoRoot) => {
@@ -353,7 +353,7 @@ describe("importAttestedEvidence: idempotency and genesis", () => {
       expect(genesisLines.length).toBe(1);
       expect(JSON.parse(genesisLines[0]!).ledger_epoch_start_sha).toBe(LEDGER_EPOCH_START_SHA);
     });
-  });
+  }, 30_000);
 });
 
 describe("scripts/acceptance-receipt.ts record: attested-import wiring", () => {
@@ -466,7 +466,7 @@ describe("scripts/acceptance-receipt.ts record: attested-import wiring", () => {
     expect(accepted.length).toBe(1);
     expect(accepted[0]!.trust_class).toBe("external_attested");
     expect(accepted[0]!.event_type).toBe("acceptance_receipt.attested_import");
-  });
+  }, 30_000);
 
   test("real record --disposition reject does not touch the ledger", async () => {
     const { root, home } = setupCliFixture();
@@ -489,5 +489,5 @@ describe("scripts/acceptance-receipt.ts record: attested-import wiring", () => {
     // Existing, pre-EPC-04 behavior: reject still exits 1 (unaffected by this package's wiring).
     expect(exitCode).toBe(1);
     expect(readGenesisRecord(root)).toBeNull();
-  });
+  }, 30_000);
 });

--- a/tests/evidence-checks-materializer.test.ts
+++ b/tests/evidence-checks-materializer.test.ts
@@ -531,7 +531,7 @@ describe("checks-materializer: writeChecksLatest overwrite semantics", () => {
       expect((consumerFacing as typeof runTrace).contract.file).toBe(LONG_SLUG_CONTRACT_RELATIVE);
       expect((consumerFacing as typeof runTrace).active_plan).toBe(LONG_SLUG_ACTIVE_PLAN);
     });
-  });
+  }, 30_000);
 
   test("end-to-end (gatekeeper CRITICAL regression, fail path): a realistic-length contract slug survives materialization byte-identical on a failing verify result too", () => {
     withTempRepo("materializer-end-to-end-fail", (repoRoot) => {
@@ -574,7 +574,7 @@ describe("checks-materializer: writeChecksLatest overwrite semantics", () => {
       expect(projection.status).toBe("fail");
       expect((projection as Record<string, unknown>).exit_code).toBe(1);
     });
-  });
+  }, 30_000);
 });
 
 describe("checks-materializer: parseAcceptancePolicySummary", () => {
@@ -813,5 +813,5 @@ describe("checks-materializer: no-independent-authoring", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 });

--- a/tests/evidence-post-bash-importer.test.ts
+++ b/tests/evidence-post-bash-importer.test.ts
@@ -123,7 +123,7 @@ describe("importPostBashObservation: trust class and D3 field set", () => {
       const { accepted } = readAcceptedEvents(repoRoot);
       expect(accepted.length).toBe(1);
     });
-  });
+  }, 30_000);
 });
 
 describe("importPostBashObservation: unbound vs bound contract identity (sentinel rules)", () => {
@@ -140,7 +140,7 @@ describe("importPostBashObservation: unbound vs bound contract identity (sentine
       expect(identity.base_commit).toMatch(/^[0-9a-f]{40}$/);
       expect(identity.target_commit).toMatch(/^[0-9a-f]{40}$/);
     });
-  });
+  }, 30_000);
 
   test("a dirty (uncommitted) contract -> unbound authority/scope/contract identity", () => {
     withTempRepo("post-bash-importer-dirty-contract", (repoRoot) => {
@@ -158,7 +158,7 @@ describe("importPostBashObservation: unbound vs bound contract identity (sentine
       expect(identity.scope_hash).toBe(UNBOUND_SENTINEL);
       expect(identity.contract_hash).toBe(UNBOUND_SENTINEL);
     });
-  });
+  }, 30_000);
 
   test("an untracked (never committed) contract -> unbound authority/scope/contract identity", () => {
     withTempRepo("post-bash-importer-untracked-contract", (repoRoot) => {
@@ -171,7 +171,7 @@ describe("importPostBashObservation: unbound vs bound contract identity (sentine
       expect(identity.scope_hash).toBe(UNBOUND_SENTINEL);
       expect(identity.contract_hash).toBe(UNBOUND_SENTINEL);
     });
-  });
+  }, 30_000);
 
   test("a clean, committed contract -> bound authority/scope/contract identity", () => {
     withTempRepo("post-bash-importer-bound-contract", (repoRoot) => {
@@ -186,7 +186,7 @@ describe("importPostBashObservation: unbound vs bound contract identity (sentine
       const expectedScopeHash = `sha256:${createHash("sha256").update(JSON.stringify(["src/a.ts", "src/b.ts"])).digest("hex")}`;
       expect(identity.scope_hash).toBe(expectedScopeHash);
     });
-  });
+  }, 30_000);
 });
 
 describe("importPostBashObservation: observed-only ledger leaves authoritative gates unsatisfied", () => {
@@ -202,7 +202,7 @@ describe("importPostBashObservation: observed-only ledger leaves authoritative g
       expect(accepted.every((event) => event.trust_class === "observed")).toBe(true);
       expect(accepted.filter((event) => event.trust_class === "authoritative_machine")).toEqual([]);
     });
-  });
+  }, 30_000);
 });
 
 describe("importPostBashObservation: fail-closed on malformed input", () => {
@@ -218,7 +218,7 @@ describe("importPostBashObservation: fail-closed on malformed input", () => {
       const { accepted } = readAcceptedEvents(repoRoot);
       expect(accepted.length).toBe(0);
     });
-  });
+  }, 30_000);
 
   test("a negative durationMs fails closed and appends nothing", () => {
     withTempRepo("post-bash-importer-malformed-duration", (repoRoot) => {
@@ -230,7 +230,7 @@ describe("importPostBashObservation: fail-closed on malformed input", () => {
       const { accepted } = readAcceptedEvents(repoRoot);
       expect(accepted.length).toBe(0);
     });
-  });
+  }, 30_000);
 
   test("an absolute rawOutputPath fails closed and appends nothing", () => {
     withTempRepo("post-bash-importer-malformed-path", (repoRoot) => {
@@ -242,7 +242,7 @@ describe("importPostBashObservation: fail-closed on malformed input", () => {
       const { accepted } = readAcceptedEvents(repoRoot);
       expect(accepted.length).toBe(0);
     });
-  });
+  }, 30_000);
 
   test("a path-traversal rawOutputPath fails closed and appends nothing", () => {
     withTempRepo("post-bash-importer-malformed-traversal", (repoRoot) => {
@@ -254,7 +254,7 @@ describe("importPostBashObservation: fail-closed on malformed input", () => {
       const { accepted } = readAcceptedEvents(repoRoot);
       expect(accepted.length).toBe(0);
     });
-  });
+  }, 30_000);
 });
 
 describe("importPostBashObservation: idempotent re-import", () => {
@@ -282,7 +282,7 @@ describe("importPostBashObservation: idempotent re-import", () => {
       expect(accepted.length).toBe(1);
       expect(accepted[0]!.event_id).toBe(first.event.event_id);
     });
-  });
+  }, 30_000);
 
   test("genesis is written once with LEDGER_EPOCH_START_SHA across repeated imports", () => {
     withTempRepo("post-bash-importer-genesis-once", (repoRoot) => {
@@ -302,5 +302,5 @@ describe("importPostBashObservation: idempotent re-import", () => {
       const genesisLines = lines.filter((line) => JSON.parse(line).kind === "evidence_genesis");
       expect(genesisLines.length).toBe(1);
     });
-  });
+  }, 30_000);
 });

--- a/tests/evidence-projection-drift.test.ts
+++ b/tests/evidence-projection-drift.test.ts
@@ -448,7 +448,7 @@ describe("projection drift: materialized checks/latest", () => {
       const { provenance: driftedProvenance, ...driftedContent } = drifted;
       expect(contentHashOf(driftedContent)).not.toBe(driftedProvenance.content_hash);
     });
-  });
+  }, 30_000);
 });
 
 // ---------------------------------------------------------------------------
@@ -471,5 +471,5 @@ describe("projection drift: tasks/current.md (refresh-current-status.sh double-r
     const strip = (text: string) =>
       text.replace(/^<!-- updated_at:.*$/m, "").replace(/^> \*\*Updated At\*\*:.*$/m, "");
     expect(strip(first.stdout)).toBe(strip(second.stdout));
-  });
+  }, 30_000);
 });

--- a/tests/evidence-recovery-materializer.test.ts
+++ b/tests/evidence-recovery-materializer.test.ts
@@ -237,7 +237,7 @@ describe("recovery-view-cli.ts: standalone end-to-end", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("--print-prompt prints only the Resume Prompt body and writes no output besides the recovery views", () => {
     const cwd = mkdtempSync(join(tmpdir(), "recovery-cli-print-prompt-"));
@@ -254,7 +254,7 @@ describe("recovery-view-cli.ts: standalone end-to-end", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("--with-global-packet updates the Codex-global handoff file with a per-repo spliced section", () => {
     const cwd = mkdtempSync(join(tmpdir(), "recovery-cli-global-"));
@@ -281,7 +281,7 @@ describe("recovery-view-cli.ts: standalone end-to-end", () => {
       rmSync(cwd, { recursive: true, force: true });
       rmSync(codexHome, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 });
 
 describe("no-independent-authoring: the retired writers carry zero content assembly", () => {
@@ -349,5 +349,5 @@ describe("tasks/current.md: refresh-current-status.sh stays the sole materialize
       .replace(/^<!-- updated_at:.*$/m, "")
       .replace(/^> \*\*Updated At\*\*:.*$/m, "");
     expect(strip(first.stdout)).toBe(strip(second.stdout));
-  });
+  }, 30_000);
 });

--- a/tests/evidence-verify-producer.test.ts
+++ b/tests/evidence-verify-producer.test.ts
@@ -128,7 +128,7 @@ describe("emitAuthoritativeVerifyEvidence: fail-closed paths", () => {
       const { accepted } = readAcceptedEvents(repoRoot);
       expect(accepted.length).toBe(0);
     });
-  });
+  }, 30_000);
 
   test("a dirty (uncommitted) contract fails closed and appends nothing", () => {
     withTempRepo("verify-producer-contract-dirty", (repoRoot) => {
@@ -143,7 +143,7 @@ describe("emitAuthoritativeVerifyEvidence: fail-closed paths", () => {
       const { accepted } = readAcceptedEvents(repoRoot);
       expect(accepted.length).toBe(0);
     });
-  });
+  }, 30_000);
 
   test("an untracked (never committed) contract fails closed and appends nothing", () => {
     withTempRepo("verify-producer-contract-untracked", (repoRoot) => {
@@ -156,7 +156,7 @@ describe("emitAuthoritativeVerifyEvidence: fail-closed paths", () => {
       const { accepted } = readAcceptedEvents(repoRoot);
       expect(accepted.length).toBe(0);
     });
-  });
+  }, 30_000);
 });
 
 describe("emitAuthoritativeVerifyEvidence: success path", () => {
@@ -200,7 +200,7 @@ describe("emitAuthoritativeVerifyEvidence: success path", () => {
       expect(accepted.length).toBe(1);
       expect(accepted[0]!.event_id).toBe(result.event.event_id);
     });
-  });
+  }, 30_000);
 
   test("scope_hash reflects the contract's own allowed_paths, not the caller's", () => {
     withTempRepo("verify-producer-scope-hash", (repoRoot) => {
@@ -211,7 +211,7 @@ describe("emitAuthoritativeVerifyEvidence: success path", () => {
       const expectedScopeHash = `sha256:${createHash("sha256").update(JSON.stringify(["src/a.ts", "src/b.ts"])).digest("hex")}`;
       expect(result.event.subject_identity.scope_hash).toBe(expectedScopeHash);
     });
-  });
+  }, 30_000);
 });
 
 describe("emitAuthoritativeVerifyEvidence: idempotency and genesis", () => {
@@ -242,7 +242,7 @@ describe("emitAuthoritativeVerifyEvidence: idempotency and genesis", () => {
       expect(accepted.length).toBe(1);
       expect(accepted[0]!.event_id).toBe(first.event.event_id);
     });
-  });
+  }, 30_000);
 
   test("genesis is written once with LEDGER_EPOCH_START_SHA across repeated emissions", () => {
     withTempRepo("verify-producer-genesis-once", (repoRoot) => {
@@ -268,7 +268,7 @@ describe("emitAuthoritativeVerifyEvidence: idempotency and genesis", () => {
       expect(genesisLines.length).toBe(1);
       expect(JSON.parse(genesisLines[0]!).ledger_epoch_start_sha).toBe(LEDGER_EPOCH_START_SHA);
     });
-  });
+  }, 30_000);
 });
 
 
@@ -292,7 +292,7 @@ describe("scripts/emit-verify-evidence.ts: exit code contract", () => {
       expect(res.status, `${res.stdout}\n${res.stderr}`).toBe(0);
       expect(res.stdout).toContain("appended evt-");
     });
-  });
+  }, 30_000);
 
   test("exit 3 (cannot-bind), not 1, when the contract is dirty", () => {
     withTempRepo("wrapper-exit-dirty", (repoRoot) => {
@@ -312,7 +312,7 @@ describe("scripts/emit-verify-evidence.ts: exit code contract", () => {
       expect(res.stderr).toContain("cannot-bind");
       expect(res.stderr).toContain("contract_not_committed");
     });
-  });
+  }, 30_000);
 
   test("exit 3 (cannot-bind), not 1, when no active contract resolves", () => {
     withTempRepo("wrapper-exit-no-contract", (repoRoot) => {
@@ -327,7 +327,7 @@ describe("scripts/emit-verify-evidence.ts: exit code contract", () => {
       expect(res.stderr).toContain("cannot-bind");
       expect(res.stderr).toContain("no_active_contract");
     });
-  });
+  }, 30_000);
 
   test("exit 1 (hard fail), not 3, on subject mismatch -- must not be classified as cannot-bind", () => {
     withTempRepo("wrapper-exit-mismatch", (repoRoot) => {
@@ -344,5 +344,5 @@ describe("scripts/emit-verify-evidence.ts: exit code contract", () => {
       expect(res.stderr).toContain("fail-closed");
       expect(res.stderr).toContain("subject_mismatch");
     });
-  });
+  }, 30_000);
 });

--- a/tests/factor-factory.test.ts
+++ b/tests/factor-factory.test.ts
@@ -13,7 +13,7 @@ import { spawnSync } from "child_process";
 import { assembleTemplate } from "../scripts/assemble-template";
 
 const ROOT = join(import.meta.dir, "..");
-const FACTOR_FACTORY_SMOKE_TIMEOUT_MS = 15000;
+const FACTOR_FACTORY_SMOKE_TIMEOUT_MS = 45_000;
 
 function bootstrapRepo(prefix: string, env: Record<string, string> = {}) {
   const cwd = mkdtempSync(join(tmpdir(), `${prefix}-repo-`));

--- a/tests/harness-benchmark-matrix.test.ts
+++ b/tests/harness-benchmark-matrix.test.ts
@@ -93,7 +93,7 @@ describe('No Harness / Lite / Strict benchmark authority', () => {
     // 1 reaps it. A zombie is terminated even though kill(pid, 0) still sees
     // the process-table entry; any runnable/sleeping descendant is a failure.
     expect(state === '' || state.startsWith('Z')).toBe(true);
-  });
+  }, 30_000);
 
   test('final-content detection includes provider commits made after the arm baseline', () => {
     const dir = mkdtempSync(join(tmpdir(), 'harness-committed-final-content-'));
@@ -117,7 +117,7 @@ describe('No Harness / Lite / Strict benchmark authority', () => {
       expect(git('status', '--porcelain')).toBe('');
       expect(benchmarkChangedFiles(dir, baseline)).toEqual(['src/status.ts']);
     } finally { rmSync(dir, { recursive: true, force: true }); }
-  });
+  }, 30_000);
 
   test('workspace overlays share no mutable Git objects and push only to an arm-owned origin', () => {
     const dir = mkdtempSync(join(tmpdir(), 'harness-workspace-overlay-'));
@@ -148,7 +148,7 @@ describe('No Harness / Lite / Strict benchmark authority', () => {
       expect(git(armOrigin, 'rev-parse', 'main').stdout.toString().trim())
         .toBe(git(target, 'rev-parse', 'HEAD').stdout.toString().trim());
     } finally { rmSync(dir, { recursive: true, force: true }); }
-  });
+  }, 30_000);
 
   test('HOME overlays rebase absolute cache symlinks away from the immutable profile base', () => {
     const dir = mkdtempSync(join(tmpdir(), 'harness-home-overlay-'));
@@ -186,7 +186,7 @@ describe('No Harness / Lite / Strict benchmark authority', () => {
       expect(readFileSync(join(linked, '.ai/harness/handoff/resume.md'), 'utf8')).toContain('## Exact Next Step');
       expect(realpathSync(linked)).not.toBe('');
     } finally { rmSync(dir, { recursive: true, force: true }); }
-  });
+  }, 30_000);
 
   test('harness-enabled arm overlays grade the precreated linked provider workspace', () => {
     const dir = mkdtempSync(join(tmpdir(), 'harness-profile-linked-workspaces-'));
@@ -244,7 +244,7 @@ describe('No Harness / Lite / Strict benchmark authority', () => {
         expect(existsSync(join(layout.workspace, '.ai/harness/handoff/resume.md'))).toBe(true);
       }
     } finally { rmSync(dir, { recursive: true, force: true }); }
-  });
+  }, 30_000);
 
   test('manifest contains the exact 3x9 matrix', () => {
     const manifest = loadHarnessScenarioManifest(join(ROOT, 'evals/harness/scenarios.json'));
@@ -307,7 +307,7 @@ describe('No Harness / Lite / Strict benchmark authority', () => {
     } finally {
       rmSync(runRoot, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('reuses one packed artifact across isolated installs without mutating source authority', () => {
     const runRoot = mkdtempSync(join(tmpdir(), 'harness-runtime-install-'));
@@ -410,7 +410,7 @@ describe('No Harness / Lite / Strict benchmark authority', () => {
     expect(reportBlock).toContain('source_commit: sourceAuthority.sourceCommit');
     expect(reportBlock).toContain('...sourceAuthority.subject');
     expect(reportBlock).not.toContain('benchmarkSubject(');
-  });
+  }, 30_000);
 
   test('rejects Git-clean install-profile mode drift against the initial benchmark subject', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'harness-subject-mode-drift-'));
@@ -486,7 +486,7 @@ describe('No Harness / Lite / Strict benchmark authority', () => {
       expect(() => runner.assertBenchmarkSubjectUnchanged!(authority!, 'provider execution'))
         .toThrow(/provider execution.*install_profile_inputs_sha256|install_profile_inputs_sha256.*provider execution/);
     } finally { rmSync(dir, { recursive: true, force: true }); }
-  });
+  }, 30_000);
 
   test('parses NUL-delimited porcelain entries, stripping the leading XY status columns', () => {
     expect(parsePorcelainPaths(' M src/range.ts\0?? deploy/sql/0001.sql\0')).toEqual([
@@ -549,7 +549,7 @@ describe('No Harness / Lite / Strict benchmark authority', () => {
       expect(JSON.parse(readFileSync(reportPath, 'utf-8')).records).toHaveLength(27);
       expect(readFileSync(reportPath.replace(/\.json$/, '.md'), 'utf-8')).toContain('non-authoritative');
     } finally { rmSync(dir, { recursive: true, force: true }); }
-  });
+  }, 30_000);
 
   test('benchmark runtime evidence reads only the event-level telemetry authority', () => {
     const dir = mkdtempSync(join(tmpdir(), 'harness-event-telemetry-reader-'));
@@ -610,7 +610,7 @@ describe('No Harness / Lite / Strict benchmark authority', () => {
       expect(() => validateHarnessBenchmarkReportByteBinding(reportPath, report.benchmark_subject_sha256))
         .toThrow('benchmark markdown report bytes changed');
     } finally { rmSync(dir, { recursive: true, force: true }); }
-  });
+  }, 30_000);
 
   test('prepares one immutable base per profile and plans 27 isolated writable arm overlays', () => {
     const manifest = loadHarnessScenarioManifest(join(ROOT, 'evals/harness/scenarios.json'));
@@ -658,7 +658,7 @@ describe('No Harness / Lite / Strict benchmark authority', () => {
       const markdown = readFileSync(reportPath.replace(/\.json$/, '.md'), 'utf-8');
       expect(markdown).toContain('## Artifact Files');
     } finally { rmSync(dir, { recursive: true, force: true }); }
-  });
+  }, 30_000);
 
   test('cleanupArmHostRoot removes only the disposable host install, never base/workspace', () => {
     const dir = mkdtempSync(join(tmpdir(), 'harness-matrix-cleanup-test-'));

--- a/tests/heartbeat-triage.test.ts
+++ b/tests/heartbeat-triage.test.ts
@@ -135,7 +135,7 @@ describe("heartbeat triage runner", () => {
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("workflow check failure is recorded as an inbox finding without failing the runner", () => {
     const repo = makeRepo("heartbeat-triage-fail-");
@@ -158,7 +158,7 @@ describe("heartbeat triage runner", () => {
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("fallback finds the next pending row when no active-sprint marker exists", () => {
     const repo = makeRepo("heartbeat-triage-fallback-");
@@ -179,7 +179,7 @@ describe("heartbeat triage runner", () => {
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("unknown flags exit with usage error", () => {
     const res = spawnSync("bash", ["scripts/heartbeat-triage.sh", "run", "--bogus"], {
@@ -188,5 +188,5 @@ describe("heartbeat triage runner", () => {
     });
     expect(res.status).toBe(2);
     expect(res.stderr).toContain("unknown argument: --bogus");
-  });
+  }, 30_000);
 });

--- a/tests/helper-scripts.test.ts
+++ b/tests/helper-scripts.test.ts
@@ -381,7 +381,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("archive-architecture-request moves handled requests out of the pending queue", () => {
     const cwd = tmpWorkspace("helper-architecture-archive");
@@ -472,7 +472,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("architecture-drift should replace stale pending index lines for the same capability", () => {
     const cwd = tmpWorkspace("helper-architecture-pending-dedupe");
@@ -513,7 +513,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("contract-worktree finish runs architecture freshness before sprint verification", () => {
     const script = readFileSync(join(ROOT, "scripts/contract-worktree.sh"), "utf-8");
@@ -576,7 +576,7 @@ describe("Workflow helper scripts", () => {
       expect(readFileSync(scriptsPath, "utf-8")).toBe(readFileSync(join(HELPER_DIR, helper), "utf-8"));
       expect(statSync(scriptsPath).mode & 0o111).toBe(statSync(join(HELPER_DIR, helper)).mode & 0o111);
     }
-  });
+  }, 30_000);
 
   test("every contract template copy's ## section set is a superset of the standalone template", () => {
     const standalone = readFileSync(join(TEMPLATE_DIR, "contract.template.md"), "utf-8");
@@ -663,7 +663,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(poisonRepo, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("new-plan should create timestamped plan without compatibility pointer", () => {
     const cwd = tmpWorkspace("helper-new-plan");
@@ -696,7 +696,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("capture-plan should save planning output as an active plan artifact", () => {
     const cwd = tmpWorkspace("helper-capture-plan");
@@ -768,7 +768,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("capture-plan should name transient plan artifacts from the task title", () => {
     const cwd = tmpWorkspace("helper-capture-transient-artifact-name");
@@ -815,7 +815,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("capture-plan checklist-row appends to the active plan without durable projection", () => {
     const cwd = tmpWorkspace("helper-capture-plan-checklist-row");
@@ -873,7 +873,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("capture-plan checklist-row rejects active plans without Task Breakdown", () => {
     const cwd = tmpWorkspace("helper-capture-plan-checklist-row-missing-breakdown");
@@ -919,7 +919,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("switch-plan should ignore and not rewrite the retired legacy marker", () => {
     const cwd = tmpWorkspace("helper-switch-plan-active-marker");
@@ -945,7 +945,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("capture-plan should execute an already approved plan through plan-to-todo", () => {
     const cwd = tmpWorkspace("helper-capture-plan-execute");
@@ -995,7 +995,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("capture-plan execute should require a concrete promotion reason", () => {
     const cwd = tmpWorkspace("helper-capture-plan-execute-missing-reason");
@@ -1051,7 +1051,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("capture-plan execute transfers active markers to the linked worktree", () => {
     const cwd = tmpWorkspace("helper-capture-worktree-transfer");
@@ -1123,7 +1123,7 @@ describe("Workflow helper scripts", () => {
       rmSync(worktreePath, { recursive: true, force: true });
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("sync-brain-docs mirrors opted-in repo docs and checks drift", () => {
     const cwd = tmpWorkspace("helper-sync-brain-docs");
@@ -1182,7 +1182,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("sync-brain-docs should reject repo and brain symlink escapes", () => {
     const cwd = tmpWorkspace("helper-sync-brain-docs-symlink");
@@ -1240,7 +1240,7 @@ describe("Workflow helper scripts", () => {
       rmSync(cwd, { recursive: true, force: true });
       rmSync(outside, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("new-sprint should create a Draft sprint backlog only", () => {
     const cwd = tmpWorkspace("helper-new-sprint");
@@ -1280,7 +1280,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("plan-to-todo should archive previous todo and set plan to Executing", () => {
     const cwd = tmpWorkspace("helper-plan-to-todo");
@@ -1352,7 +1352,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("plan-to-todo should carry forward plan Out of scope bullets into the contract", () => {
     const cwd = tmpWorkspace("helper-plan-to-todo-carry-forward");
@@ -1403,7 +1403,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("plan-to-todo should carry forward a Non-scope: labeled plan section too", () => {
     const cwd = tmpWorkspace("helper-plan-to-todo-carry-forward-nonscope");
@@ -1447,7 +1447,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("plan-to-todo should keep the Out of scope placeholder when the plan has no Non-scope section", () => {
     const cwd = tmpWorkspace("helper-plan-to-todo-no-carry-forward");
@@ -1485,7 +1485,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("plan-to-todo should reject transient plan projection", () => {
     const cwd = tmpWorkspace("helper-plan-to-todo-transient-artifact-name");
@@ -1531,7 +1531,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("plan-to-todo should start a linked contract worktree when policy enables contract tasks", () => {
     const cwd = tmpWorkspace("helper-contract-auto");
@@ -1603,7 +1603,7 @@ describe("Workflow helper scripts", () => {
       rmSync(worktreePath, { recursive: true, force: true });
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("ship-worktrees should put dirty main closeout on a PR branch", () => {
     const cwd = tmpWorkspace("helper-ship-main-closeout");
@@ -1961,7 +1961,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("plan-to-todo should reject approved plans without an evidence contract", () => {
     const cwd = tmpWorkspace("helper-plan-evidence-contract");
@@ -1982,7 +1982,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("plan-to-todo should reject approved plans without a promotion gate", () => {
     const cwd = tmpWorkspace("helper-plan-promotion-gate");
@@ -2012,7 +2012,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("plan-to-todo should reject approved plans without work-package artifact metadata", () => {
     const cwd = tmpWorkspace("helper-plan-artifact-level");
@@ -2051,7 +2051,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("plan-to-todo should reject inline sprint-task projections", () => {
     const cwd = tmpWorkspace("helper-plan-inline-sprint-task");
@@ -2088,7 +2088,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("plan-to-todo should reject sprint-inline work-package projections", () => {
     const cwd = tmpWorkspace("helper-plan-sprint-inline-work-package");
@@ -2121,7 +2121,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("plan-to-todo archive should include metadata header and original todo content", () => {
     const cwd = tmpWorkspace("helper-plan-archive-meta");
@@ -2163,7 +2163,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("new-plan should suffix filename with -v2 when same slug/timestamp already exists", () => {
     const cwd = tmpWorkspace("helper-plan-collision");
@@ -2205,7 +2205,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("archive-workflow should archive plan and todo with non-completion outcome metadata", () => {
     const cwd = tmpWorkspace("helper-archive");
@@ -2268,7 +2268,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   // R-E (fix 5): a --timestamp value passed to archive-workflow.sh is used
   // verbatim for every archive-family filename instead of a fresh internal
@@ -2344,7 +2344,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   // R-E hardening (third external review round): --timestamp is interpolated
   // directly into archive filenames, so a malformed value must fail closed
@@ -2377,7 +2377,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("archive-workflow should preserve existing deferred ledger rows", () => {
     const cwd = tmpWorkspace("helper-archive-deferred-ledger");
@@ -2425,7 +2425,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   // Sixth external review round: plan/notes/contract/review archive
   // destinations all go through unique_archive_path (collision -> -v2
@@ -2476,7 +2476,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("refresh-current-status should preview and write an idle tracked snapshot", () => {
     const cwd = tmpWorkspace("helper-current-idle");
@@ -2503,7 +2503,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("refresh-current-status should derive active plan next task", () => {
     const cwd = tmpWorkspace("helper-current-active");
@@ -2536,7 +2536,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("refresh-current-status clear should not write Idle while active work exists", () => {
     const cwd = tmpWorkspace("helper-current-clear-active");
@@ -2559,7 +2559,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("archive-workflow should set plan status to Abandoned for abandoned outcome", () => {
     const cwd = tmpWorkspace("helper-archive-abandoned");
@@ -2588,7 +2588,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("verify-contract should pass strict mode and set status to Fulfilled", () => {
     const cwd = tmpWorkspace("helper-verify-contract-pass");
@@ -2644,7 +2644,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("verify-contract should pass an exact checked manual criterion with concrete review evidence", () => {
     const cwd = tmpWorkspace("helper-verify-contract-manual-evidence-pass");
@@ -2698,7 +2698,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("verify-contract should enforce snake_case QA dimensions against human-readable Scorecard labels", () => {
     const cwd = tmpWorkspace("helper-verify-contract-qa-dimension");
@@ -2778,7 +2778,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   for (const fixture of [
     {
@@ -2859,7 +2859,7 @@ describe("Workflow helper scripts", () => {
       } finally {
         rmSync(cwd, { recursive: true, force: true });
       }
-    });
+    }, 30_000);
   }
 
   test("verify-contract should fail strict mode and set status to Partial", () => {
@@ -2896,7 +2896,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("verify-contract --read-only should not rewrite contract Status on failure", () => {
     const cwd = tmpWorkspace("helper-verify-contract-read-only");
@@ -2935,7 +2935,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("verify-contract --read-only should not rewrite contract Status on pass", () => {
     const cwd = tmpWorkspace("helper-verify-contract-read-only-pass");
@@ -2982,7 +2982,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("verify-contract --read-only still executes command criteria and reports the boundary", () => {
     const cwd = tmpWorkspace("helper-verify-contract-read-only-exec");
@@ -3039,7 +3039,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("verify-contract quiet mode should emit only summary and report file", () => {
     const cwd = tmpWorkspace("helper-verify-contract-quiet");
@@ -3099,7 +3099,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("verify-contract should ignore allowed_paths metadata before exit criteria", () => {
     const cwd = tmpWorkspace("helper-verify-contract-allowed-paths");
@@ -3152,7 +3152,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("verify-contract should ignore delegation metadata before exit criteria", () => {
     const cwd = tmpWorkspace("helper-verify-contract-delegation");
@@ -3219,7 +3219,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("verify-contract should fail unsupported task profile", () => {
     const cwd = tmpWorkspace("helper-verify-contract-profile-invalid");
@@ -3252,7 +3252,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   // Deliberately does not assert on overall exit code / --strict: this contract carries
   // no ## Root Cause Evidence section, and once the bugfix root-cause gate (H2/H3) is
@@ -3288,7 +3288,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   describe("verify-contract bugfix root-cause evidence gate", () => {
     // Shared with tests/contract-run.test.ts's TypeScript-side root-cause gate tests via
@@ -3329,7 +3329,7 @@ describe("Workflow helper scripts", () => {
         } finally {
           rmSync(workDir, { recursive: true, force: true });
         }
-      });
+      }, 30_000);
     }
   });
 
@@ -3374,7 +3374,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("verify-contract should pass frontend profile when files_exist includes a design brief", () => {
     const cwd = tmpWorkspace("helper-verify-contract-profile-frontend-pass");
@@ -3419,7 +3419,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("verify-contract should fail frontend profile when files_exist has no design brief", () => {
     const cwd = tmpWorkspace("helper-verify-contract-profile-frontend-fail");
@@ -3454,7 +3454,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("bundled verify-sprint binds the package-owned evidence emitter without a source-root override", () => {
     const cwd = tmpWorkspace("helper-verify-sprint-pass");
@@ -3545,7 +3545,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("verify-sprint finalizes one AcceptanceReceipt without rerunning contract tests", () => {
     const cwd = tmpWorkspace("helper-verify-sprint-finalize");
@@ -3612,7 +3612,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("verify-sprint prints a notes promotion-candidate advisory without changing exit code", () => {
     const baseline = tmpWorkspace("helper-verify-sprint-notes-baseline");
@@ -3720,7 +3720,7 @@ describe("Workflow helper scripts", () => {
       rmSync(baseline, { recursive: true, force: true });
       rmSync(withCandidate, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("verify-sprint should fail when committed branch diff exceeds allowed_paths", () => {
     const cwd = tmpWorkspace("helper-verify-sprint-branch-scope");
@@ -3798,7 +3798,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("verify-sprint should scope the default branch diff from immutable contract-worktree metadata", () => {
     const cwd = tmpWorkspace("helper-verify-sprint-task-baseline");
@@ -3969,7 +3969,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("verify-sprint ignores Human Review Card semantics because Markdown is projection only", () => {
     const cwd = tmpWorkspace("helper-verify-sprint-card-profile");
@@ -4032,7 +4032,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("harness-trace-grade should pass all local trace fixtures", () => {
     const fixturesDir = join(ROOT, "tests/fixtures/harness-traces");
@@ -4051,7 +4051,7 @@ describe("Workflow helper scripts", () => {
       expect(report.failed).toBe(0);
       expect(report.total).toBeGreaterThanOrEqual(6);
     }
-  });
+  }, 30_000);
 
   test("harness-trace-grade should reject an unsupported task_profile", () => {
     const cwd = tmpWorkspace("helper-harness-trace-grade-invalid-profile");
@@ -4081,7 +4081,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("verify-sprint does not require a Human Review Card authoring path", () => {
     const cwd = tmpWorkspace("helper-verify-sprint-missing-card");
@@ -4143,7 +4143,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("verify-sprint should write failing structured checks before exiting", () => {
     const cwd = tmpWorkspace("helper-verify-sprint-fail");
@@ -4204,7 +4204,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("prepare-handoff should write harness handoff using workflow-state helpers", () => {
     const cwd = tmpWorkspace("helper-prepare-handoff");
@@ -4286,7 +4286,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("prepare-handoff should include untracked files in changed-file context", () => {
     const cwd = tmpWorkspace("helper-prepare-handoff-untracked");
@@ -4317,7 +4317,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("codex-handoff-resume should write resume packet and print bootstrap prompt", () => {
     const cwd = tmpWorkspace("helper-codex-resume");
@@ -4357,7 +4357,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("codex-handoff-resume should not restore historical plans without an active marker", () => {
     const cwd = tmpWorkspace("helper-codex-resume-no-active-plan");
@@ -4389,7 +4389,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("codex-handoff-resume should reject policy paths outside the repo", () => {
     const cwd = tmpWorkspace("helper-codex-resume-safe-path");
@@ -4412,7 +4412,7 @@ describe("Workflow helper scripts", () => {
       rmSync(outsidePath, { force: true });
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("codex-handoff-resume should reject policy paths outside the harness surface", () => {
     const cwd = tmpWorkspace("helper-codex-resume-harness-surface");
@@ -4433,7 +4433,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("prepare-codex-handoff should refresh repo/global handoff and resume packet", () => {
     const cwd = tmpWorkspace("helper-codex-handoff");
@@ -4477,7 +4477,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("ensure-task-workflow should create a draft plan when none exists", () => {
     const cwd = tmpWorkspace("helper-ensure-workflow");
@@ -4511,7 +4511,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("ensure-task-workflow should create a new draft plan when requested despite an existing plan", () => {
     const cwd = tmpWorkspace("helper-ensure-workflow-new-plan");
@@ -4539,7 +4539,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("check-deploy-sql-order should enforce deploy SQL location and ascending prefixes", () => {
     const cwd = tmpWorkspace("helper-check-deploy-sql");
@@ -4642,7 +4642,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("check-deploy-sql-order should accept an explicit multi-root SQL policy", () => {
     const cwd = tmpWorkspace("helper-check-deploy-sql-policy");
@@ -4691,7 +4691,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("check-deploy-sql-order should reject invalid, overlapping, or unknown SQL policy roots", () => {
     const cwd = tmpWorkspace("helper-check-deploy-sql-policy-invalid");
@@ -4795,7 +4795,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("check-deploy-sql-order should reject forged or missing explicit invariant policy", () => {
     const cwd = tmpWorkspace("helper-check-deploy-sql-invariant-policy");
@@ -4841,7 +4841,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("check-deploy-sql-order should require unambiguous full-path invariant references for configured roots", () => {
     const cwd = tmpWorkspace("helper-check-deploy-sql-invariant-collision");
@@ -4887,7 +4887,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("check-deploy-sql-order should reject regular and escaping SQL symlinks", () => {
     const cwd = tmpWorkspace("helper-check-deploy-sql-symlinks");
@@ -4938,7 +4938,7 @@ describe("Workflow helper scripts", () => {
       rmSync(cwd, { recursive: true, force: true });
       rmSync(outsideDir, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("check-deploy-sql-order should fail closed when SQL enumeration fails", () => {
     const cwd = tmpWorkspace("helper-check-deploy-sql-enumeration-failure");
@@ -4961,7 +4961,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("check-context-files should ignore external reference and local runtime dirs", () => {
     const cwd = tmpWorkspace("helper-check-context-files-ref");
@@ -4987,7 +4987,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("select-agent-context-blocks should ignore external reference and local runtime dirs", () => {
     const cwd = tmpWorkspace("helper-select-context-files-ref");
@@ -5009,7 +5009,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("check-task-workflow should fail strict mode for legacy todo content", () => {
     const cwd = tmpWorkspace("helper-check-workflow");
@@ -5038,7 +5038,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("check-task-workflow should fail strict mode for legacy task artifact terminology in generation surfaces", () => {
     const cwd = tmpWorkspace("helper-check-workflow-legacy-terminology");
@@ -5075,7 +5075,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("check-task-workflow should fail strict mode when plan template lacks a promotion gate", () => {
     const cwd = tmpWorkspace("helper-check-workflow-promotion-template");
@@ -5111,7 +5111,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("check-task-workflow should fail strict mode for legacy sprint directory", () => {
     const cwd = tmpWorkspace("helper-check-workflow-legacy-sprint-dir");
@@ -5132,7 +5132,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("check-task-workflow should fail strict mode when no-active handoff has a historical resume plan", () => {
     const cwd = tmpWorkspace("helper-check-workflow-handoff-resume");
@@ -5158,7 +5158,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("check-task-workflow should fail strict mode when current snapshot is newer than resume packet", () => {
     const cwd = tmpWorkspace("helper-check-workflow-current-newer-than-resume");
@@ -5184,7 +5184,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("check-task-workflow should not treat Todo Source Plan none as no active plan", () => {
     const cwd = tmpWorkspace("helper-check-workflow-todo-source-plan");
@@ -5212,7 +5212,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("check-task-workflow should fail strict mode when active plan is terminal", () => {
     const cwd = tmpWorkspace("helper-check-workflow-terminal-active");
@@ -5241,7 +5241,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("check-task-workflow projects terminal statuses from the policy lifecycle anchor", () => {
     const cwd = tmpWorkspace("helper-check-workflow-terminal-policy");
@@ -5275,7 +5275,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("check-task-workflow should fail strict mode when ignored runtime cache remains tracked", () => {
     const cwd = tmpWorkspace("helper-check-workflow-tracked-runtime-cache");
@@ -5332,7 +5332,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("check-task-workflow should materialize ignored runtime delegation dir", () => {
     const cwd = tmpWorkspace("helper-check-workflow-delegation-dir");
@@ -5361,7 +5361,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("check-task-workflow should accept packaged helpers without root helper scripts", () => {
     const cwd = tmpWorkspace("helper-check-workflow-package-helpers");
@@ -5446,7 +5446,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("summarize-failures should aggregate failure_class and guard counts", () => {
     const cwd = tmpWorkspace("helper-summarize-failures");
@@ -5471,7 +5471,7 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("summarize-failures should fall back to node when bun is unavailable", () => {
     const cwd = tmpWorkspace("helper-summarize-failures-node");
@@ -5504,5 +5504,5 @@ describe("Workflow helper scripts", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 });

--- a/tests/hook-dispatch-diet-report.test.ts
+++ b/tests/hook-dispatch-diet-report.test.ts
@@ -119,7 +119,7 @@ describe("hook dispatch diet report", () => {
     expect(report.runtime_evidence.authority).toBe("hook-events.jsonl");
     expect(hookDietReportPasses(report)).toBe(true);
     expect(report.guard_regression.required_command).toBe("bun test tests/hook-runtime.test.ts");
-  });
+  }, 30_000);
 
   test("aggregates valid event records by route and evaluates LOOP-12 targets", () => {
     const dir = mkdtempSync(join(tmpdir(), "hook-diet-events-"));
@@ -141,7 +141,7 @@ describe("hook dispatch diet report", () => {
       expect(renderHookDietMarkdown(report)).toContain("## LOOP-12 targets");
       expect(renderHookDietMarkdown(report)).toContain("post_edit_event_writes");
     } finally { rmSync(dir, { recursive: true, force: true }); }
-  });
+  }, 30_000);
 
   test("fails closed on malformed, mixed, and incomplete required evidence", () => {
     const dir = mkdtempSync(join(tmpdir(), "hook-diet-invalid-"));
@@ -156,7 +156,7 @@ describe("hook dispatch diet report", () => {
       expect(reportFor(incomplete).runtime_evidence.available).toBe(false);
       expect(reportFor(incomplete).runtime_evidence.targets.state_resolutions.coverage).toBe(0.5);
     } finally { rmSync(dir, { recursive: true, force: true }); }
-  });
+  }, 30_000);
 
   test("calculates nearest-rank latency percentiles and retains max as observation", () => {
     const durations = [1, 2, 3, 4, 100];
@@ -166,7 +166,7 @@ describe("hook dispatch diet report", () => {
       runProbe: (spec) => spec.name === "session-start-context" ? { exitCode: 0, durationMs: 1, stdout: "" } : { exitCode: 0, durationMs: durations[phaseIndex++ % durations.length] },
     });
     expect(report.phase_probe.probes[0]).toMatchObject({ sample_count: 5, total_ms: 110, avg_ms: 22, p50_ms: 3, p95_ms: 100, p99_ms: 100, max_ms: 100 });
-  });
+  }, 30_000);
 
   test("gates phase latency on p95 while retaining max as observation", () => {
     const durations = [...Array(19).fill(10), 1000];
@@ -177,14 +177,14 @@ describe("hook dispatch diet report", () => {
     });
     expect(report.phase_probe.probes[0]).toMatchObject({ p95_ms: 10, max_ms: 1000, within_baseline: true });
     expect(report.slo.within_slo).toBe(true);
-  });
+  }, 30_000);
 
   test("keeps SessionStart context estimate unavailable when structured context is missing", () => {
     const report = buildHookDietReport({ repo: ROOT, iterations: 1, baselineMs: 250, runProbe: (spec) => ({ exitCode: 0, durationMs: 1, stdout: spec.name === "session-start-context" ? "not structured JSON" : "" }) });
     expect(report.session_start_context.context_bytes).toBeNull();
     expect(report.session_start_context.token_estimate.estimated_tokens).toBeNull();
     expect(report.slo.within_slo).toBe(false);
-  });
+  }, 30_000);
 
   test("CLI writes JSON and Markdown reports", () => {
     const cwd = mkdtempSync(join(tmpdir(), "hook-dispatch-diet-"));
@@ -213,11 +213,11 @@ describe("hook dispatch diet report", () => {
     const run = spawnSync(process.execPath, [SCRIPT, "--bad-flag"], { encoding: "utf-8" });
     expect(run.status).toBe(2);
     expect(run.stderr).toContain("unknown argument");
-  });
+  }, 30_000);
 
   test("missing --events value exits with usage error", () => {
     const run = spawnSync(process.execPath, [SCRIPT, "--events"], { encoding: "utf-8" });
     expect(run.status).toBe(2);
     expect(run.stderr).toContain("missing required option value");
-  });
+  }, 30_000);
 });

--- a/tests/hook-protocol.test.ts
+++ b/tests/hook-protocol.test.ts
@@ -101,7 +101,7 @@ describe("Claude Code hook protocol compliance", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("pre-edit-guard: ExternalReferenceGuard uses exit 2 with reason on stderr", () => {
     const cwd = tmpWorkspace("hook-proto-ref");
@@ -115,7 +115,7 @@ describe("Claude Code hook protocol compliance", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("pre-edit-guard: OpsPrivateGuard uses exit 2 with reason on stderr", () => {
     const cwd = tmpWorkspace("hook-proto-ops");
@@ -129,7 +129,7 @@ describe("Claude Code hook protocol compliance", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("pre-edit-guard: ContractScopeGuard uses exit 2 with reason on stderr", () => {
     // This is the exact regression that surfaced as
@@ -169,7 +169,7 @@ describe("Claude Code hook protocol compliance", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("pre-edit-guard: PlanTransitionGuard uses exit 2 with reason on stderr", () => {
     const cwd = tmpWorkspace("hook-proto-plan-transition");
@@ -193,7 +193,7 @@ describe("Claude Code hook protocol compliance", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("pre-edit profile resolution fails closed with exit 2 and remediation", () => {
     const cwd = tmpWorkspace("hook-proto-plan-status");
@@ -237,7 +237,7 @@ describe("Claude Code hook protocol compliance", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("prompt-guard: ContractGuard uses exit 2 with reason on stderr", () => {
     const cwd = tmpWorkspace("hook-proto-contract-missing");
@@ -270,7 +270,7 @@ describe("Claude Code hook protocol compliance", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("hook_get_file_path: normalizes absolute paths inside the repo to repo-relative paths", () => {
     // Background: Edit/Write/post-edit hooks receive `tool_input.file_path` as an
@@ -292,7 +292,7 @@ describe("Claude Code hook protocol compliance", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("pre-edit-guard: ignores paths outside the repo contract boundary", () => {
     // Case 2: an absolute path outside the repo (e.g. a global plan file under
@@ -336,7 +336,7 @@ describe("Claude Code hook protocol compliance", () => {
       rmSync(cwd, { recursive: true, force: true });
       rmSync(outsideRoot, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("ContractScopeGuard: absolute paths under allowed_paths directories are NOT blocked", () => {
     // The bug we are fixing: an absolute path like
@@ -383,7 +383,7 @@ describe("Claude Code hook protocol compliance", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("hook_structured_error: writes the diagnostic to stderr while keeping stdout telemetry JSON", () => {
     // Spec: the structured error MUST be readable by both the human (stderr → Claude / user)
@@ -404,5 +404,5 @@ describe("Claude Code hook protocol compliance", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 });

--- a/tests/hook-runtime.test.ts
+++ b/tests/hook-runtime.test.ts
@@ -40,7 +40,7 @@ describe('hook runtime typed dispatch', () => {
       expect(record.measurement).toMatchObject({ opaque_steps: [] });
       expect((record.measurement as { incomplete_metrics: string[] }).incomplete_metrics).toContain('files_read');
     } finally { rmSync(root, { recursive: true, force: true }); }
-  });
+  }, 30_000);
 
   test('host output policy is centralized and does not leak successful Codex stdout', () => {
     const root = fixture();
@@ -54,7 +54,7 @@ describe('hook runtime typed dispatch', () => {
       });
       expect(result.handler).toBe('subagent');
     } finally { rmSync(root, { recursive: true, force: true }); }
-  });
+  }, 30_000);
 
   test('typed handlers do not consult a route filesystem or spawn a route child', () => {
     const root = fixture();
@@ -73,5 +73,5 @@ describe('hook runtime typed dispatch', () => {
       expect(record.steps.every((step) => step.execution === 'in_process')).toBe(true);
       expect(existsSync(join(root, '.ai/hooks'))).toBe(false);
     } finally { rmSync(root, { recursive: true, force: true }); }
-  });
+  }, 30_000);
 });

--- a/tests/hook-source-projection.test.ts
+++ b/tests/hook-source-projection.test.ts
@@ -88,7 +88,7 @@ describe("hook source projection", () => {
     expect(res.status).toBe(0);
     expect(res.stdout).toContain("projection OK");
     expect(res.stderr).toBe("");
-  });
+  }, 30_000);
 
   test("manifest classifies package-only files and no repo-only drift", () => {
     const manifest = readManifest();
@@ -180,7 +180,7 @@ describe("hook source projection", () => {
       ]),
     );
     expect(after).toEqual(before);
-  });
+  }, 30_000);
 
   test("projection reads reject symlinked roots and ancestor directories", () => {
     const tmp = mkdtempSync(join(tmpdir(), "source-projection-read-"));

--- a/tests/install-agent-fleet.test.ts
+++ b/tests/install-agent-fleet.test.ts
@@ -145,7 +145,7 @@ describe("install-agent-fleet", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("idempotent re-run reports up-to-date for all 12 files", () => {
     const { root, home } = setupFakeHome("install-agent-fleet-idempotent");
@@ -160,7 +160,7 @@ describe("install-agent-fleet", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("local modification to an installed target is preserved and reported as drift", () => {
     const { root, home } = setupFakeHome("install-agent-fleet-drift");
@@ -214,7 +214,7 @@ describe("install-agent-fleet", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("an explicitly accepted user-managed fleet remains idempotent until an accepted file changes", () => {
     const { root, home } = setupFakeHome("install-agent-fleet-user-managed");
@@ -270,7 +270,7 @@ describe("install-agent-fleet", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("--accept-user-managed rejects malformed or role-mismatched files without writing a receipt", () => {
     const { root, home } = setupFakeHome("install-agent-fleet-user-managed-invalid");
@@ -289,7 +289,7 @@ describe("install-agent-fleet", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("--force overwrites a drifted target back to generated content", () => {
     const { root, home } = setupFakeHome("install-agent-fleet-force");
@@ -305,7 +305,7 @@ describe("install-agent-fleet", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("invalid frontmatter fails the whole source preflight before any target mutation", () => {
     const { root, home } = setupFakeHome("install-agent-fleet-invalid");
@@ -328,7 +328,7 @@ describe("install-agent-fleet", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("a missing or unparseable source role identity fails the installer", () => {
     const { root, home } = setupFakeHome("install-agent-fleet-missing-role-identity");
@@ -362,7 +362,7 @@ describe("install-agent-fleet", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("a frontmatter name that does not match its source role fails closed", () => {
     const { root, home } = setupFakeHome("install-agent-fleet-role-name-mismatch");
@@ -396,7 +396,7 @@ describe("install-agent-fleet", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("a corrected source refuses stale installed targets with mismatched role identities", () => {
     const { root, home } = setupFakeHome("install-agent-fleet-stale-role-identity");
@@ -429,7 +429,7 @@ describe("install-agent-fleet", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("an invalid source leaves a stale installed target untouched", () => {
     const { root, home } = setupFakeHome("install-agent-fleet-stale-role-invalid-source");
@@ -458,7 +458,7 @@ describe("install-agent-fleet", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("a provider-specific description that disagrees with the model mapping fails closed", () => {
     const { root, home } = setupFakeHome("install-agent-fleet-description-mismatch");
@@ -482,7 +482,7 @@ describe("install-agent-fleet", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("a missing packaged source fails the whole preflight before any target mutation", () => {
     const { root, home } = setupFakeHome("install-agent-fleet-partial-source");
@@ -503,7 +503,7 @@ describe("install-agent-fleet", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("a decoy REPO_HARNESS_HELPER_SOURCE_PATH pointing at a different real helper still fails closed on a bad packaged fixture", () => {
     const { root, home } = setupFakeHome("install-agent-fleet-decoy-helper-source-path");
@@ -534,7 +534,7 @@ describe("install-agent-fleet", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("total failure (no source, no pre-existing targets) exits non-zero", () => {
     const { root, home } = setupFakeHome("install-agent-fleet-total-failure");
@@ -549,7 +549,7 @@ describe("install-agent-fleet", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("missing packaged source leaves existing targets untouched across retries", () => {
     const { root, home } = setupFakeHome("install-agent-fleet-persistent-remediation-failure");
@@ -578,7 +578,7 @@ describe("install-agent-fleet", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("--help exits zero and does not create any HOME state", () => {
     const { root, home } = setupFakeHome("install-agent-fleet-help");
@@ -591,7 +591,7 @@ describe("install-agent-fleet", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("the installer declares Bun as its only semantic parser runtime", () => {
     const source = readFileSync(SCRIPT, "utf-8");
@@ -604,7 +604,7 @@ describe("install-agent-fleet", () => {
     expect(source).not.toContain('spawnSync("curl"');
     expect(source).toContain('const WRITABLE_AGENTS = new Set(["fast-worker", "deep-worker", "root-cause-prover", "harness-evaluator"]);');
     expect(source).toContain("if (WRITABLE_AGENTS.has(agent))");
-  });
+  }, 30_000);
 
   test("an unsupported Bun version fails before creating HOME state", () => {
     const { root, home } = setupFakeHome("install-agent-fleet-old-bun");
@@ -633,7 +633,7 @@ describe("install-agent-fleet", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("a supported HOME Bun wins when PATH resolves an unsupported Bun", () => {
     const { root, home } = setupFakeHome("install-agent-fleet-home-bun-fallback");
@@ -675,7 +675,7 @@ describe("install-agent-fleet", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("generated developer_instructions embeds the canonical EXECUTION_BOUNDARY text verbatim", () => {
     const { root, home } = setupFakeHome("install-agent-fleet-boundary");
@@ -698,5 +698,5 @@ describe("install-agent-fleet", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 });

--- a/tests/install-profiles.test.ts
+++ b/tests/install-profiles.test.ts
@@ -136,7 +136,7 @@ describe('install profiles', () => {
     });
     expect(result.status).toBe(0);
     expect(JSON.parse(result.stdout).requested_profile).toBe('full');
-  }));
+  }), 30_000);
 
   test('explicit legacy migration dry-run targets full by default without mutating state', () => withHome((env) => {
     const statePath = join(env.HOME!, '.repo-harness', 'install-state.json');
@@ -167,7 +167,7 @@ describe('install profiles', () => {
       requested_profile: 'full',
     });
     expect(JSON.parse(readFileSync(statePath, 'utf-8'))).toEqual(legacy);
-  }));
+  }), 30_000);
 
   test('explicit migration replaces protocol 1 atomically and carries forward current owned surfaces without legacy rollback history', () => withHome((env) => {
     writeManagedHostSurfaces(env, 'full');
@@ -328,7 +328,7 @@ describe('install profiles', () => {
     expect(readFileSync(stagingSkillPath)).toEqual(before.stagingSkill);
     expect(readFileSync(stagingMarkerPath)).toEqual(before.stagingMarker);
     expect(readFileSync(lockPath)).toEqual(before.lock);
-  }));
+  }), 30_000);
 
   test('dry-run plan is explicit and has no side effects', () => withHome((env) => {
     const plan = planInstallProfile('minimal', null, env);
@@ -577,7 +577,7 @@ describe('install profiles', () => {
     expect(existsSync(join(env.HOME!, '.codex', 'skills', 'repo-harness'))).toBe(false);
     expect(existsSync(join(env.HOME!, '.agents', '.skill-lock.json'))).toBe(false);
     expect(readInstalledProfile(env)).toBeNull();
-  }));
+  }), 30_000);
 
   test('committing a host transaction only discards its backups', () => withHome((env) => {
     const path = join(env.HOME!, 'surface');
@@ -782,5 +782,5 @@ describe('install profiles', () => {
     });
     expect(state.status).toBe(0);
     expect(JSON.parse(state.stdout).profile).toBe('minimal');
-  }));
+  }), 30_000);
 });

--- a/tests/install-scripts.test.ts
+++ b/tests/install-scripts.test.ts
@@ -27,7 +27,7 @@ describe("install script contracts", () => {
     expect(script).not.toMatch(/\bnpm\b/);
     expect(script).not.toMatch(/\bnpx\b/);
     expect(script).not.toMatch(/\bnode\b/);
-  });
+  }, 30_000);
 
   test("Windows installer is Bun-owned and version-pinnable", () => {
     const script = read("install.ps1");

--- a/tests/installed-copy-sync.test.ts
+++ b/tests/installed-copy-sync.test.ts
@@ -102,7 +102,7 @@ describe("Codex installed copy sync", () => {
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("can maintain local skill roots as source-backed aliases", () => {
     const tmp = join(tmpdir(), `repo-harness-installed-link-${Date.now()}`);
@@ -147,7 +147,7 @@ describe("Codex installed copy sync", () => {
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("full sync leaves separately managed provider skills untouched", () => {
     const tmp = join(tmpdir(), `repo-harness-installed-provider-skill-${Date.now()}`);
@@ -191,7 +191,7 @@ describe("Codex installed copy sync", () => {
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("minimal removes an exact package-owned full-only facade", () => {
     const tmp = join(tmpdir(), `repo-harness-installed-minimal-${Date.now()}`);
@@ -225,7 +225,7 @@ describe("Codex installed copy sync", () => {
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("unknown facade fails closed before changing any managed surface", () => {
     const tmp = join(tmpdir(), `repo-harness-installed-unknown-${Date.now()}`);
@@ -265,7 +265,7 @@ describe("Codex installed copy sync", () => {
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("modified owner-marked canonical copy fails closed and is preserved", () => {
     const tmp = join(tmpdir(), `repo-harness-installed-drift-${Date.now()}`);
@@ -302,7 +302,7 @@ describe("Codex installed copy sync", () => {
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("wires plan/check into both profiles and product/ship into full only", () => {
     const tmp = join(tmpdir(), `repo-harness-installed-product-ship-profile-${Date.now()}`);
@@ -344,7 +344,7 @@ describe("Codex installed copy sync", () => {
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("retires an owner-marked facade once its canonical source and profile selection are both gone", () => {
     const tmp = join(tmpdir(), `repo-harness-installed-retire-${Date.now()}`);
@@ -396,7 +396,7 @@ describe("Codex installed copy sync", () => {
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("preserves and reports a modified facade even after its canonical source is removed", () => {
     const tmp = join(tmpdir(), `repo-harness-installed-retire-drift-${Date.now()}`);
@@ -444,7 +444,7 @@ describe("Codex installed copy sync", () => {
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("unknown canonical directory fails closed without rm -rf", () => {
     const tmp = join(tmpdir(), `repo-harness-installed-canonical-${Date.now()}`);
@@ -477,7 +477,7 @@ describe("Codex installed copy sync", () => {
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("copy mode reports explicit unsupported mode when rsync is missing", () => {
     const tmp = join(tmpdir(), `repo-harness-installed-no-rsync-${Date.now()}`);
@@ -512,7 +512,7 @@ describe("Codex installed copy sync", () => {
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("link mode does not require rsync when symlinks are supported", () => {
     const tmp = join(tmpdir(), `repo-harness-installed-link-no-rsync-${Date.now()}`);
@@ -548,7 +548,7 @@ describe("Codex installed copy sync", () => {
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("link mode reports explicit unsupported mode when symlink creation fails", () => {
     const tmp = join(tmpdir(), `repo-harness-installed-no-symlink-${Date.now()}`);
@@ -584,5 +584,5 @@ describe("Codex installed copy sync", () => {
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 });

--- a/tests/loop-engine-cutover-gate.test.ts
+++ b/tests/loop-engine-cutover-gate.test.ts
@@ -146,7 +146,7 @@ describe("loop-engine cutover gate", () => {
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("unknown flags exit with usage error", () => {
     const run = spawnSync(process.execPath, [SCRIPT, "--definitely-unknown"], {
@@ -154,5 +154,5 @@ describe("loop-engine cutover gate", () => {
     });
     expect(run.status).toBe(2);
     expect(run.stderr).toContain("unknown argument");
-  });
+  }, 30_000);
 });

--- a/tests/loop-event-protocol.test.ts
+++ b/tests/loop-event-protocol.test.ts
@@ -81,5 +81,5 @@ describe('loop-event-protocol route mapping', () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 });

--- a/tests/mcp-observability-report.test.ts
+++ b/tests/mcp-observability-report.test.ts
@@ -180,5 +180,5 @@ describe("MCP observability report", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 });

--- a/tests/merge-gate.test.ts
+++ b/tests/merge-gate.test.ts
@@ -125,7 +125,7 @@ describe('provider-free merge seal', () => {
     expect(verified.status, verified.stderr).toBe(0);
     expect(verified.stdout.trim()).toBe(git(fixture.cwd, 'rev-parse', 'HEAD'));
     expect(readFileSync(fixture.providerCalls, 'utf-8').trim()).toBe('1');
-  });
+  }, 30_000);
 
   test('review-only head movement needs only reseal; semantic movement invalidates acceptance', async () => {
     const fixture = await makeFixture();
@@ -143,7 +143,7 @@ describe('provider-free merge seal', () => {
     expect(invalid.status).not.toBe(0);
     expect(invalid.stderr).toContain('semantic subject is stale');
     expect(readFileSync(fixture.providerCalls, 'utf-8').trim()).toBe('1');
-  });
+  }, 30_000);
 
   test('non-overlapping target movement reuses acceptance and recomputes only the local seal', async () => {
     const fixture = await makeFixture();
@@ -154,7 +154,7 @@ describe('provider-free merge seal', () => {
     const resealed = run('bun', [fixture.harness, 'run', '--base', 'main', '--format', 'sha'], fixture.cwd);
     expect(resealed.status, resealed.stderr).toBe(0);
     expect(readFileSync(fixture.providerCalls, 'utf-8').trim()).toBe('1');
-  });
+  }, 30_000);
 
   test('post-freeze lifecycle commit verifies against the sealed head without another provider call', async () => {
     const fixture = await makeFixture();
@@ -175,5 +175,5 @@ describe('provider-free merge seal', () => {
     expect(verified.status, verified.stderr).toBe(0);
     expect(verified.stdout.trim()).toBe(git(fixture.cwd, 'rev-parse', 'HEAD'));
     expect(readFileSync(fixture.providerCalls, 'utf-8').trim()).toBe('1');
-  });
+  }, 30_000);
 });

--- a/tests/minimal-change-signals.test.ts
+++ b/tests/minimal-change-signals.test.ts
@@ -56,7 +56,7 @@ describe('minimal-change objective signals', () => {
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('does not treat a dev-to-prod dependency move as a new dependency', () => {
     const repo = tmpRepo('minimal-change-dependency-move');
@@ -73,7 +73,7 @@ describe('minimal-change objective signals', () => {
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('marks test and security validation changes as protected instead of shrink findings', () => {
     const repo = tmpRepo('minimal-change-protected');
@@ -96,7 +96,7 @@ describe('minimal-change objective signals', () => {
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('reports low-confidence abstraction candidates deterministically', () => {
     const repo = tmpRepo('minimal-change-abstraction');
@@ -122,7 +122,7 @@ describe('minimal-change objective signals', () => {
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('hook-only CLI stays stdout-silent, respects off mode, and dedupes identical events', () => {
     const repo = tmpRepo('minimal-change-cli-signals');
@@ -160,5 +160,5 @@ describe('minimal-change objective signals', () => {
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 });

--- a/tests/mutation-guard.test.ts
+++ b/tests/mutation-guard.test.ts
@@ -118,7 +118,7 @@ describe('HRD-03 falsifier: worktree refusal + SpecGuard reproduced in-process w
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('worktree block: enforcement marker present -> exit 2, structured error, failure log + circuit breaker written', () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'mutation-guard-worktree-block-')));
@@ -144,7 +144,7 @@ describe('HRD-03 falsifier: worktree refusal + SpecGuard reproduced in-process w
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('linked worktree: git-dir under .git/worktrees/ -> silent, no warning at all', () => {
     const root = realpathSync(mkdtempSync(join(tmpdir(), 'mutation-guard-linked-')));
@@ -160,7 +160,7 @@ describe('HRD-03 falsifier: worktree refusal + SpecGuard reproduced in-process w
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('SpecGuard: implementation edit without docs/spec.md -> exit 2, blocks before plan lookup', () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'mutation-guard-specguard-')));
@@ -177,7 +177,7 @@ describe('HRD-03 falsifier: worktree refusal + SpecGuard reproduced in-process w
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('SpecGuard advisory mode: reports without blocking', () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'mutation-guard-specguard-advice-')));
@@ -194,7 +194,7 @@ describe('HRD-03 falsifier: worktree refusal + SpecGuard reproduced in-process w
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('lite profile skips SpecGuard entirely (workflow surface exemption reached before it)', () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'mutation-guard-specguard-lite-')));
@@ -207,7 +207,7 @@ describe('HRD-03 falsifier: worktree refusal + SpecGuard reproduced in-process w
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 });
 
 describe('HRD-03 event-level cost proof: at most one Effective State resolution per event', () => {
@@ -239,7 +239,7 @@ describe('HRD-03 event-level cost proof: at most one Effective State resolution 
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('an apply_patch batch touching many files still resolves Effective State exactly once (collapses the old N-recursion N-resolution cost)', () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'mutation-guard-cost-batch-')));
@@ -280,7 +280,7 @@ describe('HRD-03 event-level cost proof: at most one Effective State resolution 
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 });
 
 describe('HRD-03 guard-by-guard parity: previously-uncovered decision branches', () => {
@@ -389,7 +389,7 @@ describe('HRD-03 guard-by-guard parity: previously-uncovered decision branches',
       rmSync(cwd, { recursive: true, force: true });
       rmSync(escapedRoot, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('ContractScopeGuard: an edit outside the active contract allowed_paths blocks', () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'mutation-guard-scope-')));
@@ -424,7 +424,7 @@ describe('HRD-03 guard-by-guard parity: previously-uncovered decision branches',
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('strict profile without a contract blocks with StrictContractGuard, not StrictWorktreeGuard', () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'mutation-guard-strict-contract-')));
@@ -442,7 +442,7 @@ describe('HRD-03 guard-by-guard parity: previously-uncovered decision branches',
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('gate mode off: no SpecGuard, no PlanStatusGuard, edit passes silently through the plan gate', () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'mutation-guard-gate-off-')));
@@ -456,7 +456,7 @@ describe('HRD-03 guard-by-guard parity: previously-uncovered decision branches',
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('apply_patch: paths are processed in patch order, stopping at the first blocking path', () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'mutation-guard-apply-patch-order-')));
@@ -482,7 +482,7 @@ describe('HRD-03 guard-by-guard parity: previously-uncovered decision branches',
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('apply_patch with an unparseable command blocks with ApplyPatchScopeGuard', () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'mutation-guard-apply-patch-unparseable-')));
@@ -495,7 +495,7 @@ describe('HRD-03 guard-by-guard parity: previously-uncovered decision branches',
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 });
 
 describe('MainLoopDispatchGuard: opt-in orchestrator/subagent edit split', () => {
@@ -519,7 +519,7 @@ describe('MainLoopDispatchGuard: opt-in orchestrator/subagent edit split', () =>
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('armed, agent_id present -> subagent edit passes this guard', () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'mutation-guard-main-loop-subagent-')));
@@ -535,7 +535,7 @@ describe('MainLoopDispatchGuard: opt-in orchestrator/subagent edit split', () =>
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('env unset -> guard is inert, existing behavior unchanged', () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'mutation-guard-main-loop-unset-')));
@@ -548,7 +548,7 @@ describe('MainLoopDispatchGuard: opt-in orchestrator/subagent edit split', () =>
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('armed, markdown path -> not blocked (plans and docs stay a main-loop surface)', () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'mutation-guard-main-loop-md-')));
@@ -564,7 +564,7 @@ describe('MainLoopDispatchGuard: opt-in orchestrator/subagent edit split', () =>
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('armed but HOOK_HOST=codex -> guard is inert', () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'mutation-guard-main-loop-codex-')));
@@ -580,7 +580,7 @@ describe('MainLoopDispatchGuard: opt-in orchestrator/subagent edit split', () =>
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('armed, apply_patch expanding to a code file, no agent_id -> blocked on that path', () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'mutation-guard-main-loop-apply-patch-')));
@@ -604,7 +604,7 @@ describe('MainLoopDispatchGuard: opt-in orchestrator/subagent edit split', () =>
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 });
 
 describe('gate round-1 parity closure: restored input-normalization fallbacks', () => {
@@ -628,7 +628,7 @@ describe('gate round-1 parity closure: restored input-normalization fallbacks', 
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('symlink-canonicalization: an absolute file_path reached through a symlinked repo ancestor still normalizes to repo-relative', () => {
     // Mirrors the macOS /var -> /private/var shape the bash port's comment
@@ -652,5 +652,5 @@ describe('gate round-1 parity closure: restored input-normalization fallbacks', 
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 });

--- a/tests/mutation-observed.test.ts
+++ b/tests/mutation-observed.test.ts
@@ -107,7 +107,7 @@ describe('mutation-observed: non-qualifying edits', () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 });
 
 describe('mutation-observed: journal schema', () => {
@@ -137,7 +137,7 @@ describe('mutation-observed: journal schema', () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 });
 
 describe('mutation-observed: dirty-bit derivation', () => {
@@ -153,7 +153,7 @@ describe('mutation-observed: dirty-bit derivation', () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('contract-verification is true only when the active contract\'s exit_criteria references the edited path', () => {
     const cwd = tmpWorkspace('mo-contract-bit');
@@ -186,7 +186,7 @@ describe('mutation-observed: dirty-bit derivation', () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('contract-verification is false with no active plan', () => {
     const cwd = tmpWorkspace('mo-contract-bit-no-plan');
@@ -198,7 +198,7 @@ describe('mutation-observed: dirty-bit derivation', () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('minimal-change reflects policy.minimal_change.mode/post_edit_observer', () => {
     const cwd = tmpWorkspace('mo-minimal-change-bit');
@@ -228,7 +228,7 @@ describe('mutation-observed: dirty-bit derivation', () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('checkpoint is true for tasks/todos.md, plans/*.md, tasks/reviews/*.review.md, and .ai/harness/checks/latest.json, false otherwise', () => {
     const cwd = tmpWorkspace('mo-checkpoint-bit');
@@ -255,7 +255,7 @@ describe('mutation-observed: dirty-bit derivation', () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 });
 
 describe('mutation-observed: session-scoped dedupe', () => {
@@ -279,7 +279,7 @@ describe('mutation-observed: session-scoped dedupe', () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('a different session editing the same path does NOT coalesce (separate pending events)', () => {
     const cwd = tmpWorkspace('mo-no-coalesce-cross-session');
@@ -299,7 +299,7 @@ describe('mutation-observed: session-scoped dedupe', () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('dirty bits are OR-combined (monotonic) across a coalesced pair, not overwritten', () => {
     const cwd = tmpWorkspace('mo-coalesce-or');
@@ -335,7 +335,7 @@ describe('mutation-observed: session-scoped dedupe', () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 });
 
 describe('mutation-observed: crash-replay', () => {
@@ -377,7 +377,7 @@ describe('mutation-observed: crash-replay', () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('consumePendingPostEditEvents is a clean no-op with nothing pending', () => {
     const cwd = tmpWorkspace('mo-consume-empty');
@@ -388,7 +388,7 @@ describe('mutation-observed: crash-replay', () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('a corrupt pending file is removed at consumption with a stderr warning, without disturbing valid events', () => {
     const cwd = tmpWorkspace('mo-corrupt-pending');
@@ -431,7 +431,7 @@ describe('mutation-observed: crash-replay', () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 });
 
 describe('mutation-observed: advisory stdout parity', () => {
@@ -446,7 +446,7 @@ describe('mutation-observed: advisory stdout parity', () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('first-principles guidance is rendered in-process from the current diff', () => {
     const cwd = tmpWorkspace('mo-first-principles');
@@ -467,7 +467,7 @@ describe('mutation-observed: advisory stdout parity', () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('turbo.json and metro config advisories match the base script verbatim', () => {
     const cwd = tmpWorkspace('mo-advisories-misc');
@@ -485,7 +485,7 @@ describe('mutation-observed: advisory stdout parity', () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 });
 
 describe('mutation-observed: gitignore coverage (gate round-1 second widening)', () => {
@@ -511,5 +511,5 @@ describe('mutation-observed: gitignore coverage (gate round-1 second widening)',
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 });

--- a/tests/plan-status-gate.test.ts
+++ b/tests/plan-status-gate.test.ts
@@ -133,7 +133,7 @@ describe('pre-edit-guard plan-status fail-closed default (falsifier-resolved aut
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('empty status blocks with a structured reason', () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'plan-status-empty-')));
@@ -152,7 +152,7 @@ describe('pre-edit-guard plan-status fail-closed default (falsifier-resolved aut
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('unrecognized (but plausible-looking) status blocks -- not just literal garbage', () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'plan-status-unrecognized-')));
@@ -167,7 +167,7 @@ describe('pre-edit-guard plan-status fail-closed default (falsifier-resolved aut
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('casing variant of a known status is not byte-equal and blocks', () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'plan-status-casing-')));
@@ -181,7 +181,7 @@ describe('pre-edit-guard plan-status fail-closed default (falsifier-resolved aut
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('missing plan file keeps the existing missing_artifact path unchanged', () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'plan-status-missing-plan-')));
@@ -198,7 +198,7 @@ describe('pre-edit-guard plan-status fail-closed default (falsifier-resolved aut
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   describe('each known-good status', () => {
     for (const status of KNOWN_STATUSES) {
@@ -226,7 +226,7 @@ describe('pre-edit-guard plan-status fail-closed default (falsifier-resolved aut
         } finally {
           rmSync(cwd, { recursive: true, force: true });
         }
-      });
+      }, 30_000);
     }
   });
 
@@ -248,7 +248,7 @@ describe('pre-edit-guard plan-status fail-closed default (falsifier-resolved aut
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('missing active_plan.lifecycle projection is fail-closed even when the known-status array exists', () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'plan-status-no-lifecycle-')));
@@ -263,7 +263,7 @@ describe('pre-edit-guard plan-status fail-closed default (falsifier-resolved aut
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('missing policy.json entirely is also fail-closed', () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'plan-status-no-policy-file-')));
@@ -278,7 +278,7 @@ describe('pre-edit-guard plan-status fail-closed default (falsifier-resolved aut
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('advice mode reports the same unrecognized status without hard-blocking', () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'plan-status-advice-')));
@@ -292,5 +292,5 @@ describe('pre-edit-guard plan-status fail-closed default (falsifier-resolved aut
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 });

--- a/tests/prompt-handler.test.ts
+++ b/tests/prompt-handler.test.ts
@@ -162,7 +162,7 @@ describe('typed UserPromptSubmit.default handler', () => {
     } finally {
       repo.cleanup();
     }
-  });
+  }, 30_000);
 
   test('owner waiver grant is contract-bound and never asks for a repeated subject hash', () => {
     const repo = fixture({ contract: true });
@@ -176,7 +176,7 @@ describe('typed UserPromptSubmit.default handler', () => {
     } finally {
       repo.cleanup();
     }
-  });
+  }, 30_000);
 
   test('long plan prose with a literal Completed token does not trigger done', () => {
     const repo = fixture({ contract: true });
@@ -197,7 +197,7 @@ describe('typed UserPromptSubmit.default handler', () => {
     } finally {
       repo.cleanup();
     }
-  });
+  }, 30_000);
 
   test('completionToken substring and Chinese future-completion wording do not trigger done', () => {
     const repo = fixture({ contract: true });
@@ -211,7 +211,7 @@ describe('typed UserPromptSubmit.default handler', () => {
     } finally {
       repo.cleanup();
     }
-  });
+  }, 30_000);
 
   test('done with fresh contract, checks, and AcceptanceReceipt allows archive once', () => {
     const repo = fixture({ contract: true, checks: passingChecks() });
@@ -230,7 +230,7 @@ describe('typed UserPromptSubmit.default handler', () => {
     } finally {
       repo.cleanup();
     }
-  });
+  }, 30_000);
 
   test('semantic change after an AcceptanceReceipt is rejected even when prose is unchanged', () => {
     const repo = fixture({ contract: true, checks: passingChecks() });
@@ -247,7 +247,7 @@ describe('typed UserPromptSubmit.default handler', () => {
     } finally {
       repo.cleanup();
     }
-  });
+  }, 30_000);
 
   test('malformed or pending Markdown review prose does not override a structured receipt', () => {
     for (const review of [
@@ -276,7 +276,7 @@ describe('typed UserPromptSubmit.default handler', () => {
         repo.cleanup();
       }
     }
-  });
+  }, 30_000);
 
   test('done blocks when the approved plan lacks its Evidence Contract', () => {
     const repo = fixture({ contract: true, evidenceContract: false });
@@ -288,7 +288,7 @@ describe('typed UserPromptSubmit.default handler', () => {
     } finally {
       repo.cleanup();
     }
-  });
+  }, 30_000);
 
   test('done blocks for empty, failing, and stale structured checks', () => {
     const cases: Array<[string, unknown]> = [
@@ -306,7 +306,7 @@ describe('typed UserPromptSubmit.default handler', () => {
         repo.cleanup();
       }
     }
-  });
+  }, 30_000);
 
   test('done blocks when contract verification fails before archive', () => {
     const repo = fixture({ contract: true, checks: passingChecks() });
@@ -323,7 +323,7 @@ describe('typed UserPromptSubmit.default handler', () => {
     } finally {
       repo.cleanup();
     }
-  });
+  }, 30_000);
 
   test('minimal-change advice is emitted only for execution prompts', () => {
     const repo = fixture({ contract: true, minimalChange: 'advice' });
@@ -341,7 +341,7 @@ describe('typed UserPromptSubmit.default handler', () => {
     } finally {
       repo.cleanup();
     }
-  });
+  }, 30_000);
 
   test('typed parser remains the only input read and malformed payload stays observable', () => {
     const input = parseHookInput('not json');
@@ -359,7 +359,7 @@ describe('typed UserPromptSubmit.default handler', () => {
     } finally {
       repo.cleanup();
     }
-  });
+  }, 30_000);
 
   // Sibling of the workflow-state.sh recorder/validator policy-key split
   // (tests/workflow-state-lib.test.ts): emitReviewHints's [AcceptanceSubject]
@@ -440,5 +440,5 @@ describe('typed UserPromptSubmit.default handler', () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 });

--- a/tests/prompt-routing-explicit-first.test.ts
+++ b/tests/prompt-routing-explicit-first.test.ts
@@ -51,5 +51,5 @@ describe('explicit-first prompt routing', () => {
     expect(result.status).toBe(0);
     expect(JSON.parse(result.stdout)).toEqual({ kind: 'bypass' });
     expect(result.stderr).toBe('');
-  });
+  }, 30_000);
 });

--- a/tests/review-freshness.test.ts
+++ b/tests/review-freshness.test.ts
@@ -66,7 +66,7 @@ describe('review subject', () => {
       rmSync(source, { recursive: true, force: true });
       rmSync(cloneParent, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('excludes review and check artifacts from the review subject', () => {
     const cwd = tmpRepo('repo-harness-review-freshness-exclude');
@@ -107,7 +107,7 @@ describe('review subject', () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('excludes regenerated authoritative harness reports from review freshness', () => {
     const repo = tmpRepo('repo-harness-review-freshness-report');
@@ -132,7 +132,7 @@ describe('review subject', () => {
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('includes untracked file content in the subject', () => {
     const cwd = tmpRepo('repo-harness-review-freshness-untracked');
@@ -150,7 +150,7 @@ describe('review subject', () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('keeps the content subject stable when the target advances on unrelated paths', () => {
     const cwd = tmpFeatureRepo('repo-harness-review-freshness-target');
@@ -180,7 +180,7 @@ describe('review subject', () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('reports target overlap without folding target revision into the content subject', () => {
     const cwd = tmpFeatureRepo('repo-harness-review-freshness-overlap');
@@ -203,7 +203,7 @@ describe('review subject', () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('represents deletion as normalized final content', () => {
     const cwd = tmpFeatureRepo('repo-harness-review-freshness-delete');
@@ -221,7 +221,7 @@ describe('review subject', () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('hashes untracked file content above the legacy 1 MiB cap', () => {
     const cwd = tmpFeatureRepo('repo-harness-review-freshness-large');
@@ -238,7 +238,7 @@ describe('review subject', () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('observes untracked files with non-ASCII pathnames', () => {
     const cwd = tmpFeatureRepo('repo-harness-review-freshness-unicode');
@@ -255,7 +255,7 @@ describe('review subject', () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('fails closed with status unknown when git state is unreadable', () => {
     const nonRepo = mkdtempSync(join(tmpdir(), 'repo-harness-review-freshness-nonrepo-'));
@@ -287,7 +287,7 @@ describe('review subject', () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('detects content changes in untracked files whose names use git pathspec magic', () => {
     const cwd = tmpFeatureRepo('repo-harness-review-freshness-pathspec');
@@ -307,7 +307,7 @@ describe('review subject', () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('detects an untracked symlink retargeted to a same-content file', () => {
     const cwd = tmpFeatureRepo('repo-harness-review-freshness-symlink');
@@ -330,7 +330,7 @@ describe('review subject', () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('hashes raw symlink target bytes so a non-utf-8 retarget is observed', () => {
     const cwd = tmpFeatureRepo('repo-harness-review-freshness-symlink-bytes');
@@ -350,7 +350,7 @@ describe('review subject', () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('detects an untracked executable-bit flip with no content change', () => {
     const cwd = tmpFeatureRepo('repo-harness-review-freshness-mode');
@@ -368,7 +368,7 @@ describe('review subject', () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('splitNul fails closed when a git pathname does not round-trip through utf-8', () => {
     // macOS/APFS rejects non-utf-8 filenames, so this Linux-reproducible case is

--- a/tests/review-rubric.test.ts
+++ b/tests/review-rubric.test.ts
@@ -58,5 +58,5 @@ describe('review rubric renderer', () => {
     expect(res.status).toBe(0);
     expect(res.stdout).toContain('[ReviewRubric] Deep Diff Review Rubric v2');
     expect(res.stderr).toBe('');
-  });
+  }, 30_000);
 });

--- a/tests/route-nl-vs-ts-eval.test.ts
+++ b/tests/route-nl-vs-ts-eval.test.ts
@@ -183,7 +183,7 @@ describe("route-nl-vs-ts eval", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("writeRouteReport creates parent directories", () => {
     const cwd = tempPath("route-nl-vs-ts-write");

--- a/tests/run-bdd2-evals.test.ts
+++ b/tests/run-bdd2-evals.test.ts
@@ -109,7 +109,7 @@ describe("BDD2 Phase E3 authority", () => {
     expect(evaluation.corpus.rows.filter((row) => row.experiment === "S3")).toHaveLength(72);
     expect(evaluation.corpus.rows.filter((row) => row.experiment === "EB3")).toHaveLength(24);
     expect(evaluation.corpus.rows.filter((row) => row.experiment === "EI3")).toHaveLength(24);
-  });
+  }, 30_000);
 
   test("outcome packets withhold condition, source id, provider, appendix, URL, and tracked-artifact judgment", () => {
     const evaluation = validateEvaluation();
@@ -122,7 +122,7 @@ describe("BDD2 Phase E3 authority", () => {
     expect(text).not.toContain("appendix");
     expect(text).not.toMatch(/https?:\/\//);
     expect(text).not.toContain("unnecessary_tracked_artifact_count");
-  });
+  }, 30_000);
 
   test("fresh adjudicator packet is explicit and does not expose condition", () => {
     const evaluation = validateEvaluation();
@@ -132,7 +132,7 @@ describe("BDD2 Phase E3 authority", () => {
     const packet = buildAdjudicatorPacket(evaluation, row, primary);
     expect(packet.schema).toBe("repo-harness-bdd2-outcome-adjudication-packet.e3");
     expect(JSON.stringify(packet)).not.toContain('"condition"');
-  });
+  }, 30_000);
 
   test("score schema excludes proposal-only artifacts", () => {
     expect(() => validateOutcomeScore({ ...neutralScore(), unnecessary_tracked_artifact_count: 1 })).toThrow("keys must be exactly");
@@ -143,7 +143,7 @@ describe("BDD2 Phase E3 authority", () => {
     manifest.model_profile.command = "/usr/bin/env";
     const root = join(REPO_ROOT, ".ai/harness/runs/bdd2", `test-e3-manifest-${Date.now()}`); created.push(root); write(join(root, "manifest.json"), manifest);
     expect(() => validateEvaluation(REPO_ROOT, relative(REPO_ROOT, join(root, "manifest.json")))).toThrow("absolute codex CLI path");
-  });
+  }, 30_000);
 
   test("source corpus cannot replace the deterministic normalized projection", () => {
     const manifest = materializeAuthorityMutation((corpus) => {
@@ -151,26 +151,26 @@ describe("BDD2 Phase E3 authority", () => {
       corpus.rows[0].normalized_outcome_sha256 = sha256Text(canonicalJson(corpus.rows[0].normalized_outcome));
     });
     expect(() => validateEvaluation(REPO_ROOT, manifest)).toThrow("normalized outcome is not the deterministic full-response projection");
-  });
+  }, 30_000);
 
   test("source corpus provenance is structurally validated", () => {
     const manifest = materializeAuthorityMutation((corpus) => { corpus.sources[0].packet_count = "72"; });
     expect(() => validateEvaluation(REPO_ROOT, manifest)).toThrow("provenance invalid");
-  });
+  }, 30_000);
 
   test("source corpus provenance must resolve to the sealed historical manifest", () => {
     const manifest = materializeAuthorityMutation((corpus) => { corpus.sources[0].source_commit = "f".repeat(40); });
     expect(() => validateEvaluation(REPO_ROOT, manifest)).toThrow("source corpus commit is unavailable");
-  });
+  }, 30_000);
 
   test("adapter evidence coordinates remain bound to the reviewed appendix", () => {
     const manifest = materializeAuthorityMutation((corpus) => { const row = corpus.rows.find((item: any) => item.experiment === "EB3" && item.condition === "treatment"); row.appendix_sha256 = "f".repeat(64); });
     expect(() => validateEvaluation(REPO_ROOT, manifest)).toThrow("corpus appendix authority mismatch");
-  });
+  }, 30_000);
 
   test("model transport rejects when the child closes stdin early", async () => {
     await expect(runJsonProcess("/bin/sh", ["-c", "exec 0<&-; sleep 0.05; exit 7"], REPO_ROOT, { PATH: process.env.PATH ?? "/usr/bin:/bin" }, "x".repeat(8 * 1024 * 1024))).rejects.toThrow();
-  });
+  }, 30_000);
 
   test("complete score runs require fresh adjudication only on disagreement", () => {
     const evaluation = validateEvaluation();
@@ -181,7 +181,7 @@ describe("BDD2 Phase E3 authority", () => {
     const first = report.packets.find((packet: any) => packet.adjudication_sha256);
     rmSync(join(root, "adjudications", `${first.packet_id}.json`));
     expect(() => validateScoreRun(evaluation, run)).toThrow("disagreement requires fresh adjudicator score");
-  });
+  }, 30_000);
 });
 
 // ============================================================================
@@ -559,7 +559,7 @@ describe("BDD3 EA1 score-run validation and evidence projection (fixture round t
     const reportText = readFileSync(join(REPO_ROOT, reportRel), "utf8");
     expect(reportText).toContain("EA1");
     expect(reportText).toContain("pass");
-  });
+  }, 30_000);
 
   // Pre-Stage-B correction #2 supersedes the prior "Stage B preflight
   // correction" leniency: a purely descriptive not_established entry is not
@@ -574,7 +574,7 @@ describe("BDD3 EA1 score-run validation and evidence projection (fixture round t
     const projected = projectEa1Evidence(evaluation, run, evidenceRel, reportRel);
     expect(projected).toEqual({ intervention: "reshape", thesis: "unresolved" });
     expect(verifyEa1EvidenceProjection(evaluation, evidenceRel)).toEqual(projected);
-  });
+  }, 30_000);
 
   test("verify-evidence fails closed when a treatment row's ceiling_violation is tampered with post-projection", () => {
     const evaluation = validateEa1Evaluation(REPO_ROOT, EA1_MANIFEST);
@@ -588,7 +588,7 @@ describe("BDD3 EA1 score-run validation and evidence projection (fixture round t
     treatmentRow.treatment_result.violations = [{ rule: 3, detail: "tampered for test" }];
     writeFileSync(evidencePath, `${JSON.stringify(evidence, null, 2)}\n`);
     expect(() => verifyEa1EvidenceProjection(evaluation, evidenceRel)).toThrow("EA1 evidence projection drift");
-  });
+  }, 30_000);
 
   // Gate P2: run.json must self-attest the generation substrate; a run.json
   // missing model_profile (e.g. produced before this correction) fails closed.
@@ -614,7 +614,7 @@ describe("BDD3 EA1 score-run validation and evidence projection (fixture round t
     delete evidenceRaw.model_profile;
     writeFileSync(evidencePath, `${JSON.stringify(evidenceRaw, null, 2)}\n`);
     expect(() => verifyEa1EvidenceProjection(evaluation, evidenceRel)).toThrow("model_profile");
-  });
+  }, 30_000);
 });
 
 // ============================================================================

--- a/tests/run-skill-evals.test.ts
+++ b/tests/run-skill-evals.test.ts
@@ -156,7 +156,7 @@ describe("run-skill-evals helpers", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("disposable boundary rejects the real HOME before evaluator writes", () => {
     const boundary = tempPath("benchmark-real-home-guard");
@@ -364,7 +364,7 @@ describe("run-skill-evals execution", () => {
       else process.env.EVAL_GRADER_ENV_PROOF = originalGraderProof;
       rmSync(disposableBoundary, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("blocks disposable mode against the source checkout before writing", () => {
     const disposableHome = tempPath("benchmark-disposable-home");
@@ -380,7 +380,7 @@ describe("run-skill-evals execution", () => {
     } finally {
       rmSync(disposableHome, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("blocks swapped source-checkout HOME and real-HOME repo inputs", () => {
     const boundary = tempPath("benchmark-swapped-boundary");
@@ -477,7 +477,7 @@ describe("run-skill-evals execution", () => {
     } finally {
       rmSync(boundary, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("adoption profile injects one validated repo and HOME into both existing commands", () => {
     const boundary = tempPath("benchmark-adoption-boundary");
@@ -517,7 +517,7 @@ describe("run-skill-evals execution", () => {
       else process.env.REPO_HARNESS_SOURCE_ROOT = originalSourceRoot;
       rmSync(boundary, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("runs a filtered benchmark matrix with grader metadata", () => {
     const tempDir = tempPath("benchmark-run");
@@ -626,7 +626,7 @@ describe("run-skill-evals execution", () => {
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("keeps agent and grader status when structured usage is malformed", () => {
     const tempDir = tempPath("benchmark-malformed-usage");
@@ -700,7 +700,7 @@ printf 'not-json\\n'
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("records failures when graders fail even if agent exits 0", () => {
     const tempDir = tempPath("benchmark-grader-fail");
@@ -759,7 +759,7 @@ printf 'not-json\\n'
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("records agent process failures without crashing the full report generation", () => {
     const tempDir = tempPath("benchmark-fail");
@@ -817,7 +817,7 @@ printf 'not-json\\n'
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("marks all-dry-run benchmark summaries as non-authoritative", () => {
     const tempDir = tempPath("benchmark-dry-run");
@@ -873,5 +873,5 @@ printf 'not-json\\n'
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 });

--- a/tests/runtime-profile-enforcement.test.ts
+++ b/tests/runtime-profile-enforcement.test.ts
@@ -110,7 +110,7 @@ describe('risk-based runtime profile enforcement', () => {
       expect(result.stdout).not.toContain('PlanStatusGuard');
       expect(result.stdout).toContain('TDD Guard');
     } finally { rmSync(cwd, { recursive: true, force: true }); }
-  });
+  }, 30_000);
 
   test('editing a .ts file outside the repo skips the TDD reminder instead of crashing the sandbox', () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'profile-oor-')));
@@ -128,7 +128,7 @@ describe('risk-based runtime profile enforcement', () => {
       rmSync(cwd, { recursive: true, force: true });
       rmSync(outside, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('Win32 absolute .ts paths outside the repo skip repo-scoped TDD probes', () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'profile-oor-win32-')));
@@ -144,7 +144,7 @@ describe('risk-based runtime profile enforcement', () => {
         expect(result.stdout).not.toContain('TDD Guard');
       }
     } finally { rmSync(cwd, { recursive: true, force: true }); }
-  });
+  }, 30_000);
 
   test('Standard requires a plan but not the Strict contract/worktree chain', () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'profile-standard-')));
@@ -156,7 +156,7 @@ describe('risk-based runtime profile enforcement', () => {
       expect(result.stderr).toMatch(/SpecGuard|PlanStatusGuard/);
       expect(result.stderr).not.toContain('StrictContractGuard');
     } finally { rmSync(cwd, { recursive: true, force: true }); }
-  });
+  }, 30_000);
 
   test('Strict high-risk paths fail closed without a contract and pass in an isolated contract worktree', () => {
     const root = realpathSync(mkdtempSync(join(tmpdir(), 'profile-strict-')));
@@ -204,7 +204,7 @@ describe('risk-based runtime profile enforcement', () => {
       expect(allowed.status).toBe(0);
       expect(allowed.stdout).toContain('TDD Guard');
     } finally { rmSync(root, { recursive: true, force: true }); }
-  });
+  }, 30_000);
 
   test('Codex apply_patch expands every target path and blocks high-risk or private writes', () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'profile-apply-patch-')));
@@ -235,7 +235,7 @@ describe('risk-based runtime profile enforcement', () => {
       expect(multi.status).toBe(2);
       expect(multi.stderr).toContain('OpsPrivateGuard');
     } finally { rmSync(cwd, { recursive: true, force: true }); }
-  });
+  }, 30_000);
 
   test('release workflows under .github remain Strict implementation surfaces', () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'profile-github-release-')));
@@ -245,7 +245,7 @@ describe('risk-based runtime profile enforcement', () => {
       expect(result.status).toBe(2);
       expect(result.stderr).toMatch(/SpecGuard|PlanStatusGuard|StrictContractGuard/);
     } finally { rmSync(cwd, { recursive: true, force: true }); }
-  });
+  }, 30_000);
 });
 
 describe('apply_patch batch-scope resolves the full pending write scope (guard gap regression)', () => {
@@ -258,7 +258,7 @@ describe('apply_patch batch-scope resolves the full pending write scope (guard g
       expect(result.stdout).not.toContain('PlanStatusGuard');
       expect(result.stdout).not.toContain('SpecGuard');
     } finally { rmSync(cwd, { recursive: true, force: true }); }
-  });
+  }, 30_000);
 
   test('b) a single apply_patch touching 4 normal implementation files resolves standard and trips the plan gate by default', () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'profile-batch-standard-')));
@@ -269,7 +269,7 @@ describe('apply_patch batch-scope resolves the full pending write scope (guard g
       expect(result.stderr).toMatch(/SpecGuard|PlanStatusGuard/);
       expect(result.stderr).not.toContain('StrictContractGuard');
     } finally { rmSync(cwd, { recursive: true, force: true }); }
-  });
+  }, 30_000);
 
   test('c) a patch spanning two capability prefixes resolves standard via the cross-capability signal', () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'profile-batch-capability-')));
@@ -314,7 +314,7 @@ describe('apply_patch batch-scope resolves the full pending write scope (guard g
       expect(result.stderr).toMatch(/SpecGuard|PlanStatusGuard/);
       expect(result.stderr).not.toContain('StrictContractGuard');
     } finally { rmSync(cwd, { recursive: true, force: true }); }
-  });
+  }, 30_000);
 
   test('d) duplicate and reordered patch paths produce a stable count matching the 4-file case', () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'profile-batch-reordered-')));
@@ -332,7 +332,7 @@ describe('apply_patch batch-scope resolves the full pending write scope (guard g
       expect(direct.json.profile_signals?.targetPathCount).toBe(4);
       expect(direct.json.workflow_profile).toBe('standard');
     } finally { rmSync(cwd, { recursive: true, force: true }); }
-  });
+  }, 30_000);
 
   test('e) a batch containing one strict-category path promotes every implementation path in the batch to strict', () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'profile-batch-strict-leak-')));
@@ -374,7 +374,7 @@ describe('apply_patch batch-scope resolves the full pending write scope (guard g
       expect(result.stderr).toContain('StrictContractGuard');
       expect(result.stderr).toContain('Strict workflow edit to src/plain1.ts has no active contract.');
     } finally { rmSync(cwd, { recursive: true, force: true }); }
-  });
+  }, 30_000);
 
   test('f) a 4-file batch requesting an explicit lite override is rejected below the deterministic risk floor', () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'profile-batch-below-floor-')));
@@ -392,7 +392,7 @@ describe('apply_patch batch-scope resolves the full pending write scope (guard g
       expect(direct.json.workflow_profile).toBeNull();
       expect(direct.json.blockers).toContain('workflow_profile:profile_below_risk_floor');
     } finally { rmSync(cwd, { recursive: true, force: true }); }
-  });
+  }, 30_000);
 });
 
 describe('implementation-surface predicate excludes workflow-surface paths from medium-scope (guard gap regression, C2)', () => {
@@ -406,7 +406,7 @@ describe('implementation-surface predicate excludes workflow-surface paths from 
       expect(direct.json.profile_signals?.targetPathCount).toBe(0);
       expect(direct.json.blockers).toEqual([]);
     } finally { rmSync(cwd, { recursive: true, force: true }); }
-  });
+  }, 30_000);
 
   test('h) 3 docs files plus 1 src file counts only the implementation path and resolves lite', () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'profile-mixed-lite-')));
@@ -417,7 +417,7 @@ describe('implementation-surface predicate excludes workflow-surface paths from 
       expect(direct.json.workflow_profile).toBe('lite');
       expect(direct.json.profile_signals?.targetPathCount).toBe(1);
     } finally { rmSync(cwd, { recursive: true, force: true }); }
-  });
+  }, 30_000);
 
   test('i) a batch mixing workflow-surface and implementation paths counts only the implementation paths toward standard', () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'profile-mixed-standard-')));
@@ -428,7 +428,7 @@ describe('implementation-surface predicate excludes workflow-surface paths from 
       expect(direct.json.profile_signals?.targetPathCount).toBe(4);
       expect(direct.json.workflow_profile).toBe('standard');
     } finally { rmSync(cwd, { recursive: true, force: true }); }
-  });
+  }, 30_000);
 
   test('j) a single deploy/sql path still resolves strict after the workflow-surface exclusion', () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'profile-deploy-strict-')));
@@ -437,7 +437,7 @@ describe('implementation-surface predicate excludes workflow-surface paths from 
       const direct = resolveStateDirect(cwd, ['deploy/sql/0001_demo.sql']);
       expect(direct.json.workflow_profile).toBe('strict');
     } finally { rmSync(cwd, { recursive: true, force: true }); }
-  });
+  }, 30_000);
 
   test('k) a docs-only apply_patch batch passes without a Plan gate and resolves lite ceremony guidance', () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'profile-docs-apply-patch-')));
@@ -448,7 +448,7 @@ describe('implementation-surface predicate excludes workflow-surface paths from 
       expect(result.stdout).not.toContain('PlanStatusGuard');
       expect(result.stdout).not.toContain('SpecGuard');
     } finally { rmSync(cwd, { recursive: true, force: true }); }
-  });
+  }, 30_000);
 
   test('l) a workflow-surface strict-token path batched with a plain implementation file still resolves strict (guard gap regression, external acceptance)', () => {
     // docs/auth/runbook.md is workflow surface (excluded from medium-scope
@@ -463,7 +463,7 @@ describe('implementation-surface predicate excludes workflow-surface paths from 
       expect(direct.json.workflow_profile).toBe('strict');
       expect(direct.json.profile_signals?.targetPathCount).toBe(1);
     } finally { rmSync(cwd, { recursive: true, force: true }); }
-  });
+  }, 30_000);
 
   test('m) a single deploy-named workflow-surface path (deploy/notes.md) resolves strict on its own -- locked semantics', () => {
     // deploy/notes.md is workflow surface (matches the *.md extension
@@ -486,7 +486,7 @@ describe('implementation-surface predicate excludes workflow-surface paths from 
       expect(direct.json.profile_signals?.targetPathCount).toBe(0);
       expect(direct.json.profile_signals?.strictCategories).toEqual(['deploy']);
     } finally { rmSync(cwd, { recursive: true, force: true }); }
-  });
+  }, 30_000);
 });
 
 describe('pre-edit-guard.sh fails closed on any state-resolve blocker (guard gap regression, external acceptance)', () => {
@@ -515,7 +515,7 @@ describe('pre-edit-guard.sh fails closed on any state-resolve blocker (guard gap
       expect(result.status).toBe(2);
       expect(result.stderr).toContain('WorkflowProfileGuard');
     } finally { rmSync(cwd, { recursive: true, force: true }); }
-  });
+  }, 30_000);
 
   // Round 2 external acceptance, HRD-03 retirement note: the original pair of
   // fake-CLI tests here (see notes file) substituted REPO_HARNESS_CLI with a

--- a/tests/session-context-packet-panel.test.ts
+++ b/tests/session-context-packet-panel.test.ts
@@ -50,7 +50,7 @@ describe("session-context-packet-panel: fixture builder produces a valid opt-in 
         fixture.cleanup();
       }
     }
-  });
+  }, 30_000);
 });
 
 describe("session-context-packet-panel: packet determinism per state", () => {

--- a/tests/session-context.test.ts
+++ b/tests/session-context.test.ts
@@ -178,7 +178,7 @@ describe("securitySentinelSessionSection (security-sentinel.sh port)", () => {
         expect(latest.status).toBe("ok");
       });
     });
-  });
+  }, 30_000);
 
   test("cache-hit (fingerprint unchanged) -> skips scan and cache writes entirely", () => {
     withTmpRepo("sec-hit", (repoRoot) => {
@@ -196,7 +196,7 @@ describe("securitySentinelSessionSection (security-sentinel.sh port)", () => {
         expect(readFileSync(join(repoRoot, ".ai/harness/security/latest.json"), "utf-8")).toBe(latestMtimeFirst);
       });
     });
-  });
+  }, 30_000);
 
   test("cache-miss with a suspicious hook config -> [SecurityConfig] section, mandatory+actionable", () => {
     withTmpRepo("sec-finding", (repoRoot) => {
@@ -233,7 +233,7 @@ describe("securitySentinelSessionSection (security-sentinel.sh port)", () => {
         expect(section?.actionable).toBe(true);
       });
     });
-  });
+  }, 30_000);
 });
 
 describe("sessionStartMainContent (session-start-context.sh port) — empty/gating cases", () => {
@@ -438,7 +438,7 @@ describe("sessionStartMainContent — pending plan capture, current status, acti
       expect(content).toContain("git show main:tasks/current.md");
       expect(content).toContain("Target snapshot metadata: status=Active");
     });
-  });
+  }, 30_000);
 
   test("active sprint: backlog progress counted, next unchecked task surfaced", () => {
     withTmpRepo("main-sprint", (repoRoot) => {
@@ -558,7 +558,7 @@ describe("sessionStartMainSection — actionable header detection", () => {
       expect(section).not.toBeNull();
       expect(section?.actionable).toBe(false);
     });
-  });
+  }, 30_000);
 });
 
 describe("buildSessionStartSections — composition order and shape", () => {
@@ -603,7 +603,7 @@ describe("buildSessionStartSections — composition order and shape", () => {
         expect(sections.map((s) => s.priority)).toEqual([5, 6, 2]);
       });
     });
-  });
+  }, 30_000);
 });
 
 describe("sessionStartMainContent — provider diagnostics", () => {

--- a/tests/session-state-authority.test.ts
+++ b/tests/session-state-authority.test.ts
@@ -289,7 +289,7 @@ describe('SessionStart Effective State authority', () => {
     expect(runtime).not.toContain('spawnSync');
     expect(runtime).not.toContain('PACKAGE_ROOT');
     expect(runtime).not.toContain("'state', 'resolve', '--json'");
-  });
+  }, 30_000);
 
   test('preserves exact healthy context, budget evidence, and route-runtime metrics', () => {
     const expected = JSON.parse(readFileSync(
@@ -297,7 +297,7 @@ describe('SessionStart Effective State authority', () => {
       'utf8',
     ));
     expect(captureHealthyBaseline()).toEqual(expected);
-  });
+  }, 30_000);
 
   test('distinguishes actionable, non-actionable, and blocked-but-resolved state', () => {
     const actionable = fixtureState();

--- a/tests/setup-plugins-structure.test.ts
+++ b/tests/setup-plugins-structure.test.ts
@@ -19,7 +19,7 @@ describe("setup-plugins compatibility shim", () => {
 
     expect(res.status).toBe(0);
     expect(res.stderr).toBe("");
-  });
+  }, 30_000);
 
   test("delegates to the modern repo-harness install path", () => {
     const setup = readSetup();

--- a/tests/skill-hooks.test.ts
+++ b/tests/skill-hooks.test.ts
@@ -114,7 +114,7 @@ describe("runHooks() with empty scripts", () => {
     const result = await runHooks("pre-init");
     expect(result.success).toBe(true);
     expect(result.results).toEqual([]);
-  });
+  }, 30_000);
 });
 
 describe("Hook Execution (temp directory)", () => {
@@ -141,12 +141,12 @@ describe("Hook Execution (temp directory)", () => {
     const result = await executeHookScript(tmpSuccessScript, "pre-init");
     expect(result.success).toBe(true);
     expect(result.output).toContain("hook ran successfully");
-  });
+  }, 30_000);
 
   test("executeHookScript reports failure for failing script", async () => {
     const result = await executeHookScript(tmpFailScript, "pre-init");
     expect(result.success).toBe(false);
-  });
+  }, 30_000);
 
   test("executeHookScript passes context via stdin and env", async () => {
     const result = await executeHookScript(tmpContextScript, "pre-assemble", {
@@ -155,13 +155,13 @@ describe("Hook Execution (temp directory)", () => {
     expect(result.success).toBe(true);
     expect(result.output).toContain("event=pre-assemble");
     expect(result.output).toContain('"planType":"C"');
-  });
+  }, 30_000);
 
   test("executeHookScript returns error for missing script", async () => {
     const result = await executeHookScript("/nonexistent/script.sh", "pre-init");
     expect(result.success).toBe(false);
     expect(result.error).toContain("not found");
-  });
+  }, 30_000);
 
   test("sync hook failure aborts remaining hooks", async () => {
     const config = {
@@ -180,7 +180,7 @@ describe("Hook Execution (temp directory)", () => {
     // Only the first (failing) script should have run
     expect(result.results.length).toBe(1);
     expect(result.results[0].success).toBe(false);
-  });
+  }, 30_000);
 
   test("advisory hook failure does not abort remaining hooks", async () => {
     const config = {
@@ -200,7 +200,7 @@ describe("Hook Execution (temp directory)", () => {
     expect(result.results.length).toBe(2);
     expect(result.results[0].success).toBe(false);
     expect(result.results[1].success).toBe(true);
-  });
+  }, 30_000);
 
   // Cleanup
   test("cleanup temp directory", () => {

--- a/tests/skill-routing-eval.test.ts
+++ b/tests/skill-routing-eval.test.ts
@@ -205,13 +205,13 @@ describe("scripts/run-skill-routing-eval.ts CLI", () => {
     const result = runCli(["validate"]);
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("validate OK");
-  });
+  }, 30_000);
 
   test("hash exits 0 (verify-only) on the committed corpus", () => {
     const result = runCli(["hash"]);
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("hash OK");
-  });
+  }, 30_000);
 
   test("dry-run exits 0 and prints a count for every canonical route plus none", () => {
     const result = runCli(["dry-run"]);
@@ -224,18 +224,18 @@ describe("scripts/run-skill-routing-eval.ts CLI", () => {
     ]) {
       expect(result.stdout).toContain(`${route}:`);
     }
-  });
+  }, 30_000);
 
   test("an unknown subcommand exits non-zero with usage on stderr", () => {
     const result = runCli(["bogus"]);
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain("unknown or missing subcommand");
-  });
+  }, 30_000);
 
   test("missing subcommand exits non-zero", () => {
     const result = runCli([]);
     expect(result.status).not.toBe(0);
-  });
+  }, 30_000);
 });
 
 describe("scripts/run-skill-routing-eval.ts provider mode (run subcommand, SSD-07 phase A / D1)", () => {
@@ -381,7 +381,7 @@ describe("scripts/run-skill-routing-eval.ts provider mode (run subcommand, SSD-0
     expect(result.outcome).toBe("routed");
     expect(result.routes).toEqual(["repo-harness-plan"]);
     expect(result.rawExitCode).toBe(0);
-  });
+  }, 30_000);
 
   describe("computeRoutingMetrics / evaluateThresholds (pure, synthetic records — proves both the small-sample and large-sample branches)", () => {
     function record(overrides: Partial<RoutingRunRecord> & Pick<RoutingRunRecord, "id" | "kind" | "expected_route">): RoutingRunRecord {
@@ -507,7 +507,7 @@ describe("scripts/run-skill-routing-eval.ts provider mode (run subcommand, SSD-0
       expect(report.discovered_surface.map((d) => d.name).sort()).toEqual(
         ["repo-harness", "repo-harness-check", "repo-harness-chatgpt", "repo-harness-cross-review", "repo-harness-plan", "repo-harness-product", "repo-harness-ship"].sort(),
       );
-    });
+    }, 30_000);
 
     test("minimal/claude excludes product, ship, and cross-review from scoring", () => {
       const reportPath = tmpReportPath("minimal-perfect");
@@ -523,7 +523,7 @@ describe("scripts/run-skill-routing-eval.ts provider mode (run subcommand, SSD-0
       expect(report.metrics.per_route_recall["repo-harness-ship"]).toEqual({ numerator: 0, denominator: 0, rate: null, reachable: false });
       expect(report.metrics.per_route_recall["repo-harness-cross-review"]).toEqual({ numerator: 0, denominator: 0, rate: null, reachable: false });
       expect(report.metrics.excluded_unreachable_count).toBe(12);
-    });
+    }, 30_000);
 
     test("host-awareness changes nothing about route scoring for full (claude-plan is not canonical)", () => {
       const claudeReport = runProviderEval({
@@ -537,7 +537,7 @@ describe("scripts/run-skill-routing-eval.ts provider mode (run subcommand, SSD-0
       expect(codexReport.metrics.top1_accuracy).toEqual(claudeReport.metrics.top1_accuracy);
       expect(codexReport.discovered_surface.map((d) => d.name)).toContain("claude-plan");
       expect(claudeReport.discovered_surface.map((d) => d.name)).not.toContain("claude-plan");
-    });
+    }, 30_000);
   });
 
   describe("report shape, byte binding, and corpus/manifest sha256 embedding", () => {
@@ -550,7 +550,7 @@ describe("scripts/run-skill-routing-eval.ts provider mode (run subcommand, SSD-0
       expect(report.manifest_sha256).toBe(sha256Hex(readFileSync(join(ROOT, "assets", "skill-commands", "manifest.json"))));
       expect(report.records).toHaveLength(68);
       expect(report.protocol).toBe(1);
-    });
+    }, 30_000);
 
     test("the written report file and its .sha256 sidecar are byte-bound", () => {
       const reportPath = tmpReportPath("sidecar");
@@ -558,7 +558,7 @@ describe("scripts/run-skill-routing-eval.ts provider mode (run subcommand, SSD-0
       const bytes = readFileSync(reportPath);
       const sidecar = readFileSync(`${reportPath}.sha256`, "utf-8").trim();
       expect(sidecar.startsWith(sha256Hex(bytes))).toBe(true);
-    });
+    }, 30_000);
 
     test("re-running with an identical stub produces byte-identical report JSON except generated_at", () => {
       const pathA = tmpReportPath("repeat-a");
@@ -567,7 +567,7 @@ describe("scripts/run-skill-routing-eval.ts provider mode (run subcommand, SSD-0
       const reportB = runProviderEval({ profile: "minimal", host: "claude", provider: "stub", reportPath: pathB, dryRun: false, stubOptions: { routeFor: perfectEchoRouteFor } });
       const stripGeneratedAt = (r: unknown) => JSON.parse(JSON.stringify(r).replace(/"generated_at":"[^"]*"/, '"generated_at":""'));
       expect(stripGeneratedAt(reportA)).toEqual(stripGeneratedAt(reportB));
-    });
+    }, 30_000);
   });
 
   describe("run subcommand CLI (--dry-run pipeline end to end via the real binary)", () => {
@@ -661,7 +661,7 @@ describe("scripts/run-skill-routing-eval.ts provider mode (run subcommand, SSD-0
       expect(report.evidence_scope).toBe("single_run_partial");
       expect(report.evidence_note).toContain("PARTIAL evidence");
       expect(report.evidence_note.toLowerCase()).toContain("aggregate");
-    });
+    }, 30_000);
 
     test("a genuinely bad REACHABLE route still fails its own floor and overall_pass end to end (exclusion does not neuter real failures)", () => {
       const reportPath = tmpReportPath("reach-bad-reachable");
@@ -681,7 +681,7 @@ describe("scripts/run-skill-routing-eval.ts provider mode (run subcommand, SSD-0
       expect(report.metrics.per_route_recall["repo-harness"]).toEqual({ numerator: 0, denominator: 4, rate: 0, reachable: true });
       expect(report.thresholds.per_route_recall["repo-harness"].pass).toBe(false);
       expect(report.thresholds.overall_pass).toBe(false);
-    });
+    }, 30_000);
   });
 
   describe("buildAggregateReport / aggregate subcommand (SSD-07 phase A HIGH-finding fix, layer 2)", () => {
@@ -810,7 +810,7 @@ describe("scripts/run-skill-routing-eval.ts provider mode (run subcommand, SSD-0
           canonicalRoutes,
         ),
       ).toThrow(/repo-harness-product/);
-    });
+    }, 30_000);
 
     test("fewer than 2 inputs is rejected", () => {
       const { claude, claudePath } = runTwoReports();
@@ -885,7 +885,7 @@ describe("scripts/run-skill-routing-eval.ts provider mode (run subcommand, SSD-0
       const sidecar = readFileSync(`${aggregateReportPath}.sha256`, "utf-8").trim();
       const bytes = readFileSync(aggregateReportPath);
       expect(sidecar.startsWith(sha256Hex(bytes))).toBe(true);
-    });
+    }, 30_000);
 
     test("aggregate CLI: fewer than 2 input paths exits non-zero with a clear usage error", () => {
       const result = spawnSync(
@@ -895,12 +895,12 @@ describe("scripts/run-skill-routing-eval.ts provider mode (run subcommand, SSD-0
       );
       expect(result.status).not.toBe(0);
       expect(result.stderr).toContain("at least 2");
-    });
+    }, 30_000);
 
     test("--help on aggregate prints usage and exits 0", () => {
       const result = spawnSync("bun", ["scripts/run-skill-routing-eval.ts", "aggregate", "--help"], { cwd: ROOT, encoding: "utf-8" });
       expect(result.status).toBe(0);
       expect(result.stdout).toContain("aggregate --report");
-    });
+    }, 30_000);
   });
 });

--- a/tests/sprint-backlog-grammar-drift.test.ts
+++ b/tests/sprint-backlog-grammar-drift.test.ts
@@ -68,7 +68,7 @@ describe('sprint backlog row grammar: bash authority vs TS projection', () => {
       expect(ts).toEqual(bash);
       // A fixture that parses to nothing on both sides would pass vacuously.
       expect(bash.length).toBeGreaterThan(0);
-    });
+    }, 30_000);
   }
 
   test('the check has teeth: a one-sided grammar widening is caught', () => {
@@ -81,5 +81,5 @@ describe('sprint backlog row grammar: bash authority vs TS projection', () => {
     const ts = backlogRowStatuses(readFileSync(path, 'utf-8'));
     expect(drifted.length).toBeGreaterThan(ts.length);
     expect(drifted).not.toEqual(ts);
-  });
+  }, 30_000);
 });

--- a/tests/sprint-backlog.test.ts
+++ b/tests/sprint-backlog.test.ts
@@ -115,7 +115,7 @@ describe("sprint-backlog helper", () => {
       rmSync(cwd, { recursive: true, force: true });
       rmSync(poisonRepo, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("accepts target repo root when it matches the helper cwd", () => {
     const cwd = tmpWorkspace("sprint-env-match");
@@ -135,7 +135,7 @@ describe("sprint-backlog helper", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("init creates a draft sprint, sets the marker, and refuses a second active sprint", () => {
     const cwd = tmpWorkspace("sprint-backlog-init");
@@ -161,7 +161,7 @@ describe("sprint-backlog helper", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("status, next, and complete-task drive the backlog lifecycle", () => {
     const cwd = tmpWorkspace("sprint-backlog-lifecycle");
@@ -220,7 +220,7 @@ describe("sprint-backlog helper", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("init renders titles with sed/awk metacharacters literally", () => {
     const cwd = tmpWorkspace("sprint-backlog-metachar");
@@ -242,7 +242,7 @@ describe("sprint-backlog helper", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("complete-task rejects ambiguous refs, resolves duplicates by unique slug, and preserves backslashes", () => {
     const cwd = tmpWorkspace("sprint-backlog-plan-escape");
@@ -277,7 +277,7 @@ describe("sprint-backlog helper", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("markers pointing outside plans/sprints are treated as no active sprint", () => {
     const cwd = tmpWorkspace("sprint-backlog-containment");
@@ -300,7 +300,7 @@ describe("sprint-backlog helper", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("next and complete-task fail without an active sprint", () => {
     const cwd = tmpWorkspace("sprint-backlog-no-active");
@@ -317,7 +317,7 @@ describe("sprint-backlog helper", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("start-task captures a thin sprint-task plan seed; contract rows leave the Plan cell to finish back-fill", () => {
     const cwd = tmpWorkspace("sprint-backlog-start-task");
@@ -362,7 +362,7 @@ describe("sprint-backlog helper", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("duplicate start-task is refused, auto-select skips in-flight rows, --force restarts", () => {
     const cwd = tmpWorkspace("sprint-backlog-in-flight");
@@ -397,7 +397,7 @@ describe("sprint-backlog helper", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("a non-empty stale lock times out instead of hot-looping", () => {
     const cwd = tmpWorkspace("sprint-backlog-lock-timeout");
@@ -417,7 +417,7 @@ describe("sprint-backlog helper", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("start-task refuses draft sprints and missing capture helper", () => {
     const cwd = tmpWorkspace("sprint-backlog-start-task-gates");
@@ -436,7 +436,7 @@ describe("sprint-backlog helper", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("inline start-task requires an active plan for checklist-row capture", () => {
     const cwd = tmpWorkspace("sprint-backlog-inline-no-active-plan");
@@ -455,7 +455,7 @@ describe("sprint-backlog helper", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("complete-task --sprint override works without the runtime marker", () => {
     const cwd = tmpWorkspace("sprint-backlog-sprint-override");
@@ -495,7 +495,7 @@ describe("sprint-backlog helper", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("mutations reclaim a stale backlog lock instead of deadlocking", () => {
     const cwd = tmpWorkspace("sprint-backlog-stale-lock");
@@ -515,7 +515,7 @@ describe("sprint-backlog helper", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 });
 
 describe("check-task-workflow sprint validation", () => {
@@ -561,7 +561,7 @@ describe("check-task-workflow sprint validation", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("reports unknown status instead of crashing on quotes in sprint status", () => {
     const cwd = tmpWorkspace("sprint-check-quote");
@@ -579,7 +579,7 @@ describe("check-task-workflow sprint validation", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("flags markers pointing outside the sprints dir", () => {
     const cwd = tmpWorkspace("sprint-check-outside-marker");
@@ -595,7 +595,7 @@ describe("check-task-workflow sprint validation", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("draft skeletons and execution-ready sprints emit no sprint issues", () => {
     const cwd = tmpWorkspace("sprint-check-ok");
@@ -614,7 +614,7 @@ describe("check-task-workflow sprint validation", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 });
 
 describe("sprint projection", () => {
@@ -634,7 +634,7 @@ describe("sprint projection", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("refresh-current-status reports no sprint when the marker is absent", () => {
     const cwd = tmpWorkspace("sprint-refresh-none");
@@ -647,7 +647,7 @@ describe("sprint projection", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   // HRD-04 retired session-start-context.sh; the direct-spawn vehicle
   // retargets through the in-process session-context builder with identical

--- a/tests/state/adapter-parity.test.ts
+++ b/tests/state/adapter-parity.test.ts
@@ -154,7 +154,7 @@ describe('Effective State adapter authority parity and policy boundaries', () =>
       } finally {
         fixture.cleanup();
       }
-    });
+    }, 30_000);
   }
 
   test('default MCP summary truthfully declares and materializes its canonical read model', () => {
@@ -184,7 +184,7 @@ describe('Effective State adapter authority parity and policy boundaries', () =>
     } finally {
       fixture.cleanup();
     }
-  });
+  }, 30_000);
 
   test('MCP allocates the next durable version after authority mutation', () => {
     const fixture = createEffectiveStateFixture();
@@ -215,7 +215,7 @@ describe('Effective State adapter authority parity and policy boundaries', () =>
     } finally {
       fixture.cleanup();
     }
-  });
+  }, 30_000);
 
   test('public MCP dispatch keeps canonical authority independent from its labeled current preview', async () => {
     const fixture = createEffectiveStateFixture();
@@ -250,7 +250,7 @@ describe('Effective State adapter authority parity and policy boundaries', () =>
     } finally {
       fixture.cleanup();
     }
-  });
+  }, 30_000);
 
   // LSC-08 falsifier: the frozen strict.stop.not-ready-to-ship-still-allows
   // cell (tests/state/fixtures/loop-semantics/characterization.json) is the
@@ -326,5 +326,5 @@ describe('Effective State adapter authority parity and policy boundaries', () =>
     } finally {
       fixture.cleanup();
     }
-  });
+  }, 30_000);
 });

--- a/tests/state/effective-state-stability.test.ts
+++ b/tests/state/effective-state-stability.test.ts
@@ -227,5 +227,5 @@ describe('Effective State stability contract: authority-only partition (hook-gua
     } finally {
       fixture.cleanup();
     }
-  });
+  }, 30_000);
 });

--- a/tests/state/state-concurrency.test.ts
+++ b/tests/state/state-concurrency.test.ts
@@ -63,7 +63,7 @@ describe('Effective State lock and source-stability characterization', () => {
     } finally {
       fixture.cleanup();
     }
-  });
+  }, 30_000);
 
   test('concurrent stale reclaimers preserve exclusive critical-section ownership', async () => {
     const fixture = createEffectiveStateFixture();

--- a/tests/state/state-effects.test.ts
+++ b/tests/state/state-effects.test.ts
@@ -73,7 +73,7 @@ describe('Effective State lock effects', () => {
     } finally {
       fixture.cleanup();
     }
-  });
+  }, 30_000);
 
   test('a token mismatch never deletes a lock now owned by another resolver', () => {
     const fixture = createEffectiveStateFixture();
@@ -92,7 +92,7 @@ describe('Effective State lock effects', () => {
     } finally {
       fixture.cleanup();
     }
-  });
+  }, 30_000);
 
   test('a symlinked lock directory fails closed without deleting an external entry', () => {
     const fixture = createEffectiveStateFixture();
@@ -111,7 +111,7 @@ describe('Effective State lock effects', () => {
       fixture.cleanup();
       external.cleanup();
     }
-  });
+  }, 30_000);
 
   for (const ancestor of ['.ai', '.ai/harness', '.ai/harness/state']) {
     test(`a symlinked repo-local lock ancestor ${ancestor} fails closed`, () => {
@@ -136,7 +136,7 @@ describe('Effective State lock effects', () => {
         fixture.cleanup();
         external.cleanup();
       }
-    });
+    }, 30_000);
   }
 
   test('a symlinked canonical root fails closed before running the critical section', () => {
@@ -151,7 +151,7 @@ describe('Effective State lock effects', () => {
       rmSync(link, { force: true });
       fixture.cleanup();
     }
-  });
+  }, 30_000);
 
   test('a symlinked Git common-dir lock ancestor fails closed without external publication', () => {
     const fixture = createEffectiveStateFixture();
@@ -170,7 +170,7 @@ describe('Effective State lock effects', () => {
       fixture.cleanup();
       external.cleanup();
     }
-  });
+  }, 30_000);
 });
 
 describe('Effective State authority read faults', () => {
@@ -185,7 +185,7 @@ describe('Effective State authority read faults', () => {
     } finally {
       fixture.cleanup();
     }
-  });
+  }, 30_000);
 
 });
 
@@ -214,7 +214,7 @@ describe('Effective State version/cache publication transaction', () => {
     } finally {
       fixture.cleanup();
     }
-  });
+  }, 30_000);
 
   for (const fault of ['cache-temp', 'cache-publish', 'owner-temp', 'owner-publish'] as const) {
     test(`${fault} failure preserves exact owner/cache bytes and retry consumes only version 2`, () => {
@@ -261,7 +261,7 @@ describe('Effective State version/cache publication transaction', () => {
       } finally {
         fixture.cleanup();
       }
-    });
+    }, 30_000);
   }
 
   test('a confirmSnapshot mismatch leaves owner/cache bytes identical, writes no temp files, and the next successful call consumes exactly +1', () => {
@@ -295,7 +295,7 @@ describe('Effective State version/cache publication transaction', () => {
     } finally {
       fixture.cleanup();
     }
-  });
+  }, 30_000);
 
   test('same-revision cache reconstruction never invokes version-owner write effects', () => {
     const fixture = createEffectiveStateFixture();
@@ -315,7 +315,7 @@ describe('Effective State version/cache publication transaction', () => {
     } finally {
       fixture.cleanup();
     }
-  });
+  }, 30_000);
 });
 
 describe('Effective State authority metadata failures', () => {
@@ -347,7 +347,7 @@ describe('Effective State authority metadata failures', () => {
         if (restrictedPath) chmodSync(restrictedPath, authority === 'plan-directory' ? 0o700 : 0o600);
         fixture.cleanup();
       }
-    });
+    }, 30_000);
   }
 
   test('worktree-owner canonicalization errors fail closed before publication', () => {
@@ -362,7 +362,7 @@ describe('Effective State authority metadata failures', () => {
     } finally {
       fixture.cleanup();
     }
-  });
+  }, 30_000);
 });
 
 describe('Effective State version read effects', () => {
@@ -388,7 +388,7 @@ describe('Effective State version read effects', () => {
       if (existsSync(backupPath)) renameSync(backupPath, gitPath);
       fixture.cleanup();
     }
-  });
+  }, 30_000);
 
   test('read-only version lookup preserves non-Git compatibility without hiding a corrupt owner', () => {
     const fixture = createEffectiveStateFixture();
@@ -400,5 +400,5 @@ describe('Effective State version read effects', () => {
     } finally {
       fixture.cleanup();
     }
-  });
+  }, 30_000);
 });

--- a/tests/subagent-handler.test.ts
+++ b/tests/subagent-handler.test.ts
@@ -380,7 +380,7 @@ describe('typed subagent hook handlers', () => {
     } finally {
       rmSync(repoRoot, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('does not roll latest.json back when a stale scoped SubagentStart arrives', () => {
     const repoRoot = tempRepo();

--- a/tests/tooling/codegraph-integration.test.ts
+++ b/tests/tooling/codegraph-integration.test.ts
@@ -30,7 +30,7 @@ describe("CodeGraph tooling integration", () => {
     });
     expect(local.status).toBe(0);
     expect(local.stdout).toContain(pinnedVersion);
-  });
+  }, 30_000);
 
   test("shell adapter and CLI tools command share the same readiness model", () => {
     const viaScript = runJson("bash", [SCRIPT, "--check", "--json"]);

--- a/tests/unit/closeout-runner-guardrails.test.ts
+++ b/tests/unit/closeout-runner-guardrails.test.ts
@@ -194,7 +194,7 @@ describe('closeout runner guardrails', () => {
     expect(JSON.parse(readFileSync(receipt, 'utf-8')).interruptedBy).toBe('SIGTERM');
     await Bun.sleep(1_100);
     expect(existsSync(sentinel)).toBe(false);
-  });
+  }, 30_000);
 
   test('supervised spawn failure returns a bounded error instead of hanging on pipe close', () => {
     const startedAt = Date.now();
@@ -231,7 +231,7 @@ describe('closeout runner guardrails', () => {
 
     expect(await worker.exited).toBe(0);
     expect(await new Response(worker.stdout).text()).toContain('target:barrier-safe');
-  });
+  }, 30_000);
 
   test('the parent hard timeout returns even when the supervisor event loop is stopped', async () => {
     if (process.platform === 'win32') return;
@@ -311,7 +311,7 @@ describe('closeout runner guardrails', () => {
     expect(await holder.exited).toBe(0);
     expect(result.reason).toBe('timeout');
     expect(existsSync(targetStarted)).toBe(false);
-  });
+  }, 30_000);
 
   test('helper timeout releases the shared expensive-run token after group cleanup', async () => {
     if (process.platform === 'win32') return;
@@ -336,7 +336,7 @@ describe('closeout runner guardrails', () => {
     nextOwner.release();
     await Bun.sleep(1_100);
     expect(existsSync(sentinel)).toBe(false);
-  });
+  }, 30_000);
 
   test('caller-only SIGTERM makes the supervisor clean its group and release its token', async () => {
     if (process.platform === 'win32') return;
@@ -446,7 +446,7 @@ describe('closeout runner guardrails', () => {
 
     expect(() => acquireExpensiveRunLock(root)).toThrow('unsafe lock ancestor');
     expect(readdirSync(victim)).toEqual([]);
-  });
+  }, 30_000);
 
   test('a lock handle revalidates its ancestor identities before protected work starts', () => {
     const root = temporaryRoot('repo-harness-lock-revalidation-');
@@ -629,7 +629,7 @@ describe('closeout runner guardrails', () => {
       'child_args=(--ready "two words"); set -- ${child_args[@]+"${child_args[@]}"}; test "$#" -eq 2 && test "$1" = --ready && test "$2" = "two words"',
     ], { encoding: 'utf-8' });
     expect(nonEmptyProbe.status).toBe(0);
-  });
+  }, 30_000);
 
   test('the fixed source retains the ordinary default without making it closeout authority', () => {
     const processRunner = readFileSync(join(ROOT, 'src/effects/process-runner.ts'), 'utf-8');
@@ -641,5 +641,5 @@ describe('closeout runner guardrails', () => {
     expect(processRunner).toContain('DEFAULT_PROCESS_TIMEOUT_MS = 120_000');
     expect(helperRunner).toContain('helperTimeoutMs');
     expect(ship).not.toContain('run_cmd bash "$helper_dir/verify-sprint.sh"');
-  });
+  }, 30_000);
 });

--- a/tests/unit/hook-entry-single-file-bundle.test.ts
+++ b/tests/unit/hook-entry-single-file-bundle.test.ts
@@ -105,12 +105,12 @@ describe('hook-entry single-file bundle', () => {
   test('unbundled hook entry dispatches the detached tooling populate', () => {
     const fixture = populateFixture();
     expectPopulateRan(runDetachedPopulate(HOOK_ENTRY, fixture), fixture);
-  });
+  }, 30_000);
 
   test('bundled hook entry dispatches the detached tooling populate', () => {
     const fixture = populateFixture();
     expectPopulateRan(runDetachedPopulate(buildBundle('0.0.0-test'), fixture), fixture);
-  });
+  }, 30_000);
 
   test('bundle keeps the shebang and survives without the eliminated bootstrap', () => {
     const bundle = readFileSync(buildBundle('0.0.0-test'), 'utf-8');
@@ -118,7 +118,7 @@ describe('hook-entry single-file bundle', () => {
     // Present via the hook-entry import; absent when only session-context's
     // dead-code-eliminated bootstrap referenced it.
     expect(bundle).toContain('runDetachedToolingPopulate');
-  });
+  }, 30_000);
 
   test('bundle carries the injected provider version and never the undefined identifier', () => {
     const bundle = readFileSync(buildBundle('9.9.9-injected'), 'utf-8');
@@ -127,7 +127,7 @@ describe('hook-entry single-file bundle', () => {
     // defect, and the prepack script fails on exactly this condition.
     expect(bundle).not.toContain('REPO_HARNESS_BUNDLED_CLI_VERSION');
     expect(readFileSync(buildBundle(null), 'utf-8')).toContain('REPO_HARNESS_BUNDLED_CLI_VERSION');
-  });
+  }, 30_000);
 
   test('package wiring ships the built bundle as the hook bin', () => {
     const pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf-8')) as {

--- a/tests/unit/verifier-evidence-lifecycle-cutover.test.ts
+++ b/tests/unit/verifier-evidence-lifecycle-cutover.test.ts
@@ -32,7 +32,7 @@ describe('verifier evidence lifecycle cutover', () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('bounded runner keeps the deadline active after the group leader exits', async () => {
     if (process.platform === 'win32') return;
@@ -56,7 +56,7 @@ describe('verifier evidence lifecycle cutover', () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('bounded runner strips REPO_HARNESS_* wiring from the verified command', () => {
     if (process.platform === 'win32') return;
@@ -92,7 +92,7 @@ describe('verifier evidence lifecycle cutover', () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('bounded runner passes non-harness environment through unchanged', () => {
     if (process.platform === 'win32') return;
@@ -116,7 +116,7 @@ describe('verifier evidence lifecycle cutover', () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('strict verifier has a fixed budget and records timing evidence', () => {
     const source = readFileSync(join(ROOT, 'scripts/verify-contract.sh'), 'utf-8');
@@ -171,7 +171,7 @@ describe('verifier evidence lifecycle cutover', () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('sprint and active contract surfaces contain no live matrix command', () => {
     for (const path of [

--- a/tests/unit/verifier-failure-log-retention.test.ts
+++ b/tests/unit/verifier-failure-log-retention.test.ts
@@ -93,14 +93,14 @@ describe('verifier failure log retention', () => {
     // The retained log carries the failing command's own output, which is the
     // attribution that was previously destroyed with the temp dir.
     expect(readFileSync(join(runsDir, retained[0] as string), 'utf-8')).toContain(MARKER);
-  });
+  }, 30_000);
 
   test('a passing criterion retains nothing', () => {
     const { result, retained, criterion } = runVerifier(VERIFY_CONTRACT, `echo ${MARKER}`);
 
     expect(criterion, `${result.stdout}\n${result.stderr}`).toMatchObject({ passed: true, exit_code: 0 });
     expect(retained).toEqual([]);
-  });
+  }, 30_000);
 
   test('both helper copies carry the retention path', () => {
     for (const path of ['scripts/verify-contract.sh', 'assets/templates/helpers/verify-contract.sh']) {

--- a/tests/ux-feature-guardrail.test.ts
+++ b/tests/ux-feature-guardrail.test.ts
@@ -47,7 +47,7 @@ describe("UX feature pre-implementation guard", () => {
     );
     expect(shown.status).toBe(0);
     expect(shown.stdout).toContain("# UX Feature Guard");
-  });
+  }, 30_000);
 
   test("projects the same guard card through every design-brief template authority", () => {
     const template = read("assets/templates/design-brief.template.md");

--- a/tests/workflow-contract.test.ts
+++ b/tests/workflow-contract.test.ts
@@ -255,7 +255,7 @@ describe("workflow contract manifest", () => {
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("workflow contract loader fails closed for missing and malformed contracts", () => {
     const tmp = mkdtempSync(join(tmpdir(), "workflow-contract-invalid-"));
@@ -321,7 +321,7 @@ describe("workflow contract manifest", () => {
     expect(gitignore).toContain(".ai/harness/triage/*");
     expect(gitignore).toContain("!.ai/harness/triage/.gitkeep");
     expect(gitignore).toContain(".archcontext/");
-  });
+  }, 30_000);
 });
 
 describe("state inspection and legacy doc migration", () => {

--- a/tests/workflow-state-lib.test.ts
+++ b/tests/workflow-state-lib.test.ts
@@ -195,7 +195,7 @@ describe("workflow-state shared library", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("reads only the verified AcceptanceReceipt projection from structured checks", () => {
     const cwd = mkdtempSync(join(tmpdir(), "workflow-acceptance-receipt-"));
@@ -218,7 +218,7 @@ describe("workflow-state shared library", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("verify-sprint treats review Markdown as an AcceptanceReceipt projection only", () => {
     const helper = readFileSync(
@@ -313,7 +313,7 @@ describe("workflow-state shared library", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   // R-D (fix 4, hardened in fix-round-2 after external review): benchmark:
   // must be an unambiguous DIRECT child of the single declaring
@@ -383,7 +383,7 @@ describe("workflow-state shared library", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   // R-D (fix 4, second hardening after a third external review round): a `#`
   // only starts a YAML comment when it is the first character on the line or
@@ -430,7 +430,7 @@ describe("workflow-state shared library", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("workflow_contract_evidence_requirement fails closed when parser sentinels appear as yaml content", () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), "workflow-evidence-requirement-sentinel-")));
@@ -461,7 +461,7 @@ describe("workflow-state shared library", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("workflow_contract_evidence_requirement fails closed on quoted spellings of canonical evidence keys", () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), "workflow-evidence-requirement-quoted-key-")));
@@ -490,7 +490,7 @@ describe("workflow-state shared library", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("workflow_contract_evidence_requirement fails closed on whitespace-before-colon spellings of canonical evidence keys", () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), "workflow-evidence-requirement-spaced-key-")));
@@ -514,7 +514,7 @@ describe("workflow-state shared library", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("workflow_benchmark_evidence_checks_match never invokes the validator when the contract declares not_applicable", () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), "workflow-evidence-requirement-na-no-invoke-")));
@@ -568,7 +568,7 @@ describe("workflow-state shared library", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   // Regression guard for the recorder/validator policy-key split: the
   // recorder (workflow_current_review_subject_json, via
@@ -655,6 +655,6 @@ describe("workflow-state shared library", () => {
       rmSync(upstream, { recursive: true, force: true });
       rmSync(cwd, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
 });

--- a/tests/workflow-state-lock.test.ts
+++ b/tests/workflow-state-lock.test.ts
@@ -86,7 +86,7 @@ describe("workflow-state locking", () => {
     expect(res.status).toBe(0);
     expect(res.stdout).toContain("ran-after-stale-break");
     expect(existsSync(join(cwd, ".ai/harness/.locks/stale-test.lock"))).toBe(false);
-  });
+  }, 30_000);
 
   test("rotation keeps the newest lines and archives the rest", () => {
     const file = join(cwd, ".ai/harness/rotation-test.jsonl");
@@ -106,7 +106,7 @@ describe("workflow-state locking", () => {
       .split("\n");
     expect(archive.length).toBe(2000);
     expect(archive[0]).toBe('{"n":0}');
-  });
+  }, 30_000);
 
   test("rotation is a no-op under the thresholds", () => {
     const file = join(cwd, ".ai/harness/small-test.jsonl");
@@ -114,7 +114,7 @@ describe("workflow-state locking", () => {
     const res = shell(`${SOURCE_LIB}; workflow_rotate_events_file "${file}" 2000 524288 500`);
     expect(res.status).toBe(0);
     expect(readFileSync(file, "utf-8").trim().split("\n").length).toBe(2);
-  });
+  }, 30_000);
 });
 
 function archiveStamp(): string {

--- a/tests/write-all-sync.test.ts
+++ b/tests/write-all-sync.test.ts
@@ -42,5 +42,5 @@ describe('writeAllSync', () => {
     expect(child.status).toBe(0);
     expect(child.stderr).toBe('');
     expect(child.stdout).toBe(payload);
-  });
+  }, 30_000);
 });


### PR DESCRIPTION
## Motivation

`a2381159` established the convention — a subprocess-spawning test carries an explicit generous per-test timeout, because bun's 5000ms default measures machine load rather than correctness — but it fixed only the five instances that had failed by then. The sibling class stayed open, and it kept blocking work that had nothing to do with it.

Concretely: `verify-sprint` runs `bun test` as a child of the already-running harness, so per-test wall clock inflates under that contention. Three consecutive acceptance rounds on mcp-scope-retirement were blocked, each by a *different* threshold-marginal test, each of which passed standalone:

- `session-context-packet-panel` fixture builder — 5163ms against 5000
- `factor-factory` lifecycle — 29323ms against its explicit 15000
- `continuation-attempt` no-progress-breaker siblings — 5036ms and 5073ms against 5000

Every one was a timeout, not an assertion failure. Every future contract on this repo blocks on this class until it is closed.

## What this does

Closes the class rather than the three newly observed instances. Every test that spawns CLI subprocesses — directly via `spawnSync`/`spawn`/`execSync`/`execFileSync`/`Bun.spawn`, or transitively through a fixture helper — now declares a positional `30_000` timeout in the a2381159 shape.

The one existing bound with observed evidence of insufficiency, `tests/factor-factory.test.ts`'s `FACTOR_FACTORY_SMOKE_TIMEOUT_MS`, widens from `15000` to `45_000` against the measured 29.3s. Assertion-only tests keep bun's default.

A global `bunfig` default was rejected: the 5000ms fence is still the right guard for the assertion-only majority, where a 5s test really is a regression. An explicit per-test bound also keeps hang detection at 30s instead of removing it.

## Method

Class membership came from a static scan, not from eyeballing: a throwaway scanner parsed every file under `tests/`, computed per-file transitive spawning-helper sets across `tests/**` and `scripts/**`, matched each `test(...)`/`it(...)` call by paren balancing, and reported the spawning tests carrying no positional timeout. One scanner hit was a false positive — the substring `it (` inside a prose comment at `tests/state/loop-semantics-characterization.test.ts:808` — and was left unpatched after reading the source.

Propagation was deliberately *not* extended into `src/`. A test calling a product function that internally spawns is arguably in the same class, but the name-based closure over `src/` cascaded into obvious non-spawning helpers (`profileEnablesCodegraph`, `currentStateVersion`, `readLatestPackageVersion`), which would have widened 149 more tests on unsound evidence.

## Statistics

- Timeout declarations added: **749**, all `30_000`, across **96** files
- Existing bound raised: **1** (`tests/factor-factory.test.ts:16`)
- Total diff: **97** test files, **750** changed lines
- In-class tests found by the scan: 863, of which 114 already carried an explicit bound

## Purity

No test logic changed, no timeout removed, nothing outside `tests/`. Verified mechanically rather than by sampling: all 750 hunks are single-line-for-single-line replacements, and normalizing each added line by deleting one `, 30_000` reproduces its removed line byte-for-byte in 749 of 750 cases — the remainder being the factor-factory constant. Every insertion closes a `test(`/`it(` declaration: 744 in the plain `});` → `}, 30_000);` form, 5 in `install-profiles.test.ts`'s wrapped-callback `}));` → `}), 30_000);` form where the timeout is still `test`'s third argument.

Existing bounds were left alone even where tighter than 30s (`SCAFFOLD_PARITY_TIMEOUT_MS`, `DOCTOR_CHECK_TIMEOUT_MS`, `state-concurrency`, `closeout-runner-guardrails`) — only `factor-factory` was observed insufficient. `continuation-attempt.test.ts:238` keeps its pre-existing, more generous `120_000`.

## Verification

- `bun test` standalone: 2217 pass / 1 skip / 0 fail, 177 files, 502.57s
- `bun run check:type`: clean
- `repo-harness run verify-sprint --prepare-acceptance`: `total=8 failed=0 status=Fulfilled`, with its own contended `bun test` green at 518810ms

That last contended run is the real signal. It was 0-for-3 before this sweep.

## Rollback

Single sweep commit, test files only; revert restores the defaults.