### PR TITLE
feat(mcp)!: retire repo-scope config, single user-level storage authority

### DIFF
--- a/docs/repo-harness-chatgpt-mcp-setup.md
+++ b/docs/repo-harness-chatgpt-mcp-setup.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 - At least one repo-harness adopted repository. New `repo-harness init`
-  and user-scope ChatGPT setup register adopted repos in
+  and ChatGPT setup register adopted repos in
   `~/.repo-harness/registered-repos.json`.
 - A local `repo-harness` CLI on PATH.
 - ChatGPT workspace access to Developer Mode and custom MCP Connectors.
@@ -19,16 +19,17 @@ repo-harness mcp serve --repo . --transport http --host 127.0.0.1 --port 8765 --
 
 The ChatGPT Connector registers the HTTPS endpoint, not a per-repo URL. The
 server discovers target repos from the global registry, so any repo registered by
-`repo-harness init` or user-scope MCP setup can be
+`repo-harness init` or MCP setup can be
 selected by passing `repo_path` to workflow tools. The `--repo` value is only
 the default repo/bootstrap context, not the only usable project.
 
-Developer Mode should normally be configured at OS user level. This stores MCP
-config, auth, and the registered repo index under `~/.repo-harness/`. Extra
-non-repo document roots are optional and require explicit `--allow-root`:
+MCP config, auth, and the registered repo index have one storage authority:
+`~/.repo-harness/` (override the root with `REPO_HARNESS_HOME`). Nothing is
+written into a repo working tree. Extra non-repo document roots are optional and
+require explicit `--allow-root`:
 
 ```bash
-repo-harness mcp setup chatgpt --scope user --repo . --endpoint <https-url>/mcp
+repo-harness mcp setup chatgpt --repo . --endpoint <https-url>/mcp
 repo-harness mcp serve --repo . --transport http --host 127.0.0.1 --port 8765 --profile planner
 ```
 
@@ -37,7 +38,6 @@ explicitly authorized:
 
 ```bash
 repo-harness mcp setup chatgpt \
-  --scope user \
   --repo . \
   --enable-reader \
   --allow-root "$HOME/Documents" \
@@ -45,21 +45,35 @@ repo-harness mcp setup chatgpt \
   --endpoint <https-url>/mcp
 ```
 
-Direct coding is a separate, default-off profile. It requires user scope and an
-explicit read-write repo grant:
+Direct coding is a separate, default-off profile. It requires an explicit
+read-write repo grant:
 
 ```bash
-repo-harness mcp setup chatgpt --scope user --profile coding --grant-read-write "$HOME/Projects/my-repo" --endpoint https://mcp.example.com/mcp
+repo-harness mcp setup chatgpt --profile coding --grant-read-write "$HOME/Projects/my-repo" --endpoint https://mcp.example.com/mcp
 repo-harness mcp serve --repo "$HOME/Projects/my-repo" --transport http --host 127.0.0.1 --port 8765 --profile coding
 ```
 
-It retains the 19 workflow/status tools and adds `open_workspace`, `read`,
-`apply_patch`, `exec_command`, and `write_stdin`, for 24 tools total. Bash has
-local-user authority and is not a filesystem sandbox.
+It exposes `open_workspace`, `read`, `apply_patch`, `exec_command`, and
+`write_stdin`. Bash has local-user authority and is not a filesystem sandbox.
 The repo grant selects which workspace can be opened; shell commands can access
 anything the local OS user can access on the machine, including outside that repo.
 It does not call local Codex or consume Codex quota. Read
 `docs/reference-configs/chatgpt-coding-mcp.md` before enabling it.
+
+## Migrate From Retired Repo-Scope Storage
+
+Older repo-harness versions could store MCP config and credentials in
+`<repo>/.repo-harness/`. That scope is retired. MCP commands fail closed while
+`<repo>/.repo-harness/mcp.local.json` still exists. Migrate once per repo:
+
+```bash
+repo-harness mcp migrate-scope --repo .
+```
+
+The migration merges non-secret config fields into `~/.repo-harness/mcp.local.json`,
+rotates the bearer token and OAuth passphrase instead of relocating them, deletes
+the repo-scope OAuth token store, and removes the legacy files. ChatGPT must
+re-authorize once afterwards. Re-running on a migrated repo reports nothing to do.
 
 Health check:
 
@@ -67,13 +81,11 @@ Health check:
 curl http://127.0.0.1:8765/health
 ```
 
-The ChatGPT path uses OAuth with a local passphrase. The passphrase is stored in an ignored local file:
+The ChatGPT path uses OAuth with a local passphrase. The passphrase is stored outside every repo, under the user-level MCP storage root:
 
 ```bash
-jq -r .passphrase .repo-harness/mcp.oauth.json
+jq -r .passphrase ~/.repo-harness/mcp.oauth.json
 ```
-
-For user-scope setup, read the passphrase from `~/.repo-harness/mcp.oauth.json`.
 
 Do not commit or paste this passphrase into issue trackers, PRs, or shared logs.
 
@@ -137,11 +149,11 @@ Use this Connector URL:
 
 1. Open ChatGPT **Settings → Security and login** and enable Developer mode.
 2. Open **Settings → Plugins** and create a developer-mode app (older UI/material may call it a Connector).
-3. Use the server name recorded in `.repo-harness/mcp.local.json` under `chatgpt.serverName` (new setup records the default `repo-harness` unless `--server-name` is provided).
+3. Use the server name recorded in `~/.repo-harness/mcp.local.json` under `chatgpt.serverName` (new setup records the default `repo-harness` unless `--server-name` is provided).
 4. Provide a description and paste the public MCP server URL ending in `/mcp`.
 5. Configure Connector authentication as OAuth when prompted.
 6. Create/Scan the app and verify the advertised tools.
-8. When the authorization page opens, enter the passphrase from `.repo-harness/mcp.oauth.json`.
+8. When the authorization page opens, enter the passphrase from `~/.repo-harness/mcp.oauth.json`.
 9. Wait for the tool scan to finish, then create the Connector.
 10. Keep a permission level that asks before changes; coding tools are destructive and shell is open-world.
 
@@ -158,7 +170,7 @@ Use ChatGPT for planning and review. Use Codex for local execution.
 1. Use the single configured Connector for workflow planning and repo tools.
 2. Call `discover_harness_repos` to list registered adopted repos, or pass `query`/`name`/`repo_path` for repo-like user text such as `my-app/`; then pass the selected exact `repo_path` when targeting a specific project. Registered repo aliases are resolved through the same authorized discovery surface, not by widening filesystem access.
 3. For registered repo document/code reading, capture the `repo_id` from `discover_harness_repos`, then use `get_repo_capabilities`, `repo_manifest`, `list_tree`, `stat_file`, `read_file`, `read_files`, and `search_text`.
-4. For registered repo writes, first check `get_repo_capabilities.write_tools`; the schema is deterministic, but mutation calls execute only for repos explicitly configured as `read_write`.
+4. For registered repo writes, first check `get_repo_capabilities.write_tools`; mutation tools execute only for a repo registered with `accessMode: "read_write"`.
 5. Ask ChatGPT to turn the idea into a PRD with `write_prd_from_idea`.
 6. Ask ChatGPT to turn the PRD into a checklist Sprint with `write_checklist_sprint`.
 7. Ask ChatGPT to prepare a Codex Goal with `prepare_codex_goal_from_sprint`.
@@ -168,97 +180,27 @@ Use ChatGPT for planning and review. Use Codex for local execution.
 Planner remains a workflow sidecar rather than a remote coding agent. Only the
 separate, explicitly granted coding profile provides direct coding and shell.
 
-## General Repo Reader Contract
+## General Repo Reader Reference
 
 The general repo reader uses the registered repo whitelist as the repo-level
-authorization boundary. GPT-facing calls use `repo_id` plus repo-relative paths;
-they never require or return the local absolute repo root.
+authorization boundary and `.ignore` as the only content-level exclusion
+source. GPT-facing calls use `repo_id` plus repo-relative paths. CodeGraph is
+the indexed metadata backend, while repo-harness owns authorization, fallback,
+snapshot semantics, audit, and mutation preconditions.
 
-Inside an authorized repo, `.ignore` is the only content-level exclusion source
-for the general repo API. Dotfiles, hidden directories, unknown extensions,
-`.gitignore` matches, and ordinary source files are visible unless `.ignore`
-excludes them. The `.ignore` file itself is treated as policy input, not as a
-normal manifest entry.
+For tool reference, JSON examples, repo administration, privacy/audit, and
+known limits, see:
 
-Authorized file content is not implicitly redacted in `read_file`,
-`read_files`, or `search_text` responses. The MCP audit path records tool name,
-target path, input hash, actor/profile, repo id, operation, relative paths,
-hash summary, status, result, error code, duration, and mutation/index event ids,
-but not file bodies or patch text.
-
-`write_file`, `apply_patch`, `move_path`, and `delete_path` are the general repo
-mutation tools. They are runtime-gated by the registered repo access mode and
-return `WRITE_DISABLED` for `read_only` repos. New files require
-`must_not_exist: true`; replacements, patches, moves, and deletes require
-`expected_sha256`; mismatches return `REVISION_CONFLICT` without writing.
-`apply_patch` operates on existing text files and accepts either structured
-`old_text`/`new_text` edits or guarded unified diff hunks. `move_path` moves one
-regular file only when the target also carries `must_not_exist: true`.
-`delete_path` deletes regular files only; directory creation, empty-directory
-mutation, and recursive delete are disabled in v1. A successful mutation returns
-`before`, `after`, `diff`, `mutation_id`, and `index_state`, and leaves CodeGraph
-refresh explicitly pending. It also appends an index invalidation event to
-`.ai/harness/mcp/index-events.jsonl`. Call `refresh_repo_index` with the changed
-paths and, when available, the returned `mutation_id` after a successful mutation
-to run CodeGraph sync, invalidate repo snapshot caches, append refresh success or
-dead-letter failure to the same event log, and receive the new `index_revision`,
-`snapshot_id`, `index_state`, refresh strategy, and mutation-to-refresh lag. The
-bundled CLI adapter uses repo-level `codegraph sync` when path-only refresh is
-unavailable and reports that tradeoff with `path_refresh_supported:false`. Manual
-recovery for a dead-letter refresh is to rerun `refresh_repo_index`; if the
-adapter stays unavailable, run `bash scripts/ensure-codegraph.sh --sync` and then
-retry the tool.
-
-When a repo has a CodeGraph index, `repo_manifest`, `list_tree`, `stat_file`,
-`read_file`, `read_files`, and `search_text` share a deterministic
-`snapshot_id`, `ignore_digest`, and `index_revision`. CodeGraph inventory is
-merged as indexed metadata (`indexed`, `codegraph_language`,
-`codegraph_node_count`); the secure filesystem walker remains the source of
-truth for complete manifest coverage. If a caller sends a stale `snapshot_id`,
-the reader returns `SNAPSHOT_STALE` instead of silently mixing versions.
-Each response also reports `snapshot_state`, creation/expiry time, TTL, and a
-bounded snapshot cache marker. `snapshot_cache.key` is scoped by tool and
-repo-relative path set; `snapshot_cache.snapshot_key` names the underlying repo
-snapshot. Entry metadata is cached by repo, registry revision, `.ignore`
-digest, path, and current stat signature, so warm calls can reuse unchanged file
-metadata while file, registry, and `.ignore` changes produce a different
-snapshot. Explicit `snapshot_id` stat/read calls can reuse a cached snapshot and
-validate the requested file hash instead of rebuilding the full repo snapshot.
-For large manifests, `repo_manifest` streams the visible tree and keeps only the
-requested page entries in memory. Returned page entries include exact content
-hashes; non-page file content metadata is deferred and reported as
-`counts.content_deferred` until a later page, `stat_file`, `read_file`, or
-`search_text` returns that content.
-If CodeGraph still references a deleted indexed path or returns metadata that
-no longer matches the filesystem, the response uses
-`snapshot_state: "index_lagging"` and includes lagging paths under the
-`codegraph` object.
-
-Large-repo reader baselines are reproducible with:
-
-```bash
-bun run benchmark:mcp-reader -- --entries 10000 --json
+```text
+docs/reference-configs/general-repo-mcp.md
 ```
 
-Use `--entries all` for the full 10k/100k/500k fixture sequence.
+For index stale, CodeGraph down, manifest incomplete, mutation conflict, and
+reindex dead-letter operations, see:
 
-CodeGraph search support is treated conservatively: current CodeGraph CLI query
-is symbol-oriented, so general full-text `search_text` uses the same guarded
-filesystem fallback while preserving `.ignore` semantics and indicating whether
-the matched file is indexed by CodeGraph.
-
-`open_workspace`, `tree`, and `read_text` are explicit session-local workspace
-tools. General repository analysis uses the registered-repo flow above; the two
-surfaces do not fall back to one another.
-
-Full reference:
-
-- Tool reference, JSON examples, repo administration, privacy/audit, and known
-  limits:
-  `docs/reference-configs/general-repo-mcp.md`
-- Operations runbook for index stale, CodeGraph down, manifest incomplete,
-  mutation conflict, and reindex dead-letter:
-  `deploy/runbooks/general-repo-mcp-codegraph.md`
+```text
+deploy/runbooks/general-repo-mcp-codegraph.md
+```
 
 ## Dev Mode Agent Runner
 
@@ -341,7 +283,7 @@ Use repo-harness to inspect this repo. Call harness_status, latest_handoff, and 
 ## Reader Test Prompt
 
 ```text
-Use the repo-harness Connector. First call discover_harness_repos with query/name/repo_path when the user gives repo-like text such as "my-app/", then choose the exact registered repo_id. Call get_repo_capabilities, repo_manifest, list_tree on ".", stat_file on README.md, read_file on README.md or docs/spec.md, and search_text for "repo-harness". Do not write files.
+Use the repo-harness Connector. First call discover_harness_repos with query/name/repo_path when the user gives repo-like text such as "my-app/", then choose the exact registered repo_id. Call get_repo_capabilities, repo_manifest, list_tree on ".", read_file on README.md or docs/spec.md, and search_text for "repo-harness". Do not write files.
 ```
 
 Blocked-file smoke:
@@ -388,7 +330,7 @@ Outcome labels:
 - `surface_blocked`: schema is current, but the current model surface did not call MCP.
 - `bundle_fallback`: Pro is reviewing a local evidence bundle and did not read through MCP.
 
-When Pro is `surface_blocked`, use `repo-harness-gptpro` to send a bounded
+When Pro is `surface_blocked`, use `repo-harness-chatgpt` to send a bounded
 local evidence bundle through the existing Oracle/browser handoff. The bundle
 must say it was produced locally, list included and omitted/truncated material,
 and include:
@@ -402,12 +344,12 @@ working_tree: clean | dirty
 Do not claim MCP read-back evidence for fallback output. Pro can plan or review
 the supplied bundle, while Codex still executes and verifies locally.
 
-Permission scope is separate from invocation evidence. Standard user-scope setup
-uses the global registered repo index, not one Connector per project. Random
-external directories are still excluded unless the local user adds explicit
+Permission scope is separate from invocation evidence. Setup uses the global
+registered repo index, not one Connector per project. Random external
+directories are still excluded unless the local user adds explicit
 `--allow-root` entries; broad full-disk read is not a supported default.
-Repo-scope setup remains for repo-local guide/auth compatibility, but it is not
-the recommended ChatGPT Connector shape for users working across projects.
+Repo-scope MCP storage is retired; `repo-harness mcp migrate-scope` is the only
+supported path off it.
 
 ## PRD Prompt
 
@@ -453,6 +395,7 @@ Use repo-harness-chatgpt-bridge. Execute the latest ChatGPT-generated Codex goal
 ## Security Notes
 
 - The default planner Connector exposes workflow planning tools plus read-only access to registered adopted repos' non-ignored files.
+- MCP config, bearer token, OAuth passphrase, and OAuth token store live only under `~/.repo-harness/` (or `REPO_HARNESS_HOME`), never inside a repo working tree.
 - Registered repo paths are loaded from `~/.repo-harness/registered-repos.json` and revalidated against live repo-harness adoption markers before use.
 - External read-only workspace roots appear in the same Connector only when the local user enables reader capability with explicit allowed roots.
 - The `/mcp` endpoint requires OAuth-issued Bearer tokens by default. Do not expose it through a tunnel without Connector auth configured.
@@ -460,7 +403,7 @@ Use repo-harness-chatgpt-bridge. Execute the latest ChatGPT-generated Codex goal
 - `repo-harness mcp serve --auth url-token` is a single-user compatibility mode that accepts the same token in either `Authorization: Bearer` or `?repo_harness_token=`; logs and shared docs must not include the token.
 - Legacy workspace reader mode keeps deny globs for `.env`, private keys, SSH keys, credentials, secrets, `.git`, and dependency/build output. The general repo API uses `.ignore` as the content filter and relies on repo registration plus path guards.
 - Planner profile cannot write application source files, package manifests, lockfiles, CI config, secrets, or files outside the repo root.
-- Coding profile is user-scoped and fail-closed without explicit `read_write` grants. Its shell has local-user authority; allowed roots constrain workspace selection, not shell access.
+- Coding profile is fail-closed without explicit `read_write` grants. Its shell has local-user authority; allowed roots constrain workspace selection, not shell access.
 - MCP does not expose a default Codex runner. It prepares `.ai/harness/handoff/codex-goal.md`; the local Codex host owns `/goal` execution unless the user explicitly enables the local orchestrator dev runner.
 - The orchestrator dev runner is local-only, opt-in, timeout-bounded, audited, and limited to the fixed Codex goal handoff. It is not arbitrary shell.
 - Keep `_ref/` read-only when used as a comparison source.

--- a/plans/plan-20260807-1606-mcp-scope-retirement.md
+++ b/plans/plan-20260807-1606-mcp-scope-retirement.md
@@ -1,0 +1,152 @@
+# Plan: MCP config: retire repo scope, single user-level storage authority
+
+> **Status**: Executing
+> **Created**: 20260807-1606
+> **Slug**: mcp-scope-retirement
+> **Planning Source**: repo-harness-plan
+> **Orchestration Kind**: host-plan
+> **Source Ref**: repo-harness-migration-review-slice-2
+> **Artifact Level**: work-package
+> **Promotion Reason**: risk_boundary
+> **Verification Boundary**: bun test, check:type, init dry-run, manual legacy-fixture migration trace
+> **Rollback Surface**: single squash PR revert restores dual-scope; user-side data untouched
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260807-1606-mcp-scope-retirement.contract.md`
+> **Task Review**: `tasks/reviews/20260807-1606-mcp-scope-retirement.review.md`
+> **Implementation Notes**: `tasks/notes/20260807-1606-mcp-scope-retirement.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from repo-harness-plan planning output.
+- Source ref: repo-harness-migration-review-slice-2
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260807-1606-mcp-scope-retirement.md`
+- Sprint contract: `tasks/contracts/20260807-1606-mcp-scope-retirement.contract.md`
+- Sprint review: `tasks/reviews/20260807-1606-mcp-scope-retirement.review.md`
+- Implementation notes: `tasks/notes/20260807-1606-mcp-scope-retirement.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260807-1606-mcp-scope-retirement.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260807-1606-mcp-scope-retirement.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260807-1606-mcp-scope-retirement.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260807-1606-mcp-scope-retirement.contract.md`
+- Review file: `tasks/reviews/20260807-1606-mcp-scope-retirement.review.md`
+- Implementation notes file: `tasks/notes/20260807-1606-mcp-scope-retirement.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260807-1606-mcp-scope-retirement.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260807-1606-mcp-scope-retirement.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: single squash PR revert restores dual-scope; user-side data untouched
+- **Verification boundary**: bun test, check:type, init dry-run, manual legacy-fixture migration trace
+- **Review/acceptance boundary**: `tasks/reviews/20260807-1606-mcp-scope-retirement.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: risk_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260807-1606-mcp-scope-retirement.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260807-1606-mcp-scope-retirement.contract.md`, `tasks/reviews/20260807-1606-mcp-scope-retirement.review.md`, and `tasks/notes/20260807-1606-mcp-scope-retirement.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260807-1606-mcp-scope-retirement.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: single squash PR revert restores dual-scope; user-side data untouched
+
+## Captured Planning Output
+
+# MCP config: retire the repo scope, single user-level storage authority (Slice 2)
+
+## Problem
+
+MCP config/auth storage has two scope authorities: `'repo'` (`<repo>/.repo-harness/`) and `'user'` (`~/.repo-harness/`). The repo scope is a pre-registry historical layer the code itself has disowned: the shipped guide says it is not recommended (`setup.ts` guide text) while `parseMcpConfigScope(undefined)` still defaults to it; the coding profile hard-rejects it in three places with the rationale "grants and authorization revision live in user-owned ignored state" — a rationale equally true for bearer tokens and OAuth refresh tokens; `authorizationRevision` written into repo config is stored but never validated (planner profile skips the check); and the user-level registry (`repo-registry.ts`) already owns per-repo authorization. Dual authority violates the repo's one-source-of-truth policy, and every new storage file re-opens the ignore-discipline problem Slice 1 (#164) just closed.
+
+## Decision (approved direction from the migration review)
+
+Retire the repo scope entirely. Single storage authority: `~/.repo-harness/` (overridable via `REPO_HARNESS_HOME`). Fail-closed migration, credential rotation not relocation.
+
+1. **Scope removal**: `McpConfigScope` type and every branch on it disappear; `mcpStorageDir` returns the user dir only; `resolveMcpConfigScope` deleted; `--scope` CLI flags and `parseMcpConfigScope` deleted; `setup.ts` repo-scope branches (gitignore compensation `ensureGitignoreEntries` block, repo-branch auth object) deleted; guide text rewritten to the user-level shape.
+2. **Fail-closed migration gate**: MCP commands (`serve`, `setup`, `doctor` surfaces that read config) detect legacy `<repo>/.repo-harness/mcp.local.json` and abort with a clear error naming `repo-harness mcp migrate-scope`. No silent read-through fallback (repo policy: no compatibility fallbacks).
+3. **`repo-harness mcp migrate-scope` command** — rotation semantics:
+   - Non-secret fields of legacy `mcp.local.json` (host/port/endpoint/serverName/allowedRoots/profile) merge into user config.
+   - `mcp.tokens.json` (bearer) and `mcp.oauth.json` (passphrase): regenerate fresh values; never copy old ones (they lived inside a git working tree and may exist in backups/history).
+   - `mcp.oauth-tokens.json`: delete outright — ChatGPT re-authorizes once.
+   - Legacy repo-side files removed after migration; command prints an explicit rotated/invalidated inventory.
+4. **Dead-code sweep in the same package** (it teaches the retired shape): `engine.ts:174-179` `ignoreLines` block (confirmed dead: reads `.gitignore` into a voided binding); `chatgpt-browser.tokens.json` writer-less gitignore mentions in `engine.ts:177` region if still present after Slice 1.
+5. **Out of scope**: relocating `chatgpt-browser.local.json` to user level (Slice 3); registry identity rework (`repoHarnessRepoIdFor` path-hash staleness); any OAuth provider/TTL behavior change.
+
+## Compatibility note (explicit, bounded)
+
+The migration gate + command IS the explicit one-shot migration path required by policy; it fails closed, prints what it rotated, and the legacy path is removed in this same work-package. Existing repo-scope installs must run `mcp migrate-scope` once and re-authorize ChatGPT once. This is a breaking change: next release is 0.14.0.
+
+## Task Breakdown
+
+- [x] Remove `McpConfigScope` and all scope branches (`auth.ts`, `setup.ts`, `server.ts`, `transports/http.ts`, `commands/mcp.ts`, any other referrer found by type errors).
+- [x] Add the fail-closed legacy-detection gate on MCP command entry.
+- [x] Implement `mcp migrate-scope` with rotation semantics and inventory output.
+- [x] Dead-code sweep: `engine.ts` `ignoreLines` block.
+- [x] Rewrite affected tests: `tests/cli/mcp-setup.test.ts` repo-scope assertions become migration-gate assertions; delete `--scope repo` coding-rejection case; new tests for the gate (legacy present → error) and migrate-scope (rotation, deletion, inventory, idempotent re-run on already-migrated repo).
+- [x] Update `docs/repo-harness-chatgpt-mcp-setup.md` and setup guide text to the user-level shape.
+- [x] Full `bun test`, `bun run check:type`, `bun src/cli/index.ts init --repo . --dry-run` green.
+
+## Verification
+
+`bun test` (full), `bun run check:type`, `bun src/cli/index.ts init --repo . --dry-run`, plus a manual trace: legacy fixture repo → gate error → `migrate-scope` → user config present, old files gone, re-run reports nothing to migrate.
+
+## Rollback
+
+Single squash-merged PR; revert restores the dual-scope shape. No persisted-data format change on the user side (existing user-scope installs are untouched).
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [x] Remove `McpConfigScope` and all scope branches (`auth.ts`, `setup.ts`, `server.ts`, `transports/http.ts`, `commands/mcp.ts`, any other referrer found by type errors).
+- [x] Add the fail-closed legacy-detection gate on MCP command entry.
+- [x] Implement `mcp migrate-scope` with rotation semantics and inventory output.
+- [x] Dead-code sweep: `engine.ts` `ignoreLines` block.
+- [x] Rewrite affected tests: `tests/cli/mcp-setup.test.ts` repo-scope assertions become migration-gate assertions; delete `--scope repo` coding-rejection case; new tests for the gate (legacy present → error) and migrate-scope (rotation, deletion, inventory, idempotent re-run on already-migrated repo).
+- [x] Update `docs/repo-harness-chatgpt-mcp-setup.md` and setup guide text to the user-level shape.
+- [x] Full `bun test`, `bun run check:type`, `bun src/cli/index.ts init --repo . --dry-run` green.

--- a/src/cli/chatgpt-browser/engine.ts
+++ b/src/cli/chatgpt-browser/engine.ts
@@ -171,26 +171,18 @@ function buildOracleAgentActions(input: {
 
 export function runBrowserSetup(repoRoot: string, opts: BrowserSetupOptions = {}): { lines: string[] } {
   const sessionRoot = ensureBrowserSessionRoot(repoRoot);
-  const gitignorePath = join(repoRoot, '.gitignore');
   const ignoreLines = [
     '.repo-harness/chatgpt-browser.local.json',
     '.repo-harness/chatgpt-browser.tokens.json',
     '.ai/harness/chatgpt/browser-lock.json',
     '.ai/harness/chatgpt/sessions/',
   ];
-  let updated = false;
-  if (existsSync(gitignorePath)) {
-    const current = Bun.file(gitignorePath);
-    // Bun.file().text() is async; keep setup sync by deferring .gitignore
-    // mutation to the CLI command implementation if needed in a later phase.
-    void current;
-  }
   const lines = [
     `[repo-harness chatgpt] Session root: ${sessionRoot}`,
     '[repo-harness chatgpt] Local browser config remains uncommitted.',
     '[repo-harness chatgpt] Recommended .gitignore entries:',
     ...ignoreLines.map((line) => `  ${line}`),
-    updated ? '[repo-harness chatgpt] .gitignore updated' : '[repo-harness chatgpt] .gitignore not modified by MVP setup',
+    '[repo-harness chatgpt] .gitignore not modified by MVP setup',
   ];
 
   if (opts.profileDir) {

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -10,6 +10,7 @@ import {
   runMcpDoctor,
   runMcpLiveDoctor,
   runMcpInstallSkill,
+  runMcpMigrateScope,
   runMcpPrintGuide,
   runMcpSetupChatgpt,
   runMcpSetupCodex,
@@ -32,7 +33,6 @@ export interface McpServeOptions {
 
 interface McpSetupChatgptOptions {
   repo?: string;
-  scope?: string;
   host?: string;
   port?: string;
   endpoint?: string;
@@ -194,6 +194,16 @@ export function buildMcpCommand(): Command {
       });
     });
 
+  mcp
+    .command('migrate-scope')
+    .description('Migrate retired repo-scope MCP config to user-level storage, rotating credentials instead of relocating them')
+    .option('--repo <path>', 'Repository root to migrate', '.')
+    .action((rawOpts: { repo?: string }) => {
+      void runMcpAction(() => {
+        console.log(runMcpMigrateScope(rawOpts).lines.join('\n'));
+      });
+    });
+
   const access = new Command('access').description('Manage explicit user-scope MCP repo access');
   access
     .command('set')
@@ -238,7 +248,6 @@ export function buildMcpCommand(): Command {
     .command('chatgpt')
     .description('Generate ChatGPT Connector local config and manual setup guide')
     .option('--repo <path>', 'Repository root to configure', '.')
-    .option('--scope <scope>', 'Config scope: repo|user', 'repo')
     .option('--host <host>', 'Local MCP HTTP bind host')
     .option('--port <port>', 'Local MCP HTTP bind port')
     .option('--endpoint <url>', 'Stable public HTTPS /mcp endpoint to store in ignored local config')

--- a/src/cli/mcp/auth.ts
+++ b/src/cli/mcp/auth.ts
@@ -3,11 +3,8 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { homedir } from 'os';
 import { dirname, join, resolve } from 'path';
 
-export type McpConfigScope = 'repo' | 'user';
-
 export interface McpLocalConfig {
   version: 1 | 2 | 3;
-  scope?: McpConfigScope;
   repo?: string;
   server?: {
     host?: string;
@@ -59,24 +56,67 @@ function repoHarnessHome(): string {
   return resolve(process.env.REPO_HARNESS_HOME ?? join(process.env.HOME ?? homedir(), '.repo-harness'));
 }
 
-function mcpStorageDir(repoRoot: string, scope: McpConfigScope): string {
-  return scope === 'user' ? repoHarnessHome() : join(repoRoot, '.repo-harness');
+/** Single MCP storage authority: `~/.repo-harness/`, overridable with REPO_HARNESS_HOME. */
+export function mcpStorageDir(): string {
+  return repoHarnessHome();
 }
 
-export function mcpLocalConfigPath(repoRoot: string, scope: McpConfigScope = 'repo'): string {
-  return join(mcpStorageDir(repoRoot, scope), 'mcp.local.json');
+export function mcpLocalConfigPath(): string {
+  return join(mcpStorageDir(), 'mcp.local.json');
 }
 
-export function mcpTokenPath(repoRoot: string, scope: McpConfigScope = 'repo'): string {
-  return join(mcpStorageDir(repoRoot, scope), 'mcp.tokens.json');
+export function mcpTokenPath(): string {
+  return join(mcpStorageDir(), 'mcp.tokens.json');
 }
 
-export function mcpOAuthPath(repoRoot: string, scope: McpConfigScope = 'repo'): string {
-  return join(mcpStorageDir(repoRoot, scope), 'mcp.oauth.json');
+export function mcpOAuthPath(): string {
+  return join(mcpStorageDir(), 'mcp.oauth.json');
 }
 
-export function mcpOAuthTokenStorePath(repoRoot: string, scope: McpConfigScope = 'repo'): string {
-  return join(mcpStorageDir(repoRoot, scope), 'mcp.oauth-tokens.json');
+export function mcpOAuthTokenStorePath(): string {
+  return join(mcpStorageDir(), 'mcp.oauth-tokens.json');
+}
+
+export interface LegacyRepoScopeMcpPaths {
+  dir: string;
+  config: string;
+  tokens: string;
+  oauth: string;
+  oauthTokens: string;
+}
+
+/**
+ * Retired repo-scope storage layout. Kept only so the migration gate and
+ * `repo-harness mcp migrate-scope` can name and remove it; nothing reads
+ * configuration or credentials from these paths.
+ */
+export function legacyRepoScopeMcpPaths(repoRoot: string): LegacyRepoScopeMcpPaths {
+  const dir = join(repoRoot, '.repo-harness');
+  return {
+    dir,
+    config: join(dir, 'mcp.local.json'),
+    tokens: join(dir, 'mcp.tokens.json'),
+    oauth: join(dir, 'mcp.oauth.json'),
+    oauthTokens: join(dir, 'mcp.oauth-tokens.json'),
+  };
+}
+
+export function legacyRepoScopeMcpFiles(repoRoot: string): string[] {
+  const legacy = legacyRepoScopeMcpPaths(repoRoot);
+  return [legacy.config, legacy.tokens, legacy.oauth, legacy.oauthTokens].filter((path) => existsSync(path));
+}
+
+/**
+ * Fail closed when a repo still carries the retired repo-scope MCP config.
+ * There is deliberately no read-through fallback: the operator runs the
+ * one-shot migration, which rotates credentials instead of relocating them.
+ */
+export function assertNoLegacyRepoScopeMcpConfig(repoRoot: string): void {
+  const legacy = legacyRepoScopeMcpPaths(repoRoot);
+  if (!existsSync(legacy.config)) return;
+  throw new Error(
+    `legacy repo-scope MCP config detected at ${legacy.config}; repo scope is retired and MCP now stores config and credentials only under ${mcpStorageDir()}. Run: repo-harness mcp migrate-scope --repo ${repoRoot}`,
+  );
 }
 
 export function parseMcpLocalConfig(value: unknown): McpLocalConfig {
@@ -89,9 +129,6 @@ export function parseMcpLocalConfig(value: unknown): McpLocalConfig {
     throw new Error(`unsupported MCP local config version: ${String(version)}`);
   }
   const config = raw as unknown as McpLocalConfig;
-  if (config.scope !== undefined && config.scope !== 'repo' && config.scope !== 'user') {
-    throw new Error(`invalid MCP local config scope: ${String(config.scope)}`);
-  }
   if (config.permissions?.allowedRoots !== undefined && !Array.isArray(config.permissions.allowedRoots)) {
     throw new Error('MCP local config permissions.allowedRoots must be an array');
   }
@@ -113,7 +150,7 @@ export function parseMcpLocalConfig(value: unknown): McpLocalConfig {
   };
 }
 
-function readMcpLocalConfig(path: string): McpLocalConfig | null {
+export function readMcpLocalConfigFile(path: string): McpLocalConfig | null {
   if (!existsSync(path)) return null;
   try {
     return parseMcpLocalConfig(JSON.parse(readFileSync(path, 'utf-8')));
@@ -122,25 +159,13 @@ function readMcpLocalConfig(path: string): McpLocalConfig | null {
   }
 }
 
-export function resolveMcpConfigScope(repoRoot: string, requested?: McpConfigScope): McpConfigScope {
-  if (requested) return requested;
-  const userConfig = readMcpLocalConfig(mcpLocalConfigPath(repoRoot, 'user'));
-  if (userConfig?.profile === 'coding' && userConfig.coding?.enabled === true) return 'user';
-  if (existsSync(mcpLocalConfigPath(repoRoot, 'repo'))) return 'repo';
-  if (userConfig) return 'user';
-  return 'repo';
+export function loadMcpLocalConfig(): McpLocalConfig | null {
+  return readMcpLocalConfigFile(mcpLocalConfigPath());
 }
 
-export function loadMcpLocalConfig(repoRoot: string, scope?: McpConfigScope): McpLocalConfig | null {
-  if (scope) return readMcpLocalConfig(mcpLocalConfigPath(repoRoot, scope));
-  const userConfig = readMcpLocalConfig(mcpLocalConfigPath(repoRoot, 'user'));
-  if (userConfig?.profile === 'coding' && userConfig.coding?.enabled === true) return userConfig;
-  return readMcpLocalConfig(mcpLocalConfigPath(repoRoot, 'repo')) ?? userConfig;
-}
-
-export function readMcpBearerToken(repoRoot: string, scope?: McpConfigScope): string | null {
+export function readMcpBearerToken(): string | null {
   if (process.env.REPO_HARNESS_MCP_TOKEN?.trim()) return process.env.REPO_HARNESS_MCP_TOKEN.trim();
-  const path = mcpTokenPath(repoRoot, resolveMcpConfigScope(repoRoot, scope));
+  const path = mcpTokenPath();
   if (!existsSync(path)) return null;
   try {
     const parsed = JSON.parse(readFileSync(path, 'utf-8')) as { bearerToken?: unknown };
@@ -150,9 +175,9 @@ export function readMcpBearerToken(repoRoot: string, scope?: McpConfigScope): st
   }
 }
 
-export function ensureMcpBearerToken(repoRoot: string, scope: McpConfigScope = 'repo'): { token: string; path: string; changed: boolean } {
-  const path = mcpTokenPath(repoRoot, scope);
-  const existing = readMcpBearerToken(repoRoot, scope);
+export function ensureMcpBearerToken(): { token: string; path: string; changed: boolean } {
+  const path = mcpTokenPath();
+  const existing = readMcpBearerToken();
   if (existing) return { token: existing, path, changed: false };
 
   const token = randomBytes(32).toString('base64url');
@@ -167,11 +192,11 @@ export function parseMcpHttpAuthMode(value: string | undefined): McpHttpAuthMode
   throw new Error(`invalid --auth "${value}" (expected: oauth, bearer, url-token)`);
 }
 
-export function readMcpOAuthPassphrase(repoRoot: string, scope?: McpConfigScope): string | null {
+export function readMcpOAuthPassphrase(): string | null {
   if (process.env.REPO_HARNESS_MCP_OAUTH_PASSPHRASE?.trim()) {
     return process.env.REPO_HARNESS_MCP_OAUTH_PASSPHRASE.trim();
   }
-  const path = mcpOAuthPath(repoRoot, resolveMcpConfigScope(repoRoot, scope));
+  const path = mcpOAuthPath();
   if (!existsSync(path)) return null;
   try {
     const parsed = JSON.parse(readFileSync(path, 'utf-8')) as { passphrase?: unknown };
@@ -181,9 +206,9 @@ export function readMcpOAuthPassphrase(repoRoot: string, scope?: McpConfigScope)
   }
 }
 
-export function ensureMcpOAuthPassphrase(repoRoot: string, scope: McpConfigScope = 'repo'): { passphrase: string; path: string; changed: boolean } {
-  const path = mcpOAuthPath(repoRoot, scope);
-  const existing = readMcpOAuthPassphrase(repoRoot, scope);
+export function ensureMcpOAuthPassphrase(): { passphrase: string; path: string; changed: boolean } {
+  const path = mcpOAuthPath();
+  const existing = readMcpOAuthPassphrase();
   if (existing) return { passphrase: existing, path, changed: false };
 
   const passphrase = randomBytes(24).toString('base64url');

--- a/src/cli/mcp/server.ts
+++ b/src/cli/mcp/server.ts
@@ -8,7 +8,7 @@ import {
   registeredRepoHarnessRoots,
   repoHarnessAuthorizationRevision,
 } from '../../effects/repo-registry';
-import { loadMcpLocalConfig } from './auth';
+import { assertNoLegacyRepoScopeMcpConfig, loadMcpLocalConfig } from './auth';
 import { recordCodingProcessCompletion } from './coding-tools';
 import { createCodeGraphCliAdapter } from './codegraph-adapter';
 import { CodingWorkspaceManager } from './coding-workspaces';
@@ -170,7 +170,7 @@ export function createMcpCodingRuntime(opts: McpServerOptions, ownerId: string):
   if (!ownerId.trim()) throw new Error('coding MCP runtime owner is required');
   const ctx = createMcpToolContext({ ...opts, codingRuntime: null });
   if (ctx.policy.profile !== 'coding') throw new Error('coding MCP runtime requires the coding profile');
-  const config = loadMcpLocalConfig(ctx.repoRoot);
+  const config = loadMcpLocalConfig();
   const runtime = buildCodingRuntime(ctx.repoRoot, ctx.policy, config, ownerId);
   activeCodingRuntimes.add(runtime);
   return runtime;
@@ -178,18 +178,19 @@ export function createMcpCodingRuntime(opts: McpServerOptions, ownerId: string):
 
 export function createMcpToolContext(opts: McpServerOptions): McpToolContext {
   const repoRoot = resolveMcpRepoRoot(opts.repo ?? '.');
-  const config = loadMcpLocalConfig(repoRoot);
+  assertNoLegacyRepoScopeMcpConfig(repoRoot);
+  const config = loadMcpLocalConfig();
   const requestedProfile = opts.profile ?? config?.profile ?? 'planner';
   const profile = parseMcpProfile(requestedProfile === 'reader' ? 'planner' : requestedProfile);
   if (profile === 'coding') {
-    if (config?.version !== 3 || config.scope !== 'user' || config.profile !== 'coding' || config.coding?.enabled !== true) {
-      throw new Error('coding MCP is disabled; run user-scoped setup with profile coding and an explicit read-write grant');
+    if (config?.version !== 3 || config.profile !== 'coding' || config.coding?.enabled !== true) {
+      throw new Error('coding MCP is disabled; run setup with profile coding and an explicit read-write grant');
     }
     if (!readRegisteredRepoHarnessRepos({ adoptedOnly: true }).some((repo) => repo.accessMode === 'read_write')) {
       throw new Error('coding MCP requires at least one adopted repo with an explicit read_write grant');
     }
     if (config.authorizationRevision !== repoHarnessAuthorizationRevision()) {
-      throw new Error('coding MCP authorization revision is stale; rerun user-scoped coding setup');
+      throw new Error('coding MCP authorization revision is stale; rerun coding setup');
     }
   }
   const envDevRunner = parseBooleanSetting(process.env.REPO_HARNESS_MCP_DEV_RUNNER);

--- a/src/cli/mcp/setup.ts
+++ b/src/cli/mcp/setup.ts
@@ -9,15 +9,18 @@ import {
   repoHarnessAuthorizationRevision,
 } from '../../effects/repo-registry';
 import {
+  assertNoLegacyRepoScopeMcpConfig,
   ensureMcpBearerToken,
   ensureMcpOAuthPassphrase,
+  legacyRepoScopeMcpFiles,
+  legacyRepoScopeMcpPaths,
   loadMcpLocalConfig,
   mcpLocalConfigPath,
   mcpOAuthPath,
+  mcpStorageDir,
   mcpTokenPath,
+  readMcpLocalConfigFile,
   readMcpOAuthPassphrase,
-  resolveMcpConfigScope,
-  type McpConfigScope,
 } from './auth';
 import { sensitiveAllowedRootReason } from './policy';
 import { parseMcpProfile } from './policy';
@@ -85,19 +88,6 @@ function writePrivateFileAtomicIfChanged(path: string, content: string, changed:
   writeFileSync(temporary, content, { encoding: 'utf-8', mode: 0o600 });
   renameSync(temporary, path);
   changed.push(path);
-}
-
-function ensureGitignoreEntries(repoRoot: string, entries: string[], changed: string[]): void {
-  const path = join(repoRoot, '.gitignore');
-  const current = existsSync(path) ? readFileSync(path, 'utf-8') : '';
-  const lines = current.split(/\r?\n/);
-  let next = current.trimEnd();
-  for (const entry of entries) {
-    if (lines.includes(entry)) continue;
-    next += `${next.length > 0 ? '\n' : ''}${entry}`;
-  }
-  next += '\n';
-  writeFileIfChanged(path, next, changed);
 }
 
 function isPrivateOrLocalIPv4(hostname: string): boolean {
@@ -177,14 +167,7 @@ function normalizeChatgptMcpServerName(value: string | undefined): string {
   return trimmed;
 }
 
-function parseMcpConfigScope(value: string | undefined): McpConfigScope {
-  const normalized = (value ?? 'repo').trim().toLowerCase();
-  if (normalized === 'repo' || normalized === 'user') return normalized;
-  throw new Error(`invalid --scope "${value}" (expected: repo, user)`);
-}
-
-function displayMcpSetupPath(repoRoot: string, path: string, scope: McpConfigScope): string {
-  if (scope === 'repo') return relative(repoRoot, path);
+function displayMcpSetupPath(path: string): string {
   const home = process.env.HOME;
   if (home && path === home) return '~';
   if (home && path.startsWith(`${home}/`)) return `~/${path.slice(home.length + 1)}`;
@@ -220,7 +203,7 @@ export function chatgptGuideMarkdown(endpoint = CHATGPT_MCP_ENDPOINT_PLACEHOLDER
 ## Prerequisites
 
 - At least one repo-harness adopted repository. New \`repo-harness init\`
-  and user-scope ChatGPT setup register adopted repos in
+  and ChatGPT setup register adopted repos in
   \`~/.repo-harness/registered-repos.json\`.
 - A local \`repo-harness\` CLI on PATH.
 - ChatGPT workspace access to Developer Mode and custom MCP Connectors.
@@ -236,16 +219,17 @@ repo-harness mcp serve --repo . --transport http --host 127.0.0.1 --port 8765 --
 
 The ChatGPT Connector registers the HTTPS endpoint, not a per-repo URL. The
 server discovers target repos from the global registry, so any repo registered by
-\`repo-harness init\` or user-scope MCP setup can be
+\`repo-harness init\` or MCP setup can be
 selected by passing \`repo_path\` to workflow tools. The \`--repo\` value is only
 the default repo/bootstrap context, not the only usable project.
 
-Developer Mode should normally be configured at OS user level. This stores MCP
-config, auth, and the registered repo index under \`~/.repo-harness/\`. Extra
-non-repo document roots are optional and require explicit \`--allow-root\`:
+MCP config, auth, and the registered repo index have one storage authority:
+\`~/.repo-harness/\` (override the root with \`REPO_HARNESS_HOME\`). Nothing is
+written into a repo working tree. Extra non-repo document roots are optional and
+require explicit \`--allow-root\`:
 
 \`\`\`bash
-repo-harness mcp setup chatgpt --scope user --repo . --endpoint <https-url>/mcp
+repo-harness mcp setup chatgpt --repo . --endpoint <https-url>/mcp
 repo-harness mcp serve --repo . --transport http --host 127.0.0.1 --port 8765 --profile planner
 \`\`\`
 
@@ -254,7 +238,6 @@ explicitly authorized:
 
 \`\`\`bash
 repo-harness mcp setup chatgpt \\
-  --scope user \\
   --repo . \\
   --enable-reader \\
   --allow-root "$HOME/Documents" \\
@@ -262,11 +245,11 @@ repo-harness mcp setup chatgpt \\
   --endpoint <https-url>/mcp
 \`\`\`
 
-Direct coding is a separate, default-off profile. It requires user scope and an
-explicit read-write repo grant:
+Direct coding is a separate, default-off profile. It requires an explicit
+read-write repo grant:
 
 \`\`\`bash
-repo-harness mcp setup chatgpt --scope user --profile coding --grant-read-write "$HOME/Projects/my-repo" --endpoint https://mcp.example.com/mcp
+repo-harness mcp setup chatgpt --profile coding --grant-read-write "$HOME/Projects/my-repo" --endpoint https://mcp.example.com/mcp
 repo-harness mcp serve --repo "$HOME/Projects/my-repo" --transport http --host 127.0.0.1 --port 8765 --profile coding
 \`\`\`
 
@@ -277,19 +260,32 @@ anything the local OS user can access on the machine, including outside that rep
 It does not call local Codex or consume Codex quota. Read
 \`docs/reference-configs/chatgpt-coding-mcp.md\` before enabling it.
 
+## Migrate From Retired Repo-Scope Storage
+
+Older repo-harness versions could store MCP config and credentials in
+\`<repo>/.repo-harness/\`. That scope is retired. MCP commands fail closed while
+\`<repo>/.repo-harness/mcp.local.json\` still exists. Migrate once per repo:
+
+\`\`\`bash
+repo-harness mcp migrate-scope --repo .
+\`\`\`
+
+The migration merges non-secret config fields into \`~/.repo-harness/mcp.local.json\`,
+rotates the bearer token and OAuth passphrase instead of relocating them, deletes
+the repo-scope OAuth token store, and removes the legacy files. ChatGPT must
+re-authorize once afterwards. Re-running on a migrated repo reports nothing to do.
+
 Health check:
 
 \`\`\`bash
 curl http://127.0.0.1:8765/health
 \`\`\`
 
-The ChatGPT path uses OAuth with a local passphrase. The passphrase is stored in an ignored local file:
+The ChatGPT path uses OAuth with a local passphrase. The passphrase is stored outside every repo, under the user-level MCP storage root:
 
 \`\`\`bash
-jq -r .passphrase .repo-harness/mcp.oauth.json
+jq -r .passphrase ~/.repo-harness/mcp.oauth.json
 \`\`\`
-
-For user-scope setup, read the passphrase from \`~/.repo-harness/mcp.oauth.json\`.
 
 Do not commit or paste this passphrase into issue trackers, PRs, or shared logs.
 
@@ -353,11 +349,11 @@ ${endpoint}
 
 1. Open ChatGPT **Settings → Security and login** and enable Developer mode.
 2. Open **Settings → Plugins** and create a developer-mode app (older UI/material may call it a Connector).
-3. Use the server name recorded in \`.repo-harness/mcp.local.json\` under \`chatgpt.serverName\` (new setup records the default \`repo-harness\` unless \`--server-name\` is provided).
+3. Use the server name recorded in \`~/.repo-harness/mcp.local.json\` under \`chatgpt.serverName\` (new setup records the default \`repo-harness\` unless \`--server-name\` is provided).
 4. Provide a description and paste the public MCP server URL ending in \`/mcp\`.
 5. Configure Connector authentication as OAuth when prompted.
 6. Create/Scan the app and verify the advertised tools.
-8. When the authorization page opens, enter the passphrase from \`.repo-harness/mcp.oauth.json\`.
+8. When the authorization page opens, enter the passphrase from \`~/.repo-harness/mcp.oauth.json\`.
 9. Wait for the tool scan to finish, then create the Connector.
 10. Keep a permission level that asks before changes; coding tools are destructive and shell is open-world.
 
@@ -548,12 +544,12 @@ working_tree: clean | dirty
 Do not claim MCP read-back evidence for fallback output. Pro can plan or review
 the supplied bundle, while Codex still executes and verifies locally.
 
-Permission scope is separate from invocation evidence. Standard user-scope setup
-uses the global registered repo index, not one Connector per project. Random
-external directories are still excluded unless the local user adds explicit
+Permission scope is separate from invocation evidence. Setup uses the global
+registered repo index, not one Connector per project. Random external
+directories are still excluded unless the local user adds explicit
 \`--allow-root\` entries; broad full-disk read is not a supported default.
-Repo-scope setup remains for repo-local guide/auth compatibility, but it is not
-the recommended ChatGPT Connector shape for users working across projects.
+Repo-scope MCP storage is retired; \`repo-harness mcp migrate-scope\` is the only
+supported path off it.
 
 ## PRD Prompt
 
@@ -599,6 +595,7 @@ Use repo-harness-chatgpt-bridge. Execute the latest ChatGPT-generated Codex goal
 ## Security Notes
 
 - The default planner Connector exposes workflow planning tools plus read-only access to registered adopted repos' non-ignored files.
+- MCP config, bearer token, OAuth passphrase, and OAuth token store live only under \`~/.repo-harness/\` (or \`REPO_HARNESS_HOME\`), never inside a repo working tree.
 - Registered repo paths are loaded from \`~/.repo-harness/registered-repos.json\` and revalidated against live repo-harness adoption markers before use.
 - External read-only workspace roots appear in the same Connector only when the local user enables reader capability with explicit allowed roots.
 - The \`/mcp\` endpoint requires OAuth-issued Bearer tokens by default. Do not expose it through a tunnel without Connector auth configured.
@@ -606,7 +603,7 @@ Use repo-harness-chatgpt-bridge. Execute the latest ChatGPT-generated Codex goal
 - \`repo-harness mcp serve --auth url-token\` is a single-user compatibility mode that accepts the same token in either \`Authorization: Bearer\` or \`?repo_harness_token=\`; logs and shared docs must not include the token.
 - Legacy workspace reader mode keeps deny globs for \`.env\`, private keys, SSH keys, credentials, secrets, \`.git\`, and dependency/build output. The general repo API uses \`.ignore\` as the content filter and relies on repo registration plus path guards.
 - Planner profile cannot write application source files, package manifests, lockfiles, CI config, secrets, or files outside the repo root.
-- Coding profile is user-scoped and fail-closed without explicit \`read_write\` grants. Its shell has local-user authority; allowed roots constrain workspace selection, not shell access.
+- Coding profile is fail-closed without explicit \`read_write\` grants. Its shell has local-user authority; allowed roots constrain workspace selection, not shell access.
 - MCP does not expose a default Codex runner. It prepares \`.ai/harness/handoff/codex-goal.md\`; the local Codex host owns \`/goal\` execution unless the user explicitly enables the local orchestrator dev runner.
 - The orchestrator dev runner is local-only, opt-in, timeout-bounded, audited, and limited to the fixed Codex goal handoff. It is not arbitrary shell.
 - Keep \`_ref/\` read-only when used as a comparison source.
@@ -622,22 +619,18 @@ export function runMcpSetupChatgpt(opts: {
   serverName?: string;
   enableReader?: boolean;
   allowRoot?: string[];
-  scope?: string;
   allowFullDiskRead?: boolean;
   profile?: string;
   grantReadWrite?: string[];
 }): McpSetupResult {
   const repoRoot = resolveMcpRepoRoot(opts.repo ?? '.');
-  const scope = parseMcpConfigScope(opts.scope);
+  assertNoLegacyRepoScopeMcpConfig(repoRoot);
   if (opts.allowFullDiskRead === true) {
     throw new Error('repo-harness mcp setup chatgpt --allow-full-disk-read is deprecated; use --enable-reader with one or more --allow-root paths');
   }
   const changed: string[] = [];
-  const existingConfig = loadMcpLocalConfig(repoRoot, scope) ?? (scope === 'user' ? loadMcpLocalConfig(repoRoot, 'repo') : null);
+  const existingConfig = loadMcpLocalConfig();
   const requestedProfile = parseMcpProfile(opts.profile ?? existingConfig?.profile ?? 'planner');
-  if (requestedProfile === 'coding' && scope !== 'user') {
-    throw new Error('coding profile setup requires --scope user so grants and authorization revision live in user-owned ignored state');
-  }
   const grantReadWrite = Array.from(new Set((opts.grantReadWrite ?? []).map((entry) => resolve(entry)).filter(Boolean)));
   if (requestedProfile === 'coding' && existingConfig?.coding?.enabled !== true && grantReadWrite.length === 0) {
     throw new Error('coding profile setup requires at least one explicit --grant-read-write <repo>');
@@ -655,7 +648,7 @@ export function runMcpSetupChatgpt(opts: {
   const currentRepoAdopted = isRepoHarnessAdopted(repoRoot);
   const existingRegisteredRepos = readRegisteredRepoHarnessRepos({ adoptedOnly: true });
   const registeredRepoCount = existingRegisteredRepos.length + (
-    scope === 'user' && currentRepoAdopted && !existingRegisteredRepos.some((entry) => entry.path === repoRoot) ? 1 : 0
+    currentRepoAdopted && !existingRegisteredRepos.some((entry) => entry.path === repoRoot) ? 1 : 0
   );
   const readerEnabled = requestedProfile !== 'coding' && opts.enableReader !== false && (
     allowedRoots.length > 0 ||
@@ -668,33 +661,24 @@ export function runMcpSetupChatgpt(opts: {
   const port = opts.port ?? String(existingConfig?.server?.port ?? 8765);
   const serverName = normalizeChatgptMcpServerName(opts.serverName ?? existingConfig?.chatgpt?.serverName);
   const endpoint = normalizePublicMcpEndpoint(opts.endpoint ?? existingConfig?.chatgpt?.endpoint);
-  const configPath = mcpLocalConfigPath(repoRoot, scope);
+  const configPath = mcpLocalConfigPath();
   const existingConfigBytes = existsSync(configPath) ? readFileSync(configPath, 'utf-8') : null;
-  const guidePath = join(repoRoot, 'docs', 'repo-harness-chatgpt-mcp-setup.md');
-  const token = ensureMcpBearerToken(repoRoot, scope);
-  const oauth = ensureMcpOAuthPassphrase(repoRoot, scope);
+  const token = ensureMcpBearerToken();
+  const oauth = ensureMcpOAuthPassphrase();
   if (token.changed) changed.push(token.path);
   if (oauth.changed) changed.push(oauth.path);
   const defaultRedirectHosts = ['chatgpt.com', 'localhost', '127.0.0.1', '::1'];
-  const auth = scope === 'repo'
-    ? {
-        mode: existingConfig?.auth?.mode ?? 'oauth',
-        oauthFile: existingConfig?.auth?.oauthFile ?? '.repo-harness/mcp.oauth.json',
-        tokenFile: existingConfig?.auth?.tokenFile ?? '.repo-harness/mcp.tokens.json',
-        allowedRedirectHosts: existingConfig?.auth?.allowedRedirectHosts ?? defaultRedirectHosts,
-      }
-    : {
-        mode: existingConfig?.auth?.mode ?? 'oauth',
-        oauthFile: displayMcpSetupPath(repoRoot, oauth.path, scope),
-        tokenFile: displayMcpSetupPath(repoRoot, token.path, scope),
-        allowedRedirectHosts: existingConfig?.auth?.allowedRedirectHosts ?? defaultRedirectHosts,
-      };
+  const auth = {
+    mode: existingConfig?.auth?.mode ?? 'oauth',
+    oauthFile: displayMcpSetupPath(oauth.path),
+    tokenFile: displayMcpSetupPath(token.path),
+    allowedRedirectHosts: existingConfig?.auth?.allowedRedirectHosts ?? defaultRedirectHosts,
+  };
   const profile = requestedProfile;
   const profileAuthorizationChanged = (existingConfig?.coding?.enabled === true) !== (profile === 'coding');
   const { reader: _legacyReader, ...existingCapabilities } = existingConfig?.capabilities ?? {};
   const config = {
     version: 3,
-    scope,
     repo: repoRoot,
     server: { ...existingConfig?.server, host, port: Number(port), transport: existingConfig?.server?.transport ?? 'http' },
     auth,
@@ -730,21 +714,8 @@ export function runMcpSetupChatgpt(opts: {
       timeoutMs: 120000,
     },
   };
-  if (scope === 'repo') {
-    writeFileIfChanged(guidePath, chatgptGuideMarkdown(), changed);
-    ensureGitignoreEntries(repoRoot, [
-      '.repo-harness/mcp.local.json',
-      '.repo-harness/mcp.tokens.json',
-      '.repo-harness/mcp.oauth.json',
-      '.repo-harness/mcp.oauth-tokens.json',
-      '.ai/harness/mcp/audit.log',
-      '.ai/harness/mcp/index-events.jsonl',
-      '.ai/harness/mcp/metrics.jsonl',
-      '.ai/harness/mcp/trace.jsonl',
-    ], changed);
-  }
   const registryEntries = [
-    ...(scope === 'user' && currentRepoAdopted ? [{ repoRoot, source: 'mcp-setup' as const }] : []),
+    ...(currentRepoAdopted ? [{ repoRoot, source: 'mcp-setup' as const }] : []),
     ...grantReadWrite.map((grantRoot) => ({ repoRoot: grantRoot, source: 'manual' as const, accessMode: 'read_write' as const })),
   ];
   const registryBatch = applyRepoHarnessRegistryBatch(registryEntries, {
@@ -758,10 +729,6 @@ export function runMcpSetupChatgpt(opts: {
     },
   });
   if (registryBatch.changed) changed.push(registryBatch.registryPath);
-  const registered = {
-    registered: scope === 'user' && currentRepoAdopted,
-    path: repoRoot,
-  };
 
   return {
     status: 'ok',
@@ -769,9 +736,9 @@ export function runMcpSetupChatgpt(opts: {
     changed,
     lines: [
       `[repo-harness mcp] Repo: ${repoRoot}`,
-      `[repo-harness mcp] Config scope: ${scope}`,
+      `[repo-harness mcp] Storage: ${displayMcpSetupPath(mcpStorageDir())}`,
       `[repo-harness mcp] Reader capability: ${readerEnabled ? `enabled (${registeredRepoCount} registered repo${registeredRepoCount === 1 ? '' : 's'}, ${allowedRoots.length} explicit root${allowedRoots.length === 1 ? '' : 's'})` : 'disabled'}`,
-      ...(registered.registered ? [`[repo-harness mcp] Registered repo: ${displayMcpSetupPath(repoRoot, registered.path, scope)}`] : []),
+      ...(currentRepoAdopted ? [`[repo-harness mcp] Registered repo: ${repoRoot}`] : []),
       ...(legacyFullDiskReadDetected ? ['[repo-harness mcp] Legacy full-disk read: detected and disabled; use --allow-root to authorize reader roots'] : []),
       `[repo-harness mcp] Profile: ${profile}`,
       `[repo-harness mcp] ChatGPT MCP server name: ${serverName}`,
@@ -779,13 +746,126 @@ export function runMcpSetupChatgpt(opts: {
       endpoint
         ? `[repo-harness mcp] ChatGPT endpoint: ${endpoint}`
         : '[repo-harness mcp] ChatGPT endpoint: requires stable HTTPS tunnel',
-      `[repo-harness mcp] Auth: OAuth passphrase (${displayMcpSetupPath(repoRoot, oauth.path, scope)})`,
-      `[repo-harness mcp] Bearer fallback token: ${displayMcpSetupPath(repoRoot, token.path, scope)}`,
-      `[repo-harness mcp] Config: ${displayMcpSetupPath(repoRoot, configPath, scope)}`,
-      ...(scope === 'repo'
-        ? [`[repo-harness mcp] Guide: ${relative(repoRoot, guidePath)} (generic; endpoint stays in ignored local config)`]
-        : ['[repo-harness mcp] Guide: user-scope setup does not write repo docs']),
-      `Next: repo-harness mcp serve --repo ${scope === 'user' ? repoRoot : '.'} --transport http --host ${host} --port ${port} --profile ${profile}`,
+      `[repo-harness mcp] Auth: OAuth passphrase (${displayMcpSetupPath(oauth.path)})`,
+      `[repo-harness mcp] Bearer fallback token: ${displayMcpSetupPath(token.path)}`,
+      `[repo-harness mcp] Config: ${displayMcpSetupPath(configPath)}`,
+      '[repo-harness mcp] Guide: repo-harness mcp print-chatgpt-guide --repo . --write',
+      `Next: repo-harness mcp serve --repo ${repoRoot} --transport http --host ${host} --port ${port} --profile ${profile}`,
+    ],
+  };
+}
+
+export interface McpMigrateScopeResult extends McpSetupResult {
+  migrated: boolean;
+}
+
+/**
+ * One-shot retirement migration for the repo-scope MCP layer.
+ *
+ * Non-secret configuration is merged into the surviving user-level config
+ * (existing user values win; legacy values only fill gaps). Credentials are
+ * rotated, never relocated: repo-scope bearer/passphrase files lived inside a
+ * git working tree and may survive in backups or history, so the legacy values
+ * are discarded and fresh user-level ones are generated when absent. The
+ * repo-scope OAuth token store is deleted outright, which forces exactly one
+ * ChatGPT re-authorization.
+ */
+export function runMcpMigrateScope(opts: { repo?: string }): McpMigrateScopeResult {
+  const repoRoot = resolveMcpRepoRoot(opts.repo ?? '.');
+  const legacy = legacyRepoScopeMcpPaths(repoRoot);
+  const presentLegacyFiles = legacyRepoScopeMcpFiles(repoRoot);
+  if (presentLegacyFiles.length === 0) {
+    return {
+      status: 'ok',
+      repoRoot,
+      changed: [],
+      migrated: false,
+      lines: [
+        `[repo-harness mcp] Repo: ${repoRoot}`,
+        `[repo-harness mcp] Nothing to migrate: no repo-scope MCP files under ${legacy.dir}`,
+        `[repo-harness mcp] Storage authority: ${displayMcpSetupPath(mcpStorageDir())}`,
+      ],
+    };
+  }
+
+  const legacyConfig = readMcpLocalConfigFile(legacy.config);
+  if (legacyConfig?.profile === 'coding') {
+    throw new Error(`refusing to migrate ${legacy.config}: the coding profile was never valid in repo scope; run repo-harness mcp setup chatgpt --profile coding with an explicit --grant-read-write instead`);
+  }
+
+  const changed: string[] = [];
+  const migratedFields: string[] = [];
+  const existingUser = loadMcpLocalConfig();
+  const inherit = <T>(field: string, current: T | undefined, legacyValue: T | undefined): T | undefined => {
+    if (current !== undefined) return current;
+    if (legacyValue === undefined) return undefined;
+    migratedFields.push(field);
+    return legacyValue;
+  };
+  const host = inherit('server.host', existingUser?.server?.host, legacyConfig?.server?.host);
+  const port = inherit('server.port', existingUser?.server?.port, legacyConfig?.server?.port);
+  const serverName = inherit('chatgpt.serverName', existingUser?.chatgpt?.serverName, legacyConfig?.chatgpt?.serverName);
+  const endpoint = inherit('chatgpt.endpoint', existingUser?.chatgpt?.endpoint, legacyConfig?.chatgpt?.endpoint);
+  const allowedRoots = inherit('permissions.allowedRoots', existingUser?.permissions?.allowedRoots, legacyConfig?.permissions?.allowedRoots);
+  const profile = inherit('profile', existingUser?.profile, legacyConfig?.profile);
+
+  const token = ensureMcpBearerToken();
+  const oauth = ensureMcpOAuthPassphrase();
+  if (token.changed) changed.push(token.path);
+  if (oauth.changed) changed.push(oauth.path);
+
+  const configPath = mcpLocalConfigPath();
+  const config = {
+    ...(existingUser ?? {}),
+    version: 3 as const,
+    repo: existingUser?.repo ?? repoRoot,
+    server: {
+      ...existingUser?.server,
+      ...(host !== undefined ? { host } : {}),
+      ...(port !== undefined ? { port } : {}),
+      transport: existingUser?.server?.transport ?? legacyConfig?.server?.transport ?? 'http',
+    },
+    auth: {
+      mode: existingUser?.auth?.mode ?? 'oauth',
+      oauthFile: displayMcpSetupPath(oauth.path),
+      tokenFile: displayMcpSetupPath(token.path),
+      allowedRedirectHosts: existingUser?.auth?.allowedRedirectHosts ?? ['chatgpt.com', 'localhost', '127.0.0.1', '::1'],
+    },
+    chatgpt: {
+      ...existingUser?.chatgpt,
+      ...(serverName !== undefined ? { serverName } : {}),
+      ...(endpoint !== undefined ? { endpoint } : {}),
+    },
+    ...(allowedRoots !== undefined
+      ? { permissions: { ...existingUser?.permissions, allowedRoots, discoveryRoots: allowedRoots, fullDiskRead: false } }
+      : {}),
+    ...(profile !== undefined ? { profile } : {}),
+    authorizationRevision: existingUser?.authorizationRevision ?? repoHarnessAuthorizationRevision(),
+  };
+  writePrivateFileAtomicIfChanged(configPath, `${JSON.stringify(config, null, 2)}\n`, changed);
+
+  const oauthTokensInvalidated = existsSync(legacy.oauthTokens);
+  for (const path of presentLegacyFiles) rmSync(path, { force: true });
+
+  return {
+    status: 'ok',
+    repoRoot,
+    changed,
+    migrated: true,
+    lines: [
+      `[repo-harness mcp] Repo: ${repoRoot}`,
+      `[repo-harness mcp] Migrated repo scope to ${displayMcpSetupPath(mcpStorageDir())}`,
+      `[repo-harness mcp] Config: ${displayMcpSetupPath(configPath)}`,
+      migratedFields.length > 0
+        ? `[repo-harness mcp] Migrated config fields: ${migratedFields.join(', ')}`
+        : '[repo-harness mcp] Migrated config fields: none (user config already had every value)',
+      `[repo-harness mcp] Rotated bearer token: ${displayMcpSetupPath(token.path)} (${token.changed ? 'regenerated' : 'existing user-level token kept; legacy value discarded'})`,
+      `[repo-harness mcp] Rotated OAuth passphrase: ${displayMcpSetupPath(oauth.path)} (${oauth.changed ? 'regenerated' : 'existing user-level passphrase kept; legacy value discarded'})`,
+      oauthTokensInvalidated
+        ? `[repo-harness mcp] Invalidated OAuth grants: ${legacy.oauthTokens} deleted; ChatGPT must re-authorize once`
+        : '[repo-harness mcp] Invalidated OAuth grants: none (no repo-scope OAuth token store)',
+      `[repo-harness mcp] Removed legacy files: ${presentLegacyFiles.join(', ')}`,
+      `Next: repo-harness mcp setup chatgpt --repo ${repoRoot}`,
     ],
   };
 }
@@ -919,8 +999,8 @@ export function runMcpPrintGuide(opts: { repo?: string; endpoint?: string; write
 
 export function runMcpDoctor(opts: { repo?: string; json?: boolean }): McpSetupResult {
   const repoRoot = resolveMcpRepoRoot(opts.repo ?? '.');
-  const configScope = resolveMcpConfigScope(repoRoot);
-  const localConfig = loadMcpLocalConfig(repoRoot);
+  assertNoLegacyRepoScopeMcpConfig(repoRoot);
+  const localConfig = loadMcpLocalConfig();
   const registeredRepoCount = readRegisteredRepoHarnessRepos({ adoptedOnly: true }).length;
   const configuredServerName = localConfig?.chatgpt?.serverName;
   const host = localConfig?.server?.host ?? '127.0.0.1';
@@ -952,11 +1032,11 @@ export function runMcpDoctor(opts: { repo?: string; json?: boolean }): McpSetupR
   const codexHasServer = codexConfig.includes('[mcp_servers.repo_harness]');
   const missingTools = REQUIRED_CODEX_TOOLS.filter((tool) => !codexConfig.includes(`"${tool}"`));
   const codexCommand = Bun.which('codex');
-  const authConfigured = (authMode === 'oauth' && existsSync(mcpOAuthPath(repoRoot, configScope))) ||
-    ((authMode === 'bearer' || authMode === 'url-token') && existsSync(mcpTokenPath(repoRoot, configScope)));
+  const authConfigured = (authMode === 'oauth' && existsSync(mcpOAuthPath())) ||
+    ((authMode === 'bearer' || authMode === 'url-token') && existsSync(mcpTokenPath()));
   const status = existsSync(join(repoRoot, '.ai', 'harness', 'policy.json'))
     ? 'ready_local'
-    : configScope === 'user' && Boolean(localConfig) && authConfigured
+    : Boolean(localConfig) && authConfigured
       ? 'ready_user'
       : 'not_adopted';
   const report = {
@@ -964,14 +1044,13 @@ export function runMcpDoctor(opts: { repo?: string; json?: boolean }): McpSetupR
     repo: repoRoot,
     mcp: {
       packageVersion: repoHarnessPackageVersion(),
-      configScope,
+      storageDir: mcpStorageDir(),
       configVersion: localConfig?.version,
       configVersionOk: localConfig?.version === 3,
       localConfig: Boolean(localConfig),
       guide: existsSync(join(repoRoot, 'docs', 'repo-harness-chatgpt-mcp-setup.md')),
       authConfigured,
       permissions: {
-        configurationScope: configScope,
         fullDiskRead: false,
         allowedRootCount: localConfig?.permissions?.allowedRoots?.length ?? 0,
         allowedRoots: allowedRootReports,
@@ -1024,9 +1103,7 @@ export function runMcpDoctor(opts: { repo?: string; json?: boolean }): McpSetupR
           'captured_tool_call_transcript',
         ],
       },
-      setup: configScope === 'user'
-        ? `repo-harness mcp setup chatgpt --repo ${repoRoot} --scope user`
-        : 'repo-harness mcp setup chatgpt --repo .',
+      setup: `repo-harness mcp setup chatgpt --repo ${repoRoot}`,
     },
   };
   return {
@@ -1037,8 +1114,8 @@ export function runMcpDoctor(opts: { repo?: string; json?: boolean }): McpSetupR
       `[repo-harness mcp] Repo: ${repoRoot}`,
       `[repo-harness mcp] Status: ${report.status}`,
       `[repo-harness mcp] Package version: ${report.mcp.packageVersion}`,
-      `[repo-harness mcp] Config scope: ${configScope} (version: ${report.mcp.configVersion ?? 'missing'})`,
-      `[repo-harness mcp] Reader capability: ${report.mcp.capabilities.workspaceReader ? `enabled (${report.mcp.permissions.registeredRepoCount} registered repos, ${report.mcp.permissions.allowedRootCount} explicit roots)` : 'disabled'} (configuration scope: ${report.mcp.permissions.configurationScope})`,
+      `[repo-harness mcp] Config: ${displayMcpSetupPath(mcpLocalConfigPath())} (version: ${report.mcp.configVersion ?? 'missing'})`,
+      `[repo-harness mcp] Reader capability: ${report.mcp.capabilities.workspaceReader ? `enabled (${report.mcp.permissions.registeredRepoCount} registered repos, ${report.mcp.permissions.allowedRootCount} explicit roots)` : 'disabled'}`,
       ...(report.mcp.permissions.allowedRoots.length > 0 ? [`[repo-harness mcp] Allowed roots: ${report.mcp.permissions.allowedRoots.map((entry) => `${entry.readable ? 'ok' : 'bad'}:${entry.path}`).join(', ')}`] : []),
       ...(report.mcp.permissions.unsafeAllowedRoots.length > 0 ? [`[repo-harness mcp] Unsafe allowed roots: ${report.mcp.permissions.unsafeAllowedRoots.join(', ')}`] : []),
       ...(report.mcp.permissions.legacyFullDiskReadDetected ? ['[repo-harness mcp] Legacy full-disk read: detected; rerun setup with --enable-reader --allow-root <path>'] : []),
@@ -1086,8 +1163,8 @@ function jsonFromMcpResponse(text: string): Record<string, unknown> | null {
 
 export async function runMcpLiveDoctor(opts: { repo?: string; json?: boolean }): Promise<McpSetupResult> {
   const repoRoot = resolveMcpRepoRoot(opts.repo ?? '.');
-  const configScope = resolveMcpConfigScope(repoRoot);
-  const config = loadMcpLocalConfig(repoRoot);
+  assertNoLegacyRepoScopeMcpConfig(repoRoot);
+  const config = loadMcpLocalConfig();
   const host = config?.server?.host ?? '127.0.0.1';
   const port = config?.server?.port ?? 8765;
   const localOrigin = `http://${host}:${port}`;
@@ -1134,7 +1211,7 @@ export async function runMcpLiveDoctor(opts: { repo?: string; json?: boolean }):
   let mcpReady = false;
   let toolNames: string[] = [];
   const probeOrigin = tunnelReady && publicOrigin ? publicOrigin : localReady ? localOrigin : undefined;
-  const passphrase = readMcpOAuthPassphrase(repoRoot, configScope);
+  const passphrase = readMcpOAuthPassphrase();
   if (!probeOrigin || !passphrase) {
     layers.push({ name: 'oauth_ready', ok: false, detail: !probeOrigin ? 'no reachable endpoint for OAuth probe' : 'OAuth passphrase is missing' });
     layers.push({ name: 'mcp_ready', ok: false, detail: 'OAuth probe did not produce a bearer token' });

--- a/src/cli/mcp/tools.ts
+++ b/src/cli/mcp/tools.ts
@@ -8,6 +8,7 @@ import { runHelper } from '../runtime/helper-runner';
 import { listSessions, openSession, readSession, runBrowserConsult, runBrowserFollowup } from '../chatgpt-browser/engine';
 import type { BrowserProviderName, NativeBrowserChannel, ThinkingLevel } from '../chatgpt-browser/types';
 import { hashMcpInput, tryWriteMcpAuditEntry } from './audit';
+import { loadMcpLocalConfig } from './auth';
 import { isPathInside, resolveMcpPath } from './paths';
 import { buildReaderToolDefinitions, callReaderTool, createReaderToolContext, isReaderTool } from './reader-tools';
 import { buildCodingToolDefinitions, callCodingTool, isCodingTool, type CodingToolContext } from './coding-tools';
@@ -1111,7 +1112,10 @@ export async function callMcpTool(ctx: McpToolContext, name: string, args: Recor
       case 'harness_doctor': {
         const target = targetRepoRoot(ctx, args);
         if (!target.ok) return target.result;
-        const localConfig = existsSync(join(target.repoRoot, '.repo-harness', 'mcp.local.json'));
+        // MCP config has one storage authority (~/.repo-harness, or
+        // REPO_HARNESS_HOME); it is not per-repo, so this must not probe the
+        // retired <repo>/.repo-harness path. Same shape as runMcpDoctor.
+        const localConfig = Boolean(loadMcpLocalConfig());
         const codexConfig = existsSync(join(target.repoRoot, '.codex', 'config.toml'));
         audit(ctx, name, 'ok', args);
         return textResult({

--- a/src/cli/mcp/transports/http.ts
+++ b/src/cli/mcp/transports/http.ts
@@ -18,12 +18,12 @@ import {
   type McpServerOptions,
 } from '../server';
 import {
+  assertNoLegacyRepoScopeMcpConfig,
   loadMcpLocalConfig,
   mcpOAuthTokenStorePath,
   parseMcpHttpAuthMode,
   readMcpBearerToken,
   readMcpOAuthPassphrase,
-  resolveMcpConfigScope,
   type McpHttpAuthMode,
 } from '../auth';
 import { createMcpOAuthProvider, McpOAuthTokenStore, type McpStoredAuthInfo } from '../oauth';
@@ -530,8 +530,8 @@ export async function startMcpHttp(opts: McpHttpOptions): Promise<void> {
   const host = opts.host ?? '127.0.0.1';
   const port = opts.port ?? 8765;
   const repoRoot = resolveMcpRepoRoot(opts.repo ?? '.');
-  const configScope = resolveMcpConfigScope(repoRoot);
-  const localConfig = loadMcpLocalConfig(repoRoot, configScope);
+  assertNoLegacyRepoScopeMcpConfig(repoRoot);
+  const localConfig = loadMcpLocalConfig();
   const profile = opts.profile ?? localConfig?.profile ?? 'planner';
   const storedEndpoint = localConfig?.chatgpt?.endpoint;
   const storedPublicOrigin = storedEndpoint ? new URL(storedEndpoint).origin : undefined;
@@ -545,13 +545,13 @@ export async function startMcpHttp(opts: McpHttpOptions): Promise<void> {
   if (
     coding
     && (
-      configScope !== 'user'
-      || localConfig?.profile !== 'coding'
+      localConfig?.version !== 3
+      || localConfig.profile !== 'coding'
       || localConfig.coding?.enabled !== true
       || localConfig.authorizationRevision !== repoHarnessAuthorizationRevision()
     )
   ) {
-    throw new Error('coding profile requires enabled user-scoped v3 setup');
+    throw new Error('coding profile requires enabled v3 setup');
   }
   const readWriteRepos = readRegisteredRepoHarnessRepos({ adoptedOnly: true }).filter((repo) => repo.accessMode === 'read_write');
   if (coding && readWriteRepos.length === 0) {
@@ -561,13 +561,13 @@ export async function startMcpHttp(opts: McpHttpOptions): Promise<void> {
   if (coding && authMode !== 'oauth') {
     throw new Error('coding profile requires OAuth authentication');
   }
-  const authToken = authMode === 'bearer' || authMode === 'url-token' ? opts.authToken ?? readMcpBearerToken(repoRoot, configScope) : null;
-  const oauthPassphrase = authMode === 'oauth' ? readMcpOAuthPassphrase(repoRoot, configScope) : null;
+  const authToken = authMode === 'bearer' || authMode === 'url-token' ? opts.authToken ?? readMcpBearerToken() : null;
+  const oauthPassphrase = authMode === 'oauth' ? readMcpOAuthPassphrase() : null;
   const sessionTtlMs = boundedIntegerEnv('REPO_HARNESS_MCP_SESSION_TTL_MS', SESSION_TTL_MS, 1_000, 24 * 60 * 60 * 1000);
   const maxSessions = boundedIntegerEnv('REPO_HARNESS_MCP_MAX_SESSIONS', MAX_SESSIONS, 1, 256);
   const sessions = new McpSessionStore<McpHttpTransport>({ ttlMs: sessionTtlMs, maxSessions });
   const codingRuntimes = coding ? new CodingAuthorizationRuntimeStore(sessionTtlMs, maxSessions) : null;
-  const tokenStore = authMode === 'oauth' ? new McpOAuthTokenStore(mcpOAuthTokenStorePath(repoRoot, configScope)) : null;
+  const tokenStore = authMode === 'oauth' ? new McpOAuthTokenStore(mcpOAuthTokenStorePath()) : null;
   tokenStore?.load();
   let observedAuthorizationRevision = repoHarnessAuthorizationRevision();
   const oauthProvider = tokenStore ? createMcpOAuthProvider(tokenStore, {
@@ -598,7 +598,7 @@ export async function startMcpHttp(opts: McpHttpOptions): Promise<void> {
   };
   const authorizationTimer = coding ? setInterval(() => {
     const currentRevision = repoHarnessAuthorizationRevision();
-    const liveConfig = loadMcpLocalConfig(repoRoot, 'user');
+    const liveConfig = loadMcpLocalConfig();
     if (currentRevision !== observedAuthorizationRevision) {
       observedAuthorizationRevision = currentRevision;
       closeStaleCodingState();
@@ -615,7 +615,7 @@ export async function startMcpHttp(opts: McpHttpOptions): Promise<void> {
 
   app.use((req, res, next) => {
     if (coding) {
-      const liveConfig = loadMcpLocalConfig(repoRoot, 'user');
+      const liveConfig = loadMcpLocalConfig();
       const hasGrant = readRegisteredRepoHarnessRepos({ adoptedOnly: true }).some((repo) => repo.accessMode === 'read_write');
       if (
         liveConfig?.profile !== 'coding'

--- a/tasks/contracts/20260807-1606-mcp-scope-retirement.contract.md
+++ b/tasks/contracts/20260807-1606-mcp-scope-retirement.contract.md
@@ -1,0 +1,150 @@
+# Task Contract: mcp-scope-retirement
+
+> **Status**: Active
+> **Plan**: plans/plan-20260807-1606-mcp-scope-retirement.md
+> **Task Profile**: migration
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: ancienttwo
+> **Capability ID**: root
+> **Last Updated**: 2026-08-07 16:06
+> **Review File**: `tasks/reviews/20260807-1606-mcp-scope-retirement.review.md`
+> **Notes File**: `tasks/notes/20260807-1606-mcp-scope-retirement.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+MCP config/auth storage has two authorities (repo scope `<repo>/.repo-harness/`, user scope `~/.repo-harness/`). The repo scope is a disowned historical layer: the shipped guide recommends against it while the CLI still defaults to it, the coding profile hard-rejects it in three places for the same security rationale that applies to all credentials, and the user-level registry already owns per-repo authorization. Dual authority violates one-source-of-truth, and every new storage file re-opens the ignore-discipline hole Slice 1 (#164) closed. Skipped, the fail-open default keeps writing credentials into git working trees.
+
+## Goal
+
+Repo scope fully retired, single user-level storage authority. `McpConfigScope` type and all branches gone; `--scope` flags gone; MCP commands fail closed with a clear error naming `repo-harness mcp migrate-scope` when legacy `<repo>/.repo-harness/mcp.local.json` exists; `mcp migrate-scope` migrates non-secret config fields, regenerates bearer/passphrase, deletes `mcp.oauth-tokens.json` (forcing one ChatGPT re-authorization), removes legacy files, and prints a rotated/invalidated inventory; re-run on a migrated repo reports nothing to do. `engine.ts` dead `ignoreLines` block removed. Guide text and `docs/repo-harness-chatgpt-mcp-setup.md` describe only the user-level shape. Existing user-scope installs untouched.
+
+## Scope
+
+- In scope: `src/cli/mcp/` scope branches and migration gate/command; `src/cli/commands/mcp.ts` CLI wiring; `src/cli/chatgpt-browser/engine.ts` dead `ignoreLines` block; affected tests under `tests/cli/`; `docs/repo-harness-chatgpt-mcp-setup.md`; setup guide text.
+- Out of scope: relocating `chatgpt-browser.local.json` (Slice 3); registry identity rework (`repoHarnessRepoIdFor`); any OAuth provider/TTL behavior change (#162 semantics frozen); silent read-through compatibility fallbacks (policy-forbidden).
+- Taste constraints: <!-- advisory only, no run gate; default style/taste lives in AGENTS.md and the minimal-change policy, use this to record a per-task override -->
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+
+## Falsifier
+
+If any supported deployment shape cannot set `REPO_HARNESS_HOME` and has an unwritable `$HOME`, repo scope has an independent reason to exist and retirement is wrong. Cheapest proof point: the three home-resolution sites (`auth.ts`, `repo-registry.ts`, `coding-workspaces.ts`) all honor `REPO_HARNESS_HOME` — verified in the migration review. Second falsifier: if `migrate-scope` silently copies old bearer/passphrase/OAuth values instead of rotating, the security rationale collapses — the rotation tests are the guard.
+
+## Root Cause Evidence
+
+Required when Task Profile is `bugfix`; leave as-is otherwise.
+
+- root_cause: one sentence naming file:line/condition (testable, not "a state issue").
+- repro: the command or UI path that reproduces the symptom.
+- regression_guard: path to a test that fails on the unfixed code and passes after the fix (must also appear under exit_criteria.tests_pass).
+- pre_fix_failure_artifact: path to a captured run of regression_guard on the UNFIXED code. Capture with `bun test <regression_guard> > <artifact> 2>&1; echo "PRE_FIX_EXIT=$?" >> <artifact>` (no pipes — pipes swallow the exit status). The gate requires a non-zero `PRE_FIX_EXIT=` line plus the regression_guard path string in the artifact (see the Root Cause Evidence Gate section in docs/reference-configs/sprint-contracts.md).
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260807-1606-mcp-scope-retirement.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260807-1606-mcp-scope-retirement.review.md`
+- Notes file: `tasks/notes/20260807-1606-mcp-scope-retirement.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Acceptance Policy
+
+```json
+{"protocol":1,"reviewer":"Claude","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - docs/spec.md
+  - plans/
+  - tasks/todos.md
+  - tasks/contracts/20260807-1606-mcp-scope-retirement.contract.md
+  - tasks/reviews/20260807-1606-mcp-scope-retirement.review.md
+  - tasks/notes/20260807-1606-mcp-scope-retirement.notes.md
+  - .ai/context/capabilities.json
+  - docs/repo-harness-chatgpt-mcp-setup.md
+  - src/cli/mcp/
+  - src/cli/commands/mcp.ts
+  - src/cli/chatgpt-browser/engine.ts
+  - tests/
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+      - codex-exec
+      - main-thread
+    fallback: main-thread
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - docs/spec.md
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260807-1606-mcp-scope-retirement.notes.md
+  tests_pass:
+    - path: tests/cli/mcp-setup.test.ts
+  commands_succeed:
+    - bun run check:type
+    - bun test
+    - bun src/cli/index.ts init --repo . --dry-run
+```
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior:
+- Edge cases:
+- Regression risks:
+
+## Rollback Point
+
+- Commit / checkpoint:
+- Revert strategy:

--- a/tasks/notes/20260807-1606-mcp-scope-retirement.notes.md
+++ b/tasks/notes/20260807-1606-mcp-scope-retirement.notes.md
@@ -1,0 +1,203 @@
+# Implementation Notes: mcp-scope-retirement
+
+> **Status**: Active
+> **Plan**: plans/plan-20260807-1606-mcp-scope-retirement.md
+> **Contract**: tasks/contracts/20260807-1606-mcp-scope-retirement.contract.md
+> **Review**: tasks/reviews/20260807-1606-mcp-scope-retirement.review.md
+> **Last Updated**: 2026-08-07 16:50
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- **Path helpers lost their `repoRoot` parameter, not just the `scope` one.**
+  `mcpStorageDir(repoRoot, scope)` only needed `repoRoot` to build the repo-scope
+  branch. With that branch gone, `repoRoot` is unused, so
+  `mcpLocalConfigPath()` / `mcpTokenPath()` / `mcpOAuthPath()` /
+  `mcpOAuthTokenStorePath()` / `loadMcpLocalConfig()` / `readMcpBearerToken()` /
+  `ensureMcpBearerToken()` / `readMcpOAuthPassphrase()` /
+  `ensureMcpOAuthPassphrase()` are all zero-arg now. Keeping a vestigial
+  `repoRoot` would have been dead signature surface implying a per-repo lookup
+  that no longer exists.
+
+- **The `scope` field is gone from `McpLocalConfig`, not just from the type
+  union.** Setup no longer writes it, and `parseMcpLocalConfig` no longer
+  validates it. Older user configs carrying `"scope": "user"` still parse (an
+  unknown key is ignored), so existing user-level installs are untouched, but
+  nothing reads the field. `server.ts` dropped its `config.scope !== 'user'`
+  precondition for the same reason.
+
+- **Gate placement: five command entrypoints, uniformly.**
+  `assertNoLegacyRepoScopeMcpConfig(repoRoot)` runs at `createMcpToolContext`
+  (covers `serve` on both transports and `prepare-goal`), `startMcpHttp`,
+  `runMcpSetupChatgpt`, `runMcpDoctor`, and `runMcpLiveDoctor`. `doctor` is
+  gated too even though a diagnostic that refuses to run is mildly
+  user-hostile: the thrown message already names the exact fix command, and one
+  uniform rule beats a per-command exemption list. `runMcpPrintGuide` is not
+  gated because it reads no MCP config.
+
+- **The gate keys on `<repo>/.repo-harness/mcp.local.json` only.**
+  `migrate-scope` cleans up any of the four legacy files, but a stray token file
+  without a config does not block commands — there is nothing to read from it,
+  and blocking on it would strand users with no config to migrate.
+
+- **`migrate-scope` merge direction: existing user values win, legacy fills
+  gaps.** The user config is the surviving authority, so migration must never
+  silently overwrite it with a stale repo-scope value. Fields that the user
+  config already sets are kept and are not listed in the migrated-fields
+  inventory; only the gaps are inherited.
+
+- **Rotation semantics: legacy secrets are always discarded, user secrets are
+  never rotated.** `ensureMcpBearerToken()` / `ensureMcpOAuthPassphrase()`
+  generate fresh values only when the user-level file is absent. A repo that had
+  only repo-scope storage therefore gets genuinely new credentials, while an
+  existing user-level install keeps working (contract: "Existing user-scope
+  installs untouched"). Either way the legacy bearer/passphrase values are
+  deleted, never copied. The inventory line distinguishes `regenerated` from
+  `existing user-level token kept; legacy value discarded`.
+
+- **`mcp.oauth-tokens.json`: only the repo-side store is deleted.** That forces
+  the one ChatGPT re-authorization the plan calls for. The user-side store is
+  left alone; touching it would revoke grants for unrelated repos.
+
+- **`migrate-scope` refuses a legacy config claiming `profile: coding`.**
+  Repo-scope coding setup was rejected by the old code, so such a file is
+  unreachable through supported paths. Rather than synthesize the coding grant
+  and authorization-revision state it would need, the command fails closed and
+  points at the real coding setup command.
+
+- **`harness_doctor` derives `mcp.localConfig` from the storage authority, not
+  from a path probe** (gatekeeper finding, HIGH). `tools.ts` was still doing
+  `existsSync(join(target.repoRoot, '.repo-harness', 'mcp.local.json'))`, which
+  after the retirement reports `false` for a correct user-level install and
+  `true` for an unmigrated legacy repo. Worse, `target.repoRoot` can be a
+  different repo resolved through `repo_path`, which the startup gate never
+  inspected. Now `Boolean(loadMcpLocalConfig())`, matching `setup.ts:1050`, so
+  both doctor surfaces read the same single authority.
+
+- **`migrate-scope` moves data and rotates credentials; it does not recompute
+  derived config.** `capabilities`, `coding`, and `devMode` are carried over
+  from the existing user config only. The command's `Next:` line points at
+  `repo-harness mcp setup chatgpt --repo <repo>`, which owns that derivation.
+  Duplicating setup's capability logic inside the migration would create a
+  second authority for the same computation.
+
+## Deviations From Plan Or Spec
+
+- **`mcp setup codex --scope project|user` was left in place.** The plan says
+  "`--scope` CLI flags ... deleted", but that flag selects the *Codex* config
+  location (`.codex/config.toml` project vs. user), not an `McpConfigScope`. It
+  is a different axis from MCP storage and is out of the retirement's blast
+  radius. Only `setup chatgpt --scope` was removed.
+
+- **`engine.ts`: removed the dead `.gitignore` read, kept the `ignoreLines`
+  array.** The contract names "the `ignoreLines` block", but the array itself is
+  live — it feeds the "Recommended .gitignore entries" output. The genuinely
+  dead code was the `gitignorePath` binding, the `existsSync` block that read
+  `.gitignore` into a `void`-ed `Bun.file` handle, and the `let updated = false`
+  flag whose ternary could only ever pick one branch. Those are gone; the
+  printed output is byte-identical.
+
+- **`docs/repo-harness-chatgpt-mcp-setup.md` regeneration collapsed
+  pre-existing drift.** The tracked doc was already stale against its generator
+  at HEAD (HEAD's `chatgptGuideMarkdown()` emitted "General Repo Reader
+  Reference" while the tracked file still said "General Repo Reader Contract",
+  plus a long superseded reader-contract section). Regenerating with
+  `mcp print-chatgpt-guide --repo . --write` produces the deterministic
+  projection, so the diff is larger than the scope edits alone (+56/-113). The
+  file is generated output; hand-patching only my lines would have left it
+  drifted against its own source.
+
+- **Guide section ordering corrected after acceptance review** (gatekeeper
+  finding, MEDIUM). The `## Migrate From Retired Repo-Scope Storage` heading was
+  first inserted immediately after the coding-profile command block, which
+  orphaned the trailing coding prose ("It exposes `open_workspace`...", "Bash
+  has local-user authority and is not a filesystem sandbox...", including the
+  shell-authority security warning) under the migration heading. The migration
+  block now sits after the coding section ends, so the coding prose reads
+  contiguously. Regeneration is idempotent (verified byte-identical on a second
+  `--write`).
+
+- **Added `withTmpRepoAsync` to `tests/cli/mcp-setup.test.ts`.** The existing
+  `withTmpRepo` returns `fn(...)` from a `try/finally`, so an async body would
+  have its temp dirs removed and `REPO_HARNESS_HOME` restored before it
+  finished. The new `harness_doctor` test awaits `callMcpTool`, so it needs the
+  awaiting variant.
+
+- **`tests/capability-config.test.ts` "reuses existing registry entries" got an
+  explicit `30_000` timeout — the sixth instance of a known class, not new
+  compensating code.** Precedent: `a2381159` ("test(verify): make five
+  load-sensitive tests robust under machine load", 0.13.1 changelog), which gave
+  subprocess-heavy tests explicit 30s timeouts in place of bun's default 5000ms
+  after they died at 5029-5052ms under machine load. This test spawns two cold
+  `bun scripts/capability-config.ts` subprocesses and failed at 5008ms/5095ms in
+  two consecutive full-suite runs while passing 3/3 in isolation (~2.7s) and
+  under 4-way parallel load. It has no MCP references and is untouched by this
+  work-package. Shape matches the precedent: positional `}, 30_000);`, which
+  keeps hang detection rather than removing the bound.
+
+- **Fixed a test-isolation defect surfaced by the storage change.**
+  `tests/cli/mcp-setup.test.ts`'s CLI subprocess case did not pass
+  `REPO_HARNESS_HOME` to the spawned child. Harmless while the default scope was
+  `repo`; after the change the child wrote to the real operator
+  `~/.repo-harness`. Both `spawnSync` calls in that file now pass an explicit
+  `env`. See "Incident" below.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| Gate `doctor` vs. let it diagnose the legacy state | Gate it | One uniform fail-closed rule; the error already names the fix command |
+| Rotate user secrets on every migration vs. only when absent | Only when absent | Contract requires existing user installs stay untouched; legacy values are discarded either way |
+| Legacy values win vs. user values win on merge | User values win | The user config is the surviving authority; migration must not regress it |
+| Keep `repoRoot` on path helpers vs. drop it | Drop it | Unused parameter would imply a per-repo lookup that no longer exists |
+| Hand-patch the tracked guide vs. regenerate it | Regenerate | It is generated output; hand-patching re-drifts it against its generator |
+| Delete `setup codex --scope` too vs. keep it | Keep | Different axis (Codex config location), outside the MCP storage retirement |
+
+## Incident: leaked write to the real `~/.repo-harness` during the first full-suite run
+
+The first `bun test` run (before the isolation fix) executed
+`mcp setup chatgpt` in a subprocess without `REPO_HARNESS_HOME`, so it wrote to
+the operator's real user-level MCP storage.
+
+Observed and repaired:
+
+- `~/.repo-harness/mcp.local.json` was rewritten. `chatgpt.serverName` was
+  overwritten to the test value `team-review-mcp`, and `repo` was pointed at a
+  now-deleted temp dir. The `repo` field was restored to
+  `/Users/ancienttwo/Projects/repo-harness`. **The original `serverName` is not
+  recoverable** (no backup existed); re-run
+  `repo-harness mcp setup chatgpt --repo . --server-name <real-name>` to restore it.
+- `~/.repo-harness/registered-repos.json` gained one stray entry
+  (`repo_5b0698a39f150b9f`, a temp path, `source: mcp-setup`). Removed; the
+  registry went 799 -> 798 entries.
+- `mcp.tokens.json`, `mcp.oauth.json`, and `mcp.oauth-tokens.json` were **not**
+  modified (mtimes unchanged from June). No credential was rotated or exposed.
+
+The registry already carried ~790 stale temp-path entries from earlier `init`
+test runs, so per-test registry leakage is a broader pre-existing isolation gap
+in the suite, not something this work-package introduced.
+
+## Open Questions
+
+- Whether the broader test-suite registry leakage (`init` tests writing temp
+  paths into the real `~/.repo-harness/registered-repos.json`) deserves its own
+  slice. Out of scope here; recorded for the deferred-goal ledger.
+
+## Evidence Links
+
+- Manual legacy-fixture trace: gate error -> `migrate-scope` -> rotated
+  credentials -> idempotent re-run (transcript in the task report)
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Candidate for `tasks/lessons.md` if it recurs: when a default storage location
+  moves from repo-local to user-level, every test subprocess that previously did
+  not need `REPO_HARNESS_HOME` becomes a write path into real operator state.
+  Audit `spawnSync`/`Bun.spawn` env in tests as part of any storage-authority
+  change. Holding for a second occurrence before promoting.

--- a/tasks/reviews/20260807-1606-mcp-scope-retirement.review.md
+++ b/tasks/reviews/20260807-1606-mcp-scope-retirement.review.md
@@ -1,84 +1,97 @@
 # Task Review: mcp-scope-retirement
 
-> **Status**: Pending
+> **Status**: Complete
 > **Plan**: plans/plan-20260807-1606-mcp-scope-retirement.md
 > **Contract**: tasks/contracts/20260807-1606-mcp-scope-retirement.contract.md
 > **Notes File**: tasks/notes/20260807-1606-mcp-scope-retirement.notes.md
 > **Checks File**: .ai/harness/checks/latest.json
-> **Last Updated**: 2026-08-07 16:06
-> **Recommendation**: fail
+> **Last Updated**: 2026-08-07 22:30
+> **Recommendation**: pass
 > **Review Rubric Version**: 2
 > **Reviewed Subject SHA256**: pending
 > **Reviewed Subject Scope**: normalized-final-content
 > **Reviewed Target Revision**: pending
 
+The two `pending` header fields are rubric metadata; the authoritative values
+are written into the Acceptance Receipt Projection below by the receipt tooling.
+
 ## Human Review Card
 
-- Verdict: pending
-- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
-- Intended files changed:
-- Actual files changed:
-- Commands passed:
-- Residual risks:
-- Reviewer action required: inspect diff and card
-- Rollback:
+- Verdict: pass
+- Change type: migration
+- Intended files changed: `src/cli/mcp/` scope branches plus the migration gate and command, `src/cli/commands/mcp.ts` CLI wiring, the dead `ignoreLines` block in `src/cli/chatgpt-browser/engine.ts`, affected tests under `tests/cli/`, and `docs/repo-harness-chatgpt-mcp-setup.md` — all inside contract `allowed_paths`.
+- Actual files changed: 17 paths (+1330 -513), all inside `allowed_paths`. Code: `src/cli/mcp/auth.ts`, `src/cli/mcp/setup.ts`, `src/cli/mcp/server.ts`, `src/cli/mcp/transports/http.ts`, `src/cli/mcp/tools.ts`, `src/cli/commands/mcp.ts`, `src/cli/chatgpt-browser/engine.ts`. Tests: `tests/cli/mcp-setup.test.ts`, `tests/cli/mcp-http.test.ts`, `tests/helpers/chatgpt-mcp-contract.ts`, `tests/capability-config.test.ts` (load-robustness timeout only, precedent `a2381159`). Docs: `docs/repo-harness-chatgpt-mcp-setup.md` (regenerated). Workflow artifacts: plan, contract, notes, this review, `tasks/todos.md` (timestamp only).
+- Commands passed: `repo-harness run verify-sprint --prepare-acceptance` total=9 failed=0 status=Fulfilled, including full `bun test` (491.2s) , `bun run check:type`, `bun src/cli/index.ts init --repo . --dry-run`, and `tests_pass: tests/cli/mcp-setup.test.ts`. Independent gatekeeper runs: full `bun test` 2222 pass / 1 skip / 0 fail (725s, `REPO_HARNESS_HOME` unset), targeted `bun test` over the three touched test files 48 pass / 0 fail, `bun run check:type`, `init --dry-run`.
+- Residual risks: the fail-closed gate keys only on `mcp.local.json`, so a repo whose legacy config was hand-deleted while `mcp.tokens.json` or `mcp.oauth-tokens.json` remain will not be prompted to migrate (conformant with the contract Goal wording; `migrate-scope` still cleans all four when run). Gate coverage is complete in code across five entrypoints but only three are asserted by tests — `startMcpHttp` and `runMcpLiveDoctor` are unasserted. `runMcpMigrateScope` spreads `...existingUser` at top level, so a stale `"scope"` key survives one migration where `runMcpSetupChatgpt` drops it.
+- Reviewer action required: none
+- Rollback: single squash revert restores the dual-scope shape; no user-side persisted-data format change, and existing user-level installs were never rewritten.
 
 ## Mode Evidence
 
-- Selected route:
-- P1/P2/P3 evidence:
-- Root cause or plan evidence:
+- Selected route: gatekeeper acceptance review of an uncommitted delivery in the isolated worktree `codex/mcp-scope-retirement`, across two review rounds (round 1 returned FAIL with two blocking findings; round 2 verified the fixes).
+- P1/P2/P3 evidence: P1 — enumerated every MCP subcommand in `src/cli/commands/mcp.ts` and mapped each to its config readers, establishing that only `serve`, `doctor`, `setup chatgpt`, and the doctor surfaces read MCP config, and that `access`, `workspaces`, `setup codex`, `install-skill`, and `print-chatgpt-guide` do not. P2 — traced the storage path end to end: `mcpStorageDir()` now resolves solely to `repoHarnessHome()`, with `legacyRepoScopeMcpPaths` retained only so the gate and migration can name and remove the retired layout; confirmed by an independent mktemp legacy fixture driven through gate to migration to idempotent re-run. P3 — the retirement preserves the one-source-of-truth invariant and fails closed rather than adding a read-through fallback, which repo policy forbids; the falsifier (a deployment shape that can set neither `REPO_HARNESS_HOME` nor write `$HOME`) does not exist because all three home-resolution sites honor `REPO_HARNESS_HOME`.
+- Root cause or plan evidence: plan `plans/plan-20260807-1606-mcp-scope-retirement.md` Slice 2; Task Profile is `migration`, so the Root Cause Evidence Gate does not apply.
 
 ## Verification Evidence
 
-- Waza `/check` run:
-- Commands run:
-- Manual checks:
-- Supporting artifacts:
-- Implementation notes reviewed:
-- Run snapshot:
+- Waza `/check` run: not applicable; verification ran through the contract exit criteria and the repo required checks.
+- Commands run: `verify-sprint --prepare-acceptance` (Fulfilled, 9/9) and the confirming `verify-sprint` (finalized without rerunning verification). Gatekeeper-side: full `bun test` twice with `REPO_HARNESS_HOME` unset (2221/1/0 pre-fix, 2222/1/0 post-fix), targeted `bun test` (48 pass / 0 fail), `bun run check:type`, `bun src/cli/index.ts init --repo . --dry-run`.
+- Manual checks: independent mktemp legacy fixture traced through all five steps — gate exits 2 naming `repo-harness mcp migrate-scope`, no user config written while the gate holds; `migrate-scope` carries `server.host`, `server.port`, `chatgpt.serverName`, `chatgpt.endpoint`, `profile`; regenerated bearer and passphrase both differ from the seeded legacy values with zero occurrences of the legacy secrets anywhere under the new storage root; all four legacy files removed; gate released and `doctor` exits 0; re-run reports "Nothing to migrate" with credentials unchanged. Breaking-surface check: a pre-existing user config carrying `"scope":"user"` still parses, `doctor` exits 0, and the dead key is dropped on the next setup while `chatgpt.serverName` is preserved. Residue sweep: `McpConfigScope`, `resolveMcpConfigScope`, and `parseMcpConfigScope` are absent from `src/`, `scripts/`, `assets/`, and `tests/`; the only remaining `--scope` occurrences belong to `setup codex` (Codex config location, a different axis); the only repo-root-relative `.repo-harness` MCP path left in `src/` is `legacyRepoScopeMcpPaths`, with `tools.ts:80` being a sensitive-directory deny-list entry. Out-of-scope surfaces confirmed untouched: `src/cli/mcp/oauth.ts`, `src/cli/chatgpt-browser/binding.ts`, `src/effects/repo-registry.ts`. Guide integrity: the tracked guide is byte-identical to a fresh generation and stable across a second generation. Test isolation: `~/.repo-harness` snapshotted before and after a full suite run with `REPO_HARNESS_HOME` unset — `mcp.local.json`, `mcp.tokens.json`, `mcp.oauth.json`, and `mcp.oauth-tokens.json` all byte-identical, confirming the leaked-write defect is closed.
+- Supporting artifacts: `.ai/harness/checks/latest.json` (verification evidence bound into the AcceptanceReceipt below); run snapshot `.ai/harness/runs/run-20260807T221739-96835-20260807-1606-mcp-scope-retirement.json`.
+- Implementation notes reviewed: yes — `tasks/notes/20260807-1606-mcp-scope-retirement.notes.md`, including its disclosed incident section.
+- Run snapshot: `.ai/harness/runs/run-20260807T221739-96835-20260807-1606-mcp-scope-retirement.json`
 
 ## Acceptance Receipt Projection
 
-> **Disposition**: unavailable
-> **Reviewer**: unavailable
-> **Source**: unavailable
+> **Disposition**: external_pass
+> **Reviewer**: Claude
+> **Source**: claude-review
 > **Actor**: not-applicable
-> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject SHA256**: sha256:d8ce077c27bdf773cbd8e49f38dce9f7a0af3af730bbc16e5e5f8b92b4ee731b
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: pending
-> **Verification Evidence SHA256**: pending
-> **Issued At**: pending
+> **Reviewed Target Revision**: 2058149b2de9d333cea690efc619c9bb1c1958bb
+> **Verification Evidence SHA256**: sha256:1ae7c485c2f94b3f75dcc9ddbec6ecf1f79d1c36c0893a552a873ff191047fa3
+> **Issued At**: 2026-08-07T14:27:55.427Z
 
-- Summary: No AcceptanceReceipt has been recorded.
+- Summary: Repo-scope MCP storage retired to a single user-level authority; gate, migration, and rotation verified against a legacy fixture
 - Findings: none
 
 ## Behavior Diff Notes
 
-- ...
+- MCP config and credentials resolve only under `~/.repo-harness/` (or `REPO_HARNESS_HOME`). `mcpStorageDir()` no longer takes a repo root, and no MCP command writes into a repo working tree.
+- Five entrypoints (`createMcpToolContext`, `startMcpHttp`, `runMcpSetupChatgpt`, `runMcpDoctor`, `runMcpLiveDoctor`) abort with exit 2 while a legacy `<repo>/.repo-harness/mcp.local.json` exists, naming `repo-harness mcp migrate-scope`. There is no read-through fallback.
+- `repo-harness mcp migrate-scope` is new: non-secret fields merge with user values winning, bearer and passphrase are regenerated rather than relocated, the repo-scope OAuth token store is deleted, legacy files are removed, and an inventory is printed. A second run reports nothing to migrate.
+- `harness_doctor` now reports `mcp.localConfig` from the single storage authority instead of probing the retired repo-scope path, so it agrees with `runMcpDoctor` on the same repo.
+- `setup codex --scope` is unchanged; it selects the Codex config location and is a different axis from MCP storage.
 
 ## Residual Risks / Follow-ups
 
-- ...
+- Gate detection keys only on `mcp.local.json` while the migration inventory cleans four files; widening it is deferred and does not contradict the contract Goal.
+- `startMcpHttp` and `runMcpLiveDoctor` carry the gate but have no test asserting it.
+- Operator state: the round-1 test-isolation defect overwrote `~/.repo-harness/mcp.local.json` `chatgpt.serverName` with the fixture value `team-review-mcp` before it was fixed. The original name is unrecoverable; restore with `repo-harness mcp setup chatgpt --repo . --server-name <real-name>`. Credentials were never modified.
+- Suite-wide isolation gap unrelated to this slice: `init` tests still register temp paths into the real `~/.repo-harness/registered-repos.json`, and an acceptance-gate receipt is rewritten under the real home during full runs. Recorded in the notes as an Open Question deserving its own slice.
 
 ## Scorecard
 
 | Dimension | Score | Notes |
 |-----------|-------|-------|
-| Functionality | 0/10 | |
-| Product depth | 0/10 | |
-| Design quality | 0/10 | |
-| Code quality | 0/10 | |
+| Functionality | 9/10 | Gate, migration, rotation, and idempotency all verified against an independent fixture; two gated entrypoints remain unasserted by tests. |
+| Product depth | 9/10 | One-command migration with an explicit rotated/invalidated inventory and a fail-closed error that names the fix. |
+| Design quality | 9/10 | Single storage authority with no compatibility fallback; the retired layout survives only as a named migration target. |
+| Code quality | 9/10 | Path helpers lost their dead parameter and both doctor surfaces now read one authority; `migrate-scope` still carries a stale key forward through a top-level spread. |
 
 ## Failing Items
 
-- ...
+- none
 
 ## Retest Steps
 
-- Re-run:
-- Re-check:
+- Re-run: `repo-harness run verify-sprint --prepare-acceptance`
+- Re-check: seed `<repo>/.repo-harness/mcp.local.json` in a scratch repo with an isolated `REPO_HARNESS_HOME`, confirm MCP commands exit 2 naming the migration, run `repo-harness mcp migrate-scope --repo <repo>`, confirm the regenerated bearer and passphrase differ from the seeded values, and confirm a second run reports nothing to migrate.
 
 ## Summary
 
-- ...
+- Repo scope is fully retired: `McpConfigScope` and every branch on it are gone, `--scope` is removed from `mcp setup chatgpt`, and `~/.repo-harness/` is the single storage authority.
+- The migration is the explicit, bounded one-shot path repo policy requires: it fails closed, rotates credentials instead of relocating them, deletes the repo-scope OAuth grants, removes the legacy files, and is idempotent.
+- Round 1 returned FAIL on two blocking findings — `harness_doctor` still probing the retired path, and the migration section splicing the coding-profile prose in the generated guide. Round 2 verified both fixes, including a new test asserting the two doctor surfaces agree across three states.
+- Accepted as `external_pass` against `origin/main` `2058149b`.

--- a/tasks/reviews/20260807-1606-mcp-scope-retirement.review.md
+++ b/tasks/reviews/20260807-1606-mcp-scope-retirement.review.md
@@ -1,0 +1,84 @@
+# Task Review: mcp-scope-retirement
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260807-1606-mcp-scope-retirement.md
+> **Contract**: tasks/contracts/20260807-1606-mcp-scope-retirement.contract.md
+> **Notes File**: tasks/notes/20260807-1606-mcp-scope-retirement.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-08-07 16:06
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Commands passed:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+- Waza `/check` run:
+- Commands run:
+- Manual checks:
+- Supporting artifacts:
+- Implementation notes reviewed:
+- Run snapshot:
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...

--- a/tests/cli/mcp-http.test.ts
+++ b/tests/cli/mcp-http.test.ts
@@ -267,7 +267,7 @@ describe('mcp http transport', () => {
       mkdirSync(join(repoRoot, '.ai/harness'), { recursive: true });
       writeFileSync(join(repoRoot, '.ai/harness/policy.json'), '{}\n');
       runMcpSetupChatgpt({ repo: repoRoot, port: String(port) });
-      const token = (await Bun.file(join(repoRoot, '.repo-harness/mcp.tokens.json')).json()).bearerToken;
+      const token = (await Bun.file(join(process.env.REPO_HARNESS_HOME!, 'mcp.tokens.json')).json()).bearerToken;
 
       proc = Bun.spawn(
         [
@@ -392,7 +392,7 @@ describe('mcp http transport', () => {
       mkdirSync(join(repoRoot, '.ai/harness'), { recursive: true });
       writeFileSync(join(repoRoot, '.ai/harness/policy.json'), '{}\n');
       runMcpSetupChatgpt({ repo: repoRoot, port: String(port) });
-      const token = (await Bun.file(join(repoRoot, '.repo-harness/mcp.tokens.json')).json()).bearerToken;
+      const token = (await Bun.file(join(process.env.REPO_HARNESS_HOME!, 'mcp.tokens.json')).json()).bearerToken;
 
       proc = Bun.spawn(
         [
@@ -453,7 +453,7 @@ describe('mcp http transport', () => {
       mkdirSync(join(repoRoot, '.ai/harness'), { recursive: true });
       writeFileSync(join(repoRoot, '.ai/harness/policy.json'), '{}\n');
       runMcpSetupChatgpt({ repo: repoRoot, port: String(port) });
-      const passphrase = (await Bun.file(join(repoRoot, '.repo-harness/mcp.oauth.json')).json()).passphrase;
+      const passphrase = (await Bun.file(join(process.env.REPO_HARNESS_HOME!, 'mcp.oauth.json')).json()).passphrase;
 
       proc = Bun.spawn(
         [
@@ -625,7 +625,6 @@ describe('mcp http transport', () => {
       runGit('commit', '-m', 'fixture');
       runMcpSetupChatgpt({
         repo: repoRoot,
-        scope: 'user',
         profile: 'coding',
         grantReadWrite: [repoRoot],
         endpoint: 'https://coding.test/mcp',

--- a/tests/cli/mcp-setup.test.ts
+++ b/tests/cli/mcp-setup.test.ts
@@ -8,11 +8,13 @@ import {
   patchCodexConfigToml,
   runMcpDoctor,
   runMcpInstallSkill,
+  runMcpMigrateScope,
   runMcpPrintGuide,
   runMcpSetupChatgpt,
   runMcpSetupCodex,
 } from '../../src/cli/mcp/setup';
 import { createMcpToolContext } from '../../src/cli/mcp/server';
+import { callMcpTool } from '../../src/cli/mcp/tools';
 import { repoHarnessPackageVersion } from '../../src/cli/mcp/version';
 import { assertChatGptMcpContract } from '../helpers/chatgpt-mcp-contract';
 import {
@@ -23,7 +25,7 @@ import {
 
 const CLI = join(import.meta.dir, '../..', 'src/cli/index.ts');
 
-function withTmpRepo<T>(fn: (repoRoot: string) => T): T {
+function withTmpRepo<T>(fn: (repoRoot: string, userHome: string) => T): T {
   const repoRoot = mkdtempSync(join(tmpdir(), 'repo-harness-mcp-setup-'));
   const repoHarnessHome = mkdtempSync(join(tmpdir(), 'repo-harness-mcp-setup-home-'));
   const previousRepoHarnessHome = process.env.REPO_HARNESS_HOME;
@@ -31,7 +33,7 @@ function withTmpRepo<T>(fn: (repoRoot: string) => T): T {
     process.env.REPO_HARNESS_HOME = repoHarnessHome;
     mkdirSync(join(repoRoot, '.ai/harness'), { recursive: true });
     writeFileSync(join(repoRoot, '.ai/harness/policy.json'), '{}\n');
-    return fn(repoRoot);
+    return fn(repoRoot, repoHarnessHome);
   } finally {
     if (previousRepoHarnessHome === undefined) delete process.env.REPO_HARNESS_HOME;
     else process.env.REPO_HARNESS_HOME = previousRepoHarnessHome;
@@ -40,21 +42,83 @@ function withTmpRepo<T>(fn: (repoRoot: string) => T): T {
   }
 }
 
+/**
+ * Async counterpart of withTmpRepo. The sync version returns fn's value from a
+ * try/finally, so an async body would have its temp dirs removed and its
+ * REPO_HARNESS_HOME restored before it finished.
+ */
+async function withTmpRepoAsync<T>(fn: (repoRoot: string, userHome: string) => Promise<T>): Promise<T> {
+  const repoRoot = mkdtempSync(join(tmpdir(), 'repo-harness-mcp-setup-'));
+  const repoHarnessHome = mkdtempSync(join(tmpdir(), 'repo-harness-mcp-setup-home-'));
+  const previousRepoHarnessHome = process.env.REPO_HARNESS_HOME;
+  try {
+    process.env.REPO_HARNESS_HOME = repoHarnessHome;
+    mkdirSync(join(repoRoot, '.ai/harness'), { recursive: true });
+    writeFileSync(join(repoRoot, '.ai/harness/policy.json'), '{}\n');
+    return await fn(repoRoot, repoHarnessHome);
+  } finally {
+    if (previousRepoHarnessHome === undefined) delete process.env.REPO_HARNESS_HOME;
+    else process.env.REPO_HARNESS_HOME = previousRepoHarnessHome;
+    rmSync(repoRoot, { recursive: true, force: true });
+    rmSync(repoHarnessHome, { recursive: true, force: true });
+  }
+}
+
+/** Materialize the retired repo-scope layout a pre-migration install would have. */
+function writeLegacyRepoScopeMcpState(repoRoot: string, overrides: Record<string, unknown> = {}): {
+  config: string;
+  tokens: string;
+  oauth: string;
+  oauthTokens: string;
+  bearerToken: string;
+  passphrase: string;
+} {
+  const dir = join(repoRoot, '.repo-harness');
+  mkdirSync(dir, { recursive: true });
+  const paths = {
+    config: join(dir, 'mcp.local.json'),
+    tokens: join(dir, 'mcp.tokens.json'),
+    oauth: join(dir, 'mcp.oauth.json'),
+    oauthTokens: join(dir, 'mcp.oauth-tokens.json'),
+    bearerToken: 'legacy-repo-scope-bearer-token-value',
+    passphrase: 'legacy-repo-scope-passphrase-value',
+  };
+  writeFileSync(paths.config, `${JSON.stringify({
+    version: 3,
+    scope: 'repo',
+    repo: repoRoot,
+    server: { host: '0.0.0.0', port: 9911, transport: 'http' },
+    auth: { mode: 'oauth', oauthFile: '.repo-harness/mcp.oauth.json', tokenFile: '.repo-harness/mcp.tokens.json' },
+    chatgpt: { serverName: 'legacy-repo-connector', endpoint: 'https://legacy-repo.example.com/mcp' },
+    permissions: { allowedRoots: [], discoveryRoots: [], fullDiskRead: false },
+    profile: 'planner',
+    ...overrides,
+  }, null, 2)}\n`);
+  writeFileSync(paths.tokens, `${JSON.stringify({ version: 1, bearerToken: paths.bearerToken }, null, 2)}\n`);
+  writeFileSync(paths.oauth, `${JSON.stringify({ version: 1, passphrase: paths.passphrase }, null, 2)}\n`);
+  writeFileSync(paths.oauthTokens, `${JSON.stringify({ version: 1, authorizations: {} }, null, 2)}\n`);
+  return paths;
+}
+
 describe('mcp setup', () => {
-  test('generates ChatGPT local config, guide, and ignore entries', () => {
-    withTmpRepo((repoRoot) => {
+  test('stores ChatGPT config and credentials only under user-level storage', () => {
+    withTmpRepo((repoRoot, userHome) => {
       const result = runMcpSetupChatgpt({ repo: repoRoot });
       expect(result.changed.length).toBeGreaterThan(0);
-      expect(existsSync(join(repoRoot, '.repo-harness/mcp.local.json'))).toBe(true);
-      expect(existsSync(join(repoRoot, '.repo-harness/mcp.tokens.json'))).toBe(true);
-      expect(existsSync(join(repoRoot, '.repo-harness/mcp.oauth.json'))).toBe(true);
-      expect(existsSync(join(repoRoot, 'docs/repo-harness-chatgpt-mcp-setup.md'))).toBe(true);
-      const config = JSON.parse(readFileSync(join(repoRoot, '.repo-harness/mcp.local.json'), 'utf-8'));
-      expect(config.auth).toMatchObject({
-        mode: 'oauth',
-        oauthFile: '.repo-harness/mcp.oauth.json',
-        tokenFile: '.repo-harness/mcp.tokens.json',
-      });
+      expect(existsSync(join(userHome, 'mcp.local.json'))).toBe(true);
+      expect(existsSync(join(userHome, 'mcp.tokens.json'))).toBe(true);
+      expect(existsSync(join(userHome, 'mcp.oauth.json'))).toBe(true);
+      // Retired repo scope: setup writes nothing into the repo working tree.
+      expect(existsSync(join(repoRoot, '.repo-harness'))).toBe(false);
+      expect(existsSync(join(repoRoot, '.gitignore'))).toBe(false);
+      expect(existsSync(join(repoRoot, 'docs/repo-harness-chatgpt-mcp-setup.md'))).toBe(false);
+      const config = JSON.parse(readFileSync(join(userHome, 'mcp.local.json'), 'utf-8'));
+      expect(config.scope).toBeUndefined();
+      expect(config.auth).toMatchObject({ mode: 'oauth' });
+      expect(config.auth.oauthFile).toContain('mcp.oauth.json');
+      expect(config.auth.tokenFile).toContain('mcp.tokens.json');
+      expect(config.auth.oauthFile.startsWith('.repo-harness/')).toBe(false);
+      expect(config.auth.tokenFile.startsWith('.repo-harness/')).toBe(false);
       expect(config.chatgpt.serverName).toBe('repo-harness');
       expect(config.devMode).toMatchObject({
         agentRunner: false,
@@ -62,26 +126,19 @@ describe('mcp setup', () => {
         timeoutMs: 120000,
       });
       expect(config.rollout).toBeUndefined();
-      const token = JSON.parse(readFileSync(join(repoRoot, '.repo-harness/mcp.tokens.json'), 'utf-8')).bearerToken;
+      const token = JSON.parse(readFileSync(join(userHome, 'mcp.tokens.json'), 'utf-8')).bearerToken;
       expect(typeof token).toBe('string');
       expect(token.length).toBeGreaterThan(30);
-      const passphrase = JSON.parse(readFileSync(join(repoRoot, '.repo-harness/mcp.oauth.json'), 'utf-8')).passphrase;
+      const passphrase = JSON.parse(readFileSync(join(userHome, 'mcp.oauth.json'), 'utf-8')).passphrase;
       expect(typeof passphrase).toBe('string');
       expect(passphrase.length).toBeGreaterThan(20);
-      const ignore = readFileSync(join(repoRoot, '.gitignore'), 'utf-8');
-      expect(ignore).toContain('.repo-harness/mcp.local.json');
-      expect(ignore).toContain('.repo-harness/mcp.tokens.json');
-      expect(ignore).toContain('.repo-harness/mcp.oauth.json');
-      expect(ignore).toContain('.repo-harness/mcp.oauth-tokens.json');
-      expect(ignore).toContain('.ai/harness/mcp/audit.log');
-      expect(ignore).toContain('.ai/harness/mcp/index-events.jsonl');
-      expect(ignore).toContain('.ai/harness/mcp/metrics.jsonl');
-      expect(ignore).toContain('.ai/harness/mcp/trace.jsonl');
 
       const doctor = JSON.parse(runMcpDoctor({ repo: repoRoot, json: true }).lines[0]);
       expect(doctor.mcp.packageVersion).toBe(repoHarnessPackageVersion());
       expect(doctor.mcp.authConfigured).toBe(true);
-      expect(doctor.mcp.permissions.configurationScope).toBe('repo');
+      expect(doctor.mcp.storageDir).toBe(userHome);
+      expect(doctor.mcp.configScope).toBeUndefined();
+      expect(doctor.mcp.permissions.configurationScope).toBeUndefined();
       expect(doctor.mcp.devMode.agentRunner).toBe(false);
       expect(doctor.chatgpt.serverName).toBe('repo-harness');
       expect(doctor.chatgpt.localEndpoint).toBe('http://127.0.0.1:8765/mcp');
@@ -101,20 +158,20 @@ describe('mcp setup', () => {
   });
 
   test('records and preserves the ChatGPT MCP server name in ignored local config', () => {
-    withTmpRepo((repoRoot) => {
+    withTmpRepo((repoRoot, userHome) => {
       const setup = runMcpSetupChatgpt({ repo: repoRoot, serverName: 'team-review-mcp' });
       expect(setup.lines.join('\n')).toContain('ChatGPT MCP server name: team-review-mcp');
 
-      let config = JSON.parse(readFileSync(join(repoRoot, '.repo-harness/mcp.local.json'), 'utf-8'));
+      let config = JSON.parse(readFileSync(join(userHome, 'mcp.local.json'), 'utf-8'));
       expect(config.chatgpt.serverName).toBe('team-review-mcp');
 
       runMcpSetupChatgpt({ repo: repoRoot, endpoint: 'https://repo-harness-mcp.example.com/mcp' });
-      config = JSON.parse(readFileSync(join(repoRoot, '.repo-harness/mcp.local.json'), 'utf-8'));
+      config = JSON.parse(readFileSync(join(userHome, 'mcp.local.json'), 'utf-8'));
       expect(config.chatgpt.serverName).toBe('team-review-mcp');
       expect(config.chatgpt.endpoint).toBe('https://repo-harness-mcp.example.com/mcp');
 
       runMcpSetupChatgpt({ repo: repoRoot });
-      config = JSON.parse(readFileSync(join(repoRoot, '.repo-harness/mcp.local.json'), 'utf-8'));
+      config = JSON.parse(readFileSync(join(userHome, 'mcp.local.json'), 'utf-8'));
       expect(config.chatgpt.serverName).toBe('team-review-mcp');
       expect(config.chatgpt.endpoint).toBe('https://repo-harness-mcp.example.com/mcp');
 
@@ -125,9 +182,9 @@ describe('mcp setup', () => {
   });
 
   test('ignores and removes retired general-repo rollout config on setup', () => {
-    withTmpRepo((repoRoot) => {
+    withTmpRepo((repoRoot, userHome) => {
       runMcpSetupChatgpt({ repo: repoRoot });
-      const configPath = join(repoRoot, '.repo-harness/mcp.local.json');
+      const configPath = join(userHome, 'mcp.local.json');
       const staleConfig = JSON.parse(readFileSync(configPath, 'utf-8'));
       staleConfig.rollout = {
         generalRepo: {
@@ -151,9 +208,9 @@ describe('mcp setup', () => {
   });
 
   test('fails closed when local MCP config cannot be parsed', () => {
-    withTmpRepo((repoRoot) => {
+    withTmpRepo((repoRoot, userHome) => {
       runMcpSetupChatgpt({ repo: repoRoot });
-      const configPath = join(repoRoot, '.repo-harness/mcp.local.json');
+      const configPath = join(userHome, 'mcp.local.json');
       writeFileSync(configPath, '{not-json\n');
 
       expect(() => createMcpToolContext({ repo: repoRoot, profile: 'planner' })).toThrow(
@@ -162,74 +219,212 @@ describe('mcp setup', () => {
     });
   });
 
-  test('user-scope ChatGPT setup stores MCP state under the OS user and authorizes current-repo reader access', () => {
-    withTmpRepo((repoRoot) => {
-      const userState = mkdtempSync(join(tmpdir(), 'repo-harness-user-mcp-'));
-      const previousHome = process.env.REPO_HARNESS_HOME;
-      try {
-        process.env.REPO_HARNESS_HOME = userState;
+  test('ChatGPT setup stores MCP state under the OS user and authorizes current-repo reader access', () => {
+    withTmpRepo((repoRoot, userHome) => {
+      const setup = runMcpSetupChatgpt({
+        repo: repoRoot,
+        serverName: 'team-review-mcp',
+        endpoint: 'https://repo-harness-mcp.example.com/mcp',
+      });
+      expect(setup.lines.join('\n')).toContain(`Storage: ${userHome}`);
+      expect(setup.lines.join('\n')).toContain('Reader capability: enabled');
+      expect(setup.lines.join('\n')).toContain('Registered repo:');
+      expect(setup.lines.join('\n')).toContain('--profile planner');
+      expect(existsSync(join(userHome, 'mcp.local.json'))).toBe(true);
+      expect(existsSync(join(userHome, 'mcp.tokens.json'))).toBe(true);
+      expect(existsSync(join(userHome, 'mcp.oauth.json'))).toBe(true);
+      expect(existsSync(join(userHome, 'registered-repos.json'))).toBe(true);
+      expect(existsSync(join(repoRoot, 'docs/repo-harness-chatgpt-mcp-setup.md'))).toBe(false);
 
-        const setup = runMcpSetupChatgpt({
-          repo: repoRoot,
-          scope: 'user',
+      const config = JSON.parse(readFileSync(join(userHome, 'mcp.local.json'), 'utf-8'));
+      expect(config).toMatchObject({
+        repo: repoRoot,
+        chatgpt: {
           serverName: 'team-review-mcp',
           endpoint: 'https://repo-harness-mcp.example.com/mcp',
-        });
-        expect(setup.lines.join('\n')).toContain('Config scope: user');
-        expect(setup.lines.join('\n')).toContain('Reader capability: enabled');
-        expect(setup.lines.join('\n')).toContain('Registered repo:');
-        expect(setup.lines.join('\n')).toContain('--profile planner');
-        expect(existsSync(join(userState, 'mcp.local.json'))).toBe(true);
-        expect(existsSync(join(userState, 'mcp.tokens.json'))).toBe(true);
-        expect(existsSync(join(userState, 'mcp.oauth.json'))).toBe(true);
-        expect(existsSync(join(userState, 'registered-repos.json'))).toBe(true);
-        expect(existsSync(join(repoRoot, 'docs/repo-harness-chatgpt-mcp-setup.md'))).toBe(false);
+        },
+        capabilities: { workspaceReader: true, workflowPlanner: true },
+        permissions: { fullDiskRead: false, allowedRoots: [], discoveryRoots: [] },
+        profile: 'planner',
+      });
+      expect(config.scope).toBeUndefined();
+      const registry = JSON.parse(readFileSync(join(userHome, 'registered-repos.json'), 'utf-8'));
+      expect(registry.repos).toEqual([
+        expect.objectContaining({ path: realpathSync(repoRoot), source: 'mcp-setup' }),
+      ]);
+      expect(config.auth.oauthFile).toContain('mcp.oauth.json');
+      expect(config.auth.tokenFile).toContain('mcp.tokens.json');
 
-        const config = JSON.parse(readFileSync(join(userState, 'mcp.local.json'), 'utf-8'));
-        expect(config).toMatchObject({
-          scope: 'user',
-          repo: repoRoot,
-          chatgpt: {
-            serverName: 'team-review-mcp',
-            endpoint: 'https://repo-harness-mcp.example.com/mcp',
-          },
-          capabilities: { workspaceReader: true, workflowPlanner: true },
-          permissions: { fullDiskRead: false, allowedRoots: [], discoveryRoots: [] },
-          profile: 'planner',
-        });
-        const registry = JSON.parse(readFileSync(join(userState, 'registered-repos.json'), 'utf-8'));
-        expect(registry.repos).toEqual([
-          expect.objectContaining({ path: realpathSync(repoRoot), source: 'mcp-setup' }),
-        ]);
-        expect(config.auth.oauthFile).toContain('mcp.oauth.json');
-        expect(config.auth.tokenFile).toContain('mcp.tokens.json');
+      const doctor = JSON.parse(runMcpDoctor({ repo: repoRoot, json: true }).lines[0]);
+      expect(doctor.status).toBe('ready_local');
+      expect(doctor.mcp.storageDir).toBe(userHome);
+      expect(doctor.mcp.localConfig).toBe(true);
+      expect(doctor.mcp.authConfigured).toBe(true);
+      expect(doctor.mcp.permissions.fullDiskRead).toBe(false);
+      expect(doctor.mcp.permissions.allowedRootCount).toBe(0);
+      expect(doctor.mcp.permissions.registeredRepoCount).toBe(1);
+      expect(doctor.mcp.capabilities.workspaceReader).toBe(true);
+      expect(doctor.codex.configured).toBe(false);
+      expect(doctor.chatgpt.serverName).toBe('team-review-mcp');
 
-        const doctor = JSON.parse(runMcpDoctor({ repo: repoRoot, json: true }).lines[0]);
-        expect(doctor.status).toBe('ready_local');
-        expect(doctor.mcp.configScope).toBe('user');
-        expect(doctor.mcp.localConfig).toBe(true);
-        expect(doctor.mcp.authConfigured).toBe(true);
-        expect(doctor.mcp.permissions.configurationScope).toBe('user');
-        expect(doctor.mcp.permissions.fullDiskRead).toBe(false);
-        expect(doctor.mcp.permissions.allowedRootCount).toBe(0);
-        expect(doctor.mcp.permissions.registeredRepoCount).toBe(1);
-        expect(doctor.mcp.capabilities.workspaceReader).toBe(true);
-        expect(doctor.codex.configured).toBe(false);
-        expect(doctor.chatgpt.serverName).toBe('team-review-mcp');
+      const ctx = createMcpToolContext({ repo: repoRoot, profile: 'planner' });
+      expect(ctx.policy.allowAbsoluteRead).toBe(false);
+      expect(ctx.policy.capabilities.workspaceReader).toBe(true);
+      expect(ctx.policy.allowedRoots).toEqual([realpathSync(repoRoot)]);
+      expect(ctx.policy.denyGlobs).toContain('.env');
+    });
+  });
 
-        const ctx = createMcpToolContext({ repo: repoRoot, profile: 'planner' });
-        expect(ctx.policy.allowAbsoluteRead).toBe(false);
-        expect(ctx.policy.capabilities.workspaceReader).toBe(true);
-        expect(ctx.policy.allowedRoots).toEqual([realpathSync(repoRoot)]);
-        expect(ctx.policy.denyGlobs).toContain('.env');
-      } finally {
-        if (previousHome === undefined) {
-          delete process.env.REPO_HARNESS_HOME;
-        } else {
-          process.env.REPO_HARNESS_HOME = previousHome;
-        }
-        rmSync(userState, { recursive: true, force: true });
+  test('MCP command entrypoints fail closed on legacy repo-scope config and name the migration', () => {
+    withTmpRepo((repoRoot, userHome) => {
+      const legacy = writeLegacyRepoScopeMcpState(repoRoot);
+      const expectedError = 'repo-harness mcp migrate-scope';
+
+      for (const action of [
+        () => runMcpSetupChatgpt({ repo: repoRoot }),
+        () => runMcpDoctor({ repo: repoRoot, json: true }),
+        () => createMcpToolContext({ repo: repoRoot, profile: 'planner' }),
+      ]) {
+        expect(action).toThrow(expectedError);
+        expect(action).toThrow('legacy repo-scope MCP config detected');
       }
+
+      // No silent read-through: the legacy files stay untouched until the
+      // operator runs the explicit migration.
+      expect(existsSync(legacy.config)).toBe(true);
+      expect(existsSync(legacy.tokens)).toBe(true);
+
+      const cli = spawnSync(
+        process.execPath,
+        [CLI, 'mcp', 'doctor', '--repo', repoRoot],
+        { encoding: 'utf-8', env: { ...process.env, REPO_HARNESS_HOME: userHome } },
+      );
+      expect(cli.status).toBe(2);
+      expect(cli.stderr).toContain('repo-harness mcp migrate-scope');
+    });
+  });
+
+  test('migrate-scope merges non-secret config, rotates credentials, and is idempotent', () => {
+    withTmpRepo((repoRoot, userHome) => {
+      const legacy = writeLegacyRepoScopeMcpState(repoRoot);
+
+      const migrated = runMcpMigrateScope({ repo: repoRoot });
+      const output = migrated.lines.join('\n');
+      expect(migrated.migrated).toBe(true);
+
+      // Non-secret fields land in the surviving user config.
+      const config = JSON.parse(readFileSync(join(userHome, 'mcp.local.json'), 'utf-8'));
+      expect(config).toMatchObject({
+        version: 3,
+        server: { host: '0.0.0.0', port: 9911 },
+        chatgpt: { serverName: 'legacy-repo-connector', endpoint: 'https://legacy-repo.example.com/mcp' },
+        profile: 'planner',
+      });
+      expect(config.scope).toBeUndefined();
+
+      // Credentials are rotated, never relocated.
+      const token = JSON.parse(readFileSync(join(userHome, 'mcp.tokens.json'), 'utf-8')).bearerToken;
+      const passphrase = JSON.parse(readFileSync(join(userHome, 'mcp.oauth.json'), 'utf-8')).passphrase;
+      expect(token).not.toBe(legacy.bearerToken);
+      expect(passphrase).not.toBe(legacy.passphrase);
+      expect(token.length).toBeGreaterThan(30);
+      expect(passphrase.length).toBeGreaterThan(20);
+
+      // Legacy files, including the OAuth token store, are gone.
+      expect(existsSync(legacy.config)).toBe(false);
+      expect(existsSync(legacy.tokens)).toBe(false);
+      expect(existsSync(legacy.oauth)).toBe(false);
+      expect(existsSync(legacy.oauthTokens)).toBe(false);
+
+      // Inventory output names what moved, what rotated, and what was voided.
+      expect(output).toContain('Migrated config fields: server.host, server.port, chatgpt.serverName, chatgpt.endpoint');
+      expect(output).toContain('Rotated bearer token:');
+      expect(output).toContain('Rotated OAuth passphrase:');
+      expect(output).toContain('ChatGPT must re-authorize once');
+      expect(output).toContain('Removed legacy files:');
+      expect(output).toContain(legacy.oauthTokens);
+
+      // The gate is satisfied afterwards.
+      expect(() => runMcpDoctor({ repo: repoRoot, json: true })).not.toThrow();
+
+      // Re-running on a migrated repo reports nothing to do and changes nothing.
+      const rerun = runMcpMigrateScope({ repo: repoRoot });
+      expect(rerun.migrated).toBe(false);
+      expect(rerun.changed).toEqual([]);
+      expect(rerun.lines.join('\n')).toContain('Nothing to migrate');
+      expect(JSON.parse(readFileSync(join(userHome, 'mcp.tokens.json'), 'utf-8')).bearerToken).toBe(token);
+      expect(JSON.parse(readFileSync(join(userHome, 'mcp.oauth.json'), 'utf-8')).passphrase).toBe(passphrase);
+    });
+  });
+
+  test('migrate-scope keeps existing user-level values and never adopts legacy secrets', () => {
+    withTmpRepo((repoRoot, userHome) => {
+      runMcpSetupChatgpt({ repo: repoRoot, serverName: 'existing-user-connector' });
+      const userToken = JSON.parse(readFileSync(join(userHome, 'mcp.tokens.json'), 'utf-8')).bearerToken;
+      const userPassphrase = JSON.parse(readFileSync(join(userHome, 'mcp.oauth.json'), 'utf-8')).passphrase;
+      const legacy = writeLegacyRepoScopeMcpState(repoRoot);
+
+      const migrated = runMcpMigrateScope({ repo: repoRoot });
+      expect(migrated.migrated).toBe(true);
+
+      const config = JSON.parse(readFileSync(join(userHome, 'mcp.local.json'), 'utf-8'));
+      expect(config.chatgpt.serverName).toBe('existing-user-connector');
+      expect(config.server.host).toBe('127.0.0.1');
+      // Only the value the user config lacked is inherited from the legacy file.
+      expect(config.chatgpt.endpoint).toBe('https://legacy-repo.example.com/mcp');
+      expect(migrated.lines.join('\n')).toContain('Migrated config fields: chatgpt.endpoint');
+
+      // An existing user-level install keeps its own credentials; the legacy
+      // values are discarded rather than adopted.
+      const token = JSON.parse(readFileSync(join(userHome, 'mcp.tokens.json'), 'utf-8')).bearerToken;
+      const passphrase = JSON.parse(readFileSync(join(userHome, 'mcp.oauth.json'), 'utf-8')).passphrase;
+      expect(token).toBe(userToken);
+      expect(passphrase).toBe(userPassphrase);
+      expect(token).not.toBe(legacy.bearerToken);
+      expect(passphrase).not.toBe(legacy.passphrase);
+      expect(existsSync(legacy.oauthTokens)).toBe(false);
+    });
+  });
+
+  test('harness_doctor and runMcpDoctor agree on mcp.localConfig from the single storage authority', async () => {
+    // Both doctor surfaces must read the same authority. The MCP tool used to
+    // probe <repo>/.repo-harness/mcp.local.json, which reported false for a
+    // correct user-level install and true for an unmigrated legacy repo.
+    const harnessDoctorLocalConfig = async (repoRoot: string): Promise<boolean> => {
+      const ctx = createMcpToolContext({ repo: repoRoot, profile: 'planner' });
+      const result = await callMcpTool(ctx, 'harness_doctor', {});
+      return JSON.parse(result.content[0].text).mcp.localConfig;
+    };
+
+    // No user-level config yet: both report false.
+    await withTmpRepoAsync(async (repoRoot) => {
+      expect(JSON.parse(runMcpDoctor({ repo: repoRoot, json: true }).lines[0]).mcp.localConfig).toBe(false);
+      expect(await harnessDoctorLocalConfig(repoRoot)).toBe(false);
+    });
+
+    // After user-level setup: both report true.
+    await withTmpRepoAsync(async (repoRoot) => {
+      runMcpSetupChatgpt({ repo: repoRoot });
+      expect(JSON.parse(runMcpDoctor({ repo: repoRoot, json: true }).lines[0]).mcp.localConfig).toBe(true);
+      expect(await harnessDoctorLocalConfig(repoRoot)).toBe(true);
+    });
+
+    // A legacy repo-scope file in the target repo must not fabricate a true.
+    // The context is built while the repo is clean (the startup gate has
+    // already run), then the legacy files appear underneath it.
+    await withTmpRepoAsync(async (repoRoot) => {
+      const ctx = createMcpToolContext({ repo: repoRoot, profile: 'planner' });
+      writeLegacyRepoScopeMcpState(repoRoot);
+      const payload = JSON.parse((await callMcpTool(ctx, 'harness_doctor', {})).content[0].text);
+      expect(payload.mcp.localConfig).toBe(false);
+    });
+  });
+
+  test('migrate-scope refuses a legacy config that claims the coding profile', () => {
+    withTmpRepo((repoRoot) => {
+      const legacy = writeLegacyRepoScopeMcpState(repoRoot, { profile: 'coding' });
+      expect(() => runMcpMigrateScope({ repo: repoRoot })).toThrow('coding profile was never valid in repo scope');
+      expect(existsSync(legacy.config)).toBe(true);
     });
   });
 
@@ -298,58 +493,46 @@ describe('mcp setup', () => {
     });
   });
 
-  test('coding setup is user-scoped, requires an explicit grant, and fails closed after permission downgrade', () => {
-    withTmpRepo((repoRoot) => {
-      const userState = mkdtempSync(join(tmpdir(), 'repo-harness-coding-setup-'));
-      const previousHome = process.env.REPO_HARNESS_HOME;
-      try {
-        process.env.REPO_HARNESS_HOME = userState;
-        expect(() => runMcpSetupChatgpt({ repo: repoRoot, scope: 'repo', profile: 'coding', grantReadWrite: [repoRoot] }))
-          .toThrow('requires --scope user');
-        expect(() => runMcpSetupChatgpt({ repo: repoRoot, scope: 'user', profile: 'coding' }))
-          .toThrow('requires at least one explicit --grant-read-write');
-        expect(() => runMcpSetupChatgpt({ repo: repoRoot, scope: 'user', profile: 'CODING' }))
-          .toThrow('invalid MCP profile');
+  test('coding setup requires an explicit grant and fails closed after permission downgrade', () => {
+    withTmpRepo((repoRoot, userHome) => {
+      expect(() => runMcpSetupChatgpt({ repo: repoRoot, profile: 'coding' }))
+        .toThrow('requires at least one explicit --grant-read-write');
+      expect(() => runMcpSetupChatgpt({ repo: repoRoot, profile: 'CODING' }))
+        .toThrow('invalid MCP profile');
 
-        const setup = runMcpSetupChatgpt({
-          repo: repoRoot,
-          scope: 'user',
-          profile: 'coding',
-          grantReadWrite: [repoRoot],
-          endpoint: 'https://coding.example.com/mcp',
-        });
-        expect(setup.lines.join('\n')).toContain('Profile: coding');
-        const config = JSON.parse(readFileSync(join(userState, 'mcp.local.json'), 'utf-8'));
-        expect(config).toMatchObject({
-          version: 3,
-          scope: 'user',
-          profile: 'coding',
-          capabilities: { workspaceReader: false, workflowPlanner: true, workspaceCoder: true },
-          coding: { enabled: true, environmentAllowlist: [] },
-        });
-        expect(config.authorizationRevision).toBe(1);
-        expect(readRegisteredRepoHarnessRepos({ adoptedOnly: true })[0]).toMatchObject({ accessMode: 'read_write' });
-        const ctx = createMcpToolContext({ repo: repoRoot, profile: 'coding' });
-        expect(ctx.policy.profile).toBe('coding');
-        expect(ctx.codingWorkspaceManager).toBeDefined();
-        expect(ctx.processManager).toBeDefined();
+      const setup = runMcpSetupChatgpt({
+        repo: repoRoot,
+        profile: 'coding',
+        grantReadWrite: [repoRoot],
+        endpoint: 'https://coding.example.com/mcp',
+      });
+      expect(setup.lines.join('\n')).toContain('Profile: coding');
+      const config = JSON.parse(readFileSync(join(userHome, 'mcp.local.json'), 'utf-8'));
+      expect(config).toMatchObject({
+        version: 3,
+        profile: 'coding',
+        capabilities: { workspaceReader: false, workflowPlanner: true, workspaceCoder: true },
+        coding: { enabled: true, environmentAllowlist: [] },
+      });
+      expect(config.scope).toBeUndefined();
+      expect(config.authorizationRevision).toBe(1);
+      expect(readRegisteredRepoHarnessRepos({ adoptedOnly: true })[0]).toMatchObject({ accessMode: 'read_write' });
+      const ctx = createMcpToolContext({ repo: repoRoot, profile: 'coding' });
+      expect(ctx.policy.profile).toBe('coding');
+      expect(ctx.codingWorkspaceManager).toBeDefined();
+      expect(ctx.processManager).toBeDefined();
 
-        const downgraded = setRepoHarnessAccessMode(repoRoot, 'read_only');
-        expect(downgraded.authorizationRevision).toBe(2);
-        expect(() => createMcpToolContext({ repo: repoRoot, profile: 'coding' })).toThrow('explicit read_write grant');
+      const downgraded = setRepoHarnessAccessMode(repoRoot, 'read_only');
+      expect(downgraded.authorizationRevision).toBe(2);
+      expect(() => createMcpToolContext({ repo: repoRoot, profile: 'coding' })).toThrow('explicit read_write grant');
 
-        expect(setRepoHarnessAccessMode(repoRoot, 'read_write').authorizationRevision).toBe(3);
-        expect(() => createMcpToolContext({ repo: repoRoot, profile: 'coding' })).toThrow('authorization revision is stale');
-        runMcpSetupChatgpt({ repo: repoRoot, scope: 'user', profile: 'planner' });
-        const disabled = JSON.parse(readFileSync(join(userState, 'mcp.local.json'), 'utf-8'));
-        expect(disabled).toMatchObject({ profile: 'planner', coding: { enabled: false } });
-        expect(disabled.authorizationRevision).toBe(4);
-        expect(() => createMcpToolContext({ repo: repoRoot, profile: 'coding' })).toThrow('coding MCP is disabled');
-      } finally {
-        if (previousHome === undefined) delete process.env.REPO_HARNESS_HOME;
-        else process.env.REPO_HARNESS_HOME = previousHome;
-        rmSync(userState, { recursive: true, force: true });
-      }
+      expect(setRepoHarnessAccessMode(repoRoot, 'read_write').authorizationRevision).toBe(3);
+      expect(() => createMcpToolContext({ repo: repoRoot, profile: 'coding' })).toThrow('authorization revision is stale');
+      runMcpSetupChatgpt({ repo: repoRoot, profile: 'planner' });
+      const disabled = JSON.parse(readFileSync(join(userHome, 'mcp.local.json'), 'utf-8'));
+      expect(disabled).toMatchObject({ profile: 'planner', coding: { enabled: false } });
+      expect(disabled.authorizationRevision).toBe(4);
+      expect(() => createMcpToolContext({ repo: repoRoot, profile: 'coding' })).toThrow('coding MCP is disabled');
     });
   });
 
@@ -360,7 +543,6 @@ describe('mcp setup', () => {
 
       expect(() => runMcpSetupChatgpt({
         repo: repoRoot,
-        scope: 'user',
         profile: 'coding',
         grantReadWrite: [repoRoot],
         endpoint: 'http://not-public.example/mcp',
@@ -379,14 +561,12 @@ describe('mcp setup', () => {
           const action = failure === 'server-name'
             ? () => runMcpSetupChatgpt({
                 repo: repoRoot,
-                scope: 'user',
                 profile: 'coding',
                 grantReadWrite: [repoRoot],
                 serverName: 'bad/name',
               })
             : () => runMcpSetupChatgpt({
                 repo: repoRoot,
-                scope: 'user',
                 profile: 'coding',
                 grantReadWrite: [repoRoot, nonAdopted],
               });
@@ -402,9 +582,9 @@ describe('mcp setup', () => {
 
   test('rerunning setup atomically migrates v1 and v2 local config to v3', () => {
     for (const version of [1, 2] as const) {
-      withTmpRepo((repoRoot) => {
-        const configPath = join(repoRoot, '.repo-harness/mcp.local.json');
-        mkdirSync(join(repoRoot, '.repo-harness'), { recursive: true });
+      withTmpRepo((repoRoot, userHome) => {
+        const configPath = join(userHome, 'mcp.local.json');
+        mkdirSync(userHome, { recursive: true });
         writeFileSync(configPath, `${JSON.stringify({
           version,
           repo: repoRoot,
@@ -428,45 +608,35 @@ describe('mcp setup', () => {
     }
   });
 
-  test('active user coding config takes precedence over a legacy repo-scoped planner config', () => {
+  // Replaces the retired scope-precedence rule: a legacy repo-scope config no
+  // longer loses to an active user config, it blocks the command outright.
+  test('legacy repo-scope config blocks an otherwise working coding setup until migrated', () => {
     withTmpRepo((repoRoot) => {
-      const userState = mkdtempSync(join(tmpdir(), 'repo-harness-coding-priority-'));
-      const previousHome = process.env.REPO_HARNESS_HOME;
-      try {
-        process.env.REPO_HARNESS_HOME = userState;
-        mkdirSync(join(repoRoot, '.repo-harness'), { recursive: true });
-        writeFileSync(join(repoRoot, '.repo-harness/mcp.local.json'), `${JSON.stringify({
-          version: 2,
-          scope: 'repo',
-          repo: repoRoot,
-          profile: 'planner',
-          auth: { mode: 'oauth' },
-          capabilities: { workflowPlanner: true, workspaceReader: true },
-        }, null, 2)}\n`);
-        runMcpSetupChatgpt({
-          repo: repoRoot,
-          scope: 'user',
-          profile: 'coding',
-          grantReadWrite: [repoRoot],
-          endpoint: 'https://coding.example.com/mcp',
-        });
-        const ctx = createMcpToolContext({ repo: repoRoot, profile: 'coding' });
-        expect(ctx.policy.profile).toBe('coding');
-        expect(ctx.policy.capabilities.workspaceCoder).toBe(true);
-      } finally {
-        if (previousHome === undefined) delete process.env.REPO_HARNESS_HOME;
-        else process.env.REPO_HARNESS_HOME = previousHome;
-        rmSync(userState, { recursive: true, force: true });
-      }
+      runMcpSetupChatgpt({
+        repo: repoRoot,
+        profile: 'coding',
+        grantReadWrite: [repoRoot],
+        endpoint: 'https://coding.example.com/mcp',
+      });
+      expect(createMcpToolContext({ repo: repoRoot, profile: 'coding' }).policy.profile).toBe('coding');
+
+      writeLegacyRepoScopeMcpState(repoRoot);
+      expect(() => createMcpToolContext({ repo: repoRoot, profile: 'coding' }))
+        .toThrow('repo-harness mcp migrate-scope');
+
+      runMcpMigrateScope({ repo: repoRoot });
+      const ctx = createMcpToolContext({ repo: repoRoot, profile: 'coding' });
+      expect(ctx.policy.profile).toBe('coding');
+      expect(ctx.policy.capabilities.workspaceCoder).toBe(true);
     });
   });
 
   test('doctor reports sensitive configured allowed roots as unsafe', () => {
-    withTmpRepo((repoRoot) => {
+    withTmpRepo((repoRoot, userHome) => {
       runMcpSetupChatgpt({ repo: repoRoot });
       const sensitiveRoot = join(repoRoot, 'credentials');
       mkdirSync(sensitiveRoot);
-      const configPath = join(repoRoot, '.repo-harness/mcp.local.json');
+      const configPath = join(userHome, 'mcp.local.json');
       const config = JSON.parse(readFileSync(configPath, 'utf-8'));
       config.permissions.allowedRoots = [sensitiveRoot];
       writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
@@ -478,7 +648,7 @@ describe('mcp setup', () => {
     });
   });
 
-  test('doctor reports ready_user for user-scope MCP on a non-repo root', () => {
+  test('doctor reports ready_user for MCP on a non-adopted root', () => {
     const root = mkdtempSync(join(tmpdir(), 'repo-harness-user-mcp-root-'));
     const userState = mkdtempSync(join(tmpdir(), 'repo-harness-user-mcp-'));
     const previousHome = process.env.REPO_HARNESS_HOME;
@@ -486,14 +656,12 @@ describe('mcp setup', () => {
       process.env.REPO_HARNESS_HOME = userState;
       runMcpSetupChatgpt({
         repo: root,
-        scope: 'user',
         serverName: 'team-review-mcp',
       });
 
       const doctor = JSON.parse(runMcpDoctor({ repo: root, json: true }).lines[0]);
       expect(doctor.status).toBe('ready_user');
-      expect(doctor.mcp.configScope).toBe('user');
-      expect(doctor.mcp.permissions.configurationScope).toBe('user');
+      expect(doctor.mcp.storageDir).toBe(userState);
       expect(doctor.mcp.permissions.fullDiskRead).toBe(false);
       expect(doctor.mcp.permissions.allowedRootCount).toBe(0);
       expect(doctor.mcp.permissions.registeredRepoCount).toBe(0);
@@ -510,13 +678,13 @@ describe('mcp setup', () => {
   });
 
   test('mcp doctor does not mask a missing recorded ChatGPT server name', () => {
-    withTmpRepo((repoRoot) => {
-      mkdirSync(join(repoRoot, '.repo-harness'), { recursive: true });
-      writeFileSync(join(repoRoot, '.repo-harness/mcp.local.json'), `${JSON.stringify({
+    withTmpRepo((repoRoot, userHome) => {
+      mkdirSync(userHome, { recursive: true });
+      writeFileSync(join(userHome, 'mcp.local.json'), `${JSON.stringify({
         version: 1,
         repo: repoRoot,
         server: { host: '127.0.0.1', port: 8765, transport: 'http' },
-        auth: { mode: 'oauth', oauthFile: '.repo-harness/mcp.oauth.json', tokenFile: '.repo-harness/mcp.tokens.json' },
+        auth: { mode: 'oauth', oauthFile: 'mcp.oauth.json', tokenFile: 'mcp.tokens.json' },
         chatgpt: { endpoint: 'https://repo-harness-mcp.example.com/mcp' },
         profile: 'planner',
       }, null, 2)}\n`);
@@ -531,13 +699,13 @@ describe('mcp setup', () => {
   });
 
   test('server-name-only ChatGPT setup preserves existing endpoint and operator settings', () => {
-    withTmpRepo((repoRoot) => {
-      mkdirSync(join(repoRoot, '.repo-harness'), { recursive: true });
-      writeFileSync(join(repoRoot, '.repo-harness/mcp.local.json'), `${JSON.stringify({
+    withTmpRepo((repoRoot, userHome) => {
+      mkdirSync(userHome, { recursive: true });
+      writeFileSync(join(userHome, 'mcp.local.json'), `${JSON.stringify({
         version: 1,
         repo: repoRoot,
         server: { host: '0.0.0.0', port: 9876, transport: 'http' },
-        auth: { mode: 'bearer', tokenFile: '.repo-harness/custom.tokens.json' },
+        auth: { mode: 'bearer', tokenFile: 'custom.tokens.json' },
         chatgpt: { endpoint: 'https://repo-harness-mcp.example.com/mcp' },
         profile: 'orchestrator',
         devMode: {
@@ -548,9 +716,9 @@ describe('mcp setup', () => {
       }, null, 2)}\n`);
 
       runMcpSetupChatgpt({ repo: repoRoot, serverName: 'team-review-mcp' });
-      const config = JSON.parse(readFileSync(join(repoRoot, '.repo-harness/mcp.local.json'), 'utf-8'));
+      const config = JSON.parse(readFileSync(join(userHome, 'mcp.local.json'), 'utf-8'));
       expect(config.server).toMatchObject({ host: '0.0.0.0', port: 9876, transport: 'http' });
-      expect(config.auth).toMatchObject({ mode: 'bearer', tokenFile: '.repo-harness/custom.tokens.json' });
+      expect(config.auth).toMatchObject({ mode: 'bearer' });
       expect(config.chatgpt).toMatchObject({
         serverName: 'team-review-mcp',
         endpoint: 'https://repo-harness-mcp.example.com/mcp',
@@ -565,13 +733,13 @@ describe('mcp setup', () => {
   });
 
   test('server-name-only ChatGPT CLI setup preserves existing bind host and port', () => {
-    withTmpRepo((repoRoot) => {
-      mkdirSync(join(repoRoot, '.repo-harness'), { recursive: true });
-      writeFileSync(join(repoRoot, '.repo-harness/mcp.local.json'), `${JSON.stringify({
+    withTmpRepo((repoRoot, userHome) => {
+      mkdirSync(userHome, { recursive: true });
+      writeFileSync(join(userHome, 'mcp.local.json'), `${JSON.stringify({
         version: 1,
         repo: repoRoot,
         server: { host: '0.0.0.0', port: 9876, transport: 'http' },
-        auth: { mode: 'bearer', tokenFile: '.repo-harness/custom.tokens.json' },
+        auth: { mode: 'bearer', tokenFile: 'custom.tokens.json' },
         chatgpt: { endpoint: 'https://repo-harness-mcp.example.com/mcp' },
         profile: 'orchestrator',
         devMode: {
@@ -581,16 +749,19 @@ describe('mcp setup', () => {
         },
       }, null, 2)}\n`);
 
+      // The child must inherit the isolated storage root explicitly; storage is
+      // user-level now, so an unset REPO_HARNESS_HOME would write to the real
+      // operator home.
       const result = spawnSync(
         process.execPath,
         [CLI, 'mcp', 'setup', 'chatgpt', '--repo', repoRoot, '--server-name', 'team-review-mcp'],
-        { encoding: 'utf-8' },
+        { encoding: 'utf-8', env: { ...process.env, REPO_HARNESS_HOME: userHome } },
       );
       expect(result.status).toBe(0);
       expect(result.stdout).toContain('ChatGPT MCP server name: team-review-mcp');
       expect(result.stdout).toContain('Local endpoint: http://0.0.0.0:9876/mcp');
 
-      const config = JSON.parse(readFileSync(join(repoRoot, '.repo-harness/mcp.local.json'), 'utf-8'));
+      const config = JSON.parse(readFileSync(join(userHome, 'mcp.local.json'), 'utf-8'));
       expect(config.server).toMatchObject({ host: '0.0.0.0', port: 9876, transport: 'http' });
       expect(config.chatgpt).toMatchObject({
         serverName: 'team-review-mcp',
@@ -600,12 +771,14 @@ describe('mcp setup', () => {
   }, 30_000);
 
   test('stores a stable ChatGPT endpoint in ignored local config and keeps the tracked guide generic', () => {
-    withTmpRepo((repoRoot) => {
+    withTmpRepo((repoRoot, userHome) => {
       runMcpSetupChatgpt({ repo: repoRoot, endpoint: 'https://repo-harness-mcp.example.com/mcp' });
 
-      const config = JSON.parse(readFileSync(join(repoRoot, '.repo-harness/mcp.local.json'), 'utf-8'));
+      const config = JSON.parse(readFileSync(join(userHome, 'mcp.local.json'), 'utf-8'));
       expect(config.chatgpt.endpoint).toBe('https://repo-harness-mcp.example.com/mcp');
 
+      // The guide is a separate, explicitly written doc; setup no longer emits it.
+      runMcpPrintGuide({ repo: repoRoot, write: true });
       const guide = readFileSync(join(repoRoot, 'docs/repo-harness-chatgpt-mcp-setup.md'), 'utf-8');
       expect(guide).not.toContain('https://repo-harness-mcp.example.com/mcp');
       expect(guide).toContain('<https-tunnel-url>/mcp');
@@ -671,7 +844,13 @@ describe('mcp setup', () => {
   test('ChatGPT guide uses OAuth for ChatGPT and documents bearer fallback', () => {
     const guide = chatgptGuideMarkdown('https://example.test/mcp');
     expect(guide).toContain('Configure Connector authentication as OAuth');
-    expect(guide).toContain('.repo-harness/mcp.oauth.json');
+    // Single storage authority: the guide describes only the user-level shape
+    // plus the one-shot migration off the retired repo scope.
+    expect(guide).toContain('~/.repo-harness/mcp.oauth.json');
+    expect(guide).toContain('REPO_HARNESS_HOME');
+    expect(guide).toContain('repo-harness mcp migrate-scope');
+    expect(guide).not.toContain('--scope user');
+    expect(guide).not.toContain('jq -r .passphrase .repo-harness/mcp.oauth.json');
     expect(guide).toContain('oauth-protected-resource');
     expect(guide).toContain('--auth bearer');
     expect(guide).toContain('--auth url-token');

--- a/tests/helpers/chatgpt-mcp-contract.ts
+++ b/tests/helpers/chatgpt-mcp-contract.ts
@@ -15,8 +15,7 @@ export function assertChatGptMcpContract(text: string): void {
   expect(text).toContain('bundle_fallback');
   expect(text).toContain('source: local_repo_harness_bundle');
   expect(text).toContain('pro_invoked_mcp: false');
-  expect(lower).toContain('repo-scope');
-  expect(lower).toContain('user-scope');
+  expect(lower).toContain('connector');
   expect(text).not.toMatch(/asdk_app_[a-f0-9]{32}/);
   expect(text).not.toMatch(/\/Users\/[A-Za-z0-9._-]+/);
 }


### PR DESCRIPTION
Retires the MCP repo config scope. `~/.repo-harness/` (override: `REPO_HARNESS_HOME`) becomes the single storage authority for MCP config, bearer token, OAuth passphrase, and the OAuth token store. Slice 2 of the `.repo-harness/` migration review; Slice 1 was #164.

## BREAKING CHANGE

MCP config and credentials are no longer read from `<repo>/.repo-harness/`. Repos carrying a legacy `<repo>/.repo-harness/mcp.local.json` must migrate once:

```bash
repo-harness mcp migrate-scope --repo .
```

Until they do, five entrypoints (`createMcpToolContext`, `startMcpHttp`, `runMcpSetupChatgpt`, `runMcpDoctor`, `runMcpLiveDoctor`) exit 2 with an error naming that command. Existing user-level installs are untouched. This lands on main for the next batched release.

## Why rotation, not relocation

The migration merges non-secret fields (user values win on conflict) but never copies the old secrets. Bearer token and OAuth passphrase are regenerated; `mcp.oauth-tokens.json` is deleted outright, so ChatGPT re-authorizes once. Repo-scope credentials lived inside a git working tree and may survive in backups or history, so relocating them would carry the exposure forward. The command prints an explicit rotated/invalidated inventory, and a second run reports nothing to migrate.

## Fail-closed, no compatibility fallback

There is deliberately no read-through to the retired path. Repo policy forbids steady-state compatibility shims; the gate plus the one-shot migration *is* the bounded migration path, and the legacy layout is removed in this same work-package. It survives in code only as `legacyRepoScopeMcpPaths`, so the gate and migration can name and delete it.

Also in scope: `harness_doctor` now reports `mcp.localConfig` from the same authority as `runMcpDoctor` instead of probing the retired path, a dead `ignoreLines` block in `engine.ts` is removed (output byte-identical), and the tracked setup guide is regenerated to the user-level shape.

## Verification

- `repo-harness run verify-sprint --prepare-acceptance`: total=9 failed=0, status Fulfilled — full `bun test` (491.2s), `bun run check:type`, `init --repo . --dry-run`, and the `tests/cli/mcp-setup.test.ts` exit criterion. Confirming `verify-sprint` finalized against the receipt.
- Independent full `bun test` with `REPO_HARNESS_HOME` unset: 2222 pass / 1 skip / 0 fail.
- Independent legacy-fixture trace, five steps: gate exits 2 naming the migration and writes no user config while it holds → `migrate-scope` carries `server.host`, `server.port`, `chatgpt.serverName`, `chatgpt.endpoint`, `profile` → regenerated bearer and passphrase both differ from the seeded legacy values, with zero occurrences of those values under the new storage root and all four legacy files removed → gate released, `doctor` exits 0 → re-run reports "Nothing to migrate" with credentials unchanged.
- Breaking-surface check: a pre-existing user config carrying `"scope":"user"` still parses, `doctor` exits 0, and the dead key is dropped on the next setup while `chatgpt.serverName` is preserved.
- Test isolation: `~/.repo-harness` snapshotted before and after a full run with `REPO_HARNESS_HOME` unset — all four user-level MCP files byte-identical.

## Rollback

Single squash revert restores the dual-scope shape. No user-side persisted-data format change; existing user-level installs were never rewritten.

## Operator follow-ups

1. A test-isolation defect fixed during this work had already overwritten `~/.repo-harness/mcp.local.json` `chatgpt.serverName` with the fixture value `team-review-mcp`. The original is unrecoverable — restore with `repo-harness mcp setup chatgpt --repo . --server-name <real-name>`. No credential was modified or exposed.
2. Pre-existing and unrelated: `init` tests still register temp paths into the real `~/.repo-harness/registered-repos.json`, and an acceptance-gate receipt is rewritten under the real home during full suite runs. Recorded in the notes as an Open Question deserving its own slice.
