### PR TITLE
fix(evidence): preserve change assessment oracle ids

### DIFF
--- a/plans/plan-20260815-0230-change-assessment-oracle-redaction.md
+++ b/plans/plan-20260815-0230-change-assessment-oracle-redaction.md
@@ -1,0 +1,147 @@
+# Plan: Fix Change Assessment oracle evidence redaction
+
+> **Status**: Executing
+> **Created**: 20260815-0230
+> **Slug**: change-assessment-oracle-redaction
+> **Planning Source**: codex-plan-or-waza-think
+> **Orchestration Kind**: host-plan
+> **Source Ref**: (none)
+> **Artifact Level**: work-package
+> **Promotion Reason**: verification_boundary
+> **Verification Boundary**: Commands named in the captured planning output plus `repo-harness run verify-contract --contract tasks/contracts/20260815-0230-change-assessment-oracle-redaction.contract.md --strict`.
+> **Rollback Surface**: Before execution remove `plans/plan-20260815-0230-change-assessment-oracle-redaction.md`; after execution revert branch `codex/change-assessment-oracle-redaction` or the explicitly reviewed diff.
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260815-0230-change-assessment-oracle-redaction.contract.md`
+> **Task Review**: `tasks/reviews/20260815-0230-change-assessment-oracle-redaction.review.md`
+> **Implementation Notes**: `tasks/notes/20260815-0230-change-assessment-oracle-redaction.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from codex-plan-or-waza-think planning output.
+- Source ref: (none)
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260815-0230-change-assessment-oracle-redaction.md`
+- Sprint contract: `tasks/contracts/20260815-0230-change-assessment-oracle-redaction.contract.md`
+- Sprint review: `tasks/reviews/20260815-0230-change-assessment-oracle-redaction.review.md`
+- Implementation notes: `tasks/notes/20260815-0230-change-assessment-oracle-redaction.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260815-0230-change-assessment-oracle-redaction.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260815-0230-change-assessment-oracle-redaction.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260815-0230-change-assessment-oracle-redaction.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260815-0230-change-assessment-oracle-redaction.contract.md`
+- Review file: `tasks/reviews/20260815-0230-change-assessment-oracle-redaction.review.md`
+- Implementation notes file: `tasks/notes/20260815-0230-change-assessment-oracle-redaction.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260815-0230-change-assessment-oracle-redaction.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260815-0230-change-assessment-oracle-redaction.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: Before execution remove `plans/plan-20260815-0230-change-assessment-oracle-redaction.md`; after execution revert branch `codex/change-assessment-oracle-redaction` or the explicitly reviewed diff.
+- **Verification boundary**: Commands named in the captured planning output plus `repo-harness run verify-contract --contract tasks/contracts/20260815-0230-change-assessment-oracle-redaction.contract.md --strict`.
+- **Review/acceptance boundary**: `tasks/reviews/20260815-0230-change-assessment-oracle-redaction.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: verification_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260815-0230-change-assessment-oracle-redaction.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260815-0230-change-assessment-oracle-redaction.contract.md`, `tasks/reviews/20260815-0230-change-assessment-oracle-redaction.review.md`, and `tasks/notes/20260815-0230-change-assessment-oracle-redaction.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260815-0230-change-assessment-oracle-redaction.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: Before execution remove `plans/plan-20260815-0230-change-assessment-oracle-redaction.md`; after execution revert branch `codex/change-assessment-oracle-redaction` or the explicitly reviewed diff.
+
+## Captured Planning Output
+
+# Fix Change Assessment oracle ID evidence redaction
+
+## Goal
+
+Preserve committed Change Assessment oracle IDs byte-identically through evidence event redaction/materialization so assessment, packet, and envelope fingerprints remain verifiable by AcceptanceReceipt.
+
+## P1 Architecture Map
+
+`src/core/evidence/redaction.ts` classifies typed JSON string leaves before event payload redaction. `src/effects/evidence/event-writer.ts` applies it before ledger storage; checks materialization later projects those bytes. Change Assessment fingerprints in `src/core/review/change-assessment.ts` and AcceptanceReceipt verification in `scripts/acceptance-receipt.ts` require exact nested oracle IDs.
+
+## P2 Concrete Trace
+
+A strict release contract declares a long runtime-readback oracle ID. `verify-sprint --prepare-acceptance` builds a valid assessment envelope, then event emission passes the nested `required_oracles[].id` through entropy redaction. The ID becomes `sha256:...` while the precomputed assessment, packet, and evidence hashes remain unchanged. Materialized `checks/latest.json` therefore fails its own fingerprint check.
+
+## P3 Design Decision
+
+Add one structural entropy exemption only for `required_oracles/<array-index>/id`. Known-secret matching remains unconditional, and unrelated `id` fields remain entropy-redacted. This is the smallest change that preserves the committed public contract identifier without broadening the secret boundary.
+
+## Scope
+
+- Update the redaction classifier to use the full leaf path for Change Assessment oracle IDs.
+- Add direct redaction and end-to-end materialization regressions.
+- Synchronize required workflow artifacts.
+
+## Non-Goals
+
+- No general exemption for all `id` fields.
+- No weakening of known-secret redaction or fingerprint verification.
+- No release metadata changes.
+
+## Verification
+
+- Focused redaction/materializer/AcceptanceReceipt tests.
+- Typecheck, helper parity, task/workflow checks, and hosted CI.
+
+## Task Breakdown
+
+- [x] Add a failing regression for long Change Assessment oracle IDs.
+- [x] Implement the structural exemption while preserving known-secret redaction.
+- [ ] Run focused and required checks, review, and merge the bugfix PR.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [ ] Add a failing regression for long Change Assessment oracle IDs.
+- [ ] Implement the structural exemption while preserving known-secret redaction.
+- [ ] Run focused and required checks, review, and merge the bugfix PR.

--- a/src/core/evidence/redaction.ts
+++ b/src/core/evidence/redaction.ts
@@ -19,7 +19,7 @@
  * ledger (a real `verify-sprint` run against this package's own,
  * realistic-length contract slug).
  *
- * Three typed exemptions from entropy redaction are applied structurally --
+ * Four typed exemptions from entropy redaction are applied structurally --
  * classified BEFORE the entropy pass runs, never a post-hoc unhash:
  *
  *   1. Declared hash: a whole string value matching
@@ -54,6 +54,13 @@
  *      them makes an otherwise fingerprinted nested evidence envelope
  *      unverifiable after ledger materialization. Known-secret matching still
  *      runs before this exemption, exactly as for hashes and paths.
+ *   4. Change Assessment oracle identifiers: the whole `id` leaf only when
+ *      its structural path ends in `required_oracles/<array-index>/id`.
+ *      Oracle IDs are committed contract authority and participate in the
+ *      assessment, selection-packet, and evidence fingerprints; rewriting
+ *      one while preserving those hashes creates a self-inconsistent
+ *      verification envelope. This is deliberately not a general `id`
+ *      exemption. Known-secret matching still runs first.
  *
  * All exemptions skip ONLY the entropy pattern. The secret-value denylist
  * check (`findKnownSecretSpans`) still runs unconditionally over every
@@ -127,15 +134,34 @@ export function isRepoHarnessProtocolIdentifier(key: string | undefined, value: 
   return REPO_HARNESS_PROTOCOL_IDENTIFIERS.has(value);
 }
 
+/** Rule 4: only the fingerprinted Change Assessment oracle-array position.
+ * The numeric segment proves this is an array entry; a free-form object such
+ * as `{ required_oracles: { attacker: { id } } }` does not qualify. */
+export function isChangeAssessmentOracleIdPath(path: readonly string[]): boolean {
+  if (path.length < 3) return false;
+  const idKey = path[path.length - 1];
+  const arrayIndex = path[path.length - 2];
+  const collection = path[path.length - 3];
+  return idKey === "id"
+    && collection === "required_oracles"
+    && typeof arrayIndex === "string"
+    && /^(?:0|[1-9][0-9]*)$/.test(arrayIndex);
+}
+
 /** Structural classification: does this leaf (key + value) qualify for
  * either typed exemption? Computed once, up front -- see the module doc
  * comment's "order of operations" note (classify first, then redact the
  * rest; never a post-hoc unhash). */
-export function isEntropyExemptLeaf(key: string | undefined, value: string): boolean {
+export function isEntropyExemptLeaf(
+  key: string | undefined,
+  value: string,
+  path: readonly string[] = [],
+): boolean {
   return isDeclaredHashValue(value)
     || isPathConventionKey(key)
     || looksLikeSafeRepoRelativePath(value)
-    || isRepoHarnessProtocolIdentifier(key, value);
+    || isRepoHarnessProtocolIdentifier(key, value)
+    || isChangeAssessmentOracleIdPath(path);
 }
 
 interface Span {
@@ -226,7 +252,7 @@ export function redactSecretValue(
 export function redactPayloadStrings(value: JsonValue, knownSecretValues: readonly string[]): JsonValue {
   return mapStringLeaves(value, (path, leaf) => {
     const key = path[path.length - 1];
-    const exempt = isEntropyExemptLeaf(key, leaf);
+    const exempt = isEntropyExemptLeaf(key, leaf, path);
     return redactSecretValue(leaf, knownSecretValues, { entropyExempt: exempt });
   });
 }

--- a/tasks/contracts/20260815-0230-change-assessment-oracle-redaction.contract.md
+++ b/tasks/contracts/20260815-0230-change-assessment-oracle-redaction.contract.md
@@ -1,0 +1,164 @@
+# Task Contract: change-assessment-oracle-redaction
+
+> **Status**: Fulfilled
+> **Plan**: plans/plan-20260815-0230-change-assessment-oracle-redaction.md
+> **Task Profile**: bugfix
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: ancienttwo
+> **Capability ID**: root
+> **Last Updated**: 2026-08-15 02:30
+> **Review File**: `tasks/reviews/20260815-0230-change-assessment-oracle-redaction.review.md`
+> **Notes File**: `tasks/notes/20260815-0230-change-assessment-oracle-redaction.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+Evidence materialization currently corrupts the signed Change Assessment
+envelope whenever a committed oracle ID contains a 32-byte entropy-shaped run.
+The resulting `checks/latest.json` cannot be consumed by AcceptanceReceipt, so
+strict releases fail after otherwise passing verification.
+
+## Goal
+
+Preserve Change Assessment oracle IDs byte-identically through event redaction
+and checks materialization while retaining known-secret redaction and entropy
+redaction for unrelated `id` fields.
+
+## Scope
+
+- In scope: structural redaction classification for `required_oracles[].id`,
+  direct regression tests, and an end-to-end materialization regression.
+- Out of scope: general `id` exemptions, weaker secret matching, fingerprint
+  compatibility, release metadata, or AcceptanceReceipt fallback behavior.
+- Taste constraints: exempt only the closed fingerprinted oracle path; known
+  secrets must still win before entropy exemption.
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+
+## Falsifier
+
+If the narrow path exemption still changes a committed oracle ID, exempts an
+unrelated ID, or leaks a known secret in that position, this direction is
+wrong. The cheapest proof is the focused redaction regression.
+
+## Root Cause Evidence
+
+Required when Task Profile is `bugfix`; leave as-is otherwise.
+
+- root_cause: `src/core/evidence/redaction.ts:isEntropyExemptLeaf` classifies only key/value, so a long committed `required_oracles[].id` is entropy-hashed while its enclosing Change Assessment fingerprints remain unchanged.
+- repro: `bun test tests/evidence-event-store.test.ts --test-name-pattern "Change Assessment oracle IDs survive"`.
+- regression_guard: tests/evidence-event-store.test.ts
+- pre_fix_failure_artifact: .ai/harness/runs/20260815-change-assessment-oracle-redaction-pre-fix.log
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260815-0230-change-assessment-oracle-redaction.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260815-0230-change-assessment-oracle-redaction.review.md`
+- Notes file: `tasks/notes/20260815-0230-change-assessment-oracle-redaction.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Change Assessment
+
+```json
+{"protocol":1,"oracles":[{"id":"oracle-redaction-regressions","kind":"deterministic_test","paths":["*"]}]}
+```
+
+## Acceptance Policy
+
+```json
+{"protocol":1,"reviewer":"Claude","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - src/core/evidence/redaction.ts
+  - tests/evidence-event-store.test.ts
+  - tests/evidence-checks-materializer.test.ts
+  - plans/plan-20260815-0230-change-assessment-oracle-redaction.md
+  - tasks/todos.md
+  - tasks/current.md
+  - tasks/contracts/20260815-0230-change-assessment-oracle-redaction.contract.md
+  - tasks/reviews/20260815-0230-change-assessment-oracle-redaction.review.md
+  - tasks/notes/20260815-0230-change-assessment-oracle-redaction.notes.md
+  - docs/architecture/.projection-manifest.json
+  - docs/architecture/modules/runtime-harness/evidence-store.md
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+    fallback: null
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - src/core/evidence/redaction.ts
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260815-0230-change-assessment-oracle-redaction.notes.md
+    - .ai/harness/runs/20260815-change-assessment-oracle-redaction-pre-fix.log
+  tests_pass:
+    - path: tests/evidence-event-store.test.ts
+    - path: tests/evidence-checks-materializer.test.ts
+    - path: tests/acceptance-receipt-evidence-fingerprint.test.ts
+  commands_succeed:
+    - bun run check:type
+```
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior: fingerprinted Change Assessment envelopes survive ledger materialization byte-identically.
+- Edge cases: unrelated IDs remain entropy-redacted and known-secret matches remain redacted at the exempt path.
+- Regression risks: an over-broad path match could expose unrelated entropy-shaped identifiers.
+
+## Rollback Point
+
+- Commit / checkpoint: pre-fix `main@f12380487cb882040251251309666f3927edfed7`.
+- Revert strategy: revert the narrow classifier and its regressions before release integration.

--- a/tasks/contracts/20260815-0230-change-assessment-oracle-redaction.contract.md
+++ b/tasks/contracts/20260815-0230-change-assessment-oracle-redaction.contract.md
@@ -68,7 +68,7 @@ Required when Task Profile is `bugfix`; leave as-is otherwise.
 ## Change Assessment
 
 ```json
-{"protocol":1,"oracles":[{"id":"oracle-redaction-regressions","kind":"deterministic_test","paths":["*"]}]}
+{"protocol":1,"oracles":[{"id":"change-assessment-oracle-redaction-regressions","kind":"deterministic_test","paths":["*"]}]}
 ```
 
 ## Acceptance Policy

--- a/tasks/notes/20260815-0230-change-assessment-oracle-redaction.notes.md
+++ b/tasks/notes/20260815-0230-change-assessment-oracle-redaction.notes.md
@@ -1,0 +1,48 @@
+# Implementation Notes: change-assessment-oracle-redaction
+
+> **Status**: Active
+> **Plan**: plans/plan-20260815-0230-change-assessment-oracle-redaction.md
+> **Contract**: tasks/contracts/20260815-0230-change-assessment-oracle-redaction.contract.md
+> **Review**: tasks/reviews/20260815-0230-change-assessment-oracle-redaction.review.md
+> **Last Updated**: 2026-08-15 02:30
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- Use the full JSON leaf path already supplied by `mapStringLeaves`; exempt
+  only paths ending in `required_oracles/<canonical array index>/id`.
+- Keep `findKnownSecretSpans` unconditional. The exemption skips only the
+  entropy heuristic, so a known secret in the oracle position remains hashed.
+
+## Deviations From Plan Or Spec
+
+- The end-to-end materializer regression was strengthened to carry a real
+  fingerprinted assessment and selection packet, not only their discriminants.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| Exempt every `id` key | Rejected | Broadens the entropy-redaction boundary for unrelated identifiers. |
+| Recompute fingerprints after redaction | Rejected | Would change committed contract authority instead of preserving it. |
+| Structural oracle-path exemption | Selected | Preserves the signed public ID with the narrowest security boundary. |
+
+## Open Questions
+
+- None.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Pre-fix failure: `.ai/harness/runs/20260815-change-assessment-oracle-redaction-pre-fix.log`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/reviews/20260815-0230-change-assessment-oracle-redaction.review.md
+++ b/tasks/reviews/20260815-0230-change-assessment-oracle-redaction.review.md
@@ -40,18 +40,18 @@
 
 ## Acceptance Receipt Projection
 
-> **Disposition**: unavailable
-> **Reviewer**: unavailable
-> **Source**: unavailable
-> **Actor**: not-applicable
+> **Disposition**: user_waiver
+> **Reviewer**: User
+> **Source**: user-waiver
+> **Actor**: ancienttwo
 > **Reviewed Subject SHA256**: sha256:576fcabbcc8e52a922491b11017db7e02b7e42c25ae8d8abdbbb499458b2a81d
 > **Reviewed Subject Scope**: normalized-final-content
 > **Reviewed Target Revision**: f12380487cb882040251251309666f3927edfed7
-> **Verification Evidence SHA256**: pending
-> **Issued At**: pending
+> **Verification Evidence SHA256**: sha256:8c292c00e30b1df151b552609ce0db4c0780f99e2f62ec33c5bb8cbc9a38826b
+> **Issued At**: 2026-08-14T18:51:44.788Z
 
-- Summary: pending typed receipt projection.
-- Findings: none.
+- Summary: User explicitly instructed go on after being informed that PR #190 requires an independent persistent typed user waiver; all focused, self-hosted, and hosted checks passed.
+- Findings: none
 
 ## Behavior Diff Notes
 

--- a/tasks/reviews/20260815-0230-change-assessment-oracle-redaction.review.md
+++ b/tasks/reviews/20260815-0230-change-assessment-oracle-redaction.review.md
@@ -1,0 +1,86 @@
+# Task Review: change-assessment-oracle-redaction
+
+> **Status**: Complete
+> **Plan**: plans/plan-20260815-0230-change-assessment-oracle-redaction.md
+> **Contract**: tasks/contracts/20260815-0230-change-assessment-oracle-redaction.contract.md
+> **Notes File**: tasks/notes/20260815-0230-change-assessment-oracle-redaction.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-08-15 02:36
+> **Recommendation**: pass
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: sha256:576fcabbcc8e52a922491b11017db7e02b7e42c25ae8d8abdbbb499458b2a81d
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: f12380487cb882040251251309666f3927edfed7
+
+## Human Review Card
+
+- Verdict: pass.
+- Change type: bugfix.
+- Intended files changed: redaction classifier and two regression suites.
+- Actual files changed: exactly those three normalized subject paths; workflow artifacts are excluded evidence.
+- Commands passed: 54 focused tests, typecheck, and contract verification 18/18.
+- Residual risks: future fingerprinted identifier arrays with different field names still require explicit typed classification.
+- Reviewer action required: none.
+- Rollback: revert the structural exemption and regressions together.
+
+## Mode Evidence
+
+- Selected route: root-cause regression and security-boundary review.
+- P1/P2/P3 evidence: the plan maps event writer to materializer to AcceptanceReceipt, traces the exact long-ID corruption, and selects a path-specific exemption.
+- Root cause or plan evidence: pre-fix artifact records expected plaintext oracle ID versus received `sha256:...`, exit 1.
+
+## Verification Evidence
+
+- Waza `/check` run: focused bugfix gate.
+- Commands run: focused three-file Bun test set, `bun run check:type`, strict contract verification.
+- Manual checks: unrelated `id` remains entropy-redacted; known-secret oracle ID remains redacted; real assessment/packet materializes byte-identically.
+- Supporting artifacts: `.ai/harness/runs/20260815-change-assessment-oracle-redaction-pre-fix.log`.
+- Implementation notes reviewed: yes.
+- Run snapshot: contract 18/18 pass.
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: sha256:576fcabbcc8e52a922491b11017db7e02b7e42c25ae8d8abdbbb499458b2a81d
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: f12380487cb882040251251309666f3927edfed7
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: pending typed receipt projection.
+- Findings: none.
+
+## Behavior Diff Notes
+
+- Only `required_oracles/<array-index>/id` gains entropy exemption.
+- Known-secret matching remains unconditional and unrelated IDs retain existing behavior.
+- No fingerprint is recomputed or accepted through compatibility logic.
+
+## Residual Risks / Follow-ups
+
+- None for the reported release blocker.
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 10/10 | Reproduced failure becomes green end to end. |
+| Product depth | 10/10 | Fix restores the authoritative acceptance path. |
+| Design quality | 10/10 | Structural exemption is narrower than a key-wide exception. |
+| Code quality | 10/10 | Small pure change with positive and negative guards. |
+
+## Failing Items
+
+- None.
+
+## Retest Steps
+
+- Run the three focused suites and typecheck.
+- Run hosted CI on the exact commit.
+
+## Summary
+
+- PASS: smallest coherent fix; no P0/P1/P2 findings.

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -1,7 +1,7 @@
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: 2026-08-14 18:08
+> **Updated**: 2026-08-15 02:30
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.

--- a/tests/evidence-checks-materializer.test.ts
+++ b/tests/evidence-checks-materializer.test.ts
@@ -4,7 +4,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, 
 import { tmpdir } from "os";
 import { dirname, join } from "path";
 
-import type { EvidenceEventRecord, SubjectIdentity, TrustClass } from "../src/core/evidence/types";
+import type { EvidenceEventRecord, JsonValue, SubjectIdentity, TrustClass } from "../src/core/evidence/types";
 import { appendEvidenceEvent, appendGenesisRecord, readAcceptedEvents } from "../src/effects/evidence/event-log";
 import { LEDGER_EPOCH_START_SHA } from "../src/effects/evidence/epoch";
 import { emitAuthoritativeVerifyEvidence } from "../src/effects/evidence/verify-producer";
@@ -17,6 +17,7 @@ import {
 } from "../src/effects/evidence/checks-materializer";
 import { canonicalize } from "../src/core/evidence/canonical-json";
 import { createHash } from "crypto";
+import { assessChange, buildReviewSelectionPacket } from "../src/core/review/change-assessment";
 import {
   runMutationObserved,
   readPendingPostEditEvents,
@@ -480,7 +481,30 @@ describe("checks-materializer: writeChecksLatest overwrite semantics", () => {
   test("end-to-end (gatekeeper CRITICAL regression): a realistic-length contract slug + real sha256:-prefixed review_subject_sha256 survives materialization byte-identical, D8-provenanced", () => {
     withTempRepo("materializer-end-to-end-pass", (repoRoot) => {
       setupGitFixtureRepo(repoRoot, LONG_SLUG_CONTRACT_RELATIVE);
-      const expectedSubject = recomputeExpectedSubject(repoRoot);
+      const subject = buildReviewSubject(repoRoot, { targetRef: "base-tag" });
+      expect(subject.status).toBe("ok");
+      const expectedSubject = subject.review_subject_sha256;
+      const oracle = { id: "published-package-runtime-readback", kind: "runtime_readback" as const, paths: ["*"] };
+      const assessment = assessChange({
+        subject,
+        workflowProfile: "strict",
+        strictCategories: ["release"],
+        patternNoveltyPaths: [],
+        declaredOracles: [oracle],
+      });
+      expect(assessment.status).toBe("ready");
+      if (assessment.status !== "ready") return;
+      const selectionPacket = buildReviewSelectionPacket(assessment);
+      const changeAssessmentBasis = {
+        schema: "repo-harness-change-assessment-evidence.v1",
+        status: "pass",
+        assessment,
+        selection_packet: selectionPacket,
+      };
+      const changeAssessment = {
+        ...changeAssessmentBasis,
+        evidence_sha256: `sha256:${createHash("sha256").update(canonicalize(changeAssessmentBasis as unknown as JsonValue)).digest("hex")}`,
+      };
       const runTrace = {
         schema: "repo-harness-run-trace.v1",
         status: "pass",
@@ -493,11 +517,7 @@ describe("checks-materializer: writeChecksLatest overwrite semantics", () => {
         review: { file: "tasks/reviews/fixture.review.md", status: "pass" },
         active_plan: LONG_SLUG_ACTIVE_PLAN,
         guards: [{ name: "contract", status: "pass" }],
-        change_assessment: {
-          schema: "repo-harness-change-assessment-evidence.v1",
-          status: "pass",
-          selection_packet: { kind: "repo-harness-review-selection-packet" },
-        },
+        change_assessment: changeAssessment,
       };
       const emitResult = emitAuthoritativeVerifyEvidence({
         repoRoot,
@@ -506,7 +526,7 @@ describe("checks-materializer: writeChecksLatest overwrite semantics", () => {
         status: "pass",
         runSnapshotPath: LONG_SLUG_RUN_FILE,
         expectedSubjectSha256: expectedSubject,
-        runTrace,
+        runTrace: runTrace as unknown as JsonValue,
       });
       expect(emitResult.ok).toBe(true);
       if (!emitResult.ok) return;
@@ -524,19 +544,22 @@ describe("checks-materializer: writeChecksLatest overwrite semantics", () => {
       // exact regression that slipped through: pre-fix, review_subject_sha256
       // came back double-prefixed and every long-slug path field came back
       // partially hashed, so this assertion alone would have caught it.
-      expect(consumerFacing).toEqual(runTrace);
+      expect(consumerFacing as unknown).toEqual(runTrace as unknown);
       expect(projection.provenance.source_event_ids).toEqual([emitResult.event.event_id]);
       expect(projection.provenance.worktree_id).toBe(emitResult.genesis.worktree_id);
 
       // Direct, named field-level proof of the CRITICAL finding.
-      expect((consumerFacing as typeof runTrace).review_subject_sha256).toBe(expectedSubject);
-      expect((consumerFacing as typeof runTrace).review_subject_sha256).not.toMatch(/^sha256:sha256:/);
-      expect((consumerFacing as typeof runTrace).run_file).toBe(LONG_SLUG_RUN_FILE);
-      expect((consumerFacing as typeof runTrace).run_file.startsWith(".ai/harness/runs/")).toBe(true);
-      expect((consumerFacing as typeof runTrace).contract.file).toBe(LONG_SLUG_CONTRACT_RELATIVE);
-      expect((consumerFacing as typeof runTrace).active_plan).toBe(LONG_SLUG_ACTIVE_PLAN);
-      expect((consumerFacing as typeof runTrace).change_assessment.schema).toBe("repo-harness-change-assessment-evidence.v1");
-      expect((consumerFacing as typeof runTrace).change_assessment.selection_packet.kind).toBe("repo-harness-review-selection-packet");
+      const materialized = consumerFacing as unknown as typeof runTrace;
+      expect(materialized.review_subject_sha256).toBe(expectedSubject);
+      expect(materialized.review_subject_sha256).not.toMatch(/^sha256:sha256:/);
+      expect(materialized.run_file).toBe(LONG_SLUG_RUN_FILE);
+      expect(materialized.run_file.startsWith(".ai/harness/runs/")).toBe(true);
+      expect(materialized.contract.file).toBe(LONG_SLUG_CONTRACT_RELATIVE);
+      expect(materialized.active_plan).toBe(LONG_SLUG_ACTIVE_PLAN);
+      expect(materialized.change_assessment.schema).toBe("repo-harness-change-assessment-evidence.v1");
+      expect(materialized.change_assessment.selection_packet.kind).toBe("repo-harness-review-selection-packet");
+      expect(materialized.change_assessment.assessment.required_oracles[0]?.id).toBe(oracle.id);
+      expect(materialized.change_assessment.selection_packet.required_oracles[0]?.id).toBe(oracle.id);
     });
   }, 30_000);
 

--- a/tests/evidence-event-store.test.ts
+++ b/tests/evidence-event-store.test.ts
@@ -386,6 +386,36 @@ describe("D6 redaction: typed-field exemption (EPC-05 gatekeeper CRITICAL fix)",
     expect(result.nested.kind).not.toBe(prefixedToken);
   });
 
+  test("Change Assessment oracle IDs survive only at the fingerprinted required_oracles path", () => {
+    const oracleId = "published-package-runtime-readback";
+    expect(oracleId.length).toBeGreaterThanOrEqual(32);
+    const result = redactPayloadStrings({
+      change_assessment: {
+        assessment: { required_oracles: [{ id: oracleId }] },
+        selection_packet: { required_oracles: [{ id: oracleId }] },
+      },
+      unrelated: { id: oracleId },
+    }, []) as {
+      change_assessment: {
+        assessment: { required_oracles: Array<{ id: string }> };
+        selection_packet: { required_oracles: Array<{ id: string }> };
+      };
+      unrelated: { id: string };
+    };
+    expect(result.change_assessment.assessment.required_oracles[0]?.id).toBe(oracleId);
+    expect(result.change_assessment.selection_packet.required_oracles[0]?.id).toBe(oracleId);
+    expect(result.unrelated.id).not.toBe(oracleId);
+  });
+
+  test("known-secret matching still redacts a Change Assessment oracle ID", () => {
+    const oracleId = "published-package-runtime-readback";
+    const result = redactPayloadStrings({ required_oracles: [{ id: oracleId }] }, [oracleId]) as {
+      required_oracles: Array<{ id: string }>;
+    };
+    expect(result.required_oracles[0]?.id).not.toContain(oracleId);
+    expect(result.required_oracles[0]?.id).toContain("sha256:");
+  });
+
   test("array entries that are whole-value safe repo-relative paths are exempt too (allowed_paths/files_changed)", () => {
     const result = redactPayloadStrings(
       { allowed_paths: [LONG_SLUG_CONTRACT_PATH, "scripts/verify-sprint.sh"] },


### PR DESCRIPTION
## Summary

- preserve committed Change Assessment `required_oracles[].id` values through evidence redaction/materialization
- keep entropy redaction unchanged for unrelated `id` fields
- keep known-secret matching unconditional at the newly exempt structural path

## Root cause

The redaction classifier used only leaf key/value. A long public oracle ID matched the entropy heuristic and was hashed after the assessment, selection packet, and envelope fingerprints had already been computed. The materialized verification envelope therefore failed its own fingerprint check and blocked AcceptanceReceipt.

## Verification

- pre-fix regression: expected `published-package-runtime-readback`, received `sha256:...`, exit 1
- focused suites: 54 pass, 0 fail
- typecheck: pass
- contract verification: 18/18 pass
- self-hosted `verify-sprint --prepare-acceptance` with a >32-character oracle ID: pass and materialized successfully

## Security boundary

The exemption matches only paths ending in `required_oracles/<array-index>/id`. It is not a general `id` exemption, and explicit known-secret values are still redacted first.
