### PR TITLE
chore(repo): ignore Cursor editor artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ bun.lockb
 # IDE
 .idea/
 .vscode/settings.json
+.cursor/
 
 # Sisyphus internal state (not project deliverables)
 .sisyphus/boulder.json


### PR DESCRIPTION
## What
Ignore the CodeGraph-generated Cursor editor directory.

## Why
The tracked artifact is already absent from main, but the directory was not ignored, so a future CodeGraph or editor run could reintroduce it.

## Scope
One .gitignore line only. No workflow artifacts or unrelated historical branch changes are included.

## Checks
- git ls-files .cursor returns empty
- git check-ignore -q .cursor/rules/codegraph.mdc
- git diff --check