### PR TITLE
fix(hook): reject out-of-repository paths in mutation-observed journal

### DIFF
--- a/plans/plan-20260811-1659-mutation-observed-in-repo-qualifier.md
+++ b/plans/plan-20260811-1659-mutation-observed-in-repo-qualifier.md
@@ -1,0 +1,162 @@
+# Plan: Mutation-observed in-repo qualifier gate
+
+> **Status**: Executing
+> **Created**: 20260811-1659
+> **Slug**: mutation-observed-in-repo-qualifier
+> **Planning Source**: codex-plan
+> **Orchestration Kind**: host-plan
+> **Source Ref**: cross-review 20260811 P3 decision
+> **Artifact Level**: work-package
+> **Promotion Reason**: human_decision_boundary
+> **Verification Boundary**: Commands named in the captured planning output plus `repo-harness run verify-contract --contract tasks/contracts/20260811-1659-mutation-observed-in-repo-qualifier.contract.md --strict`.
+> **Rollback Surface**: Before execution remove `plans/plan-20260811-1659-mutation-observed-in-repo-qualifier.md`; after execution revert branch `codex/mutation-observed-in-repo-qualifier` or the explicitly reviewed diff.
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260811-1659-mutation-observed-in-repo-qualifier.contract.md`
+> **Task Review**: `tasks/reviews/20260811-1659-mutation-observed-in-repo-qualifier.review.md`
+> **Implementation Notes**: `tasks/notes/20260811-1659-mutation-observed-in-repo-qualifier.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from codex-plan planning output.
+- Source ref: cross-review 20260811 P3 decision
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260811-1659-mutation-observed-in-repo-qualifier.md`
+- Sprint contract: `tasks/contracts/20260811-1659-mutation-observed-in-repo-qualifier.contract.md`
+- Sprint review: `tasks/reviews/20260811-1659-mutation-observed-in-repo-qualifier.review.md`
+- Implementation notes: `tasks/notes/20260811-1659-mutation-observed-in-repo-qualifier.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260811-1659-mutation-observed-in-repo-qualifier.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260811-1659-mutation-observed-in-repo-qualifier.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260811-1659-mutation-observed-in-repo-qualifier.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260811-1659-mutation-observed-in-repo-qualifier.contract.md`
+- Review file: `tasks/reviews/20260811-1659-mutation-observed-in-repo-qualifier.review.md`
+- Implementation notes file: `tasks/notes/20260811-1659-mutation-observed-in-repo-qualifier.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260811-1659-mutation-observed-in-repo-qualifier.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260811-1659-mutation-observed-in-repo-qualifier.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: Before execution remove `plans/plan-20260811-1659-mutation-observed-in-repo-qualifier.md`; after execution revert branch `codex/mutation-observed-in-repo-qualifier` or the explicitly reviewed diff.
+- **Verification boundary**: Commands named in the captured planning output plus `repo-harness run verify-contract --contract tasks/contracts/20260811-1659-mutation-observed-in-repo-qualifier.contract.md --strict`.
+- **Review/acceptance boundary**: `tasks/reviews/20260811-1659-mutation-observed-in-repo-qualifier.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: human_decision_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260811-1659-mutation-observed-in-repo-qualifier.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260811-1659-mutation-observed-in-repo-qualifier.contract.md`, `tasks/reviews/20260811-1659-mutation-observed-in-repo-qualifier.review.md`, and `tasks/notes/20260811-1659-mutation-observed-in-repo-qualifier.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260811-1659-mutation-observed-in-repo-qualifier.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: Before execution remove `plans/plan-20260811-1659-mutation-observed-in-repo-qualifier.md`; after execution revert branch `codex/mutation-observed-in-repo-qualifier` or the explicitly reviewed diff.
+
+## Captured Planning Output
+
+# Goal
+
+Close the mutation-observed poison-event defect: out-of-repository absolute
+paths (for example plan files under `~/.claude/plans/` and memory files under
+`~/.claude/projects/`) currently qualify as post-edit journal events, set the
+architecture/context/capability dirty bits, and produce projection jobs that
+archctx rejects with non-retryable `AC_SCHEMA_INVALID`, permanently blocking
+the Stop-hook strict projection gate.
+
+Root cause (verified 2026-08-11, reproduced in a disposable fixture): in
+`src/cli/hook/mutation-observed.ts`, `normalizeFilePath` returns out-of-repo
+absolute paths unchanged and `runMutationObserved` only checks for an empty
+path before setting dirty bits and writing the journal event.
+
+## Task Breakdown
+
+- [x] Add an in-repo qualification gate to `runMutationObserved` using the
+      existing `canonicalRepoRelativePath` helper
+      (`src/effects/state/collect-state-inputs.ts`): when it returns `null`,
+      no-op before any advisory, dirty-bit derivation, or journal write —
+      same contract as the existing empty-path branch.
+- [x] Red-green regression in `tests/mutation-observed.test.ts`
+      (non-qualifying block): an out-of-repository absolute path writes no
+      journal event and emits no output; a traversal-escaping relative path
+      is likewise a no-op. The existing journal-schema test remains the
+      proof that an in-repo path still writes exactly one event.
+- [x] After the fix lands, remove the two currently-pending poison events in
+      the primary tree
+      (`.ai/harness/journal/post-edit/pending/` entries pointing at
+      `~/.claude/projects/.../memory/*`), and verify the source journal and
+      projection queue are empty.
+
+## Verification
+
+- `bun test tests/mutation-observed.test.ts` (new tests RED before the fix,
+  GREEN after)
+- `bun test tests/architecture-projection-provider.test.ts` (adjacent surface
+  unchanged)
+- Primary tree: `readPendingPostEditEvents` empty via
+  `repo-harness architecture-projection drain --json` reporting
+  `sourceJournalPending: 0`, queue empty.
+
+## Out of scope (independent release gates, per cross-review decision)
+
+- Digest ignore-contract convergence between
+  `PROJECTION_WORKTREE_IGNORE_PATHS` and archctx's validator ignore list
+  (needs an archctx-side release or request-supplied ignores; single
+  authority, not two hardcoded lists).
+- `repo-harness@0.14.2` publish/install readback (global 0.14.1 ships
+  archctx@0.4.0 while the repo contract requires 0.4.1).
+
+## Rollback
+
+Single-commit revert of the qualifier gate + tests; no schema, storage, or
+policy change.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [x] Add an in-repo qualification gate to `runMutationObserved` using the
+- [x] Red-green regression in `tests/mutation-observed.test.ts`
+- [x] After the fix lands, remove the two currently-pending poison events in

--- a/src/cli/hook/mutation-observed.ts
+++ b/src/cli/hook/mutation-observed.ts
@@ -39,7 +39,7 @@ import { basename, dirname, join } from 'path';
 import type { SessionContextSection } from './session-context-budget';
 import { loadMinimalChangePolicy } from './minimal-change-policy';
 import { collectMinimalChangeSignals } from './minimal-change-signals';
-import { fileExists, readText } from '../../effects/state/collect-state-inputs';
+import { canonicalRepoRelativePath, fileExists, readText } from '../../effects/state/collect-state-inputs';
 import { withExclusiveDirectoryLock } from '../../effects/locking/exclusive-directory-lock';
 import type { WorktreeOwnership } from '../../effects/loop/state-input-collector';
 import {
@@ -83,9 +83,13 @@ export function runMutationObserved(opts: MutationObservedInput): MutationObserv
   const payload = parsePayload(opts.input);
 
   const filePath = getFilePath(repoRoot, payload, env);
-  if (!filePath) {
-    // Mirrors `[[ -z "$FILE_PATH" ]] && exit 0` -- the non-qualifying case:
-    // no event, no advisories, no journal write.
+  if (!filePath || canonicalRepoRelativePath(repoRoot, filePath) === null) {
+    // Mirrors `[[ -z "$FILE_PATH" ]] && exit 0` -- the non-qualifying case --
+    // extended fail-closed to targets that do not canonicalize inside this
+    // repository (host-side plan/memory files under ~/.claude, traversal or
+    // symlink escapes): no event, no advisories, no journal write. An
+    // out-of-repo event would otherwise become a projection job that archctx
+    // rejects with non-retryable AC_SCHEMA_INVALID and block the Stop gate.
     return { exitCode: 0, stdout: '', stderr: '' };
   }
 

--- a/tasks/contracts/20260811-1659-mutation-observed-in-repo-qualifier.contract.md
+++ b/tasks/contracts/20260811-1659-mutation-observed-in-repo-qualifier.contract.md
@@ -1,0 +1,146 @@
+# Task Contract: mutation-observed-in-repo-qualifier
+
+> **Status**: Active
+> **Plan**: plans/plan-20260811-1659-mutation-observed-in-repo-qualifier.md
+> **Task Profile**: bugfix
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: ancienttwo
+> **Capability ID**: root
+> **Last Updated**: 2026-08-11 16:59
+> **Review File**: `tasks/reviews/20260811-1659-mutation-observed-in-repo-qualifier.review.md`
+> **Notes File**: `tasks/notes/20260811-1659-mutation-observed-in-repo-qualifier.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+Out-of-repository absolute paths (host-side plan files under `~/.claude/plans/`, memory files under `~/.claude/projects/`) currently qualify as post-edit journal events, become architecture projection jobs, and archctx rejects them with non-retryable `AC_SCHEMA_INVALID` — permanently blocking the Stop-hook strict projection gate. Reproduced twice in session 6021a7db on 2026-08-11; every plan-mode or memory write re-poisons the queue until this gate lands.
+
+## Goal
+
+`runMutationObserved` no-ops (no advisory, no dirty bits, no journal write) for any file path that does not canonicalize inside the repository, using the existing `canonicalRepoRelativePath` helper; in-repo paths keep writing exactly one `change_observed` event.
+
+## Scope
+
+- In scope: `src/cli/hook/mutation-observed.ts` qualifier gate; red-green regressions in `tests/mutation-observed.test.ts`.
+- Out of scope: digest ignore-contract convergence with archctx's validator; `repo-harness@0.14.2` publish/install readback; any journal schema or storage change.
+- Taste constraints: <!-- advisory only, no run gate; default style/taste lives in AGENTS.md and the minimal-change policy, use this to record a per-task override -->
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+
+## Falsifier
+
+If a legitimate in-repo edit stops producing its journal event (existing journal-schema test fails), the gate is over-broad and the direction is wrong; cheapest proof point is `bun test tests/mutation-observed.test.ts`.
+
+## Root Cause Evidence
+
+Required when Task Profile is `bugfix`; leave as-is otherwise.
+
+- root_cause: src/cli/hook/mutation-observed.ts:85 runMutationObserved only rejects an empty file path while normalizeFilePath returns out-of-repo absolute paths unchanged, so host-side files set dirty bits and write journal events.
+- repro: bun test tests/mutation-observed.test.ts
+- regression_guard: tests/mutation-observed.test.ts
+- pre_fix_failure_artifact: .ai/harness/evidence/pre-fix-mutation-observed-in-repo-qualifier.log
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260811-1659-mutation-observed-in-repo-qualifier.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260811-1659-mutation-observed-in-repo-qualifier.review.md`
+- Notes file: `tasks/notes/20260811-1659-mutation-observed-in-repo-qualifier.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Acceptance Policy
+
+```json
+{"protocol":1,"reviewer":"Claude","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - docs/spec.md
+  - plans/
+  - tasks/todos.md
+  - tasks/contracts/20260811-1659-mutation-observed-in-repo-qualifier.contract.md
+  - tasks/reviews/20260811-1659-mutation-observed-in-repo-qualifier.review.md
+  - tasks/notes/20260811-1659-mutation-observed-in-repo-qualifier.notes.md
+  - .ai/context/capabilities.json
+  - .claude/templates/
+  - src/
+  - tests/
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+      - codex-exec
+      - main-thread
+    fallback: main-thread
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - docs/spec.md
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260811-1659-mutation-observed-in-repo-qualifier.notes.md
+  tests_pass:
+    - path: tests/mutation-observed.test.ts
+  commands_succeed:
+    - bun run check:type
+```
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior:
+- Edge cases:
+- Regression risks:
+
+## Rollback Point
+
+- Commit / checkpoint: branch codex/mutation-observed-in-repo-qualifier off main@ee33d127
+- Revert strategy: single-commit revert of the qualifier gate + tests; no schema, storage, or policy change.

--- a/tasks/notes/20260811-1659-mutation-observed-in-repo-qualifier.notes.md
+++ b/tasks/notes/20260811-1659-mutation-observed-in-repo-qualifier.notes.md
@@ -1,0 +1,44 @@
+# Implementation Notes: mutation-observed-in-repo-qualifier
+
+> **Status**: Active
+> **Plan**: plans/plan-20260811-1659-mutation-observed-in-repo-qualifier.md
+> **Contract**: tasks/contracts/20260811-1659-mutation-observed-in-repo-qualifier.contract.md
+> **Review**: tasks/reviews/20260811-1659-mutation-observed-in-repo-qualifier.review.md
+> **Last Updated**: 2026-08-11 16:59
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- Gate placement: extended the existing empty-path non-qualifying branch in `runMutationObserved` instead of changing `normalizeFilePath`/`getFilePath`. The normalize helper is a verbatim shell port; keeping it byte-stable and gating at the single caller is the smaller, port-faithful change.
+- Qualifier semantics come from `canonicalRepoRelativePath` (fail-closed: `..` segments, symlink escapes, and out-of-repo absolutes all return `null`). Deliberately gate-only — the in-repo `filePath` value passed to advisories/journal is unchanged, so existing journal `changed_paths` encodings stay byte-identical.
+- Pre-fix RED evidence at `.ai/harness/evidence/pre-fix-mutation-observed-in-repo-qualifier.log` (`PRE_FIX_EXIT=1`, 2 fail on unfixed code); post-fix 20/20 pass.
+
+## Deviations From Plan Or Spec
+
+- None recorded.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| Gate inside `normalizeFilePath` (return '' for out-of-repo) | Rejected | Would silently change the shared shell-port contract other callers may re-port; caller-side gate keeps the port verbatim |
+| Rewrite `filePath` to the canonical value for in-repo paths | Rejected | Changes observable journal `changed_paths` for edge encodings; qualification-only keeps existing tests and consumers byte-stable |
+
+## Open Questions
+
+- None. Digest ignore-contract convergence and 0.14.2 publish readback are explicitly out of scope (independent release gates per the 2026-08-11 cross-review); this fix removes poison events only and does not by itself prove legitimate events auto-drain end to end.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/reviews/20260811-1659-mutation-observed-in-repo-qualifier.review.md
+++ b/tasks/reviews/20260811-1659-mutation-observed-in-repo-qualifier.review.md
@@ -1,0 +1,84 @@
+# Task Review: mutation-observed-in-repo-qualifier
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260811-1659-mutation-observed-in-repo-qualifier.md
+> **Contract**: tasks/contracts/20260811-1659-mutation-observed-in-repo-qualifier.contract.md
+> **Notes File**: tasks/notes/20260811-1659-mutation-observed-in-repo-qualifier.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-08-11 16:59
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Commands passed:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+- Waza `/check` run:
+- Commands run:
+- Manual checks:
+- Supporting artifacts:
+- Implementation notes reviewed:
+- Run snapshot:
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...

--- a/tasks/reviews/20260811-1659-mutation-observed-in-repo-qualifier.review.md
+++ b/tasks/reviews/20260811-1659-mutation-observed-in-repo-qualifier.review.md
@@ -40,17 +40,17 @@
 
 ## Acceptance Receipt Projection
 
-> **Disposition**: unavailable
-> **Reviewer**: unavailable
-> **Source**: unavailable
+> **Disposition**: external_pass
+> **Reviewer**: Claude
+> **Source**: claude-review
 > **Actor**: not-applicable
-> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject SHA256**: sha256:5a4806cfad0c4ab9aa304adbc7f3eae7dfa23e914adf6c20cb1dde6974ec99c9
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: pending
-> **Verification Evidence SHA256**: pending
-> **Issued At**: pending
+> **Reviewed Target Revision**: ee33d127fadefa58f00b63367a7a936d2335fd08
+> **Verification Evidence SHA256**: sha256:024cd00b93169600d6f4115b9fc2f83852ab262327b22913a1ce21c17d4a9b7f
+> **Issued At**: 2026-08-11T09:15:54.041Z
 
-- Summary: No AcceptanceReceipt has been recorded.
+- Summary: In-repo qualifier gate reviewed against the 2026-08-11 cross-review spec: fail-closed canonicalRepoRelativePath qualification before advisories/dirty-bits/journal, gate-only (in-repo changed_paths byte-stable), red-green regression with PRE_FIX_EXIT=1 artifact, full suite 2326 pass / 0 fail, type check clean. No P0/P1 findings.
 - Findings: none
 
 ## Behavior Diff Notes

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -1,7 +1,7 @@
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: (archive-workflow)
+> **Updated**: 2026-08-11 16:59
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.

--- a/tests/mutation-observed.test.ts
+++ b/tests/mutation-observed.test.ts
@@ -108,6 +108,44 @@ describe('mutation-observed: non-qualifying edits', () => {
       rmSync(cwd, { recursive: true, force: true });
     }
   }, 30_000);
+
+  test('an out-of-repository absolute path writes no journal event', () => {
+    const cwd = tmpWorkspace('mo-out-of-repo');
+    const outside = tmpWorkspace('mo-outside');
+    try {
+      initRepo(cwd);
+      mkdirSync(join(outside, 'plans'), { recursive: true });
+      writeFileSync(join(outside, 'plans', 'session-plan.md'), '# host-side plan\n');
+      const result = runMutationObserved({
+        collector: collectorFor(cwd),
+        input: editPayload(join(outside, 'plans', 'session-plan.md')),
+      });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe('');
+      expect(result.stderr).toBe('');
+      expect(pendingEvents(cwd)).toEqual([]);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+      rmSync(outside, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  test('a traversal-escaping relative path writes no journal event', () => {
+    const cwd = tmpWorkspace('mo-traversal-escape');
+    try {
+      initRepo(cwd);
+      const result = runMutationObserved({
+        collector: collectorFor(cwd),
+        input: editPayload('../escaped.md'),
+      });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe('');
+      expect(result.stderr).toBe('');
+      expect(pendingEvents(cwd)).toEqual([]);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  }, 30_000);
 });
 
 describe('mutation-observed: journal schema', () => {


### PR DESCRIPTION
## Why

Out-of-repo absolute paths (host-side plan/memory files under `~/.claude`) qualified as post-edit journal events, became architecture projection jobs, and archctx rejected them with non-retryable `AC_SCHEMA_INVALID` — permanently blocking the Stop-hook strict projection gate. Reproduced twice on 2026-08-11 (plan-mode plan file, then memory files).

## What

- `runMutationObserved` now no-ops before advisories, dirty bits, and the journal write when `canonicalRepoRelativePath` returns `null` (out-of-repo absolutes, `..` traversal, symlink escapes). Gate-only: in-repo paths keep writing exactly one `change_observed` event with byte-identical `changed_paths`.
- Two red-green regressions in `tests/mutation-observed.test.ts` (out-of-repo absolute, traversal-escaping relative).

## Evidence

- Pre-fix RED: 2 fail, `PRE_FIX_EXIT=1` (artifact bound in the bugfix contract)
- Post-fix: 20/20 in-file, full suite 2326 pass / 1 skip / 0 fail, `check:type` clean
- Contract gate: `verify-contract --strict` 15/15, AcceptanceReceipt `external_pass` recorded

## Out of scope (independent gates per cross-review)

- Digest ignore-contract convergence (`PROJECTION_WORKTREE_IGNORE_PATHS` vs archctx@0.4.1 validator hardcode)
- `repo-harness@0.14.2` publish/install readback (installed 0.14.1 hook keeps old behavior until then)