### PR TITLE
fix(setup-plugins): guard shift overrun on final-position retired options

### DIFF
--- a/plans/plan-20260818-0444-setup-plugins-shift-overrun.md
+++ b/plans/plan-20260818-0444-setup-plugins-shift-overrun.md
@@ -1,0 +1,222 @@
+# Plan: setup-plugins survives a retired two-token option in final position
+
+> **Status**: Executing
+> **Created**: 20260818-0444
+> **Slug**: setup-plugins-shift-overrun
+> **Planning Source**: waza-think
+> **Orchestration Kind**: host-plan
+> **Source Ref**: (none)
+> **Artifact Level**: work-package
+> **Promotion Reason**: merge_boundary
+> **Verification Boundary**: retired two-token options in final position must forward to install instead of exiting 1 on bash 3.2
+> **Rollback Surface**: two-expression revert, no external state
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260818-0444-setup-plugins-shift-overrun.contract.md`
+> **Task Review**: `tasks/reviews/20260818-0444-setup-plugins-shift-overrun.review.md`
+> **Implementation Notes**: `tasks/notes/20260818-0444-setup-plugins-shift-overrun.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from waza-think planning output.
+- Source ref: (none)
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260818-0444-setup-plugins-shift-overrun.md`
+- Sprint contract: `tasks/contracts/20260818-0444-setup-plugins-shift-overrun.contract.md`
+- Sprint review: `tasks/reviews/20260818-0444-setup-plugins-shift-overrun.review.md`
+- Implementation notes: `tasks/notes/20260818-0444-setup-plugins-shift-overrun.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260818-0444-setup-plugins-shift-overrun.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260818-0444-setup-plugins-shift-overrun.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260818-0444-setup-plugins-shift-overrun.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260818-0444-setup-plugins-shift-overrun.contract.md`
+- Review file: `tasks/reviews/20260818-0444-setup-plugins-shift-overrun.review.md`
+- Implementation notes file: `tasks/notes/20260818-0444-setup-plugins-shift-overrun.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260818-0444-setup-plugins-shift-overrun.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260818-0444-setup-plugins-shift-overrun.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: two-expression revert, no external state
+- **Verification boundary**: retired two-token options in final position must forward to install instead of exiting 1 on bash 3.2
+- **Review/acceptance boundary**: `tasks/reviews/20260818-0444-setup-plugins-shift-overrun.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: merge_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260818-0444-setup-plugins-shift-overrun.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260818-0444-setup-plugins-shift-overrun.contract.md`, `tasks/reviews/20260818-0444-setup-plugins-shift-overrun.review.md`, and `tasks/notes/20260818-0444-setup-plugins-shift-overrun.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260818-0444-setup-plugins-shift-overrun.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: two-expression revert, no external state
+
+## Captured Planning Output
+
+# setup-plugins survives a retired two-token option in final position
+
+## Problem
+
+`scripts/setup-plugins.sh` calls `shift 2` at `:21` (the `--hooks` branch) and
+`:25` (the shared `--lsp|--project-type` branch). When that option is the last
+argument, only one positional parameter remains, bash 3.2 returns non-zero from
+`shift`, and `set -e` kills the script after it already logged the "ignored"
+message and before it reaches either exec target.
+
+Reproduced on `1d1b702a` against a stub `repo-harness`:
+
+```
+$ setup-plugins.sh --hooks
+[setup-plugins] retired hook profile ignored: <missing>
+exit=1
+
+$ setup-plugins.sh --repo . --lsp
+[setup-plugins] retired option ignored: --lsp
+exit=1
+
+$ setup-plugins.sh --repo . --project-type
+[setup-plugins] retired option ignored: --project-type
+exit=1
+
+$ setup-plugins.sh --hooks none          # control
+RH_ARG:[install] RH_ARG:[--no-hooks]
+exit=0
+```
+
+This is harder to diagnose than the empty-array defect fixed in `c121a7ed`.
+That one printed `unbound variable` and a line number. This one prints a
+reassuring "ignored" line and then exits 1 silently — and in the `--repo . --lsp`
+case the user supplied a perfectly valid argument that never reaches the
+installer.
+
+The two defects are independent: this failure fires inside the parse loop, strictly
+before the expansion sites the earlier fix guarded, so neither masks the other.
+`--hooks` exited 1 identically before and after `c121a7ed`.
+
+## The semantic decision
+
+A retired two-token option in final position could be treated as a user error
+(fail with a message) or as a missing value to discard (log and continue).
+**Discard and continue.**
+
+Three reasons:
+
+1. These options are retired; their values are never consumed. `--lsp ts` and
+   `--lsp` produce the same outcome — nothing. Rejecting only the valueless form
+   draws a distinction the program does not act on.
+2. The existing branches already log and continue when the value is present.
+   Failing when it is absent is inconsistent with the behavior one token away.
+3. `:15` already reads `profile="${2:-}"` with a default, and `:19` already
+   prints `<missing>` for that case. The author anticipated the absent value and
+   handled it in the branch body; only the `shift` was left unguarded. This is a
+   half-finished guard, not a deliberate rejection.
+
+Failing loudly would also be actively unhelpful: the message would tell a user
+that an option which does nothing is missing a value that is never read.
+
+## Scope
+
+- `scripts/setup-plugins.sh:21` and `:25` become
+  `shift $(( $# >= 2 ? 2 : 1 ))`. Verified on bash 3.2.57: with one parameter
+  left it shifts 1 and continues; with two or more it shifts 2 as before.
+- Add execution tests for all three positions (`--hooks`, `--lsp`,
+  `--project-type` in final position) plus a control proving two-token forms
+  still consume both tokens.
+- Close the `:39` coverage gap left open by the previous slice: the bun-fallback
+  exec has no automated test because every existing case resolves the stub
+  `repo-harness` first. Add a case that places a stub `bun` on PATH with
+  `repo-harness` unresolvable. The previous slice's gatekeeper verified `:39`
+  by hand and recorded the gap in
+  `tasks/notes/20260818-0019-setup-plugins-empty-args.notes.md`.
+
+## Non-scope
+
+- Which options are retired and what they log. The messages stay verbatim.
+- The empty-array guards at `:35`/`:39` landed in `c121a7ed`.
+- Any other script.
+
+## Entity delta
+
+`+0 / -0`. Two expressions change.
+
+## Verification
+
+```
+bun test tests/setup-plugins-structure.test.ts
+bun test tests/bootstrap-files.test.ts
+bun test tests/cli/global-runtime-init.test.ts
+bun run check:type
+bun test
+```
+
+New tests must fail before the fix and pass after. Capture the pre-fix run as
+the Root Cause Evidence artifact.
+
+Falsifier: the guard must not change consumption when the value is present.
+`setup-plugins.sh --lsp ts --repo .` must forward `--repo .` and nothing else —
+if the fix ever shifts 1 where it should shift 2, the stray `ts` would leak into
+the forwarded arguments. That leak, not the exit code, is the signal to watch.
+
+Every test must resolve a stub on PATH. Nothing may invoke the real
+`repo-harness install` or the real bun entrypoint.
+
+## Blast radius
+
+`setup-plugins.sh` is absent from `assets/workflow-contract.v1.json#helpers.scripts`
+with no counterpart under `assets/templates/helpers/`, so it is not projected
+downstream. Contributors running the script in this repository are the only
+affected population.
+
+## Rollback
+
+Two-expression source change, no external state. Revert the commit.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [ ] Execute captured plan: setup-plugins survives a retired two-token option in final position

--- a/scripts/setup-plugins.sh
+++ b/scripts/setup-plugins.sh
@@ -18,11 +18,11 @@ while [[ $# -gt 0 ]]; do
       else
         echo "[setup-plugins] retired hook profile ignored: ${profile:-<missing>}" >&2
       fi
-      shift 2
+      shift $(( $# >= 2 ? 2 : 1 ))
       ;;
     --lsp|--project-type)
       echo "[setup-plugins] retired option ignored: $1 ${2:-}" >&2
-      shift 2
+      shift $(( $# >= 2 ? 2 : 1 ))
       ;;
     *)
       args+=("$1")

--- a/tasks/contracts/20260818-0444-setup-plugins-shift-overrun.contract.md
+++ b/tasks/contracts/20260818-0444-setup-plugins-shift-overrun.contract.md
@@ -1,0 +1,196 @@
+# Task Contract: setup-plugins-shift-overrun
+
+> **Status**: Active
+> **Plan**: plans/plan-20260818-0444-setup-plugins-shift-overrun.md
+> **Task Profile**: bugfix
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: ancienttwo
+> **Capability ID**: root
+> **Last Updated**: 2026-08-18 04:44
+> **Review File**: `tasks/reviews/20260818-0444-setup-plugins-shift-overrun.review.md`
+> **Notes File**: `tasks/notes/20260818-0444-setup-plugins-shift-overrun.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+`scripts/setup-plugins.sh` exits 1 without installing whenever a retired
+two-token option lands in final position. It prints a reassuring "ignored" line
+first, so the failure looks like a successful no-op that then died for unstated
+reasons. In the `--repo . --lsp` case the user supplied a valid argument that
+never reaches the installer.
+
+This is harder to diagnose than the empty-array defect fixed in `c121a7ed`:
+that one named `unbound variable` and a line number, this one is silent.
+
+The two are independent. This failure fires inside the parse loop, strictly
+before the expansion sites the earlier fix guarded, so neither masks the other —
+`--hooks` exited 1 identically before and after `c121a7ed`.
+
+## Goal
+
+`scripts/setup-plugins.sh` forwards to the installer when `--hooks`, `--lsp`, or
+`--project-type` is the final argument, and execution tests lock all three
+positions plus the `:39` bun-fallback branch.
+
+## Scope
+
+- In scope: change `scripts/setup-plugins.sh:21` and `:25` to
+  `shift $(( $# >= 2 ? 2 : 1 ))`; add execution tests for all three options in
+  final position plus a control proving two-token forms still consume both
+  tokens; add a bun-fallback test that places a stub `bun` on PATH with
+  `repo-harness` unresolvable.
+- Out of scope: which options are retired and what they log (messages stay
+  verbatim), the empty-array guards at `:35`/`:39` that landed in `c121a7ed`,
+  and every other script.
+- Taste constraints: keep the parse loop's shape. Do not restructure the case
+  statement, do not convert to a different argument parser, and do not relax
+  `set -euo pipefail`.
+
+## Semantic decision (frozen)
+
+A retired two-token option in final position is treated as a **missing value to
+discard**, not a user error. Log and continue, exactly as the valued form does.
+
+Three reasons, the third decisive:
+
+1. These options are retired and their values are never consumed. `--lsp ts` and
+   `--lsp` produce the same outcome — nothing. Rejecting only the valueless form
+   draws a distinction the program does not act on.
+2. The branches already log and continue when the value is present. Failing when
+   it is absent is inconsistent with the behavior one token away.
+3. `:15` already reads `profile="${2:-}"` with a default and `:19` already
+   prints `<missing>` for that case. The author anticipated the absent value and
+   handled it in the branch body; only the `shift` was left unguarded. This is a
+   half-finished guard, not a deliberate rejection.
+
+Do not implement an error path. If you believe the rejection semantics are
+better, stop and hand back rather than changing direction.
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+- Stop if a test would invoke the real `repo-harness install` or the real bun
+  entrypoint. Every execution test must resolve a stub on PATH.
+
+## Falsifier
+
+The guard must not change consumption when the value is present. Run
+`setup-plugins.sh --lsp ts --repo .` against the stub: it must forward
+`--repo` and `.` and nothing else. If the fix ever shifts 1 where it should
+shift 2, the stray `ts` leaks into the forwarded arguments. **That leak, not the
+exit code, is the signal** — the exit code stays 0 in both the correct and the
+broken version, so an exit-code-only assertion would pass a broken fix.
+
+## Root Cause Evidence
+
+- root_cause: scripts/setup-plugins.sh:21 and :25 call `shift 2` when a retired two-token option may be the last argument, and bash 3.2 returns non-zero from `shift` once the requested count exceeds `$#`, so `set -e` exits the script after the "ignored" message and before either exec target.
+- repro: with a stub `repo-harness` on PATH, `bash scripts/setup-plugins.sh --hooks`, `bash scripts/setup-plugins.sh --repo . --lsp`, and `bash scripts/setup-plugins.sh --repo . --project-type` each print their retired-option message and exit 1; `bash scripts/setup-plugins.sh --hooks none` forwards `install --no-hooks` and exits 0.
+- regression_guard: tests/setup-plugins-structure.test.ts
+- pre_fix_failure_artifact: tasks/notes/20260818-setup-plugins-shift-overrun.pre-fix.log
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260818-0444-setup-plugins-shift-overrun.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260818-0444-setup-plugins-shift-overrun.review.md`
+- Notes file: `tasks/notes/20260818-0444-setup-plugins-shift-overrun.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Change Assessment
+
+```json
+{"protocol":1,"oracles":[]}
+```
+
+## Acceptance Policy
+
+```json
+{"protocol":1,"reviewer":"Claude","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - docs/spec.md
+  - plans/
+  - tasks/todos.md
+  - tasks/contracts/20260818-0444-setup-plugins-shift-overrun.contract.md
+  - tasks/reviews/20260818-0444-setup-plugins-shift-overrun.review.md
+  - tasks/notes/20260818-0444-setup-plugins-shift-overrun.notes.md
+  - .ai/context/capabilities.json
+  - tasks/notes/20260818-setup-plugins-shift-overrun.pre-fix.log
+  - scripts/
+  - tests/
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+    fallback: null
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - docs/spec.md
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260818-0444-setup-plugins-shift-overrun.notes.md
+  tests_pass:
+    - path: tests/setup-plugins-structure.test.ts
+  commands_succeed:
+    - bun run check:type
+```
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior:
+- Edge cases:
+- Regression risks:
+
+## Rollback Point
+
+- Commit / checkpoint:
+- Revert strategy:

--- a/tasks/notes/20260818-0444-setup-plugins-shift-overrun.notes.md
+++ b/tasks/notes/20260818-0444-setup-plugins-shift-overrun.notes.md
@@ -1,0 +1,139 @@
+# Implementation Notes: setup-plugins-shift-overrun
+
+> **Status**: Active
+> **Plan**: plans/plan-20260818-0444-setup-plugins-shift-overrun.md
+> **Contract**: tasks/contracts/20260818-0444-setup-plugins-shift-overrun.contract.md
+> **Review**: tasks/reviews/20260818-0444-setup-plugins-shift-overrun.review.md
+> **Last Updated**: 2026-08-18 04:44
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- Both overrun sites now read `shift $(( $# >= 2 ? 2 : 1 ))`:
+  `scripts/setup-plugins.sh:21` (`--hooks`) and `:25` (`--lsp|--project-type`).
+  The arithmetic guard is evaluated before `shift` runs, so the requested count
+  never exceeds `$#` and bash 3.2 never returns non-zero into `set -e`. The case
+  statement, the branch messages, and `set -euo pipefail` are unchanged.
+- The frozen semantic from the contract is implemented as written: a retired
+  two-token option in final position logs and continues, exactly as the valued
+  form does. No error path was added. `:15`'s `profile="${2:-}"` and `:19`'s
+  `<missing>` render already handled the absent value; only the `shift` was
+  unguarded.
+- The `:38` bun fallback now has execution coverage, closing the gap the previous
+  slice recorded in `tasks/notes/20260818-0019-setup-plugins-empty-args.notes.md`.
+  The new `setup-plugins bun fallback path` describe block stubs `bun` in its own
+  `mkdtemp` dir and rebuilds `PATH` as `${bunStubDir}:/usr/bin:/bin`. Both the
+  real `repo-harness` and the real `bun` live in `~/.bun/bin`, which that PATH
+  excludes, so `command -v repo-harness` fails at `:34` and the stub `bun` is what
+  `:39` execs. `spawnSync` is given `/bin/bash` absolutely because the trimmed
+  PATH must not be relied on to resolve the shell; `/usr/bin:/bin` stays on it
+  because the script's `dirname` at `:4` is an external binary.
+  The contract Stop Condition holds: no test reaches the real installer or the
+  real bun entrypoint.
+- Three bun-fallback tests passed pre-fix (see the log below). That is the proof
+  the block actually reaches `:39` rather than silently re-testing `:35` — under
+  the previous shift-2 defect only the `--hooks`-final case in that block failed,
+  which is the branch-specific signature, not a stub-resolution artifact.
+
+## Deviations From Plan Or Spec
+
+- None.
+
+## Falsifier Result
+
+Contract falsifier (`## Falsifier`): the guard must not change consumption when
+the value is present. `setup-plugins.sh --lsp ts --repo .` must forward `--repo`
+and `.` and nothing else — a shift-1 where 2 is correct leaks the stray `ts`, and
+because the exit code is 0 in both the correct and the broken version, the
+forwarded argument list is the only signal. Verified against the stub on bash
+3.2.57(1)-release (arm64-apple-darwin25):
+
+```
+$ bash scripts/setup-plugins.sh --lsp ts --repo .
+[setup-plugins] retired option ignored: --lsp ts
+STUB_ARG:install
+STUB_ARG:--repo
+STUB_ARG:.
+exit=0
+```
+
+Three `STUB_ARG` lines, no `ts`. Locked as the test
+`still consumes both tokens of the valued --lsp form`, which asserts the full
+forwarded array and additionally `expect(res.forwarded).not.toContain("ts")` —
+an exit-code-only assertion would have passed a broken fix.
+
+The three reported crash shapes, same run, all now exit 0 and forward correctly:
+
+```
+$ bash scripts/setup-plugins.sh --hooks
+[setup-plugins] retired hook profile ignored: <missing>
+STUB_ARG:install
+exit=0
+$ bash scripts/setup-plugins.sh --repo . --lsp
+[setup-plugins] retired option ignored: --lsp
+STUB_ARG:install
+STUB_ARG:--repo
+STUB_ARG:.
+exit=0
+$ bash scripts/setup-plugins.sh --repo . --project-type
+[setup-plugins] retired option ignored: --project-type
+STUB_ARG:install
+STUB_ARG:--repo
+STUB_ARG:.
+exit=0
+$ bash scripts/setup-plugins.sh --hooks none        # control
+STUB_ARG:install
+STUB_ARG:--no-hooks
+exit=0
+```
+
+Pre-fix evidence: `tasks/notes/20260818-setup-plugins-shift-overrun.pre-fix.log`
+(`PRE_FIX_EXIT=1`, 4 fail / 12 pass). The four failures are exactly the three
+final-position shapes plus the bun-fallback `--hooks`-final shape; every
+two-token control and both bun-fallback base cases already passed pre-fix,
+confirming the guard changes only the overrun case.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| `shift $(( $# >= 2 ? 2 : 1 ))` at both sites | Chosen | Smallest change; guard is local to the shift, leaves the case statement, messages, and `set -euo pipefail` untouched |
+| `shift; shift \|\| true` or `shift 2 \|\| true` | Rejected | Swallows every shift failure including future real ones, and `\|\| true` masks intent rather than expressing the bound |
+| Reject the valueless form with a non-zero exit and a usage message | Rejected | Contract `## Semantic decision (frozen)` forbids it: retired options' values are never consumed, so `--lsp ts` and `--lsp` have identical outcomes and a rejection draws a distinction the program does not act on |
+| Restructure the parse loop to a `getopts`-style parser | Rejected | Contract taste constraint: keep the loop's shape |
+
+## Out Of Scope / Future Work
+
+Observed during this slice, deliberately not changed.
+
+- **`--hooks` accepts and discards any non-`none` profile silently-ish.**
+  `scripts/setup-plugins.sh:14-20` maps only the literal `none` to `--no-hooks`;
+  every other value, including a typo like `nome`, takes the retired-profile
+  branch and is dropped with a stderr line. A user who typos the profile gets an
+  install with hooks enabled and a message that reads like an intentional no-op.
+  Whether that should warn more loudly or fail is a product decision about the
+  retired surface, which the contract Scope explicitly excludes ("which options
+  are retired and what they log"). Needs its own contract if it is worth acting on.
+- **The retired `--lsp`/`--project-type` message prints a trailing space when the
+  value is absent** (`retired option ignored: --lsp ` — see the repro above,
+  from `"$1 ${2:-}"` at `:24`). Cosmetic only; the contract freezes the messages
+  verbatim, so it was left alone.
+
+## Open Questions
+
+- None.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/notes/20260818-setup-plugins-shift-overrun.pre-fix.log
+++ b/tasks/notes/20260818-setup-plugins-shift-overrun.pre-fix.log
@@ -1,0 +1,65 @@
+bun test v1.3.14 (0d9b296a)
+
+tests/setup-plugins-structure.test.ts:
+119 |   }, 30_000);
+120 | 
+121 |   test("forwards when --hooks is the final argument", () => {
+122 |     const res = runSetup(["--hooks"]);
+123 |     expect(res.stderr).toContain("retired hook profile ignored: <missing>");
+124 |     expect(res.status).toBe(0);
+                             ^
+error: expect(received).toBe(expected)
+
+Expected: 0
+Received: 1
+
+      at <anonymous> (/Users/ancienttwo/Projects/repo-harness-wt-setup-plugins-shift-overrun/tests/setup-plugins-structure.test.ts:124:24)
+(fail) setup-plugins argument forwarding > forwards when --hooks is the final argument [5.36ms]
+126 |   }, 30_000);
+127 | 
+128 |   test("forwards a preceding real argument when --lsp is the final argument", () => {
+129 |     const res = runSetup(["--repo", ".", "--lsp"]);
+130 |     expect(res.stderr).toContain("retired option ignored: --lsp");
+131 |     expect(res.status).toBe(0);
+                             ^
+error: expect(received).toBe(expected)
+
+Expected: 0
+Received: 1
+
+      at <anonymous> (/Users/ancienttwo/Projects/repo-harness-wt-setup-plugins-shift-overrun/tests/setup-plugins-structure.test.ts:131:24)
+(fail) setup-plugins argument forwarding > forwards a preceding real argument when --lsp is the final argument [6.02ms]
+133 |   }, 30_000);
+134 | 
+135 |   test("forwards a preceding real argument when --project-type is the final argument", () => {
+136 |     const res = runSetup(["--repo", ".", "--project-type"]);
+137 |     expect(res.stderr).toContain("retired option ignored: --project-type");
+138 |     expect(res.status).toBe(0);
+                             ^
+error: expect(received).toBe(expected)
+
+Expected: 0
+Received: 1
+
+      at <anonymous> (/Users/ancienttwo/Projects/repo-harness-wt-setup-plugins-shift-overrun/tests/setup-plugins-structure.test.ts:138:24)
+(fail) setup-plugins argument forwarding > forwards a preceding real argument when --project-type is the final argument [5.76ms]
+226 |   }, 30_000);
+227 | 
+228 |   test("falls back to the bun entrypoint when --hooks is the final argument", () => {
+229 |     const res = runSetupViaBun(["--repo", ".", "--hooks"]);
+230 |     expect(res.stderr).toContain("retired hook profile ignored: <missing>");
+231 |     expect(res.status).toBe(0);
+                             ^
+error: expect(received).toBe(expected)
+
+Expected: 0
+Received: 1
+
+      at <anonymous> (/Users/ancienttwo/Projects/repo-harness-wt-setup-plugins-shift-overrun/tests/setup-plugins-structure.test.ts:231:24)
+(fail) setup-plugins bun fallback path > falls back to the bun entrypoint when --hooks is the final argument [7.02ms]
+
+ 12 pass
+ 4 fail
+ 42 expect() calls
+Ran 16 tests across 1 file. [1114.00ms]
+PRE_FIX_EXIT=1

--- a/tasks/reviews/20260818-0444-setup-plugins-shift-overrun.review.md
+++ b/tasks/reviews/20260818-0444-setup-plugins-shift-overrun.review.md
@@ -1,0 +1,84 @@
+# Task Review: setup-plugins-shift-overrun
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260818-0444-setup-plugins-shift-overrun.md
+> **Contract**: tasks/contracts/20260818-0444-setup-plugins-shift-overrun.contract.md
+> **Notes File**: tasks/notes/20260818-0444-setup-plugins-shift-overrun.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-08-18 04:44
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Commands passed:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+- Waza `/check` run:
+- Commands run:
+- Manual checks:
+- Supporting artifacts:
+- Implementation notes reviewed:
+- Run snapshot:
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -1,7 +1,7 @@
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: (archive-workflow)
+> **Updated**: 2026-08-18 04:44
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.

--- a/tests/setup-plugins-structure.test.ts
+++ b/tests/setup-plugins-structure.test.ts
@@ -117,4 +117,123 @@ describe("setup-plugins argument forwarding", () => {
     expect(res.status).toBe(0);
     expect(res.forwarded).toEqual(["install", "--repo", "/tmp/a b"]);
   }, 30_000);
+
+  test("forwards when --hooks is the final argument", () => {
+    const res = runSetup(["--hooks"]);
+    expect(res.stderr).toContain("retired hook profile ignored: <missing>");
+    expect(res.status).toBe(0);
+    expect(res.forwarded).toEqual(["install"]);
+  }, 30_000);
+
+  test("forwards a preceding real argument when --lsp is the final argument", () => {
+    const res = runSetup(["--repo", ".", "--lsp"]);
+    expect(res.stderr).toContain("retired option ignored: --lsp");
+    expect(res.status).toBe(0);
+    expect(res.forwarded).toEqual(["install", "--repo", "."]);
+  }, 30_000);
+
+  test("forwards a preceding real argument when --project-type is the final argument", () => {
+    const res = runSetup(["--repo", ".", "--project-type"]);
+    expect(res.stderr).toContain("retired option ignored: --project-type");
+    expect(res.status).toBe(0);
+    expect(res.forwarded).toEqual(["install", "--repo", "."]);
+  }, 30_000);
+
+  test("still consumes both tokens of the valued --hooks form", () => {
+    const res = runSetup(["--hooks", "none", "--repo", "."]);
+    expect(res.status).toBe(0);
+    expect(res.forwarded).toEqual(["install", "--no-hooks", "--repo", "."]);
+  }, 30_000);
+
+  // Contract falsifier: the guard must not change consumption when the value is
+  // present. `ts` must be swallowed by the --lsp branch, never forwarded. Both
+  // the correct and the shift-1 version exit 0, so the forwarded argument list
+  // is the only signal.
+  test("still consumes both tokens of the valued --lsp form", () => {
+    const res = runSetup(["--lsp", "ts", "--repo", "."]);
+    expect(res.stderr).toContain("retired option ignored: --lsp ts");
+    expect(res.status).toBe(0);
+    expect(res.forwarded).toEqual(["install", "--repo", "."]);
+    expect(res.forwarded).not.toContain("ts");
+  }, 30_000);
+});
+
+describe("setup-plugins bun fallback path", () => {
+  let bunStubDir = "";
+
+  beforeAll(() => {
+    bunStubDir = mkdtempSync(join(tmpdir(), "setup-plugins-bun-stub-"));
+    const stub = join(bunStubDir, "bun");
+    writeFileSync(
+      stub,
+      ["#!/bin/bash", 'for arg in "$@"; do', '  echo "STUB_ARG:$arg"', "done", ""].join("\n"),
+      "utf-8",
+    );
+    chmodSync(stub, 0o755);
+  });
+
+  afterAll(() => {
+    if (bunStubDir) rmSync(bunStubDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Run setup-plugins.sh with `repo-harness` unresolvable and a stub `bun`
+   * first on PATH, so the `:34` branch is skipped and the `:38` bun fallback
+   * executes. PATH is rebuilt from scratch (stub dir plus the system bin dirs
+   * `dirname` needs) so neither the real `repo-harness` nor the real `bun` in
+   * ~/.bun/bin can be resolved.
+   */
+  function runSetupViaBun(argv: string[]): {
+    status: number | null;
+    stdout: string;
+    stderr: string;
+    forwarded: string[];
+  } {
+    const res = spawnSync("/bin/bash", [SCRIPT_PATH, ...argv], {
+      cwd: ROOT,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        PATH: `${bunStubDir}:/usr/bin:/bin`,
+      },
+    });
+    const stdout = res.stdout ?? "";
+    const marker = "STUB_ARG:";
+    const forwarded = stdout
+      .split("\n")
+      .filter((line) => line.startsWith(marker))
+      .map((line) => line.slice(marker.length));
+    return { status: res.status, stdout, stderr: res.stderr ?? "", forwarded };
+  }
+
+  test("falls back to the bun entrypoint when repo-harness is unresolvable", () => {
+    const res = runSetupViaBun(["--repo", "."]);
+    expect(res.stderr).not.toContain("unbound variable");
+    expect(res.status).toBe(0);
+    expect(res.forwarded).toEqual([
+      join(ROOT, "src/cli/index.ts"),
+      "install",
+      "--repo",
+      ".",
+    ]);
+  }, 30_000);
+
+  test("falls back to the bun entrypoint with no arguments", () => {
+    const res = runSetupViaBun([]);
+    expect(res.stderr).not.toContain("unbound variable");
+    expect(res.status).toBe(0);
+    expect(res.forwarded).toEqual([join(ROOT, "src/cli/index.ts"), "install"]);
+  }, 30_000);
+
+  test("falls back to the bun entrypoint when --hooks is the final argument", () => {
+    const res = runSetupViaBun(["--repo", ".", "--hooks"]);
+    expect(res.stderr).toContain("retired hook profile ignored: <missing>");
+    expect(res.status).toBe(0);
+    expect(res.forwarded).toEqual([
+      join(ROOT, "src/cli/index.ts"),
+      "install",
+      "--repo",
+      ".",
+    ]);
+  }, 30_000);
 });


### PR DESCRIPTION
## Root cause

`scripts/setup-plugins.sh:21` (`--hooks`) and `:25` (`--lsp|--project-type`) called `shift 2`. When one of those retired two-token options lands in final position, only one positional parameter remains. bash 3.2 returns non-zero from `shift` once the requested count exceeds `$#`, and `set -euo pipefail` turns that into an exit.

The failure point is precise: after the branch prints its "ignored" message, and before either `exec` target at `:35` / `:39` is reached. The caller sees a reassuring no-op line, then a silent exit 1, and nothing is installed.

`--repo . --lsp` is the damaging shape — a valid `--repo .` is parsed and then never forwarded.

Both sites now use:

```bash
shift $(( $# >= 2 ? 2 : 1 ))
```

The arithmetic is evaluated before `shift` runs, so the count never exceeds `$#`. The case statement, the branch messages, and `set -euo pipefail` are unchanged; the diff to product code is two lines.

## Why this was harder to diagnose than the previous defect

`c121a7ed` failed loudly: `unbound variable` plus a line number. This one prints a calm "retired option ignored" and exits 1 with no further output. The message reads like the script decided to do nothing on purpose.

## This is an independent defect in the same file, not a regression from `c121a7ed`

- **Different mechanism.** `c121a7ed` guarded empty-array expansion at the `exec` sites. This one is `shift` arity inside the parse loop.
- **Disjoint trigger sets.** `c121a7ed` fired when the forwarded array was empty. This fires when a retired two-token option is last, regardless of how many other arguments exist.
- **Strictly earlier failure point.** This exits inside the `while` loop, before control ever reaches the expansion sites the earlier fix guarded. Neither masks the other — `--hooks` exited 1 identically before and after `c121a7ed`.

## Semantic decision

A retired two-token option in final position is treated as a **missing value to discard, not a user error**. It logs and continues, exactly as the valued form does. No error path was added.

Three reasons, the third decisive:

1. These options are retired and their values are never consumed. `--lsp ts` and `--lsp` produce the same outcome — nothing. Rejecting only the valueless form draws a distinction the program does not act on.
2. The branches already log and continue when the value is present. Failing when it is absent is inconsistent with the behavior one token away.
3. `:15` already reads `profile="${2:-}"` with a default, and `:19` already prints `<missing>` for exactly that case. The author anticipated the absent value and handled it in the branch body; only the `shift` was left unguarded. This is a half-finished guard, not a deliberate rejection.

## Verification

The regression tests were replayed against three variants of the script to prove they fail for the right reason and in the right direction:

| Variant | Result | Failing cases |
| --- | --- | --- |
| `shift $(( $# >= 2 ? 2 : 1 ))` (this PR) | 16 pass / 0 fail | — |
| `shift 1` (a plausible but wrong fix) | 13 pass / **3 fail** | includes the falsifier |
| `shift 2` (pre-fix) | 12 pass / **4 fail** | exactly the four new final-position cases; all pre-existing cases stay green |

### The falsifier

`--lsp ts --repo .` exits 0 in **both** the correct and the `shift 1` version, with byte-identical stderr. The only difference is the forwarded argument list:

```
correct : install --repo .
shift 1 : install ts --repo .
```

So the test asserts the forwarded arguments, not the exit code. Under `shift 1` it fails at `tests/setup-plugins-structure.test.ts:156` (`expect(res.forwarded).toEqual(...)`) — the exit-code assertion on the line above passes. An exit-code-only assertion would have shipped the broken fix.

### `:39` bun-fallback coverage gap closed

`c121a7ed` left the bun fallback branch untested. The new describe block stubs `bun` and rebuilds `PATH` as `<stub>:/usr/bin:/bin`, so `command -v repo-harness` fails at `:34` and the `:38` fallback runs. Confirmed by execution trace rather than inference:

```
+ command -v repo-harness      # non-zero, branch skipped
+ command -v bun               # resolves to the stub
+ exec bun .../src/cli/index.ts install --repo .
```

Neither the real `repo-harness install` nor the real bun entrypoint is reached by any test, so nothing is installed on the host.

## Checks

```
bun test                                     2484 pass / 1 skip / 0 fail (190 files)
bun run check:type                           clean
bash scripts/check-deploy-sql-order.sh       OK
bash scripts/check-architecture-sync.sh      blocking=0, uncommitted=0
bash scripts/check-task-sync.sh              no changes detected
bash scripts/check-task-workflow.sh --strict OK
bun scripts/inspect-project-state.ts         drift_signals: none
bun src/cli/index.ts init --repo . --dry-run 0 operations
```

## Follow-up recorded, deliberately not in this PR

`--hooks` maps only the literal `none` to `--no-hooks`, so a typo such as `--hooks nome` takes the retired-profile branch and installs **with** hooks — the opposite of the user's intent, with a message that reads like an intentional no-op.

This is left alone here on purpose: the fix requires an error path, which the semantic decision above explicitly freezes out. It also sits outside this change's scope, which excludes which options are retired and what they log. It needs its own contract that re-argues that frozen boundary, because the reasoning in point 1 does not actually cover `--hooks` — unlike `--lsp`, it has one value that is still consumed.

Recorded in `tasks/notes/20260818-0444-setup-plugins-shift-overrun.notes.md` under Out Of Scope / Future Work.
