### PR TITLE
test: default-isolate the real user home in the test suite via preload

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -2,5 +2,5 @@
 root = "tests"
 timeout = 60000
 maxConcurrency = 4
-preload = ["./tests/setup-timeout.ts"]
+preload = ["./tests/preload-home-isolation.ts", "./tests/setup-timeout.ts"]
 pathIgnorePatterns = ["_ref/**", "_ops/**", ".codegraph/**", ".understand-anything/**"]

--- a/plans/plan-20260807-2321-test-home-isolation.md
+++ b/plans/plan-20260807-2321-test-home-isolation.md
@@ -1,0 +1,147 @@
+# Plan: Tests: fail-closed user-home isolation for the whole suite
+
+> **Status**: Executing
+> **Created**: 20260807-2321
+> **Slug**: test-home-isolation
+> **Planning Source**: repo-harness-plan
+> **Orchestration Kind**: host-plan
+> **Source Ref**: 20260807-leak-incidents
+> **Artifact Level**: work-package
+> **Promotion Reason**: verification_boundary
+> **Verification Boundary**: full bun test plus before/after real-home snapshot showing zero writes
+> **Rollback Surface**: single commit, test config and test files only
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260807-2321-test-home-isolation.contract.md`
+> **Task Review**: `tasks/reviews/20260807-2321-test-home-isolation.review.md`
+> **Implementation Notes**: `tasks/notes/20260807-2321-test-home-isolation.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from repo-harness-plan planning output.
+- Source ref: 20260807-leak-incidents
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260807-2321-test-home-isolation.md`
+- Sprint contract: `tasks/contracts/20260807-2321-test-home-isolation.contract.md`
+- Sprint review: `tasks/reviews/20260807-2321-test-home-isolation.review.md`
+- Implementation notes: `tasks/notes/20260807-2321-test-home-isolation.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260807-2321-test-home-isolation.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260807-2321-test-home-isolation.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260807-2321-test-home-isolation.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260807-2321-test-home-isolation.contract.md`
+- Review file: `tasks/reviews/20260807-2321-test-home-isolation.review.md`
+- Implementation notes file: `tasks/notes/20260807-2321-test-home-isolation.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260807-2321-test-home-isolation.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260807-2321-test-home-isolation.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: single commit, test config and test files only
+- **Verification boundary**: full bun test plus before/after real-home snapshot showing zero writes
+- **Review/acceptance boundary**: `tasks/reviews/20260807-2321-test-home-isolation.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: verification_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260807-2321-test-home-isolation.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260807-2321-test-home-isolation.contract.md`, `tasks/reviews/20260807-2321-test-home-isolation.review.md`, and `tasks/notes/20260807-2321-test-home-isolation.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260807-2321-test-home-isolation.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: single commit, test config and test files only
+
+## Captured Planning Output
+
+# Tests: fail-closed user-home isolation for the whole suite
+
+## Problem
+
+Tests that spawn CLI subprocesses or invoke scripts without an isolated `REPO_HARNESS_HOME` write into the operator's real `~/.repo-harness`. Empirically confirmed this week, three independent leak classes:
+
+1. `init`-family tests have accumulated ~800 temp-path entries in the real `~/.repo-harness/registered-repos.json` (paths like `repo-harness-init-*`, `repo-harness-init-handoff-*`, `repo-harness-init-npx-*`), still growing 3-9 entries per full-suite run.
+2. `scripts/acceptance-receipt.ts` invoked during tests rewrites the real `~/.repo-harness/gates/<id>/acceptance.latest.json`.
+3. An `mcp-setup` test overwrote the operator's real `chatgpt.serverName` (fixed at the spawn site mid-slice, but the class stayed open — any future test with a missed env passthrough repeats it).
+
+The per-test-site discipline ("remember to pass REPO_HARNESS_HOME to the child") has failed repeatedly; the class needs a structural fail-closed layer.
+
+## Decision
+
+Two layers, smallest structural change first:
+
+1. **Suite-level default isolation (core)**: a bun test preload (via `bunfig.toml` `[test].preload`, or extend the existing preload if one exists) that, when `REPO_HARNESS_HOME` is not already set by the environment, sets it to a fresh per-run temp directory before any test module loads. Child processes inherit `process.env`, so even a spawn site that forgets explicit env passing lands in the isolated home. Explicitly set `REPO_HARNESS_HOME` (test-specific fixtures using their own temp home) keeps precedence — the preload only fills the dangerous default.
+2. **Verification harness**: a leak probe proving the layer works — snapshot the real `~/.repo-harness` mtimes/hashes before and after a full suite run and assert zero writes (this is the acceptance evidence; the gatekeepers this week did it manually twice).
+
+Out of scope: cleaning the ~800 already-leaked registry entries (operator-state operation, handled outside the slice by the orchestrator with a backup); adding any product CLI command; changing `repo-registry.ts` or any production code; the `gates/` receipt path when invoked by real operator flows (only test invocations must be isolated).
+
+## Falsifier
+
+If any test legitimately requires the real user home, that test is itself a leak bug, not a counterexample. If the preload breaks a substantial set of tests because they depend on `REPO_HARNESS_HOME` being unset (e.g. asserting the literal `~/.repo-harness` path in output), those assertions need the isolated path instead — direction holds unless the breakage reveals tests of real-home *resolution logic* that cannot be expressed under an override; report before widening.
+
+## Task Breakdown
+
+- [x] Add (or extend) the bun test preload setting `REPO_HARNESS_HOME` to a per-run temp dir when unset; document the precedence rule in a comment.
+- [x] Full `bun test` green under the preload; fix any test whose assertions hardcode the real home path.
+- [x] Leak probe: before/after snapshot of the real `~/.repo-harness` across a full suite run shows zero writes (registry entry count stable, gates receipt untouched, mcp files byte-identical).
+- [x] `bun run check:type` green.
+
+## Verification
+
+`bun test` (full) with the before/after real-home snapshot as the primary evidence; `bun run check:type`.
+
+## Rollback
+
+Single commit touching test config/preload and test files only; revert restores prior behavior.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [x] Add (or extend) the bun test preload setting `REPO_HARNESS_HOME` to a per-run temp dir when unset; document the precedence rule in a comment.
+- [x] Full `bun test` green under the preload; fix any test whose assertions hardcode the real home path.
+- [x] Leak probe: before/after snapshot of the real `~/.repo-harness` across a full suite run shows zero writes (registry entry count stable, gates receipt untouched, mcp files byte-identical).
+- [x] `bun run check:type` green.

--- a/tasks/contracts/20260807-2321-test-home-isolation.contract.md
+++ b/tasks/contracts/20260807-2321-test-home-isolation.contract.md
@@ -1,12 +1,12 @@
 # Task Contract: test-home-isolation
 
-> **Status**: Active
+> **Status**: Fulfilled
 > **Plan**: plans/plan-20260807-2321-test-home-isolation.md
 > **Task Profile**: code-change
 > <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
 > **Owner**: ancienttwo
 > **Capability ID**: root
-> **Last Updated**: 2026-08-07 23:21
+> **Last Updated**: 2026-08-08 00:14
 > **Review File**: `tasks/reviews/20260807-2321-test-home-isolation.review.md`
 > **Notes File**: `tasks/notes/20260807-2321-test-home-isolation.notes.md`
 > **Exemplar**: `docs/reference-configs/contract-brief-example.md`

--- a/tasks/contracts/20260807-2321-test-home-isolation.contract.md
+++ b/tasks/contracts/20260807-2321-test-home-isolation.contract.md
@@ -1,0 +1,147 @@
+# Task Contract: test-home-isolation
+
+> **Status**: Active
+> **Plan**: plans/plan-20260807-2321-test-home-isolation.md
+> **Task Profile**: code-change
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: ancienttwo
+> **Capability ID**: root
+> **Last Updated**: 2026-08-07 23:21
+> **Review File**: `tasks/reviews/20260807-2321-test-home-isolation.review.md`
+> **Notes File**: `tasks/notes/20260807-2321-test-home-isolation.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+Tests spawning CLI subprocesses without isolated `REPO_HARNESS_HOME` write into the operator's real `~/.repo-harness`: ~800 leaked temp-path registry entries (still growing per run), a rewritten gates acceptance receipt, and this week an overwritten real `chatgpt.serverName`. Per-site env-passing discipline has failed repeatedly; skipped, every future missed passthrough mutates real operator state again.
+
+## Goal
+
+A bun test preload sets `REPO_HARNESS_HOME` to a fresh per-run temp directory when the environment has not set it, before any test module loads; child processes inherit it, closing the class structurally. Explicit env settings keep precedence. Full `bun test` green under the preload. Primary acceptance evidence: a before/after snapshot of the real `~/.repo-harness` across a full suite run shows zero writes (registry entry count stable, gates receipts untouched, mcp files byte-identical).
+
+## Scope
+
+- In scope: bun test preload config (`bunfig.toml` `[test].preload` or existing preload file), the preload implementation, and any test whose assertions hardcode the real home path.
+- Out of scope: production code (`src/**`, `scripts/**` runtime behavior), cleaning already-leaked registry entries (operator operation outside the slice), any new product CLI command, `repo-registry.ts`.
+  - cleaning the ~800 already-leaked registry entries (operator-state operation, handled outside the slice by the orchestrator with a backup); adding any product CLI command; changing `repo-registry.ts` or any production code; the `gates/` receipt path when invoked by real operator flows (only test invocations must be isolated).
+- Taste constraints: <!-- advisory only, no run gate; default style/taste lives in AGENTS.md and the minimal-change policy, use this to record a per-task override -->
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+
+## Falsifier
+
+If the preload breaks tests that verify real-home *resolution logic* in a way that cannot be expressed under an override, the blanket default is wrong for those cases — report before widening. A test that "needs" the real user home for fixtures is itself a leak bug, not a counterexample. Cheapest proof point: run the previously leaking files (`tests/cli/init*.test.ts` family) under the preload and diff the real registry entry count.
+
+## Root Cause Evidence
+
+Required when Task Profile is `bugfix`; leave as-is otherwise.
+
+- root_cause: one sentence naming file:line/condition (testable, not "a state issue").
+- repro: the command or UI path that reproduces the symptom.
+- regression_guard: path to a test that fails on the unfixed code and passes after the fix (must also appear under exit_criteria.tests_pass).
+- pre_fix_failure_artifact: path to a captured run of regression_guard on the UNFIXED code. Capture with `bun test <regression_guard> > <artifact> 2>&1; echo "PRE_FIX_EXIT=$?" >> <artifact>` (no pipes — pipes swallow the exit status). The gate requires a non-zero `PRE_FIX_EXIT=` line plus the regression_guard path string in the artifact (see the Root Cause Evidence Gate section in docs/reference-configs/sprint-contracts.md).
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260807-2321-test-home-isolation.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260807-2321-test-home-isolation.review.md`
+- Notes file: `tasks/notes/20260807-2321-test-home-isolation.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Acceptance Policy
+
+```json
+{"protocol":1,"reviewer":"Claude","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - docs/spec.md
+  - plans/
+  - tasks/todos.md
+  - tasks/contracts/20260807-2321-test-home-isolation.contract.md
+  - tasks/reviews/20260807-2321-test-home-isolation.review.md
+  - tasks/notes/20260807-2321-test-home-isolation.notes.md
+  - .ai/context/capabilities.json
+  - bunfig.toml
+  - tests/
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+      - codex-exec
+      - main-thread
+    fallback: main-thread
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - docs/spec.md
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260807-2321-test-home-isolation.notes.md
+  tests_pass:
+    - path: tests/cli/mcp-setup.test.ts
+  commands_succeed:
+    - bun run check:type
+    - bun test
+```
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior:
+- Edge cases:
+- Regression risks:
+
+## Rollback Point
+
+- Commit / checkpoint:
+- Revert strategy:

--- a/tasks/notes/20260807-2321-test-home-isolation.notes.md
+++ b/tasks/notes/20260807-2321-test-home-isolation.notes.md
@@ -1,0 +1,226 @@
+# Implementation Notes: test-home-isolation
+
+> **Status**: Active
+> **Plan**: plans/plan-20260807-2321-test-home-isolation.md
+> **Contract**: tasks/contracts/20260807-2321-test-home-isolation.contract.md
+> **Review**: tasks/reviews/20260807-2321-test-home-isolation.review.md
+> **Last Updated**: 2026-08-07 23:52
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- **Separate preload file, not an extension of `setup-timeout.ts`.** `bunfig.toml` already
+  had `preload = ["./tests/setup-timeout.ts"]`; that file owns one concern (`jest.setTimeout`).
+  Home isolation went into `tests/preload-home-isolation.ts` and was placed **first** in the
+  preload array, since bun runs preloads in array order and the env must be installed before
+  anything else can observe it.
+- **`REPO_HARNESS_HOME` covers the largest writer group, not all of them.** Code that writes
+  under `~/.repo-harness` splits three ways, and only the first reads this lever:
+
+  | Group | Sites | Covered by this slice |
+  |-------|-------|-----------------------|
+  | Reads `REPO_HARNESS_HOME`<br>`resolve(env.REPO_HARNESS_HOME ?? join(env.HOME ?? homedir(), ".repo-harness"))` | `src/effects/repo-registry.ts:61` (registry — the ~800-entry leak), `src/cli/mcp/coding-workspaces.ts:104`, `src/cli/mcp/auth.ts:56` (`mcp.*` — the `chatgpt.serverName` overwrite) | **Yes** |
+  | Reads `HOME` only<br>`env?.HOME ?? process.env.HOME ?? homedir()` | `src/cli/commands/brain-root.ts:24-35` → `~/.repo-harness/config.json`; `src/cli/commands/global-runtime.ts:259-261,387` → `~/.repo-harness/packages` | **No** |
+  | No env lever at all (deliberate OS-account design) | `scripts/acceptance-receipt.ts:753` (`opts.authorityHome ?? userInfo().homedir`); `scripts/merge-gate.ts:180` (`osAccountHome()` via `/usr/bin/id` + `dscl`) | **No** — needs `opts.authorityHome` injection or its own slice |
+
+  Leak class 2 (the rewritten `gates/<id>/acceptance.latest.json`) lives in the third group, so
+  **this slice does not structurally close it**; see the probe section for what the evidence
+  does and does not prove.
+- **Mutate `process.env`, do not touch `HOME`.** Overriding `HOME` would reach the second group
+  above, but at a much wider blast radius (git config, bun cache, every tool that resolves a
+  home) — a bigger decision than this slice's scope. Kept to the one lever; the `HOME`-only
+  group is recorded as uncovered rather than silently half-fixed.
+- **Child-process coverage is partial, and this was measured, not assumed.** The first version
+  of this slice claimed a bare `spawnSync(cmd, args)` inherits the preload's mutation because
+  Node documents `options.env` as defaulting to `process.env`. That is false under Bun 1.3.14,
+  which snapshots the child environment at process start. Probed inside a real `bun test` run
+  with a preload setting `THI_PROBE_VAR`:
+
+  ```
+  IN-PROCESS      : SET_BY_PRELOAD
+  BARE spawnSync  : ""              status 1   <- NOT inherited
+  SPREAD spawnSync: "SET_BY_PRELOAD"           <- inherited
+  BARE execSync   : THROW(status=1)            <- NOT inherited
+  Bun.spawnSync   : ""                         <- NOT inherited
+  ```
+
+  Real coverage boundary: (a) in-process reads of `process.env` — covered; (b) spawn sites
+  passing `env: { ...process.env, ... }` — covered; (c) bare `spawnSync`/`execSync`/`Bun.spawnSync`
+  with no `env` — **still exposed**. Scale of (c), measured with a paren-balanced scan over
+  `tests/`: **392 spawn call sites, 138 with an explicit `env:`, 254 without**. So the preload is
+  a large default-safety improvement, not the "structural, not per-call-site" guarantee first
+  claimed. Follow-up candidate: a lint/grep guard requiring an explicit `env` on spawns in
+  `tests/`.
+- **Precedence: an already-set `REPO_HARNESS_HOME` always wins.** The preload only fills the
+  dangerous default (`if (!process.env.REPO_HARNESS_HOME)`). Tests that build their own temp
+  home and pass it explicitly — e.g. the `runInit registers an adopted repo...` test at
+  `tests/cli/init.test.ts:149` — keep working untouched, as does an explicit
+  `REPO_HARNESS_HOME=... bun test` from an operator.
+- **No cleanup hook for the temp dir.** One `mkdtemp` dir per test process under `os.tmpdir()`;
+  reaping is the OS's job. An `exit` handler doing `rmSync` would add a failure path for no
+  isolation benefit.
+
+## Deviations From Plan Or Spec
+
+- **One test needed an env fix, and it was not the hardcoded-assertion class the plan
+  anticipated.** The plan expected breakage from tests asserting the literal `~/.repo-harness`
+  path. Zero such tests existed — the full suite is green with no assertion edits. Instead one
+  test leaked *through* the preload, for a different reason (see below). Total test edits: 1
+  (`tests/cli/init.test.ts:316`, env passthrough only; no assertion changed).
+
+## Root Cause Of The Residual Leak (production bug, left unfixed — out of contract scope)
+
+After the preload landed, the init family still leaked exactly 1 registry entry per run
+(`repo-harness-init-npx-*`). `src/cli/commands/init.ts:194`:
+
+```ts
+function initCommandEnv(sourceRoot: string, env?: NodeJS.ProcessEnv): NodeJS.ProcessEnv | undefined {
+  if (!isNpxCacheSource(sourceRoot)) return env;
+  if (env?.AGENTIC_DEV_LINK_INSTALLED_COPIES !== undefined) return env;
+  return { ...(env ?? {}), AGENTIC_DEV_LINK_INSTALLED_COPIES: "0" };
+}
+```
+
+When `sourceRoot` is an npx cache path **and the caller passes no `env`**, the `?? {}` builds a
+fresh env object holding only `AGENTIC_DEV_LINK_INSTALLED_COPIES`. `process.env` is discarded
+wholesale, so the `commandEnv` handed down to `runAdoptionApply` has neither `REPO_HARNESS_HOME`
+nor `HOME`, and `repoHarnessHome(env)` falls all the way through to `homedir()` — the operator's
+real `~/.repo-harness`. No preload can defend against a code path that drops `process.env`.
+
+Contract Scope puts `src/**` out of scope, so this was fixed test-side at
+`tests/cli/init.test.ts:307-331` with a sanitized `process.env` copy. The production bug is
+intact. It is one of several known gaps, not the only one — the others are the bare-spawn class
+(c) above and the two uncovered writer groups in the Design Decisions table. See Open Questions.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| Set `REPO_HARNESS_HOME` in preload | **Use** | ~4 lines; covers the registry + `mcp.*` writer group, which is where all three observed leak classes' *reproducible* damage came from |
+| Also override `HOME` in preload | Reject | Would reach the `HOME`-only group (`config.json`, `packages/`) but drags in git/bun/every-tool home resolution; wider blast radius than this slice can verify |
+| Keep fixing spawn sites one by one | Reject | The premise of the slice — this discipline failed three times this week |
+| Lint/grep guard forcing explicit `env` on spawns | Deferred | The real fix for the 254 bare-spawn sites; a separate slice, and only worth building once the default is safe |
+| Inject `opts.authorityHome` for the gates path | Deferred | The only way to isolate `userInfo().homedir`; touches test call sites broadly, own slice |
+| Fix `initCommandEnv` to spread `process.env` | Deferred | Correct structural fix, but `src/**` is out of contract scope |
+
+## Open Questions
+
+Four gaps left open on purpose, in rough priority order:
+
+1. **Bare spawns (widest gap).** 254 of 392 spawn sites under `tests/` pass no `env`, and Bun
+   does not propagate the preload's mutation to those children. A lint/grep guard requiring an
+   explicit `env` on spawns in `tests/` is the natural next slice — it is what turns this
+   preload into the structural guarantee it was first mistaken for.
+2. **`HOME`-only writers.** `brain-root.ts:24-35` (`config.json`) and
+   `global-runtime.ts:259-261,387` (`packages/`) resolve through `HOME`, which this slice
+   deliberately does not override. Uncovered.
+3. **Leak class 2 / OS-account writers.** `scripts/acceptance-receipt.ts:753` and
+   `scripts/merge-gate.ts:180` read the OS account record (`userInfo().homedir`,
+   `/usr/bin/id`+`dscl`). No env can redirect them; isolation means injecting
+   `opts.authorityHome` at the test call sites. Uncovered.
+4. **`src/cli/commands/init.ts:194`** `initCommandEnv` drops `process.env` for npx-cache
+   sources when called without an explicit `env`. Worth fixing: the same shape would leak again
+   from any new caller, and it is real production behavior (an npx-invoked `init` loses the
+   user's whole environment, not just the test's). Out of contract scope here.
+
+## Leak Probe (primary acceptance evidence)
+
+Probe: full-tree manifest of the real `~/.repo-harness` — every file's
+`relpath | size | mtime | sha256` (757 files) — plus focused hashes for the three named leak
+surfaces. Script: `/tmp/thi-snapshot.sh`.
+
+### RED control (probe validity, preload NOT yet active)
+
+`bun test tests/cli/init.test.ts tests/cli/init-hook.test.ts`, 44 pass / 0 fail:
+
+```
+registry_count BEFORE = 837
+registry_count AFTER  = 840      <- +3 leaked entries in ONE run of TWO files
+```
+
+Leaked paths (`source: "init"`, real registry):
+```
+/private/var/.../T/repo-harness-init-1786116214688/repo
+/private/var/.../T/repo-harness-init-handoff-1786116217111/repo
+/private/var/.../T/repo-harness-init-npx-1786116289875/repo
+```
+The probe detects the leak. It is not a no-op assertion.
+
+### Intermediate (preload active, `initCommandEnv` hole still open)
+
+Same two files: `840 -> 841`. Preload closed 2 of 3 leak sites; the npx one survived and led to
+the root cause above.
+
+### GREEN, targeted (preload + test env fix)
+
+Same two files, 44 pass / 0 fail: `841 -> 841`. Zero growth.
+
+### GREEN, full suite — the acceptance evidence
+
+`bun test` — **2222 pass, 1 skip, 0 fail, 2223 tests across 177 files, 521.83s, EXIT=0**.
+
+PRE vs POST snapshot of the real `~/.repo-harness`, taken immediately before and after that run:
+
+```
+$ diff /tmp/thi-PRE.summary.txt /tmp/thi-POST.summary.txt
+IDENTICAL (zero writes)
+
+$ diff /tmp/thi-PRE.manifest.txt /tmp/thi-POST.manifest.txt
+IDENTICAL (no file added, removed, retouched, or rewritten)
+```
+
+Field by field, PRE == POST:
+
+| Field | PRE | POST |
+|-------|-----|------|
+| `registry_count` | 841 | 841 |
+| `registry_sha256` | `e94ce765506a847ff30bf5c0b2da012f39c133957dda8949a0eb996b01c61b53` | same |
+| `mcp.local.json` | `92dcc96df44c2a13f7013718bd087a62cdeddc94d4fa062657286ae624b6af41` | same |
+| `mcp.oauth-tokens.json` | `320c35758bdf9bc9c66a5f3a2ce387c6951130a629346f26a2130ae0bac6469a` | same |
+| `mcp.oauth.json` | `10cefe172dbbf5a8f667cbb95b2195b7bb774d8298f599e4194cb44a4228df26` | same |
+| `mcp.tokens.json` | `d0140f72cb321be606b849cd35878dc8e16447881e4a54d804dc6ac459f4f5ff` | same |
+| `gates_receipt_count` | 48 | 48 |
+| `gates_tree_sha256` | `3f4705d1f7e3413d44b7045270a8d3b61196fb1e4e80f09ae748b05b037d29db` | same |
+| `gates_newest_mtime` | 1786112891 | 1786112891 |
+| `manifest_file_count` | 757 | 757 |
+| `manifest_sha256` | `ef9554059200bce0f38c8c0af4cbce0b76763d08cc21d1c6701af5c984a602be` | same |
+
+What this evidence does and does not establish:
+
+- `registry_count` flat and `registry_sha256` unchanged **refute leak class 1**, which is the
+  class this slice structurally closes.
+- The four byte-identical `mcp.*` hashes **refute class 3** (the overwritten
+  `chatgpt.serverName`), same mechanism.
+- `gates_newest_mtime` and `gates_tree_sha256` unchanged show **class 2 did not fire in this
+  run** — but it is *not* evidence that class 2 is closed. `scripts/acceptance-receipt.ts:753`
+  resolves its home through `userInfo().homedir`, which no environment variable can redirect,
+  so the preload cannot cover it. The observation is a negative result for this run only;
+  closing class 2 requires injecting `opts.authorityHome` at the test call sites or a separate
+  slice.
+
+Registry count moved 837 -> 841 across the whole slice: +3 from the deliberate RED control,
++1 from the intermediate run before the npx fix landed. Every run after the fix is flat. The
+pre-existing ~841 leaked entries are operator state and are out of scope to clean.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- `bun run check:type` — EXIT=0
+- `bun test` — EXIT=0, 2222 pass / 1 skip / 0 fail
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Candidate for `tasks/lessons.md` after this slice is accepted: **an env-var preload is a
+  default-safety layer, not an isolation boundary — measure the propagation before claiming
+  one.** Two independent things break the intuition: (1) under Bun 1.3.14 a child spawned with
+  no explicit `env` does *not* see a runtime mutation of `process.env`, despite Node documenting
+  `env` as defaulting to `process.env`; (2) a helper that rebuilds an env from scratch
+  (`{ ...(env ?? {}) }`) silently drops it too. Both were found only by probing the real runtime
+  and diffing real state; both were invisible to a green test suite. Meets the filter: hard to
+  reverse once tests are written against the leaky default, genuinely surprising, and a real
+  scope trade-off existed.

--- a/tasks/reviews/20260807-2321-test-home-isolation.review.md
+++ b/tasks/reviews/20260807-2321-test-home-isolation.review.md
@@ -1,84 +1,92 @@
 # Task Review: test-home-isolation
 
-> **Status**: Pending
+> **Status**: Complete
 > **Plan**: plans/plan-20260807-2321-test-home-isolation.md
 > **Contract**: tasks/contracts/20260807-2321-test-home-isolation.contract.md
 > **Notes File**: tasks/notes/20260807-2321-test-home-isolation.notes.md
 > **Checks File**: .ai/harness/checks/latest.json
-> **Last Updated**: 2026-08-07 23:21
-> **Recommendation**: fail
+> **Last Updated**: 2026-08-08 00:14
+> **Recommendation**: pass
 > **Review Rubric Version**: 2
-> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject SHA256**: sha256:6b47add986b2a4b76c42abfff97ff488652b6007ecb58e7fe0d8bfe86b0dbb4f
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: pending
+> **Reviewed Target Revision**: eae3a57b53a822ddf4160e6928de5575869fe004
 
 ## Human Review Card
 
-- Verdict: pending
-- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
-- Intended files changed:
-- Actual files changed:
-- Commands passed:
-- Residual risks:
-- Reviewer action required: inspect diff and card
-- Rollback:
+- Verdict: pass
+- Change type: code-change
+- Intended files changed: `bunfig.toml` (preload array), `tests/preload-home-isolation.ts` (new), one test whose env handling had to be hardened, plus plan/contract/notes/review workflow artifacts and `tasks/todos.md`. No `src/**` change.
+- Actual files changed: `bunfig.toml` (+1/-1), `tests/preload-home-isolation.ts` (new, 62 lines: 58 comment + 4 logic), `tests/cli/init.test.ts` (+17), `tasks/todos.md` (timestamp), `plans/plan-20260807-2321-test-home-isolation.md`, `tasks/contracts/...`, `tasks/notes/...`, `tasks/reviews/...`. `src/**` untouched — confirmed by `git diff --stat`.
+- Commands passed: `bun run check:type` EXIT=0; `bun test` 2222 pass / 1 skip / 0 fail / 2223 across 177 files, EXIT=0 (gatekeeper-run, 565.60s; verify-sprint re-ran it at 533.71s); `bun test tests/cli/init.test.ts tests/cli/init-hook.test.ts tests/cli/mcp-setup.test.ts` 79 pass / 0 fail; `bash scripts/verify-sprint.sh --prepare-acceptance` total=8 failed=0 status=Fulfilled.
+- Residual risks: the preload is a default-safety improvement, not a whole-class guarantee. Four gaps are documented in the notes and left open on purpose — (1) 254 of 392 spawn sites under `tests/` pass no `env` and Bun 1.3.14 does not propagate a runtime `process.env` mutation to them; (2) `HOME`-only writers (`brain-root.ts` `config.json`, `global-runtime.ts` `packages/`); (3) OS-account writers (`acceptance-receipt.ts:753`, `merge-gate.ts:180`) that no env var can redirect, which is where leak class 2 lives; (4) the `initCommandEnv` production bug at `src/cli/commands/init.ts:194`.
+- Reviewer action required: none — gates clean, findings from review round 1 all closed in round 2.
+- Rollback: revert commit `667a106c`. Test config and test files only; no production surface, no data migration.
 
 ## Mode Evidence
 
-- Selected route:
-- P1/P2/P3 evidence:
-- Root cause or plan evidence:
+- Selected route: planning -> contract execution -> gatekeeper acceptance (two review rounds).
+- P1/P2/P3 evidence: P1 — three groups of code write under `~/.repo-harness`, split by which home lever they read (`REPO_HARNESS_HOME` / `HOME` only / OS account record); the writer table in the notes and the header comment of `tests/preload-home-isolation.ts` are the map. P2 — traced `bun test` -> preload -> `process.env.REPO_HARNESS_HOME` -> child spawn -> `repoHarnessHome(env)` -> `registered-repos.json`, and measured each spawn shape in a live `bun test` run. P3 — `HOME` deliberately not overridden: it would reach the second writer group but drag in git/bun/every tool that resolves a home, a wider blast radius than this slice can verify.
+- Root cause or plan evidence: `plans/plan-20260807-2321-test-home-isolation.md` Captured Planning Output names the three observed leak classes; the notes record which of them this slice structurally closes (class 1 and 3) and which it does not (class 2).
 
 ## Verification Evidence
 
-- Waza `/check` run:
-- Commands run:
-- Manual checks:
-- Supporting artifacts:
-- Implementation notes reviewed:
-- Run snapshot:
+- Waza `/check` run: covered by `bash scripts/verify-sprint.sh --prepare-acceptance` (8 checks, 0 failed, status Fulfilled).
+- Commands run: `bun run check:type`; `bun test` (full); `bun test tests/cli/init.test.ts tests/cli/init-hook.test.ts tests/cli/mcp-setup.test.ts`; `bash scripts/verify-sprint.sh --prepare-acceptance --contract ...`; `bun scripts/acceptance-receipt.ts record --disposition external_pass ...`; `bash scripts/verify-sprint.sh --contract ...`.
+- Manual checks: (1) zero-write probe — a 757-file `relpath|size|mtime` manifest of the real `~/.repo-harness` captured before any run and re-diffed after the init/mcp family, after the full suite, and after the round-2 runs: IDENTICAL every time, with `registry_count` flat at 841, the four `mcp.*` hashes and `config.json` unchanged, and the gates tree mtime unchanged. (2) preload semantics probed directly — precedence (an explicit `REPO_HARNESS_HOME` survives untouched), `mkdtempSync` uniqueness across runs, and the child-inheritance boundary measured inside a real `bun test` process: bare `spawnSync` / `execSync` / `Bun.spawnSync` children see the variable unset while `env: { ...process.env }` children see it, which is exactly what the committed comment now states. (3) determinism of the hardened test confirmed by running it with `AGENTIC_DEV_LINK_INSTALLED_COPIES=1` exported: 1 pass. (4) every file:line citation in the writer table read and confirmed, including `merge-gate.ts:180`'s `/usr/bin/id` + `dscl` path.
+- Supporting artifacts: `.ai/harness/checks/latest.json`; gatekeeper probe files under `/tmp/gk-*` (manifests and full-suite log, transient).
+- Implementation notes reviewed: yes — `tasks/notes/20260807-2321-test-home-isolation.notes.md`, including the three-group writer table, the measured coverage boundary, and the four open gaps.
+- Run snapshot: `.ai/harness/runs/run-20260808T000445-18436-20260807-2321-test-home-isolation.json`
 
 ## Acceptance Receipt Projection
 
-> **Disposition**: unavailable
-> **Reviewer**: unavailable
-> **Source**: unavailable
+> **Disposition**: external_pass
+> **Reviewer**: Claude
+> **Source**: claude-review
 > **Actor**: not-applicable
-> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject SHA256**: sha256:6b47add986b2a4b76c42abfff97ff488652b6007ecb58e7fe0d8bfe86b0dbb4f
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: pending
-> **Verification Evidence SHA256**: pending
-> **Issued At**: pending
+> **Reviewed Target Revision**: eae3a57b53a822ddf4160e6928de5575869fe004
+> **Verification Evidence SHA256**: sha256:ae8c5a7a9d96e10ad81f03297cd3db624e3046adac6794854574ed08fe51f597
+> **Issued At**: 2026-08-07T16:14:08.413Z
 
-- Summary: No AcceptanceReceipt has been recorded.
+- Summary: Gatekeeper round 2: preload semantics, coverage boundary, and the three-group writer table verified against the real Bun 1.3.14 runtime; zero-write probe over a 757-file manifest of the real ~/.repo-harness reproduced independently across the full suite and the init/mcp leak family; check:type and bun test green.
 - Findings: none
 
 ## Behavior Diff Notes
 
-- ...
+- Under `bun test`, `REPO_HARNESS_HOME` is now always set: to a caller-supplied value when one exists, otherwise to a fresh `mkdtemp` directory per test process. Nothing else about the suite changes.
+- In-process home resolution and every spawn site that spreads `process.env` now land in that temp directory instead of the operator's real `~/.repo-harness`. Bare spawn sites are unchanged in behavior and still resolve through the real `HOME`.
+- `tests/cli/init.test.ts` "npx cache sources force copy-based installed skill sync" now passes a sanitized `process.env` copy with `AGENTIC_DEV_LINK_INSTALLED_COPIES` deleted; the assertion under test is unchanged and the forced-`0` path is still the one exercised.
 
 ## Residual Risks / Follow-ups
 
-- ...
+- **Bare spawns (widest gap).** 254 of 392 spawn sites under `tests/` pass no `env`. A lint/grep guard requiring an explicit `env` on spawns in `tests/` is the follow-up that would turn this preload into the structural guarantee it was first mistaken for.
+- **`HOME`-only writers.** `src/cli/commands/brain-root.ts:24-35` (`config.json`) and `src/cli/commands/global-runtime.ts:259-261,387` (`packages/`) are not covered.
+- **OS-account writers / leak class 2.** `scripts/acceptance-receipt.ts:753` and `scripts/merge-gate.ts:180` read the OS account record; no env var redirects them. Isolating them means injecting `opts.authorityHome` at the test call sites.
+- **`initCommandEnv` production bug.** `src/cli/commands/init.ts:194` drops `process.env` wholesale for npx-cache sources when the caller passes no `env` — real production behavior, not just a test artifact. Out of contract scope here; worth its own slice.
+- **Already-leaked operator state.** The ~841 temp-path entries in the real `registered-repos.json` are pre-existing and deliberately not cleaned by this slice.
 
 ## Scorecard
 
 | Dimension | Score | Notes |
 |-----------|-------|-------|
-| Functionality | 0/10 | |
-| Product depth | 0/10 | |
-| Design quality | 0/10 | |
-| Code quality | 0/10 | |
+| Functionality | 9/10 | Closes leak classes 1 and 3 for the covered surface; zero-write probe reproduced independently three times. Not 10 because class 2 and the bare-spawn population stay open by design. |
+| Product depth | 8/10 | Operator-state safety is the product here, and the default is now safe rather than discipline-dependent. |
+| Design quality | 9/10 | Smallest coherent change: 4 lines of logic on the one lever that covers the largest writer group, with the uncovered groups named instead of half-fixed. `HOME` deliberately left alone. |
+| Code quality | 9/10 | Comment-to-code ratio is high but every claim in it is measured against the real runtime, and the coverage boundary is the load-bearing part a future reader needs. |
 
 ## Failing Items
 
-- ...
+- None outstanding. Review round 1 returned three findings — a false bare-spawn inheritance claim, a false "one lever covers all resolvers" completeness claim that also mis-framed leak class 2 as refuted, and an ambient-env dependency in the hardened test. All three are closed in round 2 and re-verified against the live runtime.
 
 ## Retest Steps
 
-- Re-run:
-- Re-check:
+- Re-run: `bun run check:type` and `bun test` (or `bash scripts/verify-sprint.sh --prepare-acceptance --contract tasks/contracts/20260807-2321-test-home-isolation.contract.md`, which runs both).
+- Re-check: snapshot the real `~/.repo-harness` before and after a full suite run and diff a `relpath|size|mtime` manifest — it must be identical, with `registered-repos.json` entry count flat. To re-confirm the coverage boundary, run a throwaway test under this preload that spawns a child both bare and with `env: { ...process.env }` and print `REPO_HARNESS_HOME` from each.
 
 ## Summary
 
-- ...
+- A bun test preload sets `REPO_HARNESS_HOME` to a fresh per-run temp directory when the environment has not set it, so the operator's real `~/.repo-harness` stops being the effective default for the test suite's largest writer group. Explicit settings keep precedence; `HOME` is untouched.
+- Accepted after two review rounds. Round 1 failed the delivery for claiming a whole-class structural guarantee that the runtime does not provide; round 2 replaced those claims with a measured coverage boundary and a three-group writer table, and hardened the one edited test against an ambient-env dependency. The code itself never needed a functional change.
+- Evidence: full suite 2222 pass / 0 fail EXIT=0, `check:type` EXIT=0, and a 757-file manifest of the real `~/.repo-harness` identical before and after — reproduced by the gatekeeper, not taken on report.

--- a/tasks/reviews/20260807-2321-test-home-isolation.review.md
+++ b/tasks/reviews/20260807-2321-test-home-isolation.review.md
@@ -1,0 +1,84 @@
+# Task Review: test-home-isolation
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260807-2321-test-home-isolation.md
+> **Contract**: tasks/contracts/20260807-2321-test-home-isolation.contract.md
+> **Notes File**: tasks/notes/20260807-2321-test-home-isolation.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-08-07 23:21
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Commands passed:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+- Waza `/check` run:
+- Commands run:
+- Manual checks:
+- Supporting artifacts:
+- Implementation notes reviewed:
+- Run snapshot:
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -1,7 +1,7 @@
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: (archive-workflow)
+> **Updated**: 2026-08-07 23:21
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.

--- a/tests/cli/init.test.ts
+++ b/tests/cli/init.test.ts
@@ -313,6 +313,22 @@ describe("init command", () => {
       mkdirSync(repo, { recursive: true });
       setupFakeSource(source);
 
+      // Explicit env is required here, not decorative: for an npx cache source
+      // initCommandEnv() (src/cli/commands/init.ts) builds `{ ...(env ?? {}),
+      // AGENTIC_DEV_LINK_INSTALLED_COPIES: "0" }`, so passing no env yields a
+      // command env holding only that key. REPO_HARNESS_HOME and HOME are both
+      // dropped and the registry write falls back to homedir() — the operator's
+      // real ~/.repo-harness. Spreading process.env keeps the isolated home
+      // installed by tests/preload-home-isolation.ts.
+      //
+      // The delete keeps this test deterministic: initCommandEnv() only forces
+      // the flag to "0" when it is undefined, so an ambient
+      // AGENTIC_DEV_LINK_INSTALLED_COPIES in the operator's shell would be passed
+      // straight through and the `sync link=0` assertion below would fail for a
+      // reason that has nothing to do with the code under test.
+      const childEnv = { ...process.env };
+      delete childEnv.AGENTIC_DEV_LINK_INSTALLED_COPIES;
+
       const result = runInit({
         repo,
         sourceRoot: source,
@@ -320,6 +336,7 @@ describe("init command", () => {
         externalSkills: false,
         verify: false,
         codegraph: false,
+        env: childEnv,
       });
 
       expect(result.exitCode).toBe(0);

--- a/tests/preload-home-isolation.ts
+++ b/tests/preload-home-isolation.ts
@@ -1,0 +1,63 @@
+/**
+ * Fail-closed user-home isolation for the whole test suite.
+ *
+ * Three groups of code write under `~/.repo-harness`, and only the first reads
+ * the `REPO_HARNESS_HOME` lever this file sets:
+ *
+ *   - REPO_HARNESS_HOME, so covered here — `src/effects/repo-registry.ts:61`
+ *     (`registered-repos.json`), `src/cli/mcp/coding-workspaces.ts:104`,
+ *     `src/cli/mcp/auth.ts:56` (the `mcp.*` files):
+ *       resolve(env.REPO_HARNESS_HOME ?? join(env.HOME ?? homedir(), ".repo-harness"))
+ *   - HOME only, NOT covered here — `src/cli/commands/brain-root.ts:24-35`
+ *     (`config.json`), `src/cli/commands/global-runtime.ts:259-261,387`
+ *     (`packages/`): `env?.HOME ?? process.env.HOME ?? homedir()`.
+ *   - No env lever at all, NOT covered here — `scripts/acceptance-receipt.ts:753`
+ *     (`opts.authorityHome ?? userInfo().homedir`) and `scripts/merge-gate.ts:180`
+ *     (`osAccountHome()` via `/usr/bin/id` + `dscl`). These read the OS account
+ *     record on purpose; isolating them means injecting `opts.authorityHome`.
+ *
+ * When a test spawns the CLI without threading an isolated home through, group
+ * one lands on the operator's real `~/.repo-harness` and mutates it for real:
+ * temp-path entries pile up in `registered-repos.json`, an `mcp-setup` test
+ * overwrites the operator's `chatgpt.serverName`. Per-spawn-site discipline
+ * ("remember to pass REPO_HARNESS_HOME to the child") has failed repeatedly, so
+ * the default itself has to be safe.
+ *
+ * This preload runs before any test module loads and mutates `process.env` of
+ * the test process.
+ *
+ * Coverage boundary — measured in the real bun test runtime (Bun 1.3.14), not
+ * assumed. Bun snapshots the environment handed to a child at process start, so
+ * a runtime mutation of `process.env` does NOT reach a child spawned without an
+ * explicit `env`, despite Node's documented `env` default:
+ *
+ *   (a) COVERED  in-process code reading `process.env` (this is the bulk of the
+ *                registry and mcp home resolution).
+ *   (b) COVERED  spawn sites passing `env: { ...process.env, ... }` — the spread
+ *                copies the mutated value.
+ *   (c) EXPOSED  bare `spawnSync(cmd, args)`, `execSync(cmd)`, `Bun.spawnSync([...])`
+ *                with no `env` option. Verified: the child sees the variable unset.
+ *                Most spawn sites under tests/ are in this shape.
+ *
+ * So this preload is a large default-safety improvement, not a total guarantee.
+ * Closing (c) needs a separate guard (a lint/grep rule requiring an explicit
+ * `env` on spawns in tests/), which is deliberately not part of this file.
+ *
+ * Precedence, highest first:
+ *   1. `REPO_HARNESS_HOME` already set in the environment (an explicit
+ *      `REPO_HARNESS_HOME=... bun test`, or a test fixture that sets its own
+ *      home before spawning) — always wins, untouched.
+ *   2. Otherwise: a fresh per-run temp directory created here.
+ *
+ * Within the covered surface — (a)+(b) above, group one of the three writer
+ * groups — the real `~/.repo-harness` is no longer the effective default under
+ * `bun test`. A test that "needs" the real user home is a leak bug, not an
+ * exception.
+ */
+import { mkdtempSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+if (!process.env.REPO_HARNESS_HOME) {
+  process.env.REPO_HARNESS_HOME = mkdtempSync(join(tmpdir(), "repo-harness-test-home-"));
+}


### PR DESCRIPTION
## Problem

Tests that spawn CLI subprocesses without an isolated `REPO_HARNESS_HOME` have been writing into the operator's real `~/.repo-harness`. Three observed classes:

1. **Registry pollution.** The `init` family accumulated ~841 temp-path entries in the real `registered-repos.json` (`repo-harness-init-*`, `repo-harness-init-handoff-*`, `repo-harness-init-npx-*`), still growing every run.
2. **Gates receipt rewrite.** `scripts/acceptance-receipt.ts` invoked during tests rewrote the real `~/.repo-harness/gates/<id>/acceptance.latest.json`.
3. **Connector overwrite.** An `mcp-setup` test overwrote the operator's real `chatgpt.serverName`.

Per-spawn-site discipline ("remember to pass `REPO_HARNESS_HOME` to the child") failed three times in one week.

## Mechanism

`tests/preload-home-isolation.ts` runs first in `bunfig.toml`'s `[test].preload` array, before any test module loads:

```ts
if (!process.env.REPO_HARNESS_HOME) {
  process.env.REPO_HARNESS_HOME = mkdtempSync(join(tmpdir(), "repo-harness-test-home-"));
}
```

**Precedence, highest first:** an already-set `REPO_HARNESS_HOME` — an explicit `REPO_HARNESS_HOME=... bun test`, or a fixture that builds its own temp home — always wins and is left untouched. The preload only fills the dangerous default. `HOME` is deliberately not overridden: it would reach a second group of writers but drag in git config, bun cache, and every other tool that resolves a home, a wider blast radius than this slice can verify.

## Real coverage boundary

This is a default-safety improvement, **not a whole-class guarantee**. The boundary was measured inside a live `bun test` process on Bun 1.3.14, not assumed from Node's documented `options.env` default:

| | Shape | Sees the isolated home |
|---|---|---|
| (a) | in-process reads of `process.env` | yes |
| (b) | spawn sites passing `env: { ...process.env, ... }` | yes |
| (c) | bare `spawnSync(cmd, args)` / `execSync(cmd)` / `Bun.spawnSync([...])` | **no** |

Bun snapshots the environment handed to a child at process start, so a runtime mutation of `process.env` never reaches (c). **254 of 392 spawn sites under `tests/` are in shape (c).** The follow-up that closes it is a lint/grep guard requiring an explicit `env` on spawns in `tests/`, deliberately not part of this change.

Three groups of code write under `~/.repo-harness`, and only the first reads this lever:

| Group | Sites | Covered |
|---|---|---|
| Reads `REPO_HARNESS_HOME` | `src/effects/repo-registry.ts:61`, `src/cli/mcp/coding-workspaces.ts:104`, `src/cli/mcp/auth.ts:56` | **yes** |
| Reads `HOME` only | `src/cli/commands/brain-root.ts:24-35` (`config.json`), `src/cli/commands/global-runtime.ts:259-261,387` (`packages/`) | no |
| No env lever (OS account record, by design) | `scripts/acceptance-receipt.ts:753` (`userInfo().homedir`), `scripts/merge-gate.ts:180` (`/usr/bin/id` + `dscl`) | no |

Leak class 2 lives in the third group, so **this change does not structurally close it** — no environment variable can redirect those paths. Isolating them means injecting `opts.authorityHome` at the test call sites.

## Evidence

**Zero-write probe.** A 757-file `relpath | size | mtime | sha256` manifest of the real `~/.repo-harness`, captured before any run and re-diffed after: identical every time, across the full suite and the init/mcp leak family. `registry_count` flat at 841, the four `mcp.*` hashes and `config.json` byte-identical, gates tree mtime unchanged.

**RED control** (probe validity, preload not yet active): `bun test tests/cli/init.test.ts tests/cli/init-hook.test.ts`, 44 pass — registry `837 -> 840`, three leaked entries in one run of two files. The probe detects the leak; it is not a no-op assertion. With the preload plus the test fix, the same two files hold at `841 -> 841`.

`gates_newest_mtime` unchanged shows class 2 **did not fire in this run** — it is not evidence that class 2 is closed, for the reason above.

**Commands:** `bun run check:type` EXIT=0; `bun test` 2222 pass / 1 skip / 0 fail / 2223 across 177 files EXIT=0; `verify-sprint` 8 checks, 0 failed, status Fulfilled.

## Out of scope: a production bug this surfaced

`initCommandEnv` at `src/cli/commands/init.ts:194`:

```ts
if (!isNpxCacheSource(sourceRoot)) return env;
if (env?.AGENTIC_DEV_LINK_INSTALLED_COPIES !== undefined) return env;
return { ...(env ?? {}), AGENTIC_DEV_LINK_INSTALLED_COPIES: "0" };
```

When `sourceRoot` is an npx cache path **and the caller passes no `env`**, `?? {}` builds a fresh object holding only that one key — `process.env` is discarded wholesale, so the command env has neither `REPO_HARNESS_HOME` nor `HOME` and the registry write falls through to `homedir()`. No preload can defend against a code path that drops `process.env`.

This is real production behavior, not just a test artifact: an npx-invoked `init` loses the user's whole environment. `src/**` is out of this contract's scope, so it is fixed test-side at `tests/cli/init.test.ts` with a sanitized `process.env` copy (with `AGENTIC_DEV_LINK_INSTALLED_COPIES` deleted, so the forced-`0` path stays deterministic under an operator shell that exports it). **The production bug is intact and needs its own slice.**

## Rollback

Revert `667a106c`. Test config and test files only; `src/**` is untouched.