### PR TITLE
chore: prepare repo-harness 0.17.1

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -467,8 +467,8 @@ repositorio adopte la misma política.
 
 ## Versión actual
 
-- Paquete npm: `repo-harness@0.17.0`
-- Sello de workflow generado: `repo-harness@0.17.0+template@0.17.0`
+- Paquete npm: `repo-harness@0.17.1`
+- Sello de workflow generado: `repo-harness@0.17.1+template@0.17.1`
 - Repositorio de GitHub: `Ancienttwo/repo-harness`
 - Notas de versión e historial: [`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -462,8 +462,8 @@ adopte la même policy.
 
 ## Release actuelle
 
-- Package npm : `repo-harness@0.17.0`
-- Generated workflow stamp : `repo-harness@0.17.0+template@0.17.0`
+- Package npm : `repo-harness@0.17.1`
+- Generated workflow stamp : `repo-harness@0.17.1+template@0.17.1`
 - Dépôt GitHub : `Ancienttwo/repo-harness`
 - Notes et historique de release : [`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -470,8 +470,8 @@ commit script や hooks に組み込まないでください。
 
 ## 現在の Release
 
-- npm package：`repo-harness@0.17.0`
-- Generated workflow stamp：`repo-harness@0.17.0+template@0.17.0`
+- npm package：`repo-harness@0.17.1`
+- Generated workflow stamp：`repo-harness@0.17.1+template@0.17.1`
 - GitHub repository：`Ancienttwo/repo-harness`
 - Release notes and history：[`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -463,8 +463,8 @@ repo-harness commit scripts or hooks unless that repo adopts the same policy.
 
 ## Current Release
 
-- npm package: `repo-harness@0.17.0`
-- Generated workflow stamp: `repo-harness@0.17.0+template@0.17.0`
+- npm package: `repo-harness@0.17.1`
+- Generated workflow stamp: `repo-harness@0.17.1+template@0.17.1`
 - GitHub repository: `Ancienttwo/repo-harness`
 - Release notes and history: [`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -457,8 +457,8 @@ policy。
 
 ## 当前 Release
 
-- npm package：`repo-harness@0.17.0`
-- Generated workflow stamp：`repo-harness@0.17.0+template@0.17.0`
+- npm package：`repo-harness@0.17.1`
+- Generated workflow stamp：`repo-harness@0.17.1+template@0.17.1`
 - GitHub repository：`Ancienttwo/repo-harness`
 - Release notes 和 history：[`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/assets/skill-version.json
+++ b/assets/skill-version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.17.0",
-  "templateVersion": "0.17.0",
+  "version": "0.17.1",
+  "templateVersion": "0.17.1",
   "skillName": "repo-harness",
   "contractId": "tasks-first-harness-v1",
   "compatibility": {
@@ -267,6 +267,10 @@
     {
       "version": "0.17.0",
       "description": "Adds the Git-backed Fleet control plane: immutable PublicationReceiptV1 identity and recovery, Lease protocol 2 reviewing/reopen/takeover lifecycle, fenced merge readiness and integration reconcile, deterministic cross-repo offers/acquire and FleetBoardSnapshotV1/watch, immutable provider feedback and task inbox delivery, GPT Pro advisory orchestration, Fleet MCP mirrors, and a Bun 1.4 runtime floor"
+    },
+    {
+      "version": "0.17.1",
+      "description": "Delivers the persistent module-engineer control plane on the existing early-access line: durable engineer records, bindings and authenticated principal claims, a task/claim-scoped engineer inbox, the loopback operator control board, fail-closed read-only delegation admission, verified evidence context, interface change authority, integration acceptance, and the exclusive engineer MCP profile; pins ArchContext 0.4.7 and isolates fixture HOME outside the repo under test"
     }
   ],
   "generatedProjectStamp": {

--- a/deploy/release-checklists/260828-repo-harness-0.17.1.md
+++ b/deploy/release-checklists/260828-repo-harness-0.17.1.md
@@ -1,0 +1,101 @@
+# repo-harness 0.17.1 Release Filing
+
+- Date: 2026-08-28
+- Package: `repo-harness@0.17.1`
+- Base release: `v0.17.0` (`cc64a1049dfb`)
+- Product source range: `v0.17.0..683eafd4fbb7` (148 commits)
+- Release-prep branch: `codex/release-0-17-1`
+- Candidate commit: bound by the release PR Head after the metadata commit
+- Release scope: patch on the existing early-access module-engineer line. The
+  range delivers the ME program closeout — persistent module engineers, the
+  local operator control board, read-only delegation admission, verified
+  evidence context, interface change authority, integration acceptance, the
+  engineer MCP profile — plus an ArchContext 0.4.7 pin and fixture isolation
+  fixes.
+- Publish status: **candidate preparation**. npm publish, tag creation, merge
+  to `main`, and installed-runtime refresh have not occurred.
+
+## Release Content
+
+### Persistent module engineers
+
+- Durable engineer records with capability bindings through `engineer
+  create/enroll/bind/retire`, and read-only projection through
+  `board/status/inspect/show/list`.
+- `engineer offers` and `engineer acquire` hand a bound work envelope to an
+  authenticated engineer principal; claims carry the principal actor rather
+  than only the worktree identity.
+- Durable task- and claim-scoped engineer inbox through
+  `engineer send/receive/ack`, with immutable messages that supersede on
+  takeover.
+
+### Control plane surfaces
+
+- `operator serve` runs a loopback-authenticated human control board over the
+  engineer fleet, backed by the bundled `build:operator-web` client. The board
+  is a projection surface, not a second mutation authority.
+- `delegation` compiles a profile and capability set, admits a delegated run,
+  dispatches from a frozen argv template, and collects observations. Admission
+  is fail-closed against an admitted profile and a writability-checked
+  contract.
+- `verified-context` compiles a verified-evidence catalog, binds a decision to
+  it, and persists the receipt; catalog and receipt writes are validated.
+- `interface-change` records proposals against the scheduler projection
+  authority and drives their human transition.
+- `integration` reads the acceptance envelope, contract, and matrix and records
+  product acceptance.
+
+### Runtime behavior
+
+- The MCP `engineer` profile exposes ten engineer tools and is exclusive:
+  a non-engineer tool under that profile returns `TOOL_NOT_AVAILABLE`.
+- Provider thread effects resolve through a dedicated adapter, and the
+  thread-effect status read is pure.
+- Cross-review on a Codex host uses the official Codex plugin bound to an
+  immutable subject.
+- ArchContext is pinned to 0.4.7; the projection manifest carries explicit
+  restamp provenance.
+- Test fixtures allocate HOME through `mkdtemp` outside the repo under test.
+
+## Semantic Version Decision
+
+`0.17.1` rather than `0.18.0`. `0.17.0` is already the early-access release
+line for this module surface (the `engineer`/`operator`/`delegation` command
+family and the engineer MCP tool surface); this range is an iteration delivery
+within the same early-access line rather than the first appearance of a new
+public surface, so the patch number holds and no minor bump is taken.
+
+## Authority Boundary
+
+- This candidate changes release metadata only; product implementation is the
+  already accepted source range on `main`.
+- npm `latest`, tag `v0.17.1`, tarball metadata, source commit, version files,
+  and installed runtime must resolve to one immutable release.
+- Registry publication, tag creation, merge, and global runtime mutation are
+  covered by the current owner authorization for the 0.17.1 release.
+
+## Candidate Gate Evidence
+
+| Gate | Candidate result |
+| --- | --- |
+| `git status` clean at `683eafd4`, `main == origin/main` | pass |
+| `npm view repo-harness version` before publish | `0.17.0`, dist-tag `latest: 0.17.0` |
+| `bun test --timeout 60000` | pass: 3184 passed, 2 skipped, 0 failed (262 files, 967.13s) |
+| `bash scripts/check-deploy-sql-order.sh` | pass |
+| `bash scripts/check-architecture-sync.sh` | pass: blocking=0, dead_letters=0, uncommitted=0 |
+| `bash scripts/check-task-sync.sh` | pass: no changes detected |
+| `repo-harness run check-task-workflow --strict` | pass |
+| `bun src/cli/index.ts init --repo . --dry-run` | pass: 0 operations |
+| `bun run check:release` | recorded at candidate time |
+| tarball install smoke | recorded post-publish |
+| GitHub Required/CI on release PR | pending |
+
+## Publish Follow-through
+
+1. Merge the reviewed release PR into `main`.
+2. Create tag `v0.17.1` at the merged commit and push it.
+3. Publish `repo-harness@0.17.1` to npm.
+4. Run `bun run check:release-published` to bind registry metadata, dist-tag,
+   tarball integrity, tag, installed CLI, and installed hook runtime.
+5. Refresh the selected Bun-global runtime and confirm `repo-harness --version`
+   reports `0.17.1`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,91 @@
 
 All notable changes to this skill are documented here.
 
+## [0.17.1] - 2026-08-28
+
+### Added
+
+- **Persistent module engineers.** `repo-harness engineer` owns a durable
+  module-engineer control plane: `create`/`enroll`/`bind`/`retire` maintain
+  persistent engineer records and their capability bindings, `offers` and
+  `acquire` hand a bound work envelope to an authenticated engineer principal,
+  and `board`/`status`/`inspect`/`show`/`list` project read-only state. Claims
+  carry an authenticated principal actor, so a claim identifies which engineer
+  holds it rather than only which worktree does. `send`/`receive`/`ack` back a
+  durable task- and claim-scoped engineer inbox whose messages are immutable
+  and supersede on takeover.
+- **Engineering overlay control board and local operator UI.** `repo-harness
+  operator serve` runs a loopback-authenticated human control board over the
+  engineer fleet, backed by a bundled web client built through
+  `build:operator-web`. Request authority is pinned to loopback; the board is a
+  projection surface and never a second mutation authority.
+- **Read-only delegation admission.** `repo-harness delegation` compiles a
+  delegation profile and capability set, admits a delegated run, dispatches it
+  from a frozen argv template, and collects its observations. Admission is
+  fail-closed: a run that cannot be bound to an admitted profile and a
+  writability-checked contract is rejected instead of downgraded.
+- **Verified evidence context.** `repo-harness verified-context` compiles a
+  catalog of verified evidence, binds a decision to it, and persists the
+  resulting receipt. Catalog entries and receipts are validated on write, so a
+  decision cannot cite evidence that was never verified.
+- **Interface change authority.** `repo-harness interface-change` records
+  interface-change proposals against the scheduler projection authority and
+  drives their human transition, with `lookup`/`read` exposing the bound
+  record.
+- **Integration acceptance surface.** `repo-harness integration` reads the
+  acceptance envelope, contract, and matrix and records product acceptance
+  against them.
+- **Engineer MCP profile.** The MCP `engineer` profile exposes
+  `engineer_offers`, `engineer_acquire`, `engineer_status`,
+  `engineer_messages`, `engineer_message_send`, `engineer_message_ack`,
+  `engineer_interface_change_propose`,
+  `engineer_interface_change_transition`, `engineer_thread_effect_capability`,
+  and `engineer_thread_effect_status`. The profile is exclusive: a non-engineer
+  tool called under it returns `TOOL_NOT_AVAILABLE` rather than falling through
+  to the coding profile.
+- **Provider thread effect adapter.** Engineer dispatch resolves provider
+  thread effects through a dedicated adapter, and the thread-effect status read
+  is pure — reading status never mutates thread state.
+- **Official Codex plugin for review on Codex hosts.** Cross-review on a Codex
+  host uses the official Codex plugin and binds the review to an immutable
+  subject.
+- **Incremental sprint verification retry.** `verify-sprint` retries
+  incrementally instead of restarting the whole verification pass.
+
+### Changed
+
+- **ArchContext is pinned to 0.4.7.** Architecture projection acceptance runs
+  against that provider version, and the projection manifest carries explicit
+  provenance for each restamp.
+- **Module engineers are documented as a control plane**, not an execution
+  tier: they schedule, admit, and accept work; they do not hold mutation
+  authority that the contract worktree owns.
+
+### Fixed
+
+- **Engineer CLI errors are layered and typed.** Engineer command failures
+  carry layered error codes, `FleetOffersError` routes through the domain error
+  whitelist, and profile resolution errors stay inside the work-graph domain
+  instead of surfacing as generic runtime faults. Binding comparison is
+  canonical, so an equivalent binding no longer compares unequal.
+- **N-way engineer election proves mutual exclusion.** Concurrent claim
+  election is covered by a test that asserts exactly one winner rather than
+  asserting only that a winner exists.
+- **Header projection into generated helper templates is unconditional.**
+  Generated helpers and acceptance-projection review headers always receive the
+  synced header, so a stale template no longer produces a header that drifts
+  from its source.
+- **Architecture restamp commits are exempt from task sync.** A restamp no
+  longer trips the task-sync gate, and archived acceptance authority survives
+  archival instead of being dropped.
+- **Fixture HOME stays outside the repo under test.** Test fixtures allocate
+  HOME through `mkdtemp` outside the working tree, so a fixture run can no
+  longer write cache state into the repo it is exercising. Install
+  compensation, interactive init, and official Codex plugin fixtures are
+  isolated from each other.
+- **Provider concurrency deadline in fleet tests is stabilized**, removing a
+  timing-dependent failure in the board stability probe.
+
 ## [0.17.0] - 2026-08-23
 
 ### Added

--- a/docs/architecture/.projection-manifest.json
+++ b/docs/architecture/.projection-manifest.json
@@ -5,12 +5,12 @@
   "sourceDigest": "sha256:a23d2bc659e963369ccb1fb5f291ab496c81295fc401e3755c835d4141301c5d",
   "provenance": {
     "schemaVersion": "archcontext.architecture-docs-projection-provenance/v1",
-    "baseHeadSha": "02f71398d0bd5a5e784f4176410e27e0e0214fc4",
-    "worktreeDigest": "sha256:dddb4d11f17eeb21cac70f74841ff3f75999414428ce79784f2fb29296a4de42",
-    "sourceTreeDigest": "sha256:52b35bb1f22e41144857bec8dd42a8b4605b2c0068af29d88d792ac5d3000523",
+    "baseHeadSha": "683eafd4fbb7ca80b1d5e4def93e6b4fbca647fe",
+    "worktreeDigest": "sha256:4883d299db4f9bf6bdaee95d37cd19cba14645574f5999ad723dacf79110c2de",
+    "sourceTreeDigest": "sha256:2726a1a1cdbab077f1b93f699eeaa93c86148be8e2689b4cb4a9128ebfc726b0",
     "modelDigest": "sha256:5c7b6bee15c23e8619de802909877a67b9efa2553f284b377fadfe83caf62bbf",
-    "codeGraphDigest": "sha256:260ec1f1216fe377603aefa65c7f9cc4a34c58dab378773d379a5d627f2b795e",
-    "indexedWorktreeDigest": "sha256:fa974f89f1e9881571a8e56e78449fb3ca771fb74bc3be9c34e52fe277de7e3e",
+    "codeGraphDigest": "sha256:83a161be41b133d9d8ffe21084054b51bc22edb48060fcc76d9267b4f96f4764",
+    "indexedWorktreeDigest": "sha256:e6eb2f8ac3ff2f6c707bfb663b57dcfa78b4394fc3f6e214b0faee27b47198e3",
     "rendererVersion": "archcontext.docs-renderer/v4",
     "layoutVersion": "archcontext.docs-layout/v1",
     "generatedFrom": {
@@ -19,9 +19,9 @@
       "codeGraphBinaryDigest": "sha256:e4be48573fdf16196ca0d2867be2790aa161534e9973dcb89bc70465100ea537",
       "codeGraphStatus": "ready"
     },
-    "projectionInputDigest": "sha256:e38cfc9f6ca911238c26e57bf17b27d6cdbd0091c34a213e53a2fed1052bfed7"
+    "projectionInputDigest": "sha256:b2ca99a1e7b5ab0f9ea265baeef3cbc5ecc5304d26a47b1643c6cd179319c9d6"
   },
-  "projectionDigest": "sha256:64a988154c5422bc1ee66d9ddb082274fc36518a12fb253432f4a10a499194dc",
+  "projectionDigest": "sha256:12608577722f1d8e15d18e8cb8971d78a96e85276c900985e30a40f0db7e6ab2",
   "semanticBaseline": {
     "semanticState": {
       "schemaVersion": "archcontext.architecture-semantic-state/v1",
@@ -557,12 +557,12 @@
     },
     "digests": {
       "modelDigest": "sha256:5c7b6bee15c23e8619de802909877a67b9efa2553f284b377fadfe83caf62bbf",
-      "sourceTreeDigest": "sha256:52b35bb1f22e41144857bec8dd42a8b4605b2c0068af29d88d792ac5d3000523",
+      "sourceTreeDigest": "sha256:2726a1a1cdbab077f1b93f699eeaa93c86148be8e2689b4cb4a9128ebfc726b0",
       "flowProofDigest": "sha256:857ea8a8c0e9856186266b177c05dac2045220bc808bb17e07b1e3860cef2198",
-      "projectionDigest": "sha256:64a988154c5422bc1ee66d9ddb082274fc36518a12fb253432f4a10a499194dc"
+      "projectionDigest": "sha256:12608577722f1d8e15d18e8cb8971d78a96e85276c900985e30a40f0db7e6ab2"
     }
   },
-  "receiptDigest": "sha256:88a9e16262d0dabee0b96d81c0502263e06d7624fcf14d23d9c4d3ce7db797db",
+  "receiptDigest": "sha256:eebdca34fe51eafa5c17060d541be62f9b882a373033dbd7711ed7ae4c5b8dda",
   "refreshSignalIds": [],
   "targetCount": 27,
   "fileCount": 27,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "repo-harness",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Installs, migrates, audits, and repairs repo-local agentic development harnesses",
   "license": "MIT",
   "repository": {

--- a/tasks/notes/20260828-release-0-17-1.notes.md
+++ b/tasks/notes/20260828-release-0-17-1.notes.md
@@ -1,0 +1,60 @@
+# Implementation Notes: release-0-17-1
+
+> **Status**: Active
+> **Plan**: (none — release metadata slice, no work-package plan captured)
+> **Filing**: deploy/release-checklists/260828-repo-harness-0.17.1.md
+> **Last Updated**: 2026-08-28
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- Version `0.17.1`, not `0.18.0`. `0.17.0` is already the early-access release
+  line for this module surface (the `engineer`/`operator`/`delegation` command
+  family and the engineer MCP tool surface). This range is an iteration
+  delivery within the same early-access line rather than the first appearance
+  of a new public surface, so the patch number holds.
+- Keep this slice metadata-only. Product behavior is the already accepted
+  `v0.17.0..683eafd4` range on `main`.
+- The version bump must land on five version-carrying surfaces at once:
+  `package.json`, `assets/skill-version.json` (`version` and `templateVersion`
+  plus a `breakingChanges` entry), and the `Current Release` block in all five
+  READMEs. `checkConsistency` and `tests/readme-dx.test.ts` fail closed on any
+  one of them lagging.
+
+## Deviations From Plan Or Spec
+
+- The 0.17.0 release ran through a full work-package set
+  (`plans/plan-*`, `tasks/contracts/*`, `tasks/reviews/*`, notes). This slice
+  carries only the filing and these notes: the release scope is metadata over
+  an already accepted source range, and the durable record lives in the
+  release filing. `check-task-sync.sh` is satisfied by this notes file.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| `0.18.0` minor | Reject | The module surface shipped on the 0.17.0 early-access line; this is iteration within it, not a new public surface. |
+| Publish from `main` directly | Reject | Release metadata goes through a `codex/release-0-17-1` branch and PR, matching every prior release. |
+
+## Open Questions
+
+- None.
+
+## Evidence Links
+
+- Version consistency: `bun scripts/check-skill-version.ts`
+- Full suite: `bun test --timeout 60000` — 3184 passed, 2 skipped, 0 failed
+  (262 files).
+- Repository required checks: deploy-sql, architecture-sync, task-sync,
+  `check-task-workflow --strict`, and `init --repo . --dry-run` all pass.
+- Full package gate: `bun run check:release`.
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Candidate for `tasks/lessons.md` if a future release again trips
+  `checkConsistency` or `readme-dx`: the version bump is a five-surface atomic
+  edit, not a `package.json` edit.


### PR DESCRIPTION
Release metadata for `repo-harness@0.17.1`, a patch on the existing 0.17.0 early-access module-engineer line.

Bumps `package.json`, `assets/skill-version.json` (version + templateVersion + breakingChanges entry), and the Current Release block in all five READMEs; adds the 0.17.1 Changelog section and the release filing at `deploy/release-checklists/260828-repo-harness-0.17.1.md`.

No product code changes — the shipped behavior is the already accepted `v0.17.0..683eafd4` range on main.

`bun run check:release` passes: 3184 passed / 2 skipped / 0 failed, workflow checks, package dry-run, and packed-tarball install smoke all green.