### PR TITLE
docs(plans): add ArchContext-backed Refactor Mode PRD and Program B research; fix waiver validator under bash 3.2

### DIFF
--- a/assets/templates/helpers/check-task-sync.sh
+++ b/assets/templates/helpers/check-task-sync.sh
@@ -108,7 +108,7 @@ for (const file of waivers) {
 }
 if (invalid) process.exit(2);
 if (!schemaOnly && !admitted) process.exit(1);
-' "$expected_digest" "$schema_only" "${substantive[@]}" --waivers "${waivers[@]}"
+' "$expected_digest" "$schema_only" ${substantive[@]+"${substantive[@]}"} --waivers "${waivers[@]}"
 }
 
 if [[ "$validate_waivers_only" -eq 1 ]]; then

--- a/docs/researches/20260902-restructure.md
+++ b/docs/researches/20260902-restructure.md
@@ -1,0 +1,1976 @@
+# 代码重构模式：双仓权威边界与实施 Sprint
+
+> contract 字段对照的权威是 arch-context 主干的 `docs/researches/20260902-restructure.md` §0 修订记录；本文 §二十二 是下游对齐记录，只指回它、不独立演化。
+
+## 最终决策
+
+应采用一条非常清晰的分界：
+
+```text
+ArchContext
+= 观察代码
++ 定义模块
++ 统计模块
++ 分析依赖与结构压力
++ 判断模块级 / 跨模块 / 架构级
++ 生成重构建议
++ 验证重构前后结构变化
++ 保存语义重构账本
+
+repo-harness
+= 接收用户或 Campaign 授权
++ 调用并验证 archctx CLI
++ 把建议物化为 Sprint / Work Package / Plan / Contract
++ 派发 Claude / Codex
++ 管理 Lease / Worktree / WorkEnvelope
++ 执行 Cutover Closure
++ 测试、验收、PR、合并、Issue 关闭和分支清理
++ 展示“建议—执行—完成”的联合看板
+```
+
+一句话判断规则：
+
+> **任何脱离 repo-harness 也应该对其他代码仓库有用的重构分析能力，都放进 ArchContext；任何涉及 Task、Plan、Contract、Lease、Agent、PR、AcceptanceReceipt、GitHub Issue 或 Campaign 的功能，都留在 repo-harness。**
+
+不应在 repo-harness 中自行实现：
+
+* LOC／文件／symbol 统计器；
+* import graph、fan-in/fan-out、SCC或cycle分析器；
+* 模块边界解析器；
+* “整体架构还是单模块”的第二套判定器；
+* 第二份 `refactor-ledger.json`；
+* 直接解析 CodeGraph输出的适配器。
+
+---
+
+# 一、当前基础与真正缺口
+
+ArchContext 当前已经不是一张简单架构图工具。它已有 CodeGraph adapter、architecture pressure、refactor posture、Architecture Intervention、Architecture Ledger、Recommendation lifecycle、audit、book、investigation和projection等基础能力。CLI目前提供 `prepare`、`checkpoint`、`recommendations`、`book`、`investigate`、`audit` 等命令，但尚无一个 first-class、稳定版本化的 `archctx refactor` 协议。
+
+它已经可以按 `.archcontext/model/nodes/*.yaml` 中声明的 `source.include - source.exclude` 计算每个 node的精确文件数和行数，也已有每个 capability的真实已解析 import edge图和 `truncated` 状态。不过生成架构文档时，当前故意只输出 1–2–5 量级区间，而不是精确数字，避免每次普通代码修改都造成文档 churn。
+
+CodeGraph adapter已经固定 `@colbymchenry/codegraph@1.5.0`，支持 index、context、symbol search、impact radius，也会把相对 import解析到真实文件；无法解析的bare package或不存在目标不会被猜成一条边。其projection handshake还会绑定binary、版本、index状态和worktree digest。
+
+但当前判定层还不能直接成为无人值守重构的机器权威：
+
+* pressure engine仍混合task text regex和observed graph evidence；
+* `prepareTask()`在调用者没有提供证据时，会默认 `callerCoverage=0.8`、`testsAvailable=true`、`rollbackAvailable=true`；
+* `createInterventionProposal()`目前生成的target owner、relation和kill-list仍有通用placeholder；
+* 当前 `ArchitecturePosture` 只有 `normal | structural | intervention | proof-required`，还没有明确区分“单模块”“跨模块但不改架构”“整体架构切换”。
+
+所以正确方向不是在 repo-harness 补这些算法，而是先把它们在 ArchContext上游收敛成一个可消费的公开协议。
+
+---
+
+# 二、P1 架构
+
+```mermaid
+flowchart TD
+    U["User / Repair Campaign
+    请求重构"]
+
+    RH["repo-harness Refactor Mode
+    workflow authority"]
+
+    REQ["RefactorRequestV1
+    exact HEAD/worktree fence"]
+
+    AC["archctx refactor scan
+    measurement + classification"]
+
+    STATS["ModuleStatisticsSnapshotV1
+    exact machine evidence"]
+
+    ASSESS["RefactorAssessmentV1
+    scale + scaleReasonCodes"]
+
+    ROUTE["RefactorWorkflowRoute
+    repo-harness 确定性投影"]
+
+    LEDGER["ArchContext Recommendation /
+    Refactor Ledger"]
+
+    MOD["Module Refactor Program
+    one module per WP"]
+
+    CROSS["Cross-module Refactor Sprint
+    ordered WPs"]
+
+    ARCH["Architecture Intervention
+    target state + migration + kill list"]
+
+    PROOF["Proof / Investigation WP"]
+
+    EXEC["Existing repo-harness flow
+    Plan → Contract → Worktree
+    → Lease → Agent"]
+
+    VERIFY["verify-contract
+    Cutover Closure
+    archctx refactor verify"]
+
+    MERGE["Acceptance → PR → Merge"]
+
+    AFTER["Post-merge scan
+    exact new main"]
+
+    RESOLVE["ArchContext resolves
+    recommendation"]
+
+    BOARD["Joined Refactor Board
+    read-only projection"]
+
+    U --> RH --> REQ --> AC
+    AC --> STATS --> ASSESS
+    ASSESS --> LEDGER
+
+    ASSESS --> ROUTE
+    ROUTE -->|module_refactor| MOD
+    ROUTE -->|cross_module_refactor| CROSS
+    ROUTE -->|architecture_intervention| ARCH
+    ROUTE -->|proof_required| PROOF
+
+    MOD --> EXEC
+    CROSS --> EXEC
+    ARCH --> EXEC
+    PROOF --> AC
+
+    EXEC --> VERIFY --> MERGE --> AFTER
+    AFTER --> RESOLVE --> BOARD
+    LEDGER --> BOARD
+    EXEC --> BOARD
+```
+
+## 权威关系
+
+```text
+ArchContext assessment.scale + assessment.scaleReasonCodes
+    是唯一“这次改动实际是多大规模、证据够不够”的判定
+
+repo-harness RefactorWorkflowRoute
+    是 (scale, scaleReasonCodes, majorChangeReasons) 的确定性投影
+    可以比assessment更保守地停止
+    但scale = 'architecture'不得被投影成低于architecture_intervention的任何路由
+```
+
+也就是说：
+
+* ArchContext可以说“这次提案的规模是 architecture”；
+* repo-harness可以说“需要人工批准”，也可以在证据充足时仍选择停在 `proof_required`；
+* repo-harness不能说“为了自动执行，我把它当单模块改动”。
+
+---
+
+# 三、功能归属表
+
+| 功能                                     |   ArchContext上游  |            repo-harness            |
+| -------------------------------------- | :--------------: | :--------------------------------: |
+| Architecture node／module身份             |      **权威**      |                 只消费                |
+| `source.include/exclude` footprint     |      **权威**      |                 不重算                |
+| 文件数、行数、symbol数                         |     **计算与协议**    |                只显示摘要               |
+| CodeGraph index和版本绑定                   |     **权威适配器**    |           不直接调用CodeGraph           |
+| import graph、fan-in、fan-out            |      **计算**      |                 只消费                |
+| SCC、cycle、跨边界edge                      |      **计算**      |              用于调度但不重算              |
+| entrypoint、owner、lifecycle             |    **架构模型权威**    |                 不推断                |
+| unowned／multiply-owned path            |      **检测**      |       遇到即停止或触发model adoption       |
+| caller coverage                        | **测量，允许unknown** | Cutover Closure补work-package proof |
+| test evidence availability             |     **观察信号**     |              实际测试执行权威              |
+| persisted data／external consumer       |     **结构证据**     |          Contract风险和迁移gate         |
+| architecture pressure                  |      **计算**      |              不复制score              |
+| module／cross-module／architecture判级     |     **唯一权威**     |             映射到workflow            |
+| Architecture Intervention target state |     **权威模型**     |             生成Sprint和执行            |
+| Refactor recommendation fingerprint    |      **权威**      |               绑定到Task              |
+| 重构语义账本                                 |     **唯一权威**     |               不建第二账本               |
+| Task／Sprint／Work Graph                 |         否        |               **权威**               |
+| Plan／Contract／allowed paths            |         否        |               **权威**               |
+| Lease／Claim／WorkEnvelope               |         否        |               **权威**               |
+| Claude／Codex并行派工                       |         否        |               **权威**               |
+| Cutover Closure                        |      提供结构复测      |             **执行收口权威**             |
+| 验证命令和AcceptanceReceipt                 |      可提供检查结果     |               **权威**               |
+| PR、merge、Issue closure                 |         否        |               **权威**               |
+| GPT Pro出Issue／审计main                   |         否        |           **Campaign权威**           |
+| 重构联合看板                                 |      提供语义状态      |            **生成执行联合投影**            |
+
+---
+
+# 四、ArchContext 上游需要新增的能力
+
+## 4.1 模块定义不得按文件夹猜测
+
+“模块”必须定义为：
+
+```text
+.archcontext node
++ source.include
+- source.exclude
++ declared entrypoints
++ declared relations
+```
+
+不得做：
+
+```text
+src/foo 文件夹 = foo module
+packages/bar = bar module
+```
+
+除非 `.archcontext/model` 已明确如此声明。
+
+当出现：
+
+* 文件不属于任何node；
+* 同一个文件被多个node覆盖；
+* source selector冲突；
+* CodeGraph index缺失；
+* import graph被截断；
+
+结果必须是上游冻结的 scale 值之一：
+
+```text
+insufficient_evidence
+或
+model_adoption_required
+```
+
+不能继续用目录启发式猜一个module。
+
+---
+
+## 4.2 `ModuleStatisticsSnapshotV1`
+
+已在上游冻结（`packages/contracts/src/refactor.ts:219-250`，rf1a）：
+
+```ts
+export interface ModuleStatisticsSnapshotV1 {
+  schemaVersion: typeof MODULE_STATISTICS_SCHEMA_VERSION; // 'archcontext.module-statistics/v1'
+  repository: ArchitectureRepositoryIdentityV1;   // { repositoryId, storageRepositoryId }
+  worktree: ArchitectureWorktreeIdentityV1;       // { workspaceId, storageWorkspaceId, branch, headSha, worktreeDigest }
+  modelDigest: string;
+  codeFacts: {
+    provider: "codegraph";
+    version: string;
+    binaryDigest: string;
+    indexedWorktreeDigest: string | null;
+    coverage: EvidenceCoverageLevelV2;            // 'complete' | 'partial' | 'unknown'
+    truncated: boolean;
+    edgeLimit: number | null;
+    reasonCodes: RefactorScaleReasonCode[];
+  };
+  modules: ModuleStatisticsV1[];
+  repositorySummary: {
+    moduleCount: number;
+    undeclaredFootprintNodeCount: number;
+    ownedFileCount: number;
+    unownedFileCount: number;
+    multiplyOwnedFileCount: number;
+    crossModuleEdgeCount: number;
+    crossModuleCycleCount: number;
+    stronglyConnectedComponentCount: number;
+    unresolvedImportCount: number;
+    dynamicInvocationRiskCount: number;
+  };
+  createdAt: string;
+  snapshotDigest: string;
+  extensions?: Record<string, Json>;
+}
+```
+
+与本文早期草案的差异：`repository` / `worktree` 复用 ledger 身份类型而不是新声明第三种形状；`codeFacts.reasonCodes` 收敛成闭合枚举 `RefactorScaleReasonCode[]` 而不是 `string[]`；新增 `codeFacts.edgeLimit`（index 缺失时为 `null` 而不是 `0`）、`repositorySummary.undeclaredFootprintNodeCount` 与 `createdAt`（`createdAt` 被 `moduleStatisticsSnapshotDigest()` 排除）。
+
+每个module（`refactor.ts:175-217`）：
+
+```ts
+export interface ModuleStatisticsV1 {
+  nodeId: string;
+  nodeDigest: string;
+  parentNodeId: string | null;
+  footprintDeclared: boolean;
+  footprint: {
+    fileCount: number;
+    lineCount: number;
+    sourceFilesDigest: string;
+    includePatterns: string[];
+    excludePatterns: string[];
+  } | null;
+  surfaces: {
+    declaredEntrypoints: string[];
+    observedEntrypoints: string[];
+    lifecycleOwners: string[];
+    datastoreSubjects: string[];
+  };
+  dependencyGraph: {
+    internalEdgeCount: number;
+    inboundModuleEdges: number;
+    outboundModuleEdges: number;
+    fanIn: number;
+    fanOut: number;
+    stronglyConnectedComponentId: string | null;
+    cycleCount: number;
+    instability: number | null;
+    directionViolationCount: number | null;
+  } | null;
+  tests: {
+    testFileCount: number | null;
+    observedTestEdges: number | null;
+    callerCoverage: number | null;
+    coverageStatus: ModuleTestsCoverageStatus;      // 'measured' | 'partial' | 'unknown'
+  };
+  uncertainty: {
+    unresolvedImports: number;
+    dynamicInvocation: ModuleDynamicInvocationLevel; // 'known' | 'none_observed' | 'possible' | 'unknown'
+    ambiguousOwnership: boolean;
+  };
+  moduleDigest: string;
+  extensions?: Record<string, Json>;
+}
+```
+
+三处是 fail-closed 设计而不是命名差异：
+
+* `footprint` 可为 `null`，并由 `footprintDeclared` 判别（`refactor.ts:454` 要求两者严格互斥）——node 没声明 `source.include` 时不是返回零，而是标为未声明；
+* `dependencyGraph` 可为 `null`，且 `codeFacts.coverage === 'unknown'` 时**必须**为 `null`（`refactor.ts:501-508`）；
+* module 层没有 `graphTruncated`，截断是 snapshot 级 `codeFacts.truncated` 的全局状态。
+
+`parentNodeId` 为 ancestor/descendant 重叠归属（归最深 node）服务，非同源重叠才置 `ambiguousOwnership`。
+
+## 4.3 精确统计不进入普通架构文档
+
+现有“架构文档只显示量级bucket”的设计应保持。
+
+建议：
+
+```text
+机器JSON:
+  exact fileCount / lineCount / edgeCount
+
+docs/architecture:
+  2–5 files
+  1k–2k lines
+  high inbound coupling
+  one cycle
+```
+
+理由是：
+
+* 重构route需要精确机器输入；
+* Git追踪文档不应因每次加20行代码而重写；
+* ledger绑定 `snapshotDigest`，不需要把全部精确数字复制到Markdown。
+
+---
+
+# 五、ArchContext 的重构判定协议
+
+## 5.1 `RefactorAssessmentV1`
+
+上游没有 route 概念。冻结的词表是 scale 与 scale reason code（`packages/contracts/src/refactor.ts:28-46`）：
+
+```ts
+export const REFACTOR_SCALES = [
+  "architecture",
+  "cross_module",
+  "insufficient_evidence",
+  "model_adoption_required",
+  "module"
+] as const;
+
+export const REFACTOR_SCALE_REASON_CODES = [
+  "caller-coverage-unknown",
+  "code-facts-missing",
+  "code-facts-truncated",
+  "major-change-detected",
+  "multi-node-scope",
+  "node-footprint-undeclared",
+  "ownership-ambiguous",
+  "single-node-scope",
+  "target-unresolved",
+  "unowned-paths"
+] as const;
+```
+
+`proof_required` 与 `no_action` **不是** scale 值：
+
+* 证据不足是 `scale = 'insufficient_evidence'`，具体缺什么由 reason code 说明（`code-facts-missing`、`code-facts-truncated`、`caller-coverage-unknown`、`ownership-ambiguous`、`node-footprint-undeclared`、`unowned-paths`、`target-unresolved`）；
+* 架构模型缺失是 `scale = 'model_adoption_required'`；
+* 没有 agent proposal 的纯观察扫描是 `scale = null`，此时 `proposalDigest` 也必须为 `null`（`refactor.ts:545-547` 要求两者同时为 null），只产出 `structural_observation`。
+
+冻结后的接口（`refactor.ts:259-287`）：
+
+```ts
+export interface RefactorAssessmentV1 {
+  schemaVersion: typeof REFACTOR_ASSESSMENT_SCHEMA_VERSION; // 'archcontext.refactor-assessment/v1'
+  requestId: string;
+  statisticsSnapshotDigest: string;
+  modelDigest: string;
+  codeFactsDigest: string;
+  requestedScope: RefactorScopeV1;   // { kind:'repository' } | { kind:'node'; nodeId } | { kind:'paths'; paths }
+  proposalDigest: string | null;
+  observations: RefactorObservationV1[];
+  scale: RefactorScale | null;
+  scaleReasonCodes: RefactorScaleReasonCode[];
+  affectedNodeIds: string[];
+  majorChangeReasons: ArchitectureMajorChangeReasonCode[];
+  pressure: {
+    level: "low" | "medium" | "high";
+    score: number;                   // 整数，闭区间 [0, 100]
+    signalIds: string[];
+  };
+  confidence: {
+    level: "low" | "medium" | "high";
+    callerCoverage: number | null;
+    testsObserved: boolean | null;
+    rollbackObserved: boolean | null;
+    unresolvedEvidence: string[];
+  };
+  createdAt: string;
+  assessmentDigest: string;
+  extensions?: Record<string, Json>;
+}
+```
+
+没有 `opportunities`。观察结果走 `observations: RefactorObservationV1[]`，其 `kind` 取自闭合的 `REFACTOR_OBSERVATION_KINDS`（`cycle`、`direction-violation`、`evidence-gap`、`ownership-ambiguous`、`undeclared-footprint`、`unowned-paths`）。`majorChangeReasons` 是 `ArchitectureMajorChangeReasonCode[]`（复用现有架构 major-change 词表），且 `scale === 'architecture'` 时至少要有一项（`refactor.ts:548-550`）。
+
+**repo-harness 侧的 `RefactorWorkflowRoute`。** 上游只给规模和证据，不给工作流。repo-harness 需要自己的路由类型，并且它是一个确定性投影，不是第二个判定器：
+
+```ts
+// repo-harness 侧类型，不在 archctx-contracts 中
+type RefactorWorkflowRoute =
+  | 'module_refactor'
+  | 'cross_module_refactor'
+  | 'architecture_intervention'
+  | 'proof_required'
+  | 'no_action';
+
+// project(scale, scaleReasonCodes, majorChangeReasons) -> RefactorWorkflowRoute
+```
+
+投影规则：
+
+```text
+scale = 'architecture'                → architecture_intervention
+scale = 'cross_module'                → cross_module_refactor
+scale = 'module'                      → module_refactor
+scale = 'insufficient_evidence'       → proof_required
+scale = 'model_adoption_required'     → proof_required（model adoption 分支）
+scale = null（无 proposal 的观察扫描） → no_action 或 proof_required
+```
+
+上游定案（2026-09-03）：`RefactorProposalV1.scopePaths` 必须是**文件路径**；目录与 glob 被当作 unowned，直接回 `scale = 'model_adoption_required'`，Program B 需在提交前展开成文件清单。v1 的 `majorChangeReasons` 只推导 `ownership-changed` / `relation-changed` / `node-removed`；`node-added` 与 `lifecycle-changed` 不推导，未解析的 id 走 `targetDelta.unresolvedTargets`。
+
+不变量：repo-harness 可以沿这条阶梯**向更保守的一侧**停（例如把 `module` 投影成 `proof_required` 等待人工），但 `scale = 'architecture'` 永远不得被投影成低于 `architecture_intervention` 的任何路由。违反即 `refactor_route_conflict`。
+
+## 5.2 判级顺序
+
+判级必须按以下顺序执行，不应先看LOC：
+
+ArchContext 侧输出 scale：
+
+```text
+1. 架构模型是否存在／可用？
+   否 → scale = 'model_adoption_required'
+
+2. code facts是否完整（index存在、未截断）？
+   否 → scale = 'insufficient_evidence'
+        reason: code-facts-missing / code-facts-truncated
+
+3. module ownership是否唯一、footprint是否已声明？
+   否 → scale = 'insufficient_evidence'
+        reason: ownership-ambiguous / node-footprint-undeclared / unowned-paths
+
+4. proposal的targetDelta是否仍有unresolvedTargets？
+   是 → scale = 'insufficient_evidence'
+        reason: target-unresolved（refactor.ts:713-719 强制）
+
+5. 是否涉及architecture major change？
+   是 → scale = 'architecture'（majorChangeReasons非空）
+        reason: major-change-detected
+
+6. 是否涉及多个architecture nodes？
+   是 → scale = 'cross_module'，reason: multi-node-scope
+
+7. 是否明确只在一个node内部？
+   是 → scale = 'module'，reason: single-node-scope
+
+8. 没有proposal？
+   → scale = null，只产出structural_observation
+```
+
+repo-harness 侧再把上述结果投影成 `RefactorWorkflowRoute`；`no_action` 是 repo-harness 对 `scale = null` 且无值得执行观察时的收口，不是 ArchContext 的判定。
+
+上游定案（2026-09-03）：RF2 classifier 的 essential evidence 恰为三项——每个相关 node 的 `footprintDeclared`、每个 `scopePath` 有唯一的最深 owner、`codeFacts.coverage = 'complete'`。`caller-coverage-unknown` 只进 `scaleReasonCodes` 与 `confidence`，永不单独选出 `insufficient_evidence`。
+
+## 5.3 `architecture_intervention` 的触发
+
+应复用现有major-change语义，例如：
+
+* node added／removed／moved／renamed；
+* relation changed；
+* ownership changed；
+* lifecycle changed；
+* entrypoint changed；
+* interface changed；
+* responsibility changed；
+* risk boundary changed；
+* constraint changed；
+* migration target state changed。
+
+repo-harness当前已经用一个闭合major-change reason vocabulary处理这些架构变化，也已经有 `architecture-projection accept` 和 `reconcile` 入口。因此重构模式不应再发明一个“架构改动批准”系统。
+
+## 5.4 `cross_module_refactor` 与架构级的区别
+
+跨模块不一定等于架构切换。
+
+例如：
+
+```text
+模块A与模块B重复实现相同serializer
+→ 将实现收敛到现有模块A
+→ 不新增node
+→ 不改变owner
+→ 不改变public interface
+→ cross_module_refactor
+```
+
+而下面属于architecture intervention：
+
+```text
+模块A与模块B都有lifecycle owner
+→ 创建新的模块C作为唯一owner
+→ 删除旧relation
+→ 新增public boundary
+→ architecture_intervention
+```
+
+---
+
+# 六、必须修正的现有 ArchContext 判定缺口
+
+## 6.1 禁止默认“证据充足”
+
+当前：
+
+```ts
+callerCoverage ?? 0.8
+testsAvailable ?? true
+rollbackAvailable ?? true
+```
+
+用于交互建议尚可，但不能成为自动重构route的依据。
+
+新协议必须改为：
+
+```text
+unknown remains unknown
+unknown essential evidence
+→ proof_required
+```
+
+## 6.2 Task text只可产生advisory signal
+
+类似：
+
+```text
+task出现 wrapper / fallback / legacy / cycle
+```
+
+只能增加调查方向，不能单独令：
+
+```text
+scale = 'architecture'
+```
+
+当前pressure engine已经把纯heuristic结果上限压到25，这是正确基础；新classifier应进一步规定，`architecture` scale 至少需要一个observed或verified结构signal，并且 `majorChangeReasons` 非空。上游 sprint 的 rf2 验收里对应 heuristic-isolation fixture：带不带 `task` 文本必须得到同一个 scale。
+
+## 6.3 Intervention不能再输出placeholder target
+
+当前示例中的：
+
+```text
+module.target-owner
+relation.target-calls-boundary
+symbol.legacyWrapper
+```
+
+必须替换为：
+
+* exact architecture node ID；
+* exact relation ID；
+* exact path／symbol selector；
+* 或明确 `unresolved`，进入proof-required。
+
+不能把placeholder写进可执行Sprint。
+
+---
+
+# 七、重构账本：只保留一个语义权威
+
+## 7.1 语义账本放在 ArchContext
+
+ArchContext当前Architecture Ledger已经可以记录：
+
+* repository/worktree/head；
+* architecture events；
+* evidence items与bindings；
+* snapshots；
+* recommendations；
+* recommendation feedback；
+* recommendation状态变更；
+* audit runs。
+
+Recommendation当前已有：
+
+```text
+open
+acknowledged
+accepted
+rejected
+deferred
+waived
+resolved
+superseded
+expired
+```
+
+并且所有 accept/reject/defer/resolve均要求显式actor与reason，不允许implicit acceptance。
+
+所以不应该再建：
+
+```text
+repo-harness/refactor-ledger.json
+```
+
+记录：
+
+```json
+{ "module-a": "done" }
+```
+
+这会马上成为第二个状态权威。
+
+## 7.2 建议升级为 `RecommendationV3`
+
+当前 `RecommendationV2` 缺少typed category/payload。重构语义若只塞进自由 `extensions`，以后会难以机器验证。
+
+上游已冻结（`packages/contracts/src/ledger.ts:718-752`）。`RecommendationV3` 不是一个扁平 interface，而是 base 与 category/payload 判别联合的交叉类型，使 category 与 payload 错配在类型层不可表达：
+
+```ts
+export const RECOMMENDATION_CATEGORIES = ["practice", "refactor_proposal", "structural_observation"] as const;
+
+/** Strict superset of RecommendationV2: every v2 field is kept verbatim. */
+export interface RecommendationV3Base {
+  schemaVersion: typeof RECOMMENDATION_V3_SCHEMA_VERSION; // 'archcontext.recommendation/v3'
+  recommendationId: string;
+  runId: string;
+  fingerprint: string;
+  subject: string;
+  practiceId?: string;
+  status: RecommendationStatus;
+  confidence: "low" | "medium" | "high";
+  enforcement: "advisory" | "checkpoint" | "complete";
+  risk: "low" | "medium" | "high";
+  uncertainty: "low" | "medium" | "high";
+  evidenceBindingIds: string[];
+  explanation: string[];
+  authoredBy: RecommendationAuthorV1;   // { kind, id, source }
+  subjectSelectorId: string;
+  relations: RecommendationRelationsV1; // { supersedes?, regressesFrom? }
+  createdAt: string;
+  updatedAt: string;
+  extensions?: Record<string, Json>;
+}
+
+export type RecommendationV3CategoryPayloadV1 =
+  | { category: "practice"; payload: PracticeRecommendationPayloadV1 }
+  | { category: "structural_observation"; payload: StructuralObservationPayloadV1 }
+  | { category: "refactor_proposal"; payload: RefactorProposalPayloadV1 };
+
+export type RecommendationV3 = RecommendationV3Base & RecommendationV3CategoryPayloadV1;
+```
+
+与本文早期草案的差异：category 是 `practice | refactor_proposal | structural_observation`（没有 `refactor` 与 `architecture_intervention` —— 架构级不是一个 category，而是 `refactor_proposal` 里 `scale = 'architecture'`）；`subjectSelector` 对象被 `subjectSelectorId: string` 取代（复用已有的 selector 记录）；`status` 复用 `ledger.ts:33-42` 的 `RecommendationStatus` 共用 union（值与本文 §7.1 列出的九个一致）。
+
+三个 payload（`ledger.ts:693-716`）：
+
+```ts
+export interface PracticeRecommendationPayloadV1 {
+  practiceId: string;
+  baselineDigest: string | null;
+}
+
+export interface StructuralObservationPayloadV1 {
+  assessmentDigest: string;
+  kind: RefactorObservationKind;
+  affectedNodeIds: string[];
+  baselineSnapshotDigest: string;
+  derivedOutcomes: RefactorTargetOutcomeV1[];
+}
+
+export interface RefactorProposalPayloadV1 {
+  assessmentDigest: string;
+  proposalDigest: string;
+  scale: RefactorScale;
+  affectedNodeIds: string[];
+  majorChangeReasons: ArchitectureMajorChangeReasonCode[];
+  baselineSnapshotDigest: string;
+  targetDelta?: ArchitectureTargetDeltaV1;
+  targetOutcomes: RefactorTargetOutcomeV1[];
+  killList: RefactorKillListEntryV1[];
+}
+```
+
+`targetOutcomes` / `killList` 的元素也是具名类型，不是内联对象：
+
+```ts
+export interface RefactorTargetOutcomeV1 {
+  outcomeId: string;
+  metric: string;                  // 非 metricOrInvariant
+  subjectSelectorId: string;
+  nodeId: string | null;
+  operator: RefactorOutcomeOperator; // 'absent' | 'equals' | 'greater_than' | 'less_than' | 'present'
+  value: number | null;            // 非 expected: string|number|boolean；absent/present 时必须为 null
+  required: boolean;
+}
+
+export interface RefactorKillListEntryV1 {
+  kind: RefactorKillListKind;      // 只有 'path' | 'relation' | 'symbol'
+  selectorId: string;              // 非 id
+  required: boolean;
+}
+```
+
+`killList.kind` 没有 `fallback` 与 `compatibility`：兼容层的清除通过 `path` / `symbol` / `relation` selector 表达，或经 `targetDelta.migrationState.compatibilityContracts` 与 `cleanupBy` 表达。`risk` 不在 payload 里，它是 `RecommendationV3Base` 的顶层字段。
+
+**作者身份是硬闸门。** `refactor_proposal` 必须由 agent 或人类署名：`authoredBy.source ∈ {cli, manual, mcp, subagent}` 且 `(kind, source)` 必须成对（`cli→cli`、`mcp→mcp`、`subagent→subagent`、`developer→manual`）；`daemon` / `system` / `hook` / `migration` 是 ArchContext 代表自己行动，永远不能作者化一个 proposal。违反返回 `AC_REFACTOR_PROPOSAL_UNAUTHORED`（`packages/contracts/src/schema.ts:35,76`）。反过来，`structural_observation` 必须由 daemon 署名且 `enforcement = 'advisory'`。`refactor_proposal` 的 `enforcement` 由 scale 决定：`architecture` 要求 `complete`，其余要求 `checkpoint`（`refactor.ts:672-689`）。
+
+上游定案（2026-09-03）：0.5.0 不新增任何 source 值。`authoredBy` 记的是**把提案送进 ArchContext 并为其负责的行动者**，不是内容的产地。GPT Pro 起草的提案有两条合法路径——人审阅并署名 → `developer → manual`（责任在人）；repo-harness agent 采纳草稿后以自己名义提交 → `subagent → subagent`（责任在该 agent），来源写进 `intent` 自由文字（例如 `adopted from GPT Pro candidate C01`）。`cli → cli` 保留给操作者通过 CLI 提交自己的提案。GPT Pro 永远不是任何一种 kind。first-class provenance 字段（例如 `provenance?: { provider, ref }`）是 0.6.0 的 contract 变更，属上游 Known Unknown。
+
+repo-harness 侧的结论：**ArchContext 不会自造重构提案**。想让某次重构进入 ledger，提案必须由 repo-harness 派发的 agent（或人）署名提交，ArchContext 只负责判级、记录与事后验证。
+
+## 7.3 “已做”的严格定义
+
+不能以PR merged直接显示“重构完成”。
+
+```text
+implemented
+= repo-harness PR已合并
+
+resolved
+= PR已合并
+  + exact final main已重新扫描
+  + ArchContext验证target outcomes
+  + kill list满足
+  + Recommendation状态转为resolved
+```
+
+因此看板需要区分：
+
+```text
+open
+accepted
+planned
+executing
+merged_pending_measurement
+partially_resolved
+resolved
+deferred
+rejected
+superseded
+regressed
+stale
+```
+
+## 7.4 回归不重写历史
+
+一个已解决问题以后再次出现：
+
+```text
+旧Recommendation仍保持resolved
+→ 新scan产生新的Recommendation
+→ 新记录supersedes / regresses_from旧记录
+```
+
+不能把旧记录从resolved重新改回open，避免抹掉历史上确实完成过的重构。
+
+---
+
+# 八、重构结果验证
+
+## 8.1 `RefactorResolutionEvidenceV1`
+
+上游已冻结（`packages/contracts/src/refactor.ts:301-317`）：
+
+```ts
+export interface RefactorResolutionEvidenceV1 {
+  schemaVersion: typeof REFACTOR_RESOLUTION_EVIDENCE_SCHEMA_VERSION;
+  recommendationId: string;
+  recommendationDigest: string;
+  beforeSnapshotDigest: string;
+  afterSnapshotDigest: string;
+  verifiedHeadSha: string;
+  verifiedWorktreeDigest: string;
+  expectedOutcomes: RefactorTargetOutcomeV1[];
+  observedOutcomes: RefactorObservedOutcomeV1[];   // { outcomeId, observedValue, satisfied, direction }
+  residuals: RefactorResidualV1[];                 // { code, subject, severity: Severity }
+  executionEvidenceRefs: RefactorExecutionEvidenceRefV1[];
+  disposition: RefactorResolutionDisposition;
+  verifiedAt: string;
+  resolutionDigest: string;
+  extensions?: Record<string, Json>;
+}
+```
+
+`RefactorExecutionEvidenceKind` 的四个值不变（`acceptance_receipt`、`cutover_closure`、`merge_receipt`、`task_contract`），`sha256` 必须是裸 64 位十六进制（非 `sha256:` 前缀）。`disposition` 的五个值不变。新增 `verifiedAt`，被 `refactorResolutionEvidenceDigest()` 排除。
+
+三条 repo-harness 必须知道的验证器行为（`refactor.ts:591-625`）：
+
+* `observedOutcomes[i].satisfied` 是提交者的**主张**，验证器会用 `expectedOutcomes` 的 `operator` / `value` 重算并报告分歧；disposition 阶梯用重算值，不用主张值；
+* disposition 由 required outcome 的满足数机械决定：任一 `direction = 'regressed'` → 必须 `regressed`；全满足 → 必须 `resolved`；零满足 → 必须 `not_improved`；部分 → 必须 `partially_resolved`；
+* `disposition = 'stale'` 是唯一豁免上述阶梯的取值。
+
+`executionEvidenceRefs`只负责回答：
+
+> 哪个Task／PR执行了这项重构？
+
+真正回答：
+
+> 结构问题是否解决？
+
+必须由ArchContext重新测量后的 `afterSnapshot` 决定。
+
+---
+
+# 九、ArchContext CLI 设计
+
+建议只新增三个核心verb，复用现有 `recommendations` 和 `book`，不要再造完整平行命令族。
+
+## 9.1 扫描
+
+```bash
+archctx refactor scan \
+  --request-json '<RefactorRequestV1>'
+```
+
+支持scope：
+
+```text
+repository
+node:<node-id>
+paths:<bounded-path-set>
+```
+
+输出：
+
+```text
+ModuleStatisticsSnapshotV1
+RefactorAssessmentV1
+proposed RecommendationV3 records
+```
+
+默认只读。
+
+## 9.2 记录建议
+
+```bash
+archctx refactor record \
+  --assessment-digest sha256:... \
+  --expected-worktree-digest sha256:...
+```
+
+作用：
+
+* 把assessment和selected recommendations写入Architecture Ledger；
+* idempotent；
+* worktree/head漂移失败；
+* 不修改代码；
+* 不创建Task；
+* 不创建GitHub Issue。
+
+## 9.3 验证结果
+
+语义输入是**重新测量得到的 after `ModuleStatisticsSnapshotV1`**，加上待校验的 evidence。上游冻结的验证入口是：
+
+```ts
+refactorVerifyInvariantIssues(
+  afterSnapshot: ModuleStatisticsSnapshotV1,
+  evidence: RefactorResolutionEvidenceV1
+): string[]
+```
+
+（`packages/contracts/src/refactor.ts:723-750`）它强制 `evidence.afterSnapshotDigest`、`verifiedHeadSha`、`verifiedWorktreeDigest` 三者都绑定同一份 after snapshot，并且在 after coverage 非 `complete`、或 index 未覆盖被验证 worktree 时拒绝 `resolved`。
+
+上游没有为 verify 冻结独立的请求类型（本文早期草案里的那个名字见 §二十二）。CLI 层按上游 sprint 第 9 行（rf5b）的说法是 `archctx refactor verify --request-json`，但具体请求包络尚未冻结：
+
+```bash
+archctx refactor verify --request-json '<...>'   # [UNVERIFIED until rf5b]
+```
+
+输出：
+
+```text
+RefactorResolutionEvidenceV1
+```
+
+然后复用已有：
+
+```bash
+archctx recommendations resolve \
+  --id <recommendation-id> \
+  --reason "Resolved by exact main verification" \
+  --evidence-digest sha256:...
+```
+
+当前 `archctx recommendations` 已有 acknowledge、accept、reject、defer、waive、resolve 和 metrics，因此无需再复制一套状态转换。
+
+## 9.4 查询账本
+
+继续复用：
+
+```bash
+archctx book recommendations --open --explain
+archctx book show <node-id>
+archctx book timeline <node-id>
+archctx book diff --from <ref> --to <ref>
+archctx book evidence <recommendation-id>
+```
+
+---
+
+# 十、repo-harness 的 Refactor Mode
+
+## 10.1 产品入口
+
+建议增加root action：
+
+```bash
+repo-harness refactor scan
+repo-harness refactor start
+repo-harness refactor status
+repo-harness refactor board
+repo-harness refactor stop
+```
+
+**不要新增独立的 `repo-harness-refactor` Skill／facade package。**
+
+继续执行仍使用现有：
+
+```bash
+repo-harness execute
+```
+
+也就是：
+
+```text
+refactor start
+  负责分析、route和物化
+
+root execute
+  负责Plan → Contract → Worktree → Verify → Ship
+```
+
+这样不会复活旧autoplan，也不会建立第二个workflow engine。
+
+## 10.2 Policy
+
+`required_features` 必须按 provider stage 分开表达，因为 scan/record 与 verify 分属 `archctx@0.5.0` 与 `archctx@0.5.1` 两次发布（见 §十七）：
+
+```json
+{
+  "refactor": {
+    "mode": "off",
+    "provider": "archctx",
+    "stages": {
+      "scan": {
+        "provider_version": "0.5.0",
+        "required_features": [
+          "module-statistics-v1",
+          "refactor-assessment-v1",
+          "recommendation-v3"
+        ]
+      },
+      "verify": {
+        "provider_version": "0.5.1",
+        "required_features": [
+          "refactor-resolution-v1"
+        ]
+      }
+    },
+    "workflow_routing": {
+      "module_refactor": "auto_plan_low_risk",
+      "cross_module_refactor": "refactor_sprint",
+      "architecture_intervention": "human_architecture_approval",
+      "proof_required": "investigation_only",
+      "no_action": "record_and_stop"
+    },
+    "maximum_modules_per_program": 10,
+    "maximum_parallel_modules": 3,
+    "require_cutover_closure": true,
+    "require_post_merge_measurement": true
+  }
+}
+```
+
+`workflow_routing` 的键是 `RefactorWorkflowRoute` 值，不是 ArchContext scale；映射由 §5.1 的投影函数产生。`require_cutover_closure` 只有在 repo-harness 侧真正存在 Cutover Closure Gate 之后才能置 `true`（见 §十八 RH-RF4）。`verify` stage 未就绪时，`require_post_merge_measurement` 只能保持 `false`，不得用本地推断顶替。
+
+状态：
+
+```text
+off
+shadow
+active
+```
+
+### `off`
+
+完全禁止Refactor Program mutation。
+
+### `shadow`
+
+允许：
+
+* scan；
+* assessment；
+* recommendation record；
+* joined board；
+* GPT Pro生成Issue。
+
+禁止：
+
+* Task materialization；
+* Worktree；
+  -代码修改；
+* PR／merge。
+
+### `active`
+
+允许进入正常Task执行流，但auto-merge仍由独立merge policy控制。
+
+---
+
+# 十一、repo-harness 路由行为
+
+以下五个小节的标题是 `RefactorWorkflowRoute` 的取值，属于 repo-harness 概念，由 §5.1 的投影函数从 `(scale, scaleReasonCodes, majorChangeReasons)` 确定性导出；ArchContext 本身不产生也不消费这些值。
+
+## 11.1 `module_refactor`
+
+条件（投影自 `scale = 'module'`）：
+
+* 恰好一个architecture node（`single-node-scope`）；
+* 无major architecture reason；
+* 无owner/lifecycle/public interface变化；
+* code facts coverage完整；
+* risk不高；
+* 无protected surface。
+
+流程：
+
+```text
+Assessment
+→ one Refactor Program item
+→ one Work Package
+→ local /think
+→ Task Contract
+→ isolated worktree
+→ Cutover Closure
+→ verify
+→ PR
+```
+
+通常不需要产品PRD。
+
+## 11.2 `cross_module_refactor`
+
+条件（投影自 `scale = 'cross_module'`）：
+
+* 涉及多个node（`multi-node-scope`）；
+* 但不改变architecture node/relation/owner/lifecycle；
+* 需要有顺序的迁移或共同cutover；
+* 每个模块仍有明确rollback boundary。
+
+流程：
+
+```text
+Assessment
+→ Refactor Sprint
+→ one row per module/cutover stage
+→ Work Graph dependencies
+→ each row expands to Plan
+→ parallel where safe
+```
+
+示例：
+
+```text
+R1 freeze shared contract
+R2 move module A callers
+R3 move module B callers
+R4 remove old adapter
+R5 final closure and after-scan
+```
+
+## 11.3 `architecture_intervention`
+
+投影自 `scale = 'architecture'`（`majorChangeReasons` 非空）。这是投影的下限：不得降级成任何其他路由。
+
+流程：
+
+```text
+ArchContext ArchitectureInterventionModel
+→ target state
+→ migration state
+→ compatibility contracts
+→ kill list
+→ benefit/cost ledger
+→ repo-harness Architecture Refactor Sprint
+→ explicit human architecture approval
+→ existing architecture-projection accept
+→ implementation
+```
+
+v1下禁止自动批准和自动合并。
+
+如果重构同时改变：
+
+* 用户可见行为；
+* product requirement；
+* public API semantics；
+* 新capability；
+* 新workflow；
+
+则退出Refactor Mode，转回：
+
+```text
+PRD → Sprint → Plan
+```
+
+## 11.4 `proof_required`
+
+投影自 `scale = 'insufficient_evidence'` 或 `scale = 'model_adoption_required'`；后者对应 `AC_MODEL_ADOPTION_REQUIRED`，收口动作是补 `.archcontext` 模型而不是补证据。
+
+不允许开始重构，只能创建调查Work Package：
+
+```text
+补CodeGraph index
+确认dynamic callers
+定位unowned paths
+运行真实entrypoint fixture
+确认persisted data
+验证rollback
+```
+
+调查完成后重新执行 `archctx refactor scan`，不得由本地Agent手工把route改成module。
+
+## 11.5 `no_action`
+
+投影自 `scale = null`（无 proposal 的观察扫描）且没有值得执行的 observation。
+
+可能出现：
+
+* GPT Pro怀疑的问题无法证实；
+* metrics没有明显问题；
+* 已在ledger中resolved；
+* recommendation已被superseded。
+
+处理：
+
+```text
+记录no-action evidence
+→ Issue可按not_planned关闭
+→ 不制造无意义重构
+```
+
+---
+
+# 十二、Refactor Program 与执行绑定
+
+repo-harness需要一个**执行映射**，但它不是第二个账本。
+
+建议文件：
+
+```text
+plans/refactors/
+  <stamp>-<slug>.refactor-program.v1.json
+```
+
+```ts
+interface RefactorProgramV1 {
+  schemaVersion: 'repo-harness.refactor-program/v1';
+
+  programId: string;
+
+  baseMainSha: string;
+  archctxVersion: string;
+  statisticsSnapshotDigest: string;
+  assessmentDigest: string;
+
+  scale: RefactorScale | null;
+  scaleReasonCodes: RefactorScaleReasonCode[];
+  workflowRoute: RefactorWorkflowRoute;
+  affectedNodeIds: string[];
+
+  bindings: Array<{
+    recommendationId: string;
+    recommendationDigest: string;
+
+    workPackageId: string;
+    taskRef: string;
+
+    executionBoundary:
+      | 'module'
+      | 'cross_module_stage'
+      | 'architecture_intervention';
+  }>;
+
+  programDigest: string;
+}
+```
+
+`scale` / `scaleReasonCodes` 是从 assessment 原样复制的上游权威值；`workflowRoute` 是本地投影结果，两者同时留存才能在事后审计里证明投影没有降级。
+
+不包含：
+
+```text
+recommendationStatus
+done=true
+resolved=true
+```
+
+这些状态必须从ArchContext重新读取。
+
+## `RefactorExecutionBindingV1`
+
+每次执行只追加不可变引用：
+
+```ts
+interface RefactorExecutionBindingV1 {
+  recommendationId: string;
+  recommendationDigest: string;
+
+  taskId: string;
+  taskRevision: string;
+
+  planPath: string;
+  planSha256: string;
+
+  contractPath: string;
+  contractSha256: string;
+
+  cutoverClosureSha256: string;
+  acceptanceReceiptSha256: string;
+
+  pullRequestNumber: number;
+  pullRequestHeadSha: string;
+  mergeCommitSha: string;
+
+  bindingSha256: string;
+}
+```
+
+---
+
+# 十三、联合重构看板
+
+建议生成：
+
+```text
+tasks/workstreams/refactor/<program-id>.md
+tasks/workstreams/refactor/<program-id>.board.v1.json
+```
+
+这两份均为投影。
+
+输入：
+
+```text
+ArchContext Recommendation/Resolution
++ Refactor Program
++ Task/Lease state
++ AcceptanceReceipt
++ PR/MergeReceipt
+```
+
+输出示例：
+
+| Recommendation                     | Route        | Module         | Execution          | Architecture result |
+| ---------------------------------- | ------------ | -------------- | ------------------ | ------------------- |
+| `recommendation.auth-dual-owner`   | architecture | auth/session   | Awaiting approval  | Open                |
+| `recommendation.cli-wrapper`       | module       | cli            | PR merged          | Pending after-scan  |
+| `recommendation.legacy-hook`       | cross-module | init/hooks     | 3/4 WPs complete   | Accepted            |
+| `recommendation.state-parser-copy` | module       | workflow-state | Merged and cleaned | Resolved            |
+
+这里的：
+
+```text
+PR merged
+```
+
+来自repo-harness。
+
+```text
+Resolved
+```
+
+来自ArchContext。
+
+---
+
+# 十四、与 GPT Pro Repair Campaign 的整合
+
+## 14.1 Refactor批次应先跑archctx
+
+之前的流程是：
+
+```text
+GPT Pro读仓库
+→ 创建10个Issues
+```
+
+加入Refactor Mode后，建议改成：
+
+```text
+local archctx refactor scan
+→ RefactorAssessment
+→ open/resolved recommendation summary
+→ bounded GPT Pro authoring bundle
+→ GPT Pro读exact main并创建Issues
+```
+
+GPT Pro仍然拥有：
+
+* 独立阅读代码；
+* 独立选择哪些问题值得开Issue；
+* Issue标题和正文。
+
+但不拥有：
+
+* module/cross-module/architecture route；
+* recommendation状态；
+* Task materialization。
+
+## 14.2 使用短candidate alias
+
+本地为候选生成：
+
+```text
+C01
+C02
+...
+C25
+```
+
+Intent中保存：
+
+```text
+C01 → exact recommendationId + digest
+```
+
+GPT Pro Issue只需要写：
+
+```json
+{
+  "issue_kind": "refactor",
+  "candidate_ref": "C01"
+}
+```
+
+不要求GPT Pro复制64位digest。
+
+## 14.3 Issue kind 与 scale 是两种不同数据
+
+```text
+issue_kind = refactor
+    由GPT Pro自述
+
+refactor scale =
+    module
+    cross_module
+    architecture
+    insufficient_evidence
+    model_adoption_required
+    由ArchContext从提案与code facts判定
+
+RefactorWorkflowRoute
+    由repo-harness从scale确定性投影
+```
+
+本地不得根据Issue标题自行推断 scale，GPT Pro 也不产生 scale。
+
+## 14.4 避免双重Issue writer
+
+ArchContext当前 `audit run/approve` 已能持久化architecture audit并发行GitHub Issue drafts。由于你的Repair Campaign已经决定由GPT Pro直接写Issue，同一Campaign不应再调用 `archctx audit approve` 创建另一组Issue。ArchContext在这条lane只提供measurement、recommendation和ledger；它自己的audit issue能力保留给独立使用。
+
+---
+
+# 十五、P2 端到端数据流
+
+```text
+1. 用户启动Refactor Mode或Repair Campaign
+2. repo-harness冻结exact main SHA
+3. repo-harness构造RefactorRequestV1
+4. 通过exact-version adapter调用archctx refactor scan
+5. ArchContext读取：
+   - architecture model
+   - source footprints
+   - CodeGraph snapshot
+   - import graph
+   - ledger/recommendations
+6. ArchContext输出：
+   - ModuleStatisticsSnapshotV1
+   - RefactorAssessmentV1
+   - candidate recommendations
+7. repo-harness验证：
+   - package version
+   - capabilities
+   - repository/workspace/head/worktree
+   - assessment digest
+8. archctx refactor record写入Recommendation
+9. 可选：GPT Pro基于bounded bundle创建Issues
+10. repo-harness把accepted recommendations物化为：
+    - module Work Package
+    - cross-module Refactor Sprint
+    - architecture approval request
+    - proof investigation
+11. local parent生成Plan
+12. plan → contract → worktree
+13. Worker通过Lease/WorkEnvelope执行
+14. verify-contract
+15. Cutover Closure验证：
+    - old implementation
+    - callers
+    - fallback
+    - comments
+    - tests
+    - docs
+    - generated projections
+16. archctx refactor verify对candidate worktree预验
+17. AcceptanceReceipt
+18. PR与guarded merge
+19. exact new main重新运行archctx refactor verify
+20. 达到target outcomes：
+    → recommendations resolve
+21. 未完全达到：
+    → partially resolved / follow-up
+22. 生成joined Refactor Board
+23. Fresh GPT Pro读取exact new main做组级验收
+```
+
+---
+
+# 十六、repo-harness 对 ArchContext 的消费方式
+
+当前repo-harness已经采用一个正确模式：
+
+* package-local `archctx`解析；
+* exact version要求；
+* `capabilities` handshake；
+* Node runtime验证；
+* versioned request JSON；
+* exact expected repository/workspace/head/worktree；
+* provider结果和本地readback复核；
+* 不相信PATH中任意版本。
+
+Refactor Mode必须复制这个**调用模式**，但不复制projection实现。
+
+建议：
+
+```text
+src/core/refactor/provider-contract.ts
+    只import archctx-contracts类型
+
+src/effects/refactor/archctx-provider.ts
+    复用现有package/runtime resolver
+
+src/cli/commands/refactor.ts
+    adapter only
+```
+
+禁止：
+
+```text
+src/core/refactor/module-statistics.ts
+src/core/refactor/cycle-detector.ts
+src/core/refactor/refactor-score.ts
+```
+
+这些都应在上游。
+
+---
+
+# 十七、版本与发布顺序
+
+repo-harness 当前 provider contract 仍固定要求 `archctx@0.4.7` 以及现有 projection feature 集合（`src/core/architecture/projection.ts:12-18`：`architecture-docs-renderer-v2`、`architecture-refresh-signal-v1`、`projection-apply-receipt-v1`、`projection-protocol-v2`）。这条仍然成立，但要补两个事实：
+
+* npm 上 `archctx` 的 `latest` 已经是 `0.4.8`（发布于 2026-09-02T08:32Z），repo-harness 的 pin 落后一个 patch；
+* rf1a 冻结的 refactor contracts（2026-09-03 04:00 +0800 合入 arch-context main）**尚未进入任何已发布的 npm 包**。`ARCHCTX_FEATURES`（`packages/contracts/src/projection.ts:58-64`）目前仍不含任何 refactor feature。
+
+新协议分**两次**发布，不是一次：
+
+```text
+Stage 1  archctx@0.5.0   scan + record
+  features: module-statistics-v1
+            refactor-assessment-v1
+            recommendation-v3
+
+Stage 2  archctx@0.5.1   verify
+  features: refactor-resolution-v1
+```
+
+拆两段的原因是上游 sprint 就是这么切的：rf5a 在 0.5.0 发 `refactor scan` / `refactor record` 与前三个 feature，rf4 的 resolution 验证运行时排在 0.5.0 之后，rf5b 才在 0.5.1 发 `refactor verify` 与 `refactor-resolution-v1`。repo-harness 若把四个 feature 写成一个 required set，就会在 0.5.0 阶段整体 fail-closed，白等一次发布周期。
+
+顺序必须是：
+
+```text
+1. ArchContext完成并发布0.5.0
+2. npm/release readback（npm view archctx@0.5.0）
+3. repo-harness更新exact pin到0.5.0
+4. repo-harness增加stage-1 required feature handshake
+   (module-statistics-v1, refactor-assessment-v1, recommendation-v3)
+5. shadow canary（scan/record only）
+6. ArchContext完成并发布0.5.1
+7. npm/release readback（npm view archctx@0.5.1）
+8. repo-harness更新pin到0.5.1并加stage-2 feature
+   (refactor-resolution-v1)
+9. active canary（含post-merge measurement）
+```
+
+不得：
+
+```text
+archctx 0.4.7没有refactor功能
+→ repo-harness本地fallback自己统计
+```
+
+版本不匹配应直接：
+
+```text
+refactor_provider_version_mismatch
+```
+
+---
+
+# 十八、双仓 Program / Sprint
+
+这个“Refactor Mode”本身是一个新功能，所以仍应按你的规则走：
+
+```text
+PRD → Sprint → Plan
+```
+
+模式落地之后，普通内部重构才可以通过Refactor Mode运行，而无需每次写产品PRD。
+
+## Program A：ArchContext Refactor Intelligence
+
+建议PRD：
+
+```text
+Refactor Intelligence, Module Statistics and Resolution Ledger
+```
+
+以下切片镜像上游 `plans/sprints/20260902-2336-refactor-instrumentation-resolution-ledger.sprint.md` 的真实 backlog，编号沿用上游 slug。
+
+**状态（截至 2026-09-03，上游 session 通报）**：rf0、rf1a、rf1b 已完成并合入 arch-context main（rf1b 为 PR #132，`01c9054`），sprint 3/10；rf2（classifier）worktree 开工中，rf3 plan 已就绪；rf5a 起 pending。
+
+| # | Slug | Mode | 状态 | 产出 |
+| - | ---- | ---- | ---- | ---- |
+| 1 | `rf0-characterization-freeze` | contract | 已完成（2026-09-03 02:29） | 五个包的 `test/fixtures/refactor-baseline/` digest fixtures；`docs/architecture` 零 drift |
+| 2 | `rf1a-contracts-freeze` | contract | 已完成（2026-09-03 04:00） | `packages/contracts/src/refactor.ts` 六个 schema 常量、invariant validators、digest 函数；`RecommendationStatus` 提升为共用 union |
+| 3 | `rf1b-module-statistics-snapshot` | contract | done（PR #132） | `packages/core/module-statistics`：两次运行 `snapshotDigest` 一致；footprint 改 git-tracked 来源；ancestor/descendant 重叠归最深 node；缺 index → `coverage=unknown` 且 `dependencyGraph=null` |
+| 4 | `rf2-assessment-observations-scale` | contract | pending | `packages/core/refactor-assessment`：S1/S2/S3 scale fixtures、S5 五个 fail-closed 子案例、S7 observation-only、heuristic-isolation |
+| 5 | `rf3-recommendation-v3-ledger-recording` | contract | pending | `refactor_scan` event source、`refactorRecord` RPC、`duplicate-active-fingerprint`、`regressesFrom`、v2→v3 migration 且 `ledger rebuild` digest 不变 |
+| 6 | `rf5a-cli-rpc-capabilities-0.5.0` | contract | pending | `archctx refactor scan/record` 接 RPC；capabilities 增 `module-statistics-v1`、`refactor-assessment-v1`、`recommendation-v3`；版本升 `0.5.0` |
+| 7 | `rf5a-release-readback-0.5.0` | inline | pending | `npm view archctx@0.5.0`、`archctx-contracts@0.5.0`；clean-room readback |
+| 8 | `rf4-resolution-verification` | contract | pending | resolved / not-improved / stale base / HEAD drift / incomplete-coverage fixtures；`refactorVerify` RPC；evidence 经 `EvidenceBinding/v1` 绑定 |
+| 9 | `rf5b-cli-verify-0.5.1` | contract | pending | `archctx refactor verify --request-json` 接 RPC；capabilities 增 `refactor-resolution-v1`；版本升 `0.5.1` |
+| 10 | `rf5b-release-readback-0.5.1` | inline | pending | `npm view archctx@0.5.1`；clean-room readback |
+
+与本文早期草案（AC-RF0..AC-RF5 六段）的结构差异：
+
+* RF1 拆成 `rf1a`（contracts freeze，只冻类型与验证器，零 consumer 切换）与 `rf1b`（真实测量实现）；
+* RF5 拆成 `rf5a`（0.5.0，scan/record）与 `rf5b`（0.5.1，verify），各自带一个 inline readback 行；
+* RF4 排在 `rf5a` 之后而不是 RF3 之后——0.5.0 不含 verify 能力；
+* 上游 sprint 明确 `refactor verify` 不新增 MCP tool，本文早期草案的“CLI/MCP同一core path”验收在 0.5.x 内不成立。
+
+---
+
+## Program B：repo-harness ArchContext-backed Refactor Mode
+
+建议PRD：
+
+```text
+ArchContext-backed Refactor Mode and Execution Integration
+```
+
+### RH-RF0 — Consumer protocol and exact provider handshake
+
+Provider stage：`archctx@0.5.0`（Stage 1）。
+
+实现：
+
+* import新 `archctx-contracts`；
+* exact 0.5.0 pin；
+* refactor request/result validators；
+* package-local execution；
+* no local fallback。
+
+验收：
+
+* 0.4.x拒绝；
+* feature缺失拒绝；
+* wrong head/worktree拒绝；
+* malformed result拒绝。
+
+### RH-RF1 — Refactor Mode policy and state machine
+
+Provider stage：`archctx@0.5.0`（Stage 1）。`post_merge_measuring` / `resolving` 两个状态在 0.5.1 就绪前只能进入 `blocked`。
+
+实现：
+
+```text
+off / shadow / active
+scan / start / status / board / stop
+```
+
+状态：
+
+```text
+created
+→ scanning
+→ assessed
+→ routing
+→ materializing
+→ planning
+→ executing
+→ verifying
+→ merging
+→ post_merge_measuring
+→ resolving
+→ complete
+```
+
+异常：
+
+```text
+proof_required
+architecture_approval_required
+stale
+blocked
+reconciliation_required
+```
+
+### RH-RF2 — Module and cross-module materialization
+
+Provider stage：`archctx@0.5.0`（Stage 1）。
+
+实现：
+
+* `RefactorProgramV1`（含 `scale` / `scaleReasonCodes` / `workflowRoute` 三字段）；
+* module Work Packages；
+* cross-module Sprint；
+* dependency graph；
+* concurrency keys；
+* recommendation-to-task bindings。
+
+验收：
+
+* one module = one rollback boundary；
+* same module writers不并行；
+* cross-module依赖保持；
+* recommendation不直接成为Lease。
+
+### RH-RF3 — Architecture Intervention route
+
+Provider stage：`archctx@0.5.0`（Stage 1）。
+
+实现：
+
+* consume `ArchitectureInterventionModel`；
+* architecture request；
+* existing architecture-projection accept；
+* migration/kill-list projection；
+* human approval stop。
+
+验收：
+
+* `scale = 'architecture'` 无法被投影到低于 `architecture_intervention` 的任何 `RefactorWorkflowRoute`；
+* 未批准不能implementation；
+* public behavior变化转产品PRD；
+* generated architecture docs只通过projection更新。
+
+### RH-RF4 — Execution and Cutover Closure
+
+Provider stage：candidate `archctx refactor verify` 需要 `archctx@0.5.1`（Stage 2）；其余闭合项 provider 无关。
+
+**前置缺口**：repo-harness 目前**没有** Cutover Closure Gate。`scripts/cutover-closure.ts` 不存在，`assets/workflow-contract.v1.json` 中无 `cutoverClosure` 键；GPT Pro repair campaign PRD（`plans/prds/20260902-2238-gpt-pro-seeded-repair-campaign.prd.md`）已把 `refactor` issue kind 与 Cutover Closure Gate 本身一并推迟到 Phase B。这个 gate 需要独立设计与冻结，与 archctx 版本无关，不能等发布解决。
+
+实现：
+
+* refactor contract profile；
+* mandatory closure inventory；
+* caller/reference proof；
+* comments/tests/docs disposition；
+* projection drift；
+* compatibility expiry；
+* candidate `archctx refactor verify`。
+
+验收：
+
+* 旧fallback剩余时失败；
+* 旧test/doc未处理时失败；
+* dynamic caller unresolved时失败；
+* module metrics改善但旧public surface仍在时失败。
+
+### RH-RF5 — Post-merge resolution and joined board
+
+Provider stage：`archctx@0.5.1`（Stage 2）。post-merge measurement 依赖 `refactor verify` 与 `refactor-resolution-v1`。
+
+实现：
+
+* exact final main scan；
+* ArchContext recommendation resolution；
+* `RefactorExecutionBindingV1`；
+* workstream/board projections；
+* GPT Pro Issue candidate alias；
+* resolved duplicate prevention。
+
+验收：
+
+* merged显示`pending_measurement`；
+* only ArchContext resolved显示`resolved`；
+* stale Issue/recommendation阻止closure；
+* board可以从authority重建。
+
+### RH-RF6 — Canary and activation
+
+Canaries：
+
+1. model-free module refactor；
+2. incomplete CodeGraph → proof-required；
+3. cross-module cutover；
+4. ownership change → `scale = 'architecture'` → architecture approval；
+5. merged但指标未改善；
+6. exact final main resolved；
+7. regression产生新recommendation；
+8. GPT Pro不会重开已resolved候选；
+9. two-worker concurrency；
+10. stage version/feature mismatch fail-closed。
+
+Promotion：
+
+```text
+off
+→ shadow
+→ active/module-only
+→ active/cross-module
+```
+
+Architecture intervention始终保留human approval。
+
+---
+
+# 十九、依赖顺序
+
+```text
+rf0 characterization freeze
+  → rf1a contracts freeze
+  → rf1b module statistics
+  → rf2 assessment / scale
+  → rf3 recommendation v3 + recording
+  → rf5a CLI/RPC/capabilities → archctx 0.5.0 release → readback
+
+archctx 0.5.0（Stage 1: scan + record）
+  → RH-RF0
+  → RH-RF1
+     ├→ RH-RF2
+     └→ RH-RF3
+
+rf4 resolution verification runtime（0.5.0之后立即开始）
+  → rf5b CLI verify → archctx 0.5.1 release → readback
+
+archctx 0.5.1（Stage 2: verify）
+  + RH-RF2 + Cutover Closure Gate（repo-harness侧尚不存在）
+  → RH-RF4
+
+RH-RF3 + RH-RF4
+  → RH-RF5
+  → RH-RF6
+```
+
+rf4 只依赖 rf1b 与 rf3 的运行时，不依赖 0.5.0 已发布，因此上游可以在 readback 进行的同时开工；repo-harness 侧则严格按 stage 门控：任何触及 `refactor verify` 或 post-merge measurement 的 slice 必须等 0.5.1。
+
+两个仓库不能在未发布协议上同时猜字段开发。上游必须先冻结contract并发布，repo-harness再消费exact release。
+
+---
+
+# 二十、关键失败闭合行为
+
+ArchContext 侧（上游权威，repo-harness 必须原样透出这些 code，不得改写或本地重造）：
+
+```text
+archctx model缺失
+→ scale = 'model_adoption_required'
+→ AC_MODEL_ADOPTION_REQUIRED
+
+module ownership歧义
+→ scale = 'insufficient_evidence'
+→ scaleReasonCodes: ownership-ambiguous
+
+CodeGraph index缺失或truncated
+→ scale = 'insufficient_evidence'
+→ scaleReasonCodes: code-facts-missing / code-facts-truncated
+
+caller coverage unknown
+→ scale = 'insufficient_evidence'
+→ scaleReasonCodes: caller-coverage-unknown
+
+targetDelta仍有unresolvedTargets
+→ scale = 'insufficient_evidence'
+→ scaleReasonCodes: target-unresolved
+
+assessment base SHA漂移 / HEAD漂移
+→ AC_REFACTOR_STALE（severity warning, retryable, action rerun-refactor-scan）
+
+resolve缺少verify证据或disposition ≠ resolved
+→ AC_REFACTOR_EVIDENCE_REQUIRED（severity error, action run-refactor-verify）
+
+refactor_proposal由daemon/system/hook/migration署名
+→ AC_REFACTOR_PROPOSAL_UNAUTHORED（severity error, action attach-authoring-actor）
+
+scopePaths含目录或glob（被视为unowned）
+→ scale = 'model_adoption_required'
+
+caller coverage unknown（上游定案 2026-09-03：不再单独触发）
+→ 只进 scaleReasonCodes 与 confidence，不单独选出 insufficient_evidence
+```
+
+上游定案（2026-09-03）：`RefactorVerificationRequestV1` **会**在 `0.5.1`（RF4/RF5b）冻结，预期形状 `archcontext.refactor-verification-request/v1 { recommendationId, expectedHeadSha, expectedWorktreeDigest?, executionEvidenceRefs? }`，核心 API 维持 `refactorVerifyInvariantIssues(afterSnapshot, evidence)`。最终字段以 0.5.1 readback 通知为准，仍标 `[UNVERIFIED until rf5b]`；0.5.1 之前不得为其撰写 validator。
+
+repo-harness 侧（本地工作流错误，不是上游 code）：
+
+```text
+architecture workflow route未批准
+→ architecture_approval_required
+
+repo-harness把scale = 'architecture'投影到低于architecture_intervention
+→ refactor_route_conflict
+
+Cutover Closure缺失
+→ refactor_closure_missing
+
+PR merged但未跑after-scan
+→ merged_pending_measurement
+
+after-scan未达到target outcomes
+→ partially_resolved / not_improved（disposition由验证器机械判定）
+
+ArchContext recommendation已resolved
+→ campaign不得重复adopt
+
+archctx版本或stage feature不匹配
+→ provider_version_mismatch
+```
+
+---
+
+# 二十一、最终边界清单
+
+## 必须上游至 `Ancienttwo/arch-context`
+
+1. `ModuleStatisticsSnapshotV1`
+2. module footprint和ownership coverage
+3. CodeGraph module import graph
+4. fan-in／fan-out／SCC／cycle
+5. uncertainty和truncation
+6. `RefactorAssessmentV1`
+7. `RefactorScale` 判级（module／cross_module／architecture／insufficient_evidence／model_adoption_required）与 `RefactorScaleReasonCode`
+8. observed-only architecture pressure signal
+9. typed Architecture Intervention
+10. Recommendation V3
+11. recommendation fingerprint/dedup/supersede
+12. semantic refactor ledger
+13. before/after structural verification
+14. `RefactorResolutionEvidenceV1`
+15. `archctx refactor scan|record|verify`
+16. capabilities和MCP／daemon协议
+17. generated refactor ledger/document projection
+
+## 必须留在 `Ancienttwo/repo-harness`
+
+1. Refactor Mode用户入口
+2. off／shadow／active policy
+3. exact archctx provider adapter
+4. user／Campaign authorization
+5. GPT Pro issue-authoring bundle
+6. Issue adoption和candidate alias
+7. Refactor Program
+8. Sprint／Work Graph／Task materialization
+9. local `/hunt`／`/think` Plan
+10. Contract／allowed paths
+11. Lease／Claim／WorkEnvelope
+12. Claude／Codex并行派工
+13. Cutover Closure Gate
+14. tests和verification execution
+15. AcceptanceReceipt
+16. PR／merge
+17. GitHub Issue closure
+18. branch／worktree cleanup
+19. `RefactorExecutionBindingV1`
+20. joined Refactor Board
+21. Fresh GPT Pro final-main audit
+
+## 明确不得出现的第三层
+
+```text
+repo-harness自制module analyzer
+repo-harness自制refactor score
+repo-harness直接读CodeGraph
+repo-harness复制Recommendation状态
+ArchContext创建repo-harness Task
+ArchContext管理Lease或Agent
+GPT Pro决定module/architecture route
+PR merged自动等于refactor resolved
+```
+
+**最终架构是：ArchContext决定“哪里有结构问题、问题有多大、应该在哪个层次改、改完是否真的改善”；repo-harness决定“谁来改、如何拆任务、如何安全执行、如何验收合并以及如何把执行证据绑定回这项结构改进”。**
+
+---
+
+# 二十二、上游对齐记录（2026-09-03）
+
+contract 字段对照的权威是 `/Users/ancienttwo/Projects/arch-context/docs/researches/20260902-restructure.md` §0 修订记录（arch-context main）；本节是下游对齐记录，只指回它、不独立演化。字段口径出现分歧时以上游那一份为准。
+
+本节记录本文与 arch-context main（`144b975`）冻结契约的每处差异修正。左为本文原用词，右为上游实际用词与证据。
+
+* `RefactorRoute` 类型 → 不存在；上游是 `RefactorScale`（`arch-context/packages/contracts/src/refactor.ts:28-34,87`）。
+* `assessment.route` 字段 → `RefactorAssessmentV1.scale: RefactorScale | null`（`refactor.ts:268`）。
+* `routeReasonCodes` 字段 → `scaleReasonCodes: RefactorScaleReasonCode[]`（`refactor.ts:269`，词表 `refactor.ts:35-46`）。
+* route 值 `proof_required` → scale `insufficient_evidence`，具体缺口由 reason code 表达（`refactor.ts:31,35-46`）。
+* route 值 `no_action` → 不是 scale；无 proposal 时 `scale = null` 且 `proposalDigest = null`（`refactor.ts:545-547`）。
+* route 值 `architecture_intervention` → scale `architecture`，且要求 `majorChangeReasons` 非空（`refactor.ts:29,548-550`）。
+* “repo-harness 映射到 workflow” 的隐含类型 → 显式命名为 repo-harness 侧 `RefactorWorkflowRoute`，是 `(scale, scaleReasonCodes, majorChangeReasons)` 的确定性投影（本文 §5.1、§11、§12）。
+* `RefactorAssessmentV1.opportunities` → `observations: RefactorObservationV1[]`，kind 取自 `REFACTOR_OBSERVATION_KINDS`（`refactor.ts:47-54,252-257,267`）。
+* `RefactorAssessmentV1.majorChangeReasons: string[]` → `ArchitectureMajorChangeReasonCode[]`（`refactor.ts:271`，校验 `refactor.ts:551-554`）。
+* `ModuleStatisticsSnapshotV1.repository` / `.worktree` 内联对象 → `ArchitectureRepositoryIdentityV1` / `ArchitectureWorktreeIdentityV1`（`refactor.ts:221-222`；`ledger.ts:155-166`）。
+* `codeFacts.reasonCodes: string[]` → `RefactorScaleReasonCode[]`（`refactor.ts:232`）。
+* `codeFacts` 缺 `edgeLimit` → 新增 `edgeLimit: number | null`（`refactor.ts:231`）。
+* `repositorySummary` 缺 `undeclaredFootprintNodeCount` → 新增（`refactor.ts:237`，校验 `refactor.ts:523-526`）。
+* `ModuleStatisticsV1.footprint` 必填 → `footprint: {...} | null` + `footprintDeclared: boolean`，严格互斥（`refactor.ts:179-186,454-456`）。
+* `ModuleStatisticsV1.dependencyGraph` 必填 → 可为 `null`，且 `coverage === 'unknown'` 时必须为 `null`（`refactor.ts:193-203,501-508`）。
+* `ModuleStatisticsV1.uncertainty.graphTruncated` → 不存在；截断是 snapshot 级 `codeFacts.truncated`（`refactor.ts:210-214,229`）。
+* `ModuleStatisticsV1` 缺 `parentNodeId` → 新增，用于 ancestor/descendant 归属（`refactor.ts:178`）。
+* `tests.testFileCount` / `observedTestEdges` 必填 number → `number | null`（`refactor.ts:205-206`）。
+* `RefactorVerificationRequestV1` → 不存在；verify 的语义输入是 after `ModuleStatisticsSnapshotV1` + `RefactorResolutionEvidenceV1`（`refactor.ts:723-750`）。CLI 的 `--request-json` 包络待 rf5b 冻结，标 `[UNVERIFIED until rf5b]`（上游 sprint backlog 第 9 行）。
+* `RefactorResolutionEvidenceV1` 缺 `verifiedAt` → 新增并从 digest 排除（`refactor.ts:314`，`refactor.ts:372-380`）。
+* `RecommendationV3` 扁平 interface → `RecommendationV3Base & RecommendationV3CategoryPayloadV1`（`ledger.ts:724,747-752`）。
+* category `practice | refactor | architecture_intervention` → `practice | refactor_proposal | structural_observation`（`ledger.ts:26`）；架构级是 `refactor_proposal` 里 `scale = 'architecture'`，不是独立 category。
+* `RefactorRecommendationPayloadV1` → `RefactorProposalPayloadV1`（`ledger.ts:706-716`）。
+* `ArchitectureInterventionPayloadV1` → 不存在；架构目标态是 `RefactorProposalPayloadV1.targetDelta?: ArchitectureTargetDeltaV1`（`ledger.ts:713`；`refactor.ts:128-152`）。
+* payload 缺 `StructuralObservationPayloadV1` → 补上（`ledger.ts:698-704`）。
+* `subjectSelector: { kind, id }` → `subjectSelectorId: string`（`ledger.ts:744`）。
+* payload 内 `route` 字段 → `scale: RefactorScale`（`ledger.ts:709`）。
+* `targetOutcomes` 内联对象 → `RefactorTargetOutcomeV1`；`metricOrInvariant` → `metric`，`expected: string|number|boolean` → `value: number | null`，另有 `outcomeId` / `subjectSelectorId` / `nodeId` / `required`（`refactor.ts:105-113`）。
+* `killList` 内联对象 → `RefactorKillListEntryV1`；`id` → `selectorId`，kind 只有 `path | relation | symbol`（去掉 `fallback` / `compatibility`）（`refactor.ts:64,122-126`）。
+* payload 内 `risk` → 移到 `RecommendationV3Base.risk`（`ledger.ts:732`）。
+* 未记录 proposal 作者闸门 → `authoredBy` 必须是 `(cli|mcp|subagent|developer)` 与 `(cli|mcp|subagent|manual)` 的合法配对；违反返回 `AC_REFACTOR_PROPOSAL_UNAUTHORED`（`refactor.ts:71-83,672-689`；`schema.ts:35,76`）。
+* 未记录 refactor 错误码 → `AC_REFACTOR_STALE`、`AC_REFACTOR_EVIDENCE_REQUIRED`、`AC_REFACTOR_PROPOSAL_UNAUTHORED`（`arch-context/packages/contracts/src/schema.ts:33-35,74-76`）。
+* 单次发布 `archctx@0.5.0` 含四个 feature → 两段发布：0.5.0（`module-statistics-v1`、`refactor-assessment-v1`、`recommendation-v3`，scan/record）与 0.5.1（`refactor-resolution-v1`，verify）（上游 sprint backlog 第 6、9 行）。
+* “ArchContext 已有 refactor feature” 的隐含假设 → `ARCHCTX_FEATURES` 目前不含任何 refactor feature（`arch-context/packages/contracts/src/projection.ts:58-64`）；rf1a 契约（2026-09-03 04:00 +0800 合入 main）尚未进入任何已发布包，npm `latest` 仍是 `0.4.8`（发布于 2026-09-02T08:32Z）。
+* AC-RF0..AC-RF5 六段切片 → 上游真实 10 行 backlog（rf0、rf1a、rf1b、rf2、rf3、rf5a、rf5a-readback、rf4、rf5b、rf5b-readback），rf0/rf1a 已完成（本文 §十八）。
+* RH-RF4 假设 Cutover Closure Gate 已存在 → repo-harness 中 `scripts/cutover-closure.ts` 不存在、`assets/workflow-contract.v1.json` 无 `cutoverClosure` 键；已由 `plans/prds/20260902-2238-gpt-pro-seeded-repair-campaign.prd.md:69,149-150,538-539` 推迟到 Phase B。

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -208,3 +208,30 @@ AcceptanceReceipt field.
 - **Task profile**: The declared execution shape of a contract (for example
   `code-change`) that determines which verification and delegation rules
   apply to that task.
+- **Refactor Mode**: The `off | shadow | active` operating mode under which
+  repo-harness consumes an external structural authority to discover and
+  execute refactors. It is a narrowed entry into the existing plan, contract,
+  worktree, and ship flow, never a second workflow engine.
+- **Proposal Author**: The repo-harness-side agent or human that writes a
+  refactor proposal for the external structural authority to assess. The
+  author supplies intent, scope, target outcomes, and kill list; it never
+  decides the structural scale, the workflow route, or a recommendation's
+  status.
+- **RefactorWorkflowRoute**: The repo-harness workflow routing decision
+  deterministically projected from the external authority's structural scale
+  and its evidence reason codes. It may stop more conservatively than the
+  upstream scale but may never route below it.
+- **Refactor Program**: One authorized Refactor Mode run, holding only the
+  bindings from external recommendations to local work packages. It carries no
+  recommendation status; every status is re-read from the external authority.
+- **Cutover Closure**: The provider-independent gate asserting that every
+  declared old implementation, caller, fallback, test, document, and
+  compatibility window of a replaced surface has an explicit disposition, and
+  that nothing declared removed still exists at the candidate head.
+- **Refactor Execution Binding**: The append-only, immutable set of references
+  tying one external recommendation to the plan, contract, closure,
+  acceptance, and merge evidence of one execution. It has no status field, so
+  a merged pull request can never by itself mean the refactor is resolved.
+- **Joined Refactor Board**: The read-only projection joining the external
+  semantic refactor ledger with local execution evidence. It owns no state and
+  is fully rebuildable from its authorities.

--- a/plans/prds/20260903-0435-archctx-backed-refactor-mode.prd.md
+++ b/plans/prds/20260903-0435-archctx-backed-refactor-mode.prd.md
@@ -1,0 +1,759 @@
+# PRD: ArchContext-backed Refactor Mode and Execution Integration
+
+> **Status**: Draft
+> **Slug**: `archctx-backed-refactor-mode`
+> **Created**: 2026-09-03 04:35
+> **Updated**: 2026-09-03 05:07
+> **Source Spec**: `docs/spec.md`
+> **Tier**: standard
+> **Baseline**: `main@9e922e47a7970d8aded7a3597912df8c02f7ca34`
+> **Upstream Contract Authority**: `/Users/ancienttwo/Projects/arch-context/packages/contracts/src/{refactor,ledger,schema}.ts`（arch-context main，PR #129）
+> **Upstream Dispatch**: `/Users/ancienttwo/Projects/arch-context/docs/researches/20260903-program-b-dispatch.md`（main `278fbad`）
+> **Source Research**: `docs/researches/20260902-restructure.md`（Program B；§二十二 為上游對齊記錄）
+> **Related PRD**: `plans/prds/20260902-2238-gpt-pro-seeded-repair-campaign.prd.md`（其 Phase B 與本 PRD 共用 Cutover Closure Gate）
+
+## AI Quick-Read Card
+
+- Problem: repo-harness 想主動發現重構機會、主動清理技術債，但它沒有結構判定權威（該不該改、改在哪一層）、沒有方案作者（誰來寫出可執行的重構提案）、也沒有收口閘門（舊路徑是否真的死了）。三者缺一，重構就只能靠人記得。
+- Users: Human Refactor Owner、Refactor Program Controller、Proposal Author（本地 subagent 或 GPT Pro）、Worker、Architecture Approver、Repair Campaign Controller、Maintainer。
+- Platform: repo-harness CLI root action `refactor` + 既有 fleet acquire 執行鏈 + package-local `archctx` provider（exact version pin，CLI-only 消費）+ 既有 GPT Pro delegate 通道。
+- P0 surface: Cutover Closure Gate、discovery 與 proposal authoring loop、兩階段 provider handshake、Refactor Mode policy 與 state machine、`RefactorWorkflowRoute` 投影、module/cross-module materialization、architecture intervention route、execution binding 與 candidate verify、post-merge resolution 與 joined board、canary ladder。
+- Core metric: 一條由本地主動發現的結構問題，經 proposal authoring 取得 `scale`，走完執行鏈，最終由 ArchContext 回報 `disposition: 'resolved'`——全程零本地結構判定、零本地狀態複製、每一跳都有可重建 receipt。
+- Hard constraint: ArchContext 是儀器/閘門/賬本，repo-harness 是作者/調度/收口。repo-harness 不得實作任何模組統計、依賴圖、cycle 偵測、refactor 評分或 CodeGraph 直讀；不得持有第二份 recommendation 狀態；不得從 Issue 標題推斷 scale；版本或 feature 不匹配一律 fail closed，永不本地 fallback。
+- Key risk: 「重構做完了但舊路徑還在」。ArchContext 能證明結構指標改善，證明不了舊 public surface、舊 fallback、舊 test、舊 doc 被清乾淨；沒有 Cutover Closure，指標改善會被當成重構完成。
+- Unknowns: `archctx refactor` CLI 尚未實作（上游只凍結 contract），0.5.0/0.5.1 未發布；first-class provenance 欄位（GPT Pro 來源標註）要等 0.6.0 contract 變更；Cutover Closure inventory 能否在不做語義分析下確定性判定（本 PRD 的 falsifier）。
+- Acceptance scenarios: 無 proposal 的掃描必須回 `scale = null` 且不得物化任務；`scale = 'cross_module'` 被投影成 `module_refactor` 時 `refactor_route_conflict`；PR 合入但 after-scan 未跑時只能顯示 `merged_pending_measurement`。
+- Suggested next step: **不生成 Sprint**。先把 Module 1（Cutover Closure Gate）抽成獨立 work-package plan——它零 archctx 依賴、可立即落地、且是 GPT Pro campaign Phase B 的前置——並在一個真實歷史重構 PR 上跑 First Proof Point。
+
+## Problem
+
+用戶要的能力是一句話：**repo-harness 可以主動發現重構機會並清理技術債；必要時請 GPT Pro 獨立調研拿方案。** 這句話拆開來是三個當前都不存在的東西。
+
+**發現**缺結構判定權威。「這是單模組的事還是跨模組的事」「證據夠不夠」「這算不算動了架構」目前只有人腦答案。把這些算法補在 repo-harness 裡是錯的方向——LOC 統計、import graph、fan-in/fan-out、SCC 偵測、模組邊界解析，全都是脫離 repo-harness 也對別的倉庫有用的能力，它們屬於 ArchContext。
+
+**方案**缺作者。這是最容易被誤判的一環：上游凍結的 contract 明確規定，ArchContext **不寫提案**。`RefactorRequestV1.proposal?: RefactorProposalV1`（`refactor.ts:166-173`）是**輸入**，`RefactorProposalV1.authoredBy`（`refactor.ts:154-164`）必須是合法的 agent/human 配對，`daemon` 與 `system` 永遠不能撰寫。validator `refactor.ts:545-547` 強制 `scale === null` 恰好在 `proposalDigest === null` 時成立——**沒有提案就沒有判級**。所以一次純觀察掃描只會回 observations 與 `scale = null`；`scale` 是提案被評估之後才存在的東西。寫提案是 repo-harness 的職責，而且是可以外包的職責：本地 subagent 能寫，GPT Pro 透過既有 delegate 通道做獨立調研後也能寫。
+
+**收口**缺閘門，且這一端只在 repo-harness 有意義。ArchContext 能在合入後量出「cycle 少了 2 條、fan-out 降了」，量不出「舊的 `legacyResolve()` 還在 export」「舊測試還在跑舊路徑」「文檔還在教舊 API」「相容分支沒有移除期限」。這些是執行層事實，只有拿得到 contract kill-list、diff 與 AcceptanceReceipt 的一方能判。
+
+`scripts/cutover-closure.ts` 不存在，`assets/workflow-contract.v1.json` 沒有 `cutoverClosure` 鍵（已核）。而上游凍結的 `REFACTOR_EXECUTION_EVIDENCE_KINDS` 已經包含 `cutover_closure`，`RefactorExecutionEvidenceRefV1` 形狀為 `{ kind, locator, sha256 }`——上游已經預留了消費介面，repo-harness 一份證據都還沒有。
+
+### Product Direction
+
+- Hard Constraints:
+  - ArchContext 是儀器、閘門、賬本；repo-harness 是作者、調度、收口。repo-harness 不得出現 `src/core/refactor/module-statistics.ts`、`cycle-detector.ts`、`refactor-score.ts` 這一類本地結構算法，也不得直接解析 CodeGraph 輸出。
+  - repo-harness 不得複製 recommendation 狀態。`resolved`、`superseded`、`accepted` 一律從 ArchContext 讀回，本地資料模型不得有對應欄位。
+  - GPT Pro 與任何 proposal author 都不決定 `scale`、不決定 `RefactorWorkflowRoute`、不決定 recommendation 狀態。作者只提供 `intent` / `scopePaths` / `targetOutcomes` / `killList` / 可選 `targetDelta`；判級一律回 ArchContext。
+  - 不得從 Issue 標題或正文推斷 scale。
+  - provider 版本或 feature 集合不匹配時，一律 `refactor_provider_version_mismatch` 直接失敗，永不啟用本地 fallback 統計。
+  - 不得以 git link 或本地路徑在 runtime 依賴未發布的 contract；只允許 compile-only 型別準備。
+  - Architecture intervention 永遠需要人工批准，走既有 `architecture-projection accept`；v1 禁止自動批准與自動合入。
+  - 重構若同時改變使用者可見行為、product requirement、public API semantics、新 capability 或新 workflow，必須退出 Refactor Mode 轉回 `PRD → Sprint → Plan`。
+  - 不新增 skill 或 facade package，不復活 autoplan，不引入第二個 workflow engine。
+  - `mode = off` 時所有 mutation 命令失敗退出，不靜默 no-op（沿用 BRC3 對 `development_campaign.mode` 的既定形狀）。
+- Recommended Defaults:
+  - `refactor.mode` 安裝預設 `off`；晉級階梯 `off → shadow → active/module-only → active/cross-module`。
+  - provider 分兩階段：Stage 1 `archctx@0.5.0`（scan/record）解鎖 Module 2-8，Stage 2 `archctx@0.5.1`（verify）解鎖 Module 9-10 的測量面。`required_features` 按 stage 分組，不是一份扁平列表。
+  - `proposal_author` 預設 `local`，可選 `gpt_pro` 或 `ask`；GPT Pro 只在本地作者判定證據不足或需要外部視角時才請。
+  - `maximum_modules_per_program = 10`、`maximum_parallel_modules = 3`。
+  - `require_cutover_closure` 只有在 Module 1 真正落地後才置 `true`；`require_post_merge_measurement` 在 verify stage 就緒前只能是 `false`，不得用本地推斷頂替。
+  - concurrency key 取 architecture node id：同一 node 的 writer 不並行。
+  - 授權複用 `ProgramAuthorizationV1`，refactor 欄位作為其 payload。
+- Freedoms:
+  - 一個 program 的 module 數可以遠少於上限；一次只跑一個 module 是合法結果。
+  - proposal author 的調查手法自由（讀碼、跑 fixture、查 CodeGraph、請 GPT Pro）；受約束的只有輸出形狀與作者身份配對。
+  - proof investigation 的具體手法自由（補 CodeGraph index、跑真實 entrypoint fixture、確認 dynamic caller）。
+  - board 的 Markdown 呈現格式是顯示約定，不是權威。
+
+### Feasibility Boundary
+
+- Confirmed:
+  - 上游 rf0+rf1a 已完成並凍結：`refactor.ts` 與 `ledger.ts` 定義了 `RefactorAssessmentV1`、`ModuleStatisticsSnapshotV1`、`RefactorResolutionEvidenceV1`、`RecommendationV3` 與相關閉集枚舉。
+  - `REFACTOR_SCALES`（`refactor.ts:28-34`）恰為 `architecture | cross_module | insufficient_evidence | model_adoption_required | module`；`REFACTOR_SCALE_REASON_CODES`（`:35-46`）為另外 10 值。
+  - validator `refactor.ts:545-547` 強制 `scale === null` 恰在 `proposalDigest === null` 時成立；`:548-550` 強制 `scale === 'architecture'` 時 `majorChangeReasons` 非空。
+  - `REFACTOR_PROPOSAL_AUTHOR_PAIRS`（`refactor.ts:78-83`）恰為 `cli→cli`、`mcp→mcp`、`subagent→subagent`、`developer→manual`；違反回 `AC_REFACTOR_PROPOSAL_UNAUTHORED`（作者閘門在 `:780`）。
+  - 上游定案（2026-09-03）：0.5.0 不新增任何 source 值。`authoredBy` 的語義是**把提案送進 ArchContext 並為其負責的行動者**，不是內容的產地。GPT Pro 起草的提案有兩條合法路徑：人審閱並署名 → `developer → manual`（責任在人）；repo-harness agent 採納草稿並以自己名義提交 → `subagent → subagent`（責任在該 agent），來源寫進 `intent` 自由文字。`cli → cli` 保留給操作者透過 CLI 提交自己的提案。GPT Pro 永遠不是任何一種 kind。
+  - `REFACTOR_EXECUTION_EVIDENCE_KINDS` 已含 `cutover_closure`；`RefactorExecutionEvidenceRefV1` 為 `{ kind, locator, sha256 }`。
+  - `REFACTOR_KILL_LIST_KINDS` 恰為 `path | relation | symbol`（`refactor.ts:64`）。
+  - `RecommendationV3 = RecommendationV3Base & RecommendationV3CategoryPayloadV1`，category 恰為 `practice | structural_observation | refactor_proposal`（`ledger.ts:26`）；架構級是 `refactor_proposal` 且 `scale = 'architecture'`，不是獨立 category；`risk` 在 `RecommendationV3Base`。
+  - repo-harness 已有可直接複用的 provider 呼叫模式：`src/effects/architecture/archctx-provider.ts` 的 package-local 解析、Node runtime 檢查、`assertArchctxCapabilities`（`src/core/architecture/projection.ts:198`）feature superset handshake、exact repository/workspace/head/worktree identity 綁定。
+  - `ARCHITECTURE_MAJOR_CHANGE_REASONS`（13 值，`src/core/architecture/projection.ts:23-28`）與上游 `ArchitectureMajorChangeReasonCode` 同源。
+  - 人工架構批准路徑已存在：`src/effects/architecture/projection-acceptance.ts` 的 `acceptArchitectureProjectionCandidate` / `reconcileArchitectureProjectionCandidate`，CLI 在 `src/cli/commands/architecture-projection.ts`。
+  - 版本化 JSON 投影既有形狀：`src/core/fleet/board.ts` 的 `FLEET_BOARD_PROTOCOL = 3`；`src/core/publication/merge-readiness.ts` 的 `MERGE_READINESS_PROTOCOL = 1`。
+  - Sprint backlog 六欄列文法唯一權威在 `src/core/state/sprint-backlog-rows.ts`，與 `scripts/sprint-backlog.sh` 的 awk 掃描綁定。
+  - GPT Pro delegate 協議已存在：`assets/skills/repo-harness-chatgpt/references/delegate.md`（GPT Pro 為外部資深工程師，本地持獨立驗收權；GPT Pro 自述已驗證不構成證據；PromptBundle 內容級出境掃描強制）。
+  - `scripts/cutover-closure.ts` 不存在；`assets/workflow-contract.v1.json` 無 `cutoverClosure` 鍵。
+  - `ProgramAuthorizationV1` 不在 `src/` 中，定義在 `plans/prds/20260828-2321-guarded-merge-unattended-automation.prd.md:239`，由 campaign sprint 第 3 行 BRC3 建造。
+  - npm latest `archctx@0.4.8` / `archctx-contracts@0.4.8`，發布於 2026-09-02T08:32:49Z，早於 rf1a（2026-09-03 04:00 +0800 合入 main）。repo-harness 現 pin `0.4.7`（`src/core/architecture/projection.ts:12`）。
+  - 上游剩餘順序：RF1b（實作中）→ RF2 → RF3 → RF5a（`0.5.0` + npm readback）→ RF4 → RF5b（`0.5.1`）。每次 readback 完成後上游以 session chat 通知並附 `capabilities --json`。
+- [UNKNOWN]:
+  - `archctx refactor scan|record|verify` 的實際 CLI args、stdout 契約與退出碼。上游只凍結了 contract。
+  - `archctx@0.5.0` / `0.5.1` 的 capabilities feature 實際命名。本 PRD 使用的 feature 名來自上游 dispatch §2，仍需 readback 確認。
+  - first-class provenance 欄位（例如 `provenance?: { provider, ref }`）的形狀與時程。上游明示這是 0.6.0 的 contract 變更，0.5.x 期間來源只能寫在 `intent` 自由文字裡。
+  - Cutover Closure inventory 能否在不讀 CodeGraph、不做語義分析的前提下對真實歷史重構 PR 做出確定性判定。這是本 PRD 的 falsifier。
+- [UNVERIFIED]:
+  - `ProgramAuthorizationV1` 的最終落地欄位。BRC3 尚未合入 main。
+  - `archctx refactor verify` 的 `--request-json` 請求包絡待 rf5b 凍結（上游 sprint 第 9 行）。上游定案（2026-09-03）：`RefactorVerificationRequestV1` **會**在 `0.5.1`（RF4/RF5b）凍結，預期形狀為 `archcontext.refactor-verification-request/v1 { recommendationId, expectedHeadSha, expectedWorktreeDigest?, executionEvidenceRefs? }`，核心 API 維持 `refactorVerifyInvariantIssues(afterSnapshot, evidence)`（`refactor.ts:723`）。最終欄位以 0.5.1 readback 通知為準，標 `[UNVERIFIED until rf5b]`；0.5.1 之前不得為其撰寫 validator。
+  - 上游錯誤碼 `AC_REFACTOR_STALE`、`AC_REFACTOR_EVIDENCE_REQUIRED`、`AC_REFACTOR_PROPOSAL_UNAUTHORED`（`schema.ts:33-35,74-76`）的實際觸發條件與 stdout 呈現。
+- 研究文檔早期草案中不成立的前提（已由其 §二十二 對齊記錄修正，本 PRD 依修正後版本）:
+  - 早期草案稱「繼續執行仍使用 `repo-harness execute`」。該命令在本倉庫不存在。執行走既有 fleet acquire 鏈。
+  - 早期草案把 `required_features` 寫成扁平四元列表。若照此實作，0.5.0 發布後所有 scan 都會 fail closed。
+  - 早期草案把 `proof_required` / `no_action` 當成上游判級結果。兩者都不是 `RefactorScale` 值。
+  - 早期草案假設 Cutover Closure Gate 已存在。它不存在，且已被 campaign PRD 推遲到 Phase B。
+
+## Users
+
+### Primary Users
+
+- User: Human Refactor Owner
+  - Need: 讓倉庫自己提出「這裡該重構」，必要時外包給 GPT Pro 拿一份獨立方案，而不必自己論證。
+  - Success signal: 一輪 discovery 之後拿到的是帶 `scale` 與 `targetOutcomes` 的具體提案，不是一份感想清單。
+- User: Refactor Program Controller（本地 parent host）
+  - Need: 每次被喚醒時能確定性地算出下一個唯一動作，崩潰後能從 event chain 完全重建狀態。
+  - Success signal: 任意 step 崩潰重放後不產生重複的 `archctx refactor record` 或重複的 Work Package。
+- User: Proposal Author（本地 subagent 或 GPT Pro）
+  - Need: 明確知道要交什麼形狀（`intent` / `scopePaths` / `targetOutcomes` / `killList` / 可選 `targetDelta`），以及自己不決定什麼（scale、route、狀態）。
+  - Success signal: 提交的 proposal 通過作者身份閘門並得到 ArchContext 的判級，而不是被 `AC_REFACTOR_PROPOSAL_UNAUTHORED` 打回。
+- User: Worker（Claude/Codex）
+  - Need: contract 明確告訴它要殺掉什麼，且收口標準是機器判定而非評審口味。
+  - Success signal: closure 失敗時拿到的是閉集錯誤碼與缺項清單，不是「請再檢查一下」。
+- User: Architecture Approver
+  - Need: 拿到 target state、migration state、compatibility contracts、kill list、benefit/cost ledger 與 falsifier 之後再決定。
+  - Success signal: `unresolvedTargets` 非空時系統直接擋住，不讓提案進入批准流程。
+
+### Secondary Users
+
+- User: Repair Campaign Controller（GPT Pro campaign）
+  - Need: 能把 refactor kind 的 Issue 交給這條 lane，而不必自己判定重構層級。
+  - Success signal: campaign 用短 candidate alias（`C01`..）引用候選，不複製 64 位 digest，且不會重複 adopt 已 `resolved` 的 recommendation。
+- User: Maintainer
+  - Need: 從 board 一眼看出「發現 → 提案 → 執行 → 完成」四段分別卡在哪，且每格都能反查權威來源。
+  - Success signal: 刪掉整個 board 目錄後可以從權威完全重建，內容逐字一致。
+
+## Success Criteria
+
+| Metric | Target | Measurement Method | Degradation Threshold |
+|---|---:|---|---:|
+| repo-harness 中的本地結構算法數量 | 0 | 負向測試：禁止 `src/core/refactor/**` 出現統計/圖/評分符號；禁止 import CodeGraph | ≥1 |
+| 本地持有的 recommendation 狀態欄位數 | 0 | 型別層斷言：`RefactorProgramV1` / `RefactorExecutionBindingV1` 無 status/resolved/done 欄位 | ≥1 |
+| 無 proposal 掃描誤產 scale 的次數 | 0 | 負向 fixture：純觀察掃描斷言 `scale === null && proposalDigest === null` | ≥1 |
+| 作者身份閘門的誤放行次數 | 0 | 負向 fixture：`daemon`/`system` 與非法配對均回 `AC_REFACTOR_PROPOSAL_UNAUTHORED` | ≥1 |
+| 版本或 feature 不匹配時的 fallback 次數 | 0 | 負向 fixture：提供 0.4.8 provider，斷言 `refactor_provider_version_mismatch` 且零產出 | ≥1 |
+| `architecture` / `cross_module` 被降級的次數 | 0 | route 投影 property test，遍歷 scale × majorChangeReasons 組合 | ≥1 |
+| `insufficient_evidence` 下的任務物化次數 | 0 | 負向 fixture | ≥1 |
+| Cutover Closure 漏判率（宣告刪除但仍存在） | 0 | 真實歷史重構 PR 的 characterization fixture | ≥1 |
+| Board 從權威重建的逐字一致率 | 100% | 刪除 `tasks/workstreams/refactor/` 後重建並 diff | <100% |
+| `merged` 直接顯示為 `resolved` 的次數 | 0 | 負向 fixture：merge 後不跑 after-scan | ≥1 |
+| 同一 architecture node 的並行 writer 數 | 1 | 併發 canary | ≥2 |
+| 崩潰重放後的重複 provider mutation | 0 | 在每個 persist 邊界注入崩潰後重放 | ≥1 |
+
+## Acceptance Scenarios
+
+### Scenario 1（positive，Module 1）
+
+- Given: 一個 refactor contract 宣告 kill list 含 `symbol:legacyResolve`、`path:src/legacy/resolve.ts`，closure inventory 六類均已顯式處置。
+- When: candidate head 上執行 closure gate。
+- Then: 產出 `CutoverClosureV1`，狀態 `closed`，帶 sha256，可直接填入上游 `RefactorExecutionEvidenceRefV1` 的 `{ kind: 'cutover_closure', locator, sha256 }`。
+- Machine-checkable evidence: closure JSON `status === 'closed'`；sha256 與 canonical digest 一致。
+
+### Scenario 2（negative，Module 1）→ Non-goal「不把指標改善當成重構完成」
+
+- Given: kill list 宣告移除 `symbol:legacyResolve`，但 candidate head 上該符號仍被 `src/compat/shim.ts` export。
+- When: 執行 closure gate。
+- Then（must NOT）: 不得回 `closed`，不得降級為 warning，不得因 archctx 指標已改善而放行。必須回 `refactor_closure_residue` 並列出殘留 selector。
+- Machine-checkable evidence: 退出碼非零；輸出含 `refactor_closure_residue`；`residues[]` 非空。
+
+### Scenario 3（negative，Module 1）→ Non-goal「closure 不做語義分析」
+
+- Given: contract 未宣告任何 kill list。
+- When: 執行 closure gate。
+- Then（must NOT）: 不得自行推斷應刪什麼，不得掃 diff 猜測舊實現，不得默認 pass。必須回 `not_applicable`；在 refactor profile 下升級為 `refactor_closure_missing`。
+- Machine-checkable evidence: 輸出無任何未宣告 selector；refactor profile 下退出碼非零。
+
+### Scenario 4（positive，Module 2）
+
+- Given: `mode = shadow`，倉庫上一次 discovery 掃描產生 12 條 `structural_observation`。
+- When: 對其中一條 `cycle` observation 派本地 subagent 撰寫 proposal，`authoredBy = { kind: 'subagent', source: 'subagent' }`，再帶 proposal 重跑 scan。
+- Then: 第一次掃描 `scale === null`；第二次掃描回具體 `scale` 與 `scaleReasonCodes`；`recommendationId` 在兩次之間可追溯。
+- Machine-checkable evidence: 兩次 assessment 的 `proposalDigest` 分別為 `null` 與非空；`scale` 隨之變化。
+
+### Scenario 5（negative，Module 2）→ Non-goal「作者不決定 scale」
+
+- Given: proposal author（本地 subagent 或 GPT Pro）在返回內容中自行宣稱「這是 module 級重構」。
+- When: 提交 proposal。
+- Then（must NOT）: 不得採信作者的層級宣稱，不得跳過 `archctx refactor scan` 直接物化，不得從 Issue 標題推斷 scale。`scale` 只能來自帶 proposal 的 assessment。
+- Machine-checkable evidence: program 的 `scale` 來源標註為 `archctx`；fixture 中作者宣稱與實際 scale 不同時以 assessment 為準。
+
+### Scenario 6（negative，Module 2）→ Non-goal「非法作者不得撰寫提案」
+
+- Given: 一個 `authoredBy = { kind: 'daemon', source: 'cli' }` 的 proposal。
+- When: 提交。
+- Then（must NOT）: 不得接受，不得本地改寫成合法配對再送。必須原樣透出 `AC_REFACTOR_PROPOSAL_UNAUTHORED`。
+- Machine-checkable evidence: 錯誤碼逐字匹配；零 recommendation 寫入。
+
+### Scenario 6b（negative，Module 2）→ Non-goal「不得把目錄或 glob 當 scopePaths 提交」
+
+- Given: 一份 proposal 的 `scopePaths` 含目錄或 glob（例如 `src/effects/refactor/` 或 `src/**/*.ts`），未展開成檔案路徑。
+- When: Program B 直接提交。
+- Then: 上游把這些 path 視為 unowned，回 `scale = 'model_adoption_required'`；Program B **不得**物化任何執行型任務，也不得本地把 `model_adoption_required` 改判成別的 scale 再繼續。修法是在提交前展開成檔案清單後重跑 scan。
+- Machine-checkable evidence: assessment `scale === 'model_adoption_required'`；`plans/refactors/**` 與 `tasks/workstreams/refactor/**` 零寫入；展開後重跑得到非 `model_adoption_required` 的 scale。
+
+### Scenario 7（negative，Module 3）→ Non-goal「不做本地 fallback」
+
+- Given: package-local `archctx` 為 `0.4.8`（今日 npm latest，無 refactor 能力）。
+- When: `repo-harness refactor scan`。
+- Then（must NOT）: 不得本地統計任何模組數據，不得降級為部分結果，不得跳過 assessment 直接進 materialization，不得以 git link 指向未發布 contract 頂替。必須 `refactor_provider_version_mismatch` 且零產出。
+- Machine-checkable evidence: `plans/refactors/**` 與 `tasks/workstreams/refactor/**` 零寫入；錯誤碼精確匹配。
+
+### Scenario 8（negative，Module 4）→ Non-goal「off 不得靜默 no-op」
+
+- Given: `refactor.mode = "off"`（安裝預設）。
+- When: 執行 `repo-harness refactor start`。
+- Then（must NOT）: 不得靜默返回成功，不得寫入任何 program 檔案。必須失敗退出。
+- Machine-checkable evidence: 退出碼非零；`git status` 零變更。
+
+### Scenario 9（negative，Module 5）→ Non-goal「不得降級 route」
+
+- Given: `RefactorAssessmentV1.scale === 'cross_module'`。
+- When: 任何路徑（投影、policy 覆寫、agent 手工編輯 program 檔）試圖把 route 設成 `module_refactor`。
+- Then（must NOT）: 不得接受。必須 `refactor_route_conflict`。同一斷言對 `scale === 'architecture'` 降到 `architecture_intervention` 之下亦成立。
+- Machine-checkable evidence: property test 遍歷 `REFACTOR_SCALES × majorChangeReasons 冪集`，斷言 `architecture` → `{architecture_intervention, proof_required, no_action}`、`cross_module` → 不含 `module_refactor`。
+
+### Scenario 10（negative，Module 6）→ Non-goal「證據不足不得物化」
+
+- Given: `scale === 'insufficient_evidence'`，`scaleReasonCodes` 含 `code-facts-truncated`。
+- When: 嘗試 materialization。
+- Then（must NOT）: 不得建立 Work Package、Sprint 行、worktree 或 PR；不得因 `pressure.level === 'high'` 而放行。只能建立 investigation Work Package。
+- Machine-checkable evidence: `plans/plan-*.md` 無執行型新增；program 停在 `proof_required`。
+
+### Scenario 11（negative，Module 6）→ Non-goal「recommendation 不直接成為 Lease」
+
+- Given: 一次 materialization 產生 3 個 module Work Package，第 3 個寫入時磁碟失敗。
+- When: 重放。
+- Then（must NOT）: 不得留下孤立 Work Package；不得讓任何 recommendation 直接獲得 Lease 或 ClaimToken。materialization 必須原子。
+- Machine-checkable evidence: 崩潰注入後 `plans/` 與 sprint backlog 無部分寫入；Lease store 無 recommendation-derived 條目。
+
+### Scenario 12（negative，Module 7）→ Non-goal「架構變更不得自動批准」
+
+- Given: route 為 `architecture_intervention`，`ArchitectureTargetDeltaV1.unresolvedTargets` 非空。
+- When: 嘗試進入 implementation。
+- Then（must NOT）: 不得建立 contract，不得派工，不得因 assessment confidence 為 `high` 而放行。必須停在 `architecture_approval_required`。
+- Machine-checkable evidence: `tasks/contracts/**` 無新增；缺口清單非空。
+
+### Scenario 13（negative，Module 8）→ Non-goal「binding 不持有狀態」
+
+- Given: 一次執行完成，PR 已合入。
+- When: 寫入 `RefactorExecutionBindingV1`。
+- Then（must NOT）: binding 不得含 `status`、`resolved`、`done`、`recommendationStatus` 任何欄位；不得因合入而在本地標記 recommendation 為完成。
+- Machine-checkable evidence: 型別層測試斷言 binding 鍵集合恰為不可變引用集；JSON schema 拒絕多餘鍵。
+
+### Scenario 14（negative，Module 9）→ Non-goal「PR merged ≠ resolved」
+
+- Given: PR 已合入 main，尚未在 exact new main 上跑 after-scan；且當前只有 Stage 1 provider（`0.5.0`），refactor 類的 `resolved` 在 0.5.0 不可達。
+- When: 產生 board。
+- Then（must NOT）: architecture result 欄不得顯示 `Resolved`，不得從 merge 事件推斷結構已改善。必須顯示 `merged_pending_measurement`。
+- Machine-checkable evidence: board JSON 該列 `architectureResult === 'merged_pending_measurement'`，來源標註為 `repo-harness`。
+
+### Scenario 15（positive，Module 9）
+
+- Given: Stage 2 provider 就緒，after-scan 在 exact new main 上執行，ArchContext 回 `disposition === 'resolved'`。
+- When: 產生 board。
+- Then: 該列顯示 `Resolved`，來源標註 `archctx`；刪除整個 `tasks/workstreams/refactor/` 後重建，逐字一致。
+- Machine-checkable evidence: 重建後 `git diff --exit-code tasks/workstreams/refactor/` 為空。
+
+### Scenario 16（negative，Module 10）→ Non-goal「階梯不得跳級」
+
+- Given: 當前 `mode` 從未進入過 `shadow`。
+- When: 嘗試直接設為 `active/cross-module`。
+- Then（must NOT）: 不得接受跳級。晉級必須逐級，且每級有對應 canary 通過記錄。
+- Machine-checkable evidence: policy 校驗拒絕；錯誤訊息指名缺失的前一級與其 canary。
+
+## Non-goals
+
+- 不在 repo-harness 實作 module analyzer、cycle detector、SCC 分析、fan-in/fan-out 計算、refactor 評分或模組邊界解析器。
+- 不在 repo-harness 直接讀取或解析 CodeGraph 輸出。
+- 不建立第二份 `refactor-ledger.json`，不複製 ArchContext 的 recommendation 狀態。
+- proposal author（含 GPT Pro）不決定 `scale`、不決定 route、不決定 recommendation 狀態；不得從 Issue 標題或正文推斷 scale。
+- 不接受非法 `authoredBy` 配對，不本地改寫作者身份使其合法；不把 GPT Pro 偽裝成任何一種 `kind`，0.5.x 期間不自造 provenance 欄位。
+- 不把目錄或 glob 當 `scopePaths` 提交；展開成檔案路徑是 Program B 的責任，收到 `model_adoption_required` 不得本地改判。
+- 不依賴 v1 未推導的 `majorChangeReasons`（`node-added`、`lifecycle-changed`）作為任何 route 或閘門的觸發條件。
+- 不新增 `repo-harness execute` 命令；不新增 skill 或 facade package；不復活 autoplan。
+- provider 版本或 feature 不匹配時不提供任何本地 fallback；不以 git link 或本地路徑在 runtime 依賴未發布 contract（compile-only 型別準備除外）。
+- 0.5.x 不新增 MCP 工具，只透過 CLI 消費；0.5.1 之前不得為 `archctx refactor verify` 的請求包絡撰寫 validator。
+- 不新建第二個授權協議；複用 `ProgramAuthorizationV1`。
+- `RefactorExecutionBindingV1` 不含任何狀態欄位；`PR merged` 永遠不等於 `resolved`。
+- Closure gate 不做語義分析、不猜測應刪內容；未宣告即不判定。
+- `scale = 'insufficient_evidence'` 時不得物化執行型任務。
+- 架構 route 不得自動批准、不得自動合入、不得被本地降級；`cross_module` 不得降級為 `module_refactor`。
+- 不把 `tests.callerCoverage` 當作 essential evidence（v1 恆為 `null`）。
+- 不以 `cross-review --json` 的 `findings` 欄位判定外部審查通過；一律讀 transcript。
+- 晉級階梯不得跳級。
+- 本 PRD 不生成 Sprint，直到 Stage 1 在 npm 發布**且** campaign sprint 第 3 行 BRC3 已清。
+- `0.4.7 → 0.4.8` 的 pin bump 是獨立技術債，不屬於本 PRD。
+
+## Module Behaviors (P0)
+
+### Module 1 — Cutover Closure Gate（provider-independent，先行落地）
+
+- Purpose: 判定「被替換的舊東西是否真的死了」。repo-harness 在整條鏈上唯一的獨占判定權威，也是本 PRD 唯一不被上游發布節奏阻塞的模組。
+- Hard Constraints:
+  - 只做確定性判定。輸入是 contract 顯式宣告的 kill list 與 candidate head 的真實檔案狀態；不做語義推斷、不猜測、不讀 CodeGraph、不呼叫 archctx。
+  - inventory 六類必須全部顯式處置，缺一即失敗：`old_implementation`、`callers`、`fallback`、`tests`、`docs_and_projections`、`compatibility_expiry`。
+  - 每類 disposition ∈ `removed | migrated | retained_with_reason | not_applicable`；`retained_with_reason` 必須同時帶 `reason` 與 `expiry`。
+  - selector kind 只有 `path | relation | symbol`，對齊上游 `REFACTOR_KILL_LIST_KINDS`（`refactor.ts:64`）。
+  - 產出必須是版本化 JSON 且帶 canonical sha256，形狀能直接餵給上游 `RefactorExecutionEvidenceRefV1`。
+  - 失敗一律閉集錯誤碼，不得降級為 warning。
+- Recommended Defaults: 落 `scripts/cutover-closure.ts` + `assets/workflow-contract.v1.json#cutoverClosure`；`CUTOVER_CLOSURE_PROTOCOL = 1`；`policy.refactor.require_cutover_closure` 在本模組落地前保持 `false`。
+- Freedoms: 殘留掃描的實作手段（ripgrep / TS AST），只要對同一輸入確定性。
+- Normal path: 讀 contract kill list → 讀 closure inventory 宣告 → 對 candidate head 驗證每個 `removed` selector 確實不存在 → 校驗六類均有 disposition → 產出 `CutoverClosureV1` 與 sha256。
+- Failure path 1: 宣告 `removed` 的 selector 仍存在 → `refactor_closure_residue`，列出殘留位置。
+- Failure path 2: 有未處置類別，或 refactor profile 下無 closure 宣告 → `refactor_closure_incomplete` / `refactor_closure_missing`。
+- States: Empty（無 kill list → 非 refactor profile 回 `not_applicable`）/ Loading（掃描中）/ Ready（`closed` 與 sha256）/ Error（閉集碼，退出碼非零）。
+- Dependencies: 既有 task contract 與 allowed-path 機制；`assets/workflow-contract.v1.json` 與 `.ai/harness/workflow-contract.json` 的同步規則。**不依賴 archctx**。
+- Open decisions: None
+
+### Module 2 — Discovery 與 Proposal Authoring Loop
+
+- Purpose: 讓倉庫主動發現重構機會，並把「誰來寫方案」變成一條有身份閘門的顯式 lane——本地 subagent 或 GPT Pro 獨立調研。
+- Hard Constraints:
+  - 循環固定為 `scan（無 proposal）→ observations, scale = null` → `proposal authoring` → `scan（帶 proposal）→ scale` → route → materialize。不得跳過任一步。
+  - 無 proposal 的掃描必須回 `scale === null` 且 `proposalDigest === null`（上游 validator `refactor.ts:545-547` 強制），只產出 `structural_observation` recommendation。
+  - `authoredBy` 必須是 `REFACTOR_PROPOSAL_AUTHOR_PAIRS`（`refactor.ts:78-83`）的合法配對：`cli→cli`、`mcp→mcp`、`subagent→subagent`、`developer→manual`。`daemon` 與 `system` 永不能撰寫。非法配對原樣透出 `AC_REFACTOR_PROPOSAL_UNAUTHORED`，不得本地改寫身份。
+  - `authoredBy` 記的是**提交者與問責方**，不是內容產地（上游定案 2026-09-03）。GPT Pro 起草的提案只有兩條 lane：人審閱署名 → `developer → manual`；repo-harness agent 採納草稿後以自己名義提交 → `subagent → subagent`，並在 `intent` 自由文字寫明來源（例如 `adopted from GPT Pro candidate C01`）。`cli → cli` 保留給操作者提交自己的提案。**GPT Pro 永遠不是任何一種 kind**，不得偽裝、不得新增 source 值。
+  - proposal 只提供 `intent`、`scopePaths`、`targetOutcomes`、`killList`、可選 `targetDelta`。作者不決定 `scale`、不決定 route、不決定狀態。
+  - `RefactorProposalV1.scopePaths` 必須是**檔案路徑**。目錄與 glob 在上游被視為 unowned，直接回 `scale = 'model_adoption_required'`。Program B 在提交前必須把 scope 展開成檔案清單，不得把展開責任推給上游，也不得在收到 `model_adoption_required` 後本地重試展開再宣稱通過。
+  - `targetDelta.unresolvedTargets` 由 ArchContext 回填，且被排除在 proposal digest 之外——本地不得預填或據此判定。
+  - GPT Pro lane 走既有 delegate 協議（`assets/skills/repo-harness-chatgpt/references/delegate.md`）：本地持獨立驗收權，GPT Pro 自述已驗證不構成證據，PromptBundle 內容級出境掃描強制。
+  - essential evidence 恰為三項（上游 RF2 classifier 定案 2026-09-03）：每個相關 node 的 `footprintDeclared` 為真、每個 `scopePath` 有唯一的最深 owner、`codeFacts.coverage === 'complete'`。`caller-coverage-unknown` 只進 `scaleReasonCodes` 與 `confidence`，**永不單獨**選出 `insufficient_evidence`；`tests.callerCoverage` 在 v1 恆為 `null`，不得列為 essential evidence。
+- Recommended Defaults: `proposal_author: "local"`（可選 `gpt_pro` / `ask`）；discovery 掃描在 `shadow` 下由排程或顯式觸發；候選用短 alias（`C01`..）綁 `recommendationId` + digest，不要求外部作者複製 64 位 digest（沿用 campaign §14.2）。
+- Freedoms: 作者的調查手法；candidate 排序與呈現；GPT Pro 請求時機的具體啟發式。
+- Normal path: discovery scan → observation 候選清單 → 選定候選 → 依 `proposal_author` 派本地 subagent 或發起 GPT Pro 獨立調研 → 收到 proposal → 帶 proposal 重跑 scan → 取得 scale。
+- Failure path 1: 非法作者配對 → `AC_REFACTOR_PROPOSAL_UNAUTHORED`，零寫入。
+- Failure path 2: GPT Pro lane 出境掃描失敗或返回不可解析內容 → fail closed，不本地補寫提案。
+- States: Empty（無 observation）/ Loading（authoring 中）/ Ready（proposal 已取得 scale）/ Error（作者閘門或 lane 失敗）。
+- Dependencies: Module 3、Module 4；GPT Pro delegate 通道。
+- Open decisions: None
+
+### Module 3 — Refactor provider contract 與兩階段 exact handshake
+
+- Purpose: 用倉庫既有的 provider 呼叫模式接上 `archctx refactor`，並把「哪些能力在哪個版本可用」變成可分階段推進的機器事實。
+- Hard Constraints:
+  - `src/core/refactor/provider-contract.ts` 只 import `archctx-contracts` 型別與本地 validator，零算法。
+  - `src/effects/refactor/archctx-provider.ts` 複用 `src/effects/architecture/archctx-provider.ts` 的 package-local 解析與 Node runtime 檢查，不新寫第二套。
+  - handshake 四道全過才算成功：package version **精確相等**、capabilities feature **子集判定**、repository/workspace/head/worktree identity 精確匹配、result `schemaVersion` 與 digest readback。
+  - `required_features` 按 stage 分組。Stage 1 缺 `refactor-resolution-v1` 是合法狀態，不得因此擋住 scan。
+  - 只透過 CLI 消費；0.5.x 不新增 MCP 工具。
+  - `0.5.1` 會凍結 `RefactorVerificationRequestV1`，預期形狀 `archcontext.refactor-verification-request/v1 { recommendationId, expectedHeadSha, expectedWorktreeDigest?, executionEvidenceRefs? }`（`[UNVERIFIED until rf5b]`，最終欄位以 0.5.1 readback 通知為準）；0.5.1 之前不得為其撰寫 validator。核心 API 維持 `refactorVerifyInvariantIssues(afterSnapshot, evidence)`（`refactor.ts:723`），語義輸入是 after `ModuleStatisticsSnapshotV1` + `RefactorResolutionEvidenceV1`。
+  - 上游錯誤碼原樣透出，不本地翻譯成別的語義。
+- Recommended Defaults: Stage 1 = `0.5.0` + `["module-statistics-v1","refactor-assessment-v1","recommendation-v3"]`；Stage 2 = `0.5.1` + `["refactor-resolution-v1"]`；timeout 沿用 `projection_timeout_ms` 的 1000..120000 邊界。
+- Freedoms: request 組裝的內部結構；readback 快取策略。
+- Normal path: 解析 package-local archctx → `capabilities` handshake → 組 `RefactorRequestV1`（帶 `expectedHeadSha` / `expectedWorktreeDigest`）→ 呼叫 → 驗證 result → 回傳。
+- Failure path 1: 版本或 feature 不匹配 → `refactor_provider_version_mismatch`，零產出。
+- Failure path 2: head/worktree 漂移或上游回 `AC_REFACTOR_STALE` → `refactor_assessment_stale`，要求重新 scan。
+- States: Empty（provider 未安裝）/ Loading（呼叫中）/ Ready（result 已驗）/ Error（上述碼）。
+- Dependencies: 上游 Stage 1 發布與 npm readback 通知。
+- Open decisions: None
+
+### Module 4 — Refactor Mode policy 與 program state machine
+
+- Purpose: 定義 Refactor Mode 的權限階梯與一次 program 的生命週期，且讓狀態可從 event chain 完全重建。
+- Hard Constraints:
+  - `mode ∈ off | shadow | active`，安裝預設 `off`；`off` 時所有 mutation 命令失敗退出。
+  - `shadow` 允許 discovery scan / assess / proposal authoring / record / board 與 campaign issue 產出；禁止 materialization、worktree、程式碼修改、PR、merge。
+  - event chain append-only；current projection 必須可從 events 完全重建；同 key replay 冪等，衝突 replay 拒絕。
+  - 授權複用 `ProgramAuthorizationV1`，不新建型別。
+  - candidate branch 不得放寬 policy。
+  - `require_post_merge_measurement` 在 verify stage 未就緒時只能是 `false`，不得用本地推斷頂替。
+- Recommended Defaults: 狀態機 `created → scanning → observed → authoring → assessed → routing → materializing → planning → executing → verifying → merging → post_merge_measuring → resolving → complete`；異常態 `proof_required`、`architecture_approval_required`、`stale`、`blocked`、`reconciliation_required`；store 落 `<git-common-dir>/repo-harness/refactor-programs/v1/`（沿用 engineer binding store 慣例）。
+- Freedoms: CLI 輸出格式；status 命令呈現細節。
+- Normal path: `refactor scan` → `refactor start` 建 program 並推進 → `refactor status` 讀 projection → `refactor board` 產投影 → `refactor stop` 收口。
+- Failure path 1: `mode = off` 下任何 mutation → 失敗退出，零寫入。
+- Failure path 2: event chain 與 projection 不一致 → `reconciliation_required`，拒絕繼續推進。
+- States: Empty（無 program）/ Loading（scanning）/ Ready（observed 及之後）/ Error（異常態之一）。
+- Dependencies: Module 3；`ProgramAuthorizationV1`（BRC3）。
+- Open decisions: None
+
+### Module 5 — `RefactorWorkflowRoute` 投影與保守性不變式
+
+- Purpose: 把上游的**結構判級**（`scale`）確定性投影成 repo-harness 的**工作流路由**，並用可機檢的不變式保證這個投影只會更保守。
+- Hard Constraints:
+  - `RefactorWorkflowRoute = module_refactor | cross_module_refactor | architecture_intervention | proof_required | no_action`，是 repo-harness 自有型別，**不在** `archctx-contracts` 中。
+  - 投影輸入恰為 `(scale, scaleReasonCodes, majorChangeReasons)`，不得引入第四個輸入，不得引入本地啟發式。
+  - 不變式一：`scale === 'architecture'` → route ∈ `{architecture_intervention, proof_required, no_action}`。
+  - 不變式二：`scale === 'cross_module'` → route ∉ `{module_refactor}`。
+  - 不變式三：`scale === 'insufficient_evidence'` → 不得物化任何執行型任務。
+  - 違反任一 → `refactor_route_conflict`。
+  - 本地 agent 不得手工改寫 route；proof 完成後只能重跑 scan 重算。
+  - `scaleReasonCodes` 逐字保存為 `routeReasonCodes`，不得本地改寫或補充。
+  - v1 的 `majorChangeReasons` 只推導 `ownership-changed` / `relation-changed` / `node-removed` 三值（上游 RF2 定案 2026-09-03）；`node-added` 與 `lifecycle-changed` **不推導**，未解析目標改由 `targetDelta.unresolvedTargets` 表達。投影不得依賴未推導的 reason，也不得因其缺席而降級 route。
+- Recommended Defaults 投影表:
+
+  | upstream `scale` | `RefactorWorkflowRoute` | 備註 |
+  |---|---|---|
+  | `architecture` | `architecture_intervention` | 上游強制 `majorChangeReasons` 非空（`refactor.ts:548-550`） |
+  | `cross_module` | `cross_module_refactor` | 永不降為 `module_refactor` |
+  | `module` | `module_refactor` | |
+  | `insufficient_evidence` | `proof_required` | 缺口由 `scaleReasonCodes` 表達 |
+  | `model_adoption_required` | `proof_required`（model adoption 分支） | 補的是 `.archcontext/model`，不是程式碼調查 |
+  | `null` | `no_action` 或 `proof_required` | 無 proposal 的觀察掃描；有值得執行的 observation → 進 Module 2 authoring，否則 `no_action` |
+
+  repo-harness 可沿階梯**向更保守一側**停（例如把 `module` 停成 `proof_required` 等人工），反向一律拒絕。
+- Freedoms: 投影結果的展示措辭；`proof_required` 子類的細分粒度。
+- Normal path: 讀 assessment → 套投影表 → 校驗三條不變式 → 寫入 program。
+- Failure path 1: 不變式違反 → `refactor_route_conflict`，program 停在 `routing`。
+- Failure path 2: `scale === null` 且無值得執行的 observation → `no_action`，記錄證據後收口。
+- States: Empty（無 assessment）/ Loading（routing）/ Ready（route 已定）/ Error（conflict）。
+- Dependencies: Module 3、Module 4。
+- Open decisions: None
+
+### Module 6 — Module 與 cross-module materialization
+
+- Purpose: 把 accepted recommendation 物化成既有執行鏈認得的 Work Package / Sprint 行 / Plan，並保持一個 module 一個 rollback 邊界。
+- Hard Constraints:
+  - recommendation 不直接成為 Lease。跳數固定為 `recommendation → binding → Work Package → Plan → Contract → Lease`，每跳留 receipt。
+  - materialization 原子：Work Package、Sprint 行、bindings 全成或全不寫。
+  - 一個 module = 一個 Work Package = 一個 rollback 邊界。
+  - 同一 architecture node 的 writer 不並行（concurrency key = node id）。
+  - Sprint 行必須經 `src/core/state/sprint-backlog-rows.ts` 的六欄文法產出，不自行拼字串。
+  - `scale === 'insufficient_evidence'` 時只能建立 investigation Work Package。
+- Recommended Defaults: `module_refactor` 走 `capture-plan --artifact-level work-package`；`cross_module_refactor` 產生一份 Refactor Sprint，每個 module/cutover stage 一行，依賴進 Work Graph；`maximum_modules_per_program = 10`、`maximum_parallel_modules = 3`。
+- Freedoms: Sprint 行的 acceptance 文案；stage 切分粒度。
+- Normal path: route 決定形狀 → 組 `RefactorProgramV1` bindings → 原子寫入 plan/sprint/program → 交給既有 fleet acquire 鏈。
+- Failure path 1: 部分寫入失敗 → 全部回滾，狀態停在 `materializing`，重放冪等。
+- Failure path 2: 超過 `maximum_modules_per_program` → 拒絕物化，要求縮小 scope 或拆 program。
+- States: Empty（無 accepted recommendation）/ Loading（materializing）/ Ready（bindings 已寫）/ Error（回滾後的失敗態）。
+- Dependencies: Module 4、Module 5；既有 sprint backlog 與 Work Graph。
+- Open decisions: None
+
+### Module 7 — Architecture Intervention route
+
+- Purpose: 讓架構級變更走人工批准，且批准所需證據由上游結構化提供而非自然語言提案。
+- Hard Constraints:
+  - 消費 `RefactorProposalPayloadV1.targetDelta`（`ArchitectureTargetDeltaV1`）的 `targetState`、`migrationState`、`completionCriteria`、`falsifiers`、`benefitLedger`、`unresolvedTargets`。架構級是 `refactor_proposal` category 且 `scale = 'architecture'`，不是獨立 category。
+  - `unresolvedTargets` 非空 → 停在 `architecture_approval_required`，不得建 contract、不得派工。
+  - 人工批准只走既有 `repo-harness run architecture-projection accept`；無 acceptance receipt 即無 implementation。
+  - generated architecture docs 只透過既有 projection 更新；refactor lane 不直接寫 `docs/architecture/modules/**`。
+  - `majorChangeReasons` 含 `interface-changed` 或 `responsibility-changed` 時，是否為 product-visible 由人判定；agent 不得自行判定為「純內部」。
+  - v1 的 `majorChangeReasons` 只推導 `ownership-changed` / `relation-changed` / `node-removed`；`node-added` 與 `lifecycle-changed` 不推導，對應缺口由 `targetDelta.unresolvedTargets` 表達。architecture intervention route 不得把「新增 node」或「lifecycle 變更」寫成觸發條件，`unresolvedTargets` 非空才是硬閘門。
+- Recommended Defaults: 架構請求走 `repo-harness run architecture-queue` 的既有請求/事件面；kill list 與 migration state 投影進 contract 的 closure inventory（Module 1 消費）。
+- Freedoms: 架構請求卡片的措辭與呈現。
+- Normal path: route = `architecture_intervention` → 產生架構請求 → 人工 `accept` → 取得 receipt → 才允許物化與派工。
+- Failure path 1: `unresolvedTargets` 非空 → `architecture_approval_required` 加缺口清單。
+- Failure path 2: 判定為 product-visible → 退出 Refactor Mode，program 收口為 `blocked`，指向 `PRD → Sprint → Plan`。
+- States: Empty（無 targetDelta）/ Loading（等待批准）/ Ready（receipt 已取得）/ Error（缺口或退出）。
+- Dependencies: Module 5；`src/effects/architecture/projection-acceptance.ts`。
+- Open decisions: None
+
+### Module 8 — Execution binding 與 candidate verify
+
+- Purpose: 把一次執行的全部證據不可變地綁回一條 recommendation，並在合入前做一次結構預驗。
+- Hard Constraints:
+  - `RefactorExecutionBindingV1` append-only，全欄位是不可變引用，**無任何狀態欄位**。
+  - 驗證順序固定：`verify-contract` → Cutover Closure → candidate `archctx refactor verify` → AcceptanceReceipt。closure 失敗直接擋，不進 archctx verify。
+  - verify 的請求面由 `0.5.1` 凍結的 `RefactorVerificationRequestV1` 決定，預期形狀 `archcontext.refactor-verification-request/v1 { recommendationId, expectedHeadSha, expectedWorktreeDigest?, executionEvidenceRefs? }`（`[UNVERIFIED until rf5b]`）；`executionEvidenceRefs` 正是 Module 1 產出的 `{ kind: 'cutover_closure', locator, sha256 }` 的落點。0.5.1 之前不得為此包絡撰寫 validator。
+  - candidate verify 是**預驗**，其 `disposition` 不得寫入 board 的 architecture result 欄；權威 resolution 只能在 exact final main 上算（Module 9）。
+  - refactor task profile 在 Module 1 落地後強制 `require_cutover_closure = true`。
+  - 不得以 `cross-review --json` 的 `findings` 欄位判定外部審查通過；一律讀 transcript。
+- Recommended Defaults: binding 落在 program 檔旁；`REFACTOR_PROGRAM_PROTOCOL = 1`；`bindingSha256` 用倉庫既有 canonical JSON digest。
+- Freedoms: binding 的儲存分片策略；預驗結果的呈現。
+- Normal path: worker 完成 → 四道驗證依序過 → 寫 binding → PR。
+- Failure path 1: closure 失敗 → 停在 `verifying`，不呼叫 provider，findings 回派。
+- Failure path 2: Stage 2 provider 不可用 → 預驗跳過並標註 `verify_stage_unavailable`，但**不得**因此放寬 closure 或 acceptance。
+- States: Empty（未執行）/ Loading（verifying）/ Ready（binding 已寫）/ Error（任一道失敗）。
+- Dependencies: Module 1、Module 6；上游 Stage 2（僅預驗）。
+- Open decisions: None
+
+### Module 9 — Post-merge resolution 與 joined Refactor Board
+
+- Purpose: 在 exact final main 上取得權威 resolution，並把「發現—提案—執行—完成」四段 join 成一份純投影看板。
+- Hard Constraints:
+  - resolution 權威只在 ArchContext。repo-harness 觀察到 merge 只能標 `merged_pending_measurement`。refactor 類的 `resolved` 在 `0.5.0` 不可達（需 `0.5.1` 的 resolution evidence）。
+  - board 兩份產出（`<program-id>.md` 人讀、`<program-id>.board.v1.json` 機讀）都是純投影，可從 authorities 完全重建，自身不持有狀態。
+  - join key = `recommendationId` + `recommendationDigest`；digest 變更即新 recommendation，`superseded` 從 ArchContext `relations` 讀，不本地推斷。
+  - 已 `resolved` 的 recommendation 不得被 campaign 重複 adopt；去重依據是 ArchContext 狀態讀回。
+  - `partially_resolved` / `not_improved` / `regressed` 產生 follow-up，不自動關閉；`stale` → `reconciliation_required`。
+- Recommended Defaults: 產出落 `tasks/workstreams/refactor/`；`REFACTOR_BOARD_PROTOCOL = 1`（沿用 `FLEET_BOARD_PROTOCOL` 的版本化投影形狀）；每格標註來源（`repo-harness` 或 `archctx`）。
+- Freedoms: Markdown 表格欄位順序與措辭；投影快取。
+- Normal path: merge 觀察到 → `merged_pending_measurement` → exact new main 跑 scan + verify → 取 `RefactorResolutionEvidenceV1` → 更新 board。
+- Failure path 1: after-scan 未跑或 Stage 2 未就緒 → 停在 `merged_pending_measurement`，board 不得顯示 resolved。
+- Failure path 2: 上游回 `stale`（base 漂移）→ `reconciliation_required`，要求重新 scan。
+- States: Empty（無 program）/ Loading（post_merge_measuring）/ Ready（board 已產）/ Error（reconciliation）。
+- Dependencies: Module 8；上游 Stage 2；`scripts/workstream-sync.sh` 的投影慣例。
+- Open decisions: None
+
+### Module 10 — Canary 與 activation ladder
+
+- Purpose: 用固定 canary 集合把 mode 晉級變成有證據的動作，而不是配置開關。
+- Hard Constraints:
+  - 階梯 `off → shadow → active/module-only → active/cross-module`，不得跳級。
+  - architecture intervention 在任何階段都保留人工批准。
+  - 每級晉級需對應 canary 通過記錄。
+- Recommended Defaults 十個 canary（源 `docs/researches/20260902-restructure.md` §十八 RH-RF6）:
+  1. model-free module refactor（無 archctx，只驗 closure 與執行鏈）
+  2. CodeGraph index 不完整 → `insufficient_evidence` → `proof_required`
+  3. cross-module cutover
+  4. ownership 變更 → architecture approval
+  5. merged 但指標未改善 → `not_improved`
+  6. exact final main resolved
+  7. 回歸產生新 recommendation
+  8. GPT Pro 不重開已 resolved 候選
+  9. two-worker 併發（同 node 不並行）
+  10. 版本 mismatch fail-closed
+- Freedoms: canary fixture 的注入點與資料構造。
+- Normal path: 逐級跑 canary → 記錄通過 → 晉級。
+- Failure path 1: 跳級嘗試 → policy 校驗拒絕，指名缺失的前一級。
+- Failure path 2: canary 失敗 → 不得晉級，且不得以「已在別的倉庫驗過」為由跳過。
+- States: Empty（未跑）/ Loading（執行中）/ Ready（該級通過）/ Error（失敗）。
+- Dependencies: Module 1-9。Canary 1 只依賴 Module 1，可在上游發布前先跑。
+- Open decisions: None
+
+## Data Model
+
+```ts
+// repo-harness 自有型別。archctx-contracts 中不存在。
+export type RefactorWorkflowRoute =
+  | 'module_refactor'
+  | 'cross_module_refactor'
+  | 'architecture_intervention'
+  | 'proof_required'
+  | 'no_action';
+
+export const CUTOVER_CLOSURE_PROTOCOL = 1 as const;
+export const CUTOVER_CLOSURE_KIND = 'repo-harness-cutover-closure' as const;
+
+export type CutoverClosureCategory =
+  | 'old_implementation' | 'callers' | 'fallback'
+  | 'tests' | 'docs_and_projections' | 'compatibility_expiry';
+
+export type CutoverClosureDisposition =
+  | 'removed' | 'migrated' | 'retained_with_reason' | 'not_applicable';
+
+export interface CutoverClosureEntryV1 {
+  readonly category: CutoverClosureCategory;
+  readonly disposition: CutoverClosureDisposition;
+  // kind 對齊上游 REFACTOR_KILL_LIST_KINDS（refactor.ts:64）
+  readonly selectors: readonly { readonly kind: 'path' | 'relation' | 'symbol'; readonly value: string }[];
+  readonly reason: string | null;   // retained_with_reason 必填
+  readonly expiry: string | null;   // retained_with_reason 必填
+}
+
+export interface CutoverClosureV1 {
+  readonly protocol: typeof CUTOVER_CLOSURE_PROTOCOL;
+  readonly kind: typeof CUTOVER_CLOSURE_KIND;
+  readonly contractPath: string;
+  readonly contractSha256: string;
+  readonly headSha: string;
+  readonly entries: readonly CutoverClosureEntryV1[];
+  readonly residues: readonly { readonly selector: string; readonly foundAt: readonly string[] }[];
+  readonly status: 'closed' | 'residue' | 'incomplete' | 'not_applicable';
+  readonly closureSha256: string;
+}
+
+export const REFACTOR_PROGRAM_PROTOCOL = 1 as const;
+
+export interface RefactorProgramV1 {
+  readonly protocol: typeof REFACTOR_PROGRAM_PROTOCOL;
+  readonly programId: string;
+  readonly baseMainSha: string;
+  readonly archctxVersion: string;               // 實際解析到的 package version
+  readonly providerStage: 'scan' | 'verify';
+  readonly statisticsSnapshotDigest: string;
+  readonly assessmentDigest: string;
+  readonly proposalDigest: string | null;        // null 表示純觀察掃描
+  readonly proposalAuthor: { readonly kind: string; readonly source: string } | null;
+  readonly scale: string | null;                 // 上游 RefactorScale，原樣保存；無 proposal 時為 null
+  readonly routeReasonCodes: readonly string[];  // 上游 scaleReasonCodes，逐字保存
+  readonly majorChangeReasons: readonly string[];
+  readonly route: RefactorWorkflowRoute;         // 本地投影
+  readonly affectedNodeIds: readonly string[];
+  readonly bindings: readonly {
+    readonly recommendationId: string;
+    readonly recommendationDigest: string;
+    readonly candidateAlias: string;             // C01.. 供外部作者引用，不外傳 digest
+    readonly workPackageId: string;
+    readonly taskRef: string;
+    readonly executionBoundary: 'module' | 'cross_module_stage' | 'architecture_intervention';
+  }[];
+  readonly programDigest: string;
+  // 明確不存在：recommendationStatus / resolved / done。狀態一律從 ArchContext 讀回。
+}
+
+// append-only。全部是不可變引用，沒有任何狀態欄位。
+export interface RefactorExecutionBindingV1 {
+  readonly recommendationId: string;
+  readonly recommendationDigest: string;
+  readonly taskId: string;
+  readonly taskRevision: string;
+  readonly planPath: string;
+  readonly planSha256: string;
+  readonly contractPath: string;
+  readonly contractSha256: string;
+  readonly cutoverClosureSha256: string;   // 餵給上游 REFACTOR_EXECUTION_EVIDENCE_KINDS 的 'cutover_closure'
+  readonly acceptanceReceiptSha256: string;
+  readonly pullRequestNumber: number;
+  readonly pullRequestHeadSha: string;
+  readonly mergeCommitSha: string;
+  readonly bindingSha256: string;
+}
+```
+
+Policy 片段（`.ai/harness/policy.json`）:
+
+```jsonc
+{
+  "refactor": {
+    "mode": "off",                         // off | shadow | active
+    "provider": "archctx",
+    "proposal_author": "local",            // local | gpt_pro | ask
+    "stages": {
+      "scan":   { "provider_version": "0.5.0", "required_features": ["module-statistics-v1", "refactor-assessment-v1", "recommendation-v3"] },
+      "verify": { "provider_version": "0.5.1", "required_features": ["refactor-resolution-v1"] }
+    },
+    // 鍵是 RefactorWorkflowRoute 值，不是 ArchContext scale
+    "workflow_routing": {
+      "module_refactor": "work_package",
+      "cross_module_refactor": "refactor_sprint",
+      "architecture_intervention": "human_architecture_approval",
+      "proof_required": "investigation_only",
+      "no_action": "record_and_stop"
+    },
+    "maximum_modules_per_program": 10,
+    "maximum_parallel_modules": 3,
+    "require_cutover_closure": false,      // Module 1 落地後才可置 true
+    "require_post_merge_measurement": false // verify stage 就緒後才可置 true
+  }
+}
+```
+
+## Delivery Order and Blocking
+
+```text
+Module 1（Cutover Closure Gate）+ policy reader 骨架（fail-closed 在 off）
+  零 archctx 依賴 · 可立即落地 · 亦是 GPT Pro campaign Phase B 前置
+  → First Proof Point 在此驗
+       ↓
+   archctx 0.5.0 發布（上游 RF1b → RF2 → RF3 → RF5a + npm readback）
+       ↓
+Module 3 → Module 4 → Module 2 → Module 5
+       ↓
+Module 6 ─┬─→ Module 7
+          └─→ Module 8（closure 部分已就緒；candidate verify 待 Stage 2）
+       ↓
+   archctx 0.5.1 發布（上游 RF4 → RF5b + npm readback）
+       ↓
+Module 8 完整 → Module 9 → Module 10
+```
+
+阻塞事實：
+
+- 上游 `main` 目前只完成 rf0 + rf1a（contract 凍結），無 core 計算、無 `archctx refactor` CLI、未發布。npm latest `archctx@0.4.8` 發布於 2026-09-02T08:32:49Z，早於 rf1a。
+- Module 2-9 全部被上游阻塞；Module 1、policy reader 骨架與 canary 1 不被阻塞。
+- 上游在 0.5.0 與 0.5.1 各自 npm readback 完成時以 session chat 通知，附 `capabilities --json` 的 features 清單與 readback 記錄路徑；收到後才開 Module 3 / Module 8。
+- 本 PRD 不生成 Sprint，直到 Stage 1 在 npm 發布**且** campaign sprint 第 3 行 BRC3（`ProgramAuthorizationV1`）已清。
+- 兩個倉庫不得在未發布協議上同時猜欄位開發；只允許 compile-only 型別準備。
+
+## Performance Targets
+
+| Target | Number | Measurement Method | Degradation Threshold |
+|---|---:|---|---:|
+| Cutover Closure gate 單次執行 | 15 秒 | 在本倉庫規模上計時 | 45 秒 |
+| `refactor scan` 端到端（含 provider） | 120 秒 | 沿用 `projection_timeout_ms` 上限 | 硬上限 120 秒即失敗 |
+| Board 從權威完全重建 | 10 秒 | 刪除目錄後重建計時 | 30 秒 |
+| Program event chain 重放 | 2 秒 | 1000 event 的 projection 重建 | 8 秒 |
+
+## Known Unknowns
+
+| Item | Impact | Resolution Path | Owner |
+|---|---|---|---|
+| [UNKNOWN] `archctx refactor scan\|record\|verify` 的 CLI args、stdout 契約與退出碼 | Module 3 的 adapter 無法定稿 | 上游 RF5a/RF5b 完成後對照實作；在此之前只寫型別層 | 上游 Program A |
+| [UNKNOWN] `archctx@0.5.0` / `0.5.1` 的 capabilities feature 實際命名 | 本 PRD 的 feature 名若與上游不同則 handshake 失效 | 等上游 readback 通知附帶的 `capabilities --json` | 上游 Program A |
+| [RESOLVED 2026-09-03] GPT Pro 作為 proposal author 的合法 `authoredBy` 配對 | GPT Pro lane 的責任歸屬與可審計性已確定 | 上游定案：0.5.0 不新增 source 值；`authoredBy` 記的是**提交者與問責方**而非內容產地。人審閱署名 → `developer → manual`；harness agent 採納草稿後以己名提交 → `subagent → subagent`，來源寫進 `intent`。`cli → cli` 保留給操作者自提。GPT Pro 永不是任何 kind | 上游 Program A |
+| [UNKNOWN] first-class provenance 欄位（例如 `provenance?: { provider, ref }`）的形狀與時程 | 0.5.x 期間 GPT Pro 來源只能是 `intent` 自由文字，無法機器查詢或聚合 | 上游列為 0.6.0 contract 變更的 Known Unknown；等上游提出欄位形狀後再評估是否消費 | 上游 Program A |
+| [UNKNOWN] Cutover Closure inventory 能否在不做語義分析下確定性判定真實歷史 PR | 若不能，本 PRD 的獨占價值主張不成立（見 Falsifier） | First Proof Point：在真實歷史重構 PR 上跑 gate | Refactor Owner |
+| [UNVERIFIED] `ProgramAuthorizationV1` 最終欄位 | Module 4 的授權實作可能缺鍵 | 等 BRC3 合入 main 後對照 | 並行 campaign session |
+| [UNVERIFIED until rf5b] `RefactorVerificationRequestV1`（`archctx refactor verify --request-json` 的請求包絡） | Module 8/9 的 verify 呼叫面待定 | 上游定案：**會**在 `0.5.1`（RF4/RF5b）凍結，預期形狀 `archcontext.refactor-verification-request/v1 { recommendationId, expectedHeadSha, expectedWorktreeDigest?, executionEvidenceRefs? }`，核心 API 維持 `refactorVerifyInvariantIssues(afterSnapshot, evidence)`。最終欄位以 0.5.1 readback 通知為準；0.5.1 之前不得撰寫 validator | 上游 Program A |
+| [UNVERIFIED] 上游 `AC_REFACTOR_*` 錯誤碼的實際觸發條件與呈現 | 錯誤映射可能不完整 | 上游實作落地後補 fixture | 上游 Program A |
+| [ASSUMED] Stage 1 = `0.5.0`（scan/record）、Stage 2 = `0.5.1`（verify）。理由：讓 scan/materialization 不被 verify 能力阻塞 | 若上游一次發全部能力，兩階段是多餘複雜度 | PRD review 時確認或否決 | Refactor Owner |
+| [ASSUMED] Closure inventory 六類 + 四種 disposition。理由：覆蓋「舊實現/引用/回退/測試/文檔/相容期限」六個實際殘留面 | 過細增加 contract 負擔，過粗會漏判 | First Proof Point 後按實測調整 | Refactor Owner |
+| [ASSUMED] `retained_with_reason` 強制帶 `expiry`。理由：無期限的相容分支就是永久債 | 若某些保留確實無法定期限，會擋住合法情況 | PRD review 時確認或否決 | Refactor Owner |
+| [ASSUMED] 驗證順序 closure 先於 `archctx refactor verify`。理由：closure 零成本且是硬前置，先擋可省 provider 呼叫 | 若 provider 預驗能更早發現嚴重問題，順序應反轉 | canary 3 實測後確認 | Refactor Owner |
+| [ASSUMED] GPT Pro lane 預設走 (b) `subagent → subagent`，由採納草稿的 harness agent 具名提交，`intent` 帶 provenance `adopted from GPT Pro candidate <Cnn>`；policy knob 允許在人願意署名時切到 (a) `developer → manual`。理由：預設把問責留在能被本地驗收的 agent 身上，人工署名是升級而非常態 | 若預設為 (a)，每條 GPT Pro 提案都需要人在場，lane 退化成人工流程 | PRD review 時確認或否決 | Refactor Owner |
+| [ASSUMED] `proposal_author` 預設 `local`，GPT Pro 只在需要時請。理由：外部調研成本與出境面都高於本地 subagent | 若本地作者質量不足，預設應改 `ask` | shadow canary 統計本地 proposal 的採納率後調整 | Refactor Owner |
+| [ASSUMED] `scale = null` 時「有值得執行的 observation」的判定歸 Module 2 的候選排序，而非新增判定器 | 若這條線變成隱式判級器，就違反了非目標 | PRD review 時確認；實作時以「是否派出 authoring」為唯一分叉 | Refactor Owner |
+| [ASSUMED] concurrency key = architecture node id。理由：與既有 capability 邊界一致且保守 | 粗粒度可能成為吞吐瓶頸 | 實測出現瓶頸後才細化到 allowed-path overlap | Refactor Owner |
+| [ASSUMED] `maximum_modules_per_program = 10`、`maximum_parallel_modules = 3` | 上限過小會拆碎 program，過大會放大爆炸半徑 | canary 3 與 canary 9 後調整 | Refactor Owner |
+| [ASSUMED] program 落 `plans/refactors/<stamp>-<slug>.refactor-program.v1.json`，board 落 `tasks/workstreams/refactor/<program-id>.{md,board.v1.json}` | 路徑影響 `.rgignore`、歸檔與 check-task-sync | PRD review 時確認或否決 | Refactor Owner |
+| [ASSUMED] 三個新 protocol 常數均從 `1` 起（`CUTOVER_CLOSURE_PROTOCOL`、`REFACTOR_PROGRAM_PROTOCOL`、`REFACTOR_BOARD_PROTOCOL`） | 與既有 `FLEET_BOARD_PROTOCOL = 3` / `MERGE_READINESS_PROTOCOL = 1` 慣例一致 | 實作時確認 | 實作者 |
+| [ASSUMED] `mode = off` 時 mutation 命令失敗退出而非靜默 no-op。理由：沿用 BRC3 對 `development_campaign.mode` 的既定形狀 | 與其他 mode gate 不一致會造成心智負擔 | PRD review 時確認 | Refactor Owner |
+| [ASSUMED] Module 1 先於 provider 模組落地的交付順序 | 若 Cutover Closure 實際上必須依賴 archctx kill-list 驗證，順序不成立 | First Proof Point 直接驗 | Refactor Owner |
+| [ASSUMED] store 落 `<git-common-dir>/repo-harness/refactor-programs/v1/`。理由：沿用 `src/effects/engineers/binding-store.ts` 的 git-common-dir 慣例，避免進 candidate branch | 若 program 需要進版控供人審，位置需改 | PRD review 時確認或否決 | Refactor Owner |
+| [ASSUMED] candidate alias 沿用 campaign 的 `C01`.. 形狀 | 兩條 lane 若各用一套 alias 會造成 join 困難 | 與 campaign session 對齊後確認 | Refactor Owner |
+
+## Developer Handoff
+
+You are implementing this PRD.
+
+- Build first: **Module 1（Cutover Closure Gate）與 `policy.refactor` reader 骨架（fail-closed 在 `off`）**，且只做這兩項。它們零 archctx 依賴、對普通重構 PR 立刻有價值、是 GPT Pro campaign Phase B 的前置，也是本 PRD 的 First Proof Point。上游 0.5.0 發布之前，其餘模組只允許 compile-only 型別準備與負向測試。
+- Do not reinterpret:
+  - 不要在 repo-harness 實作任何模組統計、依賴圖、cycle 偵測或 refactor 評分；不要直接讀 CodeGraph。
+  - 不要把 `proof_required` / `no_action` 當成上游 `RefactorScale` 值。上游只有 `architecture | cross_module | insufficient_evidence | model_adoption_required | module`（`refactor.ts:28-34`）。
+  - 不要讓無 proposal 的掃描產出 `scale`；validator `refactor.ts:545-547` 強制 `scale === null` 恰在 `proposalDigest === null` 時成立。
+  - 不要讓 proposal author（含 GPT Pro）決定 scale、route 或狀態；不要從 Issue 標題推斷 scale。
+  - 不要本地改寫 `authoredBy` 使非法配對變合法；`daemon` / `system` 永不能撰寫。
+  - 不要把 `tests.callerCoverage` 當 essential evidence——v1 恆為 `null`。essential 恰為三項：每個相關 node `footprintDeclared`、每個 `scopePath` 有唯一最深 owner、`codeFacts.coverage === 'complete'`；`caller-coverage-unknown` 只影響 `scaleReasonCodes` 與 `confidence`。
+  - 不要送目錄或 glob 當 `scopePaths`；提交前展開成檔案路徑，否則上游回 `model_adoption_required`。
+  - 不要依賴 `node-added` / `lifecycle-changed` 這兩個 `majorChangeReasons`——v1 不推導它們，未解析的目標走 `targetDelta.unresolvedTargets`。
+  - 不要把 `required_features` 寫成扁平列表；按 stage 分組。
+  - 不要以 git link 或本地路徑在 runtime 依賴未發布 contract；不要為 `archctx refactor verify` 的請求包絡在 0.5.1 前寫 validator。
+  - 不要新增 MCP 工具；0.5.x 只走 CLI。
+  - 不要新增 `repo-harness execute` 命令；執行走既有 fleet acquire 鏈。
+  - 不要新建授權型別；複用 `ProgramAuthorizationV1`。
+  - 不要在 `RefactorProgramV1` 或 `RefactorExecutionBindingV1` 加任何狀態欄位。
+  - 不要讓 closure gate 猜測未宣告的內容。
+  - 不要另造 Sprint 行格式；六欄文法唯一權威在 `src/core/state/sprint-backlog-rows.ts`。
+  - 不要用 `cross-review --json` 的 `findings` 欄位判定審查通過；讀 transcript。
+- You may improve: closure 殘留掃描的實作手段、event chain 的分片與索引、board 的 Markdown 呈現、candidate 排序啟發式、canary fixture 的注入點、CLI 輸出措辭。
+- Verify with:
+  ```bash
+  bun test --timeout 60000
+  bash scripts/check-deploy-sql-order.sh
+  bash scripts/check-architecture-sync.sh
+  bash scripts/check-task-sync.sh
+  repo-harness run check-task-workflow --strict
+  bun scripts/inspect-project-state.ts --repo . --format text
+  bun src/cli/index.ts init --repo . --dry-run
+  ```
+
+### Acceptance Scripts
+
+1. **Canary 1（model-free，可立即執行）**：在一個真實歷史重構 PR 上跑 Cutover Closure Gate，覆蓋殘留 selector、未處置類別、無 kill list 三種情形。全部收斂到閉集錯誤碼，無一降級為 warning。零 archctx 依賴。
+2. **Route 投影 property test**：遍歷 `REFACTOR_SCALES × majorChangeReasons 冪集 × 關鍵 scaleReasonCodes`，斷言三條保守性不變式恆成立；不存在任何輸入使 `architecture` 映射到 `module_refactor` / `cross_module_refactor`，或使 `cross_module` 映射到 `module_refactor`。
+3. **無 proposal 掃描 fixture**：斷言 `scale === null && proposalDigest === null`，只產出 `structural_observation`，且不物化任何執行型任務。
+4. **作者身份閘門 fixture**：遍歷 `(kind, source)` 全笛卡爾積，斷言只有 `REFACTOR_PROPOSAL_AUTHOR_PAIRS` 的四組通過，其餘回 `AC_REFACTOR_PROPOSAL_UNAUTHORED`。
+5. **Version mismatch fail-closed**：提供 `archctx@0.4.8` fixture，斷言 `refactor_provider_version_mismatch` 且 `plans/refactors/` 與 `tasks/workstreams/refactor/` 零寫入。
+6. **Shadow canary**：`mode = shadow`，在 disposable repository 跑完整 discovery → authoring → assess → record → board，斷言零 task/code/PR mutation。
+7. **Board 重建**：刪除 `tasks/workstreams/refactor/` 後從 ArchContext + program + task state 重建，`git diff --exit-code` 為空。
+8. **併發 canary**：兩個 worker 同時領同一 architecture node 的 module Work Package，斷言只有一個拿到 Lease。
+
+## Adjacent Patterns
+
+- **Provider adapter：port，不 build。** `src/effects/architecture/archctx-provider.ts` 已經是本倉庫驗證過的 exact-provider 消費模式——package-local 解析（不信 PATH）、Node runtime 檢查、`assertArchctxCapabilities`（`src/core/architecture/projection.ts:198`）的 feature superset handshake、exact repository/workspace/head/worktree identity 綁定、result readback。Refactor provider port 這個**呼叫模式**到 `src/effects/refactor/archctx-provider.ts`，共用解析與 runtime 檢查，但不複製 projection 的請求語義。理由：這條路徑已被 `projection_failure_gate: "strict"` 在生產上驗過，重寫只會多一份漂移面。上游 dispatch §2 也明確要求沿用這個 handshake 模式。
+- **Policy 讀取：adopt per-section reader。** `readArchitectureProjectionPolicy`（`src/core/architecture/projection.ts:178-196`）示範了單一 section 的封閉校驗——未知值直接 throw、依賴關係在 reader 內強制。`readRefactorPolicy` adopt 同一形狀，把 mode/stage/feature 的依賴關係（例如 `require_post_merge_measurement` 不得在 verify stage 未就緒時為 `true`）壓在 reader 裡，而不是散在呼叫點。
+- **人工架構批准：adopt，不 build 第二條。** `src/effects/architecture/projection-acceptance.ts` 的 `acceptArchitectureProjectionCandidate` / `reconcileArchitectureProjectionCandidate` 加上 `src/cli/commands/architecture-projection.ts` 的 `accept` / `reconcile` 已經是倉庫唯一的架構批准權威。`ARCHITECTURE_MAJOR_CHANGE_REASONS`（`src/core/architecture/projection.ts:23-28`）的 13 值閉集與上游 `ArchitectureMajorChangeReasonCode` 同源，可直接作為 route 判定輸入。Module 7 完全複用。
+- **外部作者：adopt 既有 GPT Pro delegate 協議，不 build 第二條外包通道。** `assets/skills/repo-harness-chatgpt/references/delegate.md` 已經確立了本 PRD 需要的全部性質——GPT Pro 是外部資深工程師、本地持獨立驗收權、GPT Pro 自述已驗證不構成證據、PromptBundle 內容級出境掃描與允許讀路徑白名單。Module 2 的 GPT Pro lane 只是把「產出物」從 patch text 換成 `RefactorProposalV1`，協議本體不動。
+- **Candidate alias：adopt campaign 慣例。** `plans/prds/20260902-2238-gpt-pro-seeded-repair-campaign.prd.md` 與研究文檔 §14.2 已確立短 alias（`C01`..）綁 exact id + digest 的形狀，外部作者只寫 alias。兩條 lane 共用同一套 alias，避免 join 時對不上。
+- **版本化 JSON 投影：adopt 形狀。** `src/core/fleet/board.ts` 的 `FLEET_BOARD_PROTOCOL = 3` 與 `src/core/publication/merge-readiness.ts` 的 `MERGE_READINESS_PROTOCOL = 1` 已確立「protocol 常數 + kind 常數 + 純投影函式」形狀。Refactor board 與 closure 產出 adopt 同一形狀。
+- **Sprint 行文法：wrap，不 build。** `src/core/state/sprint-backlog-rows.ts` 是六欄文法唯一權威，與 `scripts/sprint-backlog.sh` 的 awk 掃描綁定（`tests/sprint-backlog-grammar-drift.test.ts` 守著）。cross-module materialization 的 Sprint 行必須經該模組產出。
+- **Workstream 投影：adopt。** `scripts/workstream-sync.sh` 已確立「durable capability 進度投影進本地 contract」的形狀。Refactor board 沿用同一心智：檔案是投影，權威在別處。
+- **Cutover Closure：build，且必須自建。** 本 PRD 唯一沒有可 adopt 前例的模組——`scripts/cutover-closure.ts` 不存在，`assets/workflow-contract.v1.json` 無 `cutoverClosure` 鍵（已核）。但它並非憑空發明：上游凍結的 `REFACTOR_EXECUTION_EVIDENCE_KINDS` 已含 `cutover_closure`，`RefactorExecutionEvidenceRefV1` 為 `{ kind, locator, sha256 }`，等於上游已預留消費介面；上游 dispatch §2 第 2 項也把它列為「現在可做」。build 的理由是它需要 contract kill-list、diff 與 AcceptanceReceipt——這三樣只有 repo-harness 拿得到。
+- **設計來源與權威順序**：`/Users/ancienttwo/Projects/arch-context/packages/contracts/src/{refactor,ledger,schema}.ts`（最高權威）> `/Users/ancienttwo/Projects/arch-context/docs/researches/20260903-program-b-dispatch.md`（派工單）> `docs/researches/20260902-restructure.md` §二十二 對齊記錄 > 該研究文檔正文。本 PRD 的每處欄位名均以 contract 檔為準。
+- **共享邊界**：`plans/prds/20260902-2238-gpt-pro-seeded-repair-campaign.prd.md` 的 `## Deferred / Phase B` 明確把 Cutover Closure Gate 與 `refactor` issue kind 移出 Phase A。本 PRD 的 Module 1 就是那個被移出的能力；兩份 PRD 共用同一份 gate。
+- [UNVERIFIED] 「上游測量權威 + 下游收口權威」這一分工與常見的「靜態分析工具報告 + 團隊定義 Definition of Done」流程同構；本 PRD 未引用任何具體外部產品作為依據。
+
+## Backend Perspective
+
+- **權威分層。** ArchContext 擁有結構事實、判級與 recommendation 生命週期；repo-harness 擁有提案作者身份、Task 身份（canonical Sprint）、priority/dependency/concurrency（Work Graph）、任務歸屬（Lease + ClaimActorReceipt + WorkEnvelope）、驗證結果（checks + AcceptanceReceipt）、收口事實（`CutoverClosureV1`）。`RefactorProgramV1` 只擁有「哪條 recommendation 對應哪個 Work Package」這一映射，**不擁有以上任何一項**。
+- **判級與提案的職責倒置是這條鏈最容易做錯的地方。** 直覺會以為「分析工具給建議、執行方採納」，但上游 contract 的實際形狀相反：ArchContext 只給觀察與判級，**提案由 repo-harness 側的 agent 撰寫並送進去評估**。這意味著 proposal 的質量是 repo-harness 的責任，而 scale 的正確性是 ArchContext 的責任。任何把兩者混在一起的實作（例如本地先猜 scale 再去驗證）都會退化成第二個判定器。
+- **「PR merged ≠ resolved」是資料模型層強制，不是文檔提醒。** `RefactorExecutionBindingV1` 結構上沒有狀態欄位，`RefactorProgramV1` 也沒有。repo-harness 在拿不到 ArchContext resolution 時，唯一能表達的就是 `merged_pending_measurement`——它結構上無法說謊。在只有 0.5.0 的階段這是常態，因為 refactor 類的 `resolved` 在 0.5.0 根本不可達。
+- **10x 時最先失敗的三處。** 其一，program event chain 的線性掃描：program 數上升後 projection 重建會變慢，解法是 content-addressed 索引與 per-program 投影，GC 只清 terminal runtime cache、絕不刪 binding。其二，closure gate 的殘留掃描：selector 數 × 檔案數是乘積關係，解法是把掃描限縮在 contract allowed paths 與 diff 觸及檔案，而不是全倉庫掃。其三，`maximum_parallel_modules` 與 node 粒度 concurrency key 的組合會在大型 cross-module program 上成為吞吐瓶頸——正確解法是拆小 program，不是放寬 concurrency key。
+- **provider 呼叫是外部 I/O，必須有預算。** scan 走既有 `projection_timeout_ms` 的 1000..120000 邊界；一次 program 的 provider 呼叫次數應有上限並記入 event chain，避免重試風暴打到上游。GPT Pro lane 的呼叫成本更高，`proposal_author = gpt_pro` 必須有每 program 的次數上限。
+- **兩階段 provider 的代價是狀態空間變大。** Stage 2 不可用時 Module 8 的預驗跳過、Module 9 的測量停在 `merged_pending_measurement`——這兩條路徑必須有獨立測試，否則會退化成「Stage 2 永遠不可用也沒人發現」。

--- a/scripts/check-task-sync.sh
+++ b/scripts/check-task-sync.sh
@@ -108,7 +108,7 @@ for (const file of waivers) {
 }
 if (invalid) process.exit(2);
 if (!schemaOnly && !admitted) process.exit(1);
-' "$expected_digest" "$schema_only" "${substantive[@]}" --waivers "${waivers[@]}"
+' "$expected_digest" "$schema_only" ${substantive[@]+"${substantive[@]}"} --waivers "${waivers[@]}"
 }
 
 if [[ "$validate_waivers_only" -eq 1 ]]; then

--- a/tasks/waivers/20260903-archctx-refactor-mode-prd.json
+++ b/tasks/waivers/20260903-archctx-refactor-mode-prd.json
@@ -1,0 +1,14 @@
+{
+  "protocol": 1,
+  "kind": "repo-harness-substantive-change-waiver",
+  "substantive_change_sha256": "sha256:9e396b88996b2b86b1c78bcdc0eae6d6c369651ff5fb03b184979588235c8b55",
+  "reason": "PRD planning artifact under plans/prds/ plus the minimal bash 3.2 compatibility fix of the waiver validator this waiver depends on (empty substantive array expansion under set -u in --validate-waivers-only mode) with its regression test; no workflow semantics change. The PRD explicitly defers Sprint generation until archctx 0.5.0 npm readback and campaign BRC3 clear, so no plan or sprint evidence carrier exists yet.",
+  "owner": "ancienttwo",
+  "scope": [
+    "plans/prds/20260903-0435-archctx-backed-refactor-mode.prd.md",
+    "scripts/check-task-sync.sh",
+    "assets/templates/helpers/check-task-sync.sh",
+    "tests/check-task-sync.test.ts"
+  ],
+  "revisit_trigger": "Module 1 (Cutover Closure Gate) work-package plan is captured from this PRD, or check-task-sync learns plans/prds/ as an evidence class"
+}

--- a/tests/check-task-sync.test.ts
+++ b/tests/check-task-sync.test.ts
@@ -60,6 +60,31 @@ function setupRepo(): string {
 }
 
 describe("check-task-sync helper", () => {
+  test("validates waivers with no substantive paths under bash 3.2 set -u", () => {
+    const cwd = setupRepo();
+    try {
+      mkdirSync(join(cwd, "tasks", "waivers"), { recursive: true });
+      writeFileSync(
+        join(cwd, "tasks", "waivers", "x.json"),
+        JSON.stringify({
+          protocol: 1,
+          kind: "repo-harness-substantive-change-waiver",
+          substantive_change_sha256: `sha256:${"a".repeat(64)}`,
+          reason: "Fixture waiver for schema-only validation.",
+          owner: "test-owner",
+          scope: ["src/**"],
+          revisit_trigger: "Remove when the fixture no longer exercises schema-only validation.",
+        }),
+      );
+
+      const res = run(cwd, ["bash", "scripts/check-task-sync.sh", "--validate-waivers-only"]);
+      expect(res.status).toBe(0);
+      expect(res.stdout).toContain("Machine-readable substantive-change waivers are valid.");
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  }, 30_000);
+
   test("fails when working tree has code changes without task updates", () => {
     const cwd = setupRepo();
     try {


### PR DESCRIPTION
Adds the Draft ArchContext-backed Refactor Mode PRD, the Program B cross-repository authority and implementation research, and seven canonical refactor terms in docs/spec.md. The PRD Status remains Draft.

Adds a machine-readable substantive-change waiver bound to sha256:9e396b88996b2b86b1c78bcdc0eae6d6c369651ff5fb03b184979588235c8b55 because the PRD explicitly defers Sprint generation until archctx 0.5.0 npm readback and campaign BRC3 clear, so no plan or sprint evidence carrier exists yet.

Fixes the bash 3.2 validator failure at check-task-sync.sh:111: validate-waivers-only reaches the validator with an empty substantive array, and its direct expansion is unbound under set -u. This path had not previously run because no waiver existed. The regression test exercises a schema-valid waiver with no substantive paths and requires successful schema-only validation.

Contract field comparison authority is arch-context main docs/researches/20260902-restructure.md §0.