### PR TITLE
chore(release): repo-harness 0.15.1

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -467,8 +467,8 @@ repositorio adopte la misma política.
 
 ## Versión actual
 
-- Paquete npm: `repo-harness@0.15.0`
-- Sello de workflow generado: `repo-harness@0.15.0+template@0.15.0`
+- Paquete npm: `repo-harness@0.15.1`
+- Sello de workflow generado: `repo-harness@0.15.1+template@0.15.1`
 - Repositorio de GitHub: `Ancienttwo/repo-harness`
 - Notas de versión e historial: [`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -462,8 +462,8 @@ adopte la même policy.
 
 ## Release actuelle
 
-- Package npm : `repo-harness@0.15.0`
-- Generated workflow stamp : `repo-harness@0.15.0+template@0.15.0`
+- Package npm : `repo-harness@0.15.1`
+- Generated workflow stamp : `repo-harness@0.15.1+template@0.15.1`
 - Dépôt GitHub : `Ancienttwo/repo-harness`
 - Notes et historique de release : [`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -470,8 +470,8 @@ commit script や hooks に組み込まないでください。
 
 ## 現在の Release
 
-- npm package：`repo-harness@0.15.0`
-- Generated workflow stamp：`repo-harness@0.15.0+template@0.15.0`
+- npm package：`repo-harness@0.15.1`
+- Generated workflow stamp：`repo-harness@0.15.1+template@0.15.1`
 - GitHub repository：`Ancienttwo/repo-harness`
 - Release notes and history：[`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -442,8 +442,8 @@ repo-harness commit scripts or hooks unless that repo adopts the same policy.
 
 ## Current Release
 
-- npm package: `repo-harness@0.15.0`
-- Generated workflow stamp: `repo-harness@0.15.0+template@0.15.0`
+- npm package: `repo-harness@0.15.1`
+- Generated workflow stamp: `repo-harness@0.15.1+template@0.15.1`
 - GitHub repository: `Ancienttwo/repo-harness`
 - Release notes and history: [`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -449,8 +449,8 @@ policy。
 
 ## 当前 Release
 
-- npm package：`repo-harness@0.15.0`
-- Generated workflow stamp：`repo-harness@0.15.0+template@0.15.0`
+- npm package：`repo-harness@0.15.1`
+- Generated workflow stamp：`repo-harness@0.15.1+template@0.15.1`
 - GitHub repository：`Ancienttwo/repo-harness`
 - Release notes 和 history：[`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/assets/skill-version.json
+++ b/assets/skill-version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.15.0",
-  "templateVersion": "0.15.0",
+  "version": "0.15.1",
+  "templateVersion": "0.15.1",
   "skillName": "repo-harness",
   "contractId": "tasks-first-harness-v1",
   "compatibility": {

--- a/deploy/release-checklists/260815-repo-harness-0.15.1.md
+++ b/deploy/release-checklists/260815-repo-harness-0.15.1.md
@@ -39,6 +39,10 @@
   contains 484 files, is 9,944,553 bytes (15,057,942 unpacked), and includes
   the Change Assessment, runtime receipt, and architecture queue canonical plus
   template helpers. `check-tarball-install-smoke.sh` passed under Node 24.
+- Acceptance blocker repair: PR #190 preserves long committed oracle IDs at
+  the fingerprinted `required_oracles[].id` path; 54 focused tests,
+  self-hosted typed acceptance, and exact hosted CI passed before merge to
+  `main@1185370b2a2ea660dd47e61d58e0e1a08862b9ff`.
 - Exact `main` CI: pending candidate merge.
 - Independent release review and AcceptanceReceipt: pending final subject.
 

--- a/deploy/release-checklists/260815-repo-harness-0.15.1.md
+++ b/deploy/release-checklists/260815-repo-harness-0.15.1.md
@@ -4,7 +4,8 @@
 - Package: `repo-harness@0.15.1`
 - Base release: `v0.15.0`
 - Source range: `v0.15.0..candidate`
-- Candidate commit: pending freeze
+- Release-prep commit: `eb5970dad9474638a00c7357d7eeae2e53705345`
+- Final candidate commit: pending acceptance projection
 - Release scope: publish the contract-first Change Assessment and acceptance
   authority, durable hook-effect recovery, Goal Calibration Gate, one-commit
   contract worktrees, nested capability routing, and transaction-safe semantic
@@ -27,16 +28,25 @@
 
 - npm baseline: `latest=0.15.0`; `repo-harness@0.15.1` returned E404 before
   candidate preparation.
-- Version consistency: pending candidate gate.
-- Full repository/release checks: pending candidate gate.
-- Packed tarball contents and isolated install: pending candidate gate.
+- Version consistency: `check-skill-version`, CLI `--version`, helper/hook
+  projection checks, typecheck, state boundaries, and 37 focused release tests
+  passed; all source authorities report 0.15.1.
+- Full repository/release checks: the non-isolated local run reached 2429 pass,
+  1 skip, 6 fail; the CI-isolated rerun stopped at the same macOS Node 26
+  ArchContext fixture mismatch already present on clean `main`. Exact hosted
+  Node 24 CI remains the release authority and is pending candidate push.
+- Packed tarball contents and isolated install: `repo-harness-0.15.1.tgz`
+  contains 484 files, is 9,944,553 bytes (15,057,942 unpacked), and includes
+  the Change Assessment, runtime receipt, and architecture queue canonical plus
+  template helpers. `check-tarball-install-smoke.sh` passed under Node 24.
 - Exact `main` CI: pending candidate merge.
 - Independent release review and AcceptanceReceipt: pending final subject.
 
 ## Required Release Sequence
 
 - [x] Rebuild from current `main` and classify `v0.15.0..candidate` by shipped risk surface.
-- [ ] Freeze the candidate and run `bun run check:release`.
+- [x] Freeze the candidate and run `bun run check:release`; preserve the local
+  Node 26 baseline mismatch for hosted Node 24 CI resolution.
 - [ ] Record final-subject review and AcceptanceReceipt evidence.
 - [ ] Merge the candidate to `main` and confirm exact GitHub Actions CI.
 - [ ] Publish `repo-harness@0.15.1` to npm `latest`.

--- a/deploy/release-checklists/260815-repo-harness-0.15.1.md
+++ b/deploy/release-checklists/260815-repo-harness-0.15.1.md
@@ -1,0 +1,52 @@
+# repo-harness 0.15.1 Release Filing
+
+- Date: 2026-08-15
+- Package: `repo-harness@0.15.1`
+- Base release: `v0.15.0`
+- Source range: `v0.15.0..candidate`
+- Candidate commit: pending freeze
+- Release scope: publish the contract-first Change Assessment and acceptance
+  authority, durable hook-effect recovery, Goal Calibration Gate, one-commit
+  contract worktrees, nested capability routing, and transaction-safe semantic
+  architecture queue events.
+- Publish status: **pending publish**. Registry, tag, GitHub Release, and the
+  selected Bun-global runtime are not claimed until their readbacks pass.
+
+## Authority Boundary
+
+- Release metadata changes no product behavior; the shipped implementation
+  range is already merged on `main`.
+- Change Assessment and AcceptanceReceipt remain the final-subject acceptance
+  authority; review Markdown is a projection.
+- Architecture event identity is per file and semantic scope. Record and
+  archive share one rollback-safe queue lock outside the snapshot tree.
+- npm `latest`, `v0.15.1`, GitHub Release, tarball metadata, local version
+  fields, and installed runtime must resolve to one immutable release.
+
+## Candidate Evidence
+
+- npm baseline: `latest=0.15.0`; `repo-harness@0.15.1` returned E404 before
+  candidate preparation.
+- Version consistency: pending candidate gate.
+- Full repository/release checks: pending candidate gate.
+- Packed tarball contents and isolated install: pending candidate gate.
+- Exact `main` CI: pending candidate merge.
+- Independent release review and AcceptanceReceipt: pending final subject.
+
+## Required Release Sequence
+
+- [x] Rebuild from current `main` and classify `v0.15.0..candidate` by shipped risk surface.
+- [ ] Freeze the candidate and run `bun run check:release`.
+- [ ] Record final-subject review and AcceptanceReceipt evidence.
+- [ ] Merge the candidate to `main` and confirm exact GitHub Actions CI.
+- [ ] Publish `repo-harness@0.15.1` to npm `latest`.
+- [ ] Create and push annotated tag `v0.15.1` and stable GitHub Release.
+- [ ] Run `bash scripts/check-release-published.sh 0.15.1`.
+- [ ] Install exact Bun-global `repo-harness@0.15.1` and verify version/readiness.
+- [ ] Record closeout evidence and return to clean, synchronized `main`.
+
+## Rollback
+
+- Before npm publication: abandon or revert the release-prep candidate.
+- After npm publication: never move or reuse `v0.15.1`; correct forward with a
+  later patch. The previous registry version remains installable exactly.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,10 @@ All notable changes to this skill are documented here.
   architecture snapshot tree, adds crash recovery and recurrence handling, and
   rejects forged cards, unsafe symlink targets, and stale migration authority
   before mutation.
+- Preserves committed Change Assessment oracle IDs through evidence
+  redaction/materialization so assessment, selection-packet, and envelope
+  fingerprints remain verifiable without exempting unrelated IDs or known
+  secrets.
 
 ## [0.15.0] - 2026-08-12
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to this skill are documented here.
 
+## [0.15.1] - 2026-08-15
+
+### Added
+
+- Adds a contract-first Change Assessment and typed AcceptanceReceipt path that
+  binds verification, review selection, final subject, and explicit user
+  waivers before a work package can close.
+- Adds durable hook-effect failure semantics with stop, retry, recovery, and
+  event telemetry, plus a Goal Calibration Gate that asks at most one
+  highest-information-gain planning question.
+
+### Changed
+
+- Publishes one commit per contract worktree and makes nested capability
+  architecture routing resolve arbitrary workspace `src/**` depth through the
+  canonical capability registry.
+- Records research on composable agent-harness boundaries without adopting a
+  second runtime authority.
+
+### Fixed
+
+- Makes architecture queue events semantically idempotent per changed file,
+  including mixed severity and alternating capability prefixes, while keeping
+  unchanged requests eligible for index self-healing.
+- Serializes record/archive writers with a rollback-safe queue lock outside the
+  architecture snapshot tree, adds crash recovery and recurrence handling, and
+  rejects forged cards, unsafe symlink targets, and stale migration authority
+  before mutation.
+
 ## [0.15.0] - 2026-08-12
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "repo-harness",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Installs, migrates, audits, and repairs repo-local agentic development harnesses",
   "license": "MIT",
   "repository": {

--- a/plans/plan-20260815-0140-release-0-15-1.md
+++ b/plans/plan-20260815-0140-release-0-15-1.md
@@ -1,0 +1,196 @@
+# Plan: Release repo-harness 0.15.1
+
+> **Status**: Executing
+> **Created**: 20260815-0140
+> **Slug**: release-0-15-1
+> **Planning Source**: user-approved-plan
+> **Orchestration Kind**: user-approved-plan
+> **Source Ref**: (none)
+> **Artifact Level**: work-package
+> **Promotion Reason**: release_boundary
+> **Verification Boundary**: npm registry, CI, published tarball, tag, GitHub Release, and installed-runtime readbacks
+> **Rollback Surface**: irreversible npm stable publication and immutable tag
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260815-0140-release-0-15-1.contract.md`
+> **Task Review**: `tasks/reviews/20260815-0140-release-0-15-1.review.md`
+> **Implementation Notes**: `tasks/notes/20260815-0140-release-0-15-1.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from user-approved-plan planning output.
+- Source ref: (none)
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260815-0140-release-0-15-1.md`
+- Sprint contract: `tasks/contracts/20260815-0140-release-0-15-1.contract.md`
+- Sprint review: `tasks/reviews/20260815-0140-release-0-15-1.review.md`
+- Implementation notes: `tasks/notes/20260815-0140-release-0-15-1.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260815-0140-release-0-15-1.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260815-0140-release-0-15-1.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260815-0140-release-0-15-1.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260815-0140-release-0-15-1.contract.md`
+- Review file: `tasks/reviews/20260815-0140-release-0-15-1.review.md`
+- Implementation notes file: `tasks/notes/20260815-0140-release-0-15-1.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260815-0140-release-0-15-1.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260815-0140-release-0-15-1.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: irreversible npm stable publication and immutable tag
+- **Verification boundary**: npm registry, CI, published tarball, tag, GitHub Release, and installed-runtime readbacks
+- **Review/acceptance boundary**: `tasks/reviews/20260815-0140-release-0-15-1.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: release_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260815-0140-release-0-15-1.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260815-0140-release-0-15-1.contract.md`, `tasks/reviews/20260815-0140-release-0-15-1.review.md`, and `tasks/notes/20260815-0140-release-0-15-1.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260815-0140-release-0-15-1.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: irreversible npm stable publication and immutable tag
+
+## Captured Planning Output
+
+# Release repo-harness 0.15.1
+
+## Goal
+
+Publish the current verified `main` line as stable `repo-harness@0.15.1`, with package, template, README, changelog, npm, Git tag, GitHub Release, and installed-runtime readbacks agreeing.
+
+## Success Criteria
+
+- `package.json`, `assets/skill-version.json`, localized README release lines, CLI integration fixture, and changelog all name 0.15.1.
+- A release filing records the exact `v0.15.0..candidate` scope and verification evidence.
+- `bun run check:release`, packed-package inspection, isolated install smoke, and GitHub CI pass on the final release commit.
+- npm `latest`, annotated tag `v0.15.1`, stable GitHub Release, published-package verification, and Bun-global installed runtime all read back 0.15.1.
+- Release and closeout branches/worktrees are merged and removed; `main` is clean and equals `origin/main`.
+
+## Scope
+
+- Version and release metadata only: package/template stamps, README release lines, changelog, release checklist, and required workflow artifacts.
+- Review the full shipped range `v0.15.0..HEAD` by public CLI, hook, workflow authority, architecture queue, and packaging surfaces.
+- Publish to the stable npm `latest` lane and create the matching stable GitHub Release.
+
+## Non-Goals
+
+- No feature, dependency, compatibility, or architecture behavior changes.
+- No reuse of the deleted stale 0.15.1 candidate.
+- No mutation of unrelated historical stashes or external toolchain state except the explicitly required Bun-global exact-version install.
+
+## Constraints and Invariants
+
+- npm publication is irreversible; after publish, correct forward with a new version and never move or reuse `v0.15.1`.
+- The package tarball, npm metadata, Git tag, GitHub Release, source version fields, and installed runtime must agree.
+- Publishing is blocked on dirty state, failed full release gate, failed CI, missing package contents, auth failure, or inability to prove 0.15.1 is unpublished.
+- The stable lane remains untouched until the exact candidate has passed local and hosted gates.
+
+## P1 Architecture Map
+
+- Source authority: `package.json`, `assets/skill-version.json`, `docs/CHANGELOG.md`, localized README files, and `scripts/axr7-consumer-e2e.ts`.
+- Verification authority: `scripts/check-npm-release.sh`, `scripts/check-ci.sh`, `scripts/check-tarball-install-smoke.sh`, and `scripts/check-release-published.sh`.
+- Distribution authority: npm registry `latest`, annotated Git tag, stable GitHub Release, and Bun-global installed package.
+
+## P2 Concrete Trace
+
+Version metadata is frozen on a release branch, the full gate builds and inspects the packed CLI, CI verifies the exact pushed commit, npm publishes that commit's package, tag/release bind the source revision, and published-package plus global-install probes read back the actual registry artifact.
+
+## P3 Design Decision
+
+Use a patch-only release-prep diff and the existing two-phase closeout pattern. The implementation range is already merged and reviewed; this slice changes only distribution metadata and evidence. At 10x package size, tarball/build time fails first, while the authority model remains unchanged.
+
+## Fragile Assumption
+
+The current npm credentials can publish `repo-harness` without an interactive OTP. If registry auth or OTP blocks, stop after preserving the verified candidate; do not weaken publishing gates.
+
+## Rejected Alternative
+
+Do not resurrect the stale 0.15.1 worktree because it was based before PRs #184-#188 and contained unaccepted release metadata.
+
+## Public Interfaces
+
+- Version changes from 0.15.0 to 0.15.1.
+- No CLI flags, schemas, configuration, environment variables, or dependencies change.
+
+## External Requirements
+
+- GitHub CLI authentication for PR, CI, tag, and stable Release operations.
+- npm registry authentication for publication and readback.
+- Bun, npm, Git, Node 24-compatible runtime, jq, and rsync as already declared by project CI.
+
+## Verification
+
+- `bun run check:release`
+- `npm pack --dry-run --json`
+- `bash scripts/check-release-published.sh 0.15.1`
+- exact Bun-global install plus `repo-harness --version` and `repo-harness update --check --json`
+- final GitHub CI, npm, tag, release, branch, worktree, and `main` readbacks
+
+## Rollback and Failure Handling
+
+- Before npm publication: abandon or revert the release-prep PR.
+- After npm publication: keep `v0.15.1` immutable and correct forward with a later patch.
+- Network/auth/OTP failures leave the verified candidate intact and report the exact blocked layer.
+
+## Task Breakdown
+
+- [ ] Freeze 0.15.1 metadata, changelog, release filing, and workflow artifacts from current main.
+- [ ] Run version, helper parity, full release, package-content, and isolated-install gates.
+- [ ] Review the candidate, record acceptance evidence, push PR, and merge after CI.
+- [ ] Publish npm latest, create annotated tag and stable GitHub Release, then verify registry artifact and installed runtime.
+- [ ] Record closeout evidence, merge closeout, and clean release branches/worktrees back to main.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [ ] Freeze 0.15.1 metadata, changelog, release filing, and workflow artifacts from current main.
+- [ ] Run version, helper parity, full release, package-content, and isolated-install gates.
+- [ ] Review the candidate, record acceptance evidence, push PR, and merge after CI.
+- [ ] Publish npm latest, create annotated tag and stable GitHub Release, then verify registry artifact and installed runtime.
+- [ ] Record closeout evidence, merge closeout, and clean release branches/worktrees back to main.

--- a/plans/plan-20260815-0140-release-0-15-1.md
+++ b/plans/plan-20260815-0140-release-0-15-1.md
@@ -179,7 +179,7 @@ Do not resurrect the stale 0.15.1 worktree because it was based before PRs #184-
 
 ## Task Breakdown
 
-- [ ] Freeze 0.15.1 metadata, changelog, release filing, and workflow artifacts from current main.
+- [x] Freeze 0.15.1 metadata, changelog, release filing, and workflow artifacts from current main.
 - [ ] Run version, helper parity, full release, package-content, and isolated-install gates.
 - [ ] Review the candidate, record acceptance evidence, push PR, and merge after CI.
 - [ ] Publish npm latest, create annotated tag and stable GitHub Release, then verify registry artifact and installed runtime.
@@ -189,7 +189,7 @@ Do not resurrect the stale 0.15.1 worktree because it was based before PRs #184-
 <!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
 
 ## Task Breakdown
-- [ ] Freeze 0.15.1 metadata, changelog, release filing, and workflow artifacts from current main.
+- [x] Freeze 0.15.1 metadata, changelog, release filing, and workflow artifacts from current main.
 - [ ] Run version, helper parity, full release, package-content, and isolated-install gates.
 - [ ] Review the candidate, record acceptance evidence, push PR, and merge after CI.
 - [ ] Publish npm latest, create annotated tag and stable GitHub Release, then verify registry artifact and installed runtime.

--- a/scripts/axr7-consumer-e2e.ts
+++ b/scripts/axr7-consumer-e2e.ts
@@ -19,7 +19,7 @@ import { tmpdir } from "node:os";
 import { basename, dirname, join, relative, resolve, sep } from "node:path";
 
 const VERSION = "0.4.2";
-const REPO_HARNESS_VERSION = "0.15.0";
+const REPO_HARNESS_VERSION = "0.15.1";
 const repoRoot = resolve(import.meta.dir, "..");
 const archContextRoot = resolve(flag("--arch-context-root") ?? join(repoRoot, "..", "arch-context"));
 const revision = flag("--arch-context-revision") ?? git(archContextRoot, ["rev-parse", "HEAD"]);

--- a/tasks/contracts/20260815-0140-release-0-15-1.contract.md
+++ b/tasks/contracts/20260815-0140-release-0-15-1.contract.md
@@ -1,0 +1,180 @@
+# Task Contract: release-0-15-1
+
+> **Status**: Fulfilled
+> **Plan**: plans/plan-20260815-0140-release-0-15-1.md
+> **Task Profile**: code-change
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: ancienttwo
+> **Capability ID**: root
+> **Last Updated**: 2026-08-15 01:40
+> **Review File**: `tasks/reviews/20260815-0140-release-0-15-1.review.md`
+> **Notes File**: `tasks/notes/20260815-0140-release-0-15-1.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+The implementation range since 0.15.0 is merged and verified but unavailable to
+npm users until one immutable package, tag, release, and runtime version agree.
+Publishing inconsistent metadata would make update, init, and generated
+workflow stamps report conflicting authorities.
+
+## Goal
+
+Publish stable `repo-harness@0.15.1` from current `main`, bind the exact source
+revision to npm, `v0.15.1`, and a stable GitHub Release, then prove the registry
+tarball and Bun-global installed runtime both report 0.15.1.
+
+## Scope
+
+- In scope: version stamps, five README release lines, changelog, AXR7 release
+  fixture, release filing, workflow artifacts, full release verification,
+  npm/GitHub publication, installed-runtime readback, and cleanup.
+- Out of scope: product logic, dependencies, compatibility paths, schemas,
+  configuration, or unrelated historical stashes.
+- Taste constraints: keep the release-prep diff mechanical and traceable; do
+  not resurrect the deleted stale candidate.
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+
+## Falsifier
+
+If npm already contains 0.15.1, version fields cannot align, package contents
+omit a required runtime file, full release checks fail, or exact CI is red, this
+candidate must not publish. The cheapest first proof is npm E404 plus version
+consistency and dry-run package inspection.
+
+## Root Cause Evidence
+
+Required when Task Profile is `bugfix`; leave as-is otherwise.
+
+- root_cause: one sentence naming file:line/condition (testable, not "a state issue").
+- repro: the command or UI path that reproduces the symptom.
+- regression_guard: path to a test that fails on the unfixed code and passes after the fix (must also appear under exit_criteria.tests_pass).
+- pre_fix_failure_artifact: path to a captured run of regression_guard on the UNFIXED code. Capture with `bun test <regression_guard> > <artifact> 2>&1; echo "PRE_FIX_EXIT=$?" >> <artifact>` (no pipes — pipes swallow the exit status). The gate requires a non-zero `PRE_FIX_EXIT=` line plus the regression_guard path string in the artifact (see the Root Cause Evidence Gate section in docs/reference-configs/sprint-contracts.md).
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260815-0140-release-0-15-1.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260815-0140-release-0-15-1.review.md`
+- Notes file: `tasks/notes/20260815-0140-release-0-15-1.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Change Assessment
+
+```json
+{"protocol":1,"oracles":[]}
+```
+
+## Acceptance Policy
+
+```json
+{"protocol":1,"reviewer":"Claude","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - package.json
+  - assets/skill-version.json
+  - README.md
+  - README.zh-CN.md
+  - README.es.md
+  - README.fr.md
+  - README.ja.md
+  - scripts/axr7-consumer-e2e.ts
+  - docs/CHANGELOG.md
+  - deploy/release-checklists/260815-repo-harness-0.15.1.md
+  - plans/plan-20260815-0140-release-0-15-1.md
+  - tasks/todos.md
+  - tasks/current.md
+  - tasks/contracts/20260815-0140-release-0-15-1.contract.md
+  - tasks/reviews/20260815-0140-release-0-15-1.review.md
+  - tasks/notes/20260815-0140-release-0-15-1.notes.md
+  - docs/architecture/.projection-manifest.json
+  - docs/architecture/modules/runtime-harness/global-runtime-reconciliation.md
+  - docs/architecture/modules/verification/evals-checks.md
+  - docs/architecture/modules/workflow-engine/contract-assets.md
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+    fallback: null
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - deploy/release-checklists/260815-repo-harness-0.15.1.md
+    - docs/CHANGELOG.md
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260815-0140-release-0-15-1.notes.md
+  tests_pass:
+    - path: tests/bootstrap-files.test.ts
+    - path: tests/skill-version.test.ts
+    - path: tests/readme-dx.test.ts
+    - path: tests/cli/global-runtime-init.test.ts
+  commands_succeed:
+    - bun scripts/check-skill-version.ts --project .
+    - bun src/cli/index.ts --version
+    - bun test tests/bootstrap-files.test.ts tests/skill-version.test.ts tests/readme-dx.test.ts
+    - npm pack --dry-run --json
+```
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior: all release authorities and installed package report 0.15.1.
+- Edge cases: unpublished-version proof, tarball file completeness, tag immutability, and post-publish registry propagation.
+- Regression risks: metadata drift or publishing a package from a commit different from the tagged release commit.
+
+## Rollback Point
+
+- Commit / checkpoint: the final merged release-prep commit before npm publish.
+- Revert strategy: before publish, revert or abandon the prep PR; after publish,
+  keep tag/version immutable and correct forward with a later patch.

--- a/tasks/contracts/20260815-0140-release-0-15-1.contract.md
+++ b/tasks/contracts/20260815-0140-release-0-15-1.contract.md
@@ -70,7 +70,7 @@ Required when Task Profile is `bugfix`; leave as-is otherwise.
 ## Change Assessment
 
 ```json
-{"protocol":1,"oracles":[]}
+{"protocol":1,"oracles":[{"id":"release-deterministic-gates","kind":"deterministic_test","paths":["*"]},{"id":"published-package-runtime-readback","kind":"runtime_readback","paths":["*"]}]}
 ```
 
 ## Acceptance Policy

--- a/tasks/notes/20260815-0140-release-0-15-1.notes.md
+++ b/tasks/notes/20260815-0140-release-0-15-1.notes.md
@@ -9,6 +9,11 @@
 - Stable publication remains gated on npm E404, full release checks, exact
   hosted CI, packed artifact inspection, and post-publish installed-runtime
   evidence.
+- The local full gate is not treated as green: macOS Node 26 reproduces the
+  existing ArchContext fake-runtime assertion mismatch (and the non-isolated
+  run also reproduces five global-runtime fixture failures). The packed artifact
+  passed its Node 24 install smoke; publication remains blocked until the exact
+  candidate passes hosted Node 24 CI.
 
 ## Open Questions
 

--- a/tasks/notes/20260815-0140-release-0-15-1.notes.md
+++ b/tasks/notes/20260815-0140-release-0-15-1.notes.md
@@ -1,0 +1,56 @@
+# Implementation Notes: release-0-15-1
+
+## Decisions
+
+- Rebuilt from `main@f12380487cb882040251251309666f3927edfed7`; the deleted
+  0.15.1 candidate was not reused because it predated PRs #184-#188.
+- Kept the user-requested patch version despite feature commits in the shipped
+  range; no new behavior is introduced by the release-prep diff itself.
+- Stable publication remains gated on npm E404, full release checks, exact
+  hosted CI, packed artifact inspection, and post-publish installed-runtime
+  evidence.
+
+## Open Questions
+
+- npm OTP/auth state is intentionally deferred to the actual publish command;
+  failure leaves the verified candidate intact.
+
+> **Status**: Active
+> **Plan**: plans/plan-20260815-0140-release-0-15-1.md
+> **Contract**: tasks/contracts/20260815-0140-release-0-15-1.contract.md
+> **Review**: tasks/reviews/20260815-0140-release-0-15-1.review.md
+> **Last Updated**: 2026-08-15 01:40
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- ...
+
+## Deviations From Plan Or Spec
+
+- None recorded.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| ... | ... | ... |
+
+## Open Questions
+
+- None.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/reviews/20260815-0140-release-0-15-1.review.md
+++ b/tasks/reviews/20260815-0140-release-0-15-1.review.md
@@ -1,42 +1,42 @@
 # Task Review: release-0-15-1
 
-> **Status**: Pending
+> **Status**: Complete
 > **Plan**: plans/plan-20260815-0140-release-0-15-1.md
 > **Contract**: tasks/contracts/20260815-0140-release-0-15-1.contract.md
 > **Notes File**: tasks/notes/20260815-0140-release-0-15-1.notes.md
 > **Checks File**: .ai/harness/checks/latest.json
-> **Last Updated**: 2026-08-15 01:40
-> **Recommendation**: fail
+> **Last Updated**: 2026-08-15 02:05
+> **Recommendation**: pass
 > **Review Rubric Version**: 2
-> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject SHA256**: sha256:898eb827d6a70709f5090299b974c59df0cb4d88a309e4ef6ff9ab5043362fd1
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: pending
+> **Reviewed Target Revision**: f12380487cb882040251251309666f3927edfed7
 
 ## Human Review Card
 
-- Verdict: pending
-- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
-- Intended files changed:
-- Actual files changed:
-- Commands passed:
-- Residual risks:
-- Reviewer action required: inspect diff and card
-- Rollback:
+- Verdict: pass for the release-prep subject; npm publication remains gated on exact hosted CI.
+- Change type: ledger-closeout
+- Intended files changed: ten version, README, changelog, fixture, and release-filing paths plus excluded workflow evidence.
+- Actual files changed: exactly the intended subject paths; target overlap count is zero.
+- Commands passed: contract verification 14/14; 37 focused tests; typecheck; state, hook, helper, and reference-config projection checks; npm pack; Node 24 tarball install smoke.
+- Residual risks: the local machine runs Node 26, while ArchContext supports Node >=24 <26. The known clean-main fixture mismatch makes hosted Node 24 CI the final full-suite authority.
+- Reviewer action required: none before PR; do not publish unless all exact-commit hosted checks pass.
+- Rollback: abandon or revert before npm publish; after publish correct forward without moving `v0.15.1`.
 
 ## Mode Evidence
 
-- Selected route:
-- P1/P2/P3 evidence:
-- Root cause or plan evidence:
+- Selected route: ship/release review.
+- P1/P2/P3 evidence: plan maps source, gate, registry, tag, release, and installed-runtime authorities; traces candidate to packed artifact to published readback; preserves immutable version/tag invariants.
+- Root cause or plan evidence: `plans/plan-20260815-0140-release-0-15-1.md`.
 
 ## Verification Evidence
 
-- Waza `/check` run:
-- Commands run:
-- Manual checks:
-- Supporting artifacts:
-- Implementation notes reviewed:
-- Run snapshot:
+- Waza `/check` run: ship mode, Release Gate 2.0.
+- Commands run: `verify-contract --strict`, focused Bun tests, `check:release` in default and CI-isolated modes, `npm pack`, tar content inspection, and `check-tarball-install-smoke.sh` under Node 24.
+- Manual checks: npm returned E404 for 0.15.1; package metadata, CLI, README lines, changelog, and skill stamp agree; packed archive contains all newly shipped canonical/template helpers.
+- Supporting artifacts: `.ai/harness/checks/latest.json` and `deploy/release-checklists/260815-repo-harness-0.15.1.md`.
+- Implementation notes reviewed: yes.
+- Run snapshot: contract verification passed; hosted CI pending PR.
 
 ## Acceptance Receipt Projection
 
@@ -44,41 +44,44 @@
 > **Reviewer**: unavailable
 > **Source**: unavailable
 > **Actor**: not-applicable
-> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject SHA256**: sha256:898eb827d6a70709f5090299b974c59df0cb4d88a309e4ef6ff9ab5043362fd1
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: pending
+> **Reviewed Target Revision**: f12380487cb882040251251309666f3927edfed7
 > **Verification Evidence SHA256**: pending
 > **Issued At**: pending
 
-- Summary: No AcceptanceReceipt has been recorded.
-- Findings: none
+- Summary: AcceptanceReceipt will be projected by `verify-sprint` after typed acceptance is recorded.
+- Findings: none in the release-prep subject.
 
 ## Behavior Diff Notes
 
-- ...
+- The release-prep subject changes version/distribution metadata only.
+- The shipped implementation range is `v0.15.0..f1238048`; no product code or dependency is added by this candidate.
+- The local full-suite failures reproduce unsupported Node 26 fixture behavior and are not waived as green; exact Node 24 hosted CI remains a hard publication gate.
 
 ## Residual Risks / Follow-ups
 
-- ...
+- npm auth or OTP may still block publication. That failure is recoverable before publish and must not weaken the gate.
+- Registry propagation may delay post-publish readback; retry the readback, never republish the same version.
 
 ## Scorecard
 
 | Dimension | Score | Notes |
 |-----------|-------|-------|
-| Functionality | 0/10 | |
-| Product depth | 0/10 | |
-| Design quality | 0/10 | |
-| Code quality | 0/10 | |
+| Functionality | 10/10 | All release authorities agree before publish; immutable readbacks remain gated. |
+| Product depth | 10/10 | Full shipped range and public package contents were classified. |
+| Design quality | 10/10 | Existing two-phase release/closeout authority is preserved. |
+| Code quality | 10/10 | Mechanical subject, zero target overlap, clean diff hygiene. |
 
 ## Failing Items
 
-- ...
+- None in the reviewed subject. Hosted CI is pending and blocks publication by contract.
 
 ## Retest Steps
 
-- Re-run:
-- Re-check:
+- Re-run `bun run check:release` in the supported Node 24 CI environment.
+- Re-check packed contents, exact commit CI, npm `latest`, tag, GitHub Release, and installed runtime.
 
 ## Summary
 
-- ...
+- PASS for PR: the release-prep subject is coherent and package-complete. Do not publish until exact hosted Node 24 CI is green.

--- a/tasks/reviews/20260815-0140-release-0-15-1.review.md
+++ b/tasks/reviews/20260815-0140-release-0-15-1.review.md
@@ -40,18 +40,18 @@
 
 ## Acceptance Receipt Projection
 
-> **Disposition**: unavailable
-> **Reviewer**: unavailable
-> **Source**: unavailable
-> **Actor**: not-applicable
+> **Disposition**: user_waiver
+> **Reviewer**: User
+> **Source**: user-waiver
+> **Actor**: ancienttwo
 > **Reviewed Subject SHA256**: sha256:fa6f7d76b1d12282cda8ec4642b7fa96ddab45067455d1fd53f1de00325d31e8
 > **Reviewed Subject Scope**: normalized-final-content
 > **Reviewed Target Revision**: 1185370b2a2ea660dd47e61d58e0e1a08862b9ff
-> **Verification Evidence SHA256**: pending
-> **Issued At**: pending
+> **Verification Evidence SHA256**: sha256:03421c46ee4525697518b18ea8f8cd60fcbc6afdcb58511db154322c145ef50c
+> **Issued At**: 2026-08-14T19:03:49.941Z
 
-- Summary: AcceptanceReceipt will be rematerialized from the unchanged user grant after final-subject verification.
-- Findings: none in the release-prep subject.
+- Summary: User explicitly authorized the persistent typed user waiver for repo-harness 0.15.1 after npm Web Auth and all PR #189 hosted checks passed.
+- Findings: none
 
 ## Behavior Diff Notes
 

--- a/tasks/reviews/20260815-0140-release-0-15-1.review.md
+++ b/tasks/reviews/20260815-0140-release-0-15-1.review.md
@@ -8,9 +8,9 @@
 > **Last Updated**: 2026-08-15 02:05
 > **Recommendation**: pass
 > **Review Rubric Version**: 2
-> **Reviewed Subject SHA256**: sha256:898eb827d6a70709f5090299b974c59df0cb4d88a309e4ef6ff9ab5043362fd1
+> **Reviewed Subject SHA256**: sha256:fa6f7d76b1d12282cda8ec4642b7fa96ddab45067455d1fd53f1de00325d31e8
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: f12380487cb882040251251309666f3927edfed7
+> **Reviewed Target Revision**: 1185370b2a2ea660dd47e61d58e0e1a08862b9ff
 
 ## Human Review Card
 
@@ -18,7 +18,7 @@
 - Change type: ledger-closeout
 - Intended files changed: ten version, README, changelog, fixture, and release-filing paths plus excluded workflow evidence.
 - Actual files changed: exactly the intended subject paths; target overlap count is zero.
-- Commands passed: contract verification 14/14; 37 focused tests; typecheck; state, hook, helper, and reference-config projection checks; npm pack; Node 24 tarball install smoke.
+- Commands passed: contract verification 14/14; 37 focused release tests; PR #190's 54 focused regression tests; typecheck; state, hook, helper, and reference-config projection checks; npm pack; Node 24 tarball install smoke; exact hosted CI for PRs #189 and #190.
 - Residual risks: the local machine runs Node 26, while ArchContext supports Node >=24 <26. The known clean-main fixture mismatch makes hosted Node 24 CI the final full-suite authority.
 - Reviewer action required: none before PR; do not publish unless all exact-commit hosted checks pass.
 - Rollback: abandon or revert before npm publish; after publish correct forward without moving `v0.15.1`.
@@ -44,19 +44,21 @@
 > **Reviewer**: unavailable
 > **Source**: unavailable
 > **Actor**: not-applicable
-> **Reviewed Subject SHA256**: sha256:898eb827d6a70709f5090299b974c59df0cb4d88a309e4ef6ff9ab5043362fd1
+> **Reviewed Subject SHA256**: sha256:fa6f7d76b1d12282cda8ec4642b7fa96ddab45067455d1fd53f1de00325d31e8
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: f12380487cb882040251251309666f3927edfed7
+> **Reviewed Target Revision**: 1185370b2a2ea660dd47e61d58e0e1a08862b9ff
 > **Verification Evidence SHA256**: pending
 > **Issued At**: pending
 
-- Summary: AcceptanceReceipt will be projected by `verify-sprint` after typed acceptance is recorded.
+- Summary: AcceptanceReceipt will be rematerialized from the unchanged user grant after final-subject verification.
 - Findings: none in the release-prep subject.
 
 ## Behavior Diff Notes
 
 - The release-prep subject changes version/distribution metadata only.
-- The shipped implementation range is `v0.15.0..f1238048`; no product code or dependency is added by this candidate.
+- The shipped implementation range is `v0.15.0..1185370b`; no product code or dependency is added by the release-prep subject.
+- PR #190 is now part of the shipped implementation range and restores
+  byte-identical evidence materialization for fingerprinted oracle IDs.
 - The local full-suite failures reproduce unsupported Node 26 fixture behavior and are not waived as green; exact Node 24 hosted CI remains a hard publication gate.
 
 ## Residual Risks / Follow-ups

--- a/tasks/reviews/20260815-0140-release-0-15-1.review.md
+++ b/tasks/reviews/20260815-0140-release-0-15-1.review.md
@@ -1,0 +1,84 @@
+# Task Review: release-0-15-1
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260815-0140-release-0-15-1.md
+> **Contract**: tasks/contracts/20260815-0140-release-0-15-1.contract.md
+> **Notes File**: tasks/notes/20260815-0140-release-0-15-1.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-08-15 01:40
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Commands passed:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+- Waza `/check` run:
+- Commands run:
+- Manual checks:
+- Supporting artifacts:
+- Implementation notes reviewed:
+- Run snapshot:
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -1,7 +1,7 @@
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: 2026-08-14 18:08
+> **Updated**: 2026-08-15 01:40
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.


### PR DESCRIPTION
## Summary

- prepare stable `repo-harness@0.15.1` from current `main`
- align package/template stamps, localized README release lines, fixture, changelog, and release filing
- record candidate package and acceptance evidence without changing product behavior or dependencies

## Verification

- contract verification: 14/14 pass
- focused release tests: 37 pass, 0 fail
- hook/helper/reference-config parity, typecheck, and state boundaries: pass
- packed archive: 484 files; required Change Assessment, runtime receipt, and architecture queue canonical/template helpers present
- Node 24 isolated tarball install smoke: pass
- local macOS Node 26 full run reproduces the clean-main unsupported-runtime fixture mismatch; exact hosted Node 24 CI is the publication gate

## Release boundary

npm publication, `v0.15.1`, GitHub Release, and installed-runtime readback occur only after this exact candidate passes all hosted checks and merges.
