### PR TITLE
fix(ship-worktrees): guard empty untracked array in scaffold discard on bash 3.2

### DIFF
--- a/assets/templates/helpers/ship-worktrees.sh
+++ b/assets/templates/helpers/ship-worktrees.sh
@@ -803,7 +803,7 @@ discard_scaffold_dirty_paths() {
     run_cmd git -C "$worktree" checkout -- "${tracked_paths[@]}"
   fi
 
-  for path in "${untracked_paths[@]}"; do
+  for path in ${untracked_paths[@]+"${untracked_paths[@]}"}; do
     if [[ "$DRY_RUN" -eq 1 ]]; then
       echo "[Ship] would remove scaffold file: $worktree/$path"
     else

--- a/plans/plan-20260817-2327-scaffold-discard-empty-array.md
+++ b/plans/plan-20260817-2327-scaffold-discard-empty-array.md
@@ -1,0 +1,201 @@
+# Plan: Scaffold discard survives an empty untracked array
+
+> **Status**: Executing
+> **Created**: 20260817-2327
+> **Slug**: scaffold-discard-empty-array
+> **Planning Source**: waza-think
+> **Orchestration Kind**: host-plan
+> **Source Ref**: (none)
+> **Artifact Level**: work-package
+> **Promotion Reason**: merge_boundary
+> **Verification Boundary**: tracked-only scaffold dirt must clean through --cleanup-merged --discard-scaffold-only on bash 3.2
+> **Rollback Surface**: single-expression revert, no external state
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260817-2327-scaffold-discard-empty-array.contract.md`
+> **Task Review**: `tasks/reviews/20260817-2327-scaffold-discard-empty-array.review.md`
+> **Implementation Notes**: `tasks/notes/20260817-2327-scaffold-discard-empty-array.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from waza-think planning output.
+- Source ref: (none)
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260817-2327-scaffold-discard-empty-array.md`
+- Sprint contract: `tasks/contracts/20260817-2327-scaffold-discard-empty-array.contract.md`
+- Sprint review: `tasks/reviews/20260817-2327-scaffold-discard-empty-array.review.md`
+- Implementation notes: `tasks/notes/20260817-2327-scaffold-discard-empty-array.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260817-2327-scaffold-discard-empty-array.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260817-2327-scaffold-discard-empty-array.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260817-2327-scaffold-discard-empty-array.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260817-2327-scaffold-discard-empty-array.contract.md`
+- Review file: `tasks/reviews/20260817-2327-scaffold-discard-empty-array.review.md`
+- Implementation notes file: `tasks/notes/20260817-2327-scaffold-discard-empty-array.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260817-2327-scaffold-discard-empty-array.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260817-2327-scaffold-discard-empty-array.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: single-expression revert, no external state
+- **Verification boundary**: tracked-only scaffold dirt must clean through --cleanup-merged --discard-scaffold-only on bash 3.2
+- **Review/acceptance boundary**: `tasks/reviews/20260817-2327-scaffold-discard-empty-array.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: merge_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260817-2327-scaffold-discard-empty-array.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260817-2327-scaffold-discard-empty-array.contract.md`, `tasks/reviews/20260817-2327-scaffold-discard-empty-array.review.md`, and `tasks/notes/20260817-2327-scaffold-discard-empty-array.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260817-2327-scaffold-discard-empty-array.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: single-expression revert, no external state
+
+## Captured Planning Output
+
+# Scaffold discard survives an empty untracked array
+
+## Problem
+
+`scripts/ship-worktrees.sh:806` iterates `"${untracked_paths[@]}"` under
+`set -euo pipefail`. On bash 3.2 an empty array expanded that way raises
+`unbound variable`, so `discard_scaffold_dirty_paths` aborts whenever every
+dirty scaffold path is tracked and none are untracked.
+
+bash 3.2 is not an edge case here: `/bin/bash` on macOS is 3.2.57, and
+`scripts/ship-worktrees.sh:7` defaults `BASH_BIN` to exactly that path.
+
+Reproduced directly:
+
+```
+$ /bin/bash -c 'set -euo pipefail; a=(); for x in "${a[@]}"; do echo "$x"; done; echo REACHED_END'
+/bin/bash: a[@]: unbound variable
+exit=1
+```
+
+The failure is partial, which is what makes it worth fixing rather than
+tolerating: `discard_scaffold_dirty_paths` restores the tracked scaffold paths
+first (`git checkout --`), then dies on the untracked loop. The operator sees a
+non-zero exit and an `unbound variable` message after their tracked files were
+already reverted.
+
+## Why now
+
+This is a pre-existing defect, not a regression. It was confirmed against
+`main` before the merge-authority fix: swapping in the pre-fix
+`ship-worktrees.sh` and driving an `ancestor` branch reproduces the same abort.
+
+What changed is reachability. Before `b456121a`, squash-merged branches were
+filtered out as unmerged and never reached the discard path at all, so this
+only fired on `--no-ff` merges. Squash is this project's house flow and the
+GitHub default, so the path is now routinely reachable and the crash moves from
+rare to common. Issue #196's reporter clearing 100+ worktrees is the likely
+first encounter.
+
+## Scope
+
+- `scripts/ship-worktrees.sh:806` becomes
+  `for path in ${untracked_paths[@]+"${untracked_paths[@]}"}; do`, matching the
+  idiom already used twice in this same file at `:1085` and `:1105`
+  (`${child_args[@]+"${child_args[@]}"}`). No new pattern is introduced.
+- Mirror to `assets/templates/helpers/ship-worktrees.sh` via `bun run sync:helpers`.
+- Add the missing success-path test: a merged worktree whose dirty scaffold is
+  entirely tracked, cleaned through `--cleanup-merged --discard-scaffold-only`,
+  must complete and remove the worktree. Existing coverage at
+  `tests/helper-scripts.test.ts:1913` and `:1951` only exercises the refusal
+  branches, which is why this defect survived.
+
+## Non-scope
+
+- No change to which paths count as scaffold, to the refusal branches, or to
+  the `--discard-scaffold-only` gate itself. Only the empty-array expansion.
+- No bash version bump and no change to `BASH_BIN` resolution.
+
+## Entity delta
+
+`+0 / -0`. One expression changes; the fix reuses an idiom already present in
+the same file.
+
+## Verification
+
+The guard is behavior-preserving when the array is non-empty, including
+elements containing spaces:
+
+```
+$ /bin/bash -c 'set -euo pipefail; a=("p q" r); for x in ${a[@]+"${a[@]}"}; do echo "[$x]"; done'
+[p q]
+[r]
+```
+
+Commands:
+
+```
+bun test tests/helper-scripts.test.ts
+bun test tests/contract-worktree-squash-cleanup.test.ts
+bun run check:helpers
+bun run check:type
+bun test
+```
+
+The new test must fail before the fix and pass after. Capture the pre-fix run as
+the Root Cause Evidence artifact.
+
+## Rollback
+
+Single-expression source change, no external state, no migration. Revert the
+commit; behavior returns to aborting on empty untracked arrays.
+
+## Follow-through
+
+Issue #196 already carries a public warning to avoid `--discard-scaffold-only`
+until this lands. Post a follow-up there once merged.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [ ] Execute captured plan: Scaffold discard survives an empty untracked array

--- a/scripts/ship-worktrees.sh
+++ b/scripts/ship-worktrees.sh
@@ -803,7 +803,7 @@ discard_scaffold_dirty_paths() {
     run_cmd git -C "$worktree" checkout -- "${tracked_paths[@]}"
   fi
 
-  for path in "${untracked_paths[@]}"; do
+  for path in ${untracked_paths[@]+"${untracked_paths[@]}"}; do
     if [[ "$DRY_RUN" -eq 1 ]]; then
       echo "[Ship] would remove scaffold file: $worktree/$path"
     else

--- a/tasks/contracts/20260817-2327-scaffold-discard-empty-array.contract.md
+++ b/tasks/contracts/20260817-2327-scaffold-discard-empty-array.contract.md
@@ -1,0 +1,179 @@
+# Task Contract: scaffold-discard-empty-array
+
+> **Status**: Active
+> **Plan**: plans/plan-20260817-2327-scaffold-discard-empty-array.md
+> **Task Profile**: bugfix
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: ancienttwo
+> **Capability ID**: root
+> **Last Updated**: 2026-08-17 23:27
+> **Review File**: `tasks/reviews/20260817-2327-scaffold-discard-empty-array.review.md`
+> **Notes File**: `tasks/notes/20260817-2327-scaffold-discard-empty-array.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+`discard_scaffold_dirty_paths` aborts halfway on macOS whenever every dirty
+scaffold path is tracked: it restores the tracked paths first, then dies on the
+untracked loop, leaving the operator with a non-zero exit and an `unbound
+variable` message after their files were already reverted.
+
+The defect predates `b456121a` but was nearly unreachable: squash-merged
+branches were filtered out as unmerged and never entered the discard path, so
+it only fired on `--no-ff` merges. Squash is this project's house flow and the
+GitHub default, so the path is now routinely reachable. Issue #196's reporter,
+clearing 100+ worktrees, is the likely first encounter — that issue already
+carries a public warning to avoid `--discard-scaffold-only` until this lands.
+
+## Goal
+
+`ship-worktrees --cleanup-merged --discard-scaffold-only` completes on bash 3.2
+when the dirty scaffold set contains zero untracked paths, and a test locks that
+success path.
+
+## Scope
+
+- In scope: change `scripts/ship-worktrees.sh:806` to
+  `for path in ${untracked_paths[@]+"${untracked_paths[@]}"}; do`; mirror to
+  `assets/templates/helpers/ship-worktrees.sh` via `bun run sync:helpers`; add a
+  success-path test covering a merged worktree whose dirty scaffold is entirely
+  tracked.
+- Out of scope: which paths count as scaffold, the refusal branches, the
+  `--discard-scaffold-only` gate itself, `BASH_BIN` resolution, and any bash
+  version bump. Only the empty-array expansion changes.
+- Taste constraints: use the idiom already present twice in this same file at
+  `:1085` and `:1105` (`${child_args[@]+"${child_args[@]}"}`). Do not introduce a
+  different empty-array pattern, do not restructure the loop, and do not relax
+  `set -euo pipefail`.
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+- Stop if the fix would change behavior when the array is non-empty. Word
+  splitting and quoting must be preserved for elements containing spaces.
+
+## Falsifier
+
+If the guarded expansion changes iteration for a non-empty array — in
+particular if an element containing a space is split into two iterations — the
+fix is wrong regardless of the empty case passing. Cheapest proof:
+
+```
+/bin/bash -c 'set -euo pipefail; a=("p q" r); for x in ${a[@]+"${a[@]}"}; do echo "[$x]"; done'
+```
+
+must print `[p q]` and `[r]`, not `[p]` `[q]` `[r]`.
+
+## Root Cause Evidence
+
+- root_cause: scripts/ship-worktrees.sh:806 expands `"${untracked_paths[@]}"` under `set -euo pipefail`, and bash 3.2 (macOS `/bin/bash`, the `BASH_BIN` default at scripts/ship-worktrees.sh:7) raises `unbound variable` for an empty array, so discard_scaffold_dirty_paths exits 1 after already reverting the tracked paths.
+- repro: /bin/bash -c 'set -euo pipefail; a=(); for x in "${a[@]}"; do echo "$x"; done; echo REACHED_END' prints `/bin/bash: a[@]: unbound variable` and exits 1; end to end, `ship-worktrees --cleanup-merged --discard-scaffold-only` against a merged worktree whose dirty scaffold is entirely tracked aborts the same way.
+- regression_guard: tests/helper-scripts.test.ts
+- pre_fix_failure_artifact: tasks/notes/20260817-scaffold-discard-empty-array.pre-fix.log
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260817-2327-scaffold-discard-empty-array.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260817-2327-scaffold-discard-empty-array.review.md`
+- Notes file: `tasks/notes/20260817-2327-scaffold-discard-empty-array.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Change Assessment
+
+```json
+{"protocol":1,"oracles":[]}
+```
+
+## Acceptance Policy
+
+```json
+{"protocol":1,"reviewer":"Claude","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - docs/spec.md
+  - plans/
+  - tasks/todos.md
+  - tasks/contracts/20260817-2327-scaffold-discard-empty-array.contract.md
+  - tasks/reviews/20260817-2327-scaffold-discard-empty-array.review.md
+  - tasks/notes/20260817-2327-scaffold-discard-empty-array.notes.md
+  - .ai/context/capabilities.json
+  - assets/templates/helpers/
+  - scripts/
+  - tests/
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+    fallback: null
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - docs/spec.md
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260817-2327-scaffold-discard-empty-array.notes.md
+  tests_pass:
+    - path: tests/helper-scripts.test.ts
+  commands_succeed:
+    - bun run check:type
+```
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior:
+- Edge cases:
+- Regression risks:
+
+## Rollback Point
+
+- Commit / checkpoint:
+- Revert strategy:

--- a/tasks/contracts/20260817-2327-scaffold-discard-empty-array.contract.md
+++ b/tasks/contracts/20260817-2327-scaffold-discard-empty-array.contract.md
@@ -106,6 +106,7 @@ allowed_paths:
   - tasks/contracts/20260817-2327-scaffold-discard-empty-array.contract.md
   - tasks/reviews/20260817-2327-scaffold-discard-empty-array.review.md
   - tasks/notes/20260817-2327-scaffold-discard-empty-array.notes.md
+  - tasks/notes/20260817-scaffold-discard-empty-array.pre-fix.log
   - .ai/context/capabilities.json
   - assets/templates/helpers/
   - scripts/

--- a/tasks/notes/20260817-2327-scaffold-discard-empty-array.notes.md
+++ b/tasks/notes/20260817-2327-scaffold-discard-empty-array.notes.md
@@ -1,0 +1,94 @@
+# Implementation Notes: scaffold-discard-empty-array
+
+> **Status**: Active
+> **Plan**: plans/plan-20260817-2327-scaffold-discard-empty-array.md
+> **Contract**: tasks/contracts/20260817-2327-scaffold-discard-empty-array.contract.md
+> **Review**: tasks/reviews/20260817-2327-scaffold-discard-empty-array.review.md
+> **Last Updated**: 2026-08-17 23:27
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- Reused the `${arr[@]+"${arr[@]}"}` idiom already present twice in the same
+  file (`scripts/ship-worktrees.sh:1085`, `:1105`) rather than introducing a
+  third empty-array pattern (`[[ ${#arr[@]} -gt 0 ]]` guard or `set +u` window).
+  The loop body, the tracked branch, and `set -euo pipefail` are untouched.
+- The new test fixture commits every scaffold path into the base repo before
+  `git worktree add`, then rewrites those same paths inside the worktree. That
+  makes `git ls-files --error-unmatch` succeed for all dirty paths, so
+  `untracked_paths` is empty — the exact shape that reached the defect. An
+  explicit assertion that `git status --porcelain=v1 --untracked-files=all`
+  contains no `??` entries pins the fixture so a future edit cannot silently
+  reintroduce an untracked path and hollow out the regression guard.
+- The test asserts `stderr` does not contain `unbound variable` in addition to
+  `status === 0`. Without that assertion the failure message would only say
+  "expected 0, got 1", which does not name the defect.
+- The mixed tracked + untracked case stays covered by the pre-existing
+  "can discard scaffold-only dirty merged worktree" test at
+  `tests/helper-scripts.test.ts:1886`; it still passes, which is the in-fixture
+  proof that the guard did not change non-empty behavior.
+
+## Deviations From Plan Or Spec
+
+- None to the change itself. One environment step outside the diff: this
+  worktree had no `node_modules`, so `bun run check:type` failed with
+  `Cannot find module .../typescript/bin/tsc`. Ran `bun install` (115 packages,
+  no lockfile change) and re-ran; typecheck is clean.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| `${untracked_paths[@]+"${untracked_paths[@]}"}` | Chosen | Already the file's local idiom; preserves quoting for elements containing spaces |
+| Wrap the loop in `if [[ ${#untracked_paths[@]} -gt 0 ]]` | Rejected | Restructures the loop and adds a second pattern for the same problem in one file |
+| Seed the array with a sentinel / relax `set -u` | Rejected | Explicitly out of scope; weakens the failure mode the script relies on |
+
+## Falsifier Result
+
+Contract falsifier (`Falsifier` section) — the guard must not change iteration
+for a non-empty array, in particular must not split an element with a space:
+
+```
+$ /bin/bash -c 'set -euo pipefail; a=("p q" r); for x in ${a[@]+"${a[@]}"}; do echo "[$x]"; done'
+[p q]
+[r]
+```
+
+Two iterations, `p q` intact. Not `[p]` `[q]` `[r]`. Empty case reaches the end:
+
+```
+$ /bin/bash -c 'set -euo pipefail; a=(); for x in ${a[@]+"${a[@]}"}; do echo "[$x]"; done; echo REACHED_END'
+REACHED_END
+```
+
+Pre-fix evidence: `tasks/notes/20260817-scaffold-discard-empty-array.pre-fix.log`
+(`PRE_FIX_EXIT=1`, `ship-worktrees.sh: line 787: untracked_paths[@]: unbound variable`).
+
+## Out Of Scope / Future Work
+
+- `bash --version` on this machine is 3.2.57, and `scripts/ship-worktrees.sh:7`
+  defaults `BASH_BIN` to `/bin/bash`, so the test suite exercises bash 3.2 by
+  accident of the host rather than by contract. A repo running its helper tests
+  on a bash 4.4+ host would not have caught this defect. Not fixed here —
+  `BASH_BIN` resolution is explicitly out of scope.
+- Not audited: whether other `"${arr[@]}"` expansions elsewhere in the helper
+  set can be reached with an empty array. Only the contracted site changed.
+
+## Open Questions
+
+- None.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/notes/20260817-scaffold-discard-empty-array.pre-fix.log
+++ b/tasks/notes/20260817-scaffold-discard-empty-array.pre-fix.log
@@ -1,0 +1,23 @@
+bun test v1.3.14 (0d9b296a)
+
+tests/helper-scripts.test.ts:
+1957 |       const cleanup = run(
+1958 |         "bash",
+1959 |         ["scripts/ship-worktrees.sh", "--cleanup-merged", "--discard-scaffold-only", "--target", "main"],
+1960 |         cwd
+1961 |       );
+1962 |       expect(cleanup.stderr).not.toContain("unbound variable");
+                                        ^
+error: expect(received).not.toContain(expected)
+
+Expected to not contain: "unbound variable"
+Received: "scripts/ship-worktrees.sh: line 787: untracked_paths[@]: unbound variable\n"
+
+      at <anonymous> (/Users/ancienttwo/Projects/repo-harness-wt-scaffold-discard-empty-array/tests/helper-scripts.test.ts:1962:34)
+(fail) Workflow helper scripts > ship-worktrees cleanup-merged can discard scaffold-only dirty merged worktree with no untracked paths [444.46ms]
+
+ 123 pass
+ 1 fail
+ 1377 expect() calls
+Ran 124 tests across 1 file. [43.26s]
+PRE_FIX_EXIT=1

--- a/tasks/reviews/20260817-2327-scaffold-discard-empty-array.review.md
+++ b/tasks/reviews/20260817-2327-scaffold-discard-empty-array.review.md
@@ -1,0 +1,84 @@
+# Task Review: scaffold-discard-empty-array
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260817-2327-scaffold-discard-empty-array.md
+> **Contract**: tasks/contracts/20260817-2327-scaffold-discard-empty-array.contract.md
+> **Notes File**: tasks/notes/20260817-2327-scaffold-discard-empty-array.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-08-17 23:27
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Commands passed:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+- Waza `/check` run:
+- Commands run:
+- Manual checks:
+- Supporting artifacts:
+- Implementation notes reviewed:
+- Run snapshot:
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -1,7 +1,7 @@
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: 2026-08-17 20:55
+> **Updated**: 2026-08-17 23:27
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.

--- a/tests/helper-scripts.test.ts
+++ b/tests/helper-scripts.test.ts
@@ -1927,6 +1927,53 @@ describe("Workflow helper scripts", () => {
     }
   }, 15000);
 
+  test("ship-worktrees cleanup-merged can discard scaffold-only dirty merged worktree with no untracked paths", () => {
+    const cwd = tmpWorkspace("helper-ship-cleanup-scaffold-tracked-only");
+    const worktreePath = `${cwd}-wt-demo`;
+    try {
+      copyHelpers(cwd);
+      initGitRepo(cwd);
+      mkdirSync(join(cwd, "plans"), { recursive: true });
+      mkdirSync(join(cwd, "tasks/contracts"), { recursive: true });
+      mkdirSync(join(cwd, "tasks/notes"), { recursive: true });
+      writeFileSync(join(cwd, "README.md"), "# demo\n");
+      writeFileSync(join(cwd, "tasks/todos.md"), "# Deferred Goal Ledger\n");
+      writeFileSync(join(cwd, "plans/plan-20260304-1410-demo.md"), "# Plan: demo\n");
+      writeFileSync(join(cwd, "tasks/contracts/demo.contract.md"), "# Contract\n");
+      writeFileSync(join(cwd, "tasks/notes/demo.notes.md"), "# Notes\n");
+      commitAll(cwd, "init tracked scaffold cleanup");
+
+      expect(run("git", ["worktree", "add", worktreePath, "-b", "codex/demo"], cwd).status).toBe(0);
+      mkdirSync(join(cwd, ".ai/harness/worktrees"), { recursive: true });
+      writeFileSync(join(cwd, ".ai/harness/worktrees/demo.json"), '{"slug":"demo"}\n');
+
+      // Every dirty scaffold path is tracked; the untracked set is empty.
+      writeFileSync(join(worktreePath, "tasks/todos.md"), "# Deferred Goal Ledger\n- generated scaffold\n");
+      writeFileSync(join(worktreePath, "plans/plan-20260304-1410-demo.md"), "# Plan: demo\n\n- generated\n");
+      writeFileSync(join(worktreePath, "tasks/contracts/demo.contract.md"), "# Contract\n\n- generated\n");
+      writeFileSync(join(worktreePath, "tasks/notes/demo.notes.md"), "# Notes\n\n- generated\n");
+      expect(run("git", ["status", "--porcelain=v1", "--untracked-files=all"], worktreePath).stdout).not.toContain("??");
+
+      const cleanup = run(
+        "bash",
+        ["scripts/ship-worktrees.sh", "--cleanup-merged", "--discard-scaffold-only", "--target", "main"],
+        cwd
+      );
+      expect(cleanup.stderr).not.toContain("unbound variable");
+      expect(cleanup.status).toBe(0);
+      expect(cleanup.stdout).toContain("Discarded scaffold-only changes");
+      expect(cleanup.stdout).toContain("Removed worktree");
+      expect(cleanup.stdout).toContain("Deleted branch: codex/demo");
+      expect(existsSync(worktreePath)).toBe(false);
+      expect(run("git", ["show-ref", "--verify", "--quiet", "refs/heads/codex/demo"], cwd).status).not.toBe(0);
+      expect(existsSync(join(cwd, ".ai/harness/worktrees/demo.json"))).toBe(false);
+    } finally {
+      run("git", ["worktree", "remove", "--force", worktreePath], cwd);
+      rmSync(worktreePath, { recursive: true, force: true });
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  }, 15000);
+
   test("ship-worktrees cleanup-merged should require explicit scaffold discard flag", () => {
     const cwd = tmpWorkspace("helper-ship-cleanup-scaffold-no-flag");
     const worktreePath = `${cwd}-wt-demo`;


### PR DESCRIPTION
Fixes a pre-existing bash 3.2 defect in `discard_scaffold_dirty_paths` that aborts
`ship-worktrees --cleanup-merged --discard-scaffold-only` halfway through, after it
has already reverted the operator's tracked files.

## Root cause

`scripts/ship-worktrees.sh:806` expanded `"${untracked_paths[@]}"` under `set -euo pipefail`.
bash 3.2 raises `unbound variable` for a quoted expansion of an empty array. macOS ships
bash 3.2.57 as `/bin/bash`, and `/bin/bash` is exactly the `BASH_BIN` default at
`scripts/ship-worktrees.sh:7`, so this is the default runtime, not an edge configuration.

Whenever every dirty scaffold path in a merged worktree is tracked, `untracked_paths` stays
empty and the loop dies.

## Failure shape

The tracked branch runs first:

```
git -C <worktree> reset -- <tracked scaffold paths>
git -C <worktree> checkout -- <tracked scaffold paths>
```

and only then does the untracked loop hit the unbound expansion. The operator gets the worst
of both: their files are already reverted, and the command exits non-zero without removing
the worktree or deleting the branch. State is half-applied and the error message
(`untracked_paths[@]: unbound variable`) says nothing about what happened.

## Why now

The defect predates `b456121a`, but it was nearly unreachable: squash-merged branches were
filtered out as unmerged and never entered the discard path, so it only fired on `--no-ff`
merges. `b456121a` corrected the squash detection, which made this path routinely reachable.
Squash is this project's house flow and the GitHub default, so the failure went from
occasional to routine. This is a fix for that latent defect, not a regression introduced by
the squash-detection change.

## The change

One line, using the empty-array idiom already present twice in the same file at `:1085` and
`:1105`:

```diff
-  for path in "${untracked_paths[@]}"; do
+  for path in ${untracked_paths[@]+"${untracked_paths[@]}"}; do
```

`assets/templates/helpers/ship-worktrees.sh` is the byte-identical projection.

## Verification

- **End to end on a real fixture.** A merged worktree whose dirty scaffold is entirely
  tracked, zero untracked, now completes: scaffold discarded, worktree removed, branch
  deleted, exit 0, no `unbound variable`. Host bash is 3.2.57, so the suite exercises the
  affected interpreter.
- **The guard does not change non-empty behavior.** Verified in a real fixture, not just a
  one-line echo: an untracked scaffold path containing a space (`plans/plan-...-my draft.md`)
  is iterated as a single element and removed as a single path. Running the pre-fix and
  post-fix scripts against the identical mixed fixture produces byte-identical output.
- **The new test is not fake-green.** Reverting the guard in a scratch copy turns exactly one
  test red with `untracked_paths[@]: unbound variable` and leaves the other 123 green. The
  pre-fix failure output is committed as
  `tasks/notes/20260817-scaffold-discard-empty-array.pre-fix.log`.
- **The fixture is pinned.** The new test asserts `git status --porcelain=v1 --untracked-files=all`
  contains no `??`, so a future untracked file cannot silently hollow out the guard it covers.
- Full suite: 2456 pass / 0 fail. `bun run check:type` clean. `check-task-workflow --strict`,
  `check-architecture-sync`, `check-task-sync`, `check-deploy-sql-order` all green.

## Follow-up

Issue #196 currently carries a public warning telling people to avoid `--discard-scaffold-only`.
That warning can be retracted once this lands. Deliberately no auto-close keyword here: #196 is
already closed and this is not its main-line fix.

A separate reachable instance of the same empty-array shape exists at
`scripts/setup-plugins.sh:35` and `:39` (running the script with no arguments). It is out of
scope for this contract and will be handled on its own.
