### PR TITLE
fix(init): base constructed command env on process.env, not an empty object

### DIFF
--- a/.ai/harness/checks/pre-fix-init-command-env.log
+++ b/.ai/harness/checks/pre-fix-init-command-env.log
@@ -1,0 +1,19 @@
+bun test v1.3.14 (0d9b296a)
+
+tests/cli/init.test.ts:
+394 |       });
+395 | 
+396 |       expect(result.exitCode).toBe(0);
+397 |       expect(result.steps.find((step) => step.step === "register repo harness repo")?.status).toBe("ok");
+398 |       expect(existsSync(join(home, ".repo-harness", "registered-repos.json"))).toBe(false);
+399 |       const registry = JSON.parse(readFileSync(join(harnessHome, "registered-repos.json"), "utf-8"));
+                                        ^
+error: ENOENT: no such file or directory, open '/var/folders/_6/dkz7p7251y1gqntnk0ll5n380000gn/T/repo-harness-init-npx-env-base-1786121901258/harness-home/registered-repos.json'
+      at <anonymous> (/Users/ancienttwo/Projects/repo-harness-wt-init-command-env-basedrop/tests/cli/init.test.ts:399:35)
+(fail) init command > npx cache sources keep process.env as the constructed command env base [225.70ms]
+
+ 24 pass
+ 1 fail
+ 127 expect() calls
+Ran 25 tests across 1 file. [13.88s]
+PRE_FIX_EXIT=1

--- a/plans/plan-20260808-0054-init-command-env-basedrop.md
+++ b/plans/plan-20260808-0054-init-command-env-basedrop.md
@@ -1,0 +1,137 @@
+# Plan: Fix initCommandEnv dropping process.env on the npx-cache path
+
+> **Status**: Executing
+> **Created**: 20260808-0054
+> **Slug**: init-command-env-basedrop
+> **Planning Source**: repo-harness-plan
+> **Orchestration Kind**: host-plan
+> **Source Ref**: test-home-isolation-open-question
+> **Artifact Level**: work-package
+> **Promotion Reason**: rollback_boundary
+> **Verification Boundary**: regression guard RED-to-GREEN plus full bun test
+> **Rollback Surface**: single commit; revert restores prior behavior
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260808-0054-init-command-env-basedrop.contract.md`
+> **Task Review**: `tasks/reviews/20260808-0054-init-command-env-basedrop.review.md`
+> **Implementation Notes**: `tasks/notes/20260808-0054-init-command-env-basedrop.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from repo-harness-plan planning output.
+- Source ref: test-home-isolation-open-question
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260808-0054-init-command-env-basedrop.md`
+- Sprint contract: `tasks/contracts/20260808-0054-init-command-env-basedrop.contract.md`
+- Sprint review: `tasks/reviews/20260808-0054-init-command-env-basedrop.review.md`
+- Implementation notes: `tasks/notes/20260808-0054-init-command-env-basedrop.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260808-0054-init-command-env-basedrop.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260808-0054-init-command-env-basedrop.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260808-0054-init-command-env-basedrop.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260808-0054-init-command-env-basedrop.contract.md`
+- Review file: `tasks/reviews/20260808-0054-init-command-env-basedrop.review.md`
+- Implementation notes file: `tasks/notes/20260808-0054-init-command-env-basedrop.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260808-0054-init-command-env-basedrop.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260808-0054-init-command-env-basedrop.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: single commit; revert restores prior behavior
+- **Verification boundary**: regression guard RED-to-GREEN plus full bun test
+- **Review/acceptance boundary**: `tasks/reviews/20260808-0054-init-command-env-basedrop.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: rollback_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260808-0054-init-command-env-basedrop.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260808-0054-init-command-env-basedrop.contract.md`, `tasks/reviews/20260808-0054-init-command-env-basedrop.review.md`, and `tasks/notes/20260808-0054-init-command-env-basedrop.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260808-0054-init-command-env-basedrop.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: single commit; revert restores prior behavior
+
+## Captured Planning Output
+
+# Fix initCommandEnv dropping process.env on the npx-cache path
+
+## Problem (production bug, found during test-home-isolation)
+
+`src/cli/commands/init.ts:194` `initCommandEnv(sourceRoot, env?)`: for an npx-cache source when the caller passes no `env`, the function returns `{ ...(env ?? {}), AGENTIC_DEV_LINK_INSTALLED_COPIES: "0" }` — a fresh environment holding only that one key. The entire `process.env` (PATH, HOME, REPO_HARNESS_HOME, proxy settings, everything) is silently discarded for the child invocation. Observable consequences: an npx-invoked `init` runs its skill-sync child with an empty environment; any `REPO_HARNESS_HOME` override is lost, which was the one hole the test-home-isolation preload could not defend (init family kept leaking +1 registry entry per run until a test-side workaround).
+
+## Decision
+
+When the caller provides no `env`, base the constructed environment on `process.env` instead of `{}`: `{ ...(env ?? process.env), AGENTIC_DEV_LINK_INSTALLED_COPIES: "0" }`. Callers that do pass `env` keep exact current behavior. Class sweep: search `src/` for the same `...(env ?? {})`-style base-dropping shape and fix or report every sibling (report-only if a sibling's semantics are intentional).
+
+## Root cause evidence plan (bugfix profile)
+
+- Regression guard: a test asserting the npx-cache init child env retains caller/process environment (e.g. a marker variable set in `process.env` is visible in the constructed env / child behavior) — fails on the unfixed code, passes after.
+- Pre-fix RED artifact captured before the fix.
+
+## Task Breakdown
+
+- [x] Regression guard test in `tests/cli/init.test.ts` (RED on unfixed code, artifact captured).
+- [x] Fix `initCommandEnv` to base on `process.env` when caller env is absent.
+- [x] Class sweep for sibling base-dropping shapes in `src/`; fix or report each.
+- [x] Full `bun test`, `bun run check:type`, `bun src/cli/index.ts init --repo . --dry-run` green.
+
+## Verification
+
+`bun test` (full), `bun run check:type`, `bun src/cli/index.ts init --repo . --dry-run`; the regression guard is the acceptance anchor.
+
+## Rollback
+
+Single commit; revert restores prior (buggy) behavior; no persisted-format change.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [x] Regression guard test in `tests/cli/init.test.ts` (RED on unfixed code, artifact captured).
+- [x] Fix `initCommandEnv` to base on `process.env` when caller env is absent.
+- [x] Class sweep for sibling base-dropping shapes in `src/`; fix or report each.
+- [x] Full `bun test`, `bun run check:type`, `bun src/cli/index.ts init --repo . --dry-run` green.

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -194,7 +194,7 @@ function isNpxCacheSource(sourceRoot: string): boolean {
 function initCommandEnv(sourceRoot: string, env?: NodeJS.ProcessEnv): NodeJS.ProcessEnv | undefined {
   if (!isNpxCacheSource(sourceRoot)) return env;
   if (env?.AGENTIC_DEV_LINK_INSTALLED_COPIES !== undefined) return env;
-  return { ...(env ?? {}), AGENTIC_DEV_LINK_INSTALLED_COPIES: "0" };
+  return { ...(env ?? process.env), AGENTIC_DEV_LINK_INSTALLED_COPIES: "0" };
 }
 
 function withStepName(step: InitStep, name: string, detail?: string): InitStep {
@@ -585,7 +585,7 @@ export function runInit(
   const steps: InitStep[] = [];
 
   if (opts.brainRoot) {
-    commandEnv = { ...(commandEnv ?? {}), REPO_HARNESS_BRAIN_ROOT: opts.brainRoot };
+    commandEnv = { ...(commandEnv ?? process.env), REPO_HARNESS_BRAIN_ROOT: opts.brainRoot };
   }
 
   const targetError = validateRepoAdoptionTarget(repoRoot, opts.repo !== undefined, commandEnv);
@@ -768,7 +768,7 @@ export function runInit(
   }
 
   if (apply && verify) {
-    const verifyEnv = { ...(commandEnv ?? {}), REPO_HARNESS_SOURCE_ROOT: sourceRoot };
+    const verifyEnv = { ...(commandEnv ?? process.env), REPO_HARNESS_SOURCE_ROOT: sourceRoot };
     if (migrate.status === "ok") {
       const handoff = runProcess(
         "bun",

--- a/tasks/contracts/20260808-0054-init-command-env-basedrop.contract.md
+++ b/tasks/contracts/20260808-0054-init-command-env-basedrop.contract.md
@@ -1,12 +1,12 @@
 # Task Contract: init-command-env-basedrop
 
-> **Status**: Active
+> **Status**: Fulfilled
 > **Plan**: plans/plan-20260808-0054-init-command-env-basedrop.md
 > **Task Profile**: bugfix
 > <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
 > **Owner**: ancienttwo
 > **Capability ID**: root
-> **Last Updated**: 2026-08-08 00:55
+> **Last Updated**: 2026-08-08 02:25
 > **Review File**: `tasks/reviews/20260808-0054-init-command-env-basedrop.review.md`
 > **Notes File**: `tasks/notes/20260808-0054-init-command-env-basedrop.notes.md`
 > **Exemplar**: `docs/reference-configs/contract-brief-example.md`

--- a/tasks/contracts/20260808-0054-init-command-env-basedrop.contract.md
+++ b/tasks/contracts/20260808-0054-init-command-env-basedrop.contract.md
@@ -1,0 +1,149 @@
+# Task Contract: init-command-env-basedrop
+
+> **Status**: Active
+> **Plan**: plans/plan-20260808-0054-init-command-env-basedrop.md
+> **Task Profile**: bugfix
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: ancienttwo
+> **Capability ID**: root
+> **Last Updated**: 2026-08-08 00:55
+> **Review File**: `tasks/reviews/20260808-0054-init-command-env-basedrop.review.md`
+> **Notes File**: `tasks/notes/20260808-0054-init-command-env-basedrop.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+`initCommandEnv` silently discards the entire `process.env` for the child invocation on the npx-cache path when the caller passes no env — PATH, HOME, proxy settings, and any `REPO_HARNESS_HOME` override are all lost. This is real user-facing behavior for npx-invoked `init`, and it was the one hole the test-home-isolation preload could not defend (init family kept leaking a registry entry per run until a test-side workaround). Skipped, the same base-dropping shape invites copies.
+
+## Goal
+
+`initCommandEnv` bases the constructed environment on `process.env` when the caller provides none; callers passing explicit env keep exact current behavior. A regression guard proves RED on unfixed code (artifact captured) and GREEN after. Sibling `...(env ?? {})`-style base-dropping shapes in `src/` are fixed or reported. Full suite, typecheck, and init dry-run green.
+
+## Scope
+
+- In scope: `src/cli/commands/init.ts` `initCommandEnv`; sibling base-dropping shapes found by the class sweep in `src/`; regression guard in `tests/cli/init.test.ts`.
+- Out of scope: the bare-spawn explicit-env lint guard (separate slice), preload changes, `tests/` beyond the guard, behavior of callers that already pass env.
+- Taste constraints: <!-- advisory only, no run gate; default style/taste lives in AGENTS.md and the minimal-change policy, use this to record a per-task override -->
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+
+## Falsifier
+
+If some caller depends on the child seeing a minimal environment (deliberate sanitization), basing on `process.env` would be a behavior break — cheapest proof point: enumerate `initCommandEnv` callers and check none relies on the empty-base shape (the function's own guard clause returns caller env untouched when set, so only the no-env npx path changes).
+
+## Root Cause Evidence
+
+Required when Task Profile is `bugfix`; leave as-is otherwise.
+
+- root_cause: `src/cli/commands/init.ts:194` — `initCommandEnv` returns `{ ...(env ?? {}), AGENTIC_DEV_LINK_INSTALLED_COPIES: "0" }` for an npx-cache source with no caller env, so the constructed child environment contains one key and `process.env` is discarded wholesale.
+- repro: with `REPO_HARNESS_HOME` set in `process.env`, run an npx-cache-source `init` without passing env — the child resolves home via `homedir()` and writes to the real `~/.repo-harness` (observed as the init-family +1 registry leak per full-suite run that survived the isolation preload).
+- regression_guard: tests/cli/init.test.ts
+- pre_fix_failure_artifact: .ai/harness/checks/pre-fix-init-command-env.log
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260808-0054-init-command-env-basedrop.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260808-0054-init-command-env-basedrop.review.md`
+- Notes file: `tasks/notes/20260808-0054-init-command-env-basedrop.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Acceptance Policy
+
+```json
+{"protocol":1,"reviewer":"Claude","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - docs/spec.md
+  - plans/
+  - tasks/todos.md
+  - tasks/contracts/20260808-0054-init-command-env-basedrop.contract.md
+  - tasks/reviews/20260808-0054-init-command-env-basedrop.review.md
+  - tasks/notes/20260808-0054-init-command-env-basedrop.notes.md
+  - .ai/context/capabilities.json
+  - .ai/harness/checks/
+  - src/
+  - tests/cli/
+  - tests/continuation-conformance.test.ts
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+      - codex-exec
+      - main-thread
+    fallback: main-thread
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - docs/spec.md
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260808-0054-init-command-env-basedrop.notes.md
+  tests_pass:
+    - path: tests/cli/init.test.ts
+  commands_succeed:
+    - bun run check:type
+    - bun test
+    - bun src/cli/index.ts init --repo . --dry-run
+```
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior:
+- Edge cases:
+- Regression risks:
+
+## Rollback Point
+
+- Commit / checkpoint:
+- Revert strategy:

--- a/tasks/notes/20260808-0054-init-command-env-basedrop.notes.md
+++ b/tasks/notes/20260808-0054-init-command-env-basedrop.notes.md
@@ -1,0 +1,108 @@
+# Implementation Notes: init-command-env-basedrop
+
+> **Status**: Active
+> **Plan**: plans/plan-20260808-0054-init-command-env-basedrop.md
+> **Contract**: tasks/contracts/20260808-0054-init-command-env-basedrop.contract.md
+> **Review**: tasks/reviews/20260808-0054-init-command-env-basedrop.review.md
+> **Last Updated**: 2026-08-08 00:55
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- The defect is not on the spawn path. `runProcess`/`runBoundedProcess`
+  (`src/effects/process-runner.ts:136,232`) re-merge `process.env` unless
+  `inheritEnv === false`, so a child process still sees PATH/HOME. The base drop
+  bites where `commandEnv` is consumed as an *environment record*:
+  `runInit` -> `runAdoptionApply({env: commandEnv})`
+  (`src/cli/commands/adoption-plan.ts:151`) -> `registerRepoHarnessRepo` ->
+  `repoHarnessHome(env)` (`src/effects/repo-registry.ts:60`), which resolves
+  `env.REPO_HARNESS_HOME ?? env.HOME ?? homedir()`. With a one-key record both
+  levers are absent and the registry write lands on the OS account home. That is
+  the observable that the regression guard asserts on.
+- Measured, not assumed: Bun caches `os.homedir()` at process start, so mutating
+  `process.env.HOME` inside a test does **not** redirect the `homedir()`
+  fallback (probe: `HOME=/tmp/probe-a bun -e '... process.env.HOME="/tmp/probe-b"'`
+  returns `/tmp/probe-a` both times). Consequence: the RED run of the guard wrote
+  a temp-path entry into the operator's real `~/.repo-harness/registered-repos.json`
+  — a live reproduction of the leak this contract exists to close. The entry was
+  removed after the artifact capture; the GREEN run leaves zero entries. The
+  guard therefore keys on `REPO_HARNESS_HOME` (the lever that is actually
+  threaded), not on a relocated `HOME`.
+- Falsifier cleared: `initCommandEnv` has exactly one caller
+  (`src/cli/commands/init.ts:573`). Its guard clauses return the caller env
+  untouched for non-npx sources and for an env that already carries the flag, and
+  `{...env, FLAG}` is unchanged when the caller passes an env, so only the
+  `env === undefined` npx branch changes shape. No caller depends on a sanitized
+  minimal environment.
+
+## Deviations From Plan Or Spec
+
+- Class sweep verdicts (anti-pattern 19). Fixed, same file and same
+  `commandEnv` blast radius:
+  - `src/cli/commands/init.ts:197` `initCommandEnv` — the contracted root cause.
+  - `src/cli/commands/init.ts:588` `commandEnv = {...(commandEnv ?? {}), REPO_HARNESS_BRAIN_ROOT}`
+    — live defect of the same class on the non-npx path: `--brain-root` with no
+    caller env manufactured a one-key record and threaded it into the same
+    registry write.
+  - `src/cli/commands/init.ts:771` `verifyEnv` — same shape; inert today (only
+    reaches `runProcess`, which re-merges), fixed as one word to stop the shape
+    from propagating.
+- Reported, deliberately not changed: `src/cli/commands/global-runtime.ts:124`
+  (`bindBunRuntimeEnv`) and `:272` (`commandEnv`) form the same base-dropping
+  shape on the `repo-harness setup global` surface, and there it is
+  *unconditional* — `bindBunRuntimeEnv` always returns a constructed record, so
+  with no caller env the downstream sees `{PATH}` alone. One consumer does read a
+  key without a `process.env` fallback: `readInstalledProfile(env)` ->
+  `installProfileStatePath` (`src/cli/installer/install-profile.ts:503`,
+  `env.HOME ?? homedir()`). It does not currently produce wrong behavior because
+  in production `homedir()` equals the process-start `HOME`, and every other
+  consumer either re-merges at spawn or falls back per key. Left alone because
+  the fix flips whether `commandEnv` may return `undefined` on a command surface
+  outside this contract's Scope line, and the contract's Goal permits "fixed or
+  reported".
+- Seventh member of the timeout-sweep class, not of the env class:
+  `tests/continuation-conformance.test.ts:775` (the chat-memoryless driver case)
+  carried the sweep's uniform 30s positional budget but measures 41s under full
+  suite load and 62s in isolation on a loaded machine (load ~17, real concurrent
+  sessions), so the budget was under water regardless of this slice. Raised to
+  `90_000` (measured 62s plus headroom), the same shape as the sweep's earlier
+  factor-factory 15s -> 45s adjustment. Proven independent of this contract's
+  change: the case fails identically with `src/cli/commands/init.ts` stashed
+  (baseline `2 pass / 1 fail / 61.29s`), and the file imports no init surface.
+- Not this class, checked and skipped: `src/cli/commands/init-hook.ts:701`
+  (`doctorEnv` is only handed to `withProcessEnv`, an overlay onto `process.env`,
+  where extra keys are never deleted, so a thin record is inert);
+  `src/effects/process-runner.ts:136,232`, `src/cli/commands/init-hook.ts:563`,
+  `src/cli/runtime/helper-runner.ts:359` (all already `{...process.env, ...}`);
+  every remaining `?? {}` hit in `src/` is a config/record default, not an
+  environment base.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| Guard via a spawned child's observed env | Rejected | `runProcess` re-merges `process.env`, so the child sees the marker with or without the fix — the assertion could not go RED |
+| Guard via relocated `HOME` + `homedir()` fallback | Rejected | Bun caches `os.homedir()`; the unfixed path would write to the operator's real home instead of the fixture, which is a leak, not a test |
+| Guard via `REPO_HARNESS_HOME` + registry write target | Chosen | The only lever actually threaded through `commandEnv` into `repoHarnessHome`, and it is the exact production symptom in the contract's repro field |
+| Also fix `global-runtime.ts` base drops | Deferred | Same shape, no demonstrated user-visible defect, and the fix changes that function's `undefined` return contract on a surface outside Scope |
+
+## Open Questions
+
+- Whether `commandEnv` in `src/cli/commands/global-runtime.ts:272` should keep
+  returning `undefined` at all, or always return a `process.env`-based record.
+  Answering it is the bounded next slice for the `setup global` surface.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/reviews/20260808-0054-init-command-env-basedrop.review.md
+++ b/tasks/reviews/20260808-0054-init-command-env-basedrop.review.md
@@ -1,84 +1,89 @@
 # Task Review: init-command-env-basedrop
 
-> **Status**: Pending
+> **Status**: Complete
 > **Plan**: plans/plan-20260808-0054-init-command-env-basedrop.md
 > **Contract**: tasks/contracts/20260808-0054-init-command-env-basedrop.contract.md
 > **Notes File**: tasks/notes/20260808-0054-init-command-env-basedrop.notes.md
 > **Checks File**: .ai/harness/checks/latest.json
-> **Last Updated**: 2026-08-08 00:55
-> **Recommendation**: fail
+> **Last Updated**: 2026-08-08 02:25
+> **Recommendation**: pass
 > **Review Rubric Version**: 2
-> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject SHA256**: sha256:e8718fc3ed96dc21f1a9a38891430c187968a2f40ea8fc131d5a4cc8f4beb06c
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: pending
+> **Reviewed Target Revision**: d2a5af7da1df99173c70efa833679d9584c19c45
 
 ## Human Review Card
 
-- Verdict: pending
-- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
-- Intended files changed:
-- Actual files changed:
-- Commands passed:
-- Residual risks:
-- Reviewer action required: inspect diff and card
-- Rollback:
+- Verdict: pass
+- Change type: code-change
+- Intended files changed: `src/cli/commands/init.ts` (the `initCommandEnv` root cause plus sibling base-dropping shapes found by the class sweep), a regression guard in `tests/cli/init.test.ts`, and the plan/contract/notes/review workflow artifacts plus `tasks/todos.md`.
+- Actual files changed: `src/cli/commands/init.ts` (+3/-3 across `:197`, `:588`, `:771`), `tests/cli/init.test.ts` (+62, one new guard), `tests/continuation-conformance.test.ts` (+1/-1, positional timeout 30_000 -> 90_000), `tasks/todos.md` (timestamp line), `.ai/harness/checks/pre-fix-init-command-env.log` (new RED artifact), plus the four workflow artifacts. 9 files, +564/-5. No dependency, manifest, or generated-output change.
+- Commands passed: `bun test tests/cli/init.test.ts tests/continuation-conformance.test.ts` 28 pass / 0 fail (43.69s, gatekeeper-run); `bun run check:type` EXIT=0; `repo-harness run verify-sprint --prepare-acceptance` total=17 failed=0 status=Fulfilled with full `bun test` green at 732586ms; `repo-harness run verify-sprint` finalized against the recorded receipt.
+- Residual risks: (1) `src/cli/commands/global-runtime.ts:124,272` still carry the same base-dropping shape on the `setup global` surface — reported, not fixed, because the fix decides whether `commandEnv` may still return `undefined`; the notes carry it as the Open Question and the bounded next slice. (2) The first `--prepare-acceptance` run failed on `tests/cli/init.test.ts` `defaults --repo to cwd and applies the existing-repo harness` at 30099ms against its 30000ms positional budget, and passed on rerun; that budget is now demonstrably under water under full-suite load on a loaded machine, making it the next candidate for the a2381159 timeout family. It was left alone here because widening it was not this contract's decided scope.
+- Reviewer action required: none — all gates clean, no findings.
+- Rollback: revert the fix commit. Source change is three spread bases in one file plus one test-budget constant; no persisted format, no schema, no migration.
 
 ## Mode Evidence
 
-- Selected route:
-- P1/P2/P3 evidence:
-- Root cause or plan evidence:
+- Selected route: planning -> contract execution -> gatekeeper acceptance (single round, no fix cycle).
+- P1/P2/P3 evidence: P1 — `commandEnv` in `runInit` is consumed on two different surfaces, and only one of them is safe: spawn sites (`runProcess`/`runBoundedProcess`, `src/effects/process-runner.ts:136,232`) re-merge `process.env`, while record readers (`runAdoptionApply -> registerRepoHarnessRepo -> repoHarnessHome`, `src/effects/repo-registry.ts:60`) read the record as authoritative. P2 — traced npx-cache `init` -> `initCommandEnv(sourceRoot, undefined)` -> one-key record -> `runAdoptionApply({env})` -> `repoHarnessHome(env)` -> `env.REPO_HARNESS_HOME ?? env.HOME ?? env.USERPROFILE ?? homedir()` with both levers absent -> registry write lands on the OS account home. P3 — the smallest coherent change is the base of the spread, not the resolution chain: `repoHarnessHome`'s per-key fallback is the intended contract, and the invariant to preserve is that a caller-supplied env passes through byte-identical, which `env ?? process.env` keeps by construction.
+- Root cause or plan evidence: the contract's four `Root Cause Evidence` fields are all concrete and machine-verified by the bugfix profile (root_cause, repro, regression_guard listed under `exit_criteria.tests_pass`, pre_fix_failure_artifact exists, shows `PRE_FIX_EXIT=1`, and references the guard path).
 
 ## Verification Evidence
 
-- Waza `/check` run:
-- Commands run:
-- Manual checks:
-- Supporting artifacts:
-- Implementation notes reviewed:
-- Run snapshot:
+- Waza `/check` run: covered by `repo-harness run verify-sprint --prepare-acceptance` (17 checks, 0 failed, status Fulfilled).
+- Commands run: `bun test tests/cli/init.test.ts tests/continuation-conformance.test.ts`; `bun run check:type`; `repo-harness run verify-sprint --prepare-acceptance` (twice — see residual risk 2); `bun scripts/acceptance-receipt.ts record --disposition external_pass`; `repo-harness run verify-sprint`.
+- Manual checks: (1) Independent RED reproduction — the worktree was copied to a scratch directory (tracked files untouched), `init.ts:197` reverted to `env ?? {}` there, and the guard run under `HOME=/tmp/gk-fakehome`: it failed with `ENOENT ... harness-home/registered-repos.json`, and the leaked entry landed in the fake home instead. So the guard is genuinely load-bearing, not artifact-only. (2) Real-registry integrity — `~/.repo-harness/registered-repos.json` held 7 entries before and after, all real repository paths with no `/var/folders` temp residue; the RED run's earlier leak was already cleaned. (3) Falsifier — `initCommandEnv` has exactly one caller (`src/cli/commands/init.ts:573`); the guard clauses return the caller env untouched, so only the `env === undefined` npx branch changes shape. (4) Class sweep re-run independently over every `?? {}` in `src/`: the only environment bases are `global-runtime.ts:126,272` (deferred, see residual risk 1) and `init-hook.ts:701`, and the latter is inert because all three `withProcessEnv` implementations (`init.ts:212`, `init-hook.ts:114`, `global-runtime.ts:229`) overlay onto `process.env` rather than replacing it; every other hit is a config/record default. (5) The one lever-less consumer of the `global-runtime` record, `installProfileStatePath` (`src/cli/installer/install-profile.ts:503`, `env.HOME ?? homedir()`), was read directly and confirmed not to diverge in production, which is what makes the deferral defensible. (6) `:771` `verifyEnv` confirmed inert: `runProcess` merges `{...process.env, ...opts.env}`, so the pre- and post-fix values are identical there.
+- Supporting artifacts: `.ai/harness/checks/pre-fix-init-command-env.log` (RED, `PRE_FIX_EXIT=1`); `.ai/harness/checks/latest.json`; the retained failure log for the flaked run, `.ai/harness/runs/run-20260808T014052-13354-bun-test.log`.
+- Implementation notes reviewed: yes — `tasks/notes/20260808-0054-init-command-env-basedrop.notes.md`; the spawn-vs-record split, the measured `os.homedir()` caching behavior, the class-sweep verdict table, and the global-runtime deferral all match what was verified independently here.
+- Run snapshot: `.ai/harness/runs/run-20260808T020054-92668-20260808-0054-init-command-env-basedrop.json`
 
 ## Acceptance Receipt Projection
 
-> **Disposition**: unavailable
-> **Reviewer**: unavailable
-> **Source**: unavailable
+> **Disposition**: external_pass
+> **Reviewer**: Claude
+> **Source**: claude-review
 > **Actor**: not-applicable
-> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject SHA256**: sha256:e8718fc3ed96dc21f1a9a38891430c187968a2f40ea8fc131d5a4cc8f4beb06c
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: pending
-> **Verification Evidence SHA256**: pending
-> **Issued At**: pending
+> **Reviewed Target Revision**: d2a5af7da1df99173c70efa833679d9584c19c45
+> **Verification Evidence SHA256**: sha256:3395f6fc24246b042e6768088565cf2d5fcd95416e5ba82447b333b6a7d62ad2
+> **Issued At**: 2026-08-07T18:21:28.136Z
 
-- Summary: No AcceptanceReceipt has been recorded.
+- Summary: gatekeeper acceptance: initCommandEnv and two sibling sites now base the constructed command env on process.env; regression guard independently reproduced RED on reverted code and GREEN here; global-runtime siblings reported not fixed; verify-sprint 17/17 with full bun test green on rerun after one load-timeout
 - Findings: none
 
 ## Behavior Diff Notes
 
-- ...
+- npx-cache source, no caller env: the constructed record now carries the full `process.env` instead of a single `AGENTIC_DEV_LINK_INSTALLED_COPIES` key. Observable effect — an `init` under an explicit `REPO_HARNESS_HOME` registers in that home instead of the operator's real `~/.repo-harness`.
+- `--brain-root` with no caller env (`:588`): same class, and it was live on the non-npx path too; the record threaded into the same registry write.
+- `:771` `verifyEnv`: no behavior change; `runProcess` already re-merged `process.env`. Fixed to stop the shape from propagating.
+- Callers that pass an env: byte-identical behavior, guaranteed by the `env ?? process.env` position — the caller's object is still spread first and the guard clauses still return it untouched.
+- `tests/continuation-conformance.test.ts:775`: budget only, no assertion change.
 
 ## Residual Risks / Follow-ups
 
-- ...
+- `src/cli/commands/global-runtime.ts:124,272` — same base-dropping shape on the `setup global` surface, reported not fixed. The bounded next slice is deciding whether `commandEnv` there may still return `undefined`.
+- `tests/cli/init.test.ts` `defaults --repo to cwd and applies the existing-repo harness` (30000ms positional budget) flaked once at 30099ms under full-suite load and passed on rerun; the next member of the a2381159 timeout family if it recurs.
 
 ## Scorecard
 
 | Dimension | Score | Notes |
 |-----------|-------|-------|
-| Functionality | 0/10 | |
-| Product depth | 0/10 | |
-| Design quality | 0/10 | |
-| Code quality | 0/10 | |
+| Functionality | 9/10 | Fixes the observable it names (registry write honors `REPO_HARNESS_HOME` on the npx path), proven RED-to-GREEN by independent reproduction, not by artifact alone. |
+| Product depth | 8/10 | Class sweep covered all of `src/`, fixed two live sites plus one latent, and the single deferral names its blocking decision instead of hand-waving. |
+| Design quality | 9/10 | Smallest coherent change: the spread base, not the resolution chain; caller-supplied env passes through unchanged by construction. |
+| Code quality | 9/10 | Guard comments state measured facts (Bun caches `os.homedir()`), not assumptions, and explain why `REPO_HARNESS_HOME` is the lever under test. |
 
 ## Failing Items
 
-- ...
+- none
 
 ## Retest Steps
 
-- Re-run:
-- Re-check:
+- Re-run: `bun test tests/cli/init.test.ts` (guard: `npx cache sources keep process.env as the constructed command env base`).
+- Re-check: revert `src/cli/commands/init.ts:197` to `env ?? {}` in a scratch copy and re-run the guard under an isolated `HOME` — it must fail with `ENOENT` on the fixture registry.
 
 ## Summary
 
-- ...
+- `initCommandEnv` built the child environment record from `{}` instead of `process.env` for an npx-cache source with no caller env. The damage was not on the spawn path — `runProcess` re-merges `process.env` — but on the record path, where `repoHarnessHome(env)` found `REPO_HARNESS_HOME` and `HOME` both absent and fell through to the operator's real home. Three sites in `init.ts` now base on `process.env` when the caller provides none; callers passing env are unchanged. The guard pins the production observable, `global-runtime`'s identical shape is reported for its own slice, and one load-sensitive conformance budget was widened for reasons independent of this fix.

--- a/tasks/reviews/20260808-0054-init-command-env-basedrop.review.md
+++ b/tasks/reviews/20260808-0054-init-command-env-basedrop.review.md
@@ -1,0 +1,84 @@
+# Task Review: init-command-env-basedrop
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260808-0054-init-command-env-basedrop.md
+> **Contract**: tasks/contracts/20260808-0054-init-command-env-basedrop.contract.md
+> **Notes File**: tasks/notes/20260808-0054-init-command-env-basedrop.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-08-08 00:55
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Commands passed:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+- Waza `/check` run:
+- Commands run:
+- Manual checks:
+- Supporting artifacts:
+- Implementation notes reviewed:
+- Run snapshot:
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -1,7 +1,7 @@
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: (archive-workflow)
+> **Updated**: 2026-08-08 00:55
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.

--- a/tests/cli/init.test.ts
+++ b/tests/cli/init.test.ts
@@ -348,6 +348,68 @@ describe("init command", () => {
     }
   });
 
+  test("npx cache sources keep process.env as the constructed command env base", () => {
+    // Regression guard for initCommandEnv() (src/cli/commands/init.ts): for an
+    // npx cache source with no caller env it used to return
+    // `{ ...(env ?? {}), AGENTIC_DEV_LINK_INSTALLED_COPIES: "0" }` — a child env
+    // holding exactly one key, with the whole process environment discarded.
+    // commandEnv is not only spawned with (runProcess re-merges process.env), it
+    // is also read as an environment record: runAdoptionApply threads it into
+    // registerRepoHarnessRepo, and repoHarnessHome (src/effects/repo-registry.ts:60)
+    // resolves REPO_HARNESS_HOME ?? HOME ?? homedir() off that record. Dropping
+    // the base therefore silently redirects the registry write to the operator's
+    // real home — the one hole tests/preload-home-isolation.ts cannot defend.
+    const tmp = join(tmpdir(), `repo-harness-init-npx-env-base-${Date.now()}`);
+    const source = join(tmp, "_npx", "abc123", "node_modules", "repo-harness");
+    const repo = join(tmp, "repo");
+    const home = join(tmp, "home");
+    const harnessHome = join(tmp, "harness-home");
+    // This test drives the no-env path on purpose, so the marker has to live in
+    // process.env itself: REPO_HARNESS_HOME points at harnessHome, and the guard
+    // asserts the registry write lands there. Measured, not assumed: Bun caches
+    // os.homedir() at process start, so setting process.env.HOME mid-run does
+    // NOT redirect the homedir() fallback — on unfixed code this test writes to
+    // the operator's real ~/.repo-harness, which is precisely the leak under
+    // guard here. HOME is still set for the env.HOME readers inside runInit.
+    const previous = {
+      HOME: process.env.HOME,
+      REPO_HARNESS_HOME: process.env.REPO_HARNESS_HOME,
+      AGENTIC_DEV_LINK_INSTALLED_COPIES: process.env.AGENTIC_DEV_LINK_INSTALLED_COPIES,
+    };
+    try {
+      mkdirSync(source, { recursive: true });
+      mkdirSync(repo, { recursive: true });
+      mkdirSync(home, { recursive: true });
+      setupFakeSource(source);
+      process.env.HOME = home;
+      process.env.REPO_HARNESS_HOME = harnessHome;
+      delete process.env.AGENTIC_DEV_LINK_INSTALLED_COPIES;
+
+      const result = runInit({
+        repo,
+        sourceRoot: source,
+        syncSkill: false,
+        hostAdapters: false,
+        externalSkills: false,
+        verify: false,
+        codegraph: false,
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.steps.find((step) => step.step === "register repo harness repo")?.status).toBe("ok");
+      const registry = JSON.parse(readFileSync(join(harnessHome, "registered-repos.json"), "utf-8"));
+      expect(registry.repos).toEqual([
+        expect.objectContaining({ source: "init", path: realpathSync(repo) }),
+      ]);
+    } finally {
+      for (const [key, value] of Object.entries(previous)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   test("CLI init --dry-run --json returns the adoption planner protocol", () => {
     const tmp = join(tmpdir(), `repo-harness-init-cli-codegraph-${Date.now()}`);
     try {

--- a/tests/continuation-conformance.test.ts
+++ b/tests/continuation-conformance.test.ts
@@ -772,5 +772,5 @@ describe('host Goal conformance: the full tick over a disposable repository', ()
       expect(existsSync(join(worktreeTwo, LEDGER))).toBe(true);
       expect(git(worktreeTwo, ['status', '--porcelain', '--untracked-files=all']).stdout).toBe('');
     });
-  }, 30_000);
+  }, 90_000);
 });


### PR DESCRIPTION
## The bug

`initCommandEnv` (`src/cli/commands/init.ts:194`) returned `{ ...(env ?? {}), AGENTIC_DEV_LINK_INSTALLED_COPIES: "0" }` for an npx-cache source when the caller passed no env — a record holding exactly one key, with the whole `process.env` discarded.

The damage is not on the spawn path. `runProcess`/`runBoundedProcess` (`src/effects/process-runner.ts:136,232`) re-merge `process.env`, so a child still saw PATH and HOME. It bites where the same value is consumed as an **environment record**:

```
runInit -> runAdoptionApply({ env: commandEnv }) -> registerRepoHarnessRepo
        -> repoHarnessHome(env)   # src/effects/repo-registry.ts:60
           env.REPO_HARNESS_HOME ?? env.HOME ?? env.USERPROFILE ?? homedir()
```

With a one-key record both levers are absent and resolution falls through to the OS account home: an npx-invoked `init` registered its repo in the operator's real `~/.repo-harness` even under an explicit `REPO_HARNESS_HOME` override. This was the one hole the test-home-isolation preload (#168) could not defend.

## The fix

Three sites now base on `process.env` when the caller provides none:

- `:197` `initCommandEnv` — the root cause.
- `:588` `--brain-root` — live defect of the same class, on the non-npx path too; it manufactured a one-key record that reached the same registry write.
- `:771` `verifyEnv` — same shape, inert today (only reaches `runProcess`), fixed so the shape stops propagating.

Callers that pass an env keep byte-identical behavior: the caller object is still spread first, and the guard clauses still return it untouched. `initCommandEnv` has exactly one caller (`:573`), so only the `env === undefined` npx branch changes shape.

## Evidence

Regression guard `tests/cli/init.test.ts` — an npx-cache `init` with `REPO_HARNESS_HOME` set must register in *that* home:

- RED on unfixed code, artifact committed at `.ai/harness/checks/pre-fix-init-command-env.log` (`PRE_FIX_EXIT=1`, `ENOENT` on the fixture registry).
- Independently reproduced during acceptance: the source reverted to `env ?? {}` in a scratch copy and run under an isolated `HOME` fails the same way, and the leaked registry entry lands in the isolated home instead.
- GREEN here.

`repo-harness run verify-sprint --prepare-acceptance`: 17 checks, 0 failed, status Fulfilled, full `bun test` green (732586ms). The bugfix profile machine-verified all four `Root Cause Evidence` fields plus the artifact's exit code and guard-path reference.

The guard keys on `REPO_HARNESS_HOME` rather than a relocated `HOME` for a measured reason: Bun caches `os.homedir()` at process start, so mutating `process.env.HOME` mid-run does not redirect the `homedir()` fallback — an unfixed run would write to the operator's real home, which is a leak, not a test.

## Reported, not fixed

`src/cli/commands/global-runtime.ts:124,272` carry the same base-dropping shape on the `setup global` surface. Left for its own slice: fixing it decides whether that `commandEnv` may still return `undefined`, a contract change outside this scope. Its one lever-less consumer, `installProfileStatePath` (`src/cli/installer/install-profile.ts:503`, `env.HOME ?? homedir()`), does not diverge in production, so there is no user-visible defect to chase today. Recorded as the Open Question in the task notes.

Every other `?? {}` in `src/` was swept: `init-hook.ts:701` is inert (all three `withProcessEnv` implementations overlay onto `process.env` instead of replacing it), and the rest are config/record defaults, not environment bases.

## Unrelated: one timeout widened

`tests/continuation-conformance.test.ts:775` goes 30s -> 90s. It measures 41s under full-suite load and 62s in isolation on a loaded machine, so its budget was under water regardless of this change — the seventh member of the a2381159 timeout family. Proven independent: the case fails identically with `src/cli/commands/init.ts` stashed (baseline 2 pass / 1 fail / 61.29s), and the file imports no init surface.
