### PR TITLE
fix(installer): make codegraph enablement explicit opt-in only

### DIFF
--- a/.ai/harness/policy.json
+++ b/.ai/harness/policy.json
@@ -335,6 +335,11 @@
     "recovery": "hybrid",
     "state": "file-backed"
   },
+  "tooling": {
+    "codegraph": {
+      "enabled": true
+    }
+  },
   "external_tooling": {
     "routing": {
       "simple": "waza"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,17 @@ All notable changes to this skill are documented here.
   the shared circuit breaker at two blocks per report fingerprint. Defaults stay
   `advice` with the post-edit observer opt-in; enforce is per-repo opt-in.
 
+### Changed
+
+- Makes CodeGraph enablement purely explicit. `profileEnablesCodegraph` no
+  longer auto-enables CodeGraph for repositories with at least 2000 tracked
+  files; the only true paths are the `full` profile and an explicit
+  `tooling.codegraph.enabled: true` in the target repo's
+  `.ai/harness/policy.json`. Downstream repos on the minimal profile without
+  that opt-in no longer gain CodeGraph, and policy read or parse failures fail
+  closed to disabled. This repo's own policy carries the explicit opt-in, so
+  self-host behavior is unchanged.
+
 ## [0.15.2] - 2026-08-16
 
 ### Added

--- a/docs/reference-configs/install-profiles.md
+++ b/docs/reference-configs/install-profiles.md
@@ -91,9 +91,11 @@ fails closed.
 
 CodeGraph configuration is tracked as a projected host-config surface with its
 owned-entry hash. Reinstall refreshes that ownership only when the entry is new
-or was already package-owned. Minimal keeps CodeGraph conditional; full requires
-the executable projection. Neither profile treats an unrelated pre-existing MCP
-entry as package-owned.
+or was already package-owned. Minimal enables CodeGraph only on an explicit local
+opt-in (`tooling.codegraph.enabled: true` in the target repo's
+`.ai/harness/policy.json`); repo size never enables it. Full requires the
+executable projection. Neither profile treats an unrelated pre-existing MCP entry
+as package-owned.
 
 Install and benchmark transactions must also bind `BUN_INSTALL` to the selected
 host home. Setting `HOME` alone does not isolate Bun global installation when a

--- a/plans/plan-20260818-1636-codegraph-explicit-optin.md
+++ b/plans/plan-20260818-1636-codegraph-explicit-optin.md
@@ -1,0 +1,137 @@
+# Plan: Codegraph enablement: remove size heuristic, explicit opt-in only
+
+> **Status**: Executing
+> **Created**: 20260818-1636
+> **Slug**: codegraph-explicit-optin
+> **Planning Source**: repo-harness-plan
+> **Orchestration Kind**: host-plan
+> **Source Ref**: (none)
+> **Artifact Level**: work-package
+> **Promotion Reason**: human_decision_boundary
+> **Verification Boundary**: bun test + tsc + init dry-run
+> **Rollback Surface**: revert install-profile.ts, policy.json tooling key, tests, one doc
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260818-1636-codegraph-explicit-optin.contract.md`
+> **Task Review**: `tasks/reviews/20260818-1636-codegraph-explicit-optin.review.md`
+> **Implementation Notes**: `tasks/notes/20260818-1636-codegraph-explicit-optin.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from repo-harness-plan planning output.
+- Source ref: (none)
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260818-1636-codegraph-explicit-optin.md`
+- Sprint contract: `tasks/contracts/20260818-1636-codegraph-explicit-optin.contract.md`
+- Sprint review: `tasks/reviews/20260818-1636-codegraph-explicit-optin.review.md`
+- Implementation notes: `tasks/notes/20260818-1636-codegraph-explicit-optin.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260818-1636-codegraph-explicit-optin.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260818-1636-codegraph-explicit-optin.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260818-1636-codegraph-explicit-optin.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260818-1636-codegraph-explicit-optin.contract.md`
+- Review file: `tasks/reviews/20260818-1636-codegraph-explicit-optin.review.md`
+- Implementation notes file: `tasks/notes/20260818-1636-codegraph-explicit-optin.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260818-1636-codegraph-explicit-optin.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260818-1636-codegraph-explicit-optin.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: revert install-profile.ts, policy.json tooling key, tests, one doc
+- **Verification boundary**: bun test + tsc + init dry-run
+- **Review/acceptance boundary**: `tasks/reviews/20260818-1636-codegraph-explicit-optin.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: human_decision_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260818-1636-codegraph-explicit-optin.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260818-1636-codegraph-explicit-optin.contract.md`, `tasks/reviews/20260818-1636-codegraph-explicit-optin.review.md`, and `tasks/notes/20260818-1636-codegraph-explicit-optin.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260818-1636-codegraph-explicit-optin.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: revert install-profile.ts, policy.json tooling key, tests, one doc
+
+## Captured Planning Output
+
+## Goal
+
+Remove the implicit >=2000-tracked-files size heuristic from `profileEnablesCodegraph` so downstream codegraph enablement is purely explicit: `full` profile or `tooling.codegraph.enabled === true` in the target repo's `.ai/harness/policy.json`. This closes the documented-vs-actual gap with the CLAUDE.md contract ("downstream repos keep the global MCP default unless local policy opts in") and the repo's no-heuristic-fallback principle.
+
+## Decision
+
+User approved deleting the heuristic (fail closed to disabled) over documenting it. Decision boundary: changes downstream install semantics.
+
+## Task Breakdown
+
+- [x] `src/cli/installer/install-profile.ts:1159-1170`: delete the `git ls-files` count branch; return false when neither `full` profile nor explicit policy opt-in applies. Remove the now-dead `spawnSync` import (only remaining use is this branch).
+- [x] Preserve self-host behavior: add `tooling.codegraph.enabled: true` to this repo's `.ai/harness/policy.json` so the self-host repo (2535 tracked files) keeps codegraph enabled explicitly instead of via the deleted heuristic.
+- [x] Tests (`tests/install-profiles.test.ts`): keep existing full/minimal assertions; add coverage for (a) explicit policy opt-in -> true, (b) large repo without opt-in -> false.
+- [x] Docs: `docs/reference-configs/install-profiles.md:94-95` reword "Minimal keeps CodeGraph conditional" to the explicit opt-in semantics.
+
+## Out of Scope
+
+User WIP files: `scripts/contract-worktree.sh`, `assets/templates/helpers/contract-worktree.sh`, `tasks/todos.md`, `docs/architecture/*` uncommitted changes.
+
+## Verification
+
+- `bun test tests/install-profiles.test.ts`
+- `bun test`
+- `node node_modules/typescript/bin/tsc --noEmit`
+- `bun src/cli/index.ts init --repo . --dry-run`
+
+## Rollback
+
+Single revert of the touched files; no data or migration surface.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [x] `src/cli/installer/install-profile.ts:1159-1170`: delete the `git ls-files` count branch; return false when neither `full` profile nor explicit policy opt-in applies. Remove the now-dead `spawnSync` import (only remaining use is this branch).
+- [x] Preserve self-host behavior: add `tooling.codegraph.enabled: true` to this repo's `.ai/harness/policy.json` so the self-host repo (2535 tracked files) keeps codegraph enabled explicitly instead of via the deleted heuristic.
+- [x] Tests (`tests/install-profiles.test.ts`): keep existing full/minimal assertions; add coverage for (a) explicit policy opt-in -> true, (b) large repo without opt-in -> false.
+- [x] Docs: `docs/reference-configs/install-profiles.md:94-95` reword "Minimal keeps CodeGraph conditional" to the explicit opt-in semantics.

--- a/src/cli/installer/install-profile.ts
+++ b/src/cli/installer/install-profile.ts
@@ -14,7 +14,6 @@ import {
 } from 'fs';
 import { homedir } from 'os';
 import { delimiter, dirname, join } from 'path';
-import { spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { buildManagedHooks, isManagedEntry, type HookHost, type HooksByEvent } from './managed-entries';
 import {
@@ -1164,7 +1163,5 @@ export function profileEnablesCodegraph(profile: InstallProfile, cwd = process.c
     };
     if (policy.tooling?.codegraph?.enabled === true) return true;
   } catch { /* policy opt-in absent */ }
-  const tracked = spawnSync('git', ['ls-files'], { cwd, encoding: 'utf-8' });
-  if (tracked.status !== 0) return false;
-  return tracked.stdout.split('\n').filter(Boolean).length >= 2_000;
+  return false;
 }

--- a/tasks/contracts/20260818-1636-codegraph-explicit-optin.contract.md
+++ b/tasks/contracts/20260818-1636-codegraph-explicit-optin.contract.md
@@ -1,0 +1,155 @@
+# Task Contract: codegraph-explicit-optin
+
+> **Status**: Fulfilled
+> **Plan**: plans/plan-20260818-1636-codegraph-explicit-optin.md
+> **Task Profile**: code-change
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: ancienttwo
+> **Capability ID**: root
+> **Last Updated**: 2026-08-18 16:36
+> **Review File**: `tasks/reviews/20260818-1636-codegraph-explicit-optin.review.md`
+> **Notes File**: `tasks/notes/20260818-1636-codegraph-explicit-optin.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+`profileEnablesCodegraph` currently auto-enables codegraph for any downstream repo with >=2000 tracked files, contradicting the CLAUDE.md contract ("downstream repos keep the global MCP default unless local policy opts in") and the no-heuristic-fallback principle. If left, downstream installs silently gain a codegraph dependency nobody opted into.
+
+## Goal
+
+Codegraph enablement becomes purely explicit: `profileEnablesCodegraph` returns true only for `profile === 'full'` or `tooling.codegraph.enabled === true` in the target repo's `.ai/harness/policy.json`; otherwise false. Self-host repo keeps codegraph via an explicit `tooling.codegraph.enabled: true` in its own policy.json. Tests cover all three semantics; the one doc describing "conditional" enablement is reworded to explicit opt-in.
+
+## Scope
+
+- In scope: `src/cli/installer/install-profile.ts` (delete the `git ls-files` size branch and the then-dead `spawnSync` import), `.ai/harness/policy.json` (add `tooling.codegraph.enabled: true`), `tests/install-profiles.test.ts` (add opt-in->true and large-repo-no-opt-in->false coverage), `docs/reference-configs/install-profiles.md:94-95` (reword "Minimal keeps CodeGraph conditional").
+- Out of scope: any other heuristic or installer behavior; user WIP files (`scripts/contract-worktree.sh`, `assets/templates/helpers/contract-worktree.sh`, `tasks/todos.md`, `docs/architecture/*`); no version bump; no release.
+- Taste constraints: <!-- advisory only, no run gate; default style/taste lives in AGENTS.md and the minimal-change policy, use this to record a per-task override -->
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+
+## Falsifier
+
+If some downstream generated-repo fixture or test depends on the size heuristic enabling codegraph (rg for `2_000`/`profileEnablesCodegraph` consumers beyond the two `src/cli/index.ts` call sites), the delete would break a real contract. Cheapest proof: `rg -n "profileEnablesCodegraph" src/ tests/` before editing.
+
+## Root Cause Evidence
+
+Required when Task Profile is `bugfix`; leave as-is otherwise.
+
+- root_cause: one sentence naming file:line/condition (testable, not "a state issue").
+- repro: the command or UI path that reproduces the symptom.
+- regression_guard: path to a test that fails on the unfixed code and passes after the fix (must also appear under exit_criteria.tests_pass).
+- pre_fix_failure_artifact: path to a captured run of regression_guard on the UNFIXED code. Capture with `bun test <regression_guard> > <artifact> 2>&1; echo "PRE_FIX_EXIT=$?" >> <artifact>` (no pipes — pipes swallow the exit status). The gate requires a non-zero `PRE_FIX_EXIT=` line plus the regression_guard path string in the artifact (see the Root Cause Evidence Gate section in docs/reference-configs/sprint-contracts.md).
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260818-1636-codegraph-explicit-optin.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260818-1636-codegraph-explicit-optin.review.md`
+- Notes file: `tasks/notes/20260818-1636-codegraph-explicit-optin.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Change Assessment
+
+```json
+{"protocol":1,"oracles":[]}
+```
+
+## Acceptance Policy
+
+```json
+{"protocol":1,"reviewer":"Claude","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - docs/spec.md
+  - plans/
+  - tasks/todos.md
+  - tasks/contracts/20260818-1636-codegraph-explicit-optin.contract.md
+  - tasks/reviews/20260818-1636-codegraph-explicit-optin.review.md
+  - tasks/notes/20260818-1636-codegraph-explicit-optin.notes.md
+  - .ai/context/capabilities.json
+  - .claude/templates/
+  - src/
+  - tests/
+  - docs/reference-configs/install-profiles.md
+  - .ai/harness/policy.json
+  - docs/CHANGELOG.md
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+    fallback: null
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - docs/spec.md
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260818-1636-codegraph-explicit-optin.notes.md
+  tests_pass:
+    - path: tests/install-profiles.test.ts
+  commands_succeed:
+    - bun run check:type
+    - bun test
+    - bun src/cli/index.ts init --repo . --dry-run
+```
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior:
+- Edge cases:
+- Regression risks:
+
+## Rollback Point
+
+- Commit / checkpoint:
+- Revert strategy:

--- a/tasks/notes/20260818-1636-codegraph-explicit-optin.notes.md
+++ b/tasks/notes/20260818-1636-codegraph-explicit-optin.notes.md
@@ -1,0 +1,60 @@
+# Implementation Notes: codegraph-explicit-optin
+
+> **Status**: Active
+> **Plan**: plans/plan-20260818-1636-codegraph-explicit-optin.md
+> **Contract**: tasks/contracts/20260818-1636-codegraph-explicit-optin.contract.md
+> **Review**: tasks/reviews/20260818-1636-codegraph-explicit-optin.review.md
+> **Last Updated**: 2026-08-18 16:36
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- Falsifier ran clean before editing: `rg -n "profileEnablesCodegraph" src/ tests/` found only the two
+  `src/cli/index.ts` call sites (lines 285, 383) and `tests/install-profiles.test.ts`. No fixture or
+  generated-repo test depended on the size heuristic, so the delete had no hidden consumer.
+- `spawnSync` was imported at `src/cli/installer/install-profile.ts:17` and used only by the deleted
+  `git ls-files` branch, so the import went with it.
+- The new `tooling.codegraph.enabled` key in `.ai/harness/policy.json` is placed immediately before
+  `external_tooling`. `tooling` is a distinct top-level key from the pre-existing `external_tooling`
+  (Waza/host readiness); they were not merged because `profileEnablesCodegraph` reads the
+  `tooling.codegraph.enabled` path literally and `external_tooling` has an unrelated schema.
+- The large-repo regression test builds a real 2,100-file git index rather than mocking `git ls-files`.
+  Mocking would only prove the mock is unused; a real oversized repo proves size is no longer a signal.
+  Cost is ~1s, and the surrounding test already carries a 30s timeout.
+
+## Deviations From Plan Or Spec
+
+- The existing test title `Minimal CodeGraph stays conditional while Full enables it` was renamed to
+  `CodeGraph enablement is explicit: full profile or policy opt-in, never repo size`. Both original
+  assertions are preserved verbatim; only the now-false word "conditional" left the title.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| Keep the size heuristic behind a policy flag | Rejected | Reintroduces the dual-authority shape the contract removes; policy opt-in already covers the intent. |
+| Mock `git ls-files` for the large-repo test | Rejected | Proves nothing about the deleted branch once the call site is gone. |
+| Add three separate `test()` blocks | Rejected | The three semantics are one invariant; one test keeps the failure message pointed at the invariant. |
+
+## Open Questions
+
+- `tests/install-profiles.test.ts > CLI dry-run and state query expose machine-readable profile authority`
+  failed once (exit 1 from the `install --dry-run --json` subprocess) on the first full-file run, then
+  passed on re-run and in the full `bun test` sweep. The failing test does not touch
+  `profileEnablesCodegraph`; the worktree had no `node_modules` at that point, which is the likely cause.
+  Flagged rather than fixed — out of scope for this contract.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/reviews/20260818-1636-codegraph-explicit-optin.review.md
+++ b/tasks/reviews/20260818-1636-codegraph-explicit-optin.review.md
@@ -1,12 +1,12 @@
 # Task Review: codegraph-explicit-optin
 
-> **Status**: Pending
+> **Status**: Reviewed
 > **Plan**: plans/plan-20260818-1636-codegraph-explicit-optin.md
 > **Contract**: tasks/contracts/20260818-1636-codegraph-explicit-optin.contract.md
 > **Notes File**: tasks/notes/20260818-1636-codegraph-explicit-optin.notes.md
 > **Checks File**: .ai/harness/checks/latest.json
-> **Last Updated**: 2026-08-18 16:36
-> **Recommendation**: fail
+> **Last Updated**: 2026-08-18 18:40
+> **Recommendation**: pass
 > **Review Rubric Version**: 2
 > **Reviewed Subject SHA256**: pending
 > **Reviewed Subject Scope**: normalized-final-content
@@ -14,71 +14,73 @@
 
 ## Human Review Card
 
-- Verdict: pending
-- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
-- Intended files changed:
-- Actual files changed:
-- Commands passed:
-- Residual risks:
-- Reviewer action required: inspect diff and card
-- Rollback:
+- Verdict: pass
+- Change type: code-change
+- Intended files changed: src/cli/installer/install-profile.ts, .ai/harness/policy.json, tests/install-profiles.test.ts, docs/reference-configs/install-profiles.md, docs/CHANGELOG.md, plus plan/contract/notes/review workflow artifacts and tasks/todos.md ledger restamp
+- Actual files changed: identical to intended (gatekeeper mapped every hunk to the contract scope; no out-of-scope edits)
+- Commands passed: bun test (2522 pass / 0 fail), bun test tests/install-profiles.test.ts (31 pass), tsc --noEmit clean, bun src/cli/index.ts init --repo . --dry-run (0 operations), repo-harness run verify-contract --strict (total=9 failed=0 Fulfilled), check-task-workflow --strict OK, check-architecture-sync blocking=0, check-task-sync synchronized
+- Residual risks: downstream repos >=2000 tracked files on minimal profile without explicit opt-in lose automatic codegraph enablement (intended semantic change, CHANGELOG noted); direction tension with draft PR #195 (codegraph-mandatory-runtime) needs a human merge-order decision
+- Reviewer action required: none beyond PR review
+- Rollback: single revert of commit 1c09fb1a; no data or migration surface
 
 ## Mode Evidence
 
-- Selected route:
-- P1/P2/P3 evidence:
-- Root cause or plan evidence:
+- Selected route: plan -> contract worktree -> fast-worker implementation -> gatekeeper PASS
+- P1/P2/P3 evidence: integration surface mapped by explorer (four mechanisms: adapter spawn, config writer, hook nudge, per-worktree init); falsifier check ran before edit (rg profileEnablesCodegraph: only two src/cli/index.ts call sites + tests)
+- Root cause or plan evidence: plans/plan-20260818-1636-codegraph-explicit-optin.md (doc-vs-code contract divergence, not a bugfix profile)
 
 ## Verification Evidence
 
-- Waza `/check` run:
-- Commands run:
-- Manual checks:
-- Supporting artifacts:
-- Implementation notes reviewed:
-- Run snapshot:
+- Waza `/check` run: gatekeeper review (VERDICT: PASS) with hunk-to-scope mapping and hard-stop sweep
+- Commands run: see Human Review Card; verify-sprint --prepare-acceptance total=9 failed=0 Fulfilled
+- Manual checks: profileEnablesCodegraph probed for self-host minimal/full -> true and /tmp minimal -> false; large-repo test asserts a real 2100-file git index before the negative assertion
+- Supporting artifacts: .ai/harness/checks/latest.json (status pass), run snapshot below
+- Implementation notes reviewed: tasks/notes/20260818-1636-codegraph-explicit-optin.notes.md
+- Run snapshot: .ai/harness/runs/run-20260818T182350-44616-20260818-1636-codegraph-explicit-optin.json
 
 ## Acceptance Receipt Projection
 
-> **Disposition**: unavailable
-> **Reviewer**: unavailable
-> **Source**: unavailable
+> **Disposition**: external_pass
+> **Reviewer**: Claude
+> **Source**: claude-review
 > **Actor**: not-applicable
-> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject SHA256**: sha256:766e08c90fcfcc34f522e37aa981ff6a3657d0a33ffd0e212dcd1c05bfa9e2b2
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: pending
-> **Verification Evidence SHA256**: pending
-> **Issued At**: pending
+> **Reviewed Target Revision**: 5cdfe9c2c52deb81fdb76eb42587586825eb1a49
+> **Verification Evidence SHA256**: sha256:a5478add5752d647bd09ba8fa0f742ef3718055dd8864e88b997918ca4553466
+> **Issued At**: 2026-08-18T10:55:08.855Z
 
-- Summary: No AcceptanceReceipt has been recorded.
+- Summary: Gatekeeper PASS: size heuristic removed, enablement purely explicit opt-in; scope maps hunk-for-hunk to contract; bun test 2522 pass, tsc clean, verify-contract Fulfilled 9/9
 - Findings: none
 
 ## Behavior Diff Notes
 
-- ...
+- Enablement semantics: implicit size-based auto-enable removed; only `full` profile or explicit `tooling.codegraph.enabled: true` enables codegraph. Policy read/parse failure fails closed to disabled.
+- Self-host behavior unchanged (explicit opt-in added to this repo's policy.json before the heuristic was removed).
 
 ## Residual Risks / Follow-ups
 
-- ...
+- Merge-order decision needed against draft PR #195 (codegraph-mandatory-runtime), which pushes enablement in the opposite direction.
+- One-time flake noted in tasks/notes (install-profiles CLI dry-run test failed once while node_modules was missing); not reproducible after install, unrelated to this change.
 
 ## Scorecard
 
 | Dimension | Score | Notes |
 |-----------|-------|-------|
-| Functionality | 0/10 | |
-| Product depth | 0/10 | |
-| Design quality | 0/10 | |
-| Code quality | 0/10 | |
+| Functionality | 9/10 | Three enablement semantics covered by tests incl. real 2100-file negative case |
+| Product depth | 8/10 | Closes doc-vs-code contract divergence; CHANGELOG names the downstream semantic change |
+| Design quality | 9/10 | Fail-closed, heuristic removed rather than documented; smallest coherent change |
+| Code quality | 9/10 | Net -4 lines in product code; dead import removed; no new abstraction |
 
 ## Failing Items
 
-- ...
+- none
 
 ## Retest Steps
 
-- Re-run:
-- Re-check:
+- Re-run: bun test tests/install-profiles.test.ts && bun run check:type
+- Re-check: bun src/cli/index.ts init --repo . --dry-run
 
 ## Summary
 
-- ...
+- Codegraph enablement is now purely explicit opt-in; gatekeeper PASS with full verification evidence; ship as PR #202.

--- a/tasks/reviews/20260818-1636-codegraph-explicit-optin.review.md
+++ b/tasks/reviews/20260818-1636-codegraph-explicit-optin.review.md
@@ -1,0 +1,84 @@
+# Task Review: codegraph-explicit-optin
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260818-1636-codegraph-explicit-optin.md
+> **Contract**: tasks/contracts/20260818-1636-codegraph-explicit-optin.contract.md
+> **Notes File**: tasks/notes/20260818-1636-codegraph-explicit-optin.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-08-18 16:36
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Commands passed:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+- Waza `/check` run:
+- Commands run:
+- Manual checks:
+- Supporting artifacts:
+- Implementation notes reviewed:
+- Run snapshot:
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -1,7 +1,7 @@
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: 2026-08-18 05:26
+> **Updated**: 2026-08-18 16:36
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.

--- a/tests/install-profiles.test.ts
+++ b/tests/install-profiles.test.ts
@@ -765,11 +765,34 @@ describe('install profiles', () => {
     expect(rollbackInstallProfile(env).profile).toBe('minimal');
   }));
 
-  test('Minimal CodeGraph stays conditional while Full enables it', () => withHome((env) => {
+  test('CodeGraph enablement is explicit: full profile or policy opt-in, never repo size', () => withHome((env) => {
     const cwd = env.HOME!;
     expect(profileEnablesCodegraph('minimal', cwd)).toBe(false);
     expect(profileEnablesCodegraph('full', cwd)).toBe(true);
-  }));
+
+    // Explicit local policy opt-in enables CodeGraph even on the minimal profile.
+    const optIn = mkdtempSync(join(tmpdir(), 'repo-harness-codegraph-optin-'));
+    try {
+      writePath(join(optIn, '.ai/harness/policy.json'), JSON.stringify({ tooling: { codegraph: { enabled: true } } }));
+      expect(profileEnablesCodegraph('minimal', optIn)).toBe(true);
+    } finally {
+      rmSync(optIn, { recursive: true, force: true });
+    }
+
+    // A large tracked-file count is not an opt-in signal: no policy entry, no CodeGraph.
+    const large = mkdtempSync(join(tmpdir(), 'repo-harness-codegraph-large-'));
+    try {
+      expect(spawnSync('git', ['init', '-q'], { cwd: large, encoding: 'utf-8' }).status).toBe(0);
+      mkdirSync(join(large, 'src'), { recursive: true });
+      for (let i = 0; i < 2_100; i += 1) writeFileSync(join(large, 'src', `f${i}.ts`), 'export const x = 1;\n');
+      expect(spawnSync('git', ['add', '-A'], { cwd: large, encoding: 'utf-8' }).status).toBe(0);
+      const tracked = spawnSync('git', ['ls-files'], { cwd: large, encoding: 'utf-8' });
+      expect(tracked.stdout.split('\n').filter(Boolean).length).toBeGreaterThanOrEqual(2_000);
+      expect(profileEnablesCodegraph('minimal', large)).toBe(false);
+    } finally {
+      rmSync(large, { recursive: true, force: true });
+    }
+  }), 30_000);
 
   test('CLI dry-run and state query expose machine-readable profile authority', () => withHome((env) => {
     const dryRun = spawnSync(process.execPath, [CLI, 'install', '--profile', 'full', '--dry-run', '--json'], {


### PR DESCRIPTION
## 动机

`profileEnablesCodegraph` 此前对 >=2000 tracked files 的下游 repo 隐式自动启用 CodeGraph，与 CLAUDE.md 契约（"downstream repos keep the global MCP default unless local policy opts in"）和 no-heuristic-fallback 原则相悖。

## 改动

- 删除 size heuristic：true 路径只剩 `full` profile 与目标 repo `.ai/harness/policy.json` 的 `tooling.codegraph.enabled: true`；policy 读取/解析失败一律 fail closed 到禁用
- 自宿主 repo 补显式 opt-in 保真（改前靠 heuristic 命中 2535 files，行为不变）
- 测试补三语义覆盖 + 真实 2100-file git repo 反证
- `docs/reference-configs/install-profiles.md` 措辞同步为显式 opt-in；CHANGELOG Unreleased 补 Changed 条目

## 验证

- `bun test` 全量 2522 pass / 0 fail
- `tsc --noEmit` clean
- `bun src/cli/index.ts init --repo . --dry-run` 0 operations
- gatekeeper 审查 PASS（scope 逐 hunk 映射 contract，无越界改动）

注意：与 draft PR #195（codegraph-mandatory-runtime）在启用语义上有方向张力，合并顺序需人工确认。