### PR TITLE
feat: add GPT Pro advisory orchestration mode

### DIFF
--- a/assets/skills/repo-harness-chatgpt/SKILL.md
+++ b/assets/skills/repo-harness-chatgpt/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: repo-harness-chatgpt
-description: Canonical rule owner for repo-harness ChatGPT integration -- Oracle-first browser/GPT Pro consult and continuation, MCP Connector setup, MCP bridge planning handoff, and Connector invocation read-back evidence.
-when_to_use: "repo-harness-chatgpt, ChatGPT Web consult, GPT Pro consult, gptpro, browser GPT, ChatGPT MCP Connector, ChatGPT bridge, MCP read-back, GPT Pro delegate, delegate to ChatGPT, 外包给 GPT"
+description: Canonical rule owner for repo-harness ChatGPT integration -- Oracle-first browser/GPT Pro consult and continuation, advisory orchestration, MCP Connector setup, MCP bridge planning handoff, and Connector invocation read-back evidence.
+when_to_use: "repo-harness-chatgpt, ChatGPT Web consult, GPT Pro consult, GPT Pro orchestrate, gptpro, browser GPT, ChatGPT MCP Connector, ChatGPT bridge, MCP read-back, GPT Pro delegate, delegate to ChatGPT, 外包给 GPT"
 ---
 
 # repo-harness-chatgpt
@@ -15,6 +15,8 @@ mode protocol lives under `references/`.
 ## Mode Selection
 
 - First-time Oracle browser or MCP Connector configuration -> `references/setup.md`.
+- Explicit GPT Pro orchestration -> read the setup lane in
+  `references/setup.md`, then `references/orchestrate.md`.
 - Start a new local -> ChatGPT Web browser consult -> `references/consult.md`.
 - Continue, read, or clean up a saved browser session -> `references/continue.md`.
 - Verify or accept a ChatGPT MCP tool call as real evidence -> `references/read-back.md`.
@@ -27,5 +29,7 @@ mode protocol lives under `references/`.
 - Never request or handle ChatGPT passwords, 2FA codes, cookies, browser storage, or session tokens; login/captcha/SSO stop and hand back to the user.
 - Setup, consult, and bridge modes share these safety rules by reference; none shares secrets, auth state, or tokens with another mode.
 - Consult stays planning/review/critique only, never the code-edit executor; delegate is the sole approved path for code deliverables, and GPT Pro still never executes edits.
+- Orchestrate is explicit opt-in advisory planning/review; GPT Pro never owns
+  task, lease, writes, shell, or acceptance authority.
 - A missing or unreadable canonical reference fails the calling command closed; it never synthesizes replacement prose.
 - Do not enable remote CDP or an orchestrator dev runner unless the user explicitly asks and the boundary is documented.

--- a/assets/skills/repo-harness-chatgpt/references/orchestrate.md
+++ b/assets/skills/repo-harness-chatgpt/references/orchestrate.md
@@ -1,0 +1,225 @@
+# Orchestrate Mode: GPT Pro Advisory Chief Planner and Reviewer
+
+Use this mode only after the user has explicitly enabled GPT Pro
+orchestration for the current repository and task and the orchestration lane
+in [`setup.md`](setup.md) has passed. It composes the existing ChatGPT Web
+browser consult, session read-back, and follow-up capabilities. It does not
+add a provider, runtime adapter, schema, fleet role, or second Skill.
+
+GPT Pro is an external chief planner/reviewer. Local Codex is the accountable
+coordinator and executor, including the Codex built-in browser (IAB) transport.
+Repository artifacts, the effective-state resolver, task contract, lease,
+allowed paths, real checks, and acceptance gate remain the only control-plane
+and execution authority.
+
+## Authority Boundary
+
+| Participant | May do | May not do |
+| --- | --- | --- |
+| GPT Pro Web | Read the exact context supplied to it, use the authorized GitHub Connector when visibly available, propose a plan, identify risks, and review the returned diff/evidence | Edit the local worktree, run local commands, create or change tasks, claim/release/steal a lease, widen `allowed_paths`, assert that local checks ran, or authorize commit/push/PR/merge/deploy |
+| Local Codex | Resolve state, select the remote revision, build and secret-scan the local bundle, dispatch work through the normal task/lease path, run checks, and decide acceptance | Treat GPT Pro prose or a tool-use claim as permission or as proof of a local fact |
+| GitHub Connector | Supply remote repository facts at an exact revision when its invocation is observable | Describe uncommitted local changes or replace the local repository source of truth |
+
+This is an advisory planning/review loop, not a managed `agent-fleet` role.
+Do not automatically spawn a local agent from GPT Pro's proposal. The
+`delegate.md` protocol remains the sole path for a GPT Pro-produced code
+deliverable; this mode receives advice and review only.
+
+## Readiness Gate
+
+Before opening a real conversation, verify the explicit setup checklist and
+all of the following:
+
+- the canonical Skill is projected from a durable checkout;
+- the selected browser session is signed in, visibly shows a Pro model, and
+  has no login, captcha, SSO, passkey, or workspace-picker interruption;
+- the user's GitHub Connector is selected and authorized in ChatGPT Web;
+- the target repository, ref, and exact remote commit SHA are recorded;
+- the local base commit, tracked delta, and untracked-file manifest are
+  captured separately from the remote facts;
+- the exact prompt and every local attachment pass the existing
+  `--dry-run --secret-scan` gate, and the saved prompt hash is unchanged.
+
+If any item is missing, stale, or only asserted by the model, fail closed and
+return to the setup guide. Do not switch providers, use an unbound browser
+profile,
+infer a remote fact from GitHub's default branch, or submit an unscanned
+attachment.
+
+## Evidence Binding Without a New Schema
+
+Keep these values as ordinary prompt and workflow evidence; do not invent a
+typed orchestration binding or receipt in this mode:
+
+```text
+remote.repository = <canonical owner/name>
+remote.ref        = <target branch/tag/ref>
+remote.sha        = <exact commit SHA>
+local.base        = <local base commit>
+local.delta       = <SHA-256 of the tracked-diff/untracked manifest bundle>
+git.version       = <exact stdout of `git --version`>
+conversation      = <same browser session/provider handle and URL>
+prompt            = <SHA-256 from the secret-scan receipt>
+```
+
+The untracked-file manifest identity is the SHA-256 of a canonical JSON array
+of `{path, sha256}` entries sorted by repo-relative path. Emit that manifest
+as compact UTF-8 JSON with no BOM and exactly one final LF; keep object keys in
+`path`, then `sha256`, order. The `local.delta` preimage is the exact tracked
+diff bytes followed immediately by the exact canonical manifest bytes, in that
+order: `sha256(trackedDiffBytes || manifestBytes)`. The framing adds no
+delimiter, separator, wrapper, or newline of its own; preserve each input's
+bytes exactly, including the tracked diff's own ending and the manifest's
+final LF. Reordering entries is therefore stable, while adding, removing, or
+changing an untracked file changes the identity; a tracked-diff hash alone is
+insufficient.
+
+Produce `trackedDiffBytes` from `local.base` with the following deterministic
+read-only command. Comparing a commit to the worktree includes both staged and
+unstaged changes to tracked files; untracked files are excluded here and enter
+through the manifest above. Record the exact `git --version` output alongside
+the resulting digest because Git versions can change patch rendering:
+
+```bash
+LC_ALL=C git --version
+LC_ALL=C git -c core.quotepath=false diff \
+  --binary --full-index --no-color --no-ext-diff --no-textconv \
+  --no-renames --no-indent-heuristic --diff-algorithm=myers \
+  --src-prefix=a/ --dst-prefix=b/ \
+  <local.base> --
+```
+
+Treat the command's raw stdout bytes as `trackedDiffBytes`; do not decode,
+normalize, add a delimiter, or reconstruct the diff before hashing. Pass the
+resulting tracked diff and manifest only through the existing exact
+`--dry-run --secret-scan` prompt/attachment gate.
+
+Remote GitHub facts and local worktree state are different inputs. A GitHub
+read cannot describe an uncommitted or untracked local file, and a local diff
+cannot prove that a remote SHA was read through MCP.
+
+For a branch code audit, GPT Pro must visibly invoke the GitHub Connector and
+read the pushed branch head at its exact commit SHA. A review against an
+unpublished worktree instead binds the exact remote base SHA plus the scanned
+local-delta bundle and must be labeled `local-bundle review`; it is not a
+GitHub branch audit. Never describe a branch name, model claim, or supplied
+diff alone as proof that the pushed commit was read.
+
+Classify GitHub Connector use from observable browser/tool evidence, not from
+GPT Pro's wording:
+
+- `verified`: the conversation/read-back exposes the GitHub MCP/Connector
+  invocation and the response binds the repository and exact SHA.
+- `bundle_only`: no invocation is observable, but the
+  exact remote facts were supplied in the scanned bundle. This is honest
+  context classification, not proof of GitHub MCP usage.
+- `unverified`: the invocation, repository, ref, or SHA is missing, stale, or
+  conflicts with the local record.
+
+An end-to-end GitHub-backed canary or any adoption that depends on a live
+Connector requires `verified`. `bundle_only` may be recorded for diagnosis but
+does not upgrade itself into `verified`; `unverified` blocks the round.
+
+## Protocol
+
+### 1. Prepare and send the plan turn
+
+1. Confirm the current task contract, active plan, effective state, lease, and
+   allowed paths locally. Preserve unrelated dirty worktree state.
+2. Resolve and record the exact remote repository/ref/SHA. Do not let GPT Pro
+   choose a moving branch or silently substitute another revision.
+3. Snapshot the local base, tracked diff, and untracked manifest. Render the
+   orchestration brief and attachments through the existing policy-checked
+   prompt path. Run a dry-run with `--secret-scan`, then use the exact saved
+   `prompt.md`; do not reconstruct it in the browser.
+4. Open a new conversation for this independent task. Visually record the
+   selected Pro model and wait until a conversation URL or equivalent handle
+   appears before waiting for generation. Use the existing browser consult
+   path; this mode does not create a new transport.
+5. Ask GPT Pro for an advisory plan with: proposed task slices, affected
+   paths, assumptions and evidence, risks, required local checks, and explicit
+   `blocked`/`unverified` items. Require it to distinguish GitHub Connector
+   observations from the supplied bundle.
+
+The local coordinator owns the session handle, prompt hash, remote SHA, and
+local-delta identity. GPT Pro cannot amend any of them through its response.
+
+### 2. Recheck and execute locally
+
+1. Read the saved answer only after the browser session reports a complete
+   generation and the answer is available through the managed session/read-back
+   surface. A changed message count or model self-report is not completion
+   evidence.
+2. Classify GitHub evidence as `verified`, `bundle_only`, or `unverified`.
+   Recheck the proposed paths and assumptions against the current local
+   contract and effective state. If the remote SHA or local delta changed,
+   discard the proposal and rebuild the bundle.
+3. Treat the proposal as advisory input. The local coordinator may dispatch
+   only work already authorized by the task contract and lease. It runs edits
+   and real checks locally; GPT Pro never claims those results for it.
+4. Stop closed on stale state, missing evidence, path widening, a proposed
+   commit/push/PR/deploy, or any instruction that crosses the authority table.
+
+### 3. Review the implemented result in the same conversation
+
+1. Capture the actual local diff, untracked manifest, command output, and
+   check results after implementation. Secret-scan the exact review prompt and
+   attachments again; the review bundle must identify the same remote SHA and
+   the new local-delta hash.
+2. Continue the original session with the existing follow-up command/path
+   (`browser-followup` / the Codex built-in browser's same conversation). Do
+   not open a new conversation to hide a failed continuation or silently
+   switch transports.
+3. Ask GPT Pro to review the exact result for scope, correctness risks, and
+   missing tests. Require it to mark every claim that cannot be verified from
+   the supplied diff or visible Connector evidence.
+4. Confirm the same conversation handle, visible completion state, and final
+   answer. A continuation failure, incomplete generation, or missing
+   termination/read-back evidence blocks the orchestration round.
+5. The local gatekeeper reruns the task's real checks and decides acceptance.
+   Record GPT Pro's response as review evidence only; it cannot approve the
+   task, release a lease, or override a failed gate.
+
+## Required Canary Evidence
+
+For a real Codex built-in-browser canary, retain ignored session/handoff
+evidence and promote only durable conclusions into the owning workflow review
+or notes. The evidence must make these values independently inspectable:
+
+- exact secret-scanned prompt hash and attachment outcome;
+- visible Pro model label and generation-complete state;
+- conversation URL/handle for the plan turn and same-conversation review;
+- canonical remote repository, ref, and exact SHA;
+- observable GitHub Connector invocation classification and supporting
+  read-back evidence (`verified`, `bundle_only`, or `unverified`);
+- local base commit and local-delta manifest identity;
+- actual local implementation diff and command/check output;
+- final local gatekeeper and acceptance outcome.
+
+Do not create a new JSON contract just to hold these fields. Existing session
+metadata, prompt receipts, ignored handoff artifacts, and tracked workflow
+review/notes are the evidence surfaces for this first canary.
+
+## Failure Handling
+
+Stop without inferred success when any of these occurs: setup is not explicitly
+enabled, Pro model visibility is absent, login or manual verification is
+needed, GitHub Connector selection is unavailable, the remote SHA is stale or
+unverifiable, local content changes after scanning, a secret scan fails, an
+attachment is blocked, generation is incomplete, the conversation handle is
+missing, or same-session continuation fails. Preserve the dry-run/session
+evidence and report the concrete stop reason.
+
+Never ask for passwords, 2FA codes, cookies, browser storage, session tokens,
+or GitHub credentials. Never retry through native/CDP or a different
+conversation to manufacture a passing canary. Never turn GPT Pro's plan or
+review into a task, lease, code edit, acceptance receipt, or publication
+authority.
+
+## Existing References
+
+- Setup and explicit enablement: [`setup.md`](setup.md)
+- New consult transport: [`consult.md`](consult.md)
+- Same-session follow-up and raw-evidence handling: [`continue.md`](continue.md)
+- Connector invocation read-back: [`read-back.md`](read-back.md)
+- Code-delivery delegation, if explicitly requested: [`delegate.md`](delegate.md)

--- a/assets/skills/repo-harness-chatgpt/references/setup.md
+++ b/assets/skills/repo-harness-chatgpt/references/setup.md
@@ -13,6 +13,72 @@ source.
 - ChatGPT Pro Web access is not OpenAI API quota or an API key substitute;
   never create API keys or billing projects from a ChatGPT Pro subscription.
 
+## Advisory Orchestration Enablement (Explicit Opt-In)
+
+Use this lane only after the user explicitly enables GPT Pro orchestration for
+the current repository and task. Enablement is task-scoped guidance, not a new
+install profile, managed fleet role, persistent schema, or grant of local
+write/lease/acceptance authority. Do not start an orchestration conversation
+until every prerequisite below is observable; a missing prerequisite returns
+to this guide and stops closed.
+
+1. Project the canonical Skill from a durable checkout, if it is not already
+   discoverable:
+
+   ```bash
+   repo-harness chatgpt install-skill --target both
+   ```
+
+   Use `--dry-run` first when inspecting an unfamiliar host. A projection from
+   a contract worktree is verification-only because worktree cleanup can leave
+   a dangling symlink; re-project from the durable checkout before use.
+2. Check the selected ChatGPT Web browser path (including the Codex built-in
+   browser/IAB when that is the transport) and the visible Pro model. For
+   Oracle, run:
+
+   ```bash
+   repo-harness chatgpt browser-doctor --repo <repo> --provider oracle --json
+   ```
+
+   The user must resolve sign-in, captcha, SSO, or model-plan prompts in the
+   browser. Never request credentials or switch silently to native/CDP.
+3. If the orchestration prompt needs the repo-harness ChatGPT Connector,
+   configure and verify that local server separately:
+
+   ```bash
+   repo-harness mcp setup chatgpt --repo <repo> --server-name <name>
+   repo-harness mcp doctor --repo <repo> --json
+   ```
+
+   `chatgpt.serverNameConfigured:true` and the expected server name are
+   required before starting a sidecar. This local Connector is not a substitute
+   for the user's separately authorized GitHub Connector in ChatGPT Web.
+4. In ChatGPT Web, select the user's authorized GitHub Connector for the new
+   conversation. Record the canonical repository, target ref, and exact remote
+   commit SHA that the task is allowed to use. A model claim that it used
+   GitHub MCP is not invocation evidence; the orchestration protocol classifies
+   observable use as `verified`, exact supplied context as `bundle_only`, and
+   everything else as `unverified`.
+5. Snapshot the local worktree separately from the remote facts. Include the
+   current base commit, tracked diff, and hashed untracked-file manifest only
+   through the existing policy-checked bundle path; this is the local delta
+   identity used by the review loop. Before any real submission,
+   run the exact prompt through the fail-closed secret gate:
+
+   ```bash
+   repo-harness chatgpt browser-consult \
+     --repo <repo> --provider oracle --dry-run --secret-scan \
+     --prompt "<orchestration brief>" --file <safe-context-file>
+   ```
+
+   Compare the saved `prompt.md` hash with the scan receipt; do not add an
+   unscanned attachment or paste a changed local delta into the browser.
+6. Only after the checklist passes, read `references/orchestrate.md` and start
+   the plan/review loop. If the remote SHA, local-delta hash, Connector
+   visibility, Pro model, attachment, generation completion, or conversation
+   handle cannot be verified, stop without transport fallback or inferred
+   success.
+
 ## Host Skill Projection
 
 The canonical package remains under

--- a/docs/architecture/.projection-manifest.json
+++ b/docs/architecture/.projection-manifest.json
@@ -5,12 +5,12 @@
   "sourceDigest": "sha256:dfeee72dd6b65c11c5410cf52261499a156ed11386d32cb5121711b63684470d",
   "provenance": {
     "schemaVersion": "archcontext.architecture-docs-projection-provenance/v1",
-    "baseHeadSha": "cd7cf8293e8661d88f2a17626b155c7caf67b502",
-    "worktreeDigest": "sha256:320c721f04cb22200201c66447737530d1bf77400b66dcdc26fb550903da23c4",
-    "sourceTreeDigest": "sha256:3dfde265297b94f7d46b4ebc10247ba58a90124fbd492ac35e8f446668b4d792",
+    "baseHeadSha": "fa387d261533ca6b3a00cd151e2a0a768a5379cb",
+    "worktreeDigest": "sha256:93665e1755487e7fabfe54bc40f6414ecf41c379d1cc58ac91e11659fc37ef88",
+    "sourceTreeDigest": "sha256:fd9ef727cb59e9c8f115229af5cc1992f588da17d7b16f907c2cbc5532620813",
     "modelDigest": "sha256:e7e1a02e1fb8c6e0732999db19c5ab1541d8529ffb270b2be1eb96af579fa4cb",
-    "codeGraphDigest": "sha256:4772661583c84acd0e99989736fca11f1ac57b471a66d50f21d947c97cab93fc",
-    "indexedWorktreeDigest": "sha256:16da8ab93260dcf98147624e7aaf81f829ab5f96d8144b0400d27fa8f4b4193c",
+    "codeGraphDigest": "sha256:85f36ed1444c343ef6fb17e19d0067ccc12de32e6ccbc1b3030371611a65f9a5",
+    "indexedWorktreeDigest": "sha256:ee22aafa7d22ba3a4b98ce4e272cf1bc385547eda498cb976a6c5fed0136a2bf",
     "rendererVersion": "archcontext.docs-renderer/v4",
     "layoutVersion": "archcontext.docs-layout/v1",
     "generatedFrom": {
@@ -19,9 +19,9 @@
       "codeGraphBinaryDigest": "sha256:e4be48573fdf16196ca0d2867be2790aa161534e9973dcb89bc70465100ea537",
       "codeGraphStatus": "ready"
     },
-    "projectionInputDigest": "sha256:d04ba93c3ab635ee5b65fcd90b399bc7bfbcbb8ff3132886c7b13becc862c527"
+    "projectionInputDigest": "sha256:1fc47be3fffd5257a0a999aca904573a5b0cdbdd3babb132c4c7ff42153021f7"
   },
-  "projectionDigest": "sha256:c3908de2048b217b917bdbe5bd49ab550d19b45ea30b0dd56ec0606871861514",
+  "projectionDigest": "sha256:e44add719fb0511c51e90fdbd3955c70d785b27f4cad9857450a20bf8553d30e",
   "semanticBaseline": {
     "semanticState": {
       "schemaVersion": "archcontext.architecture-semantic-state/v1",
@@ -307,12 +307,12 @@
     },
     "digests": {
       "modelDigest": "sha256:e7e1a02e1fb8c6e0732999db19c5ab1541d8529ffb270b2be1eb96af579fa4cb",
-      "sourceTreeDigest": "sha256:3dfde265297b94f7d46b4ebc10247ba58a90124fbd492ac35e8f446668b4d792",
+      "sourceTreeDigest": "sha256:fd9ef727cb59e9c8f115229af5cc1992f588da17d7b16f907c2cbc5532620813",
       "flowProofDigest": "sha256:f61c06c8566ec4ff22ec096ee22c06e91a046ceefa8fcd2f1d9faf436763a457",
-      "projectionDigest": "sha256:c3908de2048b217b917bdbe5bd49ab550d19b45ea30b0dd56ec0606871861514"
+      "projectionDigest": "sha256:e44add719fb0511c51e90fdbd3955c70d785b27f4cad9857450a20bf8553d30e"
     }
   },
-  "receiptDigest": "sha256:c38fe6d5a871ccf85bf24d5499f7c822d3495ce3cd42da2aab02d8463b4ef253",
+  "receiptDigest": "sha256:d1a8616fd52e3c17f5ecde292c2edc872c4dd5fdf831f528342b14dbedeb994a",
   "refreshSignalIds": [],
   "targetCount": 17,
   "fileCount": 17,
@@ -505,9 +505,9 @@
       "sourceDigest": "sha256:2b41a1b3f03e0f2a17b8e83607c353f16dc1370b0d6cfada99502c1048e2c342",
       "outputDigest": "sha256:66d4b7068ff03b389eb468fcfeb98d6146109c54d1e89eaf119a8f278ac9a5e4",
       "verifiedAgainst": {
-        "branch": "codex/lease-protocol-2-lifecycle",
-        "commit": "75e5419ddc5017d185732ca6391129d9ebe0bc4e",
-        "committedAt": "2026-08-22T17:11:08+08:00"
+        "branch": "codex/gpt-pro-orchestrate-mode",
+        "commit": "fa387d261533ca6b3a00cd151e2a0a768a5379cb",
+        "committedAt": "2026-08-22T21:00:09+08:00"
       }
     },
     {

--- a/docs/repo-harness-chatgpt-browser-engine.md
+++ b/docs/repo-harness-chatgpt-browser-engine.md
@@ -89,6 +89,49 @@ The old experimental Chrome extension flow has been removed from the product sur
 
 Do not use the default Chrome data directory for native CDP validation. Chrome 136+ no longer honors remote-debugging switches against the current user's default Chrome data directory; it requires a non-standard `--user-data-dir`. Existing signed-in real Chrome profiles should use Oracle instead of native CDP.
 
+## Advisory GPT Pro Orchestration
+
+The canonical `repo-harness-chatgpt` Skill has an explicit `orchestrate` mode
+for a user-authorized plan -> local implementation -> same-conversation review
+loop. It is a policy composition over the existing browser/session commands,
+not a managed `agent-fleet` role, a parallel Skill, a runtime adapter, or a new
+evidence schema. Enablement is task-scoped: project the Skill, verify the
+browser and visible Pro model, select the user's authorized GitHub Connector,
+pin the target repository/ref/SHA, and pass the exact local context through the
+existing secret-scanned prompt path. The full operator checklist is in
+`assets/skills/repo-harness-chatgpt/references/setup.md`; the protocol is in
+`assets/skills/repo-harness-chatgpt/references/orchestrate.md`.
+
+The authority split is deliberate. GPT Pro may propose work and review the
+returned diff, but it cannot edit the local worktree, run local commands,
+claim or release leases, widen allowed paths, assert check results, or approve
+commit/push/PR/merge/deploy. Local Codex and repo-harness remain accountable
+for task state, execution, verification, and acceptance. ChatGPT Web is not a
+source of local truth, and the GitHub Connector cannot describe uncommitted
+local changes.
+
+For each round, record the exact remote repository/ref/SHA separately from the
+local base commit and the SHA-256 identity of the tracked-diff/untracked-file
+bundle. Classify GitHub Connector evidence from observable browser/tool
+read-back, never from model self-report:
+
+- `verified`: the Connector invocation and exact repository/SHA are visible;
+- `bundle_only`: exact remote facts were supplied in the scanned bundle, but no
+  invocation is visible; this is not GitHub MCP proof;
+- `unverified`: invocation or revision evidence is absent, stale, or
+  conflicting and blocks adoption.
+
+The initial plan and implementation review must use the same browser
+conversation/session. Before each submission, run the exact prompt and
+attachments through `browser-consult --dry-run --secret-scan`, compare the
+saved prompt hash with its receipt, and do not paste or attach changed local
+content afterward. The canary is complete only when the visible Pro model,
+conversation URL/handle, generation completion, remote SHA, GitHub evidence
+classification, local-delta identity, same-conversation review, actual local
+checks, and local acceptance outcome are all inspectable. A missing login,
+Connector, attachment, completion state, stale SHA, failed scan, or failed
+continuation is a blocked run; do not switch transport or infer success.
+
 ## Dry Run
 
 ```bash

--- a/plans/plan-20260822-1240-gpt-pro-orchestrate-mode.md
+++ b/plans/plan-20260822-1240-gpt-pro-orchestrate-mode.md
@@ -1,0 +1,181 @@
+# Plan: GPT Pro Advisory Orchestration Mode
+
+> **Status**: Executing
+> **Created**: 20260822-1240
+> **Slug**: gpt-pro-orchestrate-mode
+> **Planning Source**: user-approved-plan
+> **Orchestration Kind**: user-approved-plan
+> **Source Ref**: (none)
+> **Artifact Level**: work-package
+> **Promotion Reason**: verification_boundary
+> **Verification Boundary**: Canonical ChatGPT Skill protocol closure plus one real Codex IAB end-to-end canary and root required checks.
+> **Rollback Surface**: Revert the canonical router, orchestrate reference, focused tests, operator documentation, and workflow artifacts together; no runtime or schema migration.
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260822-1240-gpt-pro-orchestrate-mode.contract.md`
+> **Task Review**: `tasks/reviews/20260822-1240-gpt-pro-orchestrate-mode.review.md`
+> **Implementation Notes**: `tasks/notes/20260822-1240-gpt-pro-orchestrate-mode.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from user-approved-plan planning output.
+- Source ref: (none)
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260822-1240-gpt-pro-orchestrate-mode.md`
+- Sprint contract: `tasks/contracts/20260822-1240-gpt-pro-orchestrate-mode.contract.md`
+- Sprint review: `tasks/reviews/20260822-1240-gpt-pro-orchestrate-mode.review.md`
+- Implementation notes: `tasks/notes/20260822-1240-gpt-pro-orchestrate-mode.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260822-1240-gpt-pro-orchestrate-mode.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260822-1240-gpt-pro-orchestrate-mode.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260822-1240-gpt-pro-orchestrate-mode.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260822-1240-gpt-pro-orchestrate-mode.contract.md`
+- Review file: `tasks/reviews/20260822-1240-gpt-pro-orchestrate-mode.review.md`
+- Implementation notes file: `tasks/notes/20260822-1240-gpt-pro-orchestrate-mode.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260822-1240-gpt-pro-orchestrate-mode.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260822-1240-gpt-pro-orchestrate-mode.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: Revert the canonical router, orchestrate reference, focused tests, operator documentation, and workflow artifacts together; no runtime or schema migration.
+- **Verification boundary**: Canonical ChatGPT Skill protocol closure plus one real Codex IAB end-to-end canary and root required checks.
+- **Review/acceptance boundary**: `tasks/reviews/20260822-1240-gpt-pro-orchestrate-mode.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: verification_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260822-1240-gpt-pro-orchestrate-mode.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260822-1240-gpt-pro-orchestrate-mode.contract.md`, `tasks/reviews/20260822-1240-gpt-pro-orchestrate-mode.review.md`, and `tasks/notes/20260822-1240-gpt-pro-orchestrate-mode.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260822-1240-gpt-pro-orchestrate-mode.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: Revert the canonical router, orchestrate reference, focused tests, operator documentation, and workflow artifacts together; no runtime or schema migration.
+
+## Captured Planning Output
+
+## Goal
+Add an `orchestrate` mode to the existing canonical `repo-harness-chatgpt` Skill so GPT Pro Web can act as an advisory external chief planner and reviewer while repo-harness and local Codex retain task, lease, execution, verification, and acceptance authority. Prove the mode with one real Codex built-in-browser end-to-end canary.
+
+## Success Criteria
+- `assets/skills/repo-harness-chatgpt/references/orchestrate.md` is the single protocol owner for the new mode and is explicitly routed from the canonical `SKILL.md`.
+- When the user explicitly enables orchestration, the mode routes through the existing canonical `references/setup.md` and presents a bounded configuration guide for Skill projection, Codex IAB/Pro readiness, GitHub Connector authorization, exact repository/ref selection, and Gitleaks-backed local bundle readiness; missing prerequisites stop before submission.
+- The protocol pins remote GitHub reads to an exact repository/ref/SHA, distinguishes remote GitHub facts from local worktree deltas, and requires secret-scanned local context before browser submission.
+- GPT Pro output is advisory only: it cannot mutate task state, claim/release/steal leases, widen `allowed_paths`, execute local commands, assert local checks, or authorize commit/push/PR/merge/deploy.
+- Proposal adoption rechecks current repo/task state and fails closed on stale or unverifiable inputs without introducing a new state authority, schema, receipt type, or runtime adapter.
+- One real Codex IAB canary records the exact prompt hash, visible Pro model, conversation URL, fixed remote SHA, GitHub MCP invocation evidence classification, local delta identity, same-conversation review, local checks, and final local acceptance outcome.
+- Focused canonical-package tests and root required checks pass.
+
+## Scope
+- `assets/skills/repo-harness-chatgpt/SKILL.md` routing and trigger text.
+- New `assets/skills/repo-harness-chatgpt/references/orchestrate.md` protocol.
+- `assets/skills/repo-harness-chatgpt/references/setup.md` orchestration-lane configuration guide; no parallel setup owner.
+- `tests/skill-surface/chatgpt-package.test.ts` reference-closure and protocol-boundary assertions.
+- `tests/trace-observer.test.ts` host-environment isolation for absent-host test cases.
+- `src/cli/chatgpt-skill/source.ts` canonical projection preflight closure for the new reference.
+- `docs/repo-harness-chatgpt-browser-engine.md` operator-facing orchestration guidance and evidence expectations.
+- Workflow artifacts required by the plan/contract/review lifecycle.
+- A real Codex IAB canary using ignored session/handoff evidence, with durable conclusions recorded only in the owning workflow notes/review if warranted.
+
+## Non-Scope
+- No `agents/fleet/gpt-pro-orchestrator.md` or new managed native agent.
+- No parallel `gpt-pro-orchestrator` Skill.
+- No `OrchestrationBindingV1`, `OrchestrationProposalV1`, `ExternalAdvisorReceiptV1`, fleet catalog, scheduler, or `ChatGPTWebRuntimeAdapter` implementation.
+- No changes to EffectiveState, lease semantics, Browser MCP schemas, browser engine runtime, secret scanner, or acceptance authority.
+- No automatic local agent spawning from GPT Pro advice.
+- No commit, push, PR, merge, deploy, package publication, or installed-runtime refresh.
+
+## Constraints
+- `repo-harness-chatgpt` remains the sole canonical ChatGPT rule owner.
+- Browser sessions and GPT Pro replies are evidence only; repository artifacts and EffectiveState remain authoritative.
+- The local coordinator must classify GitHub MCP use as `verified`, `bundle_only`, or `unverified` based on observable evidence; model self-report is insufficient.
+- Local dirty/untracked content must never be inferred from GitHub and must pass the existing exact-bundle secret-scan boundary before submission.
+- Absent requirements are forbidden design space; fail closed instead of adding compatibility or best-effort paths.
+
+## P1 Architecture Map
+The canonical router is `assets/skills/repo-harness-chatgpt/SKILL.md`; protocol modes live under its `references/` directory and `tests/skill-surface/chatgpt-package.test.ts` enforces a closed, fully routed reference set. `src/cli/chatgpt-browser/` and the Browser MCP tools provide transport/session capabilities but are out of scope for this protocol-only slice. `assets/skills/repo-harness-chatgpt/references/delegate.md` owns code-deliverable delegation; the new mode owns multi-turn advisory planning and review, not patch delivery. EffectiveState, contract allowed paths, leases, local commands, and acceptance remain outside the Skill as deterministic control-plane authority.
+
+## P2 Concrete Trace
+User authorizes GPT Pro orchestration -> local Codex resolves current repo/task state and exact remote SHA -> local delta is rendered through the existing secret-scanned prompt/bundle path -> Codex IAB submits the canonical prompt to a visible Pro conversation -> GPT Pro uses GitHub MCP when available and returns an advisory proposal -> local Codex classifies invocation evidence, checks the proposal against current scope/state, and dispatches only locally authorized work -> local implementation and real checks produce a diff/evidence bundle -> the same GPT Pro conversation reviews that exact result -> local gatekeeper and repo checks decide acceptance. The pressure point is the missing canonical mode protocol tying these already-existing steps together.
+
+## P3 Design Decision
+Extend the existing canonical Skill with one reference rather than create a fleet role or parallel Skill. This is the smallest coherent change because the missing behavior is orchestration policy, not a new execution runtime. The invariant is that external model advice never becomes task or acceptance authority. At 10x usage, browser-session drift and stale remote/local context are the first failures; exact SHA/local-delta identity and same-session continuity address that boundary without prematurely creating a scheduler or evidence schema.
+
+## Fragile Assumption
+The Codex built-in Browser exposes enough observable state to record a visible Pro model, conversation URL, completion state, attachment outcome, and GitHub MCP invocation classification without reading cookies, storage, or authentication material. The real canary must falsify this before the mode is accepted as operational.
+
+## Rejected Alternatives
+- A managed `agent-fleet` role is rejected because GPT Pro Web lacks native `spawn_agent`, `SubagentStart`, sandbox, lease, cancellation, and role-routing evidence.
+- A parallel Skill is rejected because it would create a second ChatGPT protocol authority.
+- New binding/receipt/runtime types are rejected until a real orchestration canary proves a concrete product gap that prose plus existing evidence surfaces cannot represent.
+
+## Public Interface Changes
+The explicit-setup-only `repo-harness-chatgpt` Skill gains a new `orchestrate` routing mode, operator protocol, and guided setup lane under the existing setup reference. No CLI, MCP, JSON schema, task contract, or runtime API changes.
+
+## External Dependencies
+No new package dependency or API key. The real canary requires an already signed-in ChatGPT Pro session and the user's existing GitHub Connector authorization; authentication remains user-owned.
+
+## Verification
+- `bun test tests/skill-surface/chatgpt-package.test.ts --timeout 60000`
+- Verify the canonical router links every reference and `references/` contains no undeclared files.
+- Execute one real Codex IAB orchestration canary and record exact evidence named in Success Criteria.
+- Run root required checks: `bun test --timeout 60000`, deploy SQL order, architecture sync, task sync, strict task workflow, project-state inspection, and init dry-run.
+
+## Rollback and Failure Handling
+Revert the router, new reference, focused tests, docs, and workflow artifacts as one work-package. If sign-in, Pro selection, GitHub MCP evidence, attachment, completion, or same-session continuation cannot be verified, stop the canary as blocked; do not switch transport, infer success, or broaden the protocol.
+
+## Phase Independence
+This work-package ends after the canonical orchestration protocol and one real E2E canary are accepted. Typed evidence bindings and a provider-neutral fleet runtime remain separate future work that requires observed need and its own design/verification boundary.
+
+## Task Breakdown
+- [x] Add the canonical `orchestrate` reference, router entry, explicit opt-in configuration guide, focused closure/boundary tests, and operator documentation.
+- [x] Run focused tests and correct only failures within the approved protocol surface.
+- [x] Execute and record one real Codex IAB end-to-end orchestration canary.
+- [x] Isolate absent-host trace-observer tests from ambient Codex host identity.
+- [ ] Run local acceptance review and all required repository checks; close workflow evidence.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->

--- a/src/cli/chatgpt-skill/source.ts
+++ b/src/cli/chatgpt-skill/source.ts
@@ -11,6 +11,7 @@ const REQUIRED_REFERENCES = [
   'read-back.md',
   'bridge.md',
   'delegate.md',
+  'orchestrate.md',
 ] as const;
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));

--- a/tasks/contracts/20260822-1240-gpt-pro-orchestrate-mode.contract.md
+++ b/tasks/contracts/20260822-1240-gpt-pro-orchestrate-mode.contract.md
@@ -1,0 +1,168 @@
+# Task Contract: gpt-pro-orchestrate-mode
+
+> **Status**: Fulfilled
+> **Plan**: plans/plan-20260822-1240-gpt-pro-orchestrate-mode.md
+> **Task Profile**: code-change
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: ancienttwo
+> **Capability ID**: root
+> **Last Updated**: 2026-08-22 12:40
+> **Review File**: `tasks/reviews/20260822-1240-gpt-pro-orchestrate-mode.review.md`
+> **Notes File**: `tasks/notes/20260822-1240-gpt-pro-orchestrate-mode.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+GPT Pro Browser already has consult, continuation, bridge, read-back, and delegate protocols, but no canonical mode owns the multi-turn loop where GPT Pro plans against an exact GitHub revision, local Codex implements against a possibly dirty worktree, and the same conversation reviews the result. Without that owner, each session can invent its own authority boundary, confuse remote GitHub state with local changes, or treat external advice as task/lease/acceptance authority.
+
+## Goal
+
+Add one `orchestrate` mode under the existing canonical `repo-harness-chatgpt` Skill, provide an explicit opt-in configuration guide through its existing setup mode, and prove it through a real Codex built-in-browser canary. GPT Pro remains an advisory external chief planner/reviewer; repo-harness and local Codex retain task, lease, execution, verification, and acceptance authority.
+
+## Scope
+
+- In scope: canonical Skill routing; one `references/orchestrate.md`; an orchestration setup lane in the existing `references/setup.md`; focused reference-closure and protocol assertions; operator documentation; one real Codex IAB planning-to-review canary; workflow evidence.
+- Out of scope: managed fleet roles, parallel Skills, EffectiveState/lease/acceptance changes, Browser MCP or engine changes, typed orchestration schemas/receipts, runtime adapters, automatic agent spawning, commit/push/PR/merge/deploy/publication.
+- Taste constraints: one ChatGPT protocol authority; external advice is evidence only; exact remote SHA and secret-scanned local delta stay distinct; stale or unverifiable inputs fail closed.
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+
+## Falsifier
+
+The direction is wrong if Codex IAB cannot expose enough observable state to record the visible Pro model, conversation URL, completion state, attachment outcome, and GitHub MCP invocation classification without inspecting authentication storage. The cheapest proof is the real canary before any typed binding or runtime-adapter work is authorized.
+
+## Root Cause Evidence
+
+Required when Task Profile is `bugfix`; leave as-is otherwise.
+
+- root_cause: one sentence naming file:line/condition (testable, not "a state issue").
+- repro: the command or UI path that reproduces the symptom.
+- regression_guard: path to a test that fails on the unfixed code and passes after the fix (must also appear under exit_criteria.tests_pass).
+- pre_fix_failure_artifact: path to a captured run of regression_guard on the UNFIXED code. Capture with `bun test <regression_guard> > <artifact> 2>&1; echo "PRE_FIX_EXIT=$?" >> <artifact>` (no pipes — pipes swallow the exit status). The gate requires a non-zero `PRE_FIX_EXIT=` line plus the regression_guard path string in the artifact (see the Root Cause Evidence Gate section in docs/reference-configs/sprint-contracts.md).
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260822-1240-gpt-pro-orchestrate-mode.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260822-1240-gpt-pro-orchestrate-mode.review.md`
+- Notes file: `tasks/notes/20260822-1240-gpt-pro-orchestrate-mode.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Change Assessment
+
+```json
+{"protocol":1,"oracles":[]}
+```
+
+## Acceptance Policy
+
+```json
+{"protocol":1,"reviewer":"Claude","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - plans/
+  - tasks/todos.md
+  - tasks/contracts/20260822-1240-gpt-pro-orchestrate-mode.contract.md
+  - tasks/reviews/20260822-1240-gpt-pro-orchestrate-mode.review.md
+  - tasks/notes/20260822-1240-gpt-pro-orchestrate-mode.notes.md
+  - assets/skills/repo-harness-chatgpt/SKILL.md
+  - assets/skills/repo-harness-chatgpt/references/setup.md
+  - assets/skills/repo-harness-chatgpt/references/orchestrate.md
+  - src/cli/chatgpt-skill/source.ts
+  - tests/skill-surface/chatgpt-package.test.ts
+  - tests/trace-observer.test.ts
+  - docs/repo-harness-chatgpt-browser-engine.md
+  - .ai/harness/handoff/gptpro/
+  - .ai/harness/runs/
+  - .ai/harness/checks/
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+    fallback: null
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - assets/skills/repo-harness-chatgpt/SKILL.md
+    - assets/skills/repo-harness-chatgpt/references/setup.md
+    - assets/skills/repo-harness-chatgpt/references/orchestrate.md
+    - src/cli/chatgpt-skill/source.ts
+    - tests/skill-surface/chatgpt-package.test.ts
+    - tests/trace-observer.test.ts
+    - docs/repo-harness-chatgpt-browser-engine.md
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260822-1240-gpt-pro-orchestrate-mode.notes.md
+  tests_pass:
+    - path: tests/skill-surface/chatgpt-package.test.ts
+    - path: tests/trace-observer.test.ts
+  commands_succeed:
+    - bun test --timeout 60000
+    - bash scripts/check-deploy-sql-order.sh
+    - bash scripts/check-architecture-sync.sh
+    - bash scripts/check-task-sync.sh
+    - repo-harness run check-task-workflow --strict
+    - bun scripts/inspect-project-state.ts --repo . --format text
+    - bun src/cli/index.ts init --repo . --dry-run
+```
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior: explicit enablement first produces a bounded setup guide through the canonical setup reference; canonical routing then reaches one orchestration protocol; remote/local truth and advisory/control authority remain explicit; same-conversation review is required.
+- Edge cases: missing sign-in, unavailable Pro model, absent GitHub MCP evidence, stale remote SHA or local delta, blocked attachment, incomplete generation, and continuation failure all stop without transport switching or inferred success.
+- Regression risks: expanding the closed reference set can drift installed projections or router size; focused package tests and full required checks cover those surfaces.
+
+## Rollback Point
+
+- Commit / checkpoint: `a7598ec0bced4fedce28ef73c4ab68d87474ffe1` on branch `codex/gpt-pro-orchestrate-mode` before implementation.
+- Revert strategy: revert the router, new reference, focused tests, operator documentation, and workflow artifacts together; no schema or runtime migration requires data recovery.

--- a/tasks/notes/20260822-1240-gpt-pro-orchestrate-mode.notes.md
+++ b/tasks/notes/20260822-1240-gpt-pro-orchestrate-mode.notes.md
@@ -1,0 +1,62 @@
+# Implementation Notes: gpt-pro-orchestrate-mode
+
+> **Status**: Active
+> **Plan**: plans/plan-20260822-1240-gpt-pro-orchestrate-mode.md
+> **Contract**: tasks/contracts/20260822-1240-gpt-pro-orchestrate-mode.contract.md
+> **Review**: tasks/reviews/20260822-1240-gpt-pro-orchestrate-mode.review.md
+> **Last Updated**: 2026-08-22 12:40
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- Extend `repo-harness-chatgpt` with a routed mode instead of creating a managed fleet role or parallel Skill; the missing boundary is orchestration policy, not an executable runtime.
+- Keep the first slice protocol-only. Typed bindings, receipts, and runtime adapters require a concrete gap observed in the real IAB canary.
+- Reuse `references/setup.md` for the user-facing enablement guide. `orchestrate.md` declares readiness requirements and routes missing prerequisites there instead of duplicating commands or authentication rules.
+- Treat a pushed-branch code audit and an unpublished-worktree review as distinct evidence classes. The former requires a visible GitHub Connector read of the exact branch-head SHA; the latter is labeled `local-bundle review` and binds the remote base SHA to a secret-scanned local delta.
+
+## Deviations From Plan Or Spec
+
+- The first GPT Pro review reused visible GitHub evidence from the planning turn and hashed only the implementation diff. Local gatekeeping rejected that as insufficient for the final canary. The corrected round included a canonical untracked manifest, complete untracked content, aggregate local-delta identity, and a fresh visible GitHub Connector `fetch_commit` call.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| `agents/fleet/gpt-pro-orchestrator.md` | Reject | GPT Pro Web lacks native child-agent identity, sandbox, lease, cancellation, and SubagentStart evidence. |
+| Parallel `gpt-pro-orchestrator` Skill | Reject | It would create a second ChatGPT protocol authority. |
+| `repo-harness-chatgpt/references/orchestrate.md` | Use | It preserves the existing canonical router and isolates task-level protocol from transport implementation. |
+
+## Open Questions
+
+- None. The user approved widening this work-package to isolate the two absent-host `trace-observer` cases from ambient Codex host identity.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Focused test: `bun test tests/skill-surface/chatgpt-package.test.ts --timeout 60000` — 17 pass, 0 fail, 104 assertions.
+- Canary conversation: `https://chatgpt.com/c/6a892327-046c-83e8-a4d9-552ff8729929`; visible model label `Pro`; the planning turn exposes five visible `Called tool` entries and binds remote `origin/main` to `63f0ba11017e2edf9076eeb829fa6104943bdd12`.
+- Review dry-run session: `chgpt_20260822_125420_gpt-pro-orchestrate-canary-review`; Gitleaks 8.30.1 passed; exact prompt SHA-256 `7c0201eb770bf701d87da436c3c2d5706332d25a9ba26204db64b49dfb7e4d82`; implementation diff SHA-256 `2889d6c8d8145b3a2e26608ead1ff6222566c1d83929cd19c901b16ec47ee958`.
+- IAB file chooser did not emit a chooser event through the documented upload path. No prompt was submitted on those attempts and no transport fallback was used; after explicit user approval, the same exact scanned prompt was pasted into the existing conversation.
+- After explicit user approval, Codex IAB submitted the exact scanned prompt into the same conversation. ChatGPT represented the long prompt as a `# Task` attachment, kept the visible `Pro` model, completed after 4m26s, and returned the exact `===END OF ORCHESTRATION REVIEW===` sentinel.
+- GPT Pro verdict: `PASS`; GitHub MCP evidence: `verified`; findings: none. The review explicitly remained advisory and required local gatekeeper verification. Raw reply: `.ai/harness/handoff/gptpro/gpt-pro-orchestrate-gpt-review.md`.
+- Corrected review dry-run session: `chgpt_20260822_133325_gpt-pro-orchestrate-final-review`; Gitleaks 8.30.1 passed; exact prompt SHA-256 `f23c3cfaf596d5912f6b294a1b4f60cf240d0a8d488e1737e9bd8da2cb2d9fc5`.
+- Corrected local subject: tracked diff SHA-256 `4dbdfe113b750d7fb903b33278a5d9a70bb8cddb16cb986017a60a1613b8c488`; canonical untracked-manifest SHA-256 `3a4ddfaad2182bcfd76413ba1c4dd28c82ed65b49f472e0d3cd2fdd773149af9`; `orchestrate.md` SHA-256 `94703f1aec369fb574764750ffd4bc7638a1272756152fb9d514319b218708af`; aggregate local-delta SHA-256 `8150bdf73186b9fee915fc78b2184382d2fea8bf7ec9d22ef133ec885ba4e032` over exact tracked-diff bytes followed by exact manifest bytes.
+- In the corrected same-conversation review, the visible Pro turn invoked GitHub Connector `fetch_commit` and returned `Ancienttwo/repo-harness@63f0ba11017e2edf9076eeb829fa6104943bdd12`. GPT Pro verdict: `PASS`; evidence: `verified`; review kind: `local-bundle review`; findings: none. Raw distilled reply: `.ai/harness/handoff/gptpro/gpt-pro-orchestrate-final-gpt-review.md`; parent-observed IAB tool activity: `.ai/harness/handoff/gptpro/gpt-pro-orchestrate-final-iab-observation.md`.
+- Root required checks other than the full suite passed after installing dependencies from the frozen lockfile. The ambient-host full suite produced 2827 pass, 2 skip, 2 fail only because Codex injected `CODEX_SESSION_ID`/host variables into tests that intentionally exercise absent-host defaults; the same `tests/trace-observer.test.ts` passed 9/9 with host variables cleared. No single full-suite invocation exited zero, so acceptance remains blocked.
+- Final strict contract verification recorded `17/18` criteria passing and `Partial`; the sole failure was the same contract-exact full suite (`2827 pass`, `2 skip`, `2 fail`). Retained log: `.ai/harness/runs/run-20260822T135919-18254-bun-test-timeout-60000.log`.
+- After user-approved scope widening, the three `runTraceObserver` calls in the two absent-host cases now pass `env: {}` explicitly. The focused trace-observer and ChatGPT package run passed 26/26, and the contract-exact ambient-host full suite passed `2829 pass`, `2 skip`, `0 fail` in 857.32s.
+- The remaining root checks all exited zero after the isolation correction: deploy SQL order, architecture sync, task sync, strict task workflow, project-state inspection, and init dry-run.
+- The frozen Claude reviewer found one P1 (duplicate `Task Breakdown`) and five P2 findings. The reviewed subject was corrected by retaining one plan task authority, keeping review lifecycle state nonterminal until a typed receipt exists, making the `verified` marker assertion exclusive, freezing `local.delta` byte framing, standardizing `bundle_only`, and isolating every trace-observer test invocation from ambient env unless it supplies an explicit test env.
+- The corrected focused tests passed 26/26. Contract-exact verification then passed the full suite with 2829 pass, 2 skip, 0 fail; its only failure was architecture sync after the first acceptance-freeze attempt dead-lettered because this manually opened worktree lacked the primary checkout's opted-in CodeGraph index.
+- `codegraph init` indexed 547 files (11,042 nodes and 44,401 edges). The official `architecture-projection retry-dead-letter` plus two drains converged from a manifest restamp to `noop`; the queue finished with one receipt and zero pending/running/dead-letter jobs, and strict architecture sync passed.
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/reviews/20260822-1240-gpt-pro-orchestrate-mode.review.md
+++ b/tasks/reviews/20260822-1240-gpt-pro-orchestrate-mode.review.md
@@ -1,0 +1,87 @@
+# Task Review: gpt-pro-orchestrate-mode
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260822-1240-gpt-pro-orchestrate-mode.md
+> **Contract**: tasks/contracts/20260822-1240-gpt-pro-orchestrate-mode.contract.md
+> **Notes File**: tasks/notes/20260822-1240-gpt-pro-orchestrate-mode.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-08-22 12:40
+> **Recommendation**: pending
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending — implementation and verification evidence are recorded, but the typed AcceptanceReceipt is not available.
+- Change type: code-change
+- Intended files changed: canonical ChatGPT Skill router/setup/protocol, projection preflight, focused package test, operator documentation, and owning workflow artifacts.
+- Actual files changed: intended scope only; no fleet role, parallel Skill, runtime adapter, dependency, schema, commit, or publication action.
+- Commands passed: focused trace-observer plus package tests (26/26), full suite (2829 pass, 2 skip, 0 fail), deploy SQL, architecture sync, task sync, strict workflow, project-state inspection, init dry-run, and `git diff --check`.
+- Residual risks: exact `local.delta` byte framing remains canary-defined; IAB tool activity is parent-observed rather than a captured Connector transcript; marker assertions do not prove absence of all future contradictory prose.
+- Reviewer action required: record the typed AcceptanceReceipt required by the frozen Claude acceptance policy.
+- Rollback: revert this work-package's Skill, preflight, tests, docs, and workflow artifacts together.
+
+## Mode Evidence
+
+- Selected route: planning -> delegated implementation -> GPT Pro advisory review -> local gatekeeper.
+- P1/P2/P3 evidence: canonical Skill remains the single protocol owner; exact remote SHA plus scanned local bundle flows through same-conversation review; external advice remains outside local control-plane authority.
+- Root cause or plan evidence: `plans/plan-20260822-1240-gpt-pro-orchestrate-mode.md` and implementation notes.
+
+## Verification Evidence
+
+- Waza `/check`-style run: gatekeeper final verdict PASS after the user-approved host-environment test isolation correction.
+- Commands run: root Required Checks plus focused package test, isolated trace-observer retest, Gitleaks dry-run, and diff/hash checks.
+- Manual checks: same Codex IAB conversation, visible Pro model, fresh visible GitHub Connector activity, exact repo/SHA binding, termination sentinel.
+- Supporting artifacts: `.ai/harness/handoff/gptpro/` ignored canary evidence.
+- Implementation notes reviewed: yes.
+- Run snapshot: `.ai/harness/runs/run-20260822T191239-76181-20260822-1240-gpt-pro-orchestrate-mode.json` — final `verify-sprint` and strict read-only `verify-contract` both passed with exit code 0; the
+  `acceptance_receipt` guard remains pending.
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- Explicitly enabled orchestration now routes through the canonical setup guide and one advisory protocol.
+- Missing `orchestrate.md` blocks canonical Skill projection preflight.
+- Pushed-branch audits require a visible exact-head GitHub read; unpublished worktrees are labeled `local-bundle review` and require a secret-scanned tracked diff plus untracked manifest.
+
+## Residual Risks / Follow-ups
+
+- Typed AcceptanceReceipt remains pending under the frozen Claude acceptance policy; this Markdown review is only its projection surface.
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 10/10 | Focused behavior, real IAB canary, and full-suite gate pass. |
+| Product depth | 9/10 | Explicit setup, authority, remote/local, and review boundaries are complete for a protocol slice. |
+| Design quality | 9/10 | Extends the single canonical Skill without runtime or fleet abstraction drift. |
+| Code quality | 10/10 | Minimal source change plus explicit test-environment isolation and green full-suite coverage. |
+
+## Failing Items
+
+- None in implementation or repository verification. Typed acceptance remains a separate workflow authority.
+
+## Retest Steps
+
+- Re-run: `bun test --timeout 60000` and the two focused test files if the reviewed subject changes.
+- Complete: record the typed AcceptanceReceipt against the frozen reviewed subject and verification evidence.
+
+## Summary
+
+- GPT Pro advisory review PASS, local gatekeeper PASS, and all repository checks pass. Final workflow closure now depends only on the frozen typed AcceptanceReceipt authority.

--- a/tests/skill-surface/chatgpt-package.test.ts
+++ b/tests/skill-surface/chatgpt-package.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync } from "fs";
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import {
@@ -13,6 +13,7 @@ import {
   SKILL_SURFACE_PROFILES,
 } from "../../src/core/skill-surface/catalog";
 import { PROFILE_COMPONENTS } from "../../src/cli/installer/install-profile";
+import { validateCanonicalChatgptSkillRoot } from "../../src/cli/chatgpt-skill/source";
 import { runMcpInstallSkill } from "../../src/cli/mcp/setup";
 import { assertChatGptMcpContract } from "../helpers/chatgpt-mcp-contract";
 
@@ -33,14 +34,21 @@ const PACKAGE_DIR = "repo-harness-chatgpt";
 const SKILLS_ROOT = join(ROOT, "assets", "skills");
 const PACKAGE_ROOT = join(SKILLS_ROOT, PACKAGE_DIR);
 const MANIFEST_PATH = join(ROOT, "assets", "skill-commands", "manifest.json");
-// Raised from 2048 when the 6th mode (delegate, references/delegate.md) added
-// one Mode Selection line, one when_to_use trigger clause, and one Boundaries
-// note to the router body (chatgpt-delegate-mode). Kept as a small, deliberate
-// step rather than a round jump so the router stays a compact link list, not
-// a place to inline protocol.
+// Raised from 2048 when the 6th mode (delegate, references/delegate.md) and
+// the 7th mode (orchestrate, references/orchestrate.md) added routing and
+// boundary clauses. Kept as a small, deliberate step rather than a round jump
+// so the router stays a compact link list, not a place to inline protocol.
 const ROUTER_BODY_BYTE_LIMIT = 2560;
 
-const REFERENCES = ["setup.md", "consult.md", "continue.md", "read-back.md", "bridge.md", "delegate.md"] as const;
+const REFERENCES = [
+  "setup.md",
+  "consult.md",
+  "continue.md",
+  "read-back.md",
+  "bridge.md",
+  "delegate.md",
+  "orchestrate.md",
+] as const;
 
 function readSkill(): string {
   return readFileSync(join(PACKAGE_ROOT, "SKILL.md"), "utf-8");
@@ -48,6 +56,10 @@ function readSkill(): string {
 
 function frontmatterOf(body: string): string {
   return body.match(/^---\n([\s\S]*?)\n---/)?.[1] ?? "";
+}
+
+function normalizeMarkdownWhitespace(body: string): string {
+  return body.replace(/\s+/gu, " ").trim();
 }
 
 describe("repo-harness-chatgpt canonical package: router frontmatter and size", () => {
@@ -98,6 +110,31 @@ describe("repo-harness-chatgpt canonical package: every reference is reachable",
   });
 });
 
+describe("repo-harness-chatgpt canonical package: installer preflight", () => {
+  test("installer preflight fails closed when orchestrate.md is absent", () => {
+    const sourceRoot = mkdtempSync(join(tmpdir(), "repo-harness-chatgpt-preflight-"));
+    const packageRoot = join(sourceRoot, "assets", "skills", PACKAGE_DIR);
+    const referencesRoot = join(packageRoot, "references");
+    mkdirSync(referencesRoot, { recursive: true });
+    copyFileSync(join(PACKAGE_ROOT, "SKILL.md"), join(packageRoot, "SKILL.md"));
+    for (const reference of REFERENCES) {
+      if (reference === "orchestrate.md") continue;
+      copyFileSync(join(PACKAGE_ROOT, "references", reference), join(referencesRoot, reference));
+    }
+
+    const previousSourceRoot = process.env.REPO_HARNESS_SOURCE_ROOT;
+    process.env.REPO_HARNESS_SOURCE_ROOT = sourceRoot;
+    try {
+      expect(() => validateCanonicalChatgptSkillRoot()).toThrow(/orchestrate\.md/);
+    } finally {
+      if (previousSourceRoot === undefined) delete process.env.REPO_HARNESS_SOURCE_ROOT;
+      else process.env.REPO_HARNESS_SOURCE_ROOT = previousSourceRoot;
+      rmSync(sourceRoot, { recursive: true, force: true });
+    }
+  });
+
+});
+
 describe("repo-harness-chatgpt canonical package: read-back.md is bound to the code/test Connector-invocation contract", () => {
   // SSD-04/05 wave-acceptance intake finding (carried to SSD-06, MEDIUM
   // safe_auto): read-back.md is the declared single source of the Connector
@@ -107,6 +144,71 @@ describe("repo-harness-chatgpt canonical package: read-back.md is bound to the c
   test("assertChatGptMcpContract accepts read-back.md's Connector Invocation Evidence content", () => {
     const readBack = readFileSync(join(PACKAGE_ROOT, "references", "read-back.md"), "utf-8");
     assertChatGptMcpContract(readBack);
+  });
+});
+
+describe("repo-harness-chatgpt canonical package: orchestrate mode is advisory and explicitly enabled", () => {
+  const orchestrate = readFileSync(join(PACKAGE_ROOT, "references", "orchestrate.md"), "utf-8");
+  const setup = readFileSync(join(PACKAGE_ROOT, "references", "setup.md"), "utf-8");
+  const semanticOrchestrate = normalizeMarkdownWhitespace(orchestrate);
+  const semanticSetup = normalizeMarkdownWhitespace(setup);
+
+  test("orchestrate.md binds remote SHA, local delta, MCP evidence, and same-conversation review", () => {
+    for (const marker of [
+      "explicitly enabled",
+      "remote.sha",
+      "local.delta",
+      "bundle_only",
+      "unverified",
+      "browser-followup",
+      "same conversation",
+      "--secret-scan",
+      "canonical JSON array",
+      "tracked-diff hash alone is insufficient",
+      "read the pushed branch head at its exact commit SHA",
+      "local-bundle review",
+    ]) {
+      expect(semanticOrchestrate).toContain(marker);
+    }
+    expect(semanticOrchestrate).toMatch(/(?:^|\s)- `verified`:/);
+    expect(semanticOrchestrate).not.toContain("bundle-only");
+    for (const marker of [
+      "compact UTF-8 JSON",
+      "no BOM",
+      "exact tracked",
+      "sha256(trackedDiffBytes || manifestBytes)",
+      "no delimiter",
+      "manifest's final LF",
+      "both staged and unstaged changes",
+      "raw stdout bytes",
+    ]) {
+      expect(semanticOrchestrate).toContain(marker);
+    }
+  });
+
+  test("orchestrate.md keeps GPT Pro outside local control-plane authority", () => {
+    for (const marker of [
+      "claim/release/steal a lease",
+      "authorize commit/push/PR/merge/deploy",
+      "Do not automatically spawn",
+      "it cannot approve the",
+      "Never turn GPT Pro's plan or",
+    ]) {
+      expect(semanticOrchestrate).toContain(marker);
+    }
+  });
+
+  test("setup.md provides a bounded explicit orchestration configuration guide", () => {
+    for (const marker of [
+      "Advisory Orchestration Enablement (Explicit Opt-In)",
+      "browser-doctor --repo <repo> --provider oracle --json",
+      "GitHub Connector",
+      "repo-harness mcp doctor --repo <repo> --json",
+      "--dry-run --secret-scan",
+      "references/orchestrate.md",
+    ]) {
+      expect(semanticSetup).toContain(marker);
+    }
   });
 });
 

--- a/tests/trace-observer.test.ts
+++ b/tests/trace-observer.test.ts
@@ -75,6 +75,7 @@ describe('runTraceObserver', () => {
       const result = runTraceObserver({
         repoRoot,
         input: JSON.stringify({ hook_event_name: 'PostToolUse', tool_name: 'mcp__codegraph__context', session_id: 'codex-session' }),
+        env: {},
         dependencies: {
           runGit: () => ' M plans/plan-20260721-1200-example.md\n',
           now: () => new Date('2026-07-21T12:34:56.000Z'),
@@ -87,6 +88,7 @@ describe('runTraceObserver', () => {
       const annotation = runTraceObserver({
         repoRoot,
         input: JSON.stringify({ hook_event_name: 'PostToolUse', tool_name: 'apply_patch', session_id: 'codex-session' }),
+        env: {},
         dependencies: { runGit: () => ' M plans/plan-20260721-1200-example.md\n' },
       });
       expect(annotation.exitCode).toBe(0);
@@ -104,6 +106,7 @@ describe('runTraceObserver', () => {
       const first = runTraceObserver({
         repoRoot,
         input: JSON.stringify({ hook_event_name: 'PostToolUse', tool_name: 'Read' }),
+        env: {},
         dependencies: { now: () => new Date('2026-07-21T12:34:56.000Z') },
       });
       expect(first).toMatchObject({ exitCode: 0, reason: 'ok', stdout: '', stderr: '' });
@@ -114,6 +117,7 @@ describe('runTraceObserver', () => {
       const second = runTraceObserver({
         repoRoot,
         input: JSON.stringify({ hook_event_name: 'PostToolUse', tool_name: 'Read' }),
+        env: {},
         dependencies: { now: () => new Date('2026-07-21T12:35:56.000Z') },
       });
       expect(second.exitCode).toBe(0);
@@ -170,6 +174,7 @@ describe('runTraceObserver', () => {
           session_id: 'external-session',
           source: 'other-host',
         }),
+        env: {},
       });
       expect(result.exitCode).toBe(0);
       expect(traceRecords(repoRoot)[0]).toMatchObject({
@@ -191,6 +196,7 @@ describe('runTraceObserver', () => {
       const ordinary = runTraceObserver({
         repoRoot,
         input: JSON.stringify({ hook_event_name: 'PostToolUse', tool_name: 'Read', session_id: 'session ordinary' }),
+        env: {},
         dependencies: { runGit: (args) => { gitCalls.push([...args]); return ''; } },
       });
       expect(ordinary.exitCode).toBe(0);
@@ -199,6 +205,7 @@ describe('runTraceObserver', () => {
       const codegraph = runTraceObserver({
         repoRoot,
         input: JSON.stringify({ hook_event_name: 'PostToolUse', tool_name: 'mcp__codegraph__context', session_id: 'session/ordinary' }),
+        env: {},
       });
       expect(codegraph.exitCode).toBe(0);
       expect(existsSync(join(repoRoot, '.claude/.codegraph-state/session_ordinary.used'))).toBe(true);
@@ -218,6 +225,7 @@ describe('runTraceObserver', () => {
       const result = runTraceObserver({
         repoRoot,
         input: JSON.stringify({ hook_event_name: 'PostToolUse', tool_name: 'Read', session_id: 'rotation-session' }),
+        env: {},
       });
       expect(result.exitCode).toBe(0);
       const lines = readFileSync(join(repoRoot, '.claude/.trace.jsonl'), 'utf8').trim().split('\n');
@@ -235,6 +243,7 @@ describe('runTraceObserver', () => {
       const result = runTraceObserver({
         repoRoot,
         input: JSON.stringify({ hook_event_name: 'PostToolUse', tool_name: 'apply_patch', session_id: 'session-git-error' }),
+        env: {},
         dependencies: { runGit: () => { throw new Error('git unavailable'); } },
       });
       expect(result).toMatchObject({ exitCode: 0, stdout: '', stderr: '', reason: 'ok' });
@@ -250,6 +259,7 @@ describe('runTraceObserver', () => {
       const malformed = runTraceObserver({
         repoRoot,
         input: 'not json',
+        env: {},
         dependencies: { now: () => new Date('2026-07-21T12:34:56.000Z') },
       });
       expect(malformed.exitCode).toBe(0);
@@ -268,6 +278,7 @@ describe('runTraceObserver', () => {
       const failed = runTraceObserver({
         repoRoot,
         input: JSON.stringify({ hook_event_name: 'PostToolUse', tool_name: 'Read' }),
+        env: {},
         dependencies: { fs: fsApi },
       });
       expect(failed.exitCode).toBe(1);


### PR DESCRIPTION
## Summary
- add an explicit GPT Pro advisory orchestration mode to the canonical repo-harness-chatgpt Skill
- require exact GitHub repository/ref/SHA binding, secret-scanned local delta evidence, and same-conversation review
- keep local task, lease, execution, verification, and merge authority in repo-harness/Codex
- add bounded setup guidance, projection preflight, operator docs, and focused contract tests

## Verification
- focused tests: 26 passed
- latest full suite: passed (2829 passed, 2 skipped, 0 failed)
- root checks: 19/20 passed in the final run; the sole failure was task-sync observing the automatically materialized architecture manifest before its restamp commit
- post-restamp task-sync: passed
- GPT Pro same-conversation GitHub Connector review: PASS
- local gatekeeper: PASS

## Review notes
- Claude review reported no P0/P1 findings
- two non-blocking P2 portability risks remain documented for untracked-path ordering/symlink semantics and Git content-filter/EOL effects on tracked diff bytes