### PR TITLE
fix(mcp): bind HTTP sessions to the startup profile, fail closed on config flip

### DIFF
--- a/src/cli/mcp/transports/http.ts
+++ b/src/cli/mcp/transports/http.ts
@@ -427,12 +427,17 @@ function acquireSession(sessions: McpSessionStore<McpHttpTransport>, sessionId: 
   return sessions.acquire(sessionId);
 }
 
+export function resolveMcpHttpProfile(opts: McpServerOptions, config: ReturnType<typeof loadMcpLocalConfig>): string {
+  return opts.profile ?? config?.profile ?? 'planner';
+}
+
 async function handleMcpPost(
   req: Request,
   res: Response,
   opts: McpHttpOptions,
   sessions: McpSessionStore<McpHttpTransport>,
   codingRuntimes: CodingAuthorizationRuntimeStore | null,
+  startupProfile: string,
 ): Promise<void> {
   let body: unknown;
   try {
@@ -443,6 +448,22 @@ async function handleMcpPost(
   }
   const sessionId = sessionIdFromRequest(req);
   if (!sessionId && isInitializeRequest(body)) {
+    // The whole HTTP enforcement layer (coding-grant middleware, OAuth
+    // requirement, host/origin pinning, per-authorization coding runtimes) is
+    // decided once from the startup profile. A local config flip after startup
+    // would otherwise let a new session resolve a different tool context behind
+    // that stale enforcement, so sessions are bound to the startup profile and
+    // a flip fails closed until the operator restarts the server.
+    const currentProfile = resolveMcpHttpProfile(opts, loadMcpLocalConfig());
+    if (currentProfile !== startupProfile) {
+      res.status(503).json({
+        error: {
+          code: 'PROFILE_CHANGED',
+          message: `The local MCP profile changed from "${startupProfile}" to "${currentProfile}" after startup; restart the MCP server to serve the new profile.`,
+        },
+      });
+      return;
+    }
     const authorizationId = codingRuntimes ? authorizationIdFromRequest(req) : undefined;
     if (codingRuntimes && !authorizationId) {
       sendOAuthUnauthorized(req, res, 'Coding authorization identity is missing');
@@ -485,7 +506,7 @@ async function handleMcpPost(
       transport.onclose = () => {
         if (transport?.sessionId) sessions.delete(transport.sessionId);
       };
-      const server = createRepoHarnessMcpServer({ ...opts, codingRuntime });
+      const server = createRepoHarnessMcpServer({ ...opts, profile: startupProfile, codingRuntime });
       await server.connect(transport);
       await transport.handleRequest(req, res, body);
     } finally {
@@ -561,7 +582,7 @@ export async function startMcpHttp(opts: McpHttpOptions): Promise<void> {
   const repoRoot = resolveMcpRepoRoot(opts.repo ?? '.');
   assertNoLegacyRepoScopeMcpConfig(repoRoot);
   const localConfig = loadMcpLocalConfig();
-  const profile = opts.profile ?? localConfig?.profile ?? 'planner';
+  const profile = resolveMcpHttpProfile(opts, localConfig);
   const storedEndpoint = localConfig?.chatgpt?.endpoint;
   const storedPublicOrigin = storedEndpoint ? new URL(storedEndpoint).origin : undefined;
   const configuredPublicOrigin = process.env.REPO_HARNESS_MCP_PUBLIC_ORIGIN?.trim()
@@ -764,7 +785,7 @@ export async function startMcpHttp(opts: McpHttpOptions): Promise<void> {
   }
 
   app.post('/mcp', requireMcpHttpAuth(authMode, authToken, oauthProvider, configuredPublicOrigin), express.raw({ type: '*/*', limit: '1mb' }), (req, res) => {
-    handleMcpPost(req, res, { ...opts, repo: repoRoot }, sessions, codingRuntimes).catch((error: unknown) => {
+    handleMcpPost(req, res, { ...opts, repo: repoRoot }, sessions, codingRuntimes, profile).catch((error: unknown) => {
       if (!res.headersSent) res.status(500).json({ error: error instanceof Error ? error.message : String(error) });
     });
   });

--- a/tests/cli/mcp-http.test.ts
+++ b/tests/cli/mcp-http.test.ts
@@ -619,6 +619,89 @@ describe('mcp http transport', () => {
     }
   }, 30_000);
 
+  test('binds sessions to the startup profile and fails closed when the config flips to coding', async () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'repo-harness-mcp-profile-flip-'));
+    const port = await freePort();
+    const restoreRegistryHome = useTempRegistryHome();
+    let proc: Bun.Subprocess | null = null;
+    try {
+      mkdirSync(join(repoRoot, '.ai/harness'), { recursive: true });
+      writeFileSync(join(repoRoot, '.ai/harness/policy.json'), '{}\n');
+      writeFileSync(join(repoRoot, 'AGENTS.md'), '# Profile flip test\n');
+      const runGit = (...args: string[]) => {
+        const result = Bun.spawnSync(['git', '-C', repoRoot, ...args], { stdout: 'pipe', stderr: 'pipe' });
+        if (result.exitCode !== 0) throw new Error(result.stderr.toString());
+      };
+      runGit('init', '-b', 'main');
+      runGit('config', 'user.email', 'tests@example.com');
+      runGit('config', 'user.name', 'Repo Harness Tests');
+      runGit('add', '.');
+      runGit('commit', '-m', 'fixture');
+      runMcpSetupChatgpt({ repo: repoRoot, port: String(port) });
+      const token = (await Bun.file(join(process.env.REPO_HARNESS_HOME!, 'mcp.tokens.json')).json()).bearerToken;
+
+      // `startMcpHttp` resolves the profile from the local config when the
+      // caller omits it, so this entrypoint is driven directly instead of
+      // through the CLI, which always passes an explicit --profile.
+      const entry = join(repoRoot, 'serve-entry.ts');
+      writeFileSync(
+        entry,
+        `import { startMcpHttp } from ${JSON.stringify(join(process.cwd(), 'src/cli/mcp/transports/http.ts'))};\n`
+        + `await startMcpHttp({ repo: ${JSON.stringify(repoRoot)}, host: '127.0.0.1', port: ${port}, auth: 'bearer' });\n`,
+      );
+      proc = Bun.spawn(['bun', entry], { cwd: process.cwd(), stdout: 'ignore', stderr: 'pipe', env: { ...process.env } });
+      await waitForHealth(port);
+
+      const initialize = () => fetch(`http://127.0.0.1:${port}/mcp`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${token}`,
+          'content-type': 'application/json',
+          accept: 'application/json, text/event-stream',
+        },
+        body: initializeBody(),
+      });
+
+      const beforeFlip = await initialize();
+      expect(beforeFlip.status).toBe(200);
+      expect(beforeFlip.headers.get('mcp-session-id')).toMatch(/^[0-9a-f-]{36}$/);
+
+      // The local config now becomes a fully valid coding setup. The running
+      // process still enforces the planner profile it started with: no coding
+      // grant middleware, no OAuth requirement, no Host/Origin pinning. A new
+      // session must not resolve a coding tool context behind that enforcement.
+      runMcpSetupChatgpt({
+        repo: repoRoot,
+        profile: 'coding',
+        grantReadWrite: [repoRoot],
+        endpoint: `https://coding.test/mcp`,
+        port: String(port),
+      });
+      expect(readRegisteredRepoHarnessRepos({ adoptedOnly: true })
+        .some((repo) => repo.accessMode === 'read_write')).toBe(true);
+
+      const afterFlip = await initialize();
+      expect(afterFlip.status).toBe(503);
+      expect(afterFlip.headers.get('mcp-session-id')).toBeNull();
+      const flipBody = await afterFlip.json() as { error: { code: string; message: string } };
+      expect(flipBody.error.code).toBe('PROFILE_CHANGED');
+      expect(flipBody.error.message).toContain('planner');
+      expect(flipBody.error.message).toContain('coding');
+
+      const health = await fetch(`http://127.0.0.1:${port}/health`);
+      expect(await health.json()).toMatchObject({
+        profile: 'planner',
+        active_sessions: 1,
+        sessions_created: 1,
+      });
+    } finally {
+      proc?.kill();
+      await proc?.exited.catch(() => undefined);
+      restoreRegistryHome();
+      rmSync(repoRoot, { recursive: true, force: true });
+    }
+  }, 30_000);
+
   test('supports URL token compatibility mode for single-user clients', async () => {
     const repoRoot = mkdtempSync(join(tmpdir(), 'repo-harness-mcp-url-token-'));
     const port = await freePort();


### PR DESCRIPTION
## Summary

Closes #208.

`startMcpHttp` resolved the profile once at startup for the whole HTTP enforcement layer (coding-grant middleware, OAuth requirement, Host/Origin pinning), but session initialize passed raw `opts` to `createRepoHarnessMcpServer`, which re-resolved the profile against freshly loaded config. A planner→coding config flip after startup produced a coding tool context (with a real coding runtime) behind planner-level enforcement. Reachable via the exported `startMcpHttp` API when `opts.profile` is omitted; the CLI always passes `--profile` and is unaffected.

Fix: single `resolveMcpHttpProfile` rule shared by startup and initialize; initialize re-resolves against fresh config and rejects a mismatch with 503 `PROFILE_CHANGED` before any reservation or runtime construction; server construction now receives the resolved startup profile explicitly. No hot-upgrade, no silent downgrade; the coding→planner direction stays covered by the existing `coding_disabled` middleware.

## Verification

- New regression test red on main (initialize returned 200 with a coding context after the flip), green with the fix; health counters prove no reservation slot is consumed on the 503 path.
- `bun run check:type` clean; full `bun test --timeout 60000`: 2816 pass / 0 fail.
- Independent acceptance review passed (pre-reservation ordering, both flip directions fail-closed, CLI byte-identical, single resolution authority).