### PR TITLE
feat(hook): inject long-command guardrail advisory at SubagentStart

### DIFF
--- a/assets/reference-configs/sprint-contracts.md
+++ b/assets/reference-configs/sprint-contracts.md
@@ -137,6 +137,17 @@ acceptance can validate, even if the movement is otherwise non-overlapping.
 
 `verify-contract.sh --read-only` is read-only for contract state writes only: it does not rewrite the contract `> **Status**:` line. It executes `tests_pass` with Bun and `commands_succeed` in a non-login Bash with `BASH_ENV` unset. One fixed absolute 600-second budget covers the whole invocation; each command records duration, exit status, signal, and timeout state, and expiry terminates the command's process group before the verifier returns. The budget is not a policy or environment knob.
 
+### Long Gate Commands Belong to the Orchestrator
+
+The same 600-second ceiling applies to the host stream watchdog that kills a
+delegated agent after 600 seconds of silence. Any gate command expected to
+exceed roughly five minutes (`verify-sprint`, a full `bun test`) is run by the
+orchestrator's main loop in the background, not foreground-waited inside a
+dispatched worker. A worker handed such a command reports `RESULT: BLOCKED`
+naming the command and hands control back; it does not stand watch. The
+standing advisory is injected at SubagentStart under the
+`[repo-harness:long-command-guardrail]` marker.
+
 Verification is an evidence consumer. `commands_succeed` must not launch profile benchmarks/providers, `init`, evidence-producer scripts, or substantive installs; the verifier rejects those command shapes before execution. Produce expensive evidence explicitly, validate its subject/provenance/bytes, then let `verify-sprint` consume that frozen artifact through `verify-contract --read-only`.
 
 A verifier consumes already-produced evidence; it must not become the producer of expensive, runtime-heavy evidence (for example, a full multi-provider/multi-profile benchmark matrix). An authoritative matrix or similarly expensive one-time evidence run belongs outside `commands_succeed`: the author runs it once on a clean checkout before merge and commits the resulting tracked report (for example `evals/harness/reports/profile-comparison.json`/`.md`); the contract then verifies that report's bytes and provenance, not a live re-run.

--- a/assets/reference-configs/sprint-contracts.md
+++ b/assets/reference-configs/sprint-contracts.md
@@ -143,8 +143,9 @@ The same 600-second ceiling applies to the host stream watchdog that kills a
 delegated agent after 600 seconds of silence. Any gate command expected to
 exceed roughly five minutes (`verify-sprint`, a full `bun test`) is run by the
 orchestrator's main loop in the background, not foreground-waited inside a
-dispatched worker. A worker handed such a command reports `RESULT: BLOCKED`
-naming the command and hands control back; it does not stand watch. The
+dispatched worker. An agent handed such a command names the command and returns
+BLOCKED on its role's machine-readable first line (`RESULT:` / `VERDICT:` /
+`RECOMMENDATION:`), handing control back; it does not stand watch. The
 standing advisory is injected at SubagentStart under the
 `[repo-harness:long-command-guardrail]` marker.
 

--- a/docs/reference-configs/sprint-contracts.md
+++ b/docs/reference-configs/sprint-contracts.md
@@ -137,6 +137,17 @@ acceptance can validate, even if the movement is otherwise non-overlapping.
 
 `verify-contract.sh --read-only` is read-only for contract state writes only: it does not rewrite the contract `> **Status**:` line. It executes `tests_pass` with Bun and `commands_succeed` in a non-login Bash with `BASH_ENV` unset. One fixed absolute 600-second budget covers the whole invocation; each command records duration, exit status, signal, and timeout state, and expiry terminates the command's process group before the verifier returns. The budget is not a policy or environment knob.
 
+### Long Gate Commands Belong to the Orchestrator
+
+The same 600-second ceiling applies to the host stream watchdog that kills a
+delegated agent after 600 seconds of silence. Any gate command expected to
+exceed roughly five minutes (`verify-sprint`, a full `bun test`) is run by the
+orchestrator's main loop in the background, not foreground-waited inside a
+dispatched worker. A worker handed such a command reports `RESULT: BLOCKED`
+naming the command and hands control back; it does not stand watch. The
+standing advisory is injected at SubagentStart under the
+`[repo-harness:long-command-guardrail]` marker.
+
 Verification is an evidence consumer. `commands_succeed` must not launch profile benchmarks/providers, `init`, evidence-producer scripts, or substantive installs; the verifier rejects those command shapes before execution. Produce expensive evidence explicitly, validate its subject/provenance/bytes, then let `verify-sprint` consume that frozen artifact through `verify-contract --read-only`.
 
 A verifier consumes already-produced evidence; it must not become the producer of expensive, runtime-heavy evidence (for example, a full multi-provider/multi-profile benchmark matrix). An authoritative matrix or similarly expensive one-time evidence run belongs outside `commands_succeed`: the author runs it once on a clean checkout before merge and commits the resulting tracked report (for example `evals/harness/reports/profile-comparison.json`/`.md`); the contract then verifies that report's bytes and provenance, not a live re-run.

--- a/docs/reference-configs/sprint-contracts.md
+++ b/docs/reference-configs/sprint-contracts.md
@@ -143,8 +143,9 @@ The same 600-second ceiling applies to the host stream watchdog that kills a
 delegated agent after 600 seconds of silence. Any gate command expected to
 exceed roughly five minutes (`verify-sprint`, a full `bun test`) is run by the
 orchestrator's main loop in the background, not foreground-waited inside a
-dispatched worker. A worker handed such a command reports `RESULT: BLOCKED`
-naming the command and hands control back; it does not stand watch. The
+dispatched worker. An agent handed such a command names the command and returns
+BLOCKED on its role's machine-readable first line (`RESULT:` / `VERDICT:` /
+`RECOMMENDATION:`), handing control back; it does not stand watch. The
 standing advisory is injected at SubagentStart under the
 `[repo-harness:long-command-guardrail]` marker.
 

--- a/plans/plan-20260819-0049-subagent-long-command-guardrail.md
+++ b/plans/plan-20260819-0049-subagent-long-command-guardrail.md
@@ -1,0 +1,136 @@
+# Plan: SubagentStart long-command guardrail advisory
+
+> **Status**: Executing
+> **Created**: 20260819-0049
+> **Slug**: subagent-long-command-guardrail
+> **Planning Source**: repo-harness-plan
+> **Orchestration Kind**: host-plan
+> **Source Ref**: (none)
+> **Artifact Level**: work-package
+> **Promotion Reason**: verification_boundary
+> **Verification Boundary**: bun test subagent-handler + tsc + full bun test
+> **Rollback Surface**: revert subagent-handler.ts, one test file, one doc
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260819-0049-subagent-long-command-guardrail.contract.md`
+> **Task Review**: `tasks/reviews/20260819-0049-subagent-long-command-guardrail.review.md`
+> **Implementation Notes**: `tasks/notes/20260819-0049-subagent-long-command-guardrail.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from repo-harness-plan planning output.
+- Source ref: (none)
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260819-0049-subagent-long-command-guardrail.md`
+- Sprint contract: `tasks/contracts/20260819-0049-subagent-long-command-guardrail.contract.md`
+- Sprint review: `tasks/reviews/20260819-0049-subagent-long-command-guardrail.review.md`
+- Implementation notes: `tasks/notes/20260819-0049-subagent-long-command-guardrail.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260819-0049-subagent-long-command-guardrail.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260819-0049-subagent-long-command-guardrail.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260819-0049-subagent-long-command-guardrail.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260819-0049-subagent-long-command-guardrail.contract.md`
+- Review file: `tasks/reviews/20260819-0049-subagent-long-command-guardrail.review.md`
+- Implementation notes file: `tasks/notes/20260819-0049-subagent-long-command-guardrail.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260819-0049-subagent-long-command-guardrail.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260819-0049-subagent-long-command-guardrail.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: revert subagent-handler.ts, one test file, one doc
+- **Verification boundary**: bun test subagent-handler + tsc + full bun test
+- **Review/acceptance boundary**: `tasks/reviews/20260819-0049-subagent-long-command-guardrail.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: verification_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260819-0049-subagent-long-command-guardrail.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260819-0049-subagent-long-command-guardrail.contract.md`, `tasks/reviews/20260819-0049-subagent-long-command-guardrail.review.md`, and `tasks/notes/20260819-0049-subagent-long-command-guardrail.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260819-0049-subagent-long-command-guardrail.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: revert subagent-handler.ts, one test file, one doc
+
+## Captured Planning Output
+
+## Goal
+
+Subagent handoff gains an advisory guardrail for long-running commands: SubagentStart context injects one standing line telling delegated workers not to foreground-wait verification/test commands expected to exceed 5 minutes — hand the command back to the orchestrator as BLOCKED (or run it backgrounded with log polling) because the host stream watchdog kills agents after 600s of stream silence. The convention is also recorded in docs/reference-configs/sprint-contracts.md next to the existing 600-second verify budget note.
+
+## Why
+
+2026-08-18 evidence: three consecutive delegated workers died to the 600s host watchdog while waiting on verify-sprint/full-test gates, even when instructed to poll with logs. The host watchdog cannot be fixed repo-side; the effective mitigation is workers refusing long foreground waits and returning control. The injected line's purpose is refusal/hand-back, not teaching polling (polling instructions demonstrably failed).
+
+## Task Breakdown
+
+- [ ] `src/cli/hook/subagent-handler.ts`: add a `LONG_COMMAND_GUARDRAIL` constant (pattern-match `RETURN_CONTRACT_MARKER`/`RETURN_CONTRACT_TEXT` at :86-87) with marker `[repo-harness:long-command-guardrail]`; inject it wherever RETURN_CONTRACT_TEXT is appended to SubagentStart context, guarded by the same dedupe (marker-presence check).
+- [ ] `tests/subagent-handler.test.ts`: assert SubagentStart context contains the marker exactly once and the text names the hand-back-as-BLOCKED default; assert no duplicate injection when the marker is already present.
+- [ ] `docs/reference-configs/sprint-contracts.md`: one short subsection near the 600-second verify budget note recording the convention: long gate commands run from the orchestrator main loop (backgrounded); delegated workers hand back instead of waiting.
+
+## Out of Scope
+
+- No harness-side watchdog/retry machinery (host-owned; compensating complexity).
+- No change to RETURN_CONTRACT_TEXT semantics, delegation state, or role routing.
+- No App Thread or reasoning-effort readback work.
+
+## Verification
+
+- `bun test tests/subagent-handler.test.ts`
+- `node node_modules/typescript/bin/tsc --noEmit`
+- `bun test`
+
+## Rollback
+
+Single revert; advisory text only, no state or schema surface.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [ ] `src/cli/hook/subagent-handler.ts`: add a `LONG_COMMAND_GUARDRAIL` constant (pattern-match `RETURN_CONTRACT_MARKER`/`RETURN_CONTRACT_TEXT` at :86-87) with marker `[repo-harness:long-command-guardrail]`; inject it wherever RETURN_CONTRACT_TEXT is appended to SubagentStart context, guarded by the same dedupe (marker-presence check).
+- [ ] `tests/subagent-handler.test.ts`: assert SubagentStart context contains the marker exactly once and the text names the hand-back-as-BLOCKED default; assert no duplicate injection when the marker is already present.
+- [ ] `docs/reference-configs/sprint-contracts.md`: one short subsection near the 600-second verify budget note recording the convention: long gate commands run from the orchestrator main loop (backgrounded); delegated workers hand back instead of waiting.

--- a/src/cli/hook/subagent-handler.ts
+++ b/src/cli/hook/subagent-handler.ts
@@ -86,7 +86,7 @@ interface NativeRoleRouting {
 const RETURN_CONTRACT_MARKER = '[repo-harness:return-channel]';
 const RETURN_CONTRACT_TEXT = '\n\n[repo-harness:return-channel] Your final text message is the only channel returned to your caller. Put the complete findings/report in final text. Do not call SendUserMessage for report delivery; content sent through SendUserMessage is delivered outside the Agent tool result.';
 export const LONG_COMMAND_GUARDRAIL_MARKER = '[repo-harness:long-command-guardrail]';
-const LONG_COMMAND_GUARDRAIL_TEXT = `${LONG_COMMAND_GUARDRAIL_MARKER} Do not foreground-wait on a verification, test, or gate command you expect to exceed roughly five minutes; the host stream watchdog terminates an agent after 600 seconds of silence. The default action is to hand that command back to the orchestrator: report RESULT: BLOCKED and name the command instead of waiting on it. Run it yourself only when you can start it in the background and poll a log that keeps producing output.`;
+const LONG_COMMAND_GUARDRAIL_TEXT = `${LONG_COMMAND_GUARDRAIL_MARKER} Do not foreground-wait on a verification, test, or gate command you expect to exceed roughly five minutes; the host stream watchdog terminates an agent after 600 seconds of silence. The default action is to hand that command back to the orchestrator: name the command and return BLOCKED on your role's machine-readable first line (RESULT:/VERDICT:/RECOMMENDATION:) instead of waiting on it. Run it yourself only when you can start it in the background and poll a log that keeps producing output.`;
 const NATIVE_ROLE_ROUTING_STATE_FILE = 'native-role-routing.json';
 const NATIVE_ROLE_ROUTING_LOCK_RELATIVE = `${DELEGATION_STATE_RELATIVE}/native-role-routing.lock`;
 const MAX_NATIVE_ROLE_OBSERVATIONS = 32;

--- a/src/cli/hook/subagent-handler.ts
+++ b/src/cli/hook/subagent-handler.ts
@@ -85,6 +85,8 @@ interface NativeRoleRouting {
 
 const RETURN_CONTRACT_MARKER = '[repo-harness:return-channel]';
 const RETURN_CONTRACT_TEXT = '\n\n[repo-harness:return-channel] Your final text message is the only channel returned to your caller. Put the complete findings/report in final text. Do not call SendUserMessage for report delivery; content sent through SendUserMessage is delivered outside the Agent tool result.';
+export const LONG_COMMAND_GUARDRAIL_MARKER = '[repo-harness:long-command-guardrail]';
+const LONG_COMMAND_GUARDRAIL_TEXT = `${LONG_COMMAND_GUARDRAIL_MARKER} Do not foreground-wait on a verification, test, or gate command you expect to exceed roughly five minutes; the host stream watchdog terminates an agent after 600 seconds of silence. The default action is to hand that command back to the orchestrator: report RESULT: BLOCKED and name the command instead of waiting on it. Run it yourself only when you can start it in the background and poll a log that keeps producing output.`;
 const NATIVE_ROLE_ROUTING_STATE_FILE = 'native-role-routing.json';
 const NATIVE_ROLE_ROUTING_LOCK_RELATIVE = `${DELEGATION_STATE_RELATIVE}/native-role-routing.lock`;
 const MAX_NATIVE_ROLE_OBSERVATIONS = 32;
@@ -630,6 +632,13 @@ function resolveEvidenceDir(stateDir: string, relativePath: unknown): string | n
   return current;
 }
 
+/** Append the standing long-command advisory once; marker presence is authoritative. */
+export function appendLongCommandGuardrail(context: string): string {
+  return context.includes(LONG_COMMAND_GUARDRAIL_MARKER)
+    ? context
+    : `${context}\n\n${LONG_COMMAND_GUARDRAIL_TEXT}`;
+}
+
 function runSubagentStart(repoRoot: string, input: JsonObject, env: NodeJS.ProcessEnv, now: Date): SubagentHandlerResult {
   const effective = parseEffectiveState(repoRoot);
   let profile = typeof effective?.workflow_profile === 'string' ? effective.workflow_profile : '';
@@ -702,7 +711,7 @@ function runSubagentStart(repoRoot: string, input: JsonObject, env: NodeJS.Proce
   }
 
   const contextRouting = nativeRoleRouting;
-  const context = [
+  const context = appendLongCommandGuardrail([
     '[repo-harness:subagent-context]',
     '',
     ...(contextRouting
@@ -735,7 +744,7 @@ function runSubagentStart(repoRoot: string, input: JsonObject, env: NodeJS.Proce
     'If you discover useful additional work, record it under Out of scope / Future work in the notes or review artifact. Do not implement it. Do not end with unsolicited offers to do more work.',
     '',
     'If the requested outcome cannot be completed without expanding scope, fail closed: stop, name the missing decision, and cite the exact file/section that blocks execution.',
-  ].join('\n');
+  ].join('\n'));
   return result(`${JSON.stringify({ hookSpecificOutput: { hookEventName: 'SubagentStart', additionalContext: context } })}\n`);
 }
 

--- a/tasks/contracts/20260819-0049-subagent-long-command-guardrail.contract.md
+++ b/tasks/contracts/20260819-0049-subagent-long-command-guardrail.contract.md
@@ -72,6 +72,7 @@ Required when Task Profile is `bugfix`; leave as-is otherwise.
 ```yaml
 allowed_paths:
   - docs/spec.md
+  - assets/reference-configs/sprint-contracts.md
   - docs/reference-configs/sprint-contracts.md
   - plans/
   - tasks/todos.md

--- a/tasks/contracts/20260819-0049-subagent-long-command-guardrail.contract.md
+++ b/tasks/contracts/20260819-0049-subagent-long-command-guardrail.contract.md
@@ -1,0 +1,152 @@
+# Task Contract: subagent-long-command-guardrail
+
+> **Status**: Active
+> **Plan**: plans/plan-20260819-0049-subagent-long-command-guardrail.md
+> **Task Profile**: code-change
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: ancienttwo
+> **Capability ID**: root
+> **Last Updated**: 2026-08-19 00:49
+> **Review File**: `tasks/reviews/20260819-0049-subagent-long-command-guardrail.review.md`
+> **Notes File**: `tasks/notes/20260819-0049-subagent-long-command-guardrail.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+Delegated workers foreground-waiting long gate commands (verify-sprint, full bun test) die to the host 600s stream watchdog — proven three times on 2026-08-18 even with polling instructions. The host watchdog is unfixable repo-side; the mitigation is workers refusing long waits and handing control back.
+
+## Goal
+
+SubagentStart context injects one standing advisory line (constant + marker `[repo-harness:long-command-guardrail]`, patterned on `RETURN_CONTRACT_MARKER`/`RETURN_CONTRACT_TEXT` at `src/cli/hook/subagent-handler.ts:86-87`): commands expected to exceed 5 minutes must be handed back to the orchestrator as BLOCKED (or run backgrounded with log polling) instead of foreground-waited. The convention is recorded in `docs/reference-configs/sprint-contracts.md` near the existing 600-second verify budget note. Tests pin single injection and no duplication.
+
+## Scope
+
+- In scope: `src/cli/hook/subagent-handler.ts` (one constant + injection alongside RETURN_CONTRACT_TEXT with marker-dedupe), `tests/subagent-handler.test.ts` (marker present once; hand-back-as-BLOCKED wording; no duplicate injection), `docs/reference-configs/sprint-contracts.md` (one short convention subsection).
+- Out of scope: any watchdog/retry machinery; RETURN_CONTRACT_TEXT semantics; delegation state or role routing; App Thread or reasoning-effort work; version bump; release.
+- Taste constraints: <!-- advisory only, no run gate; default style/taste lives in AGENTS.md and the minimal-change policy, use this to record a per-task override -->
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+
+## Falsifier
+
+If SubagentStart context assembly has a size budget or dedupe mechanism that drops appended advisory text, the line never reaches workers. Cheapest proof: rg RETURN_CONTRACT_MARKER usage sites in subagent-handler.ts and the existing test asserting its presence — the new line rides the identical path.
+
+## Root Cause Evidence
+
+Required when Task Profile is `bugfix`; leave as-is otherwise.
+
+- root_cause: one sentence naming file:line/condition (testable, not "a state issue").
+- repro: the command or UI path that reproduces the symptom.
+- regression_guard: path to a test that fails on the unfixed code and passes after the fix (must also appear under exit_criteria.tests_pass).
+- pre_fix_failure_artifact: path to a captured run of regression_guard on the UNFIXED code. Capture with `bun test <regression_guard> > <artifact> 2>&1; echo "PRE_FIX_EXIT=$?" >> <artifact>` (no pipes — pipes swallow the exit status). The gate requires a non-zero `PRE_FIX_EXIT=` line plus the regression_guard path string in the artifact (see the Root Cause Evidence Gate section in docs/reference-configs/sprint-contracts.md).
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260819-0049-subagent-long-command-guardrail.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260819-0049-subagent-long-command-guardrail.review.md`
+- Notes file: `tasks/notes/20260819-0049-subagent-long-command-guardrail.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Change Assessment
+
+```json
+{"protocol":1,"oracles":[]}
+```
+
+## Acceptance Policy
+
+```json
+{"protocol":1,"reviewer":"Claude","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - docs/spec.md
+  - docs/reference-configs/sprint-contracts.md
+  - plans/
+  - tasks/todos.md
+  - tasks/contracts/20260819-0049-subagent-long-command-guardrail.contract.md
+  - tasks/reviews/20260819-0049-subagent-long-command-guardrail.review.md
+  - tasks/notes/20260819-0049-subagent-long-command-guardrail.notes.md
+  - .ai/context/capabilities.json
+  - .claude/templates/
+  - src/
+  - tests/
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+    fallback: null
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - docs/spec.md
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260819-0049-subagent-long-command-guardrail.notes.md
+  tests_pass:
+    - path: tests/subagent-handler.test.ts
+  commands_succeed:
+    - bun run check:type
+    - bun test
+```
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior:
+- Edge cases:
+- Regression risks:
+
+## Rollback Point
+
+- Commit / checkpoint:
+- Revert strategy:

--- a/tasks/notes/20260819-0049-subagent-long-command-guardrail.notes.md
+++ b/tasks/notes/20260819-0049-subagent-long-command-guardrail.notes.md
@@ -1,0 +1,45 @@
+# Implementation Notes: subagent-long-command-guardrail
+
+> **Status**: Active
+> **Plan**: plans/plan-20260819-0049-subagent-long-command-guardrail.md
+> **Contract**: tasks/contracts/20260819-0049-subagent-long-command-guardrail.contract.md
+> **Review**: tasks/reviews/20260819-0049-subagent-long-command-guardrail.review.md
+> **Last Updated**: 2026-08-19 00:49
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- The advisory rides the SubagentStart `additionalContext` string, not the PreToolUse Task-prompt path that `RETURN_CONTRACT_TEXT` uses. The contract names `RETURN_CONTRACT_MARKER`/`RETURN_CONTRACT_TEXT` (`src/cli/hook/subagent-handler.ts:86-87`) as the *shape* to copy (one marker constant, one text constant, marker-dedupe), and the Goal pins SubagentStart as the delivery point. Falsifier cleared: the context array is joined and emitted verbatim with no size budget or truncation, so appended text reaches workers.
+- Dedupe lives in an exported pure `appendLongCommandGuardrail(context)` rather than inline in `runSubagentStart`. The SubagentStart context is assembled from literals, so an inline `includes` check could never fire and could never be tested; exporting the function makes "already marked -> no second copy" a real, directly asserted invariant and keeps the guard honest if the context array later grows a line containing the marker.
+- Wording pins the mechanism (600s host stream watchdog on silence) and the default action (`RESULT: BLOCKED`, name the command) rather than a command allowlist. A list of long commands would drift; the watchdog rule does not.
+
+## Deviations From Plan Or Spec
+
+- The contract's `allowed_paths` block omitted `docs/reference-configs/sprint-contracts.md` even though `## Scope` (In scope) and the dispatch brief both require editing it. Resolved through the contract's own scope gate ("update this contract before widening scope") by adding that one path to `allowed_paths`; no scope was widened beyond what Goal/Scope already declared. Flagged to the parent rather than treated as a silent fix.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| Inline `includes` dedupe in `runSubagentStart` | Rejected | Vacuous against a literal-only array; not testable, so the "no duplication" exit criterion would be asserted against nothing |
+| Export `appendLongCommandGuardrail` helper | Chosen | Smallest surface that makes single-injection a verifiable property; no new abstraction layer |
+| Enumerate long commands (`verify-sprint`, `bun test`) in the advisory | Rejected | The list drifts; the ~5-minute expectation plus the watchdog mechanism is the stable rule |
+
+## Open Questions
+
+- None.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/notes/20260819-0049-subagent-long-command-guardrail.notes.md
+++ b/tasks/notes/20260819-0049-subagent-long-command-guardrail.notes.md
@@ -15,6 +15,7 @@
 
 ## Deviations From Plan Or Spec
 
+- `docs/reference-configs/sprint-contracts.md` is a byte-identical projection of `assets/reference-configs/sprint-contracts.md`, enforced by `tests/reference-configs-projection.test.ts`. The contract named only the projection path, so the convention subsection was authored in the asset source and regenerated with `bun run sync:reference-configs`; `assets/reference-configs/sprint-contracts.md` was added to `allowed_paths` for the same reason.
 - The contract's `allowed_paths` block omitted `docs/reference-configs/sprint-contracts.md` even though `## Scope` (In scope) and the dispatch brief both require editing it. Resolved through the contract's own scope gate ("update this contract before widening scope") by adding that one path to `allowed_paths`; no scope was widened beyond what Goal/Scope already declared. Flagged to the parent rather than treated as a silent fix.
 
 ## Tradeoffs Considered

--- a/tasks/reviews/20260819-0049-subagent-long-command-guardrail.review.md
+++ b/tasks/reviews/20260819-0049-subagent-long-command-guardrail.review.md
@@ -1,12 +1,12 @@
 # Task Review: subagent-long-command-guardrail
 
-> **Status**: Pending
+> **Status**: Reviewed
 > **Plan**: plans/plan-20260819-0049-subagent-long-command-guardrail.md
 > **Contract**: tasks/contracts/20260819-0049-subagent-long-command-guardrail.contract.md
 > **Notes File**: tasks/notes/20260819-0049-subagent-long-command-guardrail.notes.md
 > **Checks File**: .ai/harness/checks/latest.json
 > **Last Updated**: 2026-08-19 00:49
-> **Recommendation**: fail
+> **Recommendation**: pass
 > **Review Rubric Version**: 2
 > **Reviewed Subject SHA256**: pending
 > **Reviewed Subject Scope**: normalized-final-content
@@ -14,14 +14,14 @@
 
 ## Human Review Card
 
-- Verdict: pending
-- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
-- Intended files changed:
-- Actual files changed:
-- Commands passed:
-- Residual risks:
-- Reviewer action required: inspect diff and card
-- Rollback:
+- Verdict: pass
+- Change type: code-change
+- Intended files changed: src/cli/hook/subagent-handler.ts, tests/subagent-handler.test.ts, assets+docs reference-configs sprint-contracts.md, plus contract/notes workflow artifacts
+- Actual files changed: identical to intended (gatekeeper round-2 mapped every hunk; no out-of-scope edits)
+- Commands passed: bun test (2528 pass / 0 fail full run), bun test tests/subagent-handler.test.ts (13 pass), tsc --noEmit clean, check:reference-configs projection OK, verify-sprint prepare-acceptance total=8 failed=0 Fulfilled
+- Residual risks: advisory is text-only (agents may still ignore it); SubagentStart side has no token SLO coverage (~132 tokens/subagent accepted)
+- Reviewer action required: none beyond PR review
+- Rollback: single revert; advisory text only, no state or schema surface
 
 ## Mode Evidence
 
@@ -40,17 +40,17 @@
 
 ## Acceptance Receipt Projection
 
-> **Disposition**: unavailable
-> **Reviewer**: unavailable
-> **Source**: unavailable
+> **Disposition**: external_pass
+> **Reviewer**: Claude
+> **Source**: claude-review
 > **Actor**: not-applicable
-> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject SHA256**: sha256:e7e89ee8514ffb596297343b6e4a27feee08e987a081f1546af6fe8c496128aa
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: pending
-> **Verification Evidence SHA256**: pending
-> **Issued At**: pending
+> **Reviewed Target Revision**: 2fa4933b82e71d5c670e6ac2da113214bf16379e
+> **Verification Evidence SHA256**: sha256:d09e35bc7afe7531870941cabba554eb79d3a903850fd3776ccec507709303a7
+> **Issued At**: 2026-08-18T17:38:28.706Z
 
-- Summary: No AcceptanceReceipt has been recorded.
+- Summary: Gatekeeper round-2 PASS: role-agnostic long-command guardrail at SubagentStart; scope maps hunk-for-hunk; full bun test 2528 pass, tsc clean, verify-contract Fulfilled 8/8
 - Findings: none
 
 ## Behavior Diff Notes
@@ -81,4 +81,4 @@
 
 ## Summary
 
-- ...
+- Long-command guardrail advisory injected at SubagentStart (role-agnostic BLOCKED hand-back), gatekeeper FAIL->fix->PASS cycle completed in one round; ship as single PR.

--- a/tasks/reviews/20260819-0049-subagent-long-command-guardrail.review.md
+++ b/tasks/reviews/20260819-0049-subagent-long-command-guardrail.review.md
@@ -1,0 +1,84 @@
+# Task Review: subagent-long-command-guardrail
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260819-0049-subagent-long-command-guardrail.md
+> **Contract**: tasks/contracts/20260819-0049-subagent-long-command-guardrail.contract.md
+> **Notes File**: tasks/notes/20260819-0049-subagent-long-command-guardrail.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-08-19 00:49
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Commands passed:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+- Waza `/check` run:
+- Commands run:
+- Manual checks:
+- Supporting artifacts:
+- Implementation notes reviewed:
+- Run snapshot:
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...

--- a/tests/subagent-handler.test.ts
+++ b/tests/subagent-handler.test.ts
@@ -335,8 +335,8 @@ describe('typed subagent hook handlers', () => {
       expect(output.exitCode).toBe(0);
       const context = additionalContext(output.stdout);
       expect(context.split(LONG_COMMAND_GUARDRAIL_MARKER).length - 1).toBe(1);
-      expect(context).toContain('RESULT: BLOCKED');
-      expect(context).toContain('hand that command back to the orchestrator');
+      expect(context).toMatch(/hand[^.]*back[^.]*orchestrator/i);
+      expect(context).toContain('BLOCKED');
       expect(context).toContain('600 seconds');
 
       expect(appendLongCommandGuardrail(context)).toBe(context);

--- a/tests/subagent-handler.test.ts
+++ b/tests/subagent-handler.test.ts
@@ -3,7 +3,11 @@ import { createHash } from 'crypto';
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, symlinkSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { runSubagentHandler } from '../src/cli/hook/subagent-handler';
+import {
+  appendLongCommandGuardrail,
+  LONG_COMMAND_GUARDRAIL_MARKER,
+  runSubagentHandler,
+} from '../src/cli/hook/subagent-handler';
 
 function tempRepo(): string {
   return mkdtempSync(join(tmpdir(), 'repo-harness-subagent-handler-'));
@@ -312,6 +316,30 @@ describe('typed subagent hook handlers', () => {
           reasoning_effort_status: 'configured_unverified',
         }),
       ]);
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('injects the long-command guardrail advisory once into SubagentStart context', () => {
+    const repoRoot = tempRepo();
+    try {
+      writeWorkerProfile(repoRoot);
+      const output = startSubagent(repoRoot, {
+        session_id: 'session-guardrail',
+        turn_id: 'turn-guardrail',
+        agent_id: 'agent-guardrail',
+        agent_type: 'fast-worker',
+        model: 'gpt-5.6-sol',
+      });
+      expect(output.exitCode).toBe(0);
+      const context = additionalContext(output.stdout);
+      expect(context.split(LONG_COMMAND_GUARDRAIL_MARKER).length - 1).toBe(1);
+      expect(context).toContain('RESULT: BLOCKED');
+      expect(context).toContain('hand that command back to the orchestrator');
+      expect(context).toContain('600 seconds');
+
+      expect(appendLongCommandGuardrail(context)).toBe(context);
     } finally {
       rmSync(repoRoot, { recursive: true, force: true });
     }


### PR DESCRIPTION
## 动机

2026-08-18 实证：受派 worker 前台守候长闸门命令（verify-sprint / 全量 bun test）连续三次被 host 600s stream watchdog 判停，即使带轮询指示也救不回。host watchdog 修不了，有效缓解是 worker 拒绝长守候、交还控制权。

## 改动

- SubagentStart context 注入一条 `[repo-harness:long-command-guardrail]` advisory：预期 >5 分钟的命令默认交还编排层，以角色自身的机读首行（`RESULT:` / `VERDICT:` / `RECOMMENDATION:`）返回 BLOCKED 并点名命令；只有能做到后台发起 + 持续轮询输出才自己跑
- marker 去重经 exported 纯函数 `appendLongCommandGuardrail`，测试钉单次注入与幂等
- 约定同步记入 `assets/reference-configs/sprint-contracts.md`（docs/ 为逐字节 projection）

## 审查与验证

- gatekeeper 第一轮 FAIL（advisory 硬编码 `RESULT: BLOCKED` 与 gatekeeper/deep-reasoner 机读首行契约冲突），fast-worker 回炉后第二轮 PASS
- 全量 `bun test` 2528 pass / 0 fail；`tsc --noEmit` clean；`check:reference-configs` projection OK
- verify-sprint prepare-acceptance 8/8 Fulfilled，AcceptanceReceipt external_pass 已记录