### PR TITLE
fix(scripts): guard empty args expansion in setup-plugins.sh

### DIFF
--- a/plans/plan-20260818-0019-setup-plugins-empty-args.md
+++ b/plans/plan-20260818-0019-setup-plugins-empty-args.md
@@ -1,0 +1,206 @@
+# Plan: setup-plugins survives an empty forwarded-args array
+
+> **Status**: Executing
+> **Created**: 20260818-0019
+> **Slug**: setup-plugins-empty-args
+> **Planning Source**: waza-think
+> **Orchestration Kind**: host-plan
+> **Source Ref**: (none)
+> **Artifact Level**: work-package
+> **Promotion Reason**: merge_boundary
+> **Verification Boundary**: setup-plugins.sh with no args and with retired-only args must forward to repo-harness install instead of crashing on bash 3.2
+> **Rollback Surface**: two-expression revert, no external state
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260818-0019-setup-plugins-empty-args.contract.md`
+> **Task Review**: `tasks/reviews/20260818-0019-setup-plugins-empty-args.review.md`
+> **Implementation Notes**: `tasks/notes/20260818-0019-setup-plugins-empty-args.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from waza-think planning output.
+- Source ref: (none)
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260818-0019-setup-plugins-empty-args.md`
+- Sprint contract: `tasks/contracts/20260818-0019-setup-plugins-empty-args.contract.md`
+- Sprint review: `tasks/reviews/20260818-0019-setup-plugins-empty-args.review.md`
+- Implementation notes: `tasks/notes/20260818-0019-setup-plugins-empty-args.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260818-0019-setup-plugins-empty-args.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260818-0019-setup-plugins-empty-args.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260818-0019-setup-plugins-empty-args.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260818-0019-setup-plugins-empty-args.contract.md`
+- Review file: `tasks/reviews/20260818-0019-setup-plugins-empty-args.review.md`
+- Implementation notes file: `tasks/notes/20260818-0019-setup-plugins-empty-args.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260818-0019-setup-plugins-empty-args.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260818-0019-setup-plugins-empty-args.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: two-expression revert, no external state
+- **Verification boundary**: setup-plugins.sh with no args and with retired-only args must forward to repo-harness install instead of crashing on bash 3.2
+- **Review/acceptance boundary**: `tasks/reviews/20260818-0019-setup-plugins-empty-args.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: merge_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260818-0019-setup-plugins-empty-args.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260818-0019-setup-plugins-empty-args.contract.md`, `tasks/reviews/20260818-0019-setup-plugins-empty-args.review.md`, and `tasks/notes/20260818-0019-setup-plugins-empty-args.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260818-0019-setup-plugins-empty-args.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: two-expression revert, no external state
+
+## Captured Planning Output
+
+# setup-plugins survives an empty forwarded-args array
+
+## Problem
+
+`scripts/setup-plugins.sh:35` and `:39` expand `"${args[@]}"` under
+`set -euo pipefail`. On bash 3.2 an empty array expanded that way raises
+`unbound variable`, so the script dies before reaching either exec target.
+
+macOS ships bash 3.2.57 as `/bin/bash`, and the script's shebang is `#!/bin/bash`.
+
+Two reachable paths produce an empty `args`, both reproduced on the current
+checkout (`09f9d8f7`) against a fake `repo-harness` on PATH:
+
+```
+$ setup-plugins.sh
+scripts/setup-plugins.sh: line 35: args[@]: unbound variable
+exit=1
+
+$ setup-plugins.sh --lsp ts
+[setup-plugins] retired option ignored: --lsp ts
+scripts/setup-plugins.sh: line 35: args[@]: unbound variable
+exit=1
+
+$ setup-plugins.sh --repo .            # control
+FAKE repo-harness got: install --repo .
+exit=0
+```
+
+The first is a setup script invoked with no arguments, which is its most
+natural call shape. The second is worse: every retired option (`--lsp`,
+`--project-type`, `--with-optional`, `--with-obsidian`, and `--hooks` with any
+profile other than `none`) is consumed and logged without appending to `args`,
+so a caller who passes only retired flags believes they supplied arguments and
+still gets an unbound-variable crash rather than the intended
+`repo-harness install`.
+
+This is the same defect class as `scripts/ship-worktrees.sh:806`, fixed in
+`09f9d8f7`. That fix's gatekeeper swept the remaining `set -u` scripts and found
+this as the only other genuinely reachable instance.
+
+## Scope
+
+- `scripts/setup-plugins.sh:35` and `:39` become
+  `${args[@]+"${args[@]}"}`, the idiom already used in
+  `scripts/ship-worktrees.sh` at `:806`, `:1085`, and `:1105`.
+- Add execution tests to `tests/setup-plugins-structure.test.ts` covering both
+  empty-args paths and the non-empty control, driven against a stub
+  `repo-harness` on PATH so nothing is actually installed.
+
+## Non-scope
+
+- Which options are retired, what they log, and the exec targets themselves.
+- The bun fallback's `ROOT_DIR` resolution.
+- Any other script surfaced by the sweep. Everything else was confirmed guarded
+  by `-gt 0`, `((${#arr[@]}))`, literal non-empty arrays, or an early exit.
+
+## Why the tests matter more than the one-line fix
+
+`tests/setup-plugins-structure.test.ts` currently holds four tests: a `bash -n`
+syntax check and three string assertions that read the file and match on its
+contents. None execute the script. A syntax check cannot catch an
+expansion error that only fires at runtime with an empty array, and a string
+assertion that the file mentions `repo-harness install` says nothing about
+whether that line is reachable.
+
+That is exactly how this survived, and it mirrors the sibling defect: there,
+`tests/helper-scripts.test.ts` covered only the refusal branches, never the
+success branch.
+
+## Entity delta
+
+`+0 / -0`. Two expressions change; the fix reuses an idiom already in the repo.
+
+## Verification
+
+```
+bun test tests/setup-plugins-structure.test.ts
+bun test tests/bootstrap-files.test.ts
+bun test tests/cli/global-runtime-init.test.ts
+bun run check:type
+bun test
+```
+
+New tests must fail before the fix and pass after. Capture the pre-fix run as
+the Root Cause Evidence artifact.
+
+Falsifier: the guard must not alter forwarding when `args` is non-empty,
+including an argument containing a space. `setup-plugins.sh --repo "/tmp/a b"`
+must forward one argument, not two.
+
+## Blast radius
+
+`setup-plugins.sh` is absent from `assets/workflow-contract.v1.json#helpers.scripts`
+and has no counterpart under `assets/templates/helpers/`, so it is not projected
+to downstream repos. The crash is confined to contributors running the script in
+this repository. That bounds the severity but not the fix cost, which is two
+expressions.
+
+## Rollback
+
+Two-expression source change, no external state, no migration. Revert the commit.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [ ] Execute captured plan: setup-plugins survives an empty forwarded-args array

--- a/scripts/setup-plugins.sh
+++ b/scripts/setup-plugins.sh
@@ -32,11 +32,11 @@ while [[ $# -gt 0 ]]; do
 done
 
 if command -v repo-harness >/dev/null 2>&1; then
-  exec repo-harness install "${args[@]}"
+  exec repo-harness install ${args[@]+"${args[@]}"}
 fi
 
 if command -v bun >/dev/null 2>&1; then
-  exec bun "$ROOT_DIR/src/cli/index.ts" install "${args[@]}"
+  exec bun "$ROOT_DIR/src/cli/index.ts" install ${args[@]+"${args[@]}"}
 fi
 
 echo "[setup-plugins] repo-harness or bun is required to run the modern install path." >&2

--- a/tasks/contracts/20260818-0019-setup-plugins-empty-args.contract.md
+++ b/tasks/contracts/20260818-0019-setup-plugins-empty-args.contract.md
@@ -1,0 +1,174 @@
+# Task Contract: setup-plugins-empty-args
+
+> **Status**: Active
+> **Plan**: plans/plan-20260818-0019-setup-plugins-empty-args.md
+> **Task Profile**: bugfix
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: ancienttwo
+> **Capability ID**: root
+> **Last Updated**: 2026-08-18 00:19
+> **Review File**: `tasks/reviews/20260818-0019-setup-plugins-empty-args.review.md`
+> **Notes File**: `tasks/notes/20260818-0019-setup-plugins-empty-args.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+`scripts/setup-plugins.sh` crashes instead of installing whenever the forwarded
+argument array ends up empty. Two call shapes reach it: no arguments at all,
+which is the most natural way to invoke a setup script, and arguments consisting
+entirely of retired options, where the caller believes they passed something and
+still gets `unbound variable`.
+
+This is the second instance of the defect class fixed in `09f9d8f7`
+(`scripts/ship-worktrees.sh:806`). That fix's acceptance sweep checked every
+`set -u` script in `scripts/` and identified this as the only other genuinely
+reachable one.
+
+## Goal
+
+`scripts/setup-plugins.sh` forwards to `repo-harness install` (or the bun
+fallback) with zero arguments instead of aborting, and tests that actually
+execute the script lock both empty-args paths.
+
+## Scope
+
+- In scope: change `scripts/setup-plugins.sh:35` and `:39` to expand
+  `${args[@]+"${args[@]}"}`; add execution tests to
+  `tests/setup-plugins-structure.test.ts` covering no-args, retired-options-only,
+  and a non-empty control, driven against a stub `repo-harness` placed on PATH.
+- Out of scope: which options are retired and what they log, the exec targets,
+  the bun fallback's `ROOT_DIR` resolution, and every other script the sweep
+  cleared. Do not fix other scripts in this contract.
+- Taste constraints: use the idiom already present at
+  `scripts/ship-worktrees.sh:806`, `:1085`, and `:1105`. Do not introduce a
+  different empty-array pattern, do not restructure the arg loop, and do not
+  relax `set -euo pipefail`.
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+- Stop if a test would invoke the real `repo-harness install` or the real bun
+  entrypoint. Every execution test must resolve a stub on PATH; nothing may be
+  installed on the host.
+
+## Falsifier
+
+If the guarded expansion changes forwarding when `args` is non-empty — in
+particular if an argument containing a space arrives as two arguments — the fix
+is wrong regardless of the empty case passing. Cheapest proof:
+`setup-plugins.sh --repo "/tmp/a b"` against the stub must forward exactly two
+arguments (`--repo` and `/tmp/a b`), not three.
+
+## Root Cause Evidence
+
+- root_cause: scripts/setup-plugins.sh:35 (and the identical :39 bun fallback) expands `"${args[@]}"` under `set -euo pipefail`, and bash 3.2 (macOS `/bin/bash`, which the `#!/bin/bash` shebang selects) raises `unbound variable` for an empty array, so the script exits 1 before reaching exec whenever no argument survives the retired-option loop.
+- repro: with a stub `repo-harness` on PATH, `bash scripts/setup-plugins.sh` prints `scripts/setup-plugins.sh: line 35: args[@]: unbound variable` and exits 1; `bash scripts/setup-plugins.sh --lsp ts` does the same after logging the retired option; `bash scripts/setup-plugins.sh --repo .` forwards normally and exits 0.
+- regression_guard: tests/setup-plugins-structure.test.ts
+- pre_fix_failure_artifact: tasks/notes/20260818-setup-plugins-empty-args.pre-fix.log
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260818-0019-setup-plugins-empty-args.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260818-0019-setup-plugins-empty-args.review.md`
+- Notes file: `tasks/notes/20260818-0019-setup-plugins-empty-args.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Change Assessment
+
+```json
+{"protocol":1,"oracles":[]}
+```
+
+## Acceptance Policy
+
+```json
+{"protocol":1,"reviewer":"Claude","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - docs/spec.md
+  - plans/
+  - tasks/todos.md
+  - tasks/contracts/20260818-0019-setup-plugins-empty-args.contract.md
+  - tasks/reviews/20260818-0019-setup-plugins-empty-args.review.md
+  - tasks/notes/20260818-0019-setup-plugins-empty-args.notes.md
+  - .ai/context/capabilities.json
+  - tasks/notes/20260818-setup-plugins-empty-args.pre-fix.log
+  - scripts/
+  - tests/
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+    fallback: null
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - docs/spec.md
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260818-0019-setup-plugins-empty-args.notes.md
+  tests_pass:
+    - path: tests/setup-plugins-structure.test.ts
+  commands_succeed:
+    - bun run check:type
+```
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior:
+- Edge cases:
+- Regression risks:
+
+## Rollback Point
+
+- Commit / checkpoint:
+- Revert strategy:

--- a/tasks/notes/20260818-0019-setup-plugins-empty-args.notes.md
+++ b/tasks/notes/20260818-0019-setup-plugins-empty-args.notes.md
@@ -1,0 +1,93 @@
+# Implementation Notes: setup-plugins-empty-args
+
+> **Status**: Active
+> **Plan**: plans/plan-20260818-0019-setup-plugins-empty-args.md
+> **Contract**: tasks/contracts/20260818-0019-setup-plugins-empty-args.contract.md
+> **Review**: tasks/reviews/20260818-0019-setup-plugins-empty-args.review.md
+> **Last Updated**: 2026-08-18 00:19
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- Both forwarding sites (`scripts/setup-plugins.sh:35` repo-harness exec, `:39` bun
+  fallback exec) now expand `${args[@]+"${args[@]}"}`, the idiom already used at
+  `scripts/ship-worktrees.sh:806`, `:1085`, `:1105`. No fourth pattern invented, the
+  arg loop is untouched, and `set -euo pipefail` stays.
+- `tests/setup-plugins-structure.test.ts` previously ran only `bash -n` plus three
+  file-content string assertions, so nothing executed the script. That is why an
+  expansion error reachable only with an empty array survived: syntax checking cannot
+  see it. The new `setup-plugins argument forwarding` describe block executes the
+  script for real.
+- Execution tests resolve a stub `repo-harness` from a `mkdtemp` directory prepended
+  to `PATH`. The stub prints `STUB_ARG:<arg>` per argument and exits 0, so
+  `command -v repo-harness` short-circuits at line 35 and neither the real
+  `repo-harness install` nor the real bun entrypoint is ever invoked — the contract
+  Stop Condition forbidding host installs holds.
+- The bun fallback at `:39` is not exercised at runtime (reaching it requires
+  `repo-harness` absent from PATH, which would then risk the real bun entrypoint).
+  It carries the identical guard and stays covered by the existing static assertion.
+
+## Deviations From Plan Or Spec
+
+- None.
+
+## Falsifier Result
+
+Contract falsifier: the guard must not change non-empty forwarding, and an argument
+containing a space must stay one argument. Verified against the stub on bash
+3.2.57(1)-release (arm64-apple-darwin25):
+
+```
+$ bash scripts/setup-plugins.sh --repo "/tmp/a b"
+STUB_ARG:install
+STUB_ARG:--repo
+STUB_ARG:/tmp/a b
+exit=0
+```
+
+Three `STUB_ARG` lines total, i.e. exactly two arguments after `install`, not three.
+Locked as the test `keeps an argument containing a space as a single argument`.
+
+Pre-fix evidence: `tasks/notes/20260818-setup-plugins-empty-args.pre-fix.log`
+(`PRE_FIX_EXIT=1`, 2 fail / 6 pass — the two failures are exactly the no-args and
+retired-options-only shapes; the non-empty control and the space-argument falsifier
+already passed pre-fix, confirming the fix changes only the empty case).
+
+Post-fix runtime repro of both crash paths:
+
+```
+$ bash scripts/setup-plugins.sh
+STUB_ARG:install
+exit=0
+$ bash scripts/setup-plugins.sh --lsp ts
+[setup-plugins] retired option ignored: --lsp ts
+STUB_ARG:install
+exit=0
+```
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| `${args[@]+"${args[@]}"}` guard | Chosen | Already the repo idiom in three places; smallest change; preserves quoting |
+| Seed `args=("")` or drop `set -u` | Rejected | Would forward a bogus empty argument or relax a project-wide invariant |
+| Restructure the retired-option loop so it always appends | Rejected | Out of scope per contract; changes retired-option behavior |
+
+## Open Questions
+
+- None.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/notes/20260818-setup-plugins-empty-args.pre-fix.log
+++ b/tasks/notes/20260818-setup-plugins-empty-args.pre-fix.log
@@ -1,0 +1,37 @@
+bun test v1.3.14 (0d9b296a)
+
+tests/setup-plugins-structure.test.ts:
+91 |     if (stubDir) rmSync(stubDir, { recursive: true, force: true });
+92 |   });
+93 | 
+94 |   test("forwards with no arguments instead of failing on an empty array", () => {
+95 |     const res = runSetup([]);
+96 |     expect(res.stderr).not.toContain("unbound variable");
+                                ^
+error: expect(received).not.toContain(expected)
+
+Expected to not contain: "unbound variable"
+Received: "/Users/ancienttwo/Projects/repo-harness-wt-setup-plugins-empty-args/scripts/setup-plugins.sh: line 35: args[@]: unbound variable\n"
+
+      at <anonymous> (/Users/ancienttwo/Projects/repo-harness-wt-setup-plugins-empty-args/tests/setup-plugins-structure.test.ts:96:28)
+(fail) setup-plugins argument forwarding > forwards with no arguments instead of failing on an empty array [9.65ms]
+ 99 |   }, 30_000);
+100 | 
+101 |   test("forwards when every argument is consumed by a retired option", () => {
+102 |     const res = runSetup(["--lsp", "ts"]);
+103 |     expect(res.stderr).toContain("retired option ignored: --lsp ts");
+104 |     expect(res.stderr).not.toContain("unbound variable");
+                                 ^
+error: expect(received).not.toContain(expected)
+
+Expected to not contain: "unbound variable"
+Received: "[setup-plugins] retired option ignored: --lsp ts\n/Users/ancienttwo/Projects/repo-harness-wt-setup-plugins-empty-args/scripts/setup-plugins.sh: line 35: args[@]: unbound variable\n"
+
+      at <anonymous> (/Users/ancienttwo/Projects/repo-harness-wt-setup-plugins-empty-args/tests/setup-plugins-structure.test.ts:104:28)
+(fail) setup-plugins argument forwarding > forwards when every argument is consumed by a retired option [11.29ms]
+
+ 6 pass
+ 2 fail
+ 18 expect() calls
+Ran 8 tests across 1 file. [1430.00ms]
+PRE_FIX_EXIT=1

--- a/tasks/reviews/20260818-0019-setup-plugins-empty-args.review.md
+++ b/tasks/reviews/20260818-0019-setup-plugins-empty-args.review.md
@@ -1,0 +1,84 @@
+# Task Review: setup-plugins-empty-args
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260818-0019-setup-plugins-empty-args.md
+> **Contract**: tasks/contracts/20260818-0019-setup-plugins-empty-args.contract.md
+> **Notes File**: tasks/notes/20260818-0019-setup-plugins-empty-args.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-08-18 00:19
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Commands passed:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+- Waza `/check` run:
+- Commands run:
+- Manual checks:
+- Supporting artifacts:
+- Implementation notes reviewed:
+- Run snapshot:
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -1,7 +1,7 @@
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: 2026-08-18 00:05
+> **Updated**: 2026-08-18 00:19
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.

--- a/tests/setup-plugins-structure.test.ts
+++ b/tests/setup-plugins-structure.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, test } from "bun:test";
-import { readFileSync } from "fs";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
 import { join } from "path";
 import { spawnSync } from "child_process";
 
@@ -8,6 +9,37 @@ const SCRIPT_PATH = join(ROOT, "scripts/setup-plugins.sh");
 
 function readSetup(): string {
   return readFileSync(SCRIPT_PATH, "utf-8");
+}
+
+let stubDir = "";
+
+/**
+ * Run setup-plugins.sh with a stub `repo-harness` resolved first on PATH.
+ * The stub prints one received argument per line and exits 0, so the real
+ * `repo-harness install` and the real bun entrypoint are never reached and
+ * nothing is installed on the host.
+ */
+function runSetup(argv: string[]): {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+  forwarded: string[];
+} {
+  const res = spawnSync("bash", [SCRIPT_PATH, ...argv], {
+    cwd: ROOT,
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      PATH: `${stubDir}:${process.env.PATH ?? ""}`,
+    },
+  });
+  const stdout = res.stdout ?? "";
+  const marker = "STUB_ARG:";
+  const forwarded = stdout
+    .split("\n")
+    .filter((line) => line.startsWith(marker))
+    .map((line) => line.slice(marker.length));
+  return { status: res.status, stdout, stderr: res.stderr ?? "", forwarded };
 }
 
 describe("setup-plugins compatibility shim", () => {
@@ -41,4 +73,48 @@ describe("setup-plugins compatibility shim", () => {
     expect(setup).toContain('profile="${2:-}"');
     expect(setup).toContain("args+=(--no-hooks)");
   });
+});
+
+describe("setup-plugins argument forwarding", () => {
+  beforeAll(() => {
+    stubDir = mkdtempSync(join(tmpdir(), "setup-plugins-stub-"));
+    const stub = join(stubDir, "repo-harness");
+    writeFileSync(
+      stub,
+      ['#!/bin/bash', 'for arg in "$@"; do', '  echo "STUB_ARG:$arg"', 'done', ""].join("\n"),
+      "utf-8",
+    );
+    chmodSync(stub, 0o755);
+  });
+
+  afterAll(() => {
+    if (stubDir) rmSync(stubDir, { recursive: true, force: true });
+  });
+
+  test("forwards with no arguments instead of failing on an empty array", () => {
+    const res = runSetup([]);
+    expect(res.stderr).not.toContain("unbound variable");
+    expect(res.status).toBe(0);
+    expect(res.forwarded).toEqual(["install"]);
+  }, 30_000);
+
+  test("forwards when every argument is consumed by a retired option", () => {
+    const res = runSetup(["--lsp", "ts"]);
+    expect(res.stderr).toContain("retired option ignored: --lsp ts");
+    expect(res.stderr).not.toContain("unbound variable");
+    expect(res.status).toBe(0);
+    expect(res.forwarded).toEqual(["install"]);
+  }, 30_000);
+
+  test("forwards non-empty arguments unchanged", () => {
+    const res = runSetup(["--repo", "."]);
+    expect(res.status).toBe(0);
+    expect(res.forwarded).toEqual(["install", "--repo", "."]);
+  }, 30_000);
+
+  test("keeps an argument containing a space as a single argument", () => {
+    const res = runSetup(["--repo", "/tmp/a b"]);
+    expect(res.status).toBe(0);
+    expect(res.forwarded).toEqual(["install", "--repo", "/tmp/a b"]);
+  }, 30_000);
 });


### PR DESCRIPTION
setup-plugins.sh crashed with `unbound variable` on bash 3.2 (macOS /bin/bash) when the forwarded-args array was empty — reachable with no arguments at all, or when every argument was consumed by retired options. Both forwarding sites now use the `${args[@]+"${args[@]}"}` idiom already present in ship-worktrees.sh, and the structure test gains an execution block that actually runs the script on both shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)