### PR TITLE
fix(handoff): bind one packaged helper runtime

### DIFF
--- a/.ai/hooks/.projection.json
+++ b/.ai/hooks/.projection.json
@@ -3,6 +3,6 @@
   "canonical_root": "assets/hooks",
   "projection_target": ".ai/hooks",
   "manifest": "assets/hooks/projection.json",
-  "digest": "sha256:56ab3edd488916e6a7d57a650fb21c05651acd51709102ce6d92e6a2fbf4fdd6",
+  "digest": "sha256:eaa99c6a4561ad4603261b82386234aacb463adaf813e37d173b7f8eb699e0bb",
   "file_count": 3
 }

--- a/.ai/hooks/lib/workflow-state.sh
+++ b/.ai/hooks/lib/workflow-state.sh
@@ -1857,7 +1857,7 @@ workflow_contract_allows_path() {
 }
 workflow_write_handoff() {
   local reason="${1:-session-stop}"
-  local source_plan parent_run_id bun_bin
+  local source_plan parent_run_id bun_bin helper_source recovery_view_cli
 
   # EPC-07: independent handoff/resume content assembly retired same-package
   # (Phase A/B: tasks/contracts/20260722-2246-epc-07-recovery-view-cutover.contract.md).
@@ -1871,7 +1871,21 @@ workflow_write_handoff() {
   # EPC-07's four named recovery views.
   workflow_ensure_harness_surface
   bun_bin="${REPO_HARNESS_BUN_BIN:-bun}"
-  "$bun_bin" "scripts/recovery-view-cli.ts" --reason "$reason" --quiet
+  helper_source="${REPO_HARNESS_HELPER_SOURCE_PATH:-}"
+  if [[ -n "$helper_source" ]]; then
+    if [[ ! -f "$helper_source" || "$(basename "$helper_source")" != "prepare-handoff.sh" ]]; then
+      echo "workflow_write_handoff: invalid REPO_HARNESS_HELPER_SOURCE_PATH for prepare-handoff" >&2
+      return 1
+    fi
+    recovery_view_cli="$(cd "$(dirname "$helper_source")" && pwd)/recovery-view-cli.ts"
+  else
+    recovery_view_cli="scripts/recovery-view-cli.ts"
+  fi
+  if [[ ! -f "$recovery_view_cli" ]]; then
+    echo "workflow_write_handoff: recovery materializer is missing: $recovery_view_cli" >&2
+    return 1
+  fi
+  "$bun_bin" "$recovery_view_cli" --reason "$reason" --quiet
 
   source_plan="$(get_todo_source_plan || true)"
   if [[ "$source_plan" == "(none)" ]]; then

--- a/assets/hooks/lib/workflow-state.sh
+++ b/assets/hooks/lib/workflow-state.sh
@@ -1857,7 +1857,7 @@ workflow_contract_allows_path() {
 }
 workflow_write_handoff() {
   local reason="${1:-session-stop}"
-  local source_plan parent_run_id bun_bin
+  local source_plan parent_run_id bun_bin helper_source recovery_view_cli
 
   # EPC-07: independent handoff/resume content assembly retired same-package
   # (Phase A/B: tasks/contracts/20260722-2246-epc-07-recovery-view-cutover.contract.md).
@@ -1871,7 +1871,21 @@ workflow_write_handoff() {
   # EPC-07's four named recovery views.
   workflow_ensure_harness_surface
   bun_bin="${REPO_HARNESS_BUN_BIN:-bun}"
-  "$bun_bin" "scripts/recovery-view-cli.ts" --reason "$reason" --quiet
+  helper_source="${REPO_HARNESS_HELPER_SOURCE_PATH:-}"
+  if [[ -n "$helper_source" ]]; then
+    if [[ ! -f "$helper_source" || "$(basename "$helper_source")" != "prepare-handoff.sh" ]]; then
+      echo "workflow_write_handoff: invalid REPO_HARNESS_HELPER_SOURCE_PATH for prepare-handoff" >&2
+      return 1
+    fi
+    recovery_view_cli="$(cd "$(dirname "$helper_source")" && pwd)/recovery-view-cli.ts"
+  else
+    recovery_view_cli="scripts/recovery-view-cli.ts"
+  fi
+  if [[ ! -f "$recovery_view_cli" ]]; then
+    echo "workflow_write_handoff: recovery materializer is missing: $recovery_view_cli" >&2
+    return 1
+  fi
+  "$bun_bin" "$recovery_view_cli" --reason "$reason" --quiet
 
   source_plan="$(get_todo_source_plan || true)"
   if [[ "$source_plan" == "(none)" ]]; then

--- a/assets/templates/helpers/prepare-handoff.sh
+++ b/assets/templates/helpers/prepare-handoff.sh
@@ -10,6 +10,7 @@ else
   cd "$SCRIPT_DIR/.."
 fi
 helper_dir="$SCRIPT_DIR"
+workflow_state_lib="${REPO_HARNESS_WORKFLOW_STATE_LIB:-.ai/hooks/lib/workflow-state.sh}"
 
 reason="manual"
 mode="write"
@@ -39,9 +40,9 @@ USAGE_EOF
   esac
 done
 
-if [[ -f ".ai/hooks/lib/workflow-state.sh" ]]; then
+if [[ -f "$workflow_state_lib" ]]; then
   # shellcheck source=/dev/null
-  . ".ai/hooks/lib/workflow-state.sh"
+  . "$workflow_state_lib"
   if [[ "$mode" == "status" ]]; then
     echo "Active plan: $(get_active_plan || printf '(none)')"
     echo "Active contract: $(workflow_active_contract || printf '(none)')"

--- a/plans/plan-20260821-1839-prepare-handoff-helper-resolution.md
+++ b/plans/plan-20260821-1839-prepare-handoff-helper-resolution.md
@@ -1,0 +1,53 @@
+# Prepare Handoff Helper Resolution
+
+> **Status**: Review
+> **Artifact Level**: work-package
+> **Promotion Reason**: verification_boundary
+> **Verification Boundary**: Packaged-helper external-target regression, hook projection parity, strict workflow gate, and the original Salesko reproduction.
+> **Rollback Surface**: Revert the workflow-state helper resolution and its regression test on `codex/fix-prepare-handoff-helper-resolution`.
+> **Task Contract**: tasks/contracts/20260821-1839-prepare-handoff-helper-resolution.contract.md
+
+## Goal
+
+Make `repo-harness run prepare-handoff` use the recovery materializer from the same selected helper runtime when the target repository does not vendor `scripts/recovery-view-cli.ts`.
+
+## P1: Architecture Map
+
+- `src/cli/runtime/helper-runner.ts` selects the package or source helper runtime and exports the selected helper and workflow-library paths.
+- `assets/templates/helpers/prepare-handoff.sh` runs in the target repository and sources the target's `.ai/hooks/lib/workflow-state.sh`.
+- `assets/hooks/lib/workflow-state.sh#workflow_write_handoff` owns the operator handoff write and delegates recovery-view rendering to `recovery-view-cli.ts`.
+- The target repository is state/output authority; the selected helper runtime is executable authority.
+
+## P2: Concrete Trace
+
+`repo-harness run prepare-handoff` selects packaged `prepare-handoff.sh`, changes cwd to the target repository, and sets `REPO_HARNESS_HELPER_SOURCE_PATH`. The sourced workflow library currently ignores that selected-runtime path and invokes target-relative `scripts/recovery-view-cli.ts`; an adopted repository without that newly introduced local helper fails before handoff materialization.
+
+## P3: Design Decision
+
+Bind `prepare-handoff.sh` to the workflow library from the same selected runtime, then resolve `recovery-view-cli.ts` beside the validated selected helper. Preserve target-local workflow state and `scripts/recovery-view-cli.ts` only for direct repo-local invocation. Fail closed if a selected executable is missing. This keeps one executable authority per invocation and avoids requiring an adoption refresh merely to run handoff recovery.
+
+At 10x adoption scale, package/target version skew is the first pressure point. Binding dependent helpers to the already selected runtime prevents that skew from mixing executable generations.
+
+## Task Breakdown
+
+- [x] Add a regression fixture for an external target without local `recovery-view-cli.ts`.
+- [x] Resolve the recovery materializer from the selected helper runtime.
+- [x] Run focused tests, hook projection drift check, and repository workflow checks.
+- [x] Re-run the failing Salesko handoff command against the fixed source runtime.
+
+## Evidence Contract
+
+- **State/progress path**: this plan and its task notes
+- **Verification evidence**: focused Bun test, helper projection check, strict workflow check, external Salesko reproduction
+- **Evaluator rubric**: external target succeeds without target-local recovery helper; direct repo-local path remains supported; missing selected helper fails closed
+- **Stop condition**: regression test and Salesko command both succeed
+- **Rollback surface**: one shell helper-library function plus its regression test
+
+## Promotion Gate
+
+- **Merge/PR unit**: helper-runtime resolution, deterministic hook projection, regression test, and workflow artifacts form one patch.
+- **Rollback surface**: revert this branch's patch; no downstream state migration is required.
+- **Verification boundary**: full helper-script test file, hook projection drift check, strict workflow check, and original downstream reproduction.
+- **Review/acceptance boundary**: repository checks must pass on the exact branch diff before opening a draft PR.
+- **High-risk surface**: helper source-path trust and mixed package/target executable generations.
+- **Why not checklist row**: verification_boundary

--- a/scripts/prepare-handoff.sh
+++ b/scripts/prepare-handoff.sh
@@ -10,6 +10,7 @@ else
   cd "$SCRIPT_DIR/.."
 fi
 helper_dir="$SCRIPT_DIR"
+workflow_state_lib="${REPO_HARNESS_WORKFLOW_STATE_LIB:-.ai/hooks/lib/workflow-state.sh}"
 
 reason="manual"
 mode="write"
@@ -39,9 +40,9 @@ USAGE_EOF
   esac
 done
 
-if [[ -f ".ai/hooks/lib/workflow-state.sh" ]]; then
+if [[ -f "$workflow_state_lib" ]]; then
   # shellcheck source=/dev/null
-  . ".ai/hooks/lib/workflow-state.sh"
+  . "$workflow_state_lib"
   if [[ "$mode" == "status" ]]; then
     echo "Active plan: $(get_active_plan || printf '(none)')"
     echo "Active contract: $(workflow_active_contract || printf '(none)')"

--- a/src/cli/runtime/helper-runner.ts
+++ b/src/cli/runtime/helper-runner.ts
@@ -414,6 +414,17 @@ export function runHelper(opts: RunHelperOptions): RunHelperResult {
     REPO_HARNESS_HELPER_SOURCE_PATH: resolved.path,
     REPO_HARNESS_TARGET_REPO_ROOT: resolved.repoRoot,
   };
+  if (resolved.id === 'prepare-handoff') {
+    const workflowStateRoot = resolved.source === 'package'
+      ? dirname(PACKAGE_WORKFLOW_STATE)
+      : join(dirname(resolved.path), '..', 'assets', 'hooks', 'lib');
+    childEnv.REPO_HARNESS_WORKFLOW_STATE_LIB = resolveFromDir(
+      'workflow-state.sh',
+      workflowStateRoot,
+      resolved.source,
+      resolved.repoRoot,
+    ).path;
+  }
   if (protectedHelper) {
     childEnv.REPO_HARNESS_BASH_BIN = trustedBash;
     childEnv.REPO_HARNESS_GIT_BIN = trustedGit;

--- a/tasks/contracts/20260821-1839-prepare-handoff-helper-resolution.contract.md
+++ b/tasks/contracts/20260821-1839-prepare-handoff-helper-resolution.contract.md
@@ -1,0 +1,35 @@
+# Prepare Handoff Helper Resolution Contract
+
+> **Status**: Active
+> **Plan**: plans/plan-20260821-1839-prepare-handoff-helper-resolution.md
+> **Task Profile**: code-change
+> **Workflow Profile**: strict
+> **Capability ID**: runtime-harness-hook-adapters
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - .ai/hooks/.projection.json
+  - .ai/hooks/lib/workflow-state.sh
+  - assets/hooks/lib/workflow-state.sh
+  - assets/templates/helpers/prepare-handoff.sh
+  - scripts/prepare-handoff.sh
+  - src/cli/runtime/helper-runner.ts
+  - tests/cli/run.test.ts
+  - tests/helper-scripts.test.ts
+  - plans/plan-20260821-1839-prepare-handoff-helper-resolution.md
+  - tasks/contracts/20260821-1839-prepare-handoff-helper-resolution.contract.md
+  - tasks/notes/20260821-1839-prepare-handoff-helper-resolution.notes.md
+exit_criteria:
+  tests_pass:
+    - bun test tests/helper-scripts.test.ts --timeout 60000
+    - bun test tests/cli/run.test.ts --timeout 60000
+  commands_succeed:
+    - bun scripts/sync-hook-sources.ts --check
+    - repo-harness run check-task-workflow --strict
+```
+
+## Boundary
+
+Repair packaged helper resolution only. Do not change recovery-view semantics, target adoption contents, host hooks, release versioning, or downstream product code.

--- a/tasks/notes/20260821-1839-prepare-handoff-helper-resolution.notes.md
+++ b/tasks/notes/20260821-1839-prepare-handoff-helper-resolution.notes.md
@@ -1,0 +1,28 @@
+# Prepare Handoff Helper Resolution Notes
+
+## Confirmed Failure
+
+- External target: `/Users/kito/Projects/salesko-new-wt-byok-db-authority-readback`
+- Command: `repo-harness run prepare-handoff --reason diagnose-helper-path`
+- Result: exit 1, `Module not found "scripts/recovery-view-cli.ts"`
+- Root cause: the runner selected the packaged helper family and exported its source path, but `workflow_write_handoff` hard-coded a target-relative dependent helper.
+
+## Invariant
+
+The target repository owns handoff outputs and workflow state. All executable helpers participating in one invocation come from the same runner-selected helper runtime.
+
+## Implementation
+
+- When `REPO_HARNESS_HELPER_SOURCE_PATH` is present, `workflow_write_handoff` validates that it names the selected `prepare-handoff.sh` and resolves `recovery-view-cli.ts` beside it.
+- The helper runner also binds `prepare-handoff.sh` to `workflow-state.sh` from that same selected runtime, so a stale target-local library cannot reintroduce mixed-generation helper resolution.
+- Without a runner-selected helper path, direct repo-local invocation continues to use `scripts/recovery-view-cli.ts`.
+- Either shape fails closed when its resolved materializer is absent.
+
+## Verification
+
+- `tests/cli/run.test.ts`: 17 pass, 0 fail.
+- `tests/helper-scripts.test.ts`: 130 pass, 0 fail.
+- Helper and hook projection checks: pass.
+- Deploy SQL, architecture sync, task sync, strict workflow, project inspection, and init dry-run checks: pass.
+- Original Salesko command succeeds with the fixed source runtime and writes the handoff.
+- An attempted ambient full-suite run exposed two pre-existing `trace-observer` failures because the Codex host injects `CODEX_SESSION_ID`/host identity into tests that expect no ambient host. The focused file passes 9/9 when those host variables are removed. The long full-suite run was stopped after establishing that unrelated environment cause; no source change was made for it.

--- a/tests/cli/run.test.ts
+++ b/tests/cli/run.test.ts
@@ -325,6 +325,37 @@ describe("run command", () => {
     }
   }, 30_000);
 
+  test("package prepare-handoff binds its workflow library and recovery helper from one runtime", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "repo-harness-run-prepare-handoff-"));
+    try {
+      mkdirSync(join(tmp, ".ai/hooks/lib"), { recursive: true });
+      mkdirSync(join(tmp, "tasks"), { recursive: true });
+      writeFileSync(
+        join(tmp, ".ai/hooks/lib/workflow-state.sh"),
+        "workflow_write_handoff() { echo stale-target-workflow >&2; return 91; }\n",
+      );
+      writeFileSync(join(tmp, "tasks/todos.md"), "# Deferred Goals\n");
+      expect(spawnSync("git", ["init"], { cwd: tmp }).status).toBe(0);
+
+      const result = runHelper({
+        helper: "prepare-handoff",
+        args: ["--reason", "package-runtime"],
+        cwd: tmp,
+        env: packageRuntimeEnv(),
+        stdio: "pipe",
+      });
+
+      expect(result.exitCode, result.stderr).toBe(0);
+      expect(result.stderr ?? "").not.toContain("stale-target-workflow");
+      expect(existsSync(join(tmp, "scripts/recovery-view-cli.ts"))).toBe(false);
+      expect(readFileSync(join(tmp, ".ai/harness/handoff/current.md"), "utf-8")).toContain(
+        "**Reason**: package-runtime",
+      );
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  }, 30_000);
+
   test("ignores repo-local helper runtime when helper_source is repo pinned", () => {
     const tmp = mkdtempSync(join(tmpdir(), "repo-harness-run-repo-pin-"));
     try {

--- a/tests/helper-scripts.test.ts
+++ b/tests/helper-scripts.test.ts
@@ -4609,6 +4609,43 @@ describe("Workflow helper scripts", () => {
     }
   }, 30_000);
 
+  test("packaged prepare-handoff should resolve recovery materializer from its selected helper runtime", () => {
+    const cwd = tmpWorkspace("helper-packaged-prepare-handoff");
+    try {
+      mkdirSync(join(cwd, ".ai/hooks/lib"), { recursive: true });
+      mkdirSync(join(cwd, "tasks"), { recursive: true });
+      copyFileSync(
+        join(ROOT, "assets/hooks/lib/workflow-state.sh"),
+        join(cwd, ".ai/hooks/lib/workflow-state.sh")
+      );
+      writeFileSync(join(cwd, "tasks/todos.md"), "# Deferred Goals\n");
+      initGitRepo(cwd);
+      commitAll(cwd, "fixture");
+
+      expect(existsSync(join(cwd, "scripts/recovery-view-cli.ts"))).toBe(false);
+      const helperSource = join(HELPER_DIR, "prepare-handoff.sh");
+      const res = run(
+        "bash",
+        [helperSource, "--reason", "package-runtime"],
+        cwd,
+        {
+          REPO_HARNESS_TARGET_REPO_ROOT: cwd,
+          REPO_HARNESS_HELPER_SOURCE_PATH: helperSource,
+          REPO_HARNESS_WORKFLOW_STATE_LIB: join(ROOT, "assets/hooks/lib/workflow-state.sh"),
+        }
+      );
+
+      expect(res.status).toBe(0);
+      expect(res.stderr).toBe("");
+      expect(readFileSync(join(cwd, ".ai/harness/handoff/current.md"), "utf-8")).toContain(
+        "**Reason**: package-runtime"
+      );
+      expect(existsSync(join(cwd, ".ai/harness/handoff/resume.md"))).toBe(true);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  }, 30_000);
+
   test("prepare-handoff should include untracked files in changed-file context", () => {
     const cwd = tmpWorkspace("helper-prepare-handoff-untracked");
     try {


### PR DESCRIPTION
## Summary

- bind `prepare-handoff` to `workflow-state.sh` from the same package/source runtime selected by the helper runner
- resolve `recovery-view-cli.ts` beside that selected helper and fail closed when the runtime is incomplete
- preserve target-local helpers only for direct repo-local invocation
- cover the external-target case where the adopted repo lacks `scripts/recovery-view-cli.ts` and carries a stale local workflow library

## Root cause

The runner selected packaged `prepare-handoff.sh`, but the target-local workflow library hard-coded `scripts/recovery-view-cli.ts`. Package/target version skew therefore mixed executable generations and failed before materializing the handoff.

## Verification

- `bun test tests/cli/run.test.ts --timeout 60000`: 17 pass
- `bun test tests/helper-scripts.test.ts --timeout 60000`: 130 pass
- helper projection and hook projection checks: pass
- deploy SQL, architecture sync, task sync, strict workflow, project inspection, and init dry-run: pass
- original Salesko external-target reproduction: pass with fixed source runtime

## Full-suite note

An ambient full-suite attempt hit two unrelated `trace-observer` assertions because this Codex host injects session/host identity; that file passes 9/9 with those ambient host variables removed. The long suite was stopped after proving the environment cause; no unrelated source change is included.