### PR TITLE
chore: prepare repo-harness 0.17.0

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -467,8 +467,8 @@ repositorio adopte la misma política.
 
 ## Versión actual
 
-- Paquete npm: `repo-harness@0.16.2`
-- Sello de workflow generado: `repo-harness@0.16.2+template@0.16.2`
+- Paquete npm: `repo-harness@0.17.0`
+- Sello de workflow generado: `repo-harness@0.17.0+template@0.17.0`
 - Repositorio de GitHub: `Ancienttwo/repo-harness`
 - Notas de versión e historial: [`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -462,8 +462,8 @@ adopte la même policy.
 
 ## Release actuelle
 
-- Package npm : `repo-harness@0.16.2`
-- Generated workflow stamp : `repo-harness@0.16.2+template@0.16.2`
+- Package npm : `repo-harness@0.17.0`
+- Generated workflow stamp : `repo-harness@0.17.0+template@0.17.0`
 - Dépôt GitHub : `Ancienttwo/repo-harness`
 - Notes et historique de release : [`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -470,8 +470,8 @@ commit script や hooks に組み込まないでください。
 
 ## 現在の Release
 
-- npm package：`repo-harness@0.16.2`
-- Generated workflow stamp：`repo-harness@0.16.2+template@0.16.2`
+- npm package：`repo-harness@0.17.0`
+- Generated workflow stamp：`repo-harness@0.17.0+template@0.17.0`
 - GitHub repository：`Ancienttwo/repo-harness`
 - Release notes and history：[`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -450,8 +450,8 @@ repo-harness commit scripts or hooks unless that repo adopts the same policy.
 
 ## Current Release
 
-- npm package: `repo-harness@0.16.2`
-- Generated workflow stamp: `repo-harness@0.16.2+template@0.16.2`
+- npm package: `repo-harness@0.17.0`
+- Generated workflow stamp: `repo-harness@0.17.0+template@0.17.0`
 - GitHub repository: `Ancienttwo/repo-harness`
 - Release notes and history: [`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -457,8 +457,8 @@ policy。
 
 ## 当前 Release
 
-- npm package：`repo-harness@0.16.2`
-- Generated workflow stamp：`repo-harness@0.16.2+template@0.16.2`
+- npm package：`repo-harness@0.17.0`
+- Generated workflow stamp：`repo-harness@0.17.0+template@0.17.0`
 - GitHub repository：`Ancienttwo/repo-harness`
 - Release notes 和 history：[`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/assets/skill-version.json
+++ b/assets/skill-version.json
@@ -1,11 +1,11 @@
 {
-  "version": "0.16.2",
-  "templateVersion": "0.16.2",
+  "version": "0.17.0",
+  "templateVersion": "0.17.0",
   "skillName": "repo-harness",
   "contractId": "tasks-first-harness-v1",
   "compatibility": {
     "minClaudeCodeVersion": "1.0.0",
-    "minBunVersion": "1.0.0"
+    "minBunVersion": "1.4.0"
   },
   "breakingChanges": [
     {
@@ -263,6 +263,10 @@
     {
       "version": "0.16.2",
       "description": "Fixes MCP runtime issues from #204, binds MCP HTTP sessions to the startup profile with fail-closed config-flip handling, publishes the architecture queue lock owner record atomically via staged hard-link creation, requires and fail-closed-validates sandbox_mode in Codex custom-agent TOMLs with EXECUTION_BOUNDARY persona de-duplication, and adds artifact-hygiene rules (final-diff-only comments and PR text) to the global working rules and generated agent contracts"
+    },
+    {
+      "version": "0.17.0",
+      "description": "Adds the Git-backed Fleet control plane: immutable PublicationReceiptV1 identity and recovery, Lease protocol 2 reviewing/reopen/takeover lifecycle, fenced merge readiness and integration reconcile, deterministic cross-repo offers/acquire and FleetBoardSnapshotV1/watch, immutable provider feedback and task inbox delivery, GPT Pro advisory orchestration, Fleet MCP mirrors, and a Bun 1.4 runtime floor"
     }
   ],
   "generatedProjectStamp": {

--- a/deploy/release-checklists/260823-repo-harness-0.17.0.md
+++ b/deploy/release-checklists/260823-repo-harness-0.17.0.md
@@ -1,0 +1,90 @@
+# repo-harness 0.17.0 Release Filing
+
+- Date: 2026-08-23
+- Package: `repo-harness@0.17.0`
+- Base release: `v0.16.2` (`ba2babbbdb09`)
+- Product source range: `v0.16.2..1fce23bf8f88` (54 commits)
+- Release-prep branch: `codex/release-0-17-0`
+- Candidate commit: bound by the release PR Head after the metadata commit
+- Release scope: minor. The range adds consumer-visible Fleet,
+  Publication, Feedback, Task Inbox, GPT Pro advisory orchestration, and MCP
+  contracts plus a Bun 1.4 runtime floor.
+- Publish status: **candidate preparation**. npm publish, tag creation, GitHub
+  Release, merge to `main`, and installed-runtime refresh have not occurred.
+
+## Release Content
+
+### Publication and review lifecycle
+
+- Deterministic immutable `PublicationReceiptV1` with reconstructible PR marker
+  and git-common-dir cache.
+- Lease protocol 2 `reviewing` lifecycle with current-publication pointer,
+  same-owner reopen, takeover through reserving/bind, abandon, and raw-steal
+  protection.
+- Crash recovery and provider-target integration reconcile for merged,
+  ancestor, absorbed, and closed-unmerged outcomes.
+- Fenced `MergeReadinessV1` on exact PR Head/base, provider facts, local
+  evidence, current publication, and Lease generation.
+
+### Fleet coordination and communication
+
+- Deterministic cross-repo `FleetOffersV1` and `fleet acquire` returning a
+  fully bound `WorkEnvelopeV1`.
+- `FleetBoardSnapshotV1` and non-overlapping JSONL watch projection with
+  repository health, readiness, feedback, inbox, and attention ownership.
+- Immutable provider feedback events, separate delivery receipts, repair
+  redispatch, and same-token no-progress escalation.
+- Immutable task/claim messages with turn-boundary delivery and supersession.
+- Coding MCP mirrors for Fleet offer/acquire and publication
+  readiness/reopen/takeover.
+
+### Agent and runtime behavior
+
+- GPT Pro browser orchestration is a commit-bound advisory planner/reviewer;
+  local Codex retains mutation and acceptance authority.
+- Contract worktrees resolve package-owned helper and test-runner dependencies.
+- Bun `>=1.4.0` is required across package and installer/runtime checks.
+- Fleet acquire workflow markers remain confined to the execution worktree.
+
+## Semantic Version Decision
+
+`0.17.0` is required rather than `0.16.3`. The previous patch filing justified
+`0.16.2` by the absence of new consumer-visible CLI verbs. This range adds
+multiple public commands, versioned JSON contracts, MCP tools, and Lease
+protocol behavior. A patch number would contradict the repository's release
+policy and understate the integration surface presented to users.
+
+## Authority Boundary
+
+- This candidate changes release metadata and workflow evidence only; product
+  implementation is the already accepted source range on `main`.
+- npm `latest`, tag `v0.17.0`, GitHub Release, tarball metadata, source commit,
+  version files, and installed runtime must eventually resolve to one immutable
+  release.
+- Registry publication, tag creation, GitHub Release, merge, and global runtime
+  mutation require a separate explicit authorization after the candidate PR is
+  reviewed and green.
+
+## Candidate Gate Evidence
+
+| Gate | Candidate result |
+| --- | --- |
+| `npm view repo-harness@0.17.0` unpublished proof | pass through `check:release` |
+| `bun run check:type` | pass |
+| `bun test --timeout 60000` | pass: 2990 passed, 2 skipped, 0 failed |
+| repository required checks | pass |
+| `bun run check:release` | pass |
+| tarball install smoke | pass: packed `repo-harness-0.17.0.tgz` installs and packaged CLI bins start |
+| GitHub Required/CI on release PR | pending |
+
+## Publish Follow-through (post-merge, separately authorized)
+
+1. Merge the reviewed release PR into `main`.
+2. Re-run `bun run check:release` at the exact merged commit.
+3. Publish `repo-harness@0.17.0` to npm.
+4. Create tag `v0.17.0` at the same merged commit and publish the GitHub
+   Release from the `0.17.0` Changelog section.
+5. Run `bun run check:release-published` to bind registry metadata, dist-tag,
+   tarball integrity, tag, installed CLI, and installed hook runtime.
+6. Refresh the selected Bun-global runtime and drain architecture projection
+   acceptance after refresh.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,93 @@
 
 All notable changes to this skill are documented here.
 
+## [0.17.0] - 2026-08-23
+
+### Added
+
+- **Git-backed publication identity and recovery.** Successful PR publication
+  now produces a deterministic immutable `PublicationReceiptV1` that binds the
+  canonical task revision, claim/generation, verified candidate, provider repo,
+  PR, and exact Head SHA. A bounded PR marker carries the complete canonical
+  receipt for cross-clone rebuild, while the git-common-dir copy remains a
+  local recovery cache. Ship retries converge on the same publication ID;
+  incomplete receipt/marker writes return typed `publication_incomplete`
+  failures instead of reporting success.
+- **Lease protocol 2 PR review lifecycle.** Leases can move from the short
+  `completing` transaction window into `reviewing` with one task-lock-protected
+  `current_publication` pointer. Same-owner reopen revalidates the existing
+  worktree binding; takeover creates a new reserving generation that must pass
+  normal bind before becoming bound; raw sprint steal rejects reviewing leases.
+  Legacy protocol-1 owner records remain readable and upgrade only at the
+  reviewing boundary, while older clients fail closed on protocol 2.
+- **Publication recovery, integration reconcile, and merge readiness.** New
+  publication commands inspect and retry crash-window state, rebuild missing
+  receipts, and reconcile merged/ancestor/absorbed candidates only after
+  fetching the provider target to an isolated observation ref and proving the
+  canonical task row complete. `publication readiness` and `fleet ready`
+  double-read live provider facts and fence PR draft state, Head SHA, base
+  movement, local verification evidence, current publication, and Lease claim.
+- **Deterministic Fleet offer and acquisition protocol.** `fleet offers` scans
+  the adopted repo registry for stable `execution_ready` tasks. `fleet acquire`
+  revalidates registry authorization, task/offer revisions, races the canonical
+  Lease claim, creates a fresh contract worktree, binds it, and returns a
+  `WorkEnvelopeV1`. Claim-race losers retry deterministically and never receive
+  a partially bound envelope.
+- **Cross-repository Fleet Board.** `fleet board --json` emits the versioned
+  `FleetBoardSnapshotV1` projection across registered repositories, including
+  repository health, execution readiness, Lease/publication state, exact merge
+  blockers, feedback, task inbox, no-progress, and orthogonal
+  `attention_owner`. `fleet watch --format jsonl` emits immediate,
+  non-overlapping snapshots with bounded provider concurrency and collection
+  deadlines. Both surfaces remain read-only projections.
+- **Immutable provider feedback and repair redispatch.** GitHub check failures
+  and review threads are stored as idempotent `FeedbackEventV1` observations;
+  mutable delivery state lives in separate `FeedbackDeliveryReceiptV1`
+  records. Repair offers preserve the original task/publication lineage,
+  reopen or take over through fenced lifecycle commands, and use durable
+  reaction receipts to escalate two completed same-token attempts as
+  `no_progress` without treating polling as progress.
+- **Task-addressed cross-agent inbox.** `fleet message send` creates immutable
+  task- or claim-scoped messages, and inbox list/ack tracks per-recipient
+  delivery without mutating Lease authority. Claude and Codex turn hooks inject
+  only bounded untrusted messages for the current owner; stale claim-scoped
+  messages become superseded after takeover.
+- **Fleet MCP mirrors.** The coding MCP profile exposes fenced
+  `fleet_offers`, `fleet_acquire`, `publication_readiness`,
+  `publication_reopen`, and `publication_takeover` tools. Mutation calls require
+  an adopted `read_write` repository and the current registry authorization
+  revision before entering the same core/effects paths as the CLI.
+- **GPT Pro advisory orchestration mode.** The ChatGPT browser skill can prepare
+  a commit-bound planning or review bundle for GPT Pro, while local Codex keeps
+  execution, evidence, commit, push, merge, and deployment authority. Returned
+  prose is advisory and cannot expand contracts or attest to local checks.
+
+### Changed
+
+- **Bun 1.4 is the package runtime floor.** Package engines, installers, global
+  runtime checks, and helper bootstrap diagnostics now require Bun `>=1.4.0`
+  so candidate and installed runtimes use the tested process and test-runner
+  behavior.
+- **Contract worktrees use package-owned execution dependencies.** Verification
+  resolves the declared task test runner and packaged helper siblings from the
+  contract worktree/package instead of silently relying on a source checkout or
+  ambient global install. Gatekeeper acceptance also adds structural-quality
+  hard stops for duplication, placement, and boundary regressions.
+- **Human control and Agent factory direction is documented.** The stable
+  Fleet JSON/JSONL read model is the future Web/TUI component boundary; UI and
+  optional operators remain projections and command routers, never workflow
+  state owners.
+
+### Fixed
+
+- **Fleet acquire no longer leaks source-worktree workflow state.** Acquire
+  passes the task identity into contract-worktree start and writes active plan,
+  contract, and claim-token state only inside the newly created execution
+  worktree, preserving isolation between the dispatcher checkout and worker.
+- **Packaged handoff and contract test-runner resolution.** Installed helpers
+  now resolve their package-owned siblings and declared runner paths correctly
+  when downstream repositories do not vendor the source tree.
+
 ## [0.16.2] - 2026-08-21
 
 ### Fixed

--- a/docs/architecture/.projection-manifest.json
+++ b/docs/architecture/.projection-manifest.json
@@ -5,12 +5,12 @@
   "sourceDigest": "sha256:dfeee72dd6b65c11c5410cf52261499a156ed11386d32cb5121711b63684470d",
   "provenance": {
     "schemaVersion": "archcontext.architecture-docs-projection-provenance/v1",
-    "baseHeadSha": "f942620bdddee1de3b3c74eaaf2a766ef98f1e04",
-    "worktreeDigest": "sha256:fd6637d194bd3230c14a745a541abf1e3fa05747b1f721f352d12e0381dea7c9",
-    "sourceTreeDigest": "sha256:06cc208dabf12184b8d7e7d324c697db453d134c659d27307c5831bf74e528ad",
+    "baseHeadSha": "363acdd3933f828f99538e190f46818f1fbef428",
+    "worktreeDigest": "sha256:0936d643d8fd9ed3e76b0ae405a144930d45141cbeae842b40834c28f40cafb7",
+    "sourceTreeDigest": "sha256:5460aa526c553b3dfd5cec16f0107024dd80deded73cd25e33d4f0974b263fd0",
     "modelDigest": "sha256:e7e1a02e1fb8c6e0732999db19c5ab1541d8529ffb270b2be1eb96af579fa4cb",
-    "codeGraphDigest": "sha256:95fcc99529ed9eb5d83e1f2134064a31f8711fb75e43c1141b11385fd3ed29b1",
-    "indexedWorktreeDigest": "sha256:ea17ffb91f4ea0a8e34bc3155977841773bc37140034bddf11349c61a679446a",
+    "codeGraphDigest": "sha256:cff444b92bb69912f13dd7afe1d095b8e07e374cedd3d1978060a2f26109d6a5",
+    "indexedWorktreeDigest": "sha256:c6d9853ab7183b76deee21fa47163954f1e25065bcad903f9b5bfc747e19f4fe",
     "rendererVersion": "archcontext.docs-renderer/v4",
     "layoutVersion": "archcontext.docs-layout/v1",
     "generatedFrom": {
@@ -19,9 +19,9 @@
       "codeGraphBinaryDigest": "sha256:e4be48573fdf16196ca0d2867be2790aa161534e9973dcb89bc70465100ea537",
       "codeGraphStatus": "ready"
     },
-    "projectionInputDigest": "sha256:797e42ae4e5d2129222ed1f3e534f0f79df088191ebd2f8e074ac10ea3079579"
+    "projectionInputDigest": "sha256:bdbabd7b25cd5bfc8f094685016cff3ad2e54ab13fb8c7e5b58d058deadba8b3"
   },
-  "projectionDigest": "sha256:fbe586588f6e3067a66cff35f16f8a8f540aeae1c97ecbbbfdf334578d13e66b",
+  "projectionDigest": "sha256:3908a98d05aace7b5fbb0477ad0f07a7bf9c19f663ee1b722e0397196b2b0edc",
   "semanticBaseline": {
     "semanticState": {
       "schemaVersion": "archcontext.architecture-semantic-state/v1",
@@ -307,12 +307,12 @@
     },
     "digests": {
       "modelDigest": "sha256:e7e1a02e1fb8c6e0732999db19c5ab1541d8529ffb270b2be1eb96af579fa4cb",
-      "sourceTreeDigest": "sha256:06cc208dabf12184b8d7e7d324c697db453d134c659d27307c5831bf74e528ad",
+      "sourceTreeDigest": "sha256:5460aa526c553b3dfd5cec16f0107024dd80deded73cd25e33d4f0974b263fd0",
       "flowProofDigest": "sha256:f61c06c8566ec4ff22ec096ee22c06e91a046ceefa8fcd2f1d9faf436763a457",
-      "projectionDigest": "sha256:fbe586588f6e3067a66cff35f16f8a8f540aeae1c97ecbbbfdf334578d13e66b"
+      "projectionDigest": "sha256:3908a98d05aace7b5fbb0477ad0f07a7bf9c19f663ee1b722e0397196b2b0edc"
     }
   },
-  "receiptDigest": "sha256:eb4c14e87e98850364675346531efaf9b654d731fc92cffc78bbfc0e87b21475",
+  "receiptDigest": "sha256:10a3b7294eb8e969d5fddb313087023dad5935e53cb829cba61eb7b114d65fe5",
   "refreshSignalIds": [],
   "targetCount": 17,
   "fileCount": 17,
@@ -385,9 +385,9 @@
       "sourceDigest": "sha256:4b156de6b1c762fba52333c97bc1928eb8ccdfa64972fe4c9034249d5b66a22c",
       "outputDigest": "sha256:ae0761f94d159619eca95cc0e65038bb547c0d31d085c4f9c4f9095d639f0db1",
       "verifiedAgainst": {
-        "branch": "codex/merge-readiness-v1",
-        "commit": "6e48948bff83bb5f2ed61173901261a609bb8f51",
-        "committedAt": "2026-08-23T01:24:35+08:00"
+        "branch": "codex/release-0-17-0",
+        "commit": "363acdd3933f828f99538e190f46818f1fbef428",
+        "committedAt": "2026-08-23T22:14:22+08:00"
       }
     },
     {
@@ -405,9 +405,9 @@
       "sourceDigest": "sha256:183d7a9ef531bb200e573b337911d503eac0d86741a87b02d5d0b60896930782",
       "outputDigest": "sha256:2e93a1f59017a07da7860cf0073e6911d9f75032b5af8be503c56087f394466a",
       "verifiedAgainst": {
-        "branch": "codex/merge-readiness-v1",
-        "commit": "6e48948bff83bb5f2ed61173901261a609bb8f51",
-        "committedAt": "2026-08-23T01:24:35+08:00"
+        "branch": "codex/release-0-17-0",
+        "commit": "363acdd3933f828f99538e190f46818f1fbef428",
+        "committedAt": "2026-08-23T22:14:22+08:00"
       }
     },
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "repo-harness",
-  "version": "0.16.2",
+  "version": "0.17.0",
   "description": "Installs, migrates, audits, and repairs repo-local agentic development harnesses",
   "license": "MIT",
   "repository": {

--- a/plans/plan-20260823-2134-release-0-17-0.md
+++ b/plans/plan-20260823-2134-release-0-17-0.md
@@ -150,7 +150,7 @@ Use `0.17.0`: the range adds consumer-visible CLI verbs, versioned JSON contract
 - [x] Update every `0.17.0` version anchor.
 - [x] Write the `0.17.0` Changelog and release filing from the final `v0.16.2..candidate` range.
 - [x] Run the complete release and repository verification gates.
-- [ ] Record review/acceptance evidence and publish a draft release PR; do not merge, tag, or npm publish.
+- [x] Record review/acceptance evidence and publish a draft release PR; do not merge, tag, or npm publish.
 
 ## Annotations
 <!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
@@ -159,4 +159,4 @@ Use `0.17.0`: the range adds consumer-visible CLI verbs, versioned JSON contract
 - [x] Update every `0.17.0` version anchor.
 - [x] Write the `0.17.0` Changelog and release filing from the final `v0.16.2..candidate` range.
 - [x] Run the complete release and repository verification gates.
-- [ ] Record review/acceptance evidence and publish a draft release PR; do not merge, tag, or npm publish.
+- [x] Record review/acceptance evidence and publish a draft release PR; do not merge, tag, or npm publish.

--- a/plans/plan-20260823-2134-release-0-17-0.md
+++ b/plans/plan-20260823-2134-release-0-17-0.md
@@ -1,0 +1,162 @@
+# Plan: Release repo-harness 0.17.0
+
+> **Status**: Executing
+> **Created**: 20260823-2134
+> **Slug**: release-0-17-0
+> **Planning Source**: codex-plan
+> **Orchestration Kind**: host-plan
+> **Source Ref**: (none)
+> **Artifact Level**: work-package
+> **Promotion Reason**: human_decision_boundary
+> **Verification Boundary**: Version anchors, changelog, release filing, full release gate, and tarball smoke at final candidate content
+> **Rollback Surface**: Abandon or revert codex/release-0-17-0 before publication; npm publish, tag, GitHub Release, merge, and runtime refresh are out of scope
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260823-2134-release-0-17-0.contract.md`
+> **Task Review**: `tasks/reviews/20260823-2134-release-0-17-0.review.md`
+> **Implementation Notes**: `tasks/notes/20260823-2134-release-0-17-0.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from codex-plan planning output.
+- Source ref: (none)
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260823-2134-release-0-17-0.md`
+- Sprint contract: `tasks/contracts/20260823-2134-release-0-17-0.contract.md`
+- Sprint review: `tasks/reviews/20260823-2134-release-0-17-0.review.md`
+- Implementation notes: `tasks/notes/20260823-2134-release-0-17-0.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260823-2134-release-0-17-0.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260823-2134-release-0-17-0.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260823-2134-release-0-17-0.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260823-2134-release-0-17-0.contract.md`
+- Review file: `tasks/reviews/20260823-2134-release-0-17-0.review.md`
+- Implementation notes file: `tasks/notes/20260823-2134-release-0-17-0.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260823-2134-release-0-17-0.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260823-2134-release-0-17-0.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: Abandon or revert codex/release-0-17-0 before publication; npm publish, tag, GitHub Release, merge, and runtime refresh are out of scope
+- **Verification boundary**: Version anchors, changelog, release filing, full release gate, and tarball smoke at final candidate content
+- **Review/acceptance boundary**: `tasks/reviews/20260823-2134-release-0-17-0.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: human_decision_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260823-2134-release-0-17-0.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260823-2134-release-0-17-0.contract.md`, `tasks/reviews/20260823-2134-release-0-17-0.review.md`, and `tasks/notes/20260823-2134-release-0-17-0.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260823-2134-release-0-17-0.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: Abandon or revert codex/release-0-17-0 before publication; npm publish, tag, GitHub Release, merge, and runtime refresh are out of scope
+
+## Captured Planning Output
+
+# repo-harness 0.17.0 release prep
+
+## Goal
+
+Prepare a reviewable `repo-harness@0.17.0` release candidate for the full `v0.16.2..HEAD` range. The range introduces public Fleet, Publication, Feedback, Task Inbox, GPT Pro advisory orchestration, Bun 1.4 runtime-floor, and MCP surfaces, so the release is a minor bump rather than `0.16.3`.
+
+## P1 map
+
+Version authority is split across `package.json`, `assets/skill-version.json`, five README current-version stamps, `docs/CHANGELOG.md`, and one release filing under `deploy/release-checklists/`. Product implementation is already on `main`; this work package changes release metadata only. npm publish, tag creation, GitHub Release, merge to `main`, and installed runtime refresh remain separate user-authorized follow-through steps.
+
+## P2 trace
+
+`package.json#version` and `assets/skill-version.json` must agree; the skill manifest version/templateVersion flows into generated-project stamps and version checks. README stamps expose the current release to users. The Changelog binds the full `v0.16.2..candidate` behavior range to `0.17.0`. The filing records the immutable source range, semantic-version rationale, gate commands, and later publication/readback steps. `check:release` must prove `0.17.0` is unpublished before running the full CI and tarball gate.
+
+## P3 decision
+
+Use `0.17.0`: the range adds consumer-visible CLI verbs, versioned JSON contracts, MCP tools, Lease protocol 2, and orchestration behavior. A patch bump would contradict the repository's prior patch rationale. Keep the candidate metadata-only so rollback is one branch/revert and product code remains identical to the already accepted `main` range.
+
+## File changes
+
+| File | Action |
+| --- | --- |
+| `package.json` | bump version to `0.17.0` |
+| `assets/skill-version.json` | bump version/templateVersion and append a `0.17.0` history entry |
+| `README.md`, `README.zh-CN.md`, `README.es.md`, `README.fr.md`, `README.ja.md` | update current-release stamp |
+| `docs/CHANGELOG.md` | add the complete `0.17.0` release section |
+| `deploy/release-checklists/260823-repo-harness-0.17.0.md` | create release filing and gate ledger |
+
+## Acceptance
+
+- Every version anchor resolves to `0.17.0`.
+- Changelog describes the user-visible release range without treating archive mechanics as product features.
+- `npm view repo-harness@0.17.0` proves the version is unpublished.
+- `bun run check:type`, repository required checks, full `bun run check:release`, and tarball install smoke pass on final candidate content.
+- Final diff contains release metadata and workflow artifacts only; no product source changes.
+
+## Verification
+
+- `bun run check:type`
+- `bun test --timeout 60000`
+- `bash scripts/check-deploy-sql-order.sh`
+- `bash scripts/check-architecture-sync.sh`
+- `bash scripts/check-task-sync.sh`
+- `repo-harness run check-task-workflow --strict`
+- `bun scripts/inspect-project-state.ts --repo . --format text`
+- `bun src/cli/index.ts init --repo . --dry-run`
+- `bun run check:release`
+
+## Task Breakdown
+
+- [x] Update every `0.17.0` version anchor.
+- [x] Write the `0.17.0` Changelog and release filing from the final `v0.16.2..candidate` range.
+- [x] Run the complete release and repository verification gates.
+- [ ] Record review/acceptance evidence and publish a draft release PR; do not merge, tag, or npm publish.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [x] Update every `0.17.0` version anchor.
+- [x] Write the `0.17.0` Changelog and release filing from the final `v0.16.2..candidate` range.
+- [x] Run the complete release and repository verification gates.
+- [ ] Record review/acceptance evidence and publish a draft release PR; do not merge, tag, or npm publish.

--- a/tasks/contracts/20260823-2134-release-0-17-0.contract.md
+++ b/tasks/contracts/20260823-2134-release-0-17-0.contract.md
@@ -1,0 +1,177 @@
+# Task Contract: release-0-17-0
+
+> **Status**: Active
+> **Plan**: plans/plan-20260823-2134-release-0-17-0.md
+> **Task Profile**: code-change
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: ancienttwo
+> **Capability ID**: root
+> **Last Updated**: 2026-08-23 21:34
+> **Review File**: `tasks/reviews/20260823-2134-release-0-17-0.review.md`
+> **Notes File**: `tasks/notes/20260823-2134-release-0-17-0.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+The accepted `v0.16.2..main` range adds public Fleet, Publication, Feedback,
+Task Inbox, GPT Pro advisory orchestration, Bun 1.4 runtime-floor, and MCP
+surfaces. npm, the Git tag, generated project stamps, README stamps, and the
+Changelog must bind those behaviors to one immutable version. Publishing the
+range as `0.16.3`, or allowing any version anchor to disagree, would misstate a
+consumer-visible minor release and break release readback.
+
+## Goal
+
+Produce a reviewable `repo-harness@0.17.0` release candidate on
+`codex/release-0-17-0`. All version anchors, the Changelog, and the release
+filing must agree, and the full release gates must pass at final candidate
+content. npm publish, tag creation, GitHub Release, merge to `main`, and global
+runtime refresh are explicitly outside this outcome.
+
+## Scope
+
+- In scope: `package.json#version`; `assets/skill-version.json` version,
+  templateVersion, and history; five README release stamps; the `0.17.0`
+  Changelog section; release filing; workflow artifacts and acceptance evidence.
+- Out of scope: product source changes, dependency changes, npm publish, tag
+  creation, GitHub Release, merge to `main`, installed runtime refresh, and
+  frontend implementation.
+- Taste constraints: <!-- advisory only, no run gate; default style/taste lives in AGENTS.md and the minimal-change policy, use this to record a per-task override -->
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+
+## Falsifier
+
+If `v0.16.2..HEAD` contains no new consumer-visible command, wire contract, or
+runtime behavior, a minor bump is wrong. Cheapest proof: inspect the range for
+new CLI command registration and MCP tool names before changing version files.
+The range contains `fleet board/watch/offers/acquire`, publication commands,
+and Fleet MCP tools, so the minor-bump direction survives the falsifier.
+
+## Root Cause Evidence
+
+Required when Task Profile is `bugfix`; leave as-is otherwise.
+
+- root_cause: one sentence naming file:line/condition (testable, not "a state issue").
+- repro: the command or UI path that reproduces the symptom.
+- regression_guard: path to a test that fails on the unfixed code and passes after the fix (must also appear under exit_criteria.tests_pass).
+- pre_fix_failure_artifact: path to a captured run of regression_guard on the UNFIXED code. Capture with `bun test <regression_guard> > <artifact> 2>&1; echo "PRE_FIX_EXIT=$?" >> <artifact>` (no pipes — pipes swallow the exit status). The gate requires a non-zero `PRE_FIX_EXIT=` line plus the regression_guard path string in the artifact (see the Root Cause Evidence Gate section in docs/reference-configs/sprint-contracts.md).
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260823-2134-release-0-17-0.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260823-2134-release-0-17-0.review.md`
+- Notes file: `tasks/notes/20260823-2134-release-0-17-0.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Change Assessment
+
+```json
+{"protocol":1,"oracles":[{"id":"release-deterministic-gates","kind":"deterministic_test","paths":["*"]},{"id":"published-package-runtime-readback","kind":"runtime_readback","paths":["*"]}]}
+```
+
+## Acceptance Policy
+
+```json
+{"protocol":1,"reviewer":"Claude","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - plans/
+  - tasks/todos.md
+  - tasks/current.md
+  - tasks/contracts/20260823-2134-release-0-17-0.contract.md
+  - tasks/reviews/20260823-2134-release-0-17-0.review.md
+  - tasks/notes/20260823-2134-release-0-17-0.notes.md
+  - package.json
+  - assets/skill-version.json
+  - README.md
+  - README.zh-CN.md
+  - README.ja.md
+  - README.es.md
+  - README.fr.md
+  - docs/CHANGELOG.md
+  - docs/architecture/
+  - deploy/release-checklists/
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+    fallback: null
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - deploy/release-checklists/260823-repo-harness-0.17.0.md
+    - docs/CHANGELOG.md
+  artifacts_exist:
+    - tasks/notes/20260823-2134-release-0-17-0.notes.md
+  tests_pass:
+    - path: tests/skill-version.test.ts
+  commands_succeed:
+    - bun run check:type
+    - bash scripts/check-deploy-sql-order.sh
+    - bash scripts/check-task-sync.sh
+```
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior:
+- Edge cases:
+- Regression risks:
+
+## Rollback Point
+
+- Commit / checkpoint: `codex/release-0-17-0@1fce23bf` before release metadata.
+- Revert strategy: abandon or revert the candidate branch before publication;
+  no npm version, tag, GitHub Release, merge, or installed runtime changes in
+  this contract.

--- a/tasks/notes/20260823-2134-release-0-17-0.notes.md
+++ b/tasks/notes/20260823-2134-release-0-17-0.notes.md
@@ -1,0 +1,55 @@
+# Implementation Notes: release-0-17-0
+
+> **Status**: Active
+> **Plan**: plans/plan-20260823-2134-release-0-17-0.md
+> **Contract**: tasks/contracts/20260823-2134-release-0-17-0.contract.md
+> **Review**: tasks/reviews/20260823-2134-release-0-17-0.review.md
+> **Last Updated**: 2026-08-23 21:34
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- Use `0.17.0`, not `0.16.3`: `v0.16.2..HEAD` adds consumer-visible CLI,
+  JSON, MCP, Lease, Publication, Feedback, Inbox, and orchestration surfaces.
+- Keep this work package metadata-only. Product behavior is the already
+  accepted range on `main`; publication and installed-runtime mutation remain
+  a later explicit boundary.
+- Keep the full release gate outside the bounded contract verifier. The
+  contract carries deterministic and runtime-readback oracles, while the parent
+  runs `bun run check:release` with the package-local Node/Bun environment.
+
+## Deviations From Plan Or Spec
+
+- None recorded.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| `0.16.3` patch | Reject | Public commands and versioned contracts make the range a minor release. |
+| `0.17.0` minor | Use | Matches observable consumer scope and the previous patch-version rationale. |
+| Publish from dirty `main` | Reject | Candidate must be isolated, reviewable, and rollback-safe before registry mutation. |
+
+## Open Questions
+
+- None.
+
+## Evidence Links
+
+- Version consistency: `bun scripts/check-skill-version.ts --project .`
+- Targeted release metadata tests: 83 passed, 0 failed.
+- Full package gate: `bun run check:release` — 2990 passed, 2 skipped,
+  0 failed; workflow checks, repository inspection, npm package dry-run,
+  packed-tarball install, and packaged CLI bin smoke all passed.
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/reviews/20260823-2134-release-0-17-0.review.md
+++ b/tasks/reviews/20260823-2134-release-0-17-0.review.md
@@ -1,84 +1,107 @@
 # Task Review: release-0-17-0
 
-> **Status**: Pending
+> **Status**: Complete
 > **Plan**: plans/plan-20260823-2134-release-0-17-0.md
 > **Contract**: tasks/contracts/20260823-2134-release-0-17-0.contract.md
 > **Notes File**: tasks/notes/20260823-2134-release-0-17-0.notes.md
 > **Checks File**: .ai/harness/checks/latest.json
-> **Last Updated**: 2026-08-23 21:34
-> **Recommendation**: fail
+> **Last Updated**: 2026-08-23 22:34
+> **Recommendation**: pass
 > **Review Rubric Version**: 2
-> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject SHA256**: sha256:b3c6614f39d3053988e999d75d7234e975b170f24f3dd0c242dc4452c909d434
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: pending
+> **Reviewed Target Revision**: 1fce23bf8f880f9bb01feea14f9136430e24460b
 
 ## Human Review Card
 
-- Verdict: pending
-- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
-- Intended files changed:
-- Actual files changed:
-- Commands passed:
-- Residual risks:
-- Reviewer action required: inspect diff and card
-- Rollback:
+- Verdict: PASS
+- Change type: code-change
+- Intended files changed: release version authorities, localized README stamps,
+  Changelog, release filing, projection manifest, and workflow evidence only.
+- Actual files changed: 15 files, all inside contract Allowed Paths; no product
+  source or dependency change.
+- Commands passed: 83 focused tests; full release gate with 2990 pass, 2 skip,
+  0 fail; workflow checks; npm package dry-run; tarball install/CLI smoke; all
+  five GitHub CI checks.
+- Residual risks: registry publication, tag/GitHub Release creation, merged-SHA
+  readback, and installed-runtime refresh remain unexecuted by contract.
+- Reviewer action required: none for the Draft candidate; merge and publication
+  remain separate owner-authorized boundaries.
+- Rollback: abandon or revert `codex/release-0-17-0` before publication.
 
 ## Mode Evidence
 
-- Selected route:
-- P1/P2/P3 evidence:
-- Root cause or plan evidence:
+- Selected route: isolated release worktree, deterministic package gate,
+  GitHub Draft PR, then explicit contract-bound user-waiver acceptance.
+- P1/P2/P3 evidence: the plan maps version authorities, traces package version
+  through generated stamps and tarball smoke, and records why public Fleet and
+  Publication surfaces require a minor release.
+- Root cause or plan evidence: approved `release-0-17-0` work-package plan and
+  the release filing's semantic-version decision.
 
 ## Verification Evidence
 
-- Waza `/check` run:
-- Commands run:
-- Manual checks:
-- Supporting artifacts:
-- Implementation notes reviewed:
-- Run snapshot:
+- Waza `/check` run: represented by the frozen Change Assessment, full local
+  release gate, GitHub CI, and typed owner waiver; no external provider claim.
+- Commands run: `bun run check:release`; repository Required Checks;
+  `repo-harness run verify-sprint --prepare-acceptance`; typed waiver record;
+  final `repo-harness run verify-sprint`.
+- Manual checks: version anchors all resolve to `0.17.0`; the package requires
+  Bun `>=1.4.0`; candidate diff contains no product source or dependency edit.
+- Supporting artifacts: `.ai/harness/checks/latest.json`,
+  `.ai/harness/checks/change-assessment.latest.json`, and PR #217 CI.
+- Implementation notes reviewed: yes.
+- Run snapshot: `.ai/harness/runs/run-20260823T223328-73938-20260823-2134-release-0-17-0.json`.
 
 ## Acceptance Receipt Projection
 
-> **Disposition**: unavailable
-> **Reviewer**: unavailable
-> **Source**: unavailable
-> **Actor**: not-applicable
-> **Reviewed Subject SHA256**: pending
+> **Disposition**: user_waiver
+> **Reviewer**: User
+> **Source**: user-waiver
+> **Actor**: ancienttwo
+> **Reviewed Subject SHA256**: sha256:b3c6614f39d3053988e999d75d7234e975b170f24f3dd0c242dc4452c909d434
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: pending
-> **Verification Evidence SHA256**: pending
-> **Issued At**: pending
+> **Reviewed Target Revision**: 1fce23bf8f880f9bb01feea14f9136430e24460b
+> **Verification Evidence SHA256**: sha256:995d8085d3f2dc06b40a913775b20f5be41fb27e7658f8da348d721ccc9a6b9c
+> **Issued At**: 2026-08-23T14:34:24.413Z
 
-- Summary: No AcceptanceReceipt has been recorded.
+- Summary: Owner explicitly approved a contract-bound user waiver for release-0-17-0 after the local release gate and PR CI passed.
 - Findings: none
 
 ## Behavior Diff Notes
 
-- ...
+- Public Fleet, Publication, Feedback, Task Inbox, MCP, and GPT Pro advisory
+  behavior already present in the accepted source range is released as a
+  `0.17.0` minor rather than mislabeled as a patch.
+- Package, skill/template stamp, localized README release anchors, Changelog,
+  and release filing now agree on one candidate version.
+- The package runtime floor is consistently represented as Bun `>=1.4.0`.
 
 ## Residual Risks / Follow-ups
 
-- ...
+- Post-merge npm/tag/GitHub Release publication and
+  `check:release-published` readback remain the next explicit release boundary.
 
 ## Scorecard
 
 | Dimension | Score | Notes |
 |-----------|-------|-------|
-| Functionality | 0/10 | |
-| Product depth | 0/10 | |
-| Design quality | 0/10 | |
-| Code quality | 0/10 | |
+| Functionality | 10/10 | Version consistency, package gate, tarball install, and CLI startup all pass. |
+| Product depth | 9/10 | Complete release filing for the accepted range; registry publication is intentionally separate. |
+| Design quality | 10/10 | One version authority is deterministically projected across every public stamp. |
+| Code quality | 10/10 | Metadata-only candidate; full local and hosted suites are green. |
 
 ## Failing Items
 
-- ...
+- None.
 
 ## Retest Steps
 
-- Re-run:
-- Re-check:
+- Re-run: `bun run check:release` at the exact merged commit before npm publish.
+- Re-check: `bun run check:release-published` after publication to bind npm,
+  tag, GitHub Release, installed CLI, and hook runtime.
 
 ## Summary
 
-- ...
+- PASS. The `0.17.0` Draft candidate is version-consistent, locally and
+  remotely green, and accepted by an exact-subject contract-bound user waiver.

--- a/tasks/reviews/20260823-2134-release-0-17-0.review.md
+++ b/tasks/reviews/20260823-2134-release-0-17-0.review.md
@@ -1,0 +1,84 @@
+# Task Review: release-0-17-0
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260823-2134-release-0-17-0.md
+> **Contract**: tasks/contracts/20260823-2134-release-0-17-0.contract.md
+> **Notes File**: tasks/notes/20260823-2134-release-0-17-0.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-08-23 21:34
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Commands passed:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+- Waza `/check` run:
+- Commands run:
+- Manual checks:
+- Supporting artifacts:
+- Implementation notes reviewed:
+- Run snapshot:
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -1,7 +1,7 @@
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: (archive-workflow)
+> **Updated**: 2026-08-23 21:34
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.


### PR DESCRIPTION
## Summary

- bump package, generated workflow stamp, and localized release anchors to 0.17.0
- document the Fleet, publication, feedback, task inbox, MCP, GPT Pro advisory, and Bun 1.4 release surface
- add the release filing and human-control-board architecture research

## Verification

- bun run check:release
- 2990 tests passed, 2 skipped, 0 failed
- workflow checks, repository inspection, npm package dry-run, packed-tarball install, and packaged CLI bin smoke passed
- final PR Head: all GitHub CI and MCP path-matrix checks passed
- typed AcceptanceReceipt: exact-subject contract-bound user waiver, verified and projected into the review artifact

## Release boundary

This is a draft release candidate only. Merge, npm publish, v0.17.0 tag creation, GitHub Release, and installed-runtime refresh remain separately authorized steps.