### PR TITLE
fix(operator): harden task messages and Fleet concurrency

### DIFF
--- a/src/effects/fleet/board.ts
+++ b/src/effects/fleet/board.ts
@@ -28,8 +28,7 @@ import {
   MergeReadinessError,
   type AbortablePublicationReadinessInput,
 } from '../publication/merge-readiness';
-import { FeedbackError, projectPendingFeedbackOffer, type PendingFeedbackOffer } from '../publication/feedback';
-import { readFeedbackEvents } from '../publication/feedback-store';
+import { FeedbackError, projectFleetFeedback } from '../publication/feedback';
 import { summarizeTaskInboxForFleet, TaskInboxError } from './task-inbox';
 import { observeAgentRuntimeEffects, projectTaskAgentRuntimeState, AgentRuntimeEffectStoreError, type AgentRuntimeEffectStatus } from '../engineers/agent-runtime-effect-store';
 
@@ -128,19 +127,18 @@ function assertRepositoryAuthority(repo: RepoHarnessRegisteredRepo): void {
   }
 }
 
-function feedbackSummary(repoRoot: string, publicationId: string): FleetBoardFeedbackSummaryV1 {
-  const projection: PendingFeedbackOffer = projectPendingFeedbackOffer({ repo_root: repoRoot, publication_id: publicationId });
-  const pendingCount = readFeedbackEvents(repoRoot, publicationId).length;
-  if (projection.state === 'none') {
-    return Object.freeze({ pending_count: pendingCount, no_progress: false, repair_actions: Object.freeze([]) });
-  }
-  if (projection.state === 'no_progress') {
-    return Object.freeze({ pending_count: pendingCount, no_progress: true, repair_actions: Object.freeze([]) });
-  }
+function feedbackSummary(repoRoot: string, publicationId: string): {
+  readonly summary: FleetBoardFeedbackSummaryV1;
+  readonly snapshot_consistency: 'stable' | 'changed_during_read';
+} {
+  const projection = projectFleetFeedback({ repo_root: repoRoot, publication_id: publicationId });
   return Object.freeze({
-    pending_count: pendingCount,
-    no_progress: false,
-    repair_actions: Object.freeze([...projection.offer.allowed_actions]),
+    summary: Object.freeze({
+      pending_count: projection.pending_count,
+      no_progress: projection.no_progress,
+      repair_actions: projection.repair_actions,
+    }),
+    snapshot_consistency: projection.snapshot_consistency,
   });
 }
 
@@ -189,6 +187,7 @@ async function cardInput(
   const currentPublication = card.claim?.current_publication ?? null;
   let readiness = null;
   let feedback = emptyFeedback();
+  let feedbackConsistency: 'stable' | 'changed_during_read' = 'stable';
   if (card.lease_state === 'reviewing' && currentPublication !== null) {
     const input: AbortablePublicationReadinessInput = {
       repo_root: repo.path,
@@ -205,7 +204,9 @@ async function cardInput(
       return resolvePublicationReadinessAbortable(input);
     });
     assertCollectionActive(options.signal, options.deadline_exceeded);
-    feedback = feedbackSummary(repo.path, currentPublication.publication_id);
+    const feedbackProjection = feedbackSummary(repo.path, currentPublication.publication_id);
+    feedback = feedbackProjection.summary;
+    feedbackConsistency = feedbackProjection.snapshot_consistency;
   }
   assertCollectionActive(options.signal, options.deadline_exceeded);
   const inbox = summarizeTaskInboxForFleet({
@@ -242,7 +243,7 @@ async function cardInput(
       addressed_to_current_claim: inbox.addressed_to_current_claim,
       ...runtime,
     }),
-    snapshot_consistency: cardInputConsistency(boardConsistency, inbox.snapshot_consistency),
+    snapshot_consistency: cardInputConsistency(boardConsistency, inbox.snapshot_consistency, feedbackConsistency),
   });
 }
 
@@ -262,8 +263,9 @@ function rowTaskIndex(rowIndex: string): number | null {
 function cardInputConsistency(
   board: 'stable' | 'changed_during_read',
   inbox: 'stable' | 'changed_during_read',
+  feedback: 'stable' | 'changed_during_read',
 ): 'stable' | 'changed_during_read' {
-  return board === 'stable' && inbox === 'stable' ? 'stable' : 'changed_during_read';
+  return board === 'stable' && inbox === 'stable' && feedback === 'stable' ? 'stable' : 'changed_during_read';
 }
 
 async function collectRepository(

--- a/src/effects/fleet/task-inbox.ts
+++ b/src/effects/fleet/task-inbox.ts
@@ -21,8 +21,9 @@ import {
   type TaskMessageEventV1,
   type TaskMessageRecipient,
 } from '../../core/fleet/task-message';
-import { lookupCanonicalTask, type CanonicalTask } from '../../core/state/coordination-identity';
+import { lookupCanonicalTask, PENDING_ROW_STATUS, type CanonicalTask } from '../../core/state/coordination-identity';
 import { resolveGitCommonDirectory } from '../git/common-directory';
+import { readActiveSprintPath, readCanonicalTargetRef } from '../state/collect-board-inputs';
 import { readCanonicalSprint, resolveRepoIdentity, type CanonicalSprintSource } from '../state/coordination-canonical-source';
 import { readLease, withTaskLock, type LeaseRead } from '../state/coordination-lease-store';
 
@@ -33,6 +34,8 @@ export type TaskInboxErrorCode =
   | 'task_message_unreadable'
   | 'message_id_conflict'
   | 'task_revision_mismatch'
+  | 'canonical_source_stale'
+  | 'task_not_pending'
   | 'task_unowned'
   | 'claim_mismatch'
   | 'recipient_unavailable'
@@ -374,6 +377,26 @@ function canonicalTask(
   return task.task;
 }
 
+/**
+ * The request's source is intentionally captured before the task lock so the
+ * operator can receive a typed stale-snapshot response. The active marker and
+ * policy target are re-read here, under that lock, to make this comparison the
+ * source-authority linearization point for publication.
+ */
+function assertCanonicalSourceIsActive(repoRoot: string, source: TaskInboxCanonicalSource): void {
+  let sprintPath: string | null;
+  let targetRef: string;
+  try {
+    sprintPath = readActiveSprintPath(repoRoot);
+    targetRef = readCanonicalTargetRef(repoRoot);
+  } catch (error) {
+    throw asInboxError(error, 'task_message_unreadable', 'cannot re-read active task board authority');
+  }
+  if (sprintPath !== source.sprintPath || targetRef !== source.targetRef) {
+    fail('canonical_source_stale', 'the active task board authority changed since the message was opened');
+  }
+}
+
 function assertLeaseCanonicalSource(lease: LeaseRead, source: TaskInboxCanonicalSource, taskId: string, expectedRevision: string): NonNullable<LeaseRead['record']> {
   if (lease.record === null) fail('task_unowned', `task ${taskId} has no owner`);
   if (lease.record.task_revision !== expectedRevision) fail('task_revision_mismatch', `lease revision does not match task inbox event for ${taskId}`);
@@ -659,11 +682,10 @@ export function summarizeTaskInboxForFleet(input: TaskInboxFleetSummaryInput): T
   });
 }
 
-/**
- * Persist an immutable event after canonical task resolution. Claim-scoped
- * sends additionally freeze the current bound claim/generation under lock.
- */
-export function sendTaskMessage(input: SendTaskMessageInput): TaskInboxSendResult {
+function sendTaskMessageWithAuthority(
+  input: SendTaskMessageInput,
+  requireActiveTaskBoardAuthority: boolean,
+): TaskInboxSendResult {
   let event: TaskMessageEventV1;
   try {
     event = validateTaskMessageEvent(input.event);
@@ -671,7 +693,13 @@ export function sendTaskMessage(input: SendTaskMessageInput): TaskInboxSendResul
     throw asInboxError(error, 'task_message_invalid', 'task message event is invalid');
   }
   return withInboxTaskLock(input.repo_root, event.task_id, () => {
-    canonicalTask(input.repo_root, input.canonical_source, event.task_id, event.task_revision);
+    if (requireActiveTaskBoardAuthority) {
+      assertCanonicalSourceIsActive(input.repo_root, input.canonical_source);
+    }
+    const task = canonicalTask(input.repo_root, input.canonical_source, event.task_id, event.task_revision);
+    if (requireActiveTaskBoardAuthority && task.row.status !== PENDING_ROW_STATUS) {
+      fail('task_not_pending', `task ${event.task_id} no longer accepts messages because its status is ${task.row.status}`);
+    }
     if (event.scope === 'claim') {
       const record = assertLeaseCanonicalSource(readLease(input.repo_root, event.task_id), input.canonical_source, event.task_id, event.task_revision);
       if (record.state !== 'bound') fail('recipient_unavailable', `task ${event.task_id} owner is ${record.state}, not bound`);
@@ -681,6 +709,23 @@ export function sendTaskMessage(input: SendTaskMessageInput): TaskInboxSendResul
     }
     return writeImmutableEvent(input.repo_root, event);
   });
+}
+
+/**
+ * Persist a producer-authorized immutable event after canonical task
+ * resolution. Claim-scoped sends additionally freeze the current bound
+ * claim/generation under lock.
+ */
+export function sendTaskMessage(input: SendTaskMessageInput): TaskInboxSendResult {
+  return sendTaskMessageWithAuthority(input, false);
+}
+
+/**
+ * Task Board's only write. Its captured source and pending-row authority are
+ * both revalidated under the task lock immediately before publication.
+ */
+export function sendTaskBoardMessage(input: SendTaskMessageInput): TaskInboxSendResult {
+  return sendTaskMessageWithAuthority(input, true);
 }
 
 /** Read-only projection for a canonical recipient. It never marks delivery. */

--- a/src/effects/fleet/task-message-request.ts
+++ b/src/effects/fleet/task-message-request.ts
@@ -4,11 +4,14 @@ import {
   type TaskMessageScope,
 } from '../../core/fleet/task-message';
 import { lookupCanonicalTask } from '../../core/state/coordination-identity';
-import { readRepoHarnessRegistryStrictSnapshot } from '../repo-registry';
+import {
+  withRepoHarnessRegistryAuthorizationLock,
+  type RepoHarnessRegistryStrictSnapshot,
+} from '../repo-registry';
 import { readActiveSprintPath, readCanonicalTargetRef } from '../state/collect-board-inputs';
 import { readCanonicalSprint, resolveRepoIdentity } from '../state/coordination-canonical-source';
 import { readLease } from '../state/coordination-lease-store';
-import { sendTaskMessage, TaskInboxError, type TaskInboxErrorCode } from './task-inbox';
+import { sendTaskBoardMessage, TaskInboxError, type TaskInboxErrorCode } from './task-inbox';
 
 /**
  * The single write the operator board is allowed to perform.
@@ -67,14 +70,11 @@ export interface SendOperatorTaskMessageResult {
   readonly created: boolean;
 }
 
-function registeredRepositoryRoot(input: SendOperatorTaskMessageInput): string {
-  let repos: ReturnType<typeof readRepoHarnessRegistryStrictSnapshot>['repos'];
-  try {
-    repos = readRepoHarnessRegistryStrictSnapshot({ env: input.env, adoptedOnly: false }).repos;
-  } catch (error) {
-    throw new OperatorTaskMessageError('registry_unavailable', 'cannot read the fleet registry authority', error);
-  }
-  const repository = repos.find((candidate) => candidate.id === input.repository_id);
+function registeredRepositoryRoot(
+  input: SendOperatorTaskMessageInput,
+  snapshot: RepoHarnessRegistryStrictSnapshot,
+): string {
+  const repository = snapshot.repos.find((candidate) => candidate.id === input.repository_id);
   if (repository === undefined) {
     throw new OperatorTaskMessageError('repository_not_found', `repository ${input.repository_id} is not registered`);
   }
@@ -138,49 +138,60 @@ function asOperatorTaskMessageError(error: unknown, fallback: OperatorTaskMessag
  * `claim_mismatch` instead of addressing a session that no longer exists.
  */
 export function sendOperatorTaskMessage(input: SendOperatorTaskMessageInput): SendOperatorTaskMessageResult {
-  const repoRoot = registeredRepositoryRoot(input);
-  if (input.scope === 'task' && (input.expected_claim_id !== null || input.expected_generation !== null)) {
-    throw new OperatorTaskMessageError('task_message_invalid', 'task-scoped messages cannot carry a claim fence');
-  }
-  if (input.scope === 'claim' && (input.expected_claim_id === null || input.expected_generation === null)) {
-    throw new OperatorTaskMessageError('task_message_invalid', 'claim-scoped messages require a claim fence');
-  }
-  const context = canonicalTaskContext(repoRoot, input.task_id, input.expected_task_revision);
-  const owner = input.scope === 'claim' ? readLease(repoRoot, context.task_id).record : null;
-  if (input.scope === 'claim' && owner === null) {
-    throw new OperatorTaskMessageError('recipient_unavailable', `task ${context.task_id} has no current owner lease`);
-  }
-  if (input.scope === 'claim'
-    && (owner!.claim_id !== input.expected_claim_id || owner!.generation !== input.expected_generation)) {
-    throw new OperatorTaskMessageError('claim_mismatch', `task ${context.task_id} owner changed since the board snapshot`);
-  }
   try {
-    const event = buildTaskMessageEvent({
-      message_id: input.message_id,
-      task_id: context.task_id,
-      task_revision: context.task_revision,
-      scope: input.scope,
-      target_claim_id: owner === null ? null : owner.claim_id,
-      target_generation: owner === null ? null : owner.generation,
-      sender_kind: OPERATOR_TASK_MESSAGE_SENDER_KIND,
-      sender_id: OPERATOR_TASK_MESSAGE_SENDER_ID,
-      sender_trust: 'local_operator',
-      audience: 'owner',
-      body: input.body,
-      created_at: new Date().toISOString(),
-      in_reply_to: null,
-    });
-    const result = sendTaskMessage({ repo_root: repoRoot, canonical_source: context.source, event });
-    return Object.freeze({
-      repository_id: input.repository_id,
-      task_id: event.task_id,
-      message_id: event.message_id,
-      scope: event.scope,
-      target_claim_id: event.target_claim_id,
-      target_generation: event.target_generation,
-      created: result.created,
+    return withRepoHarnessRegistryAuthorizationLock({ env: input.env }, (snapshot) => {
+      const repoRoot = registeredRepositoryRoot(input, snapshot);
+      if (input.scope === 'task' && (input.expected_claim_id !== null || input.expected_generation !== null)) {
+        throw new OperatorTaskMessageError('task_message_invalid', 'task-scoped messages cannot carry a claim fence');
+      }
+      if (input.scope === 'claim' && (input.expected_claim_id === null || input.expected_generation === null)) {
+        throw new OperatorTaskMessageError('task_message_invalid', 'claim-scoped messages require a claim fence');
+      }
+      const context = canonicalTaskContext(repoRoot, input.task_id, input.expected_task_revision);
+      const owner = input.scope === 'claim' ? readLease(repoRoot, context.task_id).record : null;
+      if (input.scope === 'claim' && owner === null) {
+        throw new OperatorTaskMessageError('recipient_unavailable', `task ${context.task_id} has no current owner lease`);
+      }
+      if (input.scope === 'claim'
+        && (owner!.claim_id !== input.expected_claim_id || owner!.generation !== input.expected_generation)) {
+        throw new OperatorTaskMessageError('claim_mismatch', `task ${context.task_id} owner changed since the board snapshot`);
+      }
+      try {
+        const event = buildTaskMessageEvent({
+          message_id: input.message_id,
+          task_id: context.task_id,
+          task_revision: context.task_revision,
+          scope: input.scope,
+          target_claim_id: owner === null ? null : owner.claim_id,
+          target_generation: owner === null ? null : owner.generation,
+          sender_kind: OPERATOR_TASK_MESSAGE_SENDER_KIND,
+          sender_id: OPERATOR_TASK_MESSAGE_SENDER_ID,
+          sender_trust: 'local_operator',
+          audience: 'owner',
+          body: input.body,
+          created_at: new Date().toISOString(),
+          in_reply_to: null,
+        });
+        const result = sendTaskBoardMessage({
+          repo_root: repoRoot,
+          canonical_source: context.source,
+          event,
+        });
+        return Object.freeze({
+          repository_id: input.repository_id,
+          task_id: event.task_id,
+          message_id: event.message_id,
+          scope: event.scope,
+          target_claim_id: event.target_claim_id,
+          target_generation: event.target_generation,
+          created: result.created,
+        });
+      } catch (error) {
+        throw asOperatorTaskMessageError(error, 'task_message_invalid');
+      }
     });
   } catch (error) {
-    throw asOperatorTaskMessageError(error, 'task_message_invalid');
+    if (error instanceof OperatorTaskMessageError) throw error;
+    throw asOperatorTaskMessageError(error, 'registry_unavailable');
   }
 }

--- a/src/effects/operator/fleet-worker.ts
+++ b/src/effects/operator/fleet-worker.ts
@@ -1,0 +1,54 @@
+import type { FleetBoardSnapshotV1 } from '../../core/fleet/board';
+import {
+  collectFleetBoard,
+  FleetBoardError,
+  type FleetBoardFatalErrorCode,
+} from '../fleet/board';
+
+interface FleetWorkerRequest {
+  readonly env?: Readonly<Record<string, string>>;
+  readonly sequence: number;
+  readonly max_concurrency: number;
+  readonly timeout_ms: number;
+}
+
+type FleetWorkerResponse =
+  | {
+      readonly ok: true;
+      readonly snapshot: FleetBoardSnapshotV1;
+    }
+  | {
+      readonly ok: false;
+      readonly code: FleetBoardFatalErrorCode;
+    };
+
+function unavailable(): FleetWorkerResponse {
+  return { ok: false, code: 'fleet_registry_unavailable' };
+}
+
+self.onmessage = (event: MessageEvent<FleetWorkerRequest>): void => {
+  const request = event.data;
+  if (
+    typeof request !== 'object'
+    || request === null
+    || !Number.isSafeInteger(request.sequence)
+    || !Number.isSafeInteger(request.max_concurrency)
+    || !Number.isSafeInteger(request.timeout_ms)
+  ) {
+    self.postMessage(unavailable());
+    return;
+  }
+  void collectFleetBoard({
+    env: request.env,
+    sequence: request.sequence,
+    max_concurrency: request.max_concurrency,
+    timeout_ms: request.timeout_ms,
+  }).then(
+    (snapshot) => self.postMessage({ ok: true, snapshot } satisfies FleetWorkerResponse),
+    (error) => self.postMessage(
+      error instanceof FleetBoardError
+        ? ({ ok: false, code: error.code } satisfies FleetWorkerResponse)
+        : unavailable(),
+    ),
+  );
+};

--- a/src/effects/operator/server.ts
+++ b/src/effects/operator/server.ts
@@ -14,13 +14,12 @@ import {
   type ReadOperatorCollaborationSnapshotInput,
 } from './collaboration';
 import {
-  collectFleetBoard,
   FleetBoardError,
+  type FleetBoardFatalErrorCode,
   type FleetBoardCollectorOptions,
 } from '../fleet/board';
 import {
   OperatorTaskMessageError,
-  sendOperatorTaskMessage,
   type OperatorTaskMessageErrorCode,
   type SendOperatorTaskMessageInput,
   type SendOperatorTaskMessageResult,
@@ -130,7 +129,7 @@ export interface OperatorServerOptions {
     input: OperatorCollaborationSnapshotReaderInput,
   ) => Promise<OperatorCollaborationSnapshotV1>;
   readonly send_task_message?: (
-    input: SendOperatorTaskMessageInput,
+    input: SendOperatorTaskMessageInput & { readonly signal: AbortSignal },
   ) => SendOperatorTaskMessageResult | Promise<SendOperatorTaskMessageResult>;
 }
 
@@ -246,6 +245,16 @@ function publicFleetError(error: unknown): {
   readonly status: number;
   readonly body: OperatorErrorResponseV1;
 } {
+  if (error instanceof OperatorFleetTimeoutError) {
+    return {
+      status: 503,
+      body: errorBody(
+        'fleet_snapshot_timeout',
+        'The Fleet snapshot timed out.',
+        'Refresh the board and retry.',
+      ),
+    };
+  }
   if (error instanceof FleetBoardError) {
     const messageByCode: Readonly<Record<FleetBoardError['code'], string>> = {
       fleet_registry_unavailable: 'Fleet registry cannot be read.',
@@ -262,6 +271,15 @@ function publicFleetError(error: unknown): {
     status: 503,
     body: errorBody('fleet_snapshot_unavailable', 'Fleet snapshot is unavailable.'),
   };
+}
+
+class OperatorFleetTimeoutError extends Error {
+  readonly code = 'fleet_snapshot_timeout' as const;
+
+  constructor() {
+    super('fleet snapshot deadline exceeded');
+    this.name = 'OperatorFleetTimeoutError';
+  }
 }
 
 interface PublicFailure {
@@ -297,6 +315,16 @@ function publicCollaborationError(error: unknown): {
   readonly status: number;
   readonly body: OperatorErrorResponseV1;
 } {
+  if (error instanceof OperatorCollaborationBusyError) {
+    return {
+      status: 503,
+      body: errorBody(
+        'collaboration_snapshot_busy',
+        'The collaboration snapshot service is busy.',
+        'Wait for the current collaboration refresh to finish, then retry.',
+      ),
+    };
+  }
   if (error instanceof OperatorCollaborationTimeoutError) {
     return {
       status: 503,
@@ -332,7 +360,17 @@ class OperatorCollaborationTimeoutError extends Error {
   }
 }
 
+class OperatorCollaborationBusyError extends Error {
+  readonly code = 'collaboration_snapshot_busy' as const;
+
+  constructor() {
+    super('collaboration snapshot queue is full');
+    this.name = 'OperatorCollaborationBusyError';
+  }
+}
+
 const OPERATOR_COLLABORATION_REQUEST_ABORTED = Symbol('operator-collaboration-request-aborted');
+const OPERATOR_TASK_MESSAGE_REQUEST_ABORTED = Symbol('operator-task-message-request-aborted');
 
 type OperatorCollaborationWorkerResponse =
   | {
@@ -433,6 +471,167 @@ function readDefaultCollaborationSnapshot(
   });
 }
 
+type OperatorFleetWorkerResponse =
+  | {
+      readonly ok: true;
+      readonly snapshot: FleetBoardSnapshotV1;
+    }
+  | {
+      readonly ok: false;
+      readonly code: FleetBoardFatalErrorCode;
+    };
+
+function fleetWorkerResponse(value: unknown): OperatorFleetWorkerResponse | null {
+  if (typeof value !== 'object' || value === null || !('ok' in value)) return null;
+  if (value.ok === true && 'snapshot' in value && typeof value.snapshot === 'object' && value.snapshot !== null) {
+    return { ok: true, snapshot: value.snapshot as FleetBoardSnapshotV1 };
+  }
+  if (
+    value.ok === false
+    && 'code' in value
+    && (value.code === 'fleet_registry_unavailable'
+      || value.code === 'fleet_registry_invalid'
+      || value.code === 'fleet_board_argument_invalid'
+      || value.code === 'fleet_watch_aborted_before_first_snapshot')
+  ) {
+    return { ok: false, code: value.code };
+  }
+  return null;
+}
+
+/** The parent owns request lifetime; the Worker owns only the blocking collection. */
+function readDefaultFleetSnapshot(
+  input: Required<Pick<FleetBoardCollectorOptions, 'sequence' | 'max_concurrency' | 'timeout_ms'>> & {
+    readonly env?: NodeJS.ProcessEnv;
+    readonly signal: AbortSignal;
+  },
+): Promise<FleetBoardSnapshotV1> {
+  return new Promise((resolveRead, rejectRead) => {
+    const worker = new Worker(new URL('./fleet-worker.ts', import.meta.url));
+    let settled = false;
+    const finish = (
+      outcome:
+        | { readonly ok: true; readonly snapshot: FleetBoardSnapshotV1 }
+        | { readonly ok: false; readonly error: unknown },
+    ): void => {
+      if (settled) return;
+      settled = true;
+      input.signal.removeEventListener('abort', onAbort);
+      worker.terminate();
+      if (outcome.ok) resolveRead(outcome.snapshot);
+      else rejectRead(outcome.error);
+    };
+    const onAbort = (): void => finish({ ok: false, error: new OperatorFleetTimeoutError() });
+    input.signal.addEventListener('abort', onAbort, { once: true });
+    worker.onmessage = (event: MessageEvent<unknown>) => {
+      const response = fleetWorkerResponse(event.data);
+      if (response === null) {
+        finish({ ok: false, error: new FleetBoardError('fleet_registry_unavailable', 'fleet worker returned an invalid response') });
+      } else if (response.ok) {
+        finish({ ok: true, snapshot: response.snapshot });
+      } else {
+        finish({ ok: false, error: new FleetBoardError(response.code, `fleet worker failed with ${response.code}`) });
+      }
+    };
+    worker.onerror = (error) => {
+      finish({ ok: false, error: new FleetBoardError('fleet_registry_unavailable', 'fleet worker failed', error) });
+    };
+    if (input.signal.aborted) {
+      onAbort();
+      return;
+    }
+    worker.postMessage({
+      env: collaborationWorkerEnvironment(input.env),
+      sequence: input.sequence,
+      max_concurrency: input.max_concurrency,
+      timeout_ms: input.timeout_ms,
+    });
+  });
+}
+
+type WorkerTaskMessageErrorCode = OperatorTaskMessageErrorCode;
+
+type OperatorTaskMessageWorkerResponse =
+  | {
+      readonly ok: true;
+      readonly result: SendOperatorTaskMessageResult;
+    }
+  | {
+      readonly ok: false;
+      readonly code: WorkerTaskMessageErrorCode;
+    };
+
+function taskMessageWorkerResponse(value: unknown): OperatorTaskMessageWorkerResponse | null {
+  if (typeof value !== 'object' || value === null || !('ok' in value)) return null;
+  if (value.ok === true && 'result' in value && typeof value.result === 'object' && value.result !== null) {
+    return { ok: true, result: value.result as SendOperatorTaskMessageResult };
+  }
+  if (
+    value.ok === false
+    && 'code' in value
+    && (value.code === 'registry_unavailable'
+      || value.code === 'repository_not_found'
+      || value.code === 'repository_read_only'
+      || value.code === 'canonical_sprint_unavailable'
+      || value.code === 'canonical_source_stale'
+      || value.code === 'task_not_found'
+      || value.code === 'task_message_invalid'
+      || value.code === 'task_message_unreadable'
+      || value.code === 'message_id_conflict'
+      || value.code === 'task_revision_mismatch'
+      || value.code === 'task_not_pending'
+      || value.code === 'task_unowned'
+      || value.code === 'claim_mismatch'
+      || value.code === 'recipient_unavailable'
+      || value.code === 'task_message_transition_invalid')
+  ) {
+    return { ok: false, code: value.code };
+  }
+  return null;
+}
+
+function sendDefaultTaskMessage(
+  input: SendOperatorTaskMessageInput,
+  signal: AbortSignal,
+): Promise<SendOperatorTaskMessageResult> {
+  return new Promise((resolveWrite, rejectWrite) => {
+    const worker = new Worker(new URL('./task-message-worker.ts', import.meta.url));
+    let settled = false;
+    const finish = (
+      outcome:
+        | { readonly ok: true; readonly result: SendOperatorTaskMessageResult }
+        | { readonly ok: false; readonly error: unknown },
+    ): void => {
+      if (settled) return;
+      settled = true;
+      signal.removeEventListener('abort', onAbort);
+      worker.terminate();
+      if (outcome.ok) resolveWrite(outcome.result);
+      else rejectWrite(outcome.error);
+    };
+    const onAbort = (): void => finish({ ok: false, error: OPERATOR_TASK_MESSAGE_REQUEST_ABORTED });
+    signal.addEventListener('abort', onAbort, { once: true });
+    worker.onmessage = (event: MessageEvent<unknown>) => {
+      const response = taskMessageWorkerResponse(event.data);
+      if (response === null) {
+        finish({ ok: false, error: new OperatorTaskMessageError('task_message_unreadable', 'task-message worker returned an invalid response') });
+      } else if (response.ok) {
+        finish({ ok: true, result: response.result });
+      } else {
+        finish({ ok: false, error: new OperatorTaskMessageError(response.code as OperatorTaskMessageErrorCode, `task-message worker failed with ${response.code}`) });
+      }
+    };
+    worker.onerror = (error) => {
+      finish({ ok: false, error: new OperatorTaskMessageError('task_message_unreadable', 'task-message worker failed', error) });
+    };
+    if (signal.aborted) {
+      onAbort();
+      return;
+    }
+    worker.postMessage({ input });
+  });
+}
+
 interface PublicTaskMessageFailure {
   readonly status: number;
   readonly message: string;
@@ -522,12 +721,31 @@ const TASK_MESSAGE_FAILURES: Readonly<Record<OperatorTaskMessageErrorCode, Publi
   },
 });
 
+class OperatorTaskMessageTimeoutError extends Error {
+  readonly code = 'task_message_timeout' as const;
+
+  constructor() {
+    super('task-message deadline exceeded');
+    this.name = 'OperatorTaskMessageTimeoutError';
+  }
+}
+
 function publicTaskMessageError(error: unknown): {
   readonly status: number;
   readonly body: OperatorErrorResponseV1;
 } {
+  if (error instanceof OperatorTaskMessageTimeoutError) {
+    return {
+      status: 503,
+      body: errorBody(
+        'task_message_timeout',
+        'The task message outcome is unknown because the request timed out.',
+        'Retry the exact same message_id, body, and fence. If it committed, the existing message will be returned without a duplicate.',
+      ),
+    };
+  }
   if (error instanceof OperatorTaskMessageError) {
-    const failure = TASK_MESSAGE_FAILURES[error.code];
+    const failure = TASK_MESSAGE_FAILURES[error.code as WorkerTaskMessageErrorCode];
     if (failure) {
       return { status: failure.status, body: errorBody(error.code, failure.message, failure.next_action) };
     }
@@ -682,27 +900,158 @@ export async function startOperatorServer(
   const maxConcurrency = assertCollectionOption(options.max_concurrency, 'max_concurrency', 1, 16);
   const timeoutMs = assertCollectionOption(options.timeout_ms, 'timeout_ms', 1_000, 30_000);
   const staticRoot = safePathRoot(options.static_root ?? DEFAULT_STATIC_ROOT);
-  const collect = options.collect_fleet_board ?? collectFleetBoard;
+  const collect = options.collect_fleet_board;
   const readCollaboration = options.read_collaboration_snapshot ?? readDefaultCollaborationSnapshot;
-  const send = options.send_task_message ?? sendOperatorTaskMessage;
+  const send = options.send_task_message;
   let inFlight: Promise<OperatorFleetSnapshotV1> | null = null;
   let nextSnapshotSequence = 1;
-  const activeCollaborationCancellers = new Set<() => void>();
+  let activeFleetCanceller: (() => void) | null = null;
+  const activeTaskMessageCancellers = new Set<() => void>();
+  const activeCollaborationRequestCancellers = new Set<() => void>();
+  const collaborationObservations = new Map<string, CollaborationObservation>();
+  const collaborationQueue: CollaborationObservation[] = [];
+  const collaborationQueueCapacity = maxConcurrency * 2;
+  let activeCollaborationWorkers = 0;
+
+  interface CollaborationObservation {
+    readonly repositoryId: string;
+    readonly controller: AbortController;
+    readonly promise: Promise<OperatorCollaborationSnapshotV1>;
+    readonly resolve: (snapshot: OperatorCollaborationSnapshotV1) => void;
+    readonly reject: (error: unknown) => void;
+    timer: ReturnType<typeof setTimeout> | null;
+    subscribers: number;
+    started: boolean;
+    settled: boolean;
+  }
+
+  const drainCollaborationQueue = (): void => {
+    while (activeCollaborationWorkers < maxConcurrency && collaborationQueue.length > 0) {
+      const next = collaborationQueue.shift()!;
+      if (next.settled || next.subscribers === 0) continue;
+      startCollaborationObservation(next);
+    }
+  };
+
+  const settleCollaborationObservation = (
+    observation: CollaborationObservation,
+    outcome:
+      | { readonly ok: true; readonly snapshot: OperatorCollaborationSnapshotV1 }
+      | { readonly ok: false; readonly error: unknown },
+  ): void => {
+    if (observation.settled) return;
+    observation.settled = true;
+    if (observation.timer !== null) clearTimeout(observation.timer);
+    if (observation.started) activeCollaborationWorkers -= 1;
+    else {
+      const queuedAt = collaborationQueue.indexOf(observation);
+      if (queuedAt >= 0) collaborationQueue.splice(queuedAt, 1);
+    }
+    if (collaborationObservations.get(observation.repositoryId) === observation) {
+      collaborationObservations.delete(observation.repositoryId);
+    }
+    if (outcome.ok) observation.resolve(outcome.snapshot);
+    else observation.reject(outcome.error);
+    drainCollaborationQueue();
+  };
+
+  const cancelCollaborationObservation = (observation: CollaborationObservation, error: unknown): void => {
+    if (observation.settled) return;
+    observation.controller.abort();
+    settleCollaborationObservation(observation, { ok: false, error });
+  };
+
+  const startCollaborationObservation = (observation: CollaborationObservation): void => {
+    if (observation.settled || observation.subscribers === 0) return;
+    observation.started = true;
+    activeCollaborationWorkers += 1;
+    Promise.resolve().then(() => readCollaboration({
+      env: options.env,
+      repository_id: observation.repositoryId,
+      signal: observation.controller.signal,
+    })).then(
+      (snapshot) => settleCollaborationObservation(observation, { ok: true, snapshot }),
+      (error) => settleCollaborationObservation(observation, { ok: false, error }),
+    );
+  };
+
+  const acquireCollaborationObservation = (repositoryId: string): CollaborationObservation => {
+    const existing = collaborationObservations.get(repositoryId);
+    if (existing !== undefined) {
+      existing.subscribers += 1;
+      return existing;
+    }
+    if (activeCollaborationWorkers >= maxConcurrency && collaborationQueue.length >= collaborationQueueCapacity) {
+      throw new OperatorCollaborationBusyError();
+    }
+    let resolveObservation!: (snapshot: OperatorCollaborationSnapshotV1) => void;
+    let rejectObservation!: (error: unknown) => void;
+    const observation: CollaborationObservation = {
+      repositoryId,
+      controller: new AbortController(),
+      promise: new Promise<OperatorCollaborationSnapshotV1>((resolveObservationPromise, rejectObservationPromise) => {
+        resolveObservation = resolveObservationPromise;
+        rejectObservation = rejectObservationPromise;
+      }),
+      resolve: (snapshot) => resolveObservation(snapshot),
+      reject: (error) => rejectObservation(error),
+      timer: null,
+      subscribers: 1,
+      started: false,
+      settled: false,
+    };
+    observation.timer = setTimeout(() => {
+      cancelCollaborationObservation(observation, new OperatorCollaborationTimeoutError());
+    }, timeoutMs);
+    collaborationObservations.set(repositoryId, observation);
+    if (activeCollaborationWorkers < maxConcurrency) startCollaborationObservation(observation);
+    else collaborationQueue.push(observation);
+    return observation;
+  };
+
+  const releaseCollaborationObservation = (observation: CollaborationObservation): void => {
+    if (observation.subscribers === 0) return;
+    observation.subscribers -= 1;
+    if (observation.subscribers === 0 && !observation.settled) {
+      cancelCollaborationObservation(observation, OPERATOR_COLLABORATION_REQUEST_ABORTED);
+    }
+  };
 
   const snapshot = (): Promise<OperatorFleetSnapshotV1> => {
     if (inFlight !== null) return inFlight;
     const sequence = nextSnapshotSequence;
     nextSnapshotSequence += 1;
-    const pending = collect({
-      env: options.env,
-      sequence,
-      max_concurrency: maxConcurrency,
-      timeout_ms: timeoutMs,
-    }).then(projectOperatorFleetSnapshot);
+    const controller = new AbortController();
+    const deadline = setTimeout(() => controller.abort(), timeoutMs);
+    const pending = (collect === undefined
+      ? readDefaultFleetSnapshot({
+        env: options.env,
+        sequence,
+        max_concurrency: maxConcurrency,
+        timeout_ms: timeoutMs,
+        signal: controller.signal,
+      })
+      : Promise.resolve().then(() => collect({
+        env: options.env,
+        sequence,
+        max_concurrency: maxConcurrency,
+        timeout_ms: timeoutMs,
+        signal: controller.signal,
+      }))).then(projectOperatorFleetSnapshot);
     inFlight = pending;
+    const cancelFleet = () => controller.abort();
+    activeFleetCanceller = cancelFleet;
     pending.then(
-      () => { if (inFlight === pending) inFlight = null; },
-      () => { if (inFlight === pending) inFlight = null; },
+      () => {
+        clearTimeout(deadline);
+        if (inFlight === pending) inFlight = null;
+        if (activeFleetCanceller === cancelFleet) activeFleetCanceller = null;
+      },
+      () => {
+        clearTimeout(deadline);
+        if (inFlight === pending) inFlight = null;
+        if (activeFleetCanceller === cancelFleet) activeFleetCanceller = null;
+      },
     );
     return pending;
   };
@@ -746,39 +1095,6 @@ export async function startOperatorServer(
       ));
       return;
     }
-    try {
-      const result = await send({
-        env: options.env,
-        repository_id: repositoryId,
-        task_id: taskId,
-        message_id: payload.message_id,
-        scope: payload.scope,
-        expected_task_revision: payload.expected_task_revision,
-        expected_claim_id: payload.expected_claim_id,
-        expected_generation: payload.expected_generation,
-        body: payload.body,
-      });
-      sendJson(response, result.created ? 201 : 200, {
-        ok: true,
-        protocol: OPERATOR_SERVER_PROTOCOL,
-        repository_id: result.repository_id,
-        task_id: result.task_id,
-        message_id: result.message_id,
-        scope: result.scope,
-        created: result.created,
-      });
-    } catch (error) {
-      const failure = publicTaskMessageError(error);
-      sendJson(response, failure.status, failure.body);
-    }
-  };
-
-  const handleCollaborationSnapshot = async (
-    request: IncomingMessage,
-    response: ServerResponse,
-    repositoryId: string,
-    headOnly = false,
-  ): Promise<void> => {
     const controller = new AbortController();
     let finished = false;
     let clientDisconnected = false;
@@ -794,38 +1110,119 @@ export async function startOperatorServer(
       else serverClosing = true;
       controller.abort();
       if (reason === 'server_shutdown' && !response.destroyed) response.destroy();
+      rejectCancellation?.(OPERATOR_TASK_MESSAGE_REQUEST_ABORTED);
+    };
+    const onClientDisconnect = () => cancel('client_disconnect');
+    const cancelForServerClose = () => cancel('server_shutdown');
+    request.once('aborted', onClientDisconnect);
+    response.once('close', onClientDisconnect);
+    activeTaskMessageCancellers.add(cancelForServerClose);
+    const timer = setTimeout(() => {
+      if (finished) return;
+      timeoutExpired = true;
+      controller.abort();
+      rejectCancellation?.(new OperatorTaskMessageTimeoutError());
+    }, timeoutMs);
+    const input: SendOperatorTaskMessageInput = {
+      env: options.env,
+      repository_id: repositoryId,
+      task_id: taskId,
+      message_id: payload.message_id,
+      scope: payload.scope,
+      expected_task_revision: payload.expected_task_revision,
+      expected_claim_id: payload.expected_claim_id,
+      expected_generation: payload.expected_generation,
+      body: payload.body,
+    };
+    try {
+      const result = await Promise.race([
+        send === undefined
+          ? sendDefaultTaskMessage({ ...input, env: collaborationWorkerEnvironment(input.env) }, controller.signal)
+          : Promise.resolve().then(() => send({ ...input, signal: controller.signal })),
+        cancellation,
+      ]);
+      if (clientDisconnected || serverClosing || response.destroyed) return;
+      finished = true;
+      sendJson(response, result.created ? 201 : 200, {
+        ok: true,
+        protocol: OPERATOR_SERVER_PROTOCOL,
+        repository_id: result.repository_id,
+        task_id: result.task_id,
+        message_id: result.message_id,
+        scope: result.scope,
+        created: result.created,
+      });
+    } catch (error) {
+      if (clientDisconnected || serverClosing || response.destroyed) return;
+      finished = true;
+      const failure = publicTaskMessageError(timeoutExpired ? new OperatorTaskMessageTimeoutError() : error);
+      sendJson(response, failure.status, failure.body);
+    } finally {
+      finished = true;
+      clearTimeout(timer);
+      activeTaskMessageCancellers.delete(cancelForServerClose);
+      request.removeListener('aborted', onClientDisconnect);
+      response.removeListener('close', onClientDisconnect);
+    }
+  };
+
+  const handleCollaborationSnapshot = async (
+    request: IncomingMessage,
+    response: ServerResponse,
+    repositoryId: string,
+    headOnly = false,
+  ): Promise<void> => {
+    let observation: CollaborationObservation;
+    try {
+      observation = acquireCollaborationObservation(repositoryId);
+    } catch (error) {
+      const failure = publicCollaborationError(error);
+      sendJson(response, failure.status, failure.body, headOnly);
+      return;
+    }
+    let finished = false;
+    let clientDisconnected = false;
+    let serverClosing = false;
+    let released = false;
+    let rejectCancellation: ((reason: unknown) => void) | null = null;
+    const cancellation = new Promise<never>((_resolve, reject) => {
+      rejectCancellation = reject;
+    });
+    const release = (): void => {
+      if (released) return;
+      released = true;
+      releaseCollaborationObservation(observation);
+    };
+    const cancel = (reason: 'client_disconnect' | 'server_shutdown'): void => {
+      if (finished) return;
+      if (reason === 'client_disconnect') clientDisconnected = true;
+      else serverClosing = true;
+      release();
+      if (reason === 'server_shutdown' && !response.destroyed) response.destroy();
       rejectCancellation?.(OPERATOR_COLLABORATION_REQUEST_ABORTED);
     };
     const onClientDisconnect = () => cancel('client_disconnect');
     const cancelForServerClose = () => cancel('server_shutdown');
     request.once('aborted', onClientDisconnect);
     response.once('close', onClientDisconnect);
-    activeCollaborationCancellers.add(cancelForServerClose);
-    const timer = setTimeout(() => {
-      if (finished) return;
-      timeoutExpired = true;
-      controller.abort();
-      rejectCancellation?.(new OperatorCollaborationTimeoutError());
-    }, timeoutMs);
+    activeCollaborationRequestCancellers.add(cancelForServerClose);
     try {
       const collaboration = await Promise.race([
-        Promise.resolve().then(() => readCollaboration({
-          env: options.env,
-          repository_id: repositoryId,
-          signal: controller.signal,
-        })),
+        observation.promise,
         cancellation,
       ]);
       if (clientDisconnected || serverClosing || response.destroyed) return;
+      finished = true;
       sendJson(response, 200, collaboration, headOnly);
     } catch (error) {
       if (clientDisconnected || serverClosing || response.destroyed) return;
-      const failure = publicCollaborationError(timeoutExpired ? new OperatorCollaborationTimeoutError() : error);
+      finished = true;
+      const failure = publicCollaborationError(error);
       sendJson(response, failure.status, failure.body, headOnly);
     } finally {
       finished = true;
-      clearTimeout(timer);
-      activeCollaborationCancellers.delete(cancelForServerClose);
+      release();
+      activeCollaborationRequestCancellers.delete(cancelForServerClose);
       request.removeListener('aborted', onClientDisconnect);
       response.removeListener('close', onClientDisconnect);
     }
@@ -983,7 +1380,9 @@ export async function startOperatorServer(
   const close = async (): Promise<void> => {
     if (closed) return;
     closed = true;
-    for (const cancel of activeCollaborationCancellers) cancel();
+    activeFleetCanceller?.();
+    for (const cancel of activeTaskMessageCancellers) cancel();
+    for (const cancel of activeCollaborationRequestCancellers) cancel();
     if (!server.listening) return;
     await new Promise<void>((resolveClose, rejectClose) => {
       server.close((error?: Error) => {

--- a/src/effects/operator/server.ts
+++ b/src/effects/operator/server.ts
@@ -490,6 +490,16 @@ const TASK_MESSAGE_FAILURES: Readonly<Record<OperatorTaskMessageErrorCode, Publi
     message: 'The canonical task definition moved since the snapshot.',
     next_action: OPERATOR_REOBSERVE_ACTION,
   },
+  canonical_source_stale: {
+    status: 409,
+    message: 'The active task board authority changed since the snapshot.',
+    next_action: OPERATOR_REOBSERVE_ACTION,
+  },
+  task_not_pending: {
+    status: 409,
+    message: 'This task no longer accepts messages.',
+    next_action: OPERATOR_REOBSERVE_ACTION,
+  },
   task_unowned: {
     status: 409,
     message: 'The task has no owner that can receive this message.',

--- a/src/effects/operator/task-message-worker.ts
+++ b/src/effects/operator/task-message-worker.ts
@@ -1,0 +1,45 @@
+import {
+  OperatorTaskMessageError,
+  sendOperatorTaskMessage,
+  type OperatorTaskMessageErrorCode,
+  type SendOperatorTaskMessageInput,
+  type SendOperatorTaskMessageResult,
+} from '../fleet/task-message-request';
+
+interface TaskMessageWorkerRequest {
+  readonly input: SendOperatorTaskMessageInput;
+}
+
+type TaskMessageWorkerResponse =
+  | {
+      readonly ok: true;
+      readonly result: SendOperatorTaskMessageResult;
+    }
+  | {
+      readonly ok: false;
+      readonly code: OperatorTaskMessageErrorCode;
+    };
+
+function unavailable(): TaskMessageWorkerResponse {
+  return { ok: false, code: 'task_message_unreadable' };
+}
+
+self.onmessage = (event: MessageEvent<TaskMessageWorkerRequest>): void => {
+  const request = event.data;
+  if (typeof request !== 'object' || request === null || typeof request.input !== 'object' || request.input === null) {
+    self.postMessage(unavailable());
+    return;
+  }
+  try {
+    self.postMessage({
+      ok: true,
+      result: sendOperatorTaskMessage(request.input),
+    } satisfies TaskMessageWorkerResponse);
+  } catch (error) {
+    self.postMessage(
+      error instanceof OperatorTaskMessageError
+        ? ({ ok: false, code: error.code } satisfies TaskMessageWorkerResponse)
+        : unavailable(),
+    );
+  }
+};

--- a/src/effects/publication/feedback.ts
+++ b/src/effects/publication/feedback.ts
@@ -6,6 +6,9 @@ import {
   buildFeedbackEvent,
   buildRepairDispatchProof,
   buildReactionAttemptReceipt,
+  canonicalFeedbackDeliveryReceiptBytes,
+  canonicalFeedbackEventBytes,
+  canonicalReactionAttemptReceiptBytes,
   deriveCompletionId,
   deriveFeedbackRevision,
   deriveReactionToken,
@@ -17,6 +20,7 @@ import {
   type FeedbackFailingCheckV1,
   type FeedbackMergeability,
   type ReactionAttemptReceiptV1,
+  type RepairOfferAction,
   type RepairDispatchProofV1,
   type RepairOfferV1,
   type RepairOfferProjection,
@@ -55,7 +59,9 @@ import {
 } from './publication-receipt';
 import {
   canonicalPublicationReceiptBytes,
+  publicationSha256,
   publicationReceiptDigest,
+  stablePublicationJson,
   type PublicationReceiptV1,
 } from '../../core/publication/publication-receipt';
 
@@ -114,6 +120,23 @@ export interface FeedbackIntakeResult {
 export type PendingFeedbackOffer =
   | { readonly state: 'none'; readonly publication_id: string }
   | RepairOfferProjection;
+
+export interface FleetFeedbackProjection {
+  readonly pending_count: number;
+  readonly no_progress: boolean;
+  readonly repair_actions: readonly RepairOfferAction[];
+  /** Event-set authority consumed by repair offers. */
+  readonly feedback_revision: string;
+  /** Digest of the publication, events, deliveries, and reaction attempts observed together. */
+  readonly store_revision: string;
+  readonly snapshot_consistency: 'stable' | 'changed_during_read';
+}
+
+export interface FleetFeedbackProjectionDependencies {
+  readonly read_events: typeof readFeedbackEvents;
+  readonly read_deliveries: typeof readFeedbackDeliveryReceipts;
+  readonly read_reactions: typeof readReactionAttemptReceipts;
+}
 
 interface ProviderIdentity {
   readonly provider_repo_id: string;
@@ -810,54 +833,149 @@ export function projectPendingFeedbackOffer(
   let lastTorn: unknown = null;
   for (let attempt = 0; attempt < 2; attempt += 1) {
     try {
-      const before = currentPublication(input.repo_root, input.publication_id, gitBin);
-      const events = readFeedbackEvents(input.repo_root, before.receipt.publication_id, gitBin);
-      const deliveries = readFeedbackDeliveryReceipts(input.repo_root, before.receipt.publication_id, gitBin);
-      const reactions = readReactionAttemptReceipts(input.repo_root, before.receipt.publication_id, gitBin);
-      const ids = new Set(events.map((event) => event.provider_event_id));
-      const deliveryIds = new Set<string>();
-      for (const delivery of deliveries) {
-        if (!ids.has(delivery.provider_event_id)) {
-          throw new FeedbackError('feedback_unreadable', 'feedback delivery receipt has no immutable event');
-        }
-        deliveryIds.add(delivery.provider_event_id);
-      }
-      for (const event of events) {
-        if (!deliveryIds.has(event.provider_event_id)) {
-          throw new FeedbackError('feedback_incomplete', `feedback event ${event.provider_event_id} has no delivery receipt`);
-        }
-      }
-      const after = currentPublication(input.repo_root, input.publication_id, gitBin);
-      if (canonicalPublicationReceiptBytes(before.receipt) !== canonicalPublicationReceiptBytes(after.receipt)
-        || before.lease_raw !== after.lease_raw) {
-        lastTorn = new TornReadError('current publication changed during feedback offer projection');
+      return observeFeedbackProjection(input, gitBin, productionFleetFeedbackProjectionDependencies).projection;
+    } catch (error) {
+      if (error instanceof TornReadError) {
+        lastTorn = error;
         continue;
       }
-      if (events.length === 0) return Object.freeze({ state: 'none', publication_id: before.receipt.publication_id });
-      const actionable = actionableFeedbackFacts(events);
-      return projectRepairOffer({
-        task_id: before.receipt.task_id,
-        publication_id: before.receipt.publication_id,
-        expected_claim_id: before.receipt.claim_id,
-        expected_generation: before.receipt.generation,
-        expected_head_sha: before.receipt.head_sha,
-        feedback_revision: deriveFeedbackRevision(events),
-        reaction_token: deriveReactionToken({
-          publication_id: before.receipt.publication_id,
-          head_sha: before.receipt.head_sha,
-          failing_checks: actionable.failing_checks,
-          unresolved_review_thread_ids: actionable.unresolved_review_thread_ids,
-          mergeability: actionable.mergeability,
-        }),
-        reaction_attempts: reactions,
-      });
-    } catch (error) {
       if (error instanceof FeedbackError) throw error;
       if (error instanceof FeedbackStoreError) throw new FeedbackError(error.code, error.message, error);
       throw new FeedbackError('feedback_incomplete', 'feedback offer projection failed', error);
     }
   }
   throw new FeedbackError('feedback_incomplete', 'publication changed during both feedback offer projections', lastTorn);
+}
+
+interface FeedbackProjectionObservation {
+  readonly projection: PendingFeedbackOffer;
+  readonly pending_count: number;
+  readonly feedback_revision: string;
+  readonly store_revision: string;
+}
+
+const productionFleetFeedbackProjectionDependencies: FleetFeedbackProjectionDependencies = Object.freeze({
+  read_events: readFeedbackEvents,
+  read_deliveries: readFeedbackDeliveryReceipts,
+  read_reactions: readReactionAttemptReceipts,
+});
+
+function observeFeedbackProjection(
+  input: Pick<FeedbackIntakeInput, 'repo_root' | 'publication_id'>,
+  gitBin: string,
+  dependencies: FleetFeedbackProjectionDependencies,
+): FeedbackProjectionObservation {
+  const before = currentPublication(input.repo_root, input.publication_id, gitBin);
+  const publicationId = before.receipt.publication_id;
+  const events = dependencies.read_events(input.repo_root, publicationId, gitBin);
+  const deliveries = dependencies.read_deliveries(input.repo_root, publicationId, gitBin);
+  const reactions = dependencies.read_reactions(input.repo_root, publicationId, gitBin);
+  const after = currentPublication(input.repo_root, input.publication_id, gitBin);
+  if (canonicalPublicationReceiptBytes(before.receipt) !== canonicalPublicationReceiptBytes(after.receipt)
+    || before.lease_raw !== after.lease_raw) {
+    throw new TornReadError('current publication changed during feedback projection');
+  }
+
+  const eventIds = new Set<string>();
+  for (const event of events) {
+    if (event.publication_id !== publicationId || event.head_sha !== before.receipt.head_sha) {
+      throw new FeedbackError('feedback_unreadable', 'feedback event does not match the current publication head');
+    }
+    eventIds.add(event.provider_event_id);
+  }
+  const deliveryIds = new Set<string>();
+  for (const delivery of deliveries) {
+    if (!eventIds.has(delivery.provider_event_id)) {
+      throw new FeedbackError('feedback_unreadable', 'feedback delivery receipt has no immutable event');
+    }
+    deliveryIds.add(delivery.provider_event_id);
+  }
+  for (const event of events) {
+    if (!deliveryIds.has(event.provider_event_id)) {
+      throw new FeedbackError('feedback_incomplete', `feedback event ${event.provider_event_id} has no delivery receipt`);
+    }
+  }
+
+  const feedbackRevision = deriveFeedbackRevision(events);
+  let projection: PendingFeedbackOffer;
+  if (events.length === 0) {
+    projection = Object.freeze({ state: 'none', publication_id: publicationId });
+  } else {
+    const actionable = actionableFeedbackFacts(events);
+    projection = projectRepairOffer({
+      task_id: before.receipt.task_id,
+      publication_id: publicationId,
+      expected_claim_id: before.receipt.claim_id,
+      expected_generation: before.receipt.generation,
+      expected_head_sha: before.receipt.head_sha,
+      feedback_revision: feedbackRevision,
+      reaction_token: deriveReactionToken({
+        publication_id: publicationId,
+        head_sha: before.receipt.head_sha,
+        failing_checks: actionable.failing_checks,
+        unresolved_review_thread_ids: actionable.unresolved_review_thread_ids,
+        mergeability: actionable.mergeability,
+      }),
+      reaction_attempts: reactions,
+    });
+  }
+  const storeRevision = publicationSha256(stablePublicationJson({
+    publication_receipt: canonicalPublicationReceiptBytes(before.receipt),
+    lease: before.lease_raw,
+    events: events.map(canonicalFeedbackEventBytes),
+    deliveries: deliveries.map(canonicalFeedbackDeliveryReceiptBytes),
+    reactions: reactions.map(canonicalReactionAttemptReceiptBytes),
+  }));
+  return Object.freeze({ projection, pending_count: events.length, feedback_revision: feedbackRevision, store_revision: storeRevision });
+}
+
+function fleetFeedbackProjection(
+  observation: FeedbackProjectionObservation,
+  snapshotConsistency: FleetFeedbackProjection['snapshot_consistency'],
+): FleetFeedbackProjection {
+  const projection = observation.projection;
+  return Object.freeze({
+    pending_count: observation.pending_count,
+    no_progress: projection.state === 'no_progress',
+    repair_actions: Object.freeze(projection.state === 'offered' ? [...projection.offer.allowed_actions] : []),
+    feedback_revision: observation.feedback_revision,
+    store_revision: observation.store_revision,
+    snapshot_consistency: snapshotConsistency,
+  });
+}
+
+/**
+ * Observe every Fleet feedback field from one store revision. Each attempt
+ * compares two complete observations; one changed attempt is retried, and a
+ * second change is published only as explicitly torn input.
+ */
+export function projectFleetFeedback(
+  input: Pick<FeedbackIntakeInput, 'repo_root' | 'publication_id' | 'git_bin'>,
+  dependencyOverrides: Partial<FleetFeedbackProjectionDependencies> = {},
+): FleetFeedbackProjection {
+  const gitBin = input.git_bin ?? 'git';
+  const dependencies = { ...productionFleetFeedbackProjectionDependencies, ...dependencyOverrides };
+  let latest: FeedbackProjectionObservation | null = null;
+  let lastTorn: unknown = null;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      const before = observeFeedbackProjection(input, gitBin, dependencies);
+      const after = observeFeedbackProjection(input, gitBin, dependencies);
+      latest = after;
+      if (before.store_revision === after.store_revision) return fleetFeedbackProjection(after, 'stable');
+      lastTorn = new TornReadError('feedback store changed during Fleet projection');
+    } catch (error) {
+      if (error instanceof TornReadError || (error instanceof FeedbackError && error.code === 'feedback_incomplete' && attempt === 0)) {
+        lastTorn = error;
+        continue;
+      }
+      if (error instanceof FeedbackError) throw error;
+      if (error instanceof FeedbackStoreError) throw new FeedbackError(error.code, error.message, error);
+      throw new FeedbackError('feedback_incomplete', 'Fleet feedback projection failed', error);
+    }
+  }
+  if (latest !== null) return fleetFeedbackProjection(latest, 'changed_during_read');
+  throw new FeedbackError('feedback_incomplete', 'feedback store changed during both Fleet projections', lastTorn);
 }
 
 /**

--- a/src/effects/repo-registry.ts
+++ b/src/effects/repo-registry.ts
@@ -424,6 +424,24 @@ export function readRepoHarnessRegistryStrictSnapshot(opts: {
   });
 }
 
+/**
+ * Serialize an authorization-sensitive operation with registry mutations.
+ *
+ * The callback observes one strict registry revision while its mutation lock
+ * remains held. Callers that also touch per-task state must take the task lock
+ * only inside this callback: registry authorization lock -> task lock is the
+ * sole permitted order. Registry mutation paths never acquire task locks.
+ */
+export function withRepoHarnessRegistryAuthorizationLock<T>(
+  opts: { readonly env?: NodeJS.ProcessEnv } = {},
+  action: (snapshot: RepoHarnessRegistryStrictSnapshot) => T,
+): T {
+  const registryPath = repoHarnessRegisteredReposPath(opts.env);
+  return withRegistryMutationLock(registryPath, () => (
+    action(readRepoHarnessRegistryStrictSnapshot({ env: opts.env, adoptedOnly: false }))
+  ));
+}
+
 export function repoHarnessAuthorizationRevision(env: NodeJS.ProcessEnv = process.env): number {
   return readRegistryFile(repoHarnessRegisteredReposPath(env)).authorizationRevision;
 }

--- a/src/operator-web/App.tsx
+++ b/src/operator-web/App.tsx
@@ -40,7 +40,7 @@ export interface OperatorAppProps {
   /** The board's one write, injectable so tests never touch a real repository. */
   readonly sendMessage?: (request: TaskMessageRequestV1) => Promise<void>;
   /** The read-only collaboration read, injectable on the same terms. */
-  readonly fetchCollaboration?: (repositoryId: string) => Promise<OperatorCollaborationSnapshotV1>;
+  readonly fetchCollaboration?: (repositoryId: string, signal: AbortSignal) => Promise<OperatorCollaborationSnapshotV1>;
   /** A deterministic collaboration state for fixtures and server renders. */
   readonly initialCollaboration?: CollaborationViewState;
   /** Tests pin the locale; the browser resolves it from storage or navigator. */
@@ -859,10 +859,12 @@ function assertCollaborationRepository(
 
 async function fetchOperatorCollaborationSnapshot(
   repositoryId: string,
+  signal?: AbortSignal,
 ): Promise<OperatorCollaborationSnapshotV1> {
   const response = await fetch(`/api/v1/collaboration/${encodeURIComponent(repositoryId)}/snapshot`, {
     headers: { Accept: 'application/json' },
     cache: 'no-store',
+    signal,
   });
   let body: unknown = null;
   try {
@@ -1215,6 +1217,26 @@ const TASK_MESSAGE_FAILED_ERROR: OperatorApiErrorV1 = {
 };
 
 const OWNER_GONE_CODES: readonly string[] = ['claim_mismatch', 'recipient_unavailable', 'task_unowned'];
+const STALE_FENCE_CODES: readonly string[] = [
+  'task_revision_mismatch',
+  'claim_mismatch',
+  'recipient_unavailable',
+  'task_unowned',
+  'task_not_pending',
+];
+
+type ComposerRecovery = 'rebind' | 'new_message_id' | null;
+
+function composerRecovery(error: OperatorApiErrorV1 | null): ComposerRecovery {
+  if (error === null) return null;
+  if (error.code === 'message_id_conflict') return 'new_message_id';
+  if (STALE_FENCE_CODES.includes(error.code)) return 'rebind';
+  return null;
+}
+
+function isAmbiguousMessageFailure(error: OperatorApiErrorV1): boolean {
+  return error.code === TASK_MESSAGE_FAILED_ERROR.code;
+}
 
 export interface TaskMessageFenceV1 {
   /** The task revision the operator saw when the draft was opened. */
@@ -1368,16 +1390,35 @@ function Composer({
   const claimShort = fence.expected_claim_id === null ? '' : fence.expected_claim_id.slice(-8);
   const consistency = t(`status.consistency.${card.snapshot_consistency}` as OperatorMessageKey);
   const sent = sentAt !== null && sentAt === sequence;
+  const recovery = composerRecovery(error);
+  const recoveryEnabled = block === null && !sending;
+
+  const beginDraft = () => ({ message_id: crypto.randomUUID(), fence: observedFence });
 
   const toggle = () => {
     if (!open && draft === null) {
-      setDraft({ message_id: crypto.randomUUID(), fence: observedFence });
+      setDraft(beginDraft());
+      setSentAt(null);
     }
     setOpen(!open);
   };
 
+  const rebind = () => {
+    if (!recoveryEnabled || recovery !== 'rebind') return;
+    setDraft(beginDraft());
+    setError(null);
+    setSentAt(null);
+  };
+
+  const startWithNewMessageId = () => {
+    if (!recoveryEnabled || recovery !== 'new_message_id' || draft === null) return;
+    setDraft({ ...draft, message_id: crypto.randomUUID() });
+    setError(null);
+    setSentAt(null);
+  };
+
   const submit = async () => {
-    if (block !== null || sending || draft === null) return;
+    if (block !== null || sending || draft === null || recovery !== null) return;
     setSending(true);
     setError(null);
     try {
@@ -1392,7 +1433,7 @@ function Composer({
       // A stored message is a new message: the retry id is spent, the draft is
       // gone, and the next snapshot owns what the operator sees next.
       setBody('');
-      setDraft({ message_id: crypto.randomUUID(), fence: observedFence });
+      setDraft(null);
       setSentAt(sequence);
       onSent();
     } catch (failure) {
@@ -1425,7 +1466,13 @@ function Composer({
             rows={4}
             value={body}
             placeholder={t('composer.bodyPlaceholder')}
-            onChange={(event) => setBody(event.target.value)}
+            onChange={(event) => {
+              if (draft === null) {
+                setDraft(beginDraft());
+                setSentAt(null);
+              }
+              setBody(event.target.value);
+            }}
           />
           <p className={`composer__bytes${bytes > TASK_MESSAGE_BODY_LIMIT_BYTES ? ' is-over' : ''}`}>
             {t('composer.bytes', { used: bytes, max: TASK_MESSAGE_BODY_LIMIT_BYTES })}
@@ -1437,16 +1484,43 @@ function Composer({
           </p>
           {block !== null && <p className="composer__blocked" role="status">{blockedMessage(block, t)}</p>}
           {error && (
-            <p className="composer__error" role="alert">
-              {OWNER_GONE_CODES.includes(error.code) ? t('composer.ownerGone') : `${error.message}. ${error.next_action}`}
-            </p>
+            <div className="composer__error" role="alert">
+              <p>{OWNER_GONE_CODES.includes(error.code) ? t('composer.ownerGone') : `${error.message}. ${error.next_action}`}</p>
+              {recovery === 'rebind' && (
+                <>
+                  <p>{t('composer.rebindHint')}</p>
+                  <button
+                    className="operator-button operator-button--secondary"
+                    type="button"
+                    disabled={!recoveryEnabled}
+                    onClick={rebind}
+                  >
+                    {t('composer.rebind')}
+                  </button>
+                </>
+              )}
+              {recovery === 'new_message_id' && (
+                <>
+                  <p>{t('composer.newMessageIdHint')}</p>
+                  <button
+                    className="operator-button operator-button--secondary"
+                    type="button"
+                    disabled={!recoveryEnabled}
+                    onClick={startWithNewMessageId}
+                  >
+                    {t('composer.newMessageId')}
+                  </button>
+                </>
+              )}
+              {recovery === null && isAmbiguousMessageFailure(error) && <p>{t('composer.ambiguousRetry')}</p>}
+            </div>
           )}
           {sent && <p className="composer__sent" role="status">{t('composer.sent')}</p>}
           <button
             className="operator-button composer__send"
             type="button"
             data-write-action="task-message"
-            disabled={block !== null || sending}
+            disabled={block !== null || sending || recovery !== null}
             onClick={() => void submit()}
           >
             {sending
@@ -1605,7 +1679,7 @@ function DetailPane({
               context for a decision the worklist already surfaced. */}
           <CollaborationPane state={collaboration} t={t} />
         </div>
-        {card && repository && snapshot && (
+        {card && card.column !== 'done' && repository && snapshot && (
           <Composer
             key={taskKey(card)}
             card={card}
@@ -1681,28 +1755,45 @@ export function OperatorApp({
   const { locale, setLocale, t } = useLocale(initialLocale);
   const wideLayout = useWideLayout();
   const refreshInFlight = useRef(false);
+  const refreshQueued = useRef(false);
+  const stateRef = useRef<OperatorSnapshotViewState>(initial);
   const snapshot = snapshotForState(state);
   const busy = state.kind === 'loading';
   const stateKind = state.kind;
 
   const refresh = async () => {
-    if (refreshInFlight.current) return;
-    refreshInFlight.current = true;
-    // An explicit board refresh is also the collaboration recovery action. The
-    // selected repository remains the only scope, but its read must be issued
-    // again even when the task selection identity is unchanged.
+    // Every request supersedes the selected repository's collaboration read,
+    // even when its Fleet collection is coalesced behind an active one.
     setCollaborationRefreshGeneration((current) => current + 1);
-    const previous = snapshotForState(state);
-    setState({ kind: 'loading', previous });
+    if (refreshInFlight.current) {
+      refreshQueued.current = true;
+      return;
+    }
+    refreshInFlight.current = true;
     try {
-      const nextSnapshot = await fetchSnapshot();
-      setSelection((current) => (current === null || allCards(nextSnapshot).some((card) => taskKey(card) === current.key))
-        ? current
-        : null);
-      setState(stateFromSnapshot(nextSnapshot));
-    } catch (error) {
-      const apiError = asApiError(error);
-      setState(previous ? { kind: 'stale', snapshot: previous, error: apiError } : { kind: 'fatal', error: apiError });
+      do {
+        refreshQueued.current = false;
+        const previous = snapshotForState(stateRef.current);
+        const loading: OperatorSnapshotViewState = { kind: 'loading', previous };
+        stateRef.current = loading;
+        setState(loading);
+        try {
+          const nextSnapshot = await fetchSnapshot();
+          setSelection((current) => (current === null || allCards(nextSnapshot).some((card) => taskKey(card) === current.key))
+            ? current
+            : null);
+          const nextState = stateFromSnapshot(nextSnapshot);
+          stateRef.current = nextState;
+          setState(nextState);
+        } catch (error) {
+          const apiError = asApiError(error);
+          const nextState: OperatorSnapshotViewState = previous
+            ? { kind: 'stale', snapshot: previous, error: apiError }
+            : { kind: 'fatal', error: apiError };
+          stateRef.current = nextState;
+          setState(nextState);
+        }
+      } while (refreshQueued.current);
     } finally {
       refreshInFlight.current = false;
     }
@@ -1737,11 +1828,11 @@ export function OperatorApp({
       setCollaboration({ kind: 'idle' });
       return;
     }
-    let current = true;
+    const controller = new AbortController();
     setCollaboration({ kind: 'loading', repository_id: collaborationRepositoryId });
-    void fetchCollaboration(collaborationRepositoryId).then(
+    void fetchCollaboration(collaborationRepositoryId, controller.signal).then(
       (next) => {
-        if (current) {
+        if (!controller.signal.aborted) {
           try {
             setCollaboration({
               kind: 'ready',
@@ -1757,7 +1848,7 @@ export function OperatorApp({
         }
       },
       (error) => {
-        if (current) {
+        if (!controller.signal.aborted && !(error instanceof Error && error.name === 'AbortError')) {
           setCollaboration({
             kind: 'failed',
             repository_id: collaborationRepositoryId,
@@ -1766,7 +1857,7 @@ export function OperatorApp({
         }
       },
     );
-    return () => { current = false; };
+    return () => { controller.abort(); };
     // The repository remains the scope; the explicit refresh generation is the
     // only extra trigger, so reads never fan out to other repositories.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/operator-web/i18n.ts
+++ b/src/operator-web/i18n.ts
@@ -195,6 +195,11 @@ const en = {
   'composer.blockedEmpty': 'Write the message before sending it.',
   'composer.blockedTooLarge': 'The message is over the {max} byte limit.',
   'composer.ownerGone': 'That session is gone — refresh and read the row again.',
+  'composer.ambiguousRetry': 'The send outcome is unknown. Retrying keeps the same message id and fence.',
+  'composer.rebindHint': 'This task or owner changed. Rebind only if you intend to address the current snapshot.',
+  'composer.rebind': 'Rebind to current snapshot',
+  'composer.newMessageIdHint': 'This message id belongs to a different message. Start with a new id before retrying.',
+  'composer.newMessageId': 'Start with a new message ID',
 
   'collab.title': 'Collaboration',
   'collab.scope': 'repository {repository}',
@@ -466,6 +471,11 @@ const zh: Readonly<Record<OperatorMessageKey, string>> = {
   'composer.blockedEmpty': '先把消息写出来再发。',
   'composer.blockedTooLarge': '消息超过 {max} 字节上限。',
   'composer.ownerGone': '那个 session 已经不在了 —— 刷新之后重新读这一行。',
+  'composer.ambiguousRetry': '这次发送的结果不明确。重试会保留同一个 message id 和 fence。',
+  'composer.rebindHint': '这个任务或持有者已经变了。只有明确要发给当前快照时，才重新绑定。',
+  'composer.rebind': '重新绑定到当前快照',
+  'composer.newMessageIdHint': '这个 message id 已经属于另一条消息。重试前先换一个 id。',
+  'composer.newMessageId': '用新的 message ID 重新开始',
 
   'collab.title': '协作',
   'collab.scope': '仓库 {repository}',

--- a/tests/cli/operator-serve.test.ts
+++ b/tests/cli/operator-serve.test.ts
@@ -501,12 +501,18 @@ describe('operator serve command and HTTP boundary', () => {
 
   test('UX-operator-task-message-v1-P2 hands a valid write to the effect and passes typed failures through', async () => {
     const calls: SendOperatorTaskMessageInput[] = [];
-    let behavior: 'created' | 'replay' | 'claim_mismatch' = 'created';
+    let behavior: 'created' | 'replay' | 'claim_mismatch' | 'canonical_source_stale' | 'task_not_pending' = 'created';
     const { OperatorTaskMessageError } = await import('../../src/effects/fleet/task-message-request');
     const harness = await startWriteServer(
       async (input) => {
         if (behavior === 'claim_mismatch') {
           throw new OperatorTaskMessageError('claim_mismatch', `task ${input.task_id} owner moved`);
+        }
+        if (behavior === 'canonical_source_stale') {
+          throw new OperatorTaskMessageError('canonical_source_stale', `task ${input.task_id} source moved`);
+        }
+        if (behavior === 'task_not_pending') {
+          throw new OperatorTaskMessageError('task_not_pending', `task ${input.task_id} is done`);
         }
         return sendResult({ scope: input.scope, created: behavior === 'created' });
       },
@@ -551,6 +557,28 @@ describe('operator serve command and HTTP boundary', () => {
       expect(conflictBody.error.code).toBe('claim_mismatch');
       expect(conflictBody.error.message).toBe('The task owner changed while the message was being sent.');
       expect(JSON.stringify(conflictBody)).not.toContain('owner moved');
+
+      behavior = 'canonical_source_stale';
+      const staleSource = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: taskMessagePayload('look at the base branch', 'claim'),
+      });
+      expect(staleSource.status).toBe(409);
+      expect(await staleSource.json()).toMatchObject({
+        error: { code: 'canonical_source_stale', message: 'The active task board authority changed since the snapshot.' },
+      });
+
+      behavior = 'task_not_pending';
+      const completed = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: taskMessagePayload('look at the base branch', 'claim'),
+      });
+      expect(completed.status).toBe(409);
+      expect(await completed.json()).toMatchObject({
+        error: { code: 'task_not_pending', message: 'This task no longer accepts messages.' },
+      });
     } finally {
       await stopWriteServer(harness);
     }

--- a/tests/cli/operator-serve.test.ts
+++ b/tests/cli/operator-serve.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, test } from 'bun:test';
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawn, spawnSync } from 'node:child_process';
 
 import { projectFleetBoardSnapshot } from '../../src/core/fleet/board';
 import { TASK_MESSAGE_BODY_MAX_BYTES } from '../../src/core/fleet/task-message';
+import type { OperatorCollaborationSnapshotV1 } from '../../src/core/operator/collaboration-snapshot';
 import { repoHarnessRepoIdFor } from '../../src/effects/repo-registry';
 import {
   OPERATOR_TASK_MESSAGE_BODY_MAX_BYTES,
@@ -61,6 +62,7 @@ async function startWriteServer(
   send: OperatorServerOptions['send_task_message'],
   calls: SendOperatorTaskMessageInput[],
   env?: NodeJS.ProcessEnv,
+  timeoutMs?: number,
 ): Promise<WriteHarness> {
   const staticRoot = mkdtempSync(join(tmpdir(), 'repo-harness-operator-write-'));
   writeFileSync(join(staticRoot, 'index.html'), '<!doctype html><main>operator</main>');
@@ -68,6 +70,7 @@ async function startWriteServer(
     port: 0,
     static_root: staticRoot,
     env,
+    timeout_ms: timeoutMs,
     collect_fleet_board: async () => snapshot(),
     send_task_message: send === undefined ? undefined : (input) => {
       calls.push(input);
@@ -115,6 +118,14 @@ function sendResult(overrides: Partial<SendOperatorTaskMessageResult> = {}): Sen
     created: true,
     ...overrides,
   };
+}
+
+async function waitFor(condition: () => boolean, message: string): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (condition()) return;
+    await Bun.sleep(10);
+  }
+  throw new Error(message);
 }
 
 describe('operator serve command and HTTP boundary', () => {
@@ -377,6 +388,110 @@ describe('operator serve command and HTTP boundary', () => {
     }
   });
 
+  test('bounds ambiguous task-message writes and recovers through the same message identity', async () => {
+    const calls: SendOperatorTaskMessageInput[] = [];
+    let abortObserved = false;
+    let committed = false;
+    const harness = await startWriteServer(
+      async ({ signal }) => {
+        if (committed) return sendResult({ created: false });
+        committed = true;
+        signal.addEventListener('abort', () => { abortObserved = true; }, { once: true });
+        return new Promise<never>(() => {});
+      },
+      calls,
+      undefined,
+      1_000,
+    );
+    const url = `${harness.server.url}${messagePath('repo-write')}`;
+    const headers = { 'Content-Type': 'application/json', Origin: harness.server.url };
+    try {
+      const timedOut = await fetch(url, { method: 'POST', headers, body: taskMessagePayload() });
+      expect(timedOut.status).toBe(503);
+      expect(await timedOut.json()).toMatchObject({
+        error: {
+          code: 'task_message_timeout',
+          next_action: expect.stringContaining('same message_id'),
+        },
+      });
+      expect(abortObserved).toBe(true);
+      expect((await fetch(`${harness.server.url}/healthz`)).status).toBe(200);
+
+      const retry = await fetch(url, { method: 'POST', headers, body: taskMessagePayload() });
+      expect(retry.status).toBe(200);
+      expect(await retry.json()).toMatchObject({ ok: true, created: false, message_id: MESSAGE_ID });
+      expect(calls).toHaveLength(2);
+    } finally {
+      await stopWriteServer(harness);
+    }
+  });
+
+  test('server shutdown aborts an active task-message sender', async () => {
+    const calls: SendOperatorTaskMessageInput[] = [];
+    let started = false;
+    let abortObserved = false;
+    const harness = await startWriteServer(async ({ signal }) => {
+      started = true;
+      signal.addEventListener('abort', () => { abortObserved = true; }, { once: true });
+      return new Promise<never>(() => {});
+    }, calls);
+    const request = fetch(`${harness.server.url}${messagePath('repo-write')}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Origin: harness.server.url },
+      body: taskMessagePayload(),
+    }).catch(() => null);
+    try {
+      await waitFor(() => started, 'task-message sender did not start');
+      const startedAt = Date.now();
+      await harness.server.close();
+      expect(Date.now() - startedAt).toBeLessThan(2_500);
+      expect(abortObserved).toBe(true);
+      await request;
+    } finally {
+      rmSync(harness.staticRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('isolates the default task-message sender before a blocked canonical read can freeze the server', async () => {
+    if (process.platform === 'win32') return;
+    const staticRoot = mkdtempSync(join(tmpdir(), 'repo-harness-operator-task-message-worker-'));
+    const repoRoot = realpathSync(mkdtempSync(join(tmpdir(), 'repo-harness-operator-task-message-repo-')));
+    expect(spawnSync('git', ['init', '-q', repoRoot]).status).toBe(0);
+    const registry = registryHome([{ path: repoRoot, accessMode: 'read_write' }]);
+    const markerPath = join(repoRoot, '.ai/harness/sprint/active-sprint');
+    mkdirSync(join(repoRoot, '.ai/harness/sprint'), { recursive: true });
+    writeFileSync(join(staticRoot, 'index.html'), '<!doctype html><main>operator</main>');
+    expect(spawnSync('mkfifo', [markerPath]).status).toBe(0);
+    const server = await startOperatorServer({
+      port: 0,
+      static_root: staticRoot,
+      timeout_ms: 1_000,
+      env: registry.env,
+      collect_fleet_board: async () => snapshot(),
+    });
+    const writer = spawn('bash', ['-c', 'exec 3>"$1"; sleep 10', 'bash', markerPath], { stdio: 'ignore' });
+    try {
+      const startedAt = Date.now();
+      const timedOut = await fetch(`${server.url}${messagePath(registry.ids[0]!)}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Origin: server.url },
+        body: taskMessagePayload(),
+      });
+      expect(Date.now() - startedAt).toBeLessThan(2_500);
+      expect(timedOut.status).toBe(503);
+      expect(await timedOut.json()).toMatchObject({ error: { code: 'task_message_timeout' } });
+      expect((await fetch(`${server.url}/healthz`)).status).toBe(200);
+      expect(existsSync(join(repoRoot, '.git/repo-harness/coordination/v1/locks/tasks', `${TASK_ID}.lock`))).toBe(false);
+      expect(existsSync(join(repoRoot, '.git/repo-harness/task-inbox/v1', TASK_ID, 'events'))).toBe(false);
+    } finally {
+      writer.kill('SIGTERM');
+      await server.close();
+      rmSync(staticRoot, { recursive: true, force: true });
+      rmSync(repoRoot, { recursive: true, force: true });
+      rmSync(registry.home, { recursive: true, force: true });
+    }
+  });
+
   test('bounds collaboration reads and permits a healthy retry after timeout', async () => {
     const staticRoot = mkdtempSync(join(tmpdir(), 'repo-harness-operator-collaboration-timeout-'));
     writeFileSync(join(staticRoot, 'index.html'), '<!doctype html><main>operator</main>');
@@ -414,6 +529,91 @@ describe('operator serve command and HTTP boundary', () => {
       expect(retry.status).toBe(200);
       expect(await retry.json()).toEqual({});
       expect(collaborationCalls).toBe(2);
+    } finally {
+      await server.close();
+      rmSync(staticRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('coalesces same-repository collaboration reads and retains work for a remaining subscriber', async () => {
+    const staticRoot = mkdtempSync(join(tmpdir(), 'repo-harness-operator-collaboration-coalesce-'));
+    writeFileSync(join(staticRoot, 'index.html'), '<!doctype html><main>operator</main>');
+    let calls = 0;
+    let aborts = 0;
+    let healthy = false;
+    let resolveFirst!: (snapshot: OperatorCollaborationSnapshotV1) => void;
+    const server = await startOperatorServer({
+      port: 0,
+      static_root: staticRoot,
+      max_concurrency: 1,
+      collect_fleet_board: async () => snapshot(),
+      read_collaboration_snapshot: ({ signal }) => {
+        calls += 1;
+        if (healthy) return Promise.resolve({} as never);
+        signal.addEventListener('abort', () => { aborts += 1; }, { once: true });
+        return new Promise((resolve) => { resolveFirst = resolve as (snapshot: OperatorCollaborationSnapshotV1) => void; });
+      },
+    });
+    const firstController = new AbortController();
+    const url = `${server.url}/api/v1/collaboration/repo-write/snapshot`;
+    const first = fetch(url, { signal: firstController.signal }).catch(() => null);
+    try {
+      await waitFor(() => calls === 1, 'first collaboration reader did not start');
+      const second = fetch(url);
+      await Bun.sleep(30);
+      expect(calls).toBe(1);
+
+      firstController.abort();
+      await first;
+      await Bun.sleep(30);
+      expect(aborts).toBe(0);
+
+      resolveFirst({} as never);
+      expect((await second).status).toBe(200);
+      healthy = true;
+      expect((await fetch(url)).status).toBe(200);
+      expect(calls).toBe(2);
+    } finally {
+      await server.close();
+      rmSync(staticRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('bounds cross-repository collaboration workers and rejects queue overflow', async () => {
+    const staticRoot = mkdtempSync(join(tmpdir(), 'repo-harness-operator-collaboration-queue-'));
+    writeFileSync(join(staticRoot, 'index.html'), '<!doctype html><main>operator</main>');
+    const started: string[] = [];
+    const resolvers = new Map<string, (snapshot: OperatorCollaborationSnapshotV1) => void>();
+    const server = await startOperatorServer({
+      port: 0,
+      static_root: staticRoot,
+      max_concurrency: 1,
+      collect_fleet_board: async () => snapshot(),
+      read_collaboration_snapshot: ({ repository_id }) => new Promise((resolve) => {
+        started.push(repository_id);
+        resolvers.set(repository_id, resolve as (snapshot: OperatorCollaborationSnapshotV1) => void);
+      }),
+    });
+    const url = (repositoryId: string) => `${server.url}/api/v1/collaboration/${repositoryId}/snapshot`;
+    try {
+      const first = fetch(url('repo-a'));
+      await waitFor(() => started.length === 1, 'first collaboration reader did not start');
+      const second = fetch(url('repo-b'));
+      const third = fetch(url('repo-c'));
+      const overloaded = await fetch(url('repo-d'));
+      expect(overloaded.status).toBe(503);
+      expect(await overloaded.json()).toMatchObject({ error: { code: 'collaboration_snapshot_busy' } });
+      expect(started).toEqual(['repo-a']);
+
+      resolvers.get('repo-a')!({} as never);
+      expect((await first).status).toBe(200);
+      await waitFor(() => started.length === 2, 'queued collaboration reader did not start');
+      expect(started).toEqual(['repo-a', 'repo-b']);
+      resolvers.get('repo-b')!({} as never);
+      expect((await second).status).toBe(200);
+      await waitFor(() => started.length === 3, 'second queued collaboration reader did not start');
+      resolvers.get('repo-c')!({} as never);
+      expect((await third).status).toBe(200);
     } finally {
       await server.close();
       rmSync(staticRoot, { recursive: true, force: true });
@@ -461,6 +661,60 @@ describe('operator serve command and HTTP boundary', () => {
     } finally {
       fifoWriter.kill('SIGTERM');
       await server.close();
+      rmSync(staticRoot, { recursive: true, force: true });
+      rmSync(repoRoot, { recursive: true, force: true });
+      rmSync(registry.home, { recursive: true, force: true });
+    }
+  });
+
+  test('isolates default Fleet collection and clears a blocked Worker for retry and shutdown', async () => {
+    if (process.platform === 'win32') return;
+    const staticRoot = mkdtempSync(join(tmpdir(), 'repo-harness-operator-fleet-worker-'));
+    const repoRoot = realpathSync(mkdtempSync(join(tmpdir(), 'repo-harness-operator-fleet-repo-')));
+    expect(spawnSync('git', ['init', '-q', repoRoot]).status).toBe(0);
+    const registry = registryHome([{ path: repoRoot, accessMode: 'read_write' }]);
+    const markerPath = join(repoRoot, '.ai/harness/sprint/active-sprint');
+    mkdirSync(join(repoRoot, '.ai/harness/sprint'), { recursive: true });
+    writeFileSync(join(staticRoot, 'index.html'), '<!doctype html><main>operator</main>');
+    expect(spawnSync('mkfifo', [markerPath]).status).toBe(0);
+    const server = await startOperatorServer({
+      port: 0,
+      static_root: staticRoot,
+      timeout_ms: 1_000,
+      env: registry.env,
+    });
+    let writer = spawn('bash', ['-c', 'exec 3>"$1"; sleep 10', 'bash', markerPath], { stdio: 'ignore' });
+    let closed = false;
+    try {
+      const startedAt = Date.now();
+      const blocked = fetch(`${server.url}/api/v1/fleet/snapshot`);
+      await Bun.sleep(30);
+      expect((await fetch(`${server.url}/healthz`)).status).toBe(200);
+      const timedOut = await blocked;
+      expect(Date.now() - startedAt).toBeLessThan(2_500);
+      expect(timedOut.status).toBe(503);
+      expect(await timedOut.json()).toMatchObject({ error: { code: 'fleet_snapshot_timeout' } });
+
+      writer.kill('SIGTERM');
+      rmSync(markerPath);
+      writeFileSync(markerPath, '\n');
+      const retry = await fetch(`${server.url}/api/v1/fleet/snapshot`);
+      expect(retry.status).toBe(200);
+      expect(JSON.stringify(await retry.json())).not.toContain(registry.home);
+
+      rmSync(markerPath);
+      expect(spawnSync('mkfifo', [markerPath]).status).toBe(0);
+      writer = spawn('bash', ['-c', 'exec 3>"$1"; sleep 10', 'bash', markerPath], { stdio: 'ignore' });
+      const active = fetch(`${server.url}/api/v1/fleet/snapshot`).catch(() => null);
+      await Bun.sleep(30);
+      const closeStartedAt = Date.now();
+      await server.close();
+      closed = true;
+      expect(Date.now() - closeStartedAt).toBeLessThan(2_500);
+      await active;
+    } finally {
+      writer.kill('SIGTERM');
+      if (!closed) await server.close();
       rmSync(staticRoot, { recursive: true, force: true });
       rmSync(repoRoot, { recursive: true, force: true });
       rmSync(registry.home, { recursive: true, force: true });

--- a/tests/effects/operator-task-message.test.ts
+++ b/tests/effects/operator-task-message.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, test } from 'bun:test';
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 
 import { deriveTaskId, deriveTaskRevision, buildLeaseOwnerRecord, bindLeaseRecord } from '../../src/core/state/coordination-identity';
-import { repoHarnessRepoIdFor } from '../../src/effects/repo-registry';
+import { repoHarnessRegisteredReposPath, repoHarnessRepoIdFor } from '../../src/effects/repo-registry';
 import { sendOperatorTaskMessage, OperatorTaskMessageError } from '../../src/effects/fleet/task-message-request';
 import { createLeaseDirectory, writeLeaseOwnerDurably } from '../../src/effects/state/coordination-lease-store';
-import { taskInboxEventPath } from '../../src/effects/fleet/task-inbox';
+import { taskInboxEventPath, taskInboxTaskDirectory } from '../../src/effects/fleet/task-inbox';
 import { resolveRepoIdentity } from '../../src/effects/state/coordination-canonical-source';
 
 const SPRINT_PATH = 'plans/sprints/operator-message.sprint.md';
@@ -17,6 +17,10 @@ const CLAIM_ONE = '123e4567-e89b-42d3-a456-426614174001';
 const CLAIM_TWO = '123e4567-e89b-42d3-a456-426614174002';
 const MESSAGE_ONE = '123e4567-e89b-42d3-a456-426614174010';
 const MESSAGE_TWO = '123e4567-e89b-42d3-a456-426614174011';
+const PROJECT_ROOT = resolve(import.meta.dir, '../..');
+const TASK_MESSAGE_REQUEST_MODULE = resolve(import.meta.dir, '../../src/effects/fleet/task-message-request.ts');
+const REGISTRY_MODULE = resolve(import.meta.dir, '../../src/effects/repo-registry.ts');
+const LEASE_STORE_MODULE = resolve(import.meta.dir, '../../src/effects/state/coordination-lease-store.ts');
 
 interface Fixture {
   readonly root: string;
@@ -130,17 +134,156 @@ function withFixture(run: (value: Fixture) => void): void {
   }
 }
 
+async function withFixtureAsync(run: (value: Fixture) => Promise<void>): Promise<void> {
+  const value = fixture();
+  try {
+    await run(value);
+  } finally {
+    rmSync(value.root, { recursive: true, force: true });
+    rmSync(value.home, { recursive: true, force: true });
+  }
+}
+
+async function waitFor(condition: () => boolean, description: string): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  while (!condition()) {
+    if (Date.now() >= deadline) throw new Error(`timed out waiting for ${description}`);
+    await Bun.sleep(10);
+  }
+}
+
+function spawnWorker(script: string, env: Record<string, string>): ReturnType<typeof Bun.spawn> {
+  return Bun.spawn([process.execPath, '-e', script], {
+    cwd: PROJECT_ROOT,
+    env: { ...process.env, ...env },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+}
+
+async function workerResult(worker: ReturnType<typeof Bun.spawn>): Promise<{ readonly status: number; readonly stdout: string; readonly stderr: string }> {
+  if (!(worker.stdout instanceof ReadableStream) || !(worker.stderr instanceof ReadableStream)) {
+    throw new Error('worker must expose stdout and stderr pipes');
+  }
+  const [status, stdout, stderr] = await Promise.all([
+    worker.exited,
+    new Response(worker.stdout).text(),
+    new Response(worker.stderr).text(),
+  ]);
+  return { status, stdout, stderr };
+}
+
+function operatorMessageWorker(value: Fixture, messageId: string, env: Record<string, string> = {}): ReturnType<typeof Bun.spawn> {
+  const script = `
+    const { sendOperatorTaskMessage, OperatorTaskMessageError } = await import(process.env.TASK_MESSAGE_REQUEST_MODULE);
+    try {
+      const result = sendOperatorTaskMessage(JSON.parse(process.env.TASK_INPUT));
+      process.stdout.write(JSON.stringify({ ok: true, result }));
+    } catch (error) {
+      process.stdout.write(JSON.stringify({
+        ok: false,
+        code: error instanceof OperatorTaskMessageError ? error.code : null,
+        message: error instanceof Error ? error.message : String(error),
+      }));
+    }
+  `;
+  return spawnWorker(script, {
+    TASK_MESSAGE_REQUEST_MODULE,
+    TASK_INPUT: JSON.stringify(input(value, messageId, 'task')),
+    ...env,
+  });
+}
+
+function taskLockHolder(value: Fixture, readyPath: string, releasePath: string): ReturnType<typeof Bun.spawn> {
+  const script = `
+    import { existsSync, writeFileSync } from 'node:fs';
+    const { withTaskLock } = await import(process.env.LEASE_STORE_MODULE);
+    withTaskLock(process.env.REPO_ROOT, process.env.TASK_ID, () => {
+      writeFileSync(process.env.READY_PATH, 'ready\\n');
+      const wait = new Int32Array(new SharedArrayBuffer(4));
+      while (!existsSync(process.env.RELEASE_PATH)) Atomics.wait(wait, 0, 0, 5);
+    });
+  `;
+  return spawnWorker(script, {
+    LEASE_STORE_MODULE,
+    REPO_ROOT: value.root,
+    TASK_ID: value.taskId,
+    READY_PATH: readyPath,
+    RELEASE_PATH: releasePath,
+  });
+}
+
+function readWorkerPayload(result: { readonly status: number; readonly stdout: string; readonly stderr: string }): Record<string, unknown> {
+  expect(result.status, result.stderr).toBe(0);
+  return JSON.parse(result.stdout) as Record<string, unknown>;
+}
+
+function registryRevoker(
+  value: Fixture,
+  opts: { readonly readyPath?: string; readonly releasePath?: string } = {},
+): ReturnType<typeof Bun.spawn> {
+  const script = `
+    import { existsSync, writeFileSync } from 'node:fs';
+    const { applyRepoHarnessRegistryBatch } = await import(process.env.REGISTRY_MODULE);
+    const wait = new Int32Array(new SharedArrayBuffer(4));
+    applyRepoHarnessRegistryBatch([
+      { repoRoot: process.env.REPO_ROOT, source: 'adopt', accessMode: 'read_only' },
+    ], {
+      env: { REPO_HARNESS_HOME: process.env.REGISTRY_HOME },
+      requireAdopted: false,
+      beforeCommit: () => {
+        if (!process.env.READY_PATH) return;
+        writeFileSync(process.env.READY_PATH, 'ready\\n');
+        while (!existsSync(process.env.RELEASE_PATH)) Atomics.wait(wait, 0, 0, 5);
+      },
+    });
+  `;
+  return spawnWorker(script, {
+    REGISTRY_MODULE,
+    REGISTRY_HOME: value.home,
+    REPO_ROOT: value.root,
+    READY_PATH: opts.readyPath ?? '',
+    RELEASE_PATH: opts.releasePath ?? '',
+  });
+}
+
+function pausedGitBin(value: Fixture, readyPath: string, releasePath: string): string {
+  const bin = join(value.root, 'test-bin');
+  mkdirSync(bin, { recursive: true });
+  const gitPath = join(bin, 'git');
+  const realGit = execFileSync('which', ['git'], { encoding: 'utf8' }).trim();
+  writeFileSync(gitPath, `#!/bin/sh
+"${realGit}" "$@"
+status=$?
+if [ "$1" = "show" ] && [ "$status" -eq 0 ]; then
+  : > "${readyPath}"
+  while [ ! -f "${releasePath}" ]; do sleep 0.01; done
+fi
+exit "$status"
+`);
+  chmodSync(gitPath, 0o700);
+  return bin;
+}
+
+function expectNoInboxArtifacts(value: Fixture, messageId: string): void {
+  expect(existsSync(taskInboxEventPath(value.root, value.taskId, messageId))).toBe(false);
+}
+
+function expectOperatorError(run: () => void, code: OperatorTaskMessageError['code']): void {
+  expect(run).toThrow(OperatorTaskMessageError);
+  try {
+    run();
+  } catch (error) {
+    expect((error as OperatorTaskMessageError).code).toBe(code);
+  }
+}
+
 describe('operator task-message effect fence', () => {
   test('rejects a stale task revision before creating an event', () => withFixture((value) => {
-    expect(() => sendOperatorTaskMessage(input(value, MESSAGE_ONE, 'task', {
+    expectOperatorError(() => sendOperatorTaskMessage(input(value, MESSAGE_ONE, 'task', {
       expected_task_revision: '0'.repeat(64),
-    }))).toThrow(OperatorTaskMessageError);
-    try {
-      sendOperatorTaskMessage(input(value, MESSAGE_ONE, 'task', { expected_task_revision: '0'.repeat(64) }));
-    } catch (error) {
-      expect((error as OperatorTaskMessageError).code).toBe('task_revision_mismatch');
-    }
-    expect(() => readFileSync(taskInboxEventPath(value.root, value.taskId, MESSAGE_ONE))).toThrow();
+    })), 'task_revision_mismatch');
+    expectNoInboxArtifacts(value, MESSAGE_ONE);
   }));
 
   test('keeps a claim message bound to the observed claim and rejects takeover', () => withFixture((value) => {
@@ -156,12 +299,130 @@ describe('operator task-message effect fence', () => {
     expect(stored).toMatchObject({ target_claim_id: CLAIM_ONE, target_generation: 1 });
 
     lease(value, CLAIM_TWO, 2);
-    expect(() => sendOperatorTaskMessage(input(value, MESSAGE_TWO, 'claim'))).toThrow(OperatorTaskMessageError);
-    try {
-      sendOperatorTaskMessage(input(value, MESSAGE_TWO, 'claim'));
-    } catch (error) {
-      expect((error as OperatorTaskMessageError).code).toBe('claim_mismatch');
-    }
-    expect(() => readFileSync(taskInboxEventPath(value.root, value.taskId, MESSAGE_TWO))).toThrow();
+    expectOperatorError(() => sendOperatorTaskMessage(input(value, MESSAGE_TWO, 'claim')), 'claim_mismatch');
+    expectNoInboxArtifacts(value, MESSAGE_TWO);
   }));
+
+  test('keeps an identical retry idempotent while task authority remains pending', () => withFixture((value) => {
+    expect(sendOperatorTaskMessage(input(value, MESSAGE_ONE, 'task')).created).toBe(true);
+    expect(sendOperatorTaskMessage(input(value, MESSAGE_ONE, 'task')).created).toBe(false);
+  }));
+
+  test('rejects a completed canonical row even when its task revision is unchanged', () => withFixture((value) => {
+    writeFileSync(join(value.root, SPRINT_PATH), [
+      '# Sprint: operator message', '', '## Backlog', '',
+      '| # | Status | Task | Mode | Acceptance | Plan |',
+      '|---|--------|------|------|------------|------|',
+      `| 1 | [x] | ${TASK_CELL} | contract | proves the fence | (pending) |`, '',
+    ].join('\n'));
+    git(value.root, 'add', SPRINT_PATH);
+    git(value.root, 'commit', '-m', 'complete fixture task');
+
+    expectOperatorError(() => sendOperatorTaskMessage(input(value, MESSAGE_ONE, 'task')), 'task_not_pending');
+    expectNoInboxArtifacts(value, MESSAGE_ONE);
+    expect(existsSync(taskInboxTaskDirectory(value.root, value.taskId))).toBe(false);
+  }));
+
+  test('linearizes registry revocation before a waiting task-message publication', async () => withFixtureAsync(async (value) => {
+    const readyPath = join(value.home, 'revocation-ready');
+    const releasePath = join(value.home, 'release-revocation');
+    const revoker = registryRevoker(value, { readyPath, releasePath });
+    await waitFor(() => existsSync(readyPath), 'registry revocation prepare barrier');
+
+    const sender = operatorMessageWorker(value, MESSAGE_ONE);
+    writeFileSync(releasePath, 'release\n');
+
+    const [revokerResult, senderResult] = await Promise.all([workerResult(revoker), workerResult(sender)]);
+    expect(revokerResult.status, revokerResult.stderr).toBe(0);
+    expect(readWorkerPayload(senderResult)).toMatchObject({ ok: false, code: 'repository_read_only' });
+    expectNoInboxArtifacts(value, MESSAGE_ONE);
+  }), 30_000);
+
+  test('lets a sender that holds registry authorization publish before a waiting revocation', async () => withFixtureAsync(async (value) => {
+    const lockReadyPath = join(value.home, 'task-lock-ready');
+    const lockReleasePath = join(value.home, 'task-lock-release');
+    const lockHolder = taskLockHolder(value, lockReadyPath, lockReleasePath);
+    await waitFor(() => existsSync(lockReadyPath), 'task lock holder');
+
+    const sender = operatorMessageWorker(value, MESSAGE_ONE);
+    const registryLockPath = `${repoHarnessRegisteredReposPath({ REPO_HARNESS_HOME: value.home })}.lock`;
+    await waitFor(() => {
+      if (!existsSync(registryLockPath)) return false;
+      try {
+        return JSON.parse(readFileSync(registryLockPath, 'utf8')).pid === sender.pid;
+      } catch {
+        return false;
+      }
+    }, 'sender registry authorization lock');
+
+    const revoker = registryRevoker(value);
+    writeFileSync(lockReleasePath, 'release\n');
+
+    const [lockResult, senderResult, revokerResult] = await Promise.all([
+      workerResult(lockHolder),
+      workerResult(sender),
+      workerResult(revoker),
+    ]);
+    expect(lockResult.status, lockResult.stderr).toBe(0);
+    expect(readWorkerPayload(senderResult)).toMatchObject({ ok: true, result: { created: true } });
+    expect(revokerResult.status, revokerResult.stderr).toBe(0);
+    expect(JSON.parse(readFileSync(join(value.home, 'registered-repos.json'), 'utf8'))).toMatchObject({
+      repos: [{ accessMode: 'read_only' }],
+    });
+    expect(existsSync(taskInboxEventPath(value.root, value.taskId, MESSAGE_ONE))).toBe(true);
+  }), 30_000);
+
+  if (process.platform !== 'win32') {
+    test('rejects an active-sprint change captured between source resolution and the task lock', async () => withFixtureAsync(async (value) => {
+      const gitReadyPath = join(value.home, 'initial-sprint-read');
+      const gitReleasePath = join(value.home, 'release-initial-sprint-read');
+      const bin = pausedGitBin(value, gitReadyPath, gitReleasePath);
+      const sender = operatorMessageWorker(value, MESSAGE_ONE, { PATH: `${bin}:${process.env.PATH ?? ''}` });
+      await waitFor(() => existsSync(gitReadyPath), 'initial canonical sprint read');
+      writeFileSync(join(value.root, '.ai/harness/sprint/active-sprint'), 'plans/sprints/replacement.sprint.md\n');
+      writeFileSync(gitReleasePath, 'release\n');
+
+      const senderResult = await workerResult(sender);
+      expect(readWorkerPayload(senderResult)).toMatchObject({ ok: false, code: 'canonical_source_stale' });
+      expectNoInboxArtifacts(value, MESSAGE_ONE);
+    }), 30_000);
+
+    test('rejects a canonical target-ref change captured between source resolution and the task lock', async () => withFixtureAsync(async (value) => {
+      const gitReadyPath = join(value.home, 'initial-sprint-read');
+      const gitReleasePath = join(value.home, 'release-initial-sprint-read');
+      const bin = pausedGitBin(value, gitReadyPath, gitReleasePath);
+      const sender = operatorMessageWorker(value, MESSAGE_ONE, { PATH: `${bin}:${process.env.PATH ?? ''}` });
+      await waitFor(() => existsSync(gitReadyPath), 'initial canonical sprint read');
+      writeFileSync(join(value.root, '.ai/harness/policy.json'), JSON.stringify({
+        worktree_strategy: { merge_back: { target: 'alternate' } },
+      }));
+      writeFileSync(gitReleasePath, 'release\n');
+
+      const senderResult = await workerResult(sender);
+      expect(readWorkerPayload(senderResult)).toMatchObject({ ok: false, code: 'canonical_source_stale' });
+      expectNoInboxArtifacts(value, MESSAGE_ONE);
+    }), 30_000);
+
+    test('rejects a status change that lands after draft resolution and before locked publication', async () => withFixtureAsync(async (value) => {
+      const gitReadyPath = join(value.home, 'initial-sprint-read');
+      const gitReleasePath = join(value.home, 'release-initial-sprint-read');
+      const bin = pausedGitBin(value, gitReadyPath, gitReleasePath);
+      const sender = operatorMessageWorker(value, MESSAGE_ONE, { PATH: `${bin}:${process.env.PATH ?? ''}` });
+      await waitFor(() => existsSync(gitReadyPath), 'initial canonical sprint read');
+
+      writeFileSync(join(value.root, SPRINT_PATH), [
+        '# Sprint: operator message', '', '## Backlog', '',
+        '| # | Status | Task | Mode | Acceptance | Plan |',
+        '|---|--------|------|------|------------|------|',
+        `| 1 | [x] | ${TASK_CELL} | contract | proves the fence | (pending) |`, '',
+      ].join('\n'));
+      git(value.root, 'add', SPRINT_PATH);
+      git(value.root, 'commit', '-m', 'complete fixture task after draft');
+      writeFileSync(gitReleasePath, 'release\n');
+
+      const senderResult = await workerResult(sender);
+      expect(readWorkerPayload(senderResult)).toMatchObject({ ok: false, code: 'task_not_pending' });
+      expectNoInboxArtifacts(value, MESSAGE_ONE);
+    }), 30_000);
+  }
 });

--- a/tests/operator-web/operator-collaboration.test.tsx
+++ b/tests/operator-web/operator-collaboration.test.tsx
@@ -549,6 +549,122 @@ describe('operator collaboration read', () => {
     expect(paneText()).toContain('hotspot 87');
   });
 
+  test('aborts the obsolete collaboration request when selection moves to another repository', async () => {
+    const requests: Array<{
+      readonly repositoryId: string;
+      readonly signal: AbortSignal;
+      readonly resolve: (snapshot: OperatorCollaborationSnapshotV1) => void;
+    }> = [];
+    const fetchCollaboration = (repositoryId: string, signal: AbortSignal): Promise<OperatorCollaborationSnapshotV1> => new Promise((resolve, reject) => {
+      requests.push({ repositoryId, signal, resolve });
+      signal.addEventListener('abort', () => {
+        const error = new Error('superseded');
+        error.name = 'AbortError';
+        reject(error);
+      }, { once: true });
+    });
+
+    await mount(
+      <OperatorApp
+        initialState={projectSnapshotViewState(stableSnapshot)}
+        initialLocale="en"
+        fetchCollaboration={fetchCollaboration}
+      />,
+    );
+    await act(async () => buttonWithText(fixtureTasks.console.task_label).click());
+    await act(async () => buttonWithText(fixtureTasks.blocked.task_label).click());
+
+    expect(requests.map((request) => request.repositoryId)).toEqual(['repo-console', 'repo-harness']);
+    expect(requests[0]!.signal.aborted).toBe(true);
+    expect(requests[1]!.signal.aborted).toBe(false);
+    expect(paneText()).toContain('repository repo-harness');
+    expect(paneText()).not.toContain('The collaboration store cannot be read');
+  });
+
+  test('aborts the active collaboration request when the task is deselected', async () => {
+    const observed: { signal: AbortSignal | null } = { signal: null };
+    await mount(
+      <OperatorApp
+        initialState={projectSnapshotViewState(stableSnapshot)}
+        initialLocale="en"
+        fetchCollaboration={async (_repositoryId, nextSignal) => {
+          observed.signal = nextSignal;
+          return new Promise<OperatorCollaborationSnapshotV1>(() => {});
+        }}
+      />,
+    );
+    await act(async () => buttonWithText(fixtureTasks.blocked.task_label).click());
+    expect(observed.signal?.aborted).toBe(false);
+
+    const close = document.querySelector<HTMLButtonElement>('[aria-label="Close task details"]');
+    if (!close) throw new Error('close button not found');
+    await act(async () => close.click());
+
+    expect(observed.signal?.aborted).toBe(true);
+    expect(paneText()).toContain('Select a task to read its repository collaboration lanes.');
+  });
+
+  test('refresh supersedes a collaboration generation without showing an abort failure', async () => {
+    const signals: AbortSignal[] = [];
+    const fetchCollaboration = async (repositoryId: string, signal: AbortSignal): Promise<OperatorCollaborationSnapshotV1> => {
+      signals.push(signal);
+      return new Promise((resolve, reject) => {
+        signal.addEventListener('abort', () => {
+          const error = new Error('superseded');
+          error.name = 'AbortError';
+          reject(error);
+        }, { once: true });
+        if (signal.aborted) return;
+        // Keep the current generation pending so the assertion exercises its
+        // cancellation rather than completion order.
+        void repositoryId;
+        void resolve;
+      });
+    };
+    await mount(
+      <OperatorApp
+        initialState={projectSnapshotViewState(stableSnapshot)}
+        initialLocale="en"
+        fetchSnapshot={async () => stableSnapshot}
+        fetchCollaboration={fetchCollaboration}
+      />,
+    );
+    await act(async () => buttonWithText(fixtureTasks.blocked.task_label).click());
+    expect(signals).toHaveLength(1);
+
+    await act(async () => buttonWithText('Refresh').click());
+
+    expect(signals).toHaveLength(2);
+    expect(signals[0]!.aborted).toBe(true);
+    expect(signals[1]!.aborted).toBe(false);
+    expect(paneText()).toContain('Reading the collaboration store');
+    expect(paneText()).not.toContain('The collaboration store cannot be read');
+  });
+
+  test('passes the collaboration generation signal to the production fetch transport', async () => {
+    const originalFetch = globalThis.fetch;
+    const observed: { signal: AbortSignal | null } = { signal: null };
+    const controller = new AbortController();
+    const fetchStub = async (
+      _input: Parameters<typeof fetch>[0],
+      init?: Parameters<typeof fetch>[1],
+    ) => {
+      observed.signal = (init as RequestInit).signal as AbortSignal | null;
+      return new Response(JSON.stringify(collaborationSnapshot), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    };
+    globalThis.fetch = fetchStub as unknown as typeof fetch;
+    try {
+      await expect(fetchOperatorCollaborationSnapshot(collaborationSnapshot.repository_id, controller.signal))
+        .resolves.toEqual(collaborationSnapshot);
+      expect(observed.signal).toBe(controller.signal);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   test('keeps Fleet validation copy separate from collaboration validation copy', async () => {
     const originalFetch = globalThis.fetch;
     try {

--- a/tests/operator-web/operator-interactions.test.tsx
+++ b/tests/operator-web/operator-interactions.test.tsx
@@ -754,6 +754,92 @@ describe('operator web task message composer', () => {
     await act(async () => composerToggle().click());
   }
 
+  test('coalesces a post-send refresh behind an in-flight Fleet snapshot without overlap', async () => {
+    const pending: Array<{
+      readonly resolve: (snapshot: OperatorFleetSnapshotV1) => void;
+      readonly reject: (error: unknown) => void;
+    }> = [];
+    let calls = 0;
+    let active = 0;
+    let maxActive = 0;
+    const fetchSnapshot = (): Promise<OperatorFleetSnapshotV1> => new Promise((resolve, reject) => {
+      calls += 1;
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      pending.push({
+        resolve: (snapshot) => {
+          active -= 1;
+          resolve(snapshot);
+        },
+        reject: (error) => {
+          active -= 1;
+          reject(error);
+        },
+      });
+    });
+    const postMessageSnapshot: OperatorFleetSnapshotV1 = {
+      ...stableSnapshot,
+      sequence: stableSnapshot.sequence + 2,
+      repositories: stableSnapshot.repositories.map((repository) => ({
+        ...repository,
+        cards: repository.cards.map((card) => card.task_id === fixtureTasks.blocked.task_id
+          ? { ...card, inbox: { ...card.inbox, unread_count: card.inbox.unread_count + 1 } }
+          : card),
+      })),
+    };
+
+    await openComposerFor(fixtureTasks.blocked.task_label, stableSnapshot, {
+      fetchSnapshot,
+      initialCollaboration: { kind: 'idle' },
+      sendMessage: async () => {},
+    });
+    await typeMessage('send while the board is refreshing');
+    await act(async () => buttonWithText('Refresh').click());
+    expect(calls).toBe(1);
+
+    await act(async () => sendButton().click());
+    expect(calls).toBe(1);
+    expect(maxActive).toBe(1);
+
+    await act(async () => pending[0]!.resolve(stableSnapshot));
+    expect(calls).toBe(2);
+    expect(maxActive).toBe(1);
+
+    await act(async () => pending[1]!.resolve(postMessageSnapshot));
+    expect(calls).toBe(2);
+    expect(maxActive).toBe(1);
+    expect(document.querySelector('[data-fact="sequence"]')?.textContent).toContain(String(postMessageSnapshot.sequence));
+    expect(paneText()).toContain('1 unread');
+  });
+
+  test('runs the one queued recovery read after the in-flight Fleet request fails', async () => {
+    const pending: Array<{
+      readonly resolve: (snapshot: OperatorFleetSnapshotV1) => void;
+      readonly reject: (error: unknown) => void;
+    }> = [];
+    let calls = 0;
+    const fetchSnapshot = (): Promise<OperatorFleetSnapshotV1> => new Promise((resolve, reject) => {
+      calls += 1;
+      pending.push({ resolve, reject });
+    });
+
+    await openComposerFor(fixtureTasks.blocked.task_label, stableSnapshot, {
+      fetchSnapshot,
+      initialCollaboration: { kind: 'idle' },
+      sendMessage: async () => {},
+    });
+    await typeMessage('send through a failed observation');
+    await act(async () => buttonWithText('Refresh').click());
+    await act(async () => sendButton().click());
+    expect(calls).toBe(1);
+
+    await act(async () => pending[0]!.reject(new Error('Fleet provider is offline')));
+    expect(calls).toBe(2);
+    await act(async () => pending[1]!.resolve(stableSnapshot));
+    expect(calls).toBe(2);
+    expect(document.querySelector('[data-state="stable"]')).not.toBeNull();
+  });
+
   test('UX-operator-task-message-v1-P1 stays collapsed until asked and then states the untrusted contract', async () => {
     installDom(true);
     await mount(<OperatorApp initialState={projectSnapshotViewState(stableSnapshot)} initialLocale="en" />);
@@ -821,6 +907,17 @@ describe('operator web task message composer', () => {
     expect(composerPanel()?.textContent).toContain('stale or degraded data');
   });
 
+  test('does not render the task-message composer for a completed task', async () => {
+    installDom(true);
+    await mount(<OperatorApp initialState={projectSnapshotViewState(stableSnapshot)} initialLocale="en" />);
+
+    await act(async () => buttonWithText('Done').click());
+    await act(async () => buttonWithText(fixtureTasks.done.task_label).click());
+
+    expect(document.querySelector('.detail-pane [data-slot="composer"]')).toBeNull();
+    expect(document.querySelector('[data-write-action="task-message"]')).toBeNull();
+  });
+
   test('UX-operator-task-message-v1-N2 counts UTF-8 bytes and blocks an empty or oversized body', async () => {
     await openComposerFor(fixtureTasks.blocked.task_label);
     expect(sendButton().disabled).toBe(true);
@@ -836,7 +933,7 @@ describe('operator web task message composer', () => {
     expect(document.querySelector('.composer__bytes.is-over')).not.toBeNull();
   });
 
-  test('UX-operator-task-message-v1-P3 sends once, refreshes, and keeps the draft plus the retry id on failure', async () => {
+  test('UX-operator-task-message-v1-P3 retries an ambiguous send with its exact draft identity', async () => {
     const sent: Array<Record<string, unknown>> = [];
     let refreshes = 0;
     let failure: unknown = null;
@@ -855,10 +952,10 @@ describe('operator web task message composer', () => {
     await act(async () => buttonWithText(fixtureTasks.blocked.task_label).click());
     await act(async () => composerToggle().click());
 
-    failure = { code: 'claim_mismatch', message: 'x', next_action: 'y' };
+    failure = new Error('the connection closed before the result arrived');
     await typeMessage('the base moved, rebase first');
     await act(async () => sendButton().click());
-    expect(composerPanel()?.textContent).toContain('That session is gone');
+    expect(composerPanel()?.textContent).toContain('The send outcome is unknown');
     expect((document.querySelector('#composer-body') as unknown as HTMLTextAreaElement).value)
       .toBe('the base moved, rebase first');
     expect(refreshes).toBe(0);
@@ -886,6 +983,156 @@ describe('operator web task message composer', () => {
     await act(async () => sendButton().click());
     expect(sent[2]!.message_id).not.toBe(sent[1]!.message_id);
     expect(window.localStorage.getItem('repo-harness:operator-sent')).toBeNull();
+  });
+
+  test('rotates a conflicting message id only after the operator explicitly asks', async () => {
+    const submitted: TaskMessageRequestV1[] = [];
+    let conflict = true;
+    await openComposerFor(fixtureTasks.blocked.task_label, stableSnapshot, {
+      sendMessage: async (request) => {
+        submitted.push(request);
+        if (conflict) {
+          throw {
+            code: 'message_id_conflict',
+            message: 'A different message already used this message id.',
+            next_action: 'Compose the message again so it gets a new id.',
+          };
+        }
+      },
+    });
+    await typeMessage('use the next available message id');
+    await act(async () => sendButton().click());
+
+    expect(sendButton().disabled).toBe(true);
+    expect(composerPanel()?.textContent).toContain('Start with a new message ID');
+    const conflictingId = submitted[0]!.message_id;
+
+    conflict = false;
+    await act(async () => buttonWithText('Start with a new message ID').click());
+    expect(sendButton().disabled).toBe(false);
+    expect((document.querySelector('#composer-body') as unknown as HTMLTextAreaElement).value)
+      .toBe('use the next available message id');
+
+    await act(async () => sendButton().click());
+    expect(submitted).toHaveLength(2);
+    expect(submitted[1]!.message_id).not.toBe(conflictingId);
+    expect(submitted[1]).toMatchObject({
+      body: 'use the next available message id',
+      expected_task_revision: submitted[0]!.expected_task_revision,
+      expected_claim_id: submitted[0]!.expected_claim_id,
+      expected_generation: submitted[0]!.expected_generation,
+    });
+  });
+
+  test('rebinds a stale draft only through an explicit current-snapshot action', async () => {
+    const initialCard = stableSnapshot.repositories[0]!.cards.find((card) => card.task_id === fixtureTasks.blocked.task_id)!;
+    const reboundSnapshot: OperatorFleetSnapshotV1 = {
+      ...stableSnapshot,
+      sequence: stableSnapshot.sequence + 1,
+      repositories: stableSnapshot.repositories.map((repository) => ({
+        ...repository,
+        cards: repository.cards.map((card) => card.task_id === initialCard.task_id
+          ? {
+            ...card,
+            task_revision: `${initialCard.task_revision}-next`,
+            claim_id: 'claim-current-owner',
+            generation: (initialCard.generation ?? 0) + 1,
+          }
+          : card),
+      })),
+    };
+    const submitted: TaskMessageRequestV1[] = [];
+    await openComposerFor(fixtureTasks.blocked.task_label, stableSnapshot, {
+      fetchSnapshot: async () => reboundSnapshot,
+      sendMessage: async (request) => {
+        submitted.push(request);
+        if (submitted.length === 1) {
+          throw {
+            code: 'claim_mismatch',
+            message: 'The task owner changed while the message was being sent.',
+            next_action: 'Refresh the board to re-observe the task, then retry.',
+          };
+        }
+      },
+    });
+    await typeMessage('send only if the current owner still needs this');
+    await act(async () => sendButton().click());
+
+    expect(sendButton().disabled).toBe(true);
+    expect(composerPanel()?.textContent).toContain('Rebind to current snapshot');
+    const originalId = submitted[0]!.message_id;
+
+    await act(async () => buttonWithText('Refresh').click());
+    expect(paneText()).toContain(`rev ${initialCard.task_revision}`);
+    await act(async () => buttonWithText('Rebind to current snapshot').click());
+
+    expect(sendButton().disabled).toBe(false);
+    expect((document.querySelector('#composer-body') as unknown as HTMLTextAreaElement).value)
+      .toBe('send only if the current owner still needs this');
+    await act(async () => sendButton().click());
+    expect(submitted).toHaveLength(2);
+    expect(submitted[1]).toMatchObject({
+      expected_task_revision: `${initialCard.task_revision}-next`,
+      expected_claim_id: 'claim-current-owner',
+      expected_generation: (initialCard.generation ?? 0) + 1,
+    });
+    expect(submitted[1]!.message_id).not.toBe(originalId);
+  });
+
+  test('disables stale-draft rebind when the refreshed board is degraded', async () => {
+    await openComposerFor(fixtureTasks.blocked.task_label, stableSnapshot, {
+      fetchSnapshot: async () => degradedSnapshot,
+      sendMessage: async () => {
+        throw {
+          code: 'task_revision_mismatch',
+          message: 'The canonical task definition moved since the snapshot.',
+          next_action: 'Refresh the board to re-observe the task, then retry.',
+        };
+      },
+    });
+    await typeMessage('wait for a stable board');
+    await act(async () => sendButton().click());
+    await act(async () => buttonWithText('Refresh').click());
+
+    const rebind = buttonWithText('Rebind to current snapshot');
+    expect(rebind.disabled).toBe(true);
+    expect(sendButton().disabled).toBe(true);
+  });
+
+  test('clears a successful draft and freezes the next message against the latest card', async () => {
+    const initialCard = stableSnapshot.repositories[0]!.cards.find((card) => card.task_id === fixtureTasks.blocked.task_id)!;
+    const refreshedSnapshot: OperatorFleetSnapshotV1 = {
+      ...stableSnapshot,
+      sequence: stableSnapshot.sequence + 1,
+      repositories: stableSnapshot.repositories.map((repository) => ({
+        ...repository,
+        cards: repository.cards.map((card) => card.task_id === initialCard.task_id
+          ? { ...card, task_revision: `${initialCard.task_revision}-after-send` }
+          : card),
+      })),
+    };
+    const submitted: TaskMessageRequestV1[] = [];
+    await openComposerFor(fixtureTasks.blocked.task_label, stableSnapshot, {
+      fetchSnapshot: async () => refreshedSnapshot,
+      sendMessage: async (request) => { submitted.push(request); },
+    });
+    await typeMessage('first message');
+    await act(async () => sendButton().click());
+    expect((document.querySelector('#composer-body') as unknown as HTMLTextAreaElement).value).toBe('');
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await typeMessage('second message');
+    await act(async () => sendButton().click());
+
+    expect(submitted).toHaveLength(2);
+    expect(submitted[1]!.message_id).not.toBe(submitted[0]!.message_id);
+    expect(submitted[1]).toMatchObject({
+      body: 'second message',
+      expected_task_revision: `${initialCard.task_revision}-after-send`,
+    });
   });
 
   test('keeps the draft fence bound to the rendered card across a refresh', async () => {

--- a/tests/publication-feedback-concurrency.test.ts
+++ b/tests/publication-feedback-concurrency.test.ts
@@ -9,6 +9,8 @@ import {
   publicationReceiptDigest,
 } from '../src/core/publication/publication-receipt';
 import {
+  buildFeedbackDeliveryReceipt,
+  buildFeedbackEvent,
   buildReactionAttemptReceipt,
   buildRepairDispatchProof,
   deriveReactionToken,
@@ -23,13 +25,18 @@ import {
 } from '../src/core/state/coordination-identity';
 import {
   intakeGitHubFeedback,
+  projectFleetFeedback,
   projectPendingFeedbackOffer,
   type FeedbackObservationInput,
 } from '../src/effects/publication/feedback';
 import {
   appendReactionAttemptReceipt,
+  readFeedbackDeliveryReceipts,
   readFeedbackEvents,
+  readReactionAttemptReceipts,
   transitionRepairDispatchProof,
+  writeFeedbackDeliveryReceipt,
+  writeFeedbackEvent,
   writeRepairDispatchProof,
 } from '../src/effects/publication/feedback-store';
 import { writePublicationReceiptCache } from '../src/effects/publication/publication-receipt';
@@ -225,6 +232,72 @@ describe('provider feedback intake fences', () => {
     const halted = projectPendingFeedbackOffer(input);
     expect(halted).toMatchObject({ state: 'no_progress', attention_owner: 'user', reaction_token: token });
     expect(readFileSync(ownerPath, 'utf-8')).toBe(before);
+  });
+
+  test('Fleet feedback retries an intake that lands between complete store observations', () => {
+    const subject = fixture();
+    const input = { repo_root: subject.root, publication_id: subject.publication_id, gh_runner: feedbackRunner() };
+    intakeGitHubFeedback(input);
+    const concurrentEvent = buildFeedbackEvent({
+      provider: 'github', provider_event_id: 'THREAD_CONCURRENT', publication_id: subject.publication_id, head_sha: HEAD,
+      failing_check_ids: [], failing_checks: [], unresolved_review_thread_ids: ['THREAD_CONCURRENT'],
+      changes_requested_review_ids: [], mergeability: 'MERGEABLE', summary: 'concurrent review thread',
+      provider_url: subject.receipt.pr_url, observed_at: '2026-08-23T00:05:00Z',
+    });
+    let reactionReads = 0;
+    const projected = projectFleetFeedback(input, {
+      read_reactions: (repoRoot, publicationId, gitBin) => {
+        const observed = readReactionAttemptReceipts(repoRoot, publicationId, gitBin);
+        reactionReads += 1;
+        if (reactionReads === 1) {
+          writeFeedbackEvent(subject.root, concurrentEvent);
+          writeFeedbackDeliveryReceipt(subject.root, subject.publication_id, buildFeedbackDeliveryReceipt({
+            provider_event_id: concurrentEvent.provider_event_id, delivery_state: 'pending', delivery_channel: 'none',
+            delivered_at: null, acknowledged_at: null, superseded_at: null,
+          }));
+        }
+        return observed;
+      },
+    });
+    expect(projected).toMatchObject({ pending_count: 3, no_progress: false, snapshot_consistency: 'stable' });
+    expect(projected.repair_actions).toEqual(['resume_same_owner', 'explicit_takeover']);
+    expect(reactionReads).toBe(4);
+  });
+
+  test('Fleet feedback never labels continuously changing reaction evidence stable', () => {
+    const subject = fixture();
+    const input = { repo_root: subject.root, publication_id: subject.publication_id, gh_runner: feedbackRunner() };
+    intakeGitHubFeedback(input);
+    const events = readFeedbackEvents(subject.root, subject.publication_id);
+    const token = deriveReactionToken({
+      publication_id: subject.publication_id,
+      head_sha: HEAD,
+      failing_checks: events.flatMap((event) => event.failing_checks),
+      unresolved_review_thread_ids: events.flatMap((event) => event.unresolved_review_thread_ids),
+      mergeability: 'MERGEABLE',
+    });
+    const reaction = buildReactionAttemptReceipt({
+      publication_id: subject.publication_id,
+      repair_id: `sha256:${'8'.repeat(64)}`,
+      successor_claim_id: CLAIM,
+      successor_generation: 1,
+      completion_publication_id: subject.publication_id,
+      completion_receipt_sha256: publicationReceiptDigest(subject.receipt),
+      completion_head_sha: HEAD,
+      completion_ship_transaction_key: 'ship-feedback-observation',
+      before_reaction_token: token,
+      after_reaction_token: token,
+      outcome: 'completed',
+      recorded_at: '2026-08-23T00:06:00Z',
+    });
+    let reactionReads = 0;
+    const projected = projectFleetFeedback(input, {
+      read_events: readFeedbackEvents,
+      read_deliveries: readFeedbackDeliveryReceipts,
+      read_reactions: () => Object.freeze(reactionReads++ % 2 === 0 ? [] : [reaction]),
+    });
+    expect(projected.snapshot_consistency).toBe('changed_during_read');
+    expect(reactionReads).toBe(4);
   });
 
   test('a stable provider head mismatch fails before any feedback write or lease mutation', () => {


### PR DESCRIPTION
## Summary

- linearize Task Board message writes with registry authorization revocation and revalidate sprint, target ref, and pending status at commit
- isolate and bound Task Message, Fleet, and collaboration snapshot work outside the Operator HTTP event loop
- abort obsolete browser collaboration reads, queue trailing Fleet refreshes, and recover the composer from explicit stale/conflict outcomes
- derive Fleet feedback count and repair state from one stable store observation

## Verification

- `bunx tsc --noEmit --pretty false`
- 172 directed Operator/Fleet/feedback tests passed
- `bun run build:operator-web`
- deploy SQL, architecture sync, task sync, project-state audit, init dry-run, and `git diff --check` passed
- full suite before rebasing: 3661 passed, 2 skipped, 1 environment-dependent Waza staging assertion failed outside this diff
- strict workflow after rebasing reports the base branch's pre-existing stale resume projection (`.ai/harness/handoff/resume.md < tasks/current.md`)

Closes #253
Closes #254
Closes #255
Closes #256
Closes #257
Closes #258
Closes #259
Closes #260
Closes #261
Closes #262
