### PR TITLE
chore: prepare repo-harness 0.18.0

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -467,8 +467,8 @@ repositorio adopte la misma política.
 
 ## Versión actual
 
-- Paquete npm: `repo-harness@0.17.1`
-- Sello de workflow generado: `repo-harness@0.17.1+template@0.17.1`
+- Paquete npm: `repo-harness@0.18.0`
+- Sello de workflow generado: `repo-harness@0.18.0+template@0.18.0`
 - Repositorio de GitHub: `Ancienttwo/repo-harness`
 - Notas de versión e historial: [`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -462,8 +462,8 @@ adopte la même policy.
 
 ## Release actuelle
 
-- Package npm : `repo-harness@0.17.1`
-- Generated workflow stamp : `repo-harness@0.17.1+template@0.17.1`
+- Package npm : `repo-harness@0.18.0`
+- Generated workflow stamp : `repo-harness@0.18.0+template@0.18.0`
 - Dépôt GitHub : `Ancienttwo/repo-harness`
 - Notes et historique de release : [`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -470,8 +470,8 @@ commit script や hooks に組み込まないでください。
 
 ## 現在の Release
 
-- npm package：`repo-harness@0.17.1`
-- Generated workflow stamp：`repo-harness@0.17.1+template@0.17.1`
+- npm package：`repo-harness@0.18.0`
+- Generated workflow stamp：`repo-harness@0.18.0+template@0.18.0`
 - GitHub repository：`Ancienttwo/repo-harness`
 - Release notes and history：[`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -466,8 +466,8 @@ repo-harness commit scripts or hooks unless that repo adopts the same policy.
 
 ## Current Release
 
-- npm package: `repo-harness@0.17.1`
-- Generated workflow stamp: `repo-harness@0.17.1+template@0.17.1`
+- npm package: `repo-harness@0.18.0`
+- Generated workflow stamp: `repo-harness@0.18.0+template@0.18.0`
 - GitHub repository: `Ancienttwo/repo-harness`
 - Release notes and history: [`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -457,8 +457,8 @@ policy。
 
 ## 当前 Release
 
-- npm package：`repo-harness@0.17.1`
-- Generated workflow stamp：`repo-harness@0.17.1+template@0.17.1`
+- npm package：`repo-harness@0.18.0`
+- Generated workflow stamp：`repo-harness@0.18.0+template@0.18.0`
 - GitHub repository：`Ancienttwo/repo-harness`
 - Release notes 和 history：[`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/assets/skill-version.json
+++ b/assets/skill-version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.17.1",
-  "templateVersion": "0.17.1",
+  "version": "0.18.0",
+  "templateVersion": "0.18.0",
   "skillName": "repo-harness",
   "contractId": "tasks-first-harness-v1",
   "compatibility": {
@@ -271,6 +271,10 @@
     {
       "version": "0.17.1",
       "description": "Delivers the persistent module-engineer control plane on the existing early-access line: durable engineer records, bindings and authenticated principal claims, a task/claim-scoped engineer inbox, the loopback operator control board, fail-closed read-only delegation admission, verified evidence context, interface change authority, integration acceptance, and the exclusive engineer MCP profile; pins ArchContext 0.4.7 and isolates fixture HOME outside the repo under test"
+    },
+    {
+      "version": "0.18.0",
+      "description": "Rebuilds the operator control board as an attention-first worklist with a resident detail pane, projecting task_label and task_index through FleetBoardCardV1 at FLEET_BOARD_PROTOCOL 2, and opens the board's single write channel as an authenticated task-message POST with Origin, read_only and 8 KiB gates under sender_kind operator; adds zh/en board i18n and canonical brand marks"
     }
   ],
   "generatedProjectStamp": {

--- a/deploy/release-checklists/260829-repo-harness-0.18.0.md
+++ b/deploy/release-checklists/260829-repo-harness-0.18.0.md
@@ -1,0 +1,116 @@
+# repo-harness 0.18.0 Release Filing
+
+- Date: 2026-08-29
+- Package: `repo-harness@0.18.0`
+- Base release: `v0.17.1` (`97468edb933a`)
+- Product source range: `v0.17.1..35ad134c9de6` (4 commits)
+- Release-prep branch: `codex/release-0-18-0`
+- Candidate commit: bound by the release PR Head after the metadata commit
+- Release scope: minor. The range rebuilds the local operator control board as
+  an attention-first worklist with a resident detail pane, bumps
+  `FLEET_BOARD_PROTOCOL` from 1 to 2 to carry human task labels, and opens the
+  board's single write channel as an authenticated task-message POST. It also
+  adds zh/en board internationalization and the canonical brand marks.
+- Publish status: **candidate preparation**. npm publish, tag creation, merge
+  to `main`, and installed-runtime refresh have not occurred.
+
+## Release Content
+
+### Operator board v2: attention-first worklist
+
+- The board replaces the five-column kanban with a single prioritized worklist
+  — needs you, mergeable, unreadable repo, agent in progress, external, done —
+  with the last three groups collapsed by default. The left rail anchors and
+  the separate Repositories section are removed.
+- The detail pane is resident. With nothing selected it renders the repo ×
+  stage matrix and repo health.
+- A persistent status bar reports relative data age, `seq`, and consistency.
+  A stale snapshot desaturates the surface and turns the age indicator red;
+  `changed_during_read` marks the status bar and the affected rows without
+  replacing their stage labels.
+- `FleetBoardCardV1` gains `task_label` and `task_index`, projected from
+  `row.task` and `row.index` as preimages of the same authority rather than as
+  a second source. The digest basis changes with them, so
+  `FLEET_BOARD_PROTOCOL` moves from `1` to `2`.
+- Attention semantics are recolored — user amber, agent neutral blue, external
+  purple, danger reserved for real errors — and carrot accent as a UI
+  affordance is constrained by the `--carrot-*` tokens to mean human write.
+  Brand identity art is the documented exception: its orange is a brand color
+  and carries no interaction semantics.
+
+### Task message write channel
+
+- `POST /api/v1/fleet/tasks/{repository_id}/{task_id}/messages` exposes the
+  existing `fleet message` effect as the board's one write action, under
+  `sender_kind: 'operator'` with a fixed `control-board` sender id.
+- The endpoint requires an `Origin` header (GET behavior is unchanged),
+  resolves `repository_id` through the registry, enforces `read_write` access,
+  and mirrors the 8 KiB body limit at the HTTP layer.
+- The composer sits collapsed at the foot of the detail pane, treats its fence
+  as the confirmation, refuses to send under `read_only`,
+  `changed_during_read`, `stale`, or `degraded`, carries a client-side
+  `message_id` for idempotency, and drives delivery feedback from the
+  authoritative `unread_count` instead of a local sent list.
+- The footer contract reads `observe-only · one write: task message`, and the
+  negative test is upgraded from "no writes" to an "exactly one write"
+  invariant guarded on both the server and the client.
+
+### Board internationalization and brand marks
+
+- A single in-repo dictionary module `src/operator-web/i18n.ts` provides zh/en
+  strings with no third-party dependency. The language switch lives in the
+  status bar, persists through `localStorage` behind `try/catch` on both read
+  and write, and initializes from `navigator.language` with `en` as the
+  default and the anchor for test assertions.
+- Blocker codes are translated in both languages with the raw code shown
+  alongside. Task labels, repo names, ids, and SHAs are not translated.
+- The board adopts the canonical pixel logo, favicon, and mascots.
+
+### Documentation and workflow closeout
+
+- `README.md` and `docs/design/DESIGN-local-human-control-board-v1.md` are
+  aligned with the rebuilt board.
+- `scripts/check-tarball-install-smoke.sh` accounts for the new client assets.
+- The `operator-board-redesign` slice is closed out: its contract is marked
+  fulfilled and its plan, contract, review, and notes are archived
+  (`184f3008`, `0ba78fe6`, `35ad134c`).
+
+## Semantic Version Decision
+
+`0.18.0` rather than `0.17.2`. The range adds a new public write surface — the
+task-message POST endpoint and its board composer — and bumps
+`FLEET_BOARD_PROTOCOL` from `1` to `2`, changing the `FleetBoardCardV1` payload
+and its digest basis. Those are additive capability and protocol changes on the
+operator/fleet surface, not an iteration inside an already-shipped shape, so a
+minor bump is taken. No public API was removed and no existing call signature
+changed incompatibly, so the change is not breaking.
+
+## Authority Boundary
+
+- This candidate changes release metadata only; product implementation is the
+  already accepted source range on `main`.
+- npm `latest`, tag `v0.18.0`, tarball metadata, source commit, version files,
+  and installed runtime must resolve to one immutable release.
+- Registry publication, tag creation, merge, and global runtime mutation are
+  covered by the current owner authorization for the 0.18.0 release.
+
+## Candidate Gate Evidence
+
+| Gate | Candidate result |
+| --- | --- |
+| `git status` clean at `35ad134c`, `main == origin/main` | pass |
+| `npm view repo-harness version` before publish | `0.17.1`, dist-tag `latest: 0.17.1` |
+| `bun run check:release` | recorded at candidate time |
+| `bun run smoke:tarball-install` | recorded at candidate time |
+| `bun run check:type` | recorded at candidate time |
+| GitHub Required/CI on release PR | pending |
+
+## Publish Follow-through
+
+1. Merge the reviewed release PR into `main`.
+2. Create tag `v0.18.0` at the merged commit and push it.
+3. Publish `repo-harness@0.18.0` to npm.
+4. Run `bun run check:release-published` to bind registry metadata, dist-tag,
+   tarball integrity, tag, installed CLI, and installed hook runtime.
+5. Refresh the selected Bun-global runtime and confirm `repo-harness --version`
+   reports `0.18.0`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,59 @@
 
 All notable changes to this skill are documented here.
 
+## [0.18.0] - 2026-08-29
+
+### Added
+
+- **Attention-first operator worklist.** The `operator serve` board replaces the
+  five-column kanban with a single prioritized worklist — needs you, mergeable,
+  unreadable repo, agent in progress, external, done — with the last three
+  groups collapsed by default. The rail anchors and the separate Repositories
+  section are gone.
+- **Resident detail pane.** The board keeps a detail pane open at all times;
+  with nothing selected it shows the repo × stage matrix and repo health. A
+  persistent status bar reports relative data age, `seq`, and consistency,
+  desaturating the surface when the snapshot is stale and marking
+  `changed_during_read` on the status bar and the affected rows without
+  replacing their stage labels.
+- **Human task labels in the board contract.** `FleetBoardCardV1` carries
+  `task_label` and `task_index`, projected from `row.task` and `row.index` as
+  preimages of the same authority. The digest basis changes with them, so
+  `FLEET_BOARD_PROTOCOL` moves from `1` to `2`.
+- **Task message write channel.** `POST
+  /api/v1/fleet/tasks/{repository_id}/{task_id}/messages` exposes the existing
+  `fleet message` effect as the board's one write action, under `sender_kind:
+  'operator'` with a fixed `control-board` sender id. The endpoint requires an
+  `Origin` header, resolves `repository_id` through the registry, enforces
+  `read_write` access, and mirrors the 8 KiB body limit at the HTTP layer. The
+  composer sits collapsed at the foot of the detail pane, treats its fence as
+  the confirmation, refuses to send under `read_only`, `changed_during_read`,
+  `stale`, or `degraded`, and drives delivery feedback from the authoritative
+  `unread_count` rather than a local sent list.
+- **Board internationalization.** A single in-repo dictionary module
+  (`src/operator-web/i18n.ts`) provides zh/en strings with no third-party
+  dependency. The language switch lives in the status bar, persists through
+  `localStorage`, and initializes from `navigator.language` with `en` as the
+  default. Blocker codes are translated in both languages with the raw code
+  shown alongside; task labels, repo names, ids, and SHAs are never translated.
+- **Canonical brand marks.** The board adopts the canonical pixel logo,
+  favicon, and mascots.
+
+### Changed
+
+- **The board's footer contract now reads `observe-only · one write: task
+  message`** instead of `read-only / localhost`, and the negative test is
+  upgraded from "no writes" to an "exactly one write" invariant guarded on both
+  the server and the client.
+- **Accent color discipline.** Carrot accent as a UI affordance means human
+  write and nothing else, a constraint carried by the `--carrot-*` CSS tokens;
+  brand identity art is the documented exception, where orange is a brand color
+  and carries no interaction semantics. Attention semantics are recolored: user
+  amber, agent neutral blue, external purple, and danger reserved for real
+  errors.
+- **Documentation is aligned** with the rebuilt board across the README and the
+  local human control board design note.
+
 ## [0.17.1] - 2026-08-28
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "repo-harness",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "description": "Installs, migrates, audits, and repairs repo-local agentic development harnesses",
   "license": "MIT",
   "repository": {

--- a/tasks/notes/20260829-release-0-18-0.notes.md
+++ b/tasks/notes/20260829-release-0-18-0.notes.md
@@ -1,0 +1,56 @@
+# Implementation Notes: release-0-18-0
+
+> **Status**: Active
+> **Plan**: (none — release metadata slice, no work-package plan captured)
+> **Filing**: deploy/release-checklists/260829-repo-harness-0.18.0.md
+> **Last Updated**: 2026-08-29
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- Version `0.18.0`, not `0.17.2`. The range adds a new public write surface
+  (the task-message POST endpoint plus its board composer) and bumps
+  `FLEET_BOARD_PROTOCOL` from `1` to `2`, changing the `FleetBoardCardV1`
+  payload and its digest basis. Additive capability plus a protocol bump is a
+  minor, and nothing public was removed, so it is not breaking.
+- Keep this slice metadata-only. Product behavior is the already accepted
+  `v0.17.1..35ad134c` range on `main` (4 commits, one of them the feature merge
+  `77ad435f`).
+- The version bump lands on five version-carrying surfaces at once:
+  `package.json`, `assets/skill-version.json` (`version` and `templateVersion`
+  plus a `breakingChanges` entry), and the `Current Release` block in all five
+  READMEs. `checkConsistency` and `tests/readme-dx.test.ts` fail closed on any
+  one of them lagging.
+
+## Deviations From Plan Or Spec
+
+- No work-package plan, contract, or review for this slice: the release scope
+  is metadata over an already accepted source range, and the durable record
+  lives in the release filing. `check-task-sync.sh` is satisfied by this notes
+  file, matching the 0.17.1 filing shape.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| `0.17.2` patch | Reject | A new HTTP write endpoint and a payload protocol bump are not iteration inside an already-shipped shape. |
+| `1.0.0` major | Reject | Nothing public was removed and no existing call signature changed incompatibly. |
+| Publish from `main` directly | Reject | Release metadata goes through a `codex/release-0-18-0` branch and PR, matching every prior release. |
+
+## Open Questions
+
+- None.
+
+## Evidence Links
+
+- `bun run check:release`
+- `bun run smoke:tarball-install`
+- `bun run check:type`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- None. The five-surface version bump is already recorded in the 0.17.1 notes.


### PR DESCRIPTION
Minor bump: the range adds a new public write surface (the task-message POST endpoint and its board composer) and moves `FLEET_BOARD_PROTOCOL` from 1 to 2, changing the `FleetBoardCardV1` payload and its digest basis. Nothing public was removed, so this is not breaking.

Product source range is `v0.17.1..35ad134c` (4 commits): the operator board rebuild as an attention-first worklist with a resident detail pane, the task-message write channel, zh/en board i18n, canonical brand marks, and the slice closeout. This PR itself is metadata only — `package.json`, `assets/skill-version.json`, the `Current Release` block in all five READMEs, `docs/CHANGELOG.md`, the release filing, and its notes.

Verification (worktree `codex/release-0-18-0`, all run with `CLAUDE_PLUGIN_DATA` unset so the local shell export does not shadow the cross-review fixture):

- `bun run check:release` — pass; 3216 pass / 0 fail across 262 files (1076.85s), `[release] OK: npm package gate passed.`
- `bun run smoke:tarball-install` — pass; `repo-harness-0.18.0.tgz` installs, serves the packaged Operator, and the packaged CLI bins start
- `bun run check:type` — pass, no errors

No tag, no publish, no merge.
