### PR TITLE
Fix ChatGPT browser and MCP race failures

### DIFF
--- a/src/cli/chatgpt-browser/engine.ts
+++ b/src/cli/chatgpt-browser/engine.ts
@@ -10,7 +10,7 @@ import {
 } from './binding';
 import { resolveBrowserOutputPath } from './file-policy';
 import { checkNativeChatgptSession, nativeDebuggingBlockedByDefaultProfile, nativeProviderAvailable, runNativeProvider } from './native-provider';
-import { buildOracleCommand, probeOracle, resolveOracleBin, runOracleProvider, supportsBrowserAppPreselect } from './oracle-provider';
+import { buildOracleCommand, probeOracle, REQUIRED_ORACLE_VERSION, resolveOracleBin, runOracleProvider, supportsBrowserAppPreselect, validateOracleVersion } from './oracle-provider';
 import { assemblePromptBundle } from './prompt-assembler';
 import { scanPromptBundle } from './secret-scan';
 import {
@@ -49,8 +49,8 @@ export interface BrowserDoctorAgentAction {
   automatic: false;
 }
 
-const PINNED_ORACLE_INSTALL = 'bun add -g @steipete/oracle@0.14.1';
-const PINNED_ORACLE_REPO_LOCAL_INSTALL = 'bun add -D @steipete/oracle@0.14.1';
+const PINNED_ORACLE_INSTALL = `bun add -g @steipete/oracle@${REQUIRED_ORACLE_VERSION}`;
+const PINNED_ORACLE_REPO_LOCAL_INSTALL = `bun add -D @steipete/oracle@${REQUIRED_ORACLE_VERSION}`;
 
 const EMPTY_ORACLE_CAPABILITIES = {
   browserEngine: false,
@@ -98,6 +98,7 @@ function buildOracleAgentActions(input: {
   provider: BrowserProviderName;
   oraclePresent: boolean;
   oracleCapabilitiesReady: boolean;
+  oracleVersionCompatible: boolean;
   missingOracleCapabilities: string[];
   oracleSource?: string;
 }): BrowserDoctorAgentAction[] {
@@ -146,9 +147,12 @@ function buildOracleAgentActions(input: {
     }];
   }
   if (!input.oracleCapabilitiesReady) {
+    const missingRequirements = input.oracleVersionCompatible
+      ? input.missingOracleCapabilities.join(', ') || 'nodeCompatible'
+      : `exact version ${REQUIRED_ORACLE_VERSION}`;
     if (input.oracleSource === '--oracle-bin' || input.oracleSource === 'REPO_HARNESS_ORACLE_BIN') {
       return [configuredSourceAction(
-        `Configured Oracle source ${input.oracleSource} resolved but is missing required browser-mode capabilities: ${input.missingOracleCapabilities.join(', ') || 'nodeCompatible'}.`,
+        `Configured Oracle source ${input.oracleSource} resolved but does not satisfy Oracle compatibility requirements: ${missingRequirements}.`,
       )];
     }
     const repoLocal = input.oracleSource === 'node_modules/.bin';
@@ -156,7 +160,7 @@ function buildOracleAgentActions(input: {
       id: 'chatgpt-oracle-upgrade-pinned',
       status: 'needs_agent',
       requires_agent: true,
-      reason: `Resolved Oracle is missing required browser-mode capabilities: ${input.missingOracleCapabilities.join(', ') || 'nodeCompatible'}.`,
+      reason: `Resolved Oracle does not satisfy compatibility requirements: ${missingRequirements}.`,
       risk: repoLocal
         ? 'Upgrades an optional repo-local external CLI dev dependency; verify the pinned binary before running any real GPT Pro consult.'
         : 'Upgrades an optional external CLI; verify the pinned binary before running any real GPT Pro consult.',
@@ -259,7 +263,9 @@ export async function browserDoctor(
   const missingOracleCapabilities = Object.entries(oracleCapabilities)
     .filter(([, supported]) => supported !== true)
     .map(([capability]) => capability);
-  const oracleCapabilitiesReady = Boolean(oracleProbe?.nodeCompatible && missingOracleCapabilities.length === 0);
+  const oracleVersionCompatible = oracleProbe?.versionCompatible === true;
+  const oracleVersionError = oracleProbe ? validateOracleVersion(oracleProbe.version).error : undefined;
+  const oracleCapabilitiesReady = Boolean(oracleProbe?.nodeCompatible && oracleVersionCompatible && missingOracleCapabilities.length === 0);
   const nativePresent = await nativeProviderAvailable();
   const bindingResult = readBrowserBinding(repoRoot);
   const binding = bindingResult.binding;
@@ -301,6 +307,8 @@ export async function browserDoctor(
   if (provider === 'oracle') {
     if (!oraclePresent) {
       next.push('Install oracle (pin the version) or pass --oracle-bin / set REPO_HARNESS_ORACLE_BIN before non-dry-run execution.');
+    } else if (!oracleVersionCompatible) {
+      next.push(oracleVersionError?.message ?? `Resolved oracle must report exactly version ${REQUIRED_ORACLE_VERSION}.`);
     } else if (!oracleCapabilitiesReady) {
       next.push('Resolved oracle binary did not report the required browser-mode flags; upgrade oracle or check `oracle --help`.');
     } else {
@@ -323,10 +331,10 @@ export async function browserDoctor(
     }
   }
   const oracleCode = provider === 'oracle'
-    ? (!oraclePresent ? 'ORACLE_NOT_INSTALLED' : oracleCapabilitiesReady ? undefined : 'ORACLE_INCOMPATIBLE')
+    ? (!oraclePresent ? 'ORACLE_NOT_INSTALLED' : oracleCapabilitiesReady ? undefined : !oracleVersionCompatible ? 'ORACLE_VERSION_UNSUPPORTED' : 'ORACLE_INCOMPATIBLE')
     : 'NATIVE_PROVIDER_DEPRECATED';
   const oracleError = provider === 'oracle'
-    ? oracleResolution.error ?? (!oracleCapabilitiesReady && oraclePresent ? {
+    ? oracleResolution.error ?? (!oracleCapabilitiesReady && oraclePresent ? oracleVersionError ?? {
       code: 'ORACLE_INCOMPATIBLE',
       message: `oracle binary did not report required browser-mode capabilities: ${missingOracleCapabilities.join(', ')}`,
       recovery: 'Upgrade oracle or check `oracle --help`; repo-harness requires every flag it may send at runtime.',
@@ -336,6 +344,7 @@ export async function browserDoctor(
     provider,
     oraclePresent,
     oracleCapabilitiesReady,
+    oracleVersionCompatible,
     missingOracleCapabilities,
     oracleSource: oracleResolution.source,
   });
@@ -351,6 +360,8 @@ export async function browserDoctor(
       binary: oracleResolution.binary,
       resolvedFrom: oracleResolution.source,
       version: oracleProbe?.version,
+      requiredVersion: REQUIRED_ORACLE_VERSION,
+      versionCompatible: oracleVersionCompatible,
       nodeCompatible: oracleProbe?.nodeCompatible ?? false,
       capabilities: oracleCapabilities,
       optionalCapabilities: oracleOptionalCapabilities,

--- a/src/cli/chatgpt-browser/native-provider.ts
+++ b/src/cli/chatgpt-browser/native-provider.ts
@@ -1,6 +1,5 @@
 import { spawnSync } from 'child_process';
-import { existsSync } from 'fs';
-import { createServer } from 'net';
+import { existsSync, readFileSync } from 'fs';
 import { homedir } from 'os';
 import { join, resolve } from 'path';
 import { pathToFileURL } from 'url';
@@ -44,7 +43,11 @@ const SEND_BUTTON_SELECTORS = [
 ];
 
 const ASSISTANT_SELECTOR = '[data-message-author-role="assistant"]';
-const STABLE_CAPTURE_MS = 5000;
+const STOP_GENERATING_SELECTORS = [
+  '[data-testid="stop-button"]',
+  'button[aria-label*="Stop generating"]',
+];
+const DEVTOOLS_ACTIVE_PORT_FILE = 'DevToolsActivePort';
 
 const CHANNEL_APPS: Record<NativeBrowserChannel, { appName: string; executable: string }> = {
   chrome: {
@@ -65,7 +68,7 @@ const CHANNEL_APPS: Record<NativeBrowserChannel, { appName: string; executable: 
   },
 };
 
-interface CdpConnection {
+export interface CdpConnection {
   send(method: string, params?: Record<string, unknown>, sessionId?: string): Promise<any>;
   close(): void;
 }
@@ -149,25 +152,28 @@ function normalizeAssistantText(raw: string | null | undefined): string {
   return text;
 }
 
-async function getFreePort(): Promise<number> {
-  return await new Promise((resolvePort, reject) => {
-    const server = createServer();
-    server.listen(0, '127.0.0.1', () => {
-      const address = server.address();
-      server.close(() => {
-        if (typeof address === 'object' && address) resolvePort(address.port);
-        else reject(new Error('failed to allocate local CDP port'));
-      });
-    });
-    server.on('error', reject);
-  });
+function readDevToolsActivePort(profileDir: string): { port: number; contents: string } | null {
+  try {
+    const contents = readFileSync(join(profileDir, DEVTOOLS_ACTIVE_PORT_FILE), 'utf-8');
+    const [portLine] = contents.split(/\r?\n/u);
+    const port = Number(portLine);
+    if (!Number.isInteger(port) || port < 1 || port > 65_535) return null;
+    return { port, contents };
+  } catch (_error) {
+    return null;
+  }
 }
 
-async function waitForCdp(port: number, timeoutMs: number): Promise<{ webSocketDebuggerUrl: string; Browser?: string }> {
+async function waitForCdp(profileDir: string, activePortBeforeLaunch: string | undefined, timeoutMs: number): Promise<{ webSocketDebuggerUrl: string; Browser?: string }> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
+    const activePort = readDevToolsActivePort(profileDir);
+    if (!activePort || activePort.contents === activePortBeforeLaunch) {
+      await Bun.sleep(250);
+      continue;
+    }
     try {
-      const response = await fetch(`http://127.0.0.1:${port}/json/version`);
+      const response = await fetch(`http://127.0.0.1:${activePort.port}/json/version`);
       if (response.ok) {
         const body = await response.json() as { webSocketDebuggerUrl?: string; Browser?: string };
         if (body.webSocketDebuggerUrl) return { webSocketDebuggerUrl: body.webSocketDebuggerUrl, Browser: body.Browser };
@@ -177,35 +183,68 @@ async function waitForCdp(port: number, timeoutMs: number): Promise<{ webSocketD
     }
     await Bun.sleep(250);
   }
-  throw new Error(`Chrome CDP endpoint did not become ready on port ${port}`);
+  throw new Error(`Chrome CDP endpoint did not become ready for profile ${profileDir}`);
 }
 
-function connectCdp(webSocketUrl: string): Promise<CdpConnection> {
+export function createCdpClient(webSocketUrl: string): Promise<CdpConnection> {
   return new Promise((resolveConnection, reject) => {
     const ws = new WebSocket(webSocketUrl);
     let nextId = 1;
     const pending = new Map<number, { resolve: (value: any) => void; reject: (error: Error) => void; timer: Timer }>();
+    let opened = false;
+    let closed = false;
+    const closedError = new Error('Chrome CDP websocket closed');
+
+    const teardown = () => {
+      if (closed) return;
+      closed = true;
+      for (const waiting of pending.values()) {
+        clearTimeout(waiting.timer);
+        waiting.reject(closedError);
+      }
+      pending.clear();
+    };
 
     ws.onopen = () => {
+      opened = true;
       resolveConnection({
         send(method: string, params: Record<string, unknown> = {}, sessionId?: string): Promise<any> {
+          if (closed) return Promise.reject(closedError);
           const id = nextId++;
           const payload = { id, method, params, ...(sessionId ? { sessionId } : {}) };
-          ws.send(JSON.stringify(payload));
           return new Promise((resolve, rejectSend) => {
             const timer = setTimeout(() => {
               pending.delete(id);
               rejectSend(new Error(`${method} timed out`));
             }, 30_000);
             pending.set(id, { resolve, reject: rejectSend, timer });
+            try {
+              ws.send(JSON.stringify(payload));
+            } catch (_error) {
+              teardown();
+            }
           });
         },
         close(): void {
+          teardown();
           ws.close();
         },
       });
     };
-    ws.onerror = () => reject(new Error(`failed to connect to Chrome CDP websocket: ${webSocketUrl}`));
+    ws.onerror = () => {
+      if (!opened) {
+        reject(new Error(`failed to connect to Chrome CDP websocket: ${webSocketUrl}`));
+        return;
+      }
+      teardown();
+    };
+    ws.onclose = () => {
+      if (!opened) {
+        reject(new Error(`failed to connect to Chrome CDP websocket: ${webSocketUrl}`));
+        return;
+      }
+      teardown();
+    };
     ws.onmessage = (event) => {
       const message = JSON.parse(String(event.data)) as { id?: number; result?: unknown; error?: { message?: string } };
       if (!message.id || !pending.has(message.id)) return;
@@ -237,14 +276,14 @@ export function openNativeBrowserPage(channel: NativeBrowserChannel, profileDir:
   }
 }
 
-async function launchChrome(channel: NativeBrowserChannel, profileDir: string, port: number, headless: boolean, url = 'about:blank', profileDirectory?: string): Promise<void> {
+async function launchChrome(channel: NativeBrowserChannel, profileDir: string, headless: boolean, url = 'about:blank', profileDirectory?: string): Promise<void> {
   const app = CHANNEL_APPS[channel];
   if (!existsSync(app.executable)) throw new Error(`${app.appName} is not installed at ${app.executable}`);
   const args = [
     '-na',
     app.appName,
     '--args',
-    `--remote-debugging-port=${port}`,
+    '--remote-debugging-port=0',
     '--remote-allow-origins=*',
     ...chromeProfileArgs(profileDir, profileDirectory),
     '--no-first-run',
@@ -320,10 +359,10 @@ export async function checkNativeChatgptSession(input: {
     };
   }
   try {
-    const port = await getFreePort();
-    await launchChrome(channel, profileDir, port, input.headless === true, 'about:blank', profileDirectory);
-    const version = await waitForCdp(port, Math.min(timeoutMs, 30_000));
-    connection = await connectCdp(version.webSocketDebuggerUrl);
+    const activePortBeforeLaunch = readDevToolsActivePort(profileDir)?.contents;
+    await launchChrome(channel, profileDir, input.headless === true, 'about:blank', profileDirectory);
+    const version = await waitForCdp(profileDir, activePortBeforeLaunch, Math.min(timeoutMs, 30_000));
+    connection = await createCdpClient(version.webSocketDebuggerUrl);
     const target = await connection.send('Target.createTarget', { url: 'about:blank' });
     const attached = await connection.send('Target.attachToTarget', { targetId: target.targetId, flatten: true });
     sessionId = attached.sessionId;
@@ -398,28 +437,43 @@ async function submitPrompt(connection: CdpConnection, sessionId: string, render
   await connection.send('Input.dispatchKeyEvent', { type: 'keyUp', key: 'Enter', code: 'Enter', windowsVirtualKeyCode: 13 }, sessionId);
 }
 
-async function waitForStableAssistantText(connection: CdpConnection, sessionId: string, timeoutMs: number): Promise<{ text: string; stable: boolean }> {
+async function assistantMessageCount(connection: CdpConnection, sessionId: string): Promise<number> {
+  const result = await evaluate(connection, sessionId, `
+    return document.querySelectorAll(${JSON.stringify(ASSISTANT_SELECTOR)}).length;
+  `);
+  return typeof result === 'number' && Number.isInteger(result) && result >= 0 ? result : 0;
+}
+
+/**
+ * ChatGPT's visible stop-generation control is the completion authority.  Text
+ * alone is deliberately insufficient: a temporarily paused stream can resume.
+ */
+export async function waitForVerifiedAssistantText(
+  connection: CdpConnection,
+  sessionId: string,
+  assistantIndex: number,
+  timeoutMs: number,
+): Promise<{ text: string; completed: boolean }> {
   const deadline = Date.now() + timeoutMs;
   let latest = '';
-  let stableSince = 0;
+  const stopSelectors = JSON.stringify(STOP_GENERATING_SELECTORS);
   while (Date.now() < deadline) {
     const result = await evaluate(connection, sessionId, `
-    const nodes = [...document.querySelectorAll(${JSON.stringify(ASSISTANT_SELECTOR)})];
-    const raw = nodes.at(-1)?.innerText || '';
-    return { text: raw, url: location.href };
+    const node = [...document.querySelectorAll(${JSON.stringify(ASSISTANT_SELECTOR)})][${assistantIndex}];
+    const streaming = ${stopSelectors}.some((selector) => {
+      const element = document.querySelector(selector);
+      return element && element.getClientRects().length > 0;
+    });
+    return { text: node?.innerText || '', streaming };
   `);
     const text = normalizeAssistantText(result?.text);
-    if (text) {
-      if (text !== latest) {
-        latest = text;
-        stableSince = Date.now();
-      } else if (Date.now() - stableSince >= STABLE_CAPTURE_MS) {
-        return { text, stable: true };
-      }
+    if (text) latest = text;
+    if (text && result?.streaming === false) {
+      return { text, completed: true };
     }
     await Bun.sleep(500);
   }
-  return { text: latest, stable: false };
+  return { text: latest, completed: false };
 }
 
 export async function runNativeProvider(input: BrowserConsultInput, bundle: PromptBundle): Promise<NativeProviderResult> {
@@ -460,10 +514,10 @@ export async function runNativeProvider(input: BrowserConsultInput, bundle: Prom
     };
   }
   try {
-    const port = await getFreePort();
-    await launchChrome(channel, profileDir, port, input.headless === true, 'about:blank', profileDirectory);
-    const version = await waitForCdp(port, Math.min(timeoutMs, 30_000));
-    connection = await connectCdp(version.webSocketDebuggerUrl);
+    const activePortBeforeLaunch = readDevToolsActivePort(profileDir)?.contents;
+    await launchChrome(channel, profileDir, input.headless === true, 'about:blank', profileDirectory);
+    const version = await waitForCdp(profileDir, activePortBeforeLaunch, Math.min(timeoutMs, 30_000));
+    connection = await createCdpClient(version.webSocketDebuggerUrl);
     const target = await connection.send('Target.createTarget', { url: 'about:blank' });
     const attached = await connection.send('Target.attachToTarget', { targetId: target.targetId, flatten: true });
     sessionId = attached.sessionId;
@@ -492,8 +546,9 @@ export async function runNativeProvider(input: BrowserConsultInput, bundle: Prom
       };
     }
 
+    const existingAssistantMessages = await assistantMessageCount(connection, sessionId!);
     await submitPrompt(connection, sessionId!, bundle.rendered);
-    const capture = await waitForStableAssistantText(connection, sessionId!, timeoutMs);
+    const capture = await waitForVerifiedAssistantText(connection, sessionId!, existingAssistantMessages, timeoutMs);
     const url = await currentUrl(connection, sessionId!);
     if (!capture.text) {
       return {
@@ -511,18 +566,18 @@ export async function runNativeProvider(input: BrowserConsultInput, bundle: Prom
         },
       };
     }
-    if (!capture.stable) {
+    if (!capture.completed) {
       return {
         status: 'incomplete_capture',
         output: [
           capture.text,
           '',
-          '[repo-harness native provider warning: assistant text was captured but did not remain stable before timeout.]',
+          '[repo-harness native provider warning: assistant text was captured but ChatGPT completion could not be verified before timeout.]',
         ].join('\n'),
         conversationUrl: conversationUrl(url),
         error: {
           code: 'ASSISTANT_CAPTURE_INCOMPLETE',
-          message: 'assistant text did not stabilize before timeout',
+          message: 'assistant completion could not be verified before timeout',
           recovery: 'Inspect the kept browser session or rerun with a longer --timeout-ms.',
         },
       };

--- a/src/cli/chatgpt-browser/oracle-provider.ts
+++ b/src/cli/chatgpt-browser/oracle-provider.ts
@@ -49,11 +49,21 @@ export interface OracleCapabilities {
 export interface OracleProbe {
   binary: string;
   version?: string;
+  /** True only when the binary reports the one Oracle release this transport supports. */
+  versionCompatible: boolean;
   /** True when the binary responded to a `--help`/`--version` probe at all. */
   nodeCompatible: boolean;
   capabilities: OracleCapabilities;
   helpText: string;
 }
+
+/**
+ * Oracle's browser command/output contract is release-specific. Keep this as the
+ * single version authority for both consultation and browser-doctor diagnostics.
+ */
+export const REQUIRED_ORACLE_VERSION = '0.14.1';
+
+const ORACLE_TERM_GRACE_MS = 5_000;
 
 export function supportsBrowserAppPreselect(helpText: string): boolean {
   return helpText.includes('--browser-app');
@@ -135,6 +145,27 @@ function detectVersion(text: string): string | undefined {
   return text.match(/\b\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?\b/)?.[0];
 }
 
+export function validateOracleVersion(version: string | undefined): {
+  compatible: boolean;
+  error?: { code: 'ORACLE_VERSION_UNSUPPORTED'; message: string; recovery: string };
+} {
+  if (version === REQUIRED_ORACLE_VERSION) return { compatible: true };
+  const detected = version ? `detected ${version}` : 'could not detect a version';
+  return {
+    compatible: false,
+    error: {
+      code: 'ORACLE_VERSION_UNSUPPORTED',
+      message: `oracle ${detected}; repo-harness requires exactly ${REQUIRED_ORACLE_VERSION}`,
+      recovery: `Install or select @steipete/oracle@${REQUIRED_ORACLE_VERSION}, then rerun browser-doctor before a real consult.`,
+    },
+  };
+}
+
+function probeOracleVersion(binary: string): string | undefined {
+  const versionRun = spawnSync(binary, ['--version'], { encoding: 'utf-8', timeout: 30_000, maxBuffer: 1024 * 1024 });
+  return detectVersion(`${versionRun.stdout ?? ''}\n${versionRun.stderr ?? ''}`);
+}
+
 /**
  * Probe an oracle binary's help/version output to confirm it actually accepts
  * the flags we send. The probe is the readiness gate — version comparison alone
@@ -144,13 +175,15 @@ export function probeOracle(binary: string): OracleProbe {
   const help = spawnSync(binary, ['--help'], { encoding: 'utf-8', timeout: 30_000, maxBuffer: 4 * 1024 * 1024 });
   const debugHelp = spawnSync(binary, ['--debug-help'], { encoding: 'utf-8', timeout: 30_000, maxBuffer: 4 * 1024 * 1024 });
   const helpText = `${help.stdout ?? ''}\n${help.stderr ?? ''}\n${debugHelp.stdout ?? ''}\n${debugHelp.stderr ?? ''}`;
-  const versionRun = spawnSync(binary, ['--version'], { encoding: 'utf-8', timeout: 30_000, maxBuffer: 1024 * 1024 });
-  const versionText = `${versionRun.stdout ?? ''}\n${versionRun.stderr ?? ''}`;
+  // `--version` is the compatibility authority. A help banner is not a valid
+  // substitute: it can omit or embed unrelated version-like strings.
+  const version = probeOracleVersion(binary);
   const ranOk = !help.error && (help.status === 0 || helpText.trim().length > 0);
   const browserThinkingTime = probeBrowserThinkingTime(binary);
   return {
     binary,
-    version: detectVersion(versionText) ?? detectVersion(helpText),
+    version,
+    versionCompatible: validateOracleVersion(version).compatible,
     nodeCompatible: ranOk,
     capabilities: detectCapabilities(helpText, browserThinkingTime),
     helpText,
@@ -294,6 +327,26 @@ interface OracleProcessResult {
   error?: Error;
 }
 
+function oracleProcessTreeSupportError(): { code: 'ORACLE_PROCESS_TREE_UNSUPPORTED'; message: string; recovery: string } | undefined {
+  if (process.platform !== 'win32') return undefined;
+  return {
+    code: 'ORACLE_PROCESS_TREE_UNSUPPORTED',
+    message: 'Oracle browser consults are unsupported on win32 because repo-harness cannot guarantee bounded process-tree termination.',
+    recovery: 'Run the Oracle consult from a POSIX host where repo-harness can supervise the dedicated Oracle process group.',
+  };
+}
+
+function signalOracleProcessGroup(pid: number | undefined, signal: NodeJS.Signals): Error | undefined {
+  if (!pid) return new Error('oracle process did not report a PID for process-group supervision');
+  try {
+    process.kill(-pid, signal);
+    return undefined;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ESRCH') return undefined;
+    return error instanceof Error ? error : new Error(String(error));
+  }
+}
+
 function runOracleProcess(
   binary: string,
   args: string[],
@@ -305,40 +358,81 @@ function runOracleProcess(
     let spawnError: Error | undefined;
     let timedOut = false;
     let killTimer: NodeJS.Timeout | undefined;
+    let settled = false;
     const child = spawn(binary, args, {
       cwd: opts.cwd,
       env: opts.env,
       stdio: ['ignore', 'pipe', 'pipe'],
+      // A fresh POSIX process group lets a timeout terminate Oracle wrappers and
+      // their descendants together instead of leaving inherited pipes open.
+      detached: true,
     });
-    const timeout = setTimeout(() => {
-      timedOut = true;
-      child.kill('SIGTERM');
-      killTimer = setTimeout(() => child.kill('SIGKILL'), 5_000);
-    }, opts.timeoutMs);
     const collect = (chunk: Buffer | string, stream: 'stdout' | 'stderr') => {
       const text = typeof chunk === 'string' ? chunk : chunk.toString('utf-8');
       if (stream === 'stdout') stdout += text;
       else stderr += text;
       process.stderr.write(text);
     };
-    child.stdout?.setEncoding('utf-8');
-    child.stderr?.setEncoding('utf-8');
-    child.stdout?.on('data', (chunk) => collect(chunk, 'stdout'));
-    child.stderr?.on('data', (chunk) => collect(chunk, 'stderr'));
-    child.on('error', (error) => {
-      spawnError = error;
-    });
-    child.on('close', (status, signal) => {
+    const stopCollecting = () => {
+      child.stdout?.removeListener('data', onStdout);
+      child.stderr?.removeListener('data', onStderr);
+      child.stdout?.destroy();
+      child.stderr?.destroy();
+    };
+    const settle = (result: OracleProcessResult, destroyPipes = false) => {
+      if (settled) return;
+      settled = true;
       clearTimeout(timeout);
       if (killTimer) clearTimeout(killTimer);
-      resolveResult({
+      child.removeListener('error', onError);
+      child.removeListener('close', onClose);
+      if (destroyPipes) stopCollecting();
+      resolveResult(result);
+    };
+    const onStdout = (chunk: Buffer | string) => collect(chunk, 'stdout');
+    const onStderr = (chunk: Buffer | string) => collect(chunk, 'stderr');
+    const onError = (error: Error) => {
+      spawnError = error;
+      settle({ stdout, stderr, status: null, signal: null, error }, true);
+    };
+    const onClose = (status: number | null, signal: NodeJS.Signals | null) => {
+      // A wrapper can exit from TERM before a SIGTERM-resistant descendant. Keep
+      // the group watchdog alive until the bounded SIGKILL pass has completed.
+      if (timedOut) return;
+      settle({
         stdout,
         stderr,
         status,
         signal,
         error: spawnError ?? (timedOut ? new Error(`oracle timed out after ${opts.timeoutMs}ms`) : undefined),
       });
-    });
+    };
+    const timeout = setTimeout(() => {
+      if (settled) return;
+      timedOut = true;
+      const termError = signalOracleProcessGroup(child.pid, 'SIGTERM');
+      killTimer = setTimeout(() => {
+        if (settled) return;
+        const killError = signalOracleProcessGroup(child.pid, 'SIGKILL');
+        settle({
+          stdout,
+          stderr,
+          status: null,
+          signal: 'SIGKILL',
+          error: killError
+            ? new Error(`oracle process-group forced termination failed: ${killError.message}`)
+            : termError
+              ? new Error(`oracle process-group termination failed: ${termError.message}`)
+              : new Error(`oracle timed out after ${opts.timeoutMs}ms`),
+        }, true);
+      }, ORACLE_TERM_GRACE_MS);
+    }, opts.timeoutMs);
+    child.stdout?.setEncoding('utf-8');
+    child.stderr?.setEncoding('utf-8');
+    child.stdout?.on('data', onStdout);
+    child.stderr?.on('data', onStderr);
+    child.on('error', onError);
+    child.on('close', onClose);
   });
 }
 
@@ -369,6 +463,29 @@ export async function runOracleProvider(input: BrowserConsultInput, bundle: Prom
       },
     };
   }
+  const resolvedOracleVersion = probeOracleVersion(resolution.binary);
+  const versionValidation = validateOracleVersion(resolvedOracleVersion);
+  if (!versionValidation.compatible) {
+    return {
+      status: 'failed',
+      output: versionValidation.error!.message,
+      command: [resolution.binary, ...buildOracleCommand(input)],
+      oracleBinary: resolution.binary,
+      oracleVersion: resolvedOracleVersion,
+      error: versionValidation.error,
+    };
+  }
+  const processTreeSupportError = oracleProcessTreeSupportError();
+  if (processTreeSupportError) {
+    return {
+      status: 'failed',
+      output: processTreeSupportError.message,
+      command: [resolution.binary, ...buildOracleCommand(input)],
+      oracleBinary: resolution.binary,
+      oracleVersion: resolvedOracleVersion,
+      error: processTreeSupportError,
+    };
+  }
   if (input.chatgptApp) {
     const probe = probeOracle(resolution.binary);
     if (!supportsBrowserAppPreselect(probe.helpText)) {
@@ -377,7 +494,7 @@ export async function runOracleProvider(input: BrowserConsultInput, bundle: Prom
         output: `Oracle binary does not support ChatGPT app preselection for "${input.chatgptApp}".`,
         command: [resolution.binary, ...buildOracleCommand(input)],
         oracleBinary: resolution.binary,
-        oracleVersion: probe.version,
+        oracleVersion: resolvedOracleVersion,
         error: {
           code: 'ORACLE_APP_PRESELECT_UNSUPPORTED',
           message: 'oracle binary did not report --browser-app support',
@@ -429,7 +546,7 @@ export async function runOracleProvider(input: BrowserConsultInput, bundle: Prom
     const stdout = result.stdout?.trimEnd() ?? '';
     const stderr = result.stderr?.trimEnd() ?? '';
     const log = [stdout, stderr ? `\n[stderr]\n${stderr}` : ''].filter(Boolean).join('\n').trimEnd();
-    const oracleVersion = detectVersion(`${stdout}\n${stderr}`);
+    const oracleVersion = resolvedOracleVersion;
     const conversationUrl = extractConversationUrl(log);
     const providerSessionId = extractProviderSessionId(log);
 

--- a/src/cli/chatgpt-browser/session-store.ts
+++ b/src/cli/chatgpt-browser/session-store.ts
@@ -1,5 +1,5 @@
 import { copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'fs';
-import { basename, dirname, join, relative } from 'path';
+import { basename, dirname, isAbsolute, join, relative } from 'path';
 import { resolveBrowserOutputPath } from './file-policy';
 import type {
   BrowserConsultInput,
@@ -38,7 +38,7 @@ function timestamp(date = new Date()): string {
 }
 
 function sessionRoot(repoRoot: string, customRoot?: string): string {
-  return customRoot?.startsWith('/') ? customRoot : join(repoRoot, customRoot ?? DEFAULT_SESSION_ROOT);
+  return customRoot && isAbsolute(customRoot) ? customRoot : join(repoRoot, customRoot ?? DEFAULT_SESSION_ROOT);
 }
 
 function assertValidSessionId(sessionId: string): void {
@@ -102,6 +102,19 @@ function copyArtifacts(artifactsDir: string, artifacts?: BrowserImportedArtifact
   });
 }
 
+function validateArtifactNames(artifacts?: BrowserImportedArtifact[]): void {
+  if (!artifacts?.length) return;
+  const seen = new Map<string, string>();
+  for (const artifact of artifacts) {
+    const targetName = basename(artifact.fileName);
+    if (seen.has(targetName)) {
+      const previous = seen.get(targetName)!;
+      throw new Error(`duplicate imported artifact basename "${targetName}" from "${previous}" and "${artifact.fileName}"`);
+    }
+    seen.set(targetName, artifact.fileName);
+  }
+}
+
 function allocateBrowserSessionPaths(input: BrowserConsultInput): { sessionId: string; paths: BrowserSessionPaths } {
   const baseSessionId = createBrowserSessionId(input);
   const root = sessionRoot(input.repoRoot, input.sessionRoot);
@@ -145,6 +158,7 @@ export function writeBrowserSession(opts: {
     : undefined;
   if (outputTarget && !outputTarget.ok) throw new Error(outputTarget.reason);
 
+  validateArtifactNames(opts.artifacts);
   const { sessionId, paths } = allocateBrowserSessionPaths(opts.input);
   const now = new Date().toISOString();
   const copiedArtifacts = copyArtifacts(paths.artifactsDir, opts.artifacts);
@@ -208,7 +222,18 @@ export function writeBrowserSession(opts: {
   writeFileSync(paths.events, JSON.stringify({ ts: now, event: 'session.created', sessionId, status: opts.status }) + '\n', 'utf-8');
   if (outputTarget?.ok) {
     mkdirSync(dirname(outputTarget.absolutePath), { recursive: true });
-    writeFileSync(outputTarget.absolutePath, opts.output.trimEnd() + '\n', 'utf-8');
+    try {
+      writeFileSync(outputTarget.absolutePath, opts.output.trimEnd() + '\n', {
+        encoding: 'utf-8',
+        flag: opts.input.overwriteOutput === true ? 'w' : 'wx',
+      });
+    } catch (error) {
+      rmSync(paths.sessionDir, { recursive: true, force: true });
+      if (opts.input.overwriteOutput !== true && (error as NodeJS.ErrnoException).code === 'EEXIST') {
+        throw new Error(`write output already exists: ${outputTarget.path}`);
+      }
+      throw error;
+    }
   }
   return {
     sessionId,
@@ -246,8 +271,16 @@ export function listBrowserSessions(repoRoot: string, customRoot?: string, limit
       createdAt: meta.createdAt,
       updatedAt: meta.updatedAt,
       title: basename(meta.sessionId).replace(/^chgpt_\d{8}_\d{6}_/, ''),
-      outputPath: `${DEFAULT_SESSION_ROOT}/${meta.sessionId}/output.md`,
-      transcriptPath: `${DEFAULT_SESSION_ROOT}/${meta.sessionId}/transcript.md`,
+      outputPath: customRoot === undefined
+        ? `${DEFAULT_SESSION_ROOT}/${meta.sessionId}/output.md`
+        : isAbsolute(customRoot)
+          ? join(root, meta.sessionId, 'output.md')
+          : rel(repoRoot, join(root, meta.sessionId, 'output.md')),
+      transcriptPath: customRoot === undefined
+        ? `${DEFAULT_SESSION_ROOT}/${meta.sessionId}/transcript.md`
+        : isAbsolute(customRoot)
+          ? join(root, meta.sessionId, 'transcript.md')
+          : rel(repoRoot, join(root, meta.sessionId, 'transcript.md')),
       conversationUrl: meta.browser.conversationUrl,
     }));
 }

--- a/src/cli/mcp/guarded-write.ts
+++ b/src/cli/mcp/guarded-write.ts
@@ -5,14 +5,16 @@
  * resolved `absolutePath` and never re-derives a policy decision. It owns only
  * the commit contract:
  *
- *   1. lstat guards  - any symlink at the target is refused (an in-repo symlink
+ *   1. cross-process exclusion - one target-scoped directory lock covers the
+ *      authoritative read, revision comparison, and final rename.
+ *   2. lstat guards  - any symlink at the target is refused (an in-repo symlink
  *      passes `resolveMcpPath` but would clobber the link target); anything that
  *      is not a regular file is refused.
- *   2. revision precondition - absent `expectedSha256` means create-only; a
+ *   3. revision precondition - absent `expectedSha256` means create-only; a
  *      supplied hash must match the current bytes. Conflict outcomes never echo
  *      the current hash, because echoing it turns a conflict into a blind
  *      write -> lift-hash -> rewrite loop that clobbers unread content.
- *   3. durable commit - temp file in the target directory, fsync, rename,
+ *   4. durable commit - temp file in the target directory, fsync, rename,
  *      parent-directory fsync (house idiom from
  *      `src/effects/evidence/atomic-append.ts` and
  *      `general-repo-access.ts#atomicWriteFile`).
@@ -31,12 +33,14 @@ import {
   mkdirSync,
   openSync,
   readFileSync,
+  realpathSync,
   renameSync,
   rmSync,
   statSync,
   writeSync,
 } from 'fs';
 import { basename, dirname, resolve } from 'path';
+import { withExclusiveDirectoryLock } from '../../effects/locking/exclusive-directory-lock';
 
 export type GuardedWriteErrorCode =
   | 'WOULD_OVERWRITE'
@@ -80,7 +84,7 @@ function fsyncDirectoryBestEffort(path: string): void {
   }
 }
 
-export function guardedWriteFile(
+function guardedWriteFileUnderLock(
   absolutePath: string,
   relativePath: string,
   content: string,
@@ -189,4 +193,31 @@ export function guardedWriteFile(
   }
 
   return { ok: true, sha256: hashContent(content), previousSha256 };
+}
+
+export function guardedWriteFile(
+  absolutePath: string,
+  relativePath: string,
+  content: string,
+  expectedSha256: string | undefined,
+): GuardedWriteOutcome {
+  const directory = dirname(absolutePath);
+  const lockPath = `.${basename(absolutePath)}.repo-harness.lock`;
+
+  try {
+    mkdirSync(directory, { recursive: true });
+    return withExclusiveDirectoryLock(
+      realpathSync(directory),
+      lockPath,
+      () => guardedWriteFileUnderLock(absolutePath, relativePath, content, expectedSha256),
+      { reclaimStaleEmptyDirectory: true },
+    );
+  } catch (error) {
+    return {
+      ok: false,
+      code: 'WRITE_FAILED',
+      message: `could not acquire the write exclusion boundary for ${relativePath}: ${error instanceof Error ? error.message : String(error)}`,
+      details: { path: relativePath },
+    };
+  }
 }

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -12,6 +12,12 @@
 
 ## Active Lessons
 
+- Date: 2026-08-31
+- Triggered by correction: implementation of public Issues #231-#240 against their declared baseline `5da1963` found that #236's native relay/JSON-envelope symbols and #235's `operations.ts` patch path did not exist at that commit; title/body uniqueness and issue completeness had been verified, but the cited executable authority had not.
+- Mistake pattern: treating a well-structured issue body plus a matching commit label as sufficient evidence that its paths, symbols, and runtime boundary exist, then dispatching implementation before reopening those authorities at the exact baseline.
+- Prevention rule: before publishing or dispatching a code issue, resolve every cited path and symbol at the declared commit and trace one caller-to-side-effect route. If the authority moved, bind the issue to the active owner explicitly; if the runtime path never existed, reject the issue as evidence-invalid instead of inventing the missing subsystem. Count/title/state checks validate issue hygiene, not technical truth.
+- Where to apply next time: GitHub Connector audits, generated issue batches, security/concurrency findings, and any handoff whose acceptance criteria depend on named internal symbols.
+
 - Date: 2026-08-30
 - Triggered by correction: the first C9 real-provider probe crossed the frozen `codex exec --json` argv and exposed two facts the shim-only C4 tests could not: the contribution adapter searched persisted stdout for raw marker lines even though the provider emits JSONL, and the generic 64 KiB capture ceiling could truncate the JSONL before its final agent message and `turn.completed` usage event. The fake Codex had been emitting the impossible raw shape, so every deterministic collector test passed.
 - Mistake pattern: freezing a producer argv and a consumer parser independently while the test double reproduces the consumer's assumption instead of the producer's actual wire; then sizing evidence capture for prose rather than for the full structured event stream whose terminal receipt is required.

--- a/tests/cli/chatgpt-browser.test.ts
+++ b/tests/cli/chatgpt-browser.test.ts
@@ -3,8 +3,10 @@ import { spawnSync } from 'child_process';
 import { createHash } from 'crypto';
 import { chmodSync, existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'fs';
 import { homedir, tmpdir } from 'os';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { runBrowserConsult, runBrowserFollowup } from '../../src/cli/chatgpt-browser/engine';
+import { createCdpClient, waitForVerifiedAssistantText } from '../../src/cli/chatgpt-browser/native-provider';
+import { DEFAULT_SESSION_ROOT, listBrowserSessions, writeBrowserSession } from '../../src/cli/chatgpt-browser/session-store';
 import { assertChatGptMcpContract } from '../helpers/chatgpt-mcp-contract';
 
 const ROOT = join(import.meta.dir, '../..');
@@ -18,6 +20,48 @@ function runChatgpt(args: string[], cwd = ROOT, env: NodeJS.ProcessEnv = process
     encoding: 'utf-8',
     env,
   });
+}
+
+async function runBrowserOutputRace(repoRoot: string, relativePath: string): Promise<Array<{ ok: boolean; output?: string; error?: string }>> {
+  const barrierRoot = join(repoRoot, `.chatgpt-browser-output-barrier-${Date.now()}-${process.pid}`);
+  mkdirSync(barrierRoot);
+  const releasePath = join(barrierRoot, 'release');
+  const workerPath = join(import.meta.dir, '../fixtures/chatgpt-browser-write-output-worker.ts');
+  const outputs = ['writer-a', 'writer-b'];
+  const workers = outputs.map((output, index) => Bun.spawn({
+    cmd: [
+      process.execPath,
+      workerPath,
+      repoRoot,
+      relativePath,
+      output,
+      join(barrierRoot, `ready-${index}`),
+      releasePath,
+    ],
+    stdout: 'pipe',
+    stderr: 'pipe',
+  }));
+
+  const deadline = Date.now() + 5_000;
+  while ((!existsSync(join(barrierRoot, 'ready-0')) || !existsSync(join(barrierRoot, 'ready-1'))) && Date.now() < deadline) {
+    await Bun.sleep(5);
+  }
+  expect(existsSync(join(barrierRoot, 'ready-0'))).toBe(true);
+  expect(existsSync(join(barrierRoot, 'ready-1'))).toBe(true);
+  writeFileSync(releasePath, 'go\n', { flag: 'wx' });
+
+  const exits = await Promise.all(workers.map((worker) => worker.exited));
+  expect(exits).toEqual([0, 0]);
+  const records = await Promise.all(workers.map(async (worker) => {
+    const [stdout, stderr] = await Promise.all([
+      new Response(worker.stdout).text(),
+      new Response(worker.stderr).text(),
+    ]);
+    expect(stderr).toBe('');
+    return JSON.parse(stdout) as { ok: boolean; output?: string; error?: string };
+  }));
+  rmSync(barrierRoot, { recursive: true, force: true });
+  return records;
 }
 
 function withRepo<T>(fn: (repoRoot: string) => T): T {
@@ -278,6 +322,9 @@ describe('chatgpt browser command', () => {
         const oraclePath = join(binDir, 'oracle');
         writeFileSync(oraclePath, [
           '#!/bin/sh',
+          'case "$1" in',
+          '  --version) printf "%s\\n" "0.14.1"; exit 0;;',
+          'esac',
           'OUT=""',
           'FILE=""',
           'PREV=""',
@@ -518,6 +565,118 @@ describe('chatgpt browser command', () => {
     });
   }, 30_000);
 
+  test('rejects imported artifact basename collisions before creating a session', () => {
+    withRepo((repoRoot) => {
+      const sourceRoot = mkdtempSync(join(tmpdir(), 'repo-harness-chatgpt-browser-artifacts-'));
+      try {
+        const sourceA = join(sourceRoot, 'reports');
+        const sourceB = join(sourceRoot, 'reviews');
+        mkdirSync(sourceA, { recursive: true });
+        mkdirSync(sourceB, { recursive: true });
+        const sourcePathA = join(sourceA, 'result.md');
+        const sourcePathB = join(sourceB, 'result.md');
+        writeFileSync(sourcePathA, 'report evidence\n');
+        writeFileSync(sourcePathB, 'review evidence\n');
+
+        expect(() => writeBrowserSession({
+          input: {
+            repoRoot,
+            title: 'artifact collision',
+            prompt: 'Review imported evidence.',
+            dryRun: true,
+          },
+          provider: 'oracle',
+          status: 'dry_run',
+          bundle: {
+            prompt: 'Review imported evidence.',
+            rendered: 'Review imported evidence.\n',
+            files: [],
+            followups: [],
+            totalChars: 'Review imported evidence.'.length,
+          },
+          output: 'Dry run output',
+          artifacts: [
+            { sourcePath: sourcePathA, fileName: 'reports/result.md', size: Buffer.byteLength('report evidence\n') },
+            { sourcePath: sourcePathB, fileName: 'reviews/result.md', size: Buffer.byteLength('review evidence\n') },
+          ],
+        })).toThrow('duplicate imported artifact basename "result.md"');
+
+        expect(existsSync(join(repoRoot, DEFAULT_SESSION_ROOT))).toBe(false);
+      } finally {
+        rmSync(sourceRoot, { recursive: true, force: true });
+      }
+    });
+  }, 30_000);
+
+  test('lists session output and transcript paths from the configured session root', () => {
+    withRepo((repoRoot) => {
+      const absoluteRoot = mkdtempSync(join(tmpdir(), 'repo-harness-chatgpt-browser-custom-root-'));
+      try {
+        const cases: Array<{ customRoot?: string; expectedRoot: string }> = [
+          { expectedRoot: DEFAULT_SESSION_ROOT },
+          { customRoot: '.cache/chatgpt-sessions', expectedRoot: '.cache/chatgpt-sessions' },
+          { customRoot: absoluteRoot, expectedRoot: absoluteRoot },
+        ];
+
+        for (const [index, current] of cases.entries()) {
+          const output = `output for root ${index}`;
+          const result = writeBrowserSession({
+            input: {
+              repoRoot,
+              title: `custom root ${index}`,
+              prompt: 'Review this session.',
+              dryRun: true,
+              sessionRoot: current.customRoot,
+            },
+            provider: 'oracle',
+            status: 'dry_run',
+            bundle: {
+              prompt: 'Review this session.',
+              rendered: 'Review this session.\n',
+              files: [],
+              followups: [],
+              totalChars: 'Review this session.'.length,
+            },
+            output,
+          });
+          const summary = listBrowserSessions(repoRoot, current.customRoot).find((session) => session.sessionId === result.sessionId);
+          expect(summary).toBeDefined();
+          expect(summary?.outputPath).toBe(join(current.expectedRoot, result.sessionId, 'output.md'));
+          expect(summary?.transcriptPath).toBe(join(current.expectedRoot, result.sessionId, 'transcript.md'));
+
+          const outputPath = current.customRoot === absoluteRoot
+            ? summary!.outputPath
+            : join(repoRoot, summary!.outputPath);
+          const transcriptPath = current.customRoot === absoluteRoot
+            ? summary!.transcriptPath
+            : join(repoRoot, summary!.transcriptPath);
+          expect(existsSync(outputPath)).toBe(true);
+          expect(existsSync(transcriptPath)).toBe(true);
+          expect(readFileSync(outputPath, 'utf-8')).toBe(`${output}\n`);
+          expect(readFileSync(transcriptPath, 'utf-8')).toContain(output);
+        }
+      } finally {
+        rmSync(absoluteRoot, { recursive: true, force: true });
+      }
+    });
+  }, 30_000);
+
+  test('allows exactly one concurrent no-overwrite publisher to claim an output path', async () => {
+    await withAsyncRepo(async (repoRoot) => {
+      for (let round = 0; round < 3; round += 1) {
+        const outputPath = `tasks/reviews/concurrent-${round}.md`;
+        const records = await runBrowserOutputRace(repoRoot, outputPath);
+        const successes = records.filter((record) => record.ok);
+        const failures = records.filter((record) => !record.ok);
+        expect(successes).toHaveLength(1);
+        expect(failures).toHaveLength(1);
+        expect(failures[0].error).toContain(`write output already exists: ${outputPath}`);
+        expect(readFileSync(join(repoRoot, outputPath), 'utf-8')).toBe(`${successes[0].output}\n`);
+        expect(listBrowserSessions(repoRoot)).toHaveLength(round + 1);
+      }
+    });
+  }, 30_000);
+
   test('native provider readiness and dry-run are wired without opening a browser', () => {
     withRepo((repoRoot) => {
       const doctor = runChatgpt(['browser-doctor', '--repo', repoRoot, '--provider', 'native', '--json']);
@@ -737,6 +896,251 @@ describe('chatgpt browser command', () => {
     });
   }, 30_000);
 
+  test('native CDP starts Chrome on an atomically assigned port', () => {
+    const source = readFileSync(join(ROOT, 'src/cli/chatgpt-browser/native-provider.ts'), 'utf-8');
+    expect(source).toContain("'--remote-debugging-port=0'");
+    expect(source).toContain('DevToolsActivePort');
+    expect(source).not.toContain('getFreePort');
+  });
+
+  test('native CDP rejects every pending command after a remote socket close', async () => {
+    const originalWebSocket = globalThis.WebSocket;
+    class FakeWebSocket {
+      static latest: FakeWebSocket | undefined;
+      onopen: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      onclose: (() => void) | null = null;
+      onmessage: ((event: { data: string }) => void) | null = null;
+
+      constructor(_url: string) {
+        FakeWebSocket.latest = this;
+        queueMicrotask(() => this.onopen?.());
+      }
+
+      send(_payload: string): void {}
+
+      close(): void {
+        this.onclose?.();
+      }
+
+      closeFromRemote(): void {
+        this.onclose?.();
+      }
+
+      failFromRemote(): void {
+        this.onerror?.();
+      }
+    }
+    (globalThis as { WebSocket: typeof WebSocket }).WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+    try {
+      const client = await createCdpClient('ws://fake-cdp.test');
+      const first = client.send('Runtime.evaluate');
+      const second = client.send('Page.enable');
+      const pendingFailures = Promise.all([
+        first.then(() => 'resolved', (error) => error.message),
+        second.then(() => 'resolved', (error) => error.message),
+      ]);
+      const socket = FakeWebSocket.latest;
+      expect(socket).toBeDefined();
+
+      socket!.closeFromRemote();
+
+      expect(await pendingFailures).toEqual(['Chrome CDP websocket closed', 'Chrome CDP websocket closed']);
+      await expect(client.send('Runtime.evaluate')).rejects.toThrow('Chrome CDP websocket closed');
+      client.close();
+
+      const errorClient = await createCdpClient('ws://fake-cdp.test');
+      const pendingAfterError = errorClient.send('Runtime.evaluate');
+      const errorFailure = pendingAfterError.then(() => 'resolved', (error) => error.message);
+      FakeWebSocket.latest!.failFromRemote();
+      expect(await errorFailure).toBe('Chrome CDP websocket closed');
+      await expect(errorClient.send('Runtime.evaluate')).rejects.toThrow('Chrome CDP websocket closed');
+    } finally {
+      (globalThis as { WebSocket: typeof WebSocket }).WebSocket = originalWebSocket;
+    }
+  });
+
+  test('native capture waits through a five-second streaming plateau for the terminal signal', async () => {
+    const samples = [
+      ...Array.from({ length: 12 }, () => ({ text: 'chunk A', streaming: true })),
+      { text: 'chunk A\nchunk B', streaming: true },
+      { text: 'chunk A\nchunk B', streaming: false },
+    ];
+    const client = {
+      async send(method: string): Promise<unknown> {
+        expect(method).toBe('Runtime.evaluate');
+        return { result: { value: samples.shift() } };
+      },
+      close(): void {},
+    };
+
+    const capture = await waitForVerifiedAssistantText(client, 'page-session', 1, 10_000);
+
+    expect(capture).toEqual({ text: 'chunk A\nchunk B', completed: true });
+  }, 15_000);
+
+  test('native capture accepts a new assistant message already in an explicit terminal state', async () => {
+    const client = {
+      async send(method: string): Promise<unknown> {
+        expect(method).toBe('Runtime.evaluate');
+        return { result: { value: { text: 'instant final', streaming: false } } };
+      },
+      close(): void {},
+    };
+
+    const capture = await waitForVerifiedAssistantText(client, 'page-session', 1, 600);
+
+    expect(capture).toEqual({ text: 'instant final', completed: true });
+  });
+
+  test('oracle rejects unsupported versions uniformly before consultation side effects', () => {
+    withRepo((repoRoot) => {
+      const binDir = mkdtempSync(join(tmpdir(), 'repo-harness-oracle-version-policy-'));
+      const withoutConfiguredOracle = { ...process.env };
+      delete withoutConfiguredOracle.REPO_HARNESS_ORACLE_BIN;
+      const writeOracle = (path: string, version: string) => {
+        writeFileSync(path, [
+          '#!/bin/sh',
+          'case "$1" in',
+          `  --version) printf "%s\\n" "${version}"; exit 0;;`,
+          '  --help|--debug-help) printf "%s\\n" "Usage: oracle --engine browser --browser-archive never --write-output <p> --browser-follow-up <t> --followup <id> --browser-model-strategy current --browser-cookie-path <path> --chatgpt-url <url> --heartbeat <seconds>"; exit 0;;',
+          'esac',
+          'if [ -n "$FAKE_ORACLE_EXECUTED" ]; then printf "%s\\n" "ran" > "$FAKE_ORACLE_EXECUTED"; fi',
+        ].join('\n'));
+        chmodSync(path, 0o755);
+      };
+      try {
+        const explicitOld = join(binDir, 'oracle-old');
+        const envExact = join(binDir, 'oracle-env');
+        const pathExact = join(binDir, 'oracle');
+        writeOracle(explicitOld, '0.14.0');
+        writeOracle(envExact, '0.14.1');
+        writeOracle(pathExact, '0.14.1');
+
+        const explicitDoctor = runChatgpt(['browser-doctor', '--repo', repoRoot, '--provider', 'oracle', '--oracle-bin', explicitOld, '--json'], ROOT, withoutConfiguredOracle);
+        const explicitReadiness = JSON.parse(explicitDoctor.stdout);
+        expect(explicitReadiness).toMatchObject({
+          status: 'action_required',
+          code: 'ORACLE_VERSION_UNSUPPORTED',
+          oracle: { resolvedFrom: '--oracle-bin', version: '0.14.0', requiredVersion: '0.14.1', versionCompatible: false },
+        });
+        expect(explicitReadiness.oracle.error.message).toContain('detected 0.14.0');
+        expect(explicitReadiness.oracle.error.message).toContain('exactly 0.14.1');
+
+        const executed = join(binDir, 'unexpected-execution');
+        const rejectedRun = runChatgpt([
+          'browser-consult',
+          '--repo',
+          repoRoot,
+          '--prompt',
+          'Do not submit this.',
+          '--oracle-bin',
+          explicitOld,
+        ], ROOT, { ...withoutConfiguredOracle, FAKE_ORACLE_EXECUTED: executed });
+        const rejectedPayload = JSON.parse(rejectedRun.stdout);
+        expect(rejectedPayload).toMatchObject({ status: 'failed', error: { code: 'ORACLE_VERSION_UNSUPPORTED' } });
+        expect(existsSync(executed)).toBe(false);
+        expect(existsSync(join(repoRoot, '.ai/harness/chatgpt/oracle-home'))).toBe(false);
+
+        const envDoctor = runChatgpt(['browser-doctor', '--repo', repoRoot, '--provider', 'oracle', '--json'], ROOT, {
+          ...withoutConfiguredOracle,
+          REPO_HARNESS_ORACLE_BIN: envExact,
+        });
+        expect(JSON.parse(envDoctor.stdout)).toMatchObject({
+          status: 'ready',
+          oracle: { resolvedFrom: 'REPO_HARNESS_ORACLE_BIN', version: '0.14.1', requiredVersion: '0.14.1', versionCompatible: true },
+        });
+
+        const repoLocalDir = join(repoRoot, 'node_modules/.bin');
+        mkdirSync(repoLocalDir, { recursive: true });
+        writeOracle(join(repoLocalDir, 'oracle'), '0.14.2');
+        const repoLocalDoctor = runChatgpt(['browser-doctor', '--repo', repoRoot, '--provider', 'oracle', '--json'], ROOT, withoutConfiguredOracle);
+        expect(JSON.parse(repoLocalDoctor.stdout)).toMatchObject({
+          status: 'action_required',
+          code: 'ORACLE_VERSION_UNSUPPORTED',
+          oracle: { resolvedFrom: 'node_modules/.bin', version: '0.14.2', requiredVersion: '0.14.1', versionCompatible: false },
+        });
+
+        rmSync(repoLocalDir, { recursive: true, force: true });
+        const pathDoctor = runChatgpt(['browser-doctor', '--repo', repoRoot, '--provider', 'oracle', '--json'], ROOT, {
+          ...withoutConfiguredOracle,
+          PATH: `${binDir}:${withoutConfiguredOracle.PATH ?? ''}`,
+        });
+        expect(JSON.parse(pathDoctor.stdout)).toMatchObject({
+          status: 'ready',
+          oracle: { resolvedFrom: 'PATH', version: '0.14.1', requiredVersion: '0.14.1', versionCompatible: true },
+        });
+      } finally {
+        rmSync(binDir, { recursive: true, force: true });
+      }
+    });
+  }, 30_000);
+
+  test('oracle timeout kills its POSIX process group and cleans staged egress', async () => {
+    if (process.platform === 'win32') return;
+    await withAsyncRepo(async (repoRoot) => {
+      const binDir = mkdtempSync(join(tmpdir(), 'repo-harness-oracle-process-tree-'));
+      try {
+        const oraclePath = join(binDir, 'oracle');
+        const childPidPath = join(binDir, 'descendant.pid');
+        const argsPath = join(binDir, 'args');
+        const gitleaksPath = writeFakeGitleaks(binDir);
+        writeFileSync(oraclePath, [
+          '#!/bin/sh',
+          'case "$1" in',
+          '  --version) printf "%s\\n" "0.14.1"; exit 0;;',
+          'esac',
+          'printf "%s\\n" "$@" > "$FAKE_ORACLE_ARGS_PATH"',
+          '(',
+          '  trap "" TERM',
+          '  while :; do sleep 1; done',
+          ') &',
+          'printf "%s\\n" "$!" > "$FAKE_ORACLE_DESCENDANT_PID_PATH"',
+          'while :; do sleep 1; done',
+        ].join('\n'));
+        chmodSync(oraclePath, 0o755);
+
+        const startedAt = Date.now();
+        const result = runChatgpt([
+          'browser-consult',
+          '--repo',
+          repoRoot,
+          '--secret-scan',
+          '--gitleaks-bin',
+          gitleaksPath,
+          '--oracle-bin',
+          oraclePath,
+          '--timeout-ms',
+          '100',
+          '--prompt',
+          'Stop this Oracle process tree.',
+          '--file',
+          'docs/example.md',
+        ], ROOT, {
+          ...process.env,
+          FAKE_ORACLE_ARGS_PATH: argsPath,
+          FAKE_ORACLE_DESCENDANT_PID_PATH: childPidPath,
+        });
+        expect(Date.now() - startedAt).toBeLessThan(8_000);
+        const payload = JSON.parse(result.stdout);
+        expect(payload).toMatchObject({ status: 'failed', error: { code: 'ORACLE_EXEC_FAILED' } });
+        expect(payload.error.message).toContain('timed out after 100ms');
+
+        const args = readFileSync(argsPath, 'utf-8').trimEnd().split('\n');
+        const stagedFile = args[args.indexOf('--file') + 1];
+        expect(stagedFile).toContain('repo-harness-oracle-egress-');
+        expect(existsSync(stagedFile)).toBe(false);
+        expect(existsSync(dirname(dirname(stagedFile)))).toBe(false);
+
+        await Bun.sleep(50);
+        const descendantPid = Number.parseInt(readFileSync(childPidPath, 'utf-8'), 10);
+        expect(() => process.kill(descendantPid, 0)).toThrow();
+      } finally {
+        rmSync(binDir, { recursive: true, force: true });
+      }
+    });
+  }, 15_000);
+
   test('oracle provider reads the --write-output answer file and treats stdout as logs', () => {
     withRepo((repoRoot) => {
       const binDir = mkdtempSync(join(tmpdir(), 'repo-harness-fake-oracle-bin-'));
@@ -749,6 +1153,9 @@ describe('chatgpt browser command', () => {
           oraclePath,
           [
             '#!/bin/sh',
+            'case "$1" in',
+            '  --version) printf "%s\\n" "0.14.1"; exit 0;;',
+            'esac',
             'ARGS="$*"',
             'OUT=""',
             'PREV=""',
@@ -852,6 +1259,9 @@ describe('chatgpt browser command', () => {
           oraclePath,
           [
             '#!/bin/sh',
+            'case "$1" in',
+            '  --version) printf "%s\\n" "0.14.1"; exit 0;;',
+            'esac',
             'ARGS="$*"',
             'OUT=""',
             'PREV=""',
@@ -918,6 +1328,9 @@ describe('chatgpt browser command', () => {
           oraclePath,
           [
             '#!/bin/sh',
+            'case "$1" in',
+            '  --version) printf "%s\\n" "0.14.1"; exit 0;;',
+            'esac',
             'ARGS="$*"',
             'OUT=""',
             'PREV=""',
@@ -976,6 +1389,9 @@ describe('chatgpt browser command', () => {
           oraclePath,
           [
             '#!/bin/sh',
+            'case "$1" in',
+            '  --version) printf "%s\\n" "0.14.1"; exit 0;;',
+            'esac',
             'printf "%s\\n" "unexpected oracle execution" >&2',
             'exit 99',
           ].join('\n'),
@@ -1013,6 +1429,9 @@ describe('chatgpt browser command', () => {
           oraclePath,
           [
             '#!/bin/sh',
+            'case "$1" in',
+            '  --version) printf "%s\\n" "0.14.1"; exit 0;;',
+            'esac',
             'printf "%s\\n" "Session ID: oracle_recover_789"',
             'exit 0',
           ].join('\n'),
@@ -1049,6 +1468,9 @@ describe('chatgpt browser command', () => {
           oraclePath,
           [
             '#!/bin/sh',
+            'case "$1" in',
+            '  --version) printf "%s\\n" "0.14.1"; exit 0;;',
+            'esac',
             'ARGS="$*"',
             'OUT=""',
             'PREV=""',
@@ -1096,6 +1518,9 @@ describe('chatgpt browser command', () => {
           oraclePath,
           [
             '#!/bin/sh',
+            'case "$1" in',
+            '  --version) printf "%s\\n" "0.14.1"; exit 0;;',
+            'esac',
             'PREV=""',
             'for a in "$@"; do',
             '  if [ "$PREV" = "--browser-thinking-time" ] && [ "$a" = "bogus" ]; then',
@@ -1184,7 +1609,7 @@ describe('chatgpt browser command', () => {
           [
             '#!/bin/sh',
             'case "$1" in',
-            '  --version) printf "%s\\n" "0.14.2"; exit 0;;',
+            '  --version) printf "%s\\n" "0.14.1"; exit 0;;',
             '  --help|--debug-help) printf "%s\\n" "Usage: oracle --engine browser --write-output <p> --browser-app <name> --browser-thinking-time <level>"; exit 0;;',
             'esac',
             'ARGS="$*"',
@@ -1232,7 +1657,7 @@ describe('chatgpt browser command', () => {
           [
             '#!/bin/sh',
             'case "$1" in',
-            '  --version) printf "%s\\n" "0.13.0";;',
+            '  --version) printf "%s\\n" "0.14.1";;',
             '  *) printf "%s\\n" "Usage: oracle --engine browser --browser-archive never --write-output <p> --browser-follow-up <t> --followup <id> --browser-model-strategy current --browser-cookie-path <path> --chatgpt-url <url> --heartbeat <seconds>";;',
             'esac',
           ].join('\n'),
@@ -1245,7 +1670,7 @@ describe('chatgpt browser command', () => {
         expect(readiness.agent_actions).toEqual([]);
         expect(readiness.oracle.installed).toBe(true);
         expect(readiness.oracle.binary).toBe(oraclePath);
-        expect(readiness.oracle.version).toBe('0.13.0');
+        expect(readiness.oracle.version).toBe('0.14.1');
         expect(readiness.oracle.capabilities).toEqual({
           browserEngine: true,
           writeOutput: true,
@@ -1304,7 +1729,7 @@ describe('chatgpt browser command', () => {
             '  if [ "$a" = "--browser-thinking-time" ]; then printf "%s\\n" "error: unknown option --browser-thinking-time" >&2; exit 1; fi',
             'done',
             'case "$1" in',
-            '  --version) printf "%s\\n" "0.12.0";;',
+            '  --version) printf "%s\\n" "0.14.1";;',
             '  *) printf "%s\\n" "Usage: oracle --engine browser --write-output <p>";;',
             'esac',
           ].join('\n'),
@@ -1354,7 +1779,7 @@ describe('chatgpt browser command', () => {
         [
           '#!/bin/sh',
           'case "$1" in',
-          '  --version) printf "%s\\n" "0.12.0";;',
+          '  --version) printf "%s\\n" "0.14.1";;',
           '  *) printf "%s\\n" "Usage: oracle --engine browser --write-output <p>";;',
           'esac',
         ].join('\n'),
@@ -1426,6 +1851,9 @@ describe('chatgpt browser command', () => {
           oraclePath,
           [
             '#!/bin/sh',
+            'case "$1" in',
+            '  --version) printf "%s\\n" "0.14.1"; exit 0;;',
+            'esac',
             'ARGS="$*"',
             'OUT=""',
             'PREV=""',

--- a/tests/cli/mcp-tools.test.ts
+++ b/tests/cli/mcp-tools.test.ts
@@ -38,6 +38,44 @@ async function jsonTool(ctx: McpToolContext, name: string, args: Record<string, 
   return JSON.parse(result.content[0].text);
 }
 
+async function runGuardedWriteRace(
+  repoRoot: string,
+  relativePath: string,
+  expectedSha256: string | undefined,
+): Promise<Array<Record<string, unknown>>> {
+  const barrierRoot = join(repoRoot, `.guarded-write-barrier-${Date.now()}`);
+  mkdirSync(barrierRoot);
+  const releasePath = join(barrierRoot, 'release');
+  const workerPath = join(import.meta.dir, '../fixtures/mcp-guarded-write-worker.ts');
+  const absolutePath = join(repoRoot, relativePath);
+  const workers = ['writer-a\n', 'writer-b\n'].map((content, index) => Bun.spawn({
+    cmd: [
+      process.execPath,
+      workerPath,
+      absolutePath,
+      relativePath,
+      Buffer.from(content).toString('base64'),
+      expectedSha256 ?? '-',
+      join(barrierRoot, `ready-${index}`),
+      releasePath,
+    ],
+    stdout: 'pipe',
+    stderr: 'pipe',
+  }));
+
+  const deadline = Date.now() + 5_000;
+  while ((!existsSync(join(barrierRoot, 'ready-0')) || !existsSync(join(barrierRoot, 'ready-1'))) && Date.now() < deadline) {
+    await Bun.sleep(5);
+  }
+  expect(existsSync(join(barrierRoot, 'ready-0'))).toBe(true);
+  expect(existsSync(join(barrierRoot, 'ready-1'))).toBe(true);
+  writeFileSync(releasePath, 'go\n', { flag: 'wx' });
+
+  const exits = await Promise.all(workers.map((worker) => worker.exited));
+  expect(exits).toEqual([0, 0]);
+  return Promise.all(workers.map(async (worker) => JSON.parse(await new Response(worker.stdout).text())));
+}
+
 async function withRegistryHome<T>(fn: (home: string) => Promise<T>): Promise<T> {
   const home = mkdtempSync(join(tmpdir(), 'repo-harness-mcp-registry-'));
   const previous = process.env.REPO_HARNESS_HOME;
@@ -428,6 +466,28 @@ describe('mcp tools', () => {
 
       const content = readFileSync(join(repoRoot, created.path), 'utf-8');
       expect(content.includes('Writer A.') !== content.includes('Writer B.')).toBe(true);
+    });
+  });
+
+  test('cross-process guarded writes serialize revision checks and create-only claims', async () => {
+    await withRepo(async (repoRoot, ctx) => {
+      const created = await jsonTool(ctx, 'write_plan', {
+        title: 'Process Race',
+        slug: 'process-race',
+        body: '# Process Race\n\nBase revision.',
+      });
+      const replacements = await runGuardedWriteRace(repoRoot, created.path, created.sha256);
+      expect(replacements.filter((entry) => entry.ok === true)).toHaveLength(1);
+      expect(replacements.filter((entry) => entry.code === 'REVISION_CONFLICT')).toHaveLength(1);
+      expect(['writer-a\n', 'writer-b\n']).toContain(readFileSync(join(repoRoot, created.path), 'utf-8'));
+      expect(existsSync(join(repoRoot, 'plans', '.plan-process-race.md.repo-harness.lock'))).toBe(false);
+
+      const createPath = 'plans/plan-process-create.md';
+      const creates = await runGuardedWriteRace(repoRoot, createPath, undefined);
+      expect(creates.filter((entry) => entry.ok === true)).toHaveLength(1);
+      expect(creates.filter((entry) => entry.code === 'WOULD_OVERWRITE')).toHaveLength(1);
+      expect(['writer-a\n', 'writer-b\n']).toContain(readFileSync(join(repoRoot, createPath), 'utf-8'));
+      expect(existsSync(join(repoRoot, 'plans', '.plan-process-create.md.repo-harness.lock'))).toBe(false);
     });
   });
 

--- a/tests/fixtures/chatgpt-browser-write-output-worker.ts
+++ b/tests/fixtures/chatgpt-browser-write-output-worker.ts
@@ -1,0 +1,40 @@
+import { existsSync, writeFileSync } from 'fs';
+
+import { writeBrowserSession } from '../../src/cli/chatgpt-browser/session-store';
+
+const [repoRoot, outputPath, output, readyPath, releasePath] = process.argv.slice(2);
+if (!repoRoot || !outputPath || output === undefined || !readyPath || !releasePath) {
+  throw new Error('chatgpt browser write-output worker arguments are incomplete');
+}
+
+writeFileSync(readyPath, `${process.pid}\n`, { flag: 'wx' });
+while (!existsSync(releasePath)) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5);
+}
+
+const bundle = {
+  prompt: 'Write the worker output.',
+  rendered: 'Write the worker output.\n',
+  files: [],
+  followups: [],
+  totalChars: 'Write the worker output.'.length,
+};
+
+try {
+  const result = writeBrowserSession({
+    input: {
+      repoRoot,
+      title: `atomic output ${process.pid}`,
+      prompt: 'Write the worker output.',
+      dryRun: true,
+      writeOutput: outputPath,
+    },
+    provider: 'oracle',
+    status: 'dry_run',
+    bundle,
+    output,
+  });
+  process.stdout.write(`${JSON.stringify({ ok: true, output, sessionId: result.sessionId })}\n`);
+} catch (error) {
+  process.stdout.write(`${JSON.stringify({ ok: false, error: error instanceof Error ? error.message : String(error) })}\n`);
+}

--- a/tests/fixtures/mcp-guarded-write-worker.ts
+++ b/tests/fixtures/mcp-guarded-write-worker.ts
@@ -1,0 +1,21 @@
+import { existsSync, writeFileSync } from 'fs';
+
+import { guardedWriteFile } from '../../src/cli/mcp/guarded-write';
+
+const [absolutePath, relativePath, encodedContent, expected, readyPath, releasePath] = process.argv.slice(2);
+if (!absolutePath || !relativePath || !encodedContent || !expected || !readyPath || !releasePath) {
+  throw new Error('guarded-write worker arguments are incomplete');
+}
+
+writeFileSync(readyPath, `${process.pid}\n`, { flag: 'wx' });
+while (!existsSync(releasePath)) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5);
+}
+
+const outcome = guardedWriteFile(
+  absolutePath,
+  relativePath,
+  Buffer.from(encodedContent, 'base64').toString('utf-8'),
+  expected === '-' ? undefined : expected,
+);
+process.stdout.write(`${JSON.stringify(outcome)}\n`);


### PR DESCRIPTION
## Summary

- remove the Chrome CDP probe-to-bind race and reject pending CDP work during teardown
- fail closed on imported artifact collisions, custom session roots, and concurrent external output publication
- supervise the complete Oracle process group and enforce the repository-authoritative `@steipete/oracle@0.14.1` version before side effects
- serialize MCP guarded writes across processes and revalidate expected SHA inside the target lock
- require explicit response terminal state instead of treating a five-second text plateau as completion

Issue #236 is intentionally excluded: its cited relay symbols and JSON-envelope path do not exist at the declared baseline, and the issue was closed separately as evidence-invalid.

## Verification

- `bun test --timeout 60000` — 3595 pass, 2 platform skips, 0 fail
- `bun test tests/cli/chatgpt-browser.test.ts --timeout 60000` — 39 pass
- `bun test tests/cli/mcp-tools.test.ts --timeout 60000` — 18 pass
- `bun run check:type`
- `bash scripts/check-deploy-sql-order.sh`
- `bash scripts/check-architecture-sync.sh`
- `bash scripts/check-task-sync.sh`
- `repo-harness run check-task-workflow --strict`
- `bun scripts/inspect-project-state.ts --repo . --format text`
- `bun src/cli/index.ts init --repo . --dry-run`

Closes #231
Closes #232
Closes #233
Closes #234
Closes #235
Closes #237
Closes #238
Closes #239
Closes #240