### PR TITLE
fix(setup-global): base runtime env records on process.env, not empty objects

### DIFF
--- a/.ai/harness/checks/pre-fix-global-runtime-env.log
+++ b/.ai/harness/checks/pre-fix-global-runtime-env.log
@@ -1,0 +1,41 @@
+bun test v1.3.14 (0d9b296a)
+
+tests/cli/global-runtime.test.ts:
+67 |     withOverriddenHome('npx', (tmp, home, statePath) => {
+68 |       // isNpxCacheSource() matches on the `_npx` path segment, so this drives the
+69 |       // branch that injects AGENTIC_DEV_LINK_INSTALLED_COPIES with no caller env.
+70 |       const source = join(tmp, '_npx', 'abc123', 'node_modules', 'repo-harness');
+71 |       mkdirSync(source, { recursive: true });
+72 |       expect(runWithSeededHome(source, home)).toThrow(statePath);
+                                                   ^
+error: expect(received).toThrow(expected)
+
+Expected substring: "/var/folders/_6/dkz7p7251y1gqntnk0ll5n380000gn/T/repo-harness-global-runtime-env-base-npx-1786152505737/home/.repo-harness/install-state.json"
+Received message: "invalid skill-surface catalog at /var/folders/_6/dkz7p7251y1gqntnk0ll5n380000gn/T/repo-harness-global-runtime-env-base-npx-1786152505737/_npx/abc123/node_modules/repo-harness/assets/skill-commands/manifest.json: MANIFEST_MISSING $: skill-surface manifest is missing"
+
+      at <anonymous> (/Users/ancienttwo/Projects/repo-harness-wt-global-runtime-env-basedrop/tests/cli/global-runtime.test.ts:72:47)
+      at withOverriddenHome (/Users/ancienttwo/Projects/repo-harness-wt-global-runtime-env-basedrop/tests/cli/global-runtime.test.ts:56:7)
+      at <anonymous> (/Users/ancienttwo/Projects/repo-harness-wt-global-runtime-env-basedrop/tests/cli/global-runtime.test.ts:67:5)
+(fail) global runtime setup command env base > npx cache source with no caller env keeps process.env as the constructed env base [11.02ms]
+78 |       // commandEnv() passes `undefined` straight through here (a well-defined
+79 |       // value downstream); bindBunRuntimeEnv() is the helper that must not
+80 |       // materialize a PATH-only record out of it.
+81 |       const source = join(tmp, 'installed', 'repo-harness');
+82 |       mkdirSync(source, { recursive: true });
+83 |       expect(runWithSeededHome(source, home)).toThrow(statePath);
+                                                   ^
+error: expect(received).toThrow(expected)
+
+Expected substring: "/var/folders/_6/dkz7p7251y1gqntnk0ll5n380000gn/T/repo-harness-global-runtime-env-base-plain-1786152505749/home/.repo-harness/install-state.json"
+Received message: "invalid skill-surface catalog at /var/folders/_6/dkz7p7251y1gqntnk0ll5n380000gn/T/repo-harness-global-runtime-env-base-plain-1786152505749/installed/repo-harness/assets/skill-commands/manifest.json: MANIFEST_MISSING $: skill-surface manifest is missing"
+
+      at <anonymous> (/Users/ancienttwo/Projects/repo-harness-wt-global-runtime-env-basedrop/tests/cli/global-runtime.test.ts:83:47)
+      at withOverriddenHome (/Users/ancienttwo/Projects/repo-harness-wt-global-runtime-env-basedrop/tests/cli/global-runtime.test.ts:56:7)
+      at <anonymous> (/Users/ancienttwo/Projects/repo-harness-wt-global-runtime-env-basedrop/tests/cli/global-runtime.test.ts:77:5)
+(fail) global runtime setup command env base > non-npx source with no caller env keeps process.env as the constructed env base [5.44ms]
+
+ 0 pass
+ 2 fail
+ 2 expect() calls
+Ran 2 tests across 1 file. [59.00ms]
+PRE_FIX_EXIT=1

--- a/plans/plan-20260808-0924-global-runtime-env-basedrop.md
+++ b/plans/plan-20260808-0924-global-runtime-env-basedrop.md
@@ -1,0 +1,145 @@
+# Plan: Fix global-runtime commandEnv single-key record on the npx path
+
+> **Status**: Executing
+> **Created**: 20260808-0924
+> **Slug**: global-runtime-env-basedrop
+> **Planning Source**: repo-harness-plan
+> **Orchestration Kind**: host-plan
+> **Source Ref**: pr-169-class-sweep-closeout
+> **Artifact Level**: work-package
+> **Promotion Reason**: rollback_boundary
+> **Verification Boundary**: regression guard RED-to-GREEN plus full bun test
+> **Rollback Surface**: single commit; revert restores prior behavior
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260808-0924-global-runtime-env-basedrop.contract.md`
+> **Task Review**: `tasks/reviews/20260808-0924-global-runtime-env-basedrop.review.md`
+> **Implementation Notes**: `tasks/notes/20260808-0924-global-runtime-env-basedrop.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from repo-harness-plan planning output.
+- Source ref: pr-169-class-sweep-closeout
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260808-0924-global-runtime-env-basedrop.md`
+- Sprint contract: `tasks/contracts/20260808-0924-global-runtime-env-basedrop.contract.md`
+- Sprint review: `tasks/reviews/20260808-0924-global-runtime-env-basedrop.review.md`
+- Implementation notes: `tasks/notes/20260808-0924-global-runtime-env-basedrop.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260808-0924-global-runtime-env-basedrop.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260808-0924-global-runtime-env-basedrop.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260808-0924-global-runtime-env-basedrop.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260808-0924-global-runtime-env-basedrop.contract.md`
+- Review file: `tasks/reviews/20260808-0924-global-runtime-env-basedrop.review.md`
+- Implementation notes file: `tasks/notes/20260808-0924-global-runtime-env-basedrop.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260808-0924-global-runtime-env-basedrop.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260808-0924-global-runtime-env-basedrop.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: single commit; revert restores prior behavior
+- **Verification boundary**: regression guard RED-to-GREEN plus full bun test
+- **Review/acceptance boundary**: `tasks/reviews/20260808-0924-global-runtime-env-basedrop.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: rollback_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260808-0924-global-runtime-env-basedrop.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260808-0924-global-runtime-env-basedrop.contract.md`, `tasks/reviews/20260808-0924-global-runtime-env-basedrop.review.md`, and `tasks/notes/20260808-0924-global-runtime-env-basedrop.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260808-0924-global-runtime-env-basedrop.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: single commit; revert restores prior behavior
+
+## Captured Planning Output
+
+# Fix global-runtime commandEnv single-key record on the npx path (class-sweep closeout)
+
+## Problem
+
+`src/cli/commands/global-runtime.ts:271-277` `commandEnv` carries the same base-dropping shape fixed in #169's `initCommandEnv`: for an npx-cache source with no caller env it builds `{ AGENTIC_DEV_LINK_INSTALLED_COPIES: "0" }` — a single-key environment record. Downstream, that record reaches consumers that read it as an environment (`withProcessEnv` key-swaps it into `process.env`; `readInstalledProfile(env)` → `installProfileStatePath` resolves `env.HOME ?? homedir()`), so both levers are missing whenever a caller-supplied override should have applied. Today it is masked in production because `homedir()` equals process-start HOME, but the shape is the proven-dangerous one. `bindBunRuntimeEnv` (`global-runtime.ts:124` region) shares the family and needs the same disposition (fix or verified-inert report).
+
+## Decision (design question resolved)
+
+The pre-work question — "can commandEnv still return undefined?" — dissolves on reading the consumers: `undefined` has a well-defined meaning everywhere downstream (`withProcessEnv`'s `if (!env) return fn()` runs against the live `process.env`; `readInstalledProfile` defaults to `process.env`). `undefined` is not the bug; the single-key record is. Therefore: copy the exact post-fix shape of `initCommandEnv` (#169):
+
+```ts
+function commandEnv(sourceRoot, env?) {
+  if (!isNpxCacheSource(sourceRoot)) return env;
+  if (env?.AGENTIC_DEV_LINK_INSTALLED_COPIES !== undefined) return env;
+  return { ...(env ?? process.env), AGENTIC_DEV_LINK_INSTALLED_COPIES: "0" };
+}
+```
+
+Non-npx callers keep the exact `env`-through (including `undefined`); npx-with-flag keeps env untouched; only the npx-no-flag branch changes base. No signature change, no contract flip. `bindBunRuntimeEnv`: same treatment if it constructs a partial record consumed as an environment; verified-inert report in notes otherwise.
+
+## Root cause evidence plan (bugfix profile)
+
+- regression_guard: tests/cli/global-runtime.test.ts — npx-cache-source setup-global path with `REPO_HARNESS_HOME`/marker set in `process.env` must resolve installed-profile state (or equivalent observable) under the override, not the real home. RED on unfixed code, artifact captured.
+- pre_fix_failure_artifact: .ai/harness/checks/pre-fix-global-runtime-env.log
+
+## Task Breakdown
+
+- [x] Regression guard in `tests/cli/global-runtime.test.ts` (RED captured on unfixed code).
+- [x] Fix `commandEnv` to the #169 shape; disposition `bindBunRuntimeEnv` (fix or verified-inert report).
+- [x] Full `bun test`, `bun run check:type`, `bun src/cli/index.ts init --repo . --dry-run` green.
+
+## Verification
+
+Regression guard RED→GREEN; full suite; typecheck; init dry-run.
+
+## Rollback
+
+Single commit; revert restores prior behavior.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [x] Regression guard in `tests/cli/global-runtime.test.ts` (RED captured on unfixed code).
+- [x] Fix `commandEnv` to the #169 shape; disposition `bindBunRuntimeEnv` (fix or verified-inert report).
+- [x] Full `bun test`, `bun run check:type`, `bun src/cli/index.ts init --repo . --dry-run` green.

--- a/src/cli/commands/global-runtime.ts
+++ b/src/cli/commands/global-runtime.ts
@@ -123,7 +123,7 @@ function resolveBunExecutable(env?: NodeJS.ProcessEnv): string {
 function bindBunRuntimeEnv(env: NodeJS.ProcessEnv | undefined, bunExecutable: string): NodeJS.ProcessEnv {
   const activePath = env?.PATH ?? process.env.PATH ?? "";
   return {
-    ...(env ?? {}),
+    ...(env ?? process.env),
     PATH: [dirname(bunExecutable), activePath].filter(Boolean).join(delimiter),
   };
 }
@@ -269,11 +269,9 @@ function isNpxCacheSource(sourceRoot: string): boolean {
 }
 
 function commandEnv(sourceRoot: string, env?: NodeJS.ProcessEnv): NodeJS.ProcessEnv | undefined {
-  const next = { ...(env ?? {}) };
-  if (isNpxCacheSource(sourceRoot) && next.AGENTIC_DEV_LINK_INSTALLED_COPIES === undefined) {
-    next.AGENTIC_DEV_LINK_INSTALLED_COPIES = "0";
-  }
-  return Object.keys(next).length > 0 ? next : env;
+  if (!isNpxCacheSource(sourceRoot)) return env;
+  if (env?.AGENTIC_DEV_LINK_INSTALLED_COPIES !== undefined) return env;
+  return { ...(env ?? process.env), AGENTIC_DEV_LINK_INSTALLED_COPIES: "0" };
 }
 
 function packageVersion(sourceRoot: string): string | null {

--- a/tasks/contracts/20260808-0924-global-runtime-env-basedrop.contract.md
+++ b/tasks/contracts/20260808-0924-global-runtime-env-basedrop.contract.md
@@ -1,0 +1,148 @@
+# Task Contract: global-runtime-env-basedrop
+
+> **Status**: Active
+> **Plan**: plans/plan-20260808-0924-global-runtime-env-basedrop.md
+> **Task Profile**: bugfix
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: ancienttwo
+> **Capability ID**: root
+> **Last Updated**: 2026-08-08 09:24
+> **Review File**: `tasks/reviews/20260808-0924-global-runtime-env-basedrop.review.md`
+> **Notes File**: `tasks/notes/20260808-0924-global-runtime-env-basedrop.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+`commandEnv` in global-runtime carries the same base-dropping shape fixed in #169: npx-cache source with no caller env yields a single-key environment record that downstream consumers read as an environment (`withProcessEnv` key-swaps it; `readInstalledProfile` -> `installProfileStatePath` resolves `env.HOME ?? homedir()`), losing every caller lever. Masked today only because `homedir()` equals process-start HOME. Skipped, the proven-dangerous shape stays as a template for the next copy.
+
+## Goal
+
+`commandEnv` matches the #169 post-fix shape: non-npx callers get `env` through untouched (including `undefined`, whose downstream meaning — fall back to live `process.env` — is well-defined in every consumer); npx-with-flag returns env untouched; only the npx-no-flag branch bases on `process.env`. No signature change. `bindBunRuntimeEnv` gets the same disposition: fixed if it constructs a partial record consumed as an environment, or a verified-inert report in notes. Regression guard proves RED on unfixed code (artifact captured) and GREEN after. Full suite, typecheck, init dry-run green.
+
+## Scope
+
+- In scope: `src/cli/commands/global-runtime.ts` (`commandEnv`, `bindBunRuntimeEnv` disposition); regression guard in `tests/cli/global-runtime.test.ts`.
+- Out of scope: signature/contract changes to `commandEnv` (undefined stays legal), `withProcessEnv`/`readInstalledProfile` behavior, init.ts (already fixed in #169), any other command surface.
+- Taste constraints: <!-- advisory only, no run gate; default style/taste lives in AGENTS.md and the minimal-change policy, use this to record a per-task override -->
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+
+## Falsifier
+
+If any consumer of `commandEnv`'s return distinguishes "single-key record" from "full env record" semantically (relies on the record being minimal), basing on `process.env` breaks it — cheapest proof point: enumerate the callers of `commandEnv` and every sink of its return value before editing.
+
+## Root Cause Evidence
+
+Required when Task Profile is `bugfix`; leave as-is otherwise.
+
+- root_cause: `src/cli/commands/global-runtime.ts:271-277` — `commandEnv` builds `{ ...(env ?? {}) }` so an npx-cache source with no caller env produces a single-key record that downstream environment readers treat as the whole environment, dropping REPO_HARNESS_HOME/HOME levers.
+- repro: with a home-override marker in `process.env`, drive the npx-cache setup-global path with no caller env — installed-profile/state resolution ignores the override (observable under an isolated fixture; masked in production only because homedir() equals process-start HOME).
+- regression_guard: tests/cli/global-runtime.test.ts
+- pre_fix_failure_artifact: .ai/harness/checks/pre-fix-global-runtime-env.log
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260808-0924-global-runtime-env-basedrop.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260808-0924-global-runtime-env-basedrop.review.md`
+- Notes file: `tasks/notes/20260808-0924-global-runtime-env-basedrop.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Acceptance Policy
+
+```json
+{"protocol":1,"reviewer":"Claude","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - docs/spec.md
+  - plans/
+  - tasks/todos.md
+  - tasks/contracts/20260808-0924-global-runtime-env-basedrop.contract.md
+  - tasks/reviews/20260808-0924-global-runtime-env-basedrop.review.md
+  - tasks/notes/20260808-0924-global-runtime-env-basedrop.notes.md
+  - .ai/context/capabilities.json
+  - .ai/harness/checks/
+  - src/cli/commands/global-runtime.ts
+  - tests/cli/
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+      - codex-exec
+      - main-thread
+    fallback: main-thread
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - docs/spec.md
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260808-0924-global-runtime-env-basedrop.notes.md
+  tests_pass:
+    - path: tests/cli/global-runtime.test.ts
+  commands_succeed:
+    - bun run check:type
+    - bun test
+    - bun src/cli/index.ts init --repo . --dry-run
+```
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior:
+- Edge cases:
+- Regression risks:
+
+## Rollback Point
+
+- Commit / checkpoint:
+- Revert strategy:

--- a/tasks/contracts/20260808-0924-global-runtime-env-basedrop.contract.md
+++ b/tasks/contracts/20260808-0924-global-runtime-env-basedrop.contract.md
@@ -1,12 +1,12 @@
 # Task Contract: global-runtime-env-basedrop
 
-> **Status**: Active
+> **Status**: Fulfilled
 > **Plan**: plans/plan-20260808-0924-global-runtime-env-basedrop.md
 > **Task Profile**: bugfix
 > <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
 > **Owner**: ancienttwo
 > **Capability ID**: root
-> **Last Updated**: 2026-08-08 09:24
+> **Last Updated**: 2026-08-08 10:20
 > **Review File**: `tasks/reviews/20260808-0924-global-runtime-env-basedrop.review.md`
 > **Notes File**: `tasks/notes/20260808-0924-global-runtime-env-basedrop.notes.md`
 > **Exemplar**: `docs/reference-configs/contract-brief-example.md`

--- a/tasks/notes/20260808-0924-global-runtime-env-basedrop.notes.md
+++ b/tasks/notes/20260808-0924-global-runtime-env-basedrop.notes.md
@@ -1,0 +1,72 @@
+# Implementation Notes: global-runtime-env-basedrop
+
+> **Status**: Active
+> **Plan**: plans/plan-20260808-0924-global-runtime-env-basedrop.md
+> **Contract**: tasks/contracts/20260808-0924-global-runtime-env-basedrop.contract.md
+> **Review**: tasks/reviews/20260808-0924-global-runtime-env-basedrop.review.md
+> **Last Updated**: 2026-08-08 09:24
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- **Falsifier discharged, and it moved the fix.** `commandEnv` has exactly one caller
+  (`global-runtime.ts:650`) and exactly one sink: `bindBunRuntimeEnv(...)`. No consumer
+  reads the return directly, so nothing depends on "minimal record" semantics and basing
+  on `process.env` is safe. The same enumeration showed the plan's `bindBunRuntimeEnv`
+  question is not inert: it returns a **non-optional** record, so `commandEnv`'s `undefined`
+  never reaches an undefined-aware consumer here — `bindBunRuntimeEnv` materializes it into
+  `{ PATH }`, a one-key environment. It is the effective base-dropper on this surface, and
+  it was fixed to `...(env ?? process.env)` alongside `commandEnv`.
+- **The unmasked sink is a single line.** Every `homeDir(env)` helper in this file resolves
+  `env?.HOME ?? process.env.HOME ?? homedir()`, so it re-reads `process.env` and masks the
+  drop. The one consumer with no `process.env` step is the first use of the record,
+  `readInstalledProfile(env)` -> `installProfileStatePath(env)`
+  (`src/cli/installer/install-profile.ts:502`, `env.HOME ?? homedir()`). Since Bun caches
+  `homedir()` at process start, a dropped base silently resolved install-state against the
+  operator's real home. That is the only guardable observable, and it is what the guard pins.
+- **Guard fires before any side effect.** The profile read is `global-runtime.ts:651`, ahead
+  of `ensureSupportedBunRuntime` and every spawn/write, so the regression guard drives no
+  process and touches no filesystem outside its tmp fixture on either code path.
+- **Legacy protocol-1 state as the probe.** Seeding a valid protocol-2 state would require
+  a `ownership_manifest` that satisfies `validateManagedSurface`, coupling the guard to the
+  install-profile schema. A protocol-1 file makes `readInstalledProfile` fail closed with the
+  resolved path in the message, which is exactly the datum under test. Deterministic RED in
+  all three real-home shapes: no state file (falls through, later throws on the catalog with
+  a different path), a valid state (no throw), a legacy state (throws with the *real* home path).
+
+## Deviations From Plan Or Spec
+
+- The plan framed `bindBunRuntimeEnv` as "fix or verified-inert report". Enumeration proved
+  it is not inert but load-bearing, so it was fixed. That is within Goal and Allowed Paths
+  (`src/cli/commands/global-runtime.ts`), and it is why the regression guard covers the
+  non-npx source path too — on that path `commandEnv` returns `undefined` untouched and
+  `bindBunRuntimeEnv` alone owns the drop.
+- Contract named `tests/cli/global-runtime.test.ts`; the file did not exist (only
+  `global-runtime-init.test.ts`). Created as named, under the allowed `tests/cli/` prefix.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| Fix `commandEnv` only, report `bindBunRuntimeEnv` as inert | Rejected | It is the sole sink and returns a non-optional record; leaving it would keep the non-npx path dropping the base and leave the class shape in place |
+| Assert on `install agent fleet` step status (minimal vs full profile) | Rejected | Requires a schema-valid protocol-2 state file and false-passes if the operator's real home happens to hold a minimal-profile state |
+| Change `commandEnv`'s signature to drop `undefined` | Rejected | Pre-adjudicated in the plan; `undefined` is well-defined in every consumer and the record, not the option type, was the bug |
+
+## Open Questions
+
+- None.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/reviews/20260808-0924-global-runtime-env-basedrop.review.md
+++ b/tasks/reviews/20260808-0924-global-runtime-env-basedrop.review.md
@@ -1,84 +1,88 @@
 # Task Review: global-runtime-env-basedrop
 
-> **Status**: Pending
+> **Status**: Complete
 > **Plan**: plans/plan-20260808-0924-global-runtime-env-basedrop.md
 > **Contract**: tasks/contracts/20260808-0924-global-runtime-env-basedrop.contract.md
 > **Notes File**: tasks/notes/20260808-0924-global-runtime-env-basedrop.notes.md
 > **Checks File**: .ai/harness/checks/latest.json
-> **Last Updated**: 2026-08-08 09:24
-> **Recommendation**: fail
+> **Last Updated**: 2026-08-08 10:20
+> **Recommendation**: pass
 > **Review Rubric Version**: 2
-> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject SHA256**: sha256:9578d30830f16661c330da7c92a664a6aeb2f15494091125a98cdf1d60880469
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: pending
+> **Reviewed Target Revision**: 44072affa429baa8e826c3ee89c5d873eced6238
 
 ## Human Review Card
 
-- Verdict: pending
-- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
-- Intended files changed:
-- Actual files changed:
-- Commands passed:
-- Residual risks:
-- Reviewer action required: inspect diff and card
-- Rollback:
+- Verdict: pass
+- Change type: code-change
+- Intended files changed: `src/cli/commands/global-runtime.ts` (`commandEnv` plus the `bindBunRuntimeEnv` disposition), a regression guard at the contract-named path `tests/cli/global-runtime.test.ts`, the RED artifact, and the plan/contract/notes/review workflow artifacts plus `tasks/todos.md`.
+- Actual files changed: `src/cli/commands/global-runtime.ts` (+5/-7 across `:126` and `:271-275`), `tests/cli/global-runtime.test.ts` (new, 86 lines, two guards), `.ai/harness/checks/pre-fix-global-runtime-env.log` (new RED artifact, `PRE_FIX_EXIT=1`), `tasks/todos.md` (timestamp line), plus the four workflow artifacts. 8 files, +581/-7. No dependency, manifest, or generated-output change.
+- Commands passed: `bun test tests/cli/global-runtime.test.ts tests/cli/global-runtime-init.test.ts tests/cli/init.test.ts` 53 pass / 0 fail (24.09s, gatekeeper-run); `bun run check:type` EXIT=0; `bun test` full suite 2260 pass / 1 skip / 0 fail (567.34s, gatekeeper-run); `bun src/cli/index.ts init --repo . --dry-run` EXIT=0; `verify-sprint --prepare-acceptance` total=17 failed=0 status=Fulfilled with full `bun test` green at 571687ms; `verify-sprint` finalized against the recorded receipt.
+- Residual risks: (1) `commandEnv` is now byte-identical to `initCommandEnv` (`src/cli/commands/init.ts:194-198`) in a second file. The duplication is deliberate and documented at `global-runtime.ts:54-61` as this file's existing pattern for init-shaped helpers, but the class now has two copies to keep in step if the npx flag convention changes. (2) On the npx-no-caller-env path the record now carries the full process environment into `withProcessEnv`, whose `finally` restores every key it set; that is a no-op today because no code under `runInstall` mutates `process.env` persistently (swept: the only `process.env` writers in `src/` are the three `withProcessEnv` implementations themselves).
+- Reviewer action required: none — all gates clean, no findings.
+- Rollback: revert the fix commit. Source change is two spread bases and one branch restructure in one file; no persisted format, no schema, no migration.
 
 ## Mode Evidence
 
-- Selected route:
-- P1/P2/P3 evidence:
-- Root cause or plan evidence:
+- Selected route: planning -> contract execution -> gatekeeper acceptance (single round, no fix cycle).
+- P1/P2/P3 evidence: P1 — `runGlobalRuntimeSetup` builds exactly one environment record (`global-runtime.ts:648`) and threads it into two classes of consumer: spawn sites, which are safe because `runBoundedProcess` re-merges `{...process.env, ...env}` (`src/effects/process-runner.ts:136,232`), and in-process record readers, which are safe only where they carry their own `process.env` step. P2 — traced setup-global with no caller env: `commandEnv(sourceRoot, undefined)` -> (npx) one-key record or (non-npx) `undefined` -> `bindBunRuntimeEnv` materializes either into a `{ PATH }`-shaped record -> the record's very first use, `readInstalledProfile(env)` (`:649`) -> `installProfileStatePath` (`src/cli/installer/install-profile.ts:503`, `env.HOME ?? homedir()`) with no `process.env` step -> install-state resolves against Bun's process-start `homedir()` cache, i.e. the operator's real home, whatever the caller passed. P3 — the smallest coherent change is the base of both spreads, not the resolution chains: `env ?? process.env` keeps caller-supplied env byte-identical by construction, and `commandEnv` keeps returning `undefined` on non-npx sources because that value is well-defined in every consumer.
+- Root cause or plan evidence: the contract's four `Root Cause Evidence` fields are concrete and machine-verified by the bugfix profile (root_cause; repro; regression_guard listed under `exit_criteria.tests_pass`; pre_fix_failure_artifact exists, shows `PRE_FIX_EXIT=1`, and references the guard path).
 
 ## Verification Evidence
 
-- Waza `/check` run:
-- Commands run:
-- Manual checks:
-- Supporting artifacts:
-- Implementation notes reviewed:
-- Run snapshot:
+- Waza `/check` run: covered by `verify-sprint --prepare-acceptance` (17 checks, 0 failed, status Fulfilled).
+- Commands run: `bun test tests/cli/global-runtime.test.ts tests/cli/global-runtime-init.test.ts tests/cli/init.test.ts`; `bun run check:type`; `bun test` (full); `bun src/cli/index.ts init --repo . --dry-run`; `verify-sprint --prepare-acceptance`; `bun scripts/acceptance-receipt.ts record --disposition external_pass`; `verify-sprint`.
+- Manual checks: (1) Independent RED reproduction — a detached scratch worktree was created at the base commit `44072aff` (tracked files in the delivery worktree untouched), the committed guard copied in, and run there: 0 pass / 2 fail, failure text matching the archived artifact line for line. (2) Mutation isolation — in that same scratch tree, fixing only `bindBunRuntimeEnv` left the npx guard failing (1 pass / 1 fail), and fixing only `commandEnv` left the non-npx guard failing (1 pass / 1 fail). Each test pins exactly one helper, so neither edit is guard-dead. (3) Falsifier, independently swept — `commandEnv` and `bindBunRuntimeEnv` are both module-private with exactly one call site each (`:648`), and no consumer of the record reads its key set semantically: `configureCodegraph` and `configureBrainRoot` use `env` only for HOME resolution and spawns and never serialize it into a config file, so nothing depends on the record being minimal. (4) Unmasked-sink sweep — every other consumer on this chain (`homeDir`, `isSelfManagedBun`, `bunGlobalPackageRoot`, `updateAvailableHint`, `expandHomePath`, `defaultBrainRootChoice`) carries an explicit `process.env` step and is masked either way; `installProfileStatePath` is confirmed as the only one that is not. (5) Class sweep re-run over the remaining `?? {}` env bases in `src/`: `helper-runner.ts:359`, `process-runner.ts:136,232`, and `init-hook.ts:563` already spread onto `process.env`, and `init-hook.ts:701` `doctorEnv` is inert because its only consumer is `withProcessEnv`, which overlays keys onto the live `process.env` rather than replacing it. No sibling of this class is left in `src/`. (6) Real-home integrity — `~/.repo-harness` was checksummed (494 files) before the test runs and again after both the GREEN and the scratch RED runs: byte-identical, no temp-path residue, so the guard's zero-side-effect claim holds and the RED path wrote nothing either.
+- Supporting artifacts: `.ai/harness/checks/pre-fix-global-runtime-env.log` (RED, `PRE_FIX_EXIT=1`); `.ai/harness/checks/latest.json`.
+- Implementation notes reviewed: yes — `tasks/notes/20260808-0924-global-runtime-env-basedrop.notes.md`; the Falsifier enumeration, the "bindBunRuntimeEnv is not inert" deviation, and the protocol-1 probe rationale all match what was verified independently here.
+- Run snapshot: `.ai/harness/runs/run-20260808T095855-4946-20260808-0924-global-runtime-env-basedrop.json`
 
 ## Acceptance Receipt Projection
 
-> **Disposition**: unavailable
-> **Reviewer**: unavailable
-> **Source**: unavailable
+> **Disposition**: external_pass
+> **Reviewer**: Claude
+> **Source**: claude-review
 > **Actor**: not-applicable
-> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject SHA256**: sha256:9578d30830f16661c330da7c92a664a6aeb2f15494091125a98cdf1d60880469
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: pending
-> **Verification Evidence SHA256**: pending
-> **Issued At**: pending
+> **Reviewed Target Revision**: 44072affa429baa8e826c3ee89c5d873eced6238
+> **Verification Evidence SHA256**: sha256:bb1f746456c4d1dd813674397e6509abd8fd8ef213af9f22970063fba6039f56
+> **Issued At**: 2026-08-08T02:14:20.324Z
 
-- Summary: No AcceptanceReceipt has been recorded.
+- Summary: gatekeeper acceptance: commandEnv and bindBunRuntimeEnv now base the constructed setup-global env on process.env; guard RED independently reproduced at the base commit and mutation-isolated so each test pins one helper; bindBunRuntimeEnv caller/sink enumeration confirmed no minimality dependence; verify-sprint 17/17 with full bun test 2260 pass / 0 fail
 - Findings: none
 
 ## Behavior Diff Notes
 
-- ...
+- npx-cache source, no caller env: the constructed record now carries the full `process.env` plus the bound `PATH` instead of `{ AGENTIC_DEV_LINK_INSTALLED_COPIES, PATH }`. Observable effect — `setup-global` under an overridden `HOME` resolves install state under that home instead of the operator's real `~/.repo-harness`.
+- Non-npx source, no caller env: `commandEnv` returns `undefined` exactly as before; the change is entirely in `bindBunRuntimeEnv`, which no longer materializes that `undefined` into a `{ PATH }`-only environment. Same observable.
+- Caller-supplied env, either source: byte-identical behavior. The npx-with-flag and non-npx branches now return the caller's object by reference rather than a shallow copy, which is unobservable because the sole sink spreads it into a new record and never mutates it.
+- Spawned children: no change on any path. `runBoundedProcess` already merged `{...process.env, ...env}`.
 
 ## Residual Risks / Follow-ups
 
-- ...
+- `commandEnv` is now a byte-identical twin of `initCommandEnv` in a second file; the duplication is deliberate and documented at `global-runtime.ts:54-61`, but both copies must move together if the npx flag convention changes.
+- The guard asserts through `readInstalledProfile`'s fail-closed error on a protocol-1 state file. If protocol 1 is ever dropped from the reader, the probe needs replacing with a schema-valid protocol-2 fixture; the notes already record why that shape was rejected today.
 
 ## Scorecard
 
 | Dimension | Score | Notes |
 |-----------|-------|-------|
-| Functionality | 0/10 | |
-| Product depth | 0/10 | |
-| Design quality | 0/10 | |
-| Code quality | 0/10 | |
+| Functionality | 9/10 | Both base-droppers fixed, caller-supplied env provably unchanged, spawn paths unaffected |
+| Product depth | 9/10 | Closes the class the #169 sweep opened and leaves no sibling shape in `src/` |
+| Design quality | 8/10 | Exact #169 shape reused rather than reinvented; the cost is a second copy of the same four lines |
+| Code quality | 9/10 | Net -2 lines, one branch structure replaced by three guard clauses, guard comments carry the reasoning |
 
 ## Failing Items
 
-- ...
+- None.
 
 ## Retest Steps
 
-- Re-run:
-- Re-check:
+- Re-run: `bun test tests/cli/global-runtime.test.ts` (both cases must pass), then `verify-sprint --prepare-acceptance`.
+- Re-check: revert either `global-runtime.ts:126` or `:271-275` in a scratch tree and confirm the matching guard goes RED.
 
 ## Summary
 
-- ...
+- `commandEnv` and `bindBunRuntimeEnv` both based their constructed environment on `{}`, so a `setup-global` invocation with no caller env produced a one- or two-key record that `readInstalledProfile` -> `installProfileStatePath` read as the whole environment and silently resolved against the operator's real home. Both now base on `process.env` when the caller provides none. Enumeration confirmed no consumer depends on the record being minimal, the two guards are mutation-isolated to one helper each, RED was independently reproduced at the base commit, and the full suite, typecheck, init dry-run, and `verify-sprint` are green with zero writes to the real `~/.repo-harness`.

--- a/tasks/reviews/20260808-0924-global-runtime-env-basedrop.review.md
+++ b/tasks/reviews/20260808-0924-global-runtime-env-basedrop.review.md
@@ -1,0 +1,84 @@
+# Task Review: global-runtime-env-basedrop
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260808-0924-global-runtime-env-basedrop.md
+> **Contract**: tasks/contracts/20260808-0924-global-runtime-env-basedrop.contract.md
+> **Notes File**: tasks/notes/20260808-0924-global-runtime-env-basedrop.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-08-08 09:24
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Commands passed:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+- Waza `/check` run:
+- Commands run:
+- Manual checks:
+- Supporting artifacts:
+- Implementation notes reviewed:
+- Run snapshot:
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -1,7 +1,7 @@
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: (archive-workflow)
+> **Updated**: 2026-08-08 09:24
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.

--- a/tests/cli/global-runtime.test.ts
+++ b/tests/cli/global-runtime.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { runGlobalRuntimeSetup } from '../../src/cli/commands/global-runtime';
+
+/**
+ * Regression guard for the #169 base-dropping class on the setup-global surface.
+ *
+ * `runGlobalRuntimeSetup` builds its one environment record as
+ * `bindBunRuntimeEnv(commandEnv(sourceRoot, opts.env), bunExecutable)`
+ * (src/cli/commands/global-runtime.ts). With no caller env both helpers used to
+ * base on `{}`, so the composed record held one or two keys and the whole
+ * process environment was discarded.
+ *
+ * Most consumers are masked: `homeDir(env)` resolves
+ * `env?.HOME ?? process.env.HOME ?? homedir()`, so it re-reads process.env and
+ * survives the drop. The one unmasked sink is the very first use of the record,
+ * `readInstalledProfile(env)` -> `installProfileStatePath(env)`
+ * (src/cli/installer/install-profile.ts:502), whose chain is
+ * `env.HOME ?? homedir()` with no process.env step. Bun caches `homedir()` at
+ * process start, so on a dropped base that resolves to the operator's real home
+ * and every caller-visible HOME lever is lost.
+ *
+ * Observable: a legacy protocol-1 install-state file seeded under an overridden
+ * HOME must be the file the profile read fails closed on, and the thrown message
+ * carries the resolved path. That read happens before any process spawn or
+ * filesystem write, so this guard has no side effects on either code path.
+ */
+describe('global runtime setup command env base', () => {
+  function runWithSeededHome(sourceRoot: string, home: string): () => unknown {
+    return () => runGlobalRuntimeSetup({
+      sourceRoot,
+      cwd: home,
+      installCli: false,
+      syncSkill: false,
+      hostAdapters: false,
+      externalSkills: false,
+      codegraph: false,
+    });
+  }
+
+  function withOverriddenHome(label: string, body: (tmp: string, home: string, statePath: string) => void): void {
+    const tmp = join(tmpdir(), `repo-harness-global-runtime-env-base-${label}-${Date.now()}`);
+    const home = join(tmp, 'home');
+    const statePath = join(home, '.repo-harness', 'install-state.json');
+    const previousHome = process.env.HOME;
+    const previousFlag = process.env.AGENTIC_DEV_LINK_INSTALLED_COPIES;
+    try {
+      mkdirSync(join(home, '.repo-harness'), { recursive: true });
+      // Legacy protocol-1 state: readInstalledProfile fails closed on it and the
+      // error names the path it resolved, which is exactly the datum under guard.
+      writeFileSync(statePath, JSON.stringify({ protocol: 1, profile: 'full' }));
+      process.env.HOME = home;
+      delete process.env.AGENTIC_DEV_LINK_INSTALLED_COPIES;
+      body(tmp, home, statePath);
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      if (previousFlag === undefined) delete process.env.AGENTIC_DEV_LINK_INSTALLED_COPIES;
+      else process.env.AGENTIC_DEV_LINK_INSTALLED_COPIES = previousFlag;
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  }
+
+  test('npx cache source with no caller env keeps process.env as the constructed env base', () => {
+    withOverriddenHome('npx', (tmp, home, statePath) => {
+      // isNpxCacheSource() matches on the `_npx` path segment, so this drives the
+      // branch that injects AGENTIC_DEV_LINK_INSTALLED_COPIES with no caller env.
+      const source = join(tmp, '_npx', 'abc123', 'node_modules', 'repo-harness');
+      mkdirSync(source, { recursive: true });
+      expect(runWithSeededHome(source, home)).toThrow(statePath);
+    });
+  });
+
+  test('non-npx source with no caller env keeps process.env as the constructed env base', () => {
+    withOverriddenHome('plain', (tmp, home, statePath) => {
+      // commandEnv() passes `undefined` straight through here (a well-defined
+      // value downstream); bindBunRuntimeEnv() is the helper that must not
+      // materialize a PATH-only record out of it.
+      const source = join(tmp, 'installed', 'repo-harness');
+      mkdirSync(source, { recursive: true });
+      expect(runWithSeededHome(source, home)).toThrow(statePath);
+    });
+  });
+});


### PR DESCRIPTION
Closes the env base-drop class opened by the #169 sweep. #169 fixed `initCommandEnv` on the `init` surface and explicitly deferred the two sibling shapes in `global-runtime.ts`; this is that closeout, and no sibling of the class is left in `src/`.

## What was broken

`runGlobalRuntimeSetup` builds exactly one environment record:

```ts
const env = bindBunRuntimeEnv(commandEnv(sourceRoot, opts.env), bunExecutable);
```

Both helpers based their spread on `{}`. With no caller env that produced `{ AGENTIC_DEV_LINK_INSTALLED_COPIES, PATH }` on the npx path and `{ PATH }` on every other path — a record that downstream code reads as *the whole environment*.

The load-bearing discovery is `bindBunRuntimeEnv`, which the plan had framed as "fix or report inert". It is not inert: it returns a **non-optional** record, so `commandEnv`'s `undefined` never reaches an undefined-aware consumer here — `bindBunRuntimeEnv` materializes it into a one-key `{ PATH }` environment unconditionally. It is the effective base-dropper on the non-npx path, and `commandEnv` alone would not have fixed it.

Most consumers are masked: `homeDir(env)` and friends resolve `env?.X ?? process.env.X ?? …`, so they re-read the live environment and survive the drop. The one consumer with no `process.env` step is the record's very first use:

`readInstalledProfile(env)` → `installProfileStatePath(env)` (`src/cli/installer/install-profile.ts:503`, `env.HOME ?? homedir()`)

Bun caches `homedir()` at process start, so a dropped base sends install-state resolution silently to the operator's real home no matter what the caller passed. Spawned children were never affected — `runBoundedProcess` already merged `{...process.env, ...env}`.

## The fix

Both sites base on `process.env` when the caller provides none. Callers passing env keep exact prior behavior, and `commandEnv` still passes `undefined` through on non-npx sources, where the downstream meaning is well defined. `commandEnv` now matches the post-#169 shape of `initCommandEnv` exactly.

## Verification

Two guards in the new `tests/cli/global-runtime.test.ts`, one per path, both pinning the same observable: `setup-global` under a seeded override home must resolve install state under that override. Probe is a legacy protocol-1 state file, which makes `readInstalledProfile` fail closed with the resolved path in the message — and that read happens before any spawn or write, so the guards touch nothing outside their tmp fixture.

- RED captured pre-fix (`.ai/harness/checks/pre-fix-global-runtime-env.log`, `PRE_FIX_EXIT=1`, 0 pass / 2 fail) and reproduced independently in a scratch worktree at the base commit.
- Mutation-isolated: fixing only `bindBunRuntimeEnv` leaves the npx guard RED; fixing only `commandEnv` leaves the non-npx guard RED. Neither edit is guard-dead.
- Full suite 2260 pass / 1 skip / 0 fail; `bun run check:type`, `init --repo . --dry-run` green; `verify-sprint` 17 checks / 0 failed, status Fulfilled.
- `~/.repo-harness` checksummed before and after every run, including the RED runs: byte-identical.
