### PR TITLE
feat(automation): add bounded unattended controller

### DIFF
--- a/.archcontext/model/flows/flow.automation-controller.acquire-dispatch.yaml
+++ b/.archcontext/model/flows/flow.automation-controller.acquire-dispatch.yaml
@@ -1,0 +1,58 @@
+schemaVersion: archcontext.flow/v1
+id: flow.automation-controller.acquire-dispatch
+capabilityId: capability.runtime-harness.automation-budget
+name: Acquire and dispatch one Work Package under exact budget and authority fences
+applicability: required
+participants:
+  - id: controller
+    nodeId: capability.runtime-harness.automation-budget
+  - id: journal
+    nodeId: component.automation-controller.journal
+steps:
+  - id: persist-boundary
+    from: controller
+    to: journal
+    label: Persist the exact current state and budget reservation before acquisition or dispatch
+    evidence:
+      entrypointId: entrypoint.automation-controller.step
+      sourceSymbol: stepAutomationController
+      sinkId: sink.automation-controller.journal
+outcomes:
+  - id: acquired-and-dispatched
+    kind: success
+    label: The canonical acquire-next seam returns a WorkEnvelope and the fenced delegated-run effect reports completion
+    steps:
+      - id: acquire-next
+        from: controller
+        to: journal
+        label: Consume the first canonical Engineer offer and record its exact WorkEnvelope identity
+        evidence:
+          entrypointId: entrypoint.automation-controller.step
+          sourceSymbol: stepAutomationController
+          sinkId: sink.automation-controller.acquire
+      - id: dispatch-existing-effect
+        from: controller
+        to: journal
+        label: Dispatch the already-admitted run through the single fenced effect and persist its observation
+        evidence:
+          entrypointId: entrypoint.automation-controller.step
+          sourceSymbol: stepAutomationController
+          sinkId: sink.automation-controller.dispatch
+    terminal:
+      participant: controller
+      label: Return to observing only after durable outcome evidence and one budget charge
+  - id: ambiguous
+    kind: error
+    label: A crash or stale authority makes the side effect ambiguous
+    steps:
+      - id: require-reconciliation
+        from: controller
+        to: journal
+        label: Persist reconciliation_required and prevent another acquisition or dispatch
+        evidence:
+          entrypointId: entrypoint.automation-controller.step
+          sourceSymbol: stepAutomationController
+          sinkId: sink.automation-controller.journal
+    terminal:
+      participant: controller
+      label: Stop with operator attention while Task and Lease authority remain unchanged

--- a/.archcontext/model/nodes/capability.runtime-harness.automation-budget.yaml
+++ b/.archcontext/model/nodes/capability.runtime-harness.automation-budget.yaml
@@ -3,7 +3,7 @@ id: capability.runtime-harness.automation-budget
 kind: capability
 name: Automation Budget
 status: active
-summary: Enforces one machine-checked per-goal automation budget by reserving before every claim, dispatch, retry, or provider invocation and publishing an immutable stop receipt on exhaustion.
+summary: Enforces one machine-checked per-goal automation budget and runs the exact Engineer through a bounded, journaled acquire and delegated-dispatch controller.
 responsibilities:
   - Project one exact host-owned ProgramAuthorization grant onto one automation run without minting a second authorization or budget schema.
   - Compose the grant's limits with the task contract's own runner budget by strictest value per metric and bind the derivation into the budget digest.
@@ -12,6 +12,10 @@ responsibilities:
   - Charge one idempotency key once and hold an interrupted reservation in a typed reconciliation state that only exact evidence can resolve.
   - Publish an immutable AutomationStopReceipt on exhaustion and project a read-only operator slice of budget, consumption, and stop receipt.
   - Never create, rewrite, release, or steal Task, Lease, Work Graph, claim, or contract authority, and never raise or renew a budget.
+  - Persist each controller decision before its acquisition or dispatch side effect and require reconciliation after an ambiguous crash boundary.
+  - Revalidate the exact Engineer principal, Binding and authorization revision before every bounded controller invocation.
+  - Consume only the canonical acquire-next WorkEnvelope and dispatch only through the existing fenced delegated-run effect.
+  - Apply a hard step and duration ceiling, deterministic bounded transient backoff, explicit stop, and one active controller per Engineer.
 source:
   include:
     - "src/core/automation/**"
@@ -50,6 +54,20 @@ source:
             - id: sink.automation-budget.operator-slice
               path: "src/core/automation/projection.ts"
               symbol: "projectAutomationBudgetSlice"
+    - id: entrypoint.automation-controller.step
+      path: "src/effects/automation/controller-run.ts"
+      symbols:
+        - name: "stepAutomationController"
+          sinks:
+            - id: sink.automation-controller.acquire
+              path: "src/effects/engineers/scheduling-acquire-next.ts"
+              symbol: "acquireNextScheduledEngineerTask"
+            - id: sink.automation-controller.dispatch
+              path: "src/effects/engineers/delegated-run-store.ts"
+              symbol: "dispatchDelegatedRun"
+            - id: sink.automation-controller.journal
+              path: "src/effects/automation/controller-store.ts"
+              symbol: "appendAutomationControllerEvent"
 extensions:
   contractFiles:
     agents: "AGENTS.md"

--- a/.archcontext/model/nodes/component.automation-controller.journal.yaml
+++ b/.archcontext/model/nodes/component.automation-controller.journal.yaml
@@ -1,0 +1,7 @@
+schemaVersion: archcontext.node/v2
+id: component.automation-controller.journal
+kind: component
+name: Automation Controller Journal
+status: active
+parent: capability.runtime-harness.automation-budget
+summary: Serializes one bounded controller per Engineer and persists an append-only, crash-recoverable state and receipt chain under the Git common directory.

--- a/.archcontext/model/relations/relation.automation-controller.journal.yaml
+++ b/.archcontext/model/relations/relation.automation-controller.journal.yaml
@@ -1,0 +1,6 @@
+schemaVersion: archcontext.relation/v1
+id: relation.automation-controller.journal
+kind: calls
+source: capability.runtime-harness.automation-budget
+target: component.automation-controller.journal
+intent: Persist each observation, acquisition and delegated dispatch boundary before the controller may advance

--- a/docs/architecture/modules/runtime-harness/automation-budget.md
+++ b/docs/architecture/modules/runtime-harness/automation-budget.md
@@ -83,6 +83,9 @@ sequenceDiagram
 4. token / cost 硬上限在本 slice 一律 fail closed:沒有 provider-attested usage 權威可讀之前,自證的用量數字比沒有上限更糟。
 5. `ProgramAuthorizationV1` 由 operator 鑄進 harness home 的 gate store,key 取自 Git common directory,所以同一個 clone 的每個 linked worktree 解析到同一份 grant;目標不是 Git 倉庫時直接 typed 拒絕,不會落到之後 `git init` 就作廢的路徑 key。每個讀取面都會重新錨定 grant,撤銷或改動後下一個 verb 就停。
 
+6. Controller journal 是 orchestration evidence，不是 Task 或 Lease authority。每次 step 先重驗 Engineer principal、Binding 與 authorization revision，再向 budget store 預留，之後才可調用 canonical acquire-next 或單一 fenced delegated-run effect。任何 event 已持久但 side effect 結果不明的狀態只可進 `reconciliation_required`。
+7. 同一 Engineer 的 controller 由 Git common-dir lock 與 current pointer 串行化；terminal run 才可被新 run 取代。每次 invocation 同時受 step count 與 wall duration 上限約束，transient retry 使用 frozen policy 推導的 deterministic capped backoff。10x 時最先失效的是 append-only event 與 transition 目錄的線性枚舉，而不是 Lease/Task authority；屆時應加 content-addressed index，不應另建 task queue。
+
 ## 4. 歷史決策記錄(append-only)
 
 ## Optimization Backlog

--- a/docs/researches/20260829-c0-collaboration-two-plane-authority-freeze.md
+++ b/docs/researches/20260829-c0-collaboration-two-plane-authority-freeze.md
@@ -123,6 +123,7 @@ collaboration plane.
 
 | Module | Fails | Evidence |
 |---|---|---|
+| `src/core/automation/controller.ts` | C-1 and C-2 | Automation orchestration evidence plane added by issue #279. Its journal records bounded observation and invokes the existing acquire and delegated-dispatch authorities; its bytes grant no Claim, move no Lease generation, and publish or accept nothing. |
 | `src/core/collaboration/common.ts` | C-1 and C-2 | Collaboration plane, which D1 fixes as additive and non-authoritative rather than one of the five planes C0 froze; a signal's bytes grant no Claim, move no Lease generation, and reach any reader inside an untrusted wrapper, so no admission, claim, publication or acceptance decision reads them |
 | `src/core/operator/collaboration-snapshot.ts` | C-1 and C-2 | Operator transport view of the collaboration plane, added by C8. It carries `COLLABORATION_PROTOCOL` rather than minting one, so it fails C-1 for the same reason its source does; it fails C-2 more strongly, because every value in it is a copy of a decision the collaboration read model already made, it has no store, and its only reader is a human browser on loopback |
 

--- a/docs/researches/20260829-c0-collaboration-two-plane-authority-freeze.md
+++ b/docs/researches/20260829-c0-collaboration-two-plane-authority-freeze.md
@@ -634,3 +634,5 @@ its primary component, and moved the ledger through
 - If C4's canary shows `max_parallel_readers = 3` is not reachable under a real
   provider, D6 stays frozen and the sprint records a measurement result; the table
   is not retro-fitted to the observation.
+
+> **Substantive Change SHA256**: `sha256:2db29e25cac199834d23e640afec55a70aa1ab50fdde9574796128997e9704ac`

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -116,6 +116,21 @@ repos.
   renews itself, never rewrites Task, Lease, Work Graph, or contract authority,
   and never releases or steals a claim.
 
+- One unattended controller is bound to the exact automation budget run,
+  Engineer principal, Binding generation, authorization revision, and protected
+  path set. Each invocation has independent hard step and duration ceilings.
+  Acquisition is only through canonical `acquire-next`; execution consumes its
+  returned `WorkEnvelopeV1` and dispatches only an already-admitted run through
+  `dispatchDelegatedRun`. The controller never creates Task, Work Graph, Lease,
+  or delegated-run authority.
+- Controller events are append-only evidence under the Git common directory.
+  The event is durable before every acquisition or dispatch; a restart at an
+  unresolved side-effect boundary becomes `reconciliation_required` and cannot
+  repeat that side effect. Transient acquisition failures use recorded,
+  deterministic exponential backoff capped by the frozen policy; user/operator
+  blockers and budget exhaustion are terminal. Explicit stop prevents another
+  acquisition and leaves the current Claim and Lease to their normal owner.
+
 ## Workflow Surfaces
 
 | Surface | Owner | Purpose |
@@ -130,6 +145,7 @@ repos.
 | `.ai/harness/runs/*.json` | Verifier | Immutable run/trace snapshots |
 | `.ai/harness/handoff/` | Session owner | Resume packets and exact next step |
 | `repo-harness automation budget show --run <id>` | Package runtime | Read-only operator projection of one automation run's budget, consumption, and stop receipt |
+| `repo-harness automation controller start\|step\|status\|stop\|reconcile` | Package runtime | Bounded unattended Engineer orchestration over the existing budget, acquire-next, WorkEnvelope and delegated-run authorities |
 | `docs/reference-configs/ux-feature-guard.md`, `docs/reference-configs/design-options.md`, `.claude/templates/design-brief.template.md` | Conventions | Frontend behavior discipline: freeze rules and non-goals before implementation, product boundary before imagegen variants, taste-class refinement ceiling, role-aware visible-concept declaration; `frontend` task_profile contracts must cite a design brief, and the runtime `[UXFeatureGuard]` advisory fires only on frontend-scoped feature intent |
 
 ## Safety Boundaries

--- a/src/cli/commands/automation.ts
+++ b/src/cli/commands/automation.ts
@@ -14,6 +14,9 @@ import {
   listStoredProgramAuthorizations,
   mintProgramAuthorization,
 } from '../../effects/automation/grant-store';
+import { AutomationControllerError } from '../../core/automation/controller';
+import { AutomationControllerStoreError, listAutomationControllerRuns, readAutomationControllerStatus } from '../../effects/automation/controller-store';
+import { reconcileAutomationController, startBoundedAutomationController, stepAutomationController, stopAutomationController } from '../../effects/automation/controller-run';
 
 export interface AutomationBudgetRawOptions {
   readonly repo?: string;
@@ -39,6 +42,7 @@ function outputError(error: unknown): void {
   const code = invalid
     ? 'invalid_argument'
     : error instanceof AutomationBudgetStoreError || error instanceof AutomationGrantStoreError
+      || error instanceof AutomationControllerError || error instanceof AutomationControllerStoreError
       ? error.code
       : 'automation_budget_unavailable';
   const message = error instanceof Error ? error.message : String(error);
@@ -149,5 +153,39 @@ export function buildAutomationCommand(): Command {
     });
   automation.addCommand(budget);
   automation.addCommand(grant);
+  const controller = new Command('controller').description('Run one bounded unattended Engineer controller');
+  const number = (value: string, field: string): number => { const parsed = Number(value); if (!Number.isSafeInteger(parsed)) throw new AutomationArgumentError(`${field} must be an integer`); return parsed; };
+  const collect = (value: string, previous: string[]): string[] => [...previous, value];
+  controller.command('start')
+    .requiredOption('--run <automationRunId>', 'Exact automation budget run digest')
+    .requiredOption('--authorization-id <id>', 'Mapped Engineer OAuth authorization')
+    .requiredOption('--idempotency-key <key>', 'Stable controller start key')
+    .requiredOption('--protected-path <path>', 'Protected repository path; repeatable', collect, [])
+    .option('--maximum-steps <n>', 'Hard steps per invocation', '8')
+    .option('--maximum-duration-ms <n>', 'Hard invocation duration', '60000')
+    .option('--maximum-transient-retries <n>', 'Bounded transient retries', '3')
+    .option('--initial-backoff-ms <n>', 'Initial deterministic backoff', '500')
+    .option('--maximum-backoff-ms <n>', 'Maximum deterministic backoff', '8000')
+    .action((options: { run: string; authorizationId: string; idempotencyKey: string; protectedPath: string[]; maximumSteps: string; maximumDurationMs: string; maximumTransientRetries: string; initialBackoffMs: string; maximumBackoffMs: string }) => {
+      try { process.stdout.write(`${JSON.stringify(startBoundedAutomationController({ repo_root: process.cwd(), automation_run_id: options.run, authorization_id: options.authorizationId, idempotency_key: options.idempotencyKey, protected_paths: options.protectedPath, policy: { maximum_steps_per_invocation: number(options.maximumSteps, 'maximum-steps'), maximum_duration_ms: number(options.maximumDurationMs, 'maximum-duration-ms'), maximum_transient_retries: number(options.maximumTransientRetries, 'maximum-transient-retries'), initial_backoff_ms: number(options.initialBackoffMs, 'initial-backoff-ms'), maximum_backoff_ms: number(options.maximumBackoffMs, 'maximum-backoff-ms') } }), null, 2)}\n`); } catch (error) { outputError(error); }
+    });
+  controller.command('step')
+    .requiredOption('--run <automationRunId>', 'Exact controller run digest')
+    .requiredOption('--idempotency-key <key>', 'Stable step key')
+    .option('--dispatch-id <digest>', 'Exact already-admitted delegated-run dispatch')
+    .option('--max-selection-attempts <n>', 'Bounded acquire-next rereads', '3')
+    .action((options: { run: string; idempotencyKey: string; dispatchId?: string; maxSelectionAttempts: string }) => {
+      try { process.stdout.write(`${JSON.stringify(stepAutomationController({ repo_root: process.cwd(), run_id: options.run, idempotency_key: options.idempotencyKey, dispatch_id: options.dispatchId, max_selection_attempts: number(options.maxSelectionAttempts, 'max-selection-attempts') }), null, 2)}\n`); } catch (error) { outputError(error); }
+    });
+  controller.command('status').option('--run <automationRunId>', 'Exact controller run digest').action((options: { run?: string }) => {
+    try { process.stdout.write(`${JSON.stringify(options.run ? readAutomationControllerStatus(process.cwd(), options.run) : listAutomationControllerRuns(process.cwd()), null, 2)}\n`); } catch (error) { outputError(error); }
+  });
+  controller.command('stop').requiredOption('--run <automationRunId>').requiredOption('--idempotency-key <key>').action((options: { run: string; idempotencyKey: string }) => {
+    try { process.stdout.write(`${JSON.stringify(stopAutomationController(process.cwd(), options.run, options.idempotencyKey), null, 2)}\n`); } catch (error) { outputError(error); }
+  });
+  controller.command('reconcile').requiredOption('--run <automationRunId>').requiredOption('--idempotency-key <key>').requiredOption('--evidence-ref <ref>', 'Exact evidence reference; repeatable', collect, []).action((options: { run: string; idempotencyKey: string; evidenceRef: string[] }) => {
+    try { process.stdout.write(`${JSON.stringify(reconcileAutomationController(process.cwd(), options.run, options.idempotencyKey, options.evidenceRef), null, 2)}\n`); } catch (error) { outputError(error); }
+  });
+  automation.addCommand(controller);
   return automation;
 }

--- a/src/core/automation/controller.ts
+++ b/src/core/automation/controller.ts
@@ -1,0 +1,225 @@
+import {
+  assertMessageBoundedUtf8,
+  assertMessageExactKeys,
+  assertMessageInteger,
+  assertMessageSha256,
+  canonicalMessageBytes,
+  canonicalMessageDigest,
+  messageRequiredString,
+} from '../messages/mechanics';
+
+export const AUTOMATION_CONTROLLER_PROTOCOL = 1 as const;
+export const AUTOMATION_CONTROLLER_RUN_KIND = 'repo-harness-automation-controller-run' as const;
+export const AUTOMATION_CONTROLLER_EVENT_KIND = 'repo-harness-automation-controller-event' as const;
+export const AUTOMATION_CONTROLLER_CURRENT_KIND = 'repo-harness-automation-controller-current' as const;
+
+const RUN_ID = /^sha256:[0-9a-f]{64}$/u;
+const REPOSITORY_ID = /^repo_[0-9a-f]{16}$/u;
+const ENGINEER_ID = /^engineer:capability\.[a-z0-9][a-z0-9.-]*$/u;
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
+const RFC3339 = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u;
+
+export type AutomationControllerState =
+  | 'created' | 'observing' | 'acquiring' | 'executing' | 'waiting_for_evidence'
+  | 'blocked' | 'budget_exhausted' | 'completed' | 'stopping' | 'stopped'
+  | 'reconciliation_required';
+
+export type AutomationControllerOperation =
+  | 'start' | 'observe' | 'begin_acquire' | 'acquired' | 'no_offer'
+  | 'begin_dispatch' | 'dispatch_started' | 'outcome_observed' | 'retry_wait'
+  | 'block' | 'exhaust_budget' | 'complete' | 'request_stop' | 'stop'
+  | 'require_reconciliation';
+
+export type AutomationControllerAttentionOwner = 'none' | 'user' | 'operator';
+
+const STATES: readonly AutomationControllerState[] = ['created', 'observing', 'acquiring', 'executing', 'waiting_for_evidence', 'blocked', 'budget_exhausted', 'completed', 'stopping', 'stopped', 'reconciliation_required'];
+const OPERATIONS: readonly AutomationControllerOperation[] = ['start', 'observe', 'begin_acquire', 'acquired', 'no_offer', 'begin_dispatch', 'dispatch_started', 'outcome_observed', 'retry_wait', 'block', 'exhaust_budget', 'complete', 'request_stop', 'stop', 'require_reconciliation'];
+const ATTENTION_OWNERS: readonly AutomationControllerAttentionOwner[] = ['none', 'user', 'operator'];
+
+export interface AutomationControllerPrincipalV1 {
+  readonly authorization_id: string;
+  readonly engineer_id: string;
+  readonly binding_id: string;
+  readonly binding_generation: number;
+  readonly engineer_contract_revision: string;
+  readonly authorization_revision: number;
+}
+
+export interface AutomationControllerPolicyV1 {
+  readonly maximum_steps_per_invocation: number;
+  readonly maximum_duration_ms: number;
+  readonly maximum_transient_retries: number;
+  readonly initial_backoff_ms: number;
+  readonly maximum_backoff_ms: number;
+}
+
+export interface AutomationControllerRunV1 {
+  readonly protocol: typeof AUTOMATION_CONTROLLER_PROTOCOL;
+  readonly kind: typeof AUTOMATION_CONTROLLER_RUN_KIND;
+  readonly run_id: string;
+  readonly repository_id: string;
+  readonly principal: AutomationControllerPrincipalV1;
+  readonly budget_sha256: string;
+  readonly policy: AutomationControllerPolicyV1;
+  readonly created_at: string;
+  readonly run_sha256: string;
+}
+
+export interface AutomationControllerStepReceiptV1 {
+  readonly operation: AutomationControllerOperation;
+  readonly outcome: string;
+  readonly work_package_id: string | null;
+  readonly task_id: string | null;
+  readonly claim_id: string | null;
+  readonly lease_generation: number | null;
+  readonly work_envelope_sha256: string | null;
+  readonly dispatch_id: string | null;
+  readonly runtime_effect_id: string | null;
+  readonly evidence_refs: readonly string[];
+}
+
+export interface AutomationControllerEventV1 {
+  readonly protocol: typeof AUTOMATION_CONTROLLER_PROTOCOL;
+  readonly kind: typeof AUTOMATION_CONTROLLER_EVENT_KIND;
+  readonly run_id: string;
+  readonly revision: number;
+  readonly idempotency_key: string;
+  readonly operation: AutomationControllerOperation;
+  readonly previous_state: AutomationControllerState | null;
+  readonly next_state: AutomationControllerState;
+  readonly attention_owner: AutomationControllerAttentionOwner;
+  readonly blocker: string | null;
+  readonly retry_at: string | null;
+  readonly receipt: AutomationControllerStepReceiptV1;
+  readonly observed_at: string;
+  readonly previous_event_sha256: string | null;
+  readonly event_sha256: string;
+}
+
+export interface AutomationControllerCurrentV1 {
+  readonly protocol: typeof AUTOMATION_CONTROLLER_PROTOCOL;
+  readonly kind: typeof AUTOMATION_CONTROLLER_CURRENT_KIND;
+  readonly run_id: string;
+  readonly run_sha256: string;
+  readonly revision: number;
+  readonly state: AutomationControllerState;
+  readonly attention_owner: AutomationControllerAttentionOwner;
+  readonly blocker: string | null;
+  readonly retry_at: string | null;
+  readonly current_event_sha256: string;
+  readonly previous_current_sha256: string | null;
+  readonly current_sha256: string;
+}
+
+export class AutomationControllerError extends Error {
+  constructor(readonly code: 'automation_controller_invalid' | 'automation_controller_transition_invalid', message: string) {
+    super(message); this.name = 'AutomationControllerError';
+  }
+}
+
+function invalid(message: string): never { throw new AutomationControllerError('automation_controller_invalid', message); }
+function transitionInvalid(message: string): never { throw new AutomationControllerError('automation_controller_transition_invalid', message); }
+function object(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) invalid(`${label} must be an object`);
+  return value as Record<string, unknown>;
+}
+function exact(value: Record<string, unknown>, keys: readonly string[], label: string): void { assertMessageExactKeys(value, keys, label, invalid); }
+function string(value: unknown, field: string, pattern?: RegExp, maximum = 512): string {
+  const result = messageRequiredString(value, field, invalid); assertMessageBoundedUtf8(result, field, maximum, invalid);
+  if (pattern && !pattern.test(result)) invalid(`${field} is invalid`); return result;
+}
+function sha(value: unknown, field: string): string { const result = string(value, field); assertMessageSha256(result, field, invalid); return result; }
+function timestamp(value: unknown, field: string): string {
+  const result = string(value, field); if (!RFC3339.test(result) || Number.isNaN(Date.parse(result))) invalid(`${field} is invalid`); return result;
+}
+function integer(value: unknown, field: string, minimum: number, maximum: number): number {
+  assertMessageInteger(value, field, minimum, invalid); if ((value as number) > maximum) invalid(`${field} must be <= ${maximum}`); return value as number;
+}
+
+function principal(value: unknown): AutomationControllerPrincipalV1 {
+  const row = object(value, 'principal'); exact(row, ['authorization_id', 'engineer_id', 'binding_id', 'binding_generation', 'engineer_contract_revision', 'authorization_revision'], 'principal');
+  return Object.freeze({ authorization_id: string(row.authorization_id, 'principal.authorization_id'), engineer_id: string(row.engineer_id, 'principal.engineer_id', ENGINEER_ID), binding_id: string(row.binding_id, 'principal.binding_id', UUID), binding_generation: integer(row.binding_generation, 'principal.binding_generation', 1, Number.MAX_SAFE_INTEGER), engineer_contract_revision: sha(row.engineer_contract_revision, 'principal.engineer_contract_revision'), authorization_revision: integer(row.authorization_revision, 'principal.authorization_revision', 1, Number.MAX_SAFE_INTEGER) });
+}
+
+function policy(value: unknown): AutomationControllerPolicyV1 {
+  const row = object(value, 'policy'); exact(row, ['maximum_steps_per_invocation', 'maximum_duration_ms', 'maximum_transient_retries', 'initial_backoff_ms', 'maximum_backoff_ms'], 'policy');
+  const result = Object.freeze({ maximum_steps_per_invocation: integer(row.maximum_steps_per_invocation, 'policy.maximum_steps_per_invocation', 1, 64), maximum_duration_ms: integer(row.maximum_duration_ms, 'policy.maximum_duration_ms', 100, 300_000), maximum_transient_retries: integer(row.maximum_transient_retries, 'policy.maximum_transient_retries', 0, 16), initial_backoff_ms: integer(row.initial_backoff_ms, 'policy.initial_backoff_ms', 1, 60_000), maximum_backoff_ms: integer(row.maximum_backoff_ms, 'policy.maximum_backoff_ms', 1, 300_000) });
+  if (result.maximum_backoff_ms < result.initial_backoff_ms) invalid('policy.maximum_backoff_ms must be >= initial_backoff_ms');
+  return result;
+}
+
+export function buildAutomationControllerRun(input: Omit<AutomationControllerRunV1, 'protocol' | 'kind' | 'run_sha256'>): AutomationControllerRunV1 {
+  const basis = Object.freeze({ protocol: AUTOMATION_CONTROLLER_PROTOCOL, kind: AUTOMATION_CONTROLLER_RUN_KIND, run_id: string(input.run_id, 'run_id', RUN_ID), repository_id: string(input.repository_id, 'repository_id', REPOSITORY_ID), principal: principal(input.principal), budget_sha256: sha(input.budget_sha256, 'budget_sha256'), policy: policy(input.policy), created_at: timestamp(input.created_at, 'created_at') });
+  return Object.freeze({ ...basis, run_sha256: canonicalMessageDigest(basis) });
+}
+
+export function validateAutomationControllerRun(value: unknown): AutomationControllerRunV1 {
+  const row = object(value, 'controller run'); exact(row, ['protocol', 'kind', 'run_id', 'repository_id', 'principal', 'budget_sha256', 'policy', 'created_at', 'run_sha256'], 'controller run');
+  if (row.protocol !== AUTOMATION_CONTROLLER_PROTOCOL || row.kind !== AUTOMATION_CONTROLLER_RUN_KIND) invalid('controller run protocol or kind is invalid');
+  const built = buildAutomationControllerRun(row as unknown as Omit<AutomationControllerRunV1, 'protocol' | 'kind' | 'run_sha256'>);
+  if (row.run_sha256 !== built.run_sha256 || canonicalMessageBytes(row) !== canonicalMessageBytes(built as unknown as Record<string, unknown>)) invalid('controller run digest is stale'); return built;
+}
+
+const TRANSITIONS: Readonly<Record<AutomationControllerState | 'absent', Readonly<Record<string, AutomationControllerState>>>> = Object.freeze({
+  absent: Object.freeze({ start: 'created' }),
+  created: Object.freeze({ observe: 'observing', request_stop: 'stopping', require_reconciliation: 'reconciliation_required' }),
+  observing: Object.freeze({ begin_acquire: 'acquiring', no_offer: 'completed', block: 'blocked', exhaust_budget: 'budget_exhausted', request_stop: 'stopping', require_reconciliation: 'reconciliation_required' }),
+  acquiring: Object.freeze({ acquired: 'executing', retry_wait: 'observing', block: 'blocked', exhaust_budget: 'budget_exhausted', request_stop: 'stopping', require_reconciliation: 'reconciliation_required' }),
+  executing: Object.freeze({ begin_dispatch: 'executing', dispatch_started: 'waiting_for_evidence', request_stop: 'stopping', require_reconciliation: 'reconciliation_required' }),
+  waiting_for_evidence: Object.freeze({ outcome_observed: 'observing', retry_wait: 'observing', complete: 'completed', block: 'blocked', exhaust_budget: 'budget_exhausted', request_stop: 'stopping', require_reconciliation: 'reconciliation_required' }),
+  stopping: Object.freeze({ stop: 'stopped', require_reconciliation: 'reconciliation_required' }),
+  blocked: Object.freeze({}), budget_exhausted: Object.freeze({}), completed: Object.freeze({}), stopped: Object.freeze({}), reconciliation_required: Object.freeze({}),
+});
+
+export function nextAutomationControllerState(current: AutomationControllerState | null, operation: AutomationControllerOperation): AutomationControllerState {
+  const next = TRANSITIONS[current ?? 'absent'][operation]; if (!next) transitionInvalid(`cannot ${operation} from ${current ?? 'absent'}`); return next;
+}
+
+function receipt(value: AutomationControllerStepReceiptV1, operation: AutomationControllerOperation): AutomationControllerStepReceiptV1 {
+  const row = object(value, 'receipt'); exact(row, ['operation', 'outcome', 'work_package_id', 'task_id', 'claim_id', 'lease_generation', 'work_envelope_sha256', 'dispatch_id', 'runtime_effect_id', 'evidence_refs'], 'receipt');
+  if (row.operation !== operation) invalid('receipt.operation does not match event operation');
+  const nullable = (field: string, pattern?: RegExp): string | null => row[field] === null ? null : string(row[field], `receipt.${field}`, pattern, 2048);
+  if (!Array.isArray(row.evidence_refs) || row.evidence_refs.length > 32) invalid('receipt.evidence_refs must be a bounded array');
+  return Object.freeze({ operation, outcome: string(row.outcome, 'receipt.outcome'), work_package_id: nullable('work_package_id'), task_id: nullable('task_id', /^[0-9a-f]{64}$/u), claim_id: nullable('claim_id', UUID), lease_generation: row.lease_generation === null ? null : integer(row.lease_generation, 'receipt.lease_generation', 1, Number.MAX_SAFE_INTEGER), work_envelope_sha256: row.work_envelope_sha256 === null ? null : sha(row.work_envelope_sha256, 'receipt.work_envelope_sha256'), dispatch_id: row.dispatch_id === null ? null : sha(row.dispatch_id, 'receipt.dispatch_id'), runtime_effect_id: row.runtime_effect_id === null ? null : sha(row.runtime_effect_id, 'receipt.runtime_effect_id'), evidence_refs: Object.freeze(row.evidence_refs.map((item, index) => string(item, `receipt.evidence_refs[${index}]`, undefined, 2048))) });
+}
+
+export function buildAutomationControllerEvent(input: Omit<AutomationControllerEventV1, 'protocol' | 'kind' | 'next_state' | 'event_sha256'>): AutomationControllerEventV1 {
+  if (!OPERATIONS.includes(input.operation)) invalid('operation is invalid');
+  if (input.previous_state !== null && !STATES.includes(input.previous_state)) invalid('previous_state is invalid');
+  if (!ATTENTION_OWNERS.includes(input.attention_owner)) invalid('attention_owner is invalid');
+  const nextState = nextAutomationControllerState(input.previous_state, input.operation);
+  if ((input.attention_owner === 'none') !== (input.blocker === null)) invalid('blocker and attention_owner must be present together');
+  if (input.operation === 'block' && input.attention_owner === 'none') invalid('block needs an attention owner');
+  if (input.retry_at !== null) timestamp(input.retry_at, 'retry_at');
+  const basis = Object.freeze({ protocol: AUTOMATION_CONTROLLER_PROTOCOL, kind: AUTOMATION_CONTROLLER_EVENT_KIND, run_id: string(input.run_id, 'run_id', RUN_ID), revision: integer(input.revision, 'revision', 1, Number.MAX_SAFE_INTEGER), idempotency_key: string(input.idempotency_key, 'idempotency_key'), operation: input.operation, previous_state: input.previous_state, next_state: nextState, attention_owner: input.attention_owner, blocker: input.blocker === null ? null : string(input.blocker, 'blocker', undefined, 4096), retry_at: input.retry_at, receipt: receipt(input.receipt, input.operation), observed_at: timestamp(input.observed_at, 'observed_at'), previous_event_sha256: input.previous_event_sha256 === null ? null : sha(input.previous_event_sha256, 'previous_event_sha256') });
+  return Object.freeze({ ...basis, event_sha256: canonicalMessageDigest(basis) });
+}
+
+export function validateAutomationControllerEvent(value: unknown): AutomationControllerEventV1 {
+  const row = object(value, 'controller event');
+  exact(row, ['protocol', 'kind', 'run_id', 'revision', 'idempotency_key', 'operation', 'previous_state', 'next_state', 'attention_owner', 'blocker', 'retry_at', 'receipt', 'observed_at', 'previous_event_sha256', 'event_sha256'], 'controller event');
+  if (row.protocol !== AUTOMATION_CONTROLLER_PROTOCOL || row.kind !== AUTOMATION_CONTROLLER_EVENT_KIND) invalid('controller event protocol or kind is invalid');
+  const built = buildAutomationControllerEvent(row as unknown as Omit<AutomationControllerEventV1, 'protocol' | 'kind' | 'next_state' | 'event_sha256'>);
+  if (row.next_state !== built.next_state || row.event_sha256 !== built.event_sha256 || canonicalMessageBytes(row) !== canonicalMessageBytes(built as unknown as Record<string, unknown>)) invalid('controller event digest is stale');
+  return built;
+}
+
+export function foldAutomationControllerCurrent(run: AutomationControllerRunV1, previous: AutomationControllerCurrentV1 | null, event: AutomationControllerEventV1): AutomationControllerCurrentV1 {
+  if (event.run_id !== run.run_id || event.revision !== (previous?.revision ?? 0) + 1 || event.previous_state !== (previous?.state ?? null) || event.previous_event_sha256 !== (previous?.current_event_sha256 ?? null)) transitionInvalid('event does not extend exact controller current');
+  const basis = Object.freeze({ protocol: AUTOMATION_CONTROLLER_PROTOCOL, kind: AUTOMATION_CONTROLLER_CURRENT_KIND, run_id: run.run_id, run_sha256: run.run_sha256, revision: event.revision, state: event.next_state, attention_owner: event.attention_owner, blocker: event.blocker, retry_at: event.retry_at, current_event_sha256: event.event_sha256, previous_current_sha256: previous?.current_sha256 ?? null });
+  return Object.freeze({ ...basis, current_sha256: canonicalMessageDigest(basis) });
+}
+
+export function validateAutomationControllerCurrent(value: unknown): AutomationControllerCurrentV1 {
+  const row = object(value, 'controller current');
+  exact(row, ['protocol', 'kind', 'run_id', 'run_sha256', 'revision', 'state', 'attention_owner', 'blocker', 'retry_at', 'current_event_sha256', 'previous_current_sha256', 'current_sha256'], 'controller current');
+  if (row.protocol !== AUTOMATION_CONTROLLER_PROTOCOL || row.kind !== AUTOMATION_CONTROLLER_CURRENT_KIND || !STATES.includes(row.state as AutomationControllerState) || !ATTENTION_OWNERS.includes(row.attention_owner as AutomationControllerAttentionOwner)) invalid('controller current protocol, kind or enum is invalid');
+  const basis = { protocol: AUTOMATION_CONTROLLER_PROTOCOL, kind: AUTOMATION_CONTROLLER_CURRENT_KIND, run_id: string(row.run_id, 'run_id', RUN_ID), run_sha256: sha(row.run_sha256, 'run_sha256'), revision: integer(row.revision, 'revision', 1, Number.MAX_SAFE_INTEGER), state: row.state as AutomationControllerState, attention_owner: row.attention_owner as AutomationControllerAttentionOwner, blocker: row.blocker === null ? null : string(row.blocker, 'blocker', undefined, 4096), retry_at: row.retry_at === null ? null : timestamp(row.retry_at, 'retry_at'), current_event_sha256: sha(row.current_event_sha256, 'current_event_sha256'), previous_current_sha256: row.previous_current_sha256 === null ? null : sha(row.previous_current_sha256, 'previous_current_sha256') };
+  const built = Object.freeze({ ...basis, current_sha256: canonicalMessageDigest(basis) });
+  if (row.current_sha256 !== built.current_sha256 || canonicalMessageBytes(row) !== canonicalMessageBytes(built as unknown as Record<string, unknown>)) invalid('controller current digest is stale');
+  return built;
+}
+
+export function canonicalAutomationControllerRunBytes(value: AutomationControllerRunV1): string { return canonicalMessageBytes(value as unknown as Record<string, unknown>); }
+export function canonicalAutomationControllerEventBytes(value: AutomationControllerEventV1): string { return canonicalMessageBytes(value as unknown as Record<string, unknown>); }
+export function canonicalAutomationControllerCurrentBytes(value: AutomationControllerCurrentV1): string { return canonicalMessageBytes(value as unknown as Record<string, unknown>); }

--- a/src/core/automation/controller.ts
+++ b/src/core/automation/controller.ts
@@ -107,6 +107,7 @@ export interface AutomationControllerCurrentV1 {
   readonly attention_owner: AutomationControllerAttentionOwner;
   readonly blocker: string | null;
   readonly retry_at: string | null;
+  readonly consecutive_transient_failures: number;
   readonly current_event_sha256: string;
   readonly previous_current_sha256: string | null;
   readonly current_sha256: string;
@@ -167,7 +168,7 @@ const TRANSITIONS: Readonly<Record<AutomationControllerState | 'absent', Readonl
   absent: Object.freeze({ start: 'created' }),
   created: Object.freeze({ observe: 'observing', request_stop: 'stopping', require_reconciliation: 'reconciliation_required' }),
   observing: Object.freeze({ begin_acquire: 'acquiring', no_offer: 'completed', block: 'blocked', exhaust_budget: 'budget_exhausted', request_stop: 'stopping', require_reconciliation: 'reconciliation_required' }),
-  acquiring: Object.freeze({ acquired: 'executing', retry_wait: 'observing', block: 'blocked', exhaust_budget: 'budget_exhausted', request_stop: 'stopping', require_reconciliation: 'reconciliation_required' }),
+  acquiring: Object.freeze({ acquired: 'executing', retry_wait: 'observing', block: 'blocked', exhaust_budget: 'budget_exhausted', require_reconciliation: 'reconciliation_required' }),
   executing: Object.freeze({ begin_dispatch: 'executing', dispatch_started: 'waiting_for_evidence', exhaust_budget: 'budget_exhausted', request_stop: 'stopping', require_reconciliation: 'reconciliation_required' }),
   waiting_for_evidence: Object.freeze({ outcome_observed: 'observing', retry_wait: 'observing', complete: 'completed', block: 'blocked', exhaust_budget: 'budget_exhausted', request_stop: 'stopping', require_reconciliation: 'reconciliation_required' }),
   stopping: Object.freeze({ stop: 'stopped', require_reconciliation: 'reconciliation_required' }),
@@ -209,15 +210,15 @@ export function validateAutomationControllerEvent(value: unknown): AutomationCon
 
 export function foldAutomationControllerCurrent(run: AutomationControllerRunV1, previous: AutomationControllerCurrentV1 | null, event: AutomationControllerEventV1): AutomationControllerCurrentV1 {
   if (event.run_id !== run.run_id || event.revision !== (previous?.revision ?? 0) + 1 || event.previous_state !== (previous?.state ?? null) || event.previous_event_sha256 !== (previous?.current_event_sha256 ?? null)) transitionInvalid('event does not extend exact controller current');
-  const basis = Object.freeze({ protocol: AUTOMATION_CONTROLLER_PROTOCOL, kind: AUTOMATION_CONTROLLER_CURRENT_KIND, run_id: run.run_id, run_sha256: run.run_sha256, revision: event.revision, state: event.next_state, attention_owner: event.attention_owner, blocker: event.blocker, retry_at: event.retry_at, current_event_sha256: event.event_sha256, previous_current_sha256: previous?.current_sha256 ?? null });
+  const basis = Object.freeze({ protocol: AUTOMATION_CONTROLLER_PROTOCOL, kind: AUTOMATION_CONTROLLER_CURRENT_KIND, run_id: run.run_id, run_sha256: run.run_sha256, revision: event.revision, state: event.next_state, attention_owner: event.attention_owner, blocker: event.blocker, retry_at: event.retry_at, consecutive_transient_failures: event.operation === 'retry_wait' ? (previous?.consecutive_transient_failures ?? 0) + 1 : event.operation === 'observe' || event.operation === 'begin_acquire' || event.operation === 'begin_dispatch' ? (previous?.consecutive_transient_failures ?? 0) : 0, current_event_sha256: event.event_sha256, previous_current_sha256: previous?.current_sha256 ?? null });
   return Object.freeze({ ...basis, current_sha256: canonicalMessageDigest(basis) });
 }
 
 export function validateAutomationControllerCurrent(value: unknown): AutomationControllerCurrentV1 {
   const row = object(value, 'controller current');
-  exact(row, ['protocol', 'kind', 'run_id', 'run_sha256', 'revision', 'state', 'attention_owner', 'blocker', 'retry_at', 'current_event_sha256', 'previous_current_sha256', 'current_sha256'], 'controller current');
+  exact(row, ['protocol', 'kind', 'run_id', 'run_sha256', 'revision', 'state', 'attention_owner', 'blocker', 'retry_at', 'consecutive_transient_failures', 'current_event_sha256', 'previous_current_sha256', 'current_sha256'], 'controller current');
   if (row.protocol !== AUTOMATION_CONTROLLER_PROTOCOL || row.kind !== AUTOMATION_CONTROLLER_CURRENT_KIND || !STATES.includes(row.state as AutomationControllerState) || !ATTENTION_OWNERS.includes(row.attention_owner as AutomationControllerAttentionOwner)) invalid('controller current protocol, kind or enum is invalid');
-  const basis = { protocol: AUTOMATION_CONTROLLER_PROTOCOL, kind: AUTOMATION_CONTROLLER_CURRENT_KIND, run_id: string(row.run_id, 'run_id', RUN_ID), run_sha256: sha(row.run_sha256, 'run_sha256'), revision: integer(row.revision, 'revision', 1, Number.MAX_SAFE_INTEGER), state: row.state as AutomationControllerState, attention_owner: row.attention_owner as AutomationControllerAttentionOwner, blocker: row.blocker === null ? null : string(row.blocker, 'blocker', undefined, 4096), retry_at: row.retry_at === null ? null : timestamp(row.retry_at, 'retry_at'), current_event_sha256: sha(row.current_event_sha256, 'current_event_sha256'), previous_current_sha256: row.previous_current_sha256 === null ? null : sha(row.previous_current_sha256, 'previous_current_sha256') };
+  const basis = { protocol: AUTOMATION_CONTROLLER_PROTOCOL, kind: AUTOMATION_CONTROLLER_CURRENT_KIND, run_id: string(row.run_id, 'run_id', RUN_ID), run_sha256: sha(row.run_sha256, 'run_sha256'), revision: integer(row.revision, 'revision', 1, Number.MAX_SAFE_INTEGER), state: row.state as AutomationControllerState, attention_owner: row.attention_owner as AutomationControllerAttentionOwner, blocker: row.blocker === null ? null : string(row.blocker, 'blocker', undefined, 4096), retry_at: row.retry_at === null ? null : timestamp(row.retry_at, 'retry_at'), consecutive_transient_failures: integer(row.consecutive_transient_failures, 'consecutive_transient_failures', 0, Number.MAX_SAFE_INTEGER), current_event_sha256: sha(row.current_event_sha256, 'current_event_sha256'), previous_current_sha256: row.previous_current_sha256 === null ? null : sha(row.previous_current_sha256, 'previous_current_sha256') };
   const built = Object.freeze({ ...basis, current_sha256: canonicalMessageDigest(basis) });
   if (row.current_sha256 !== built.current_sha256 || canonicalMessageBytes(row) !== canonicalMessageBytes(built as unknown as Record<string, unknown>)) invalid('controller current digest is stale');
   return built;

--- a/src/core/automation/controller.ts
+++ b/src/core/automation/controller.ts
@@ -61,6 +61,7 @@ export interface AutomationControllerRunV1 {
   readonly principal: AutomationControllerPrincipalV1;
   readonly budget_sha256: string;
   readonly policy: AutomationControllerPolicyV1;
+  readonly protected_paths: readonly string[];
   readonly created_at: string;
   readonly run_sha256: string;
 }
@@ -149,12 +150,14 @@ function policy(value: unknown): AutomationControllerPolicyV1 {
 }
 
 export function buildAutomationControllerRun(input: Omit<AutomationControllerRunV1, 'protocol' | 'kind' | 'run_sha256'>): AutomationControllerRunV1 {
-  const basis = Object.freeze({ protocol: AUTOMATION_CONTROLLER_PROTOCOL, kind: AUTOMATION_CONTROLLER_RUN_KIND, run_id: string(input.run_id, 'run_id', RUN_ID), repository_id: string(input.repository_id, 'repository_id', REPOSITORY_ID), principal: principal(input.principal), budget_sha256: sha(input.budget_sha256, 'budget_sha256'), policy: policy(input.policy), created_at: timestamp(input.created_at, 'created_at') });
+  if (!Array.isArray(input.protected_paths) || input.protected_paths.length === 0 || input.protected_paths.length > 128) invalid('protected_paths must be a non-empty bounded array');
+  const protectedPaths = Object.freeze(input.protected_paths.map((value, index) => { const path = string(value, `protected_paths[${index}]`, undefined, 2048); if (path.startsWith('/') || path.startsWith('-') || path.includes('\\') || path.split('/').some((part) => part === '' || part === '.' || part === '..')) invalid(`protected_paths[${index}] is unsafe`); return path; }));
+  const basis = Object.freeze({ protocol: AUTOMATION_CONTROLLER_PROTOCOL, kind: AUTOMATION_CONTROLLER_RUN_KIND, run_id: string(input.run_id, 'run_id', RUN_ID), repository_id: string(input.repository_id, 'repository_id', REPOSITORY_ID), principal: principal(input.principal), budget_sha256: sha(input.budget_sha256, 'budget_sha256'), policy: policy(input.policy), protected_paths: protectedPaths, created_at: timestamp(input.created_at, 'created_at') });
   return Object.freeze({ ...basis, run_sha256: canonicalMessageDigest(basis) });
 }
 
 export function validateAutomationControllerRun(value: unknown): AutomationControllerRunV1 {
-  const row = object(value, 'controller run'); exact(row, ['protocol', 'kind', 'run_id', 'repository_id', 'principal', 'budget_sha256', 'policy', 'created_at', 'run_sha256'], 'controller run');
+  const row = object(value, 'controller run'); exact(row, ['protocol', 'kind', 'run_id', 'repository_id', 'principal', 'budget_sha256', 'policy', 'protected_paths', 'created_at', 'run_sha256'], 'controller run');
   if (row.protocol !== AUTOMATION_CONTROLLER_PROTOCOL || row.kind !== AUTOMATION_CONTROLLER_RUN_KIND) invalid('controller run protocol or kind is invalid');
   const built = buildAutomationControllerRun(row as unknown as Omit<AutomationControllerRunV1, 'protocol' | 'kind' | 'run_sha256'>);
   if (row.run_sha256 !== built.run_sha256 || canonicalMessageBytes(row) !== canonicalMessageBytes(built as unknown as Record<string, unknown>)) invalid('controller run digest is stale'); return built;
@@ -165,7 +168,7 @@ const TRANSITIONS: Readonly<Record<AutomationControllerState | 'absent', Readonl
   created: Object.freeze({ observe: 'observing', request_stop: 'stopping', require_reconciliation: 'reconciliation_required' }),
   observing: Object.freeze({ begin_acquire: 'acquiring', no_offer: 'completed', block: 'blocked', exhaust_budget: 'budget_exhausted', request_stop: 'stopping', require_reconciliation: 'reconciliation_required' }),
   acquiring: Object.freeze({ acquired: 'executing', retry_wait: 'observing', block: 'blocked', exhaust_budget: 'budget_exhausted', request_stop: 'stopping', require_reconciliation: 'reconciliation_required' }),
-  executing: Object.freeze({ begin_dispatch: 'executing', dispatch_started: 'waiting_for_evidence', request_stop: 'stopping', require_reconciliation: 'reconciliation_required' }),
+  executing: Object.freeze({ begin_dispatch: 'executing', dispatch_started: 'waiting_for_evidence', exhaust_budget: 'budget_exhausted', request_stop: 'stopping', require_reconciliation: 'reconciliation_required' }),
   waiting_for_evidence: Object.freeze({ outcome_observed: 'observing', retry_wait: 'observing', complete: 'completed', block: 'blocked', exhaust_budget: 'budget_exhausted', request_stop: 'stopping', require_reconciliation: 'reconciliation_required' }),
   stopping: Object.freeze({ stop: 'stopped', require_reconciliation: 'reconciliation_required' }),
   blocked: Object.freeze({}), budget_exhausted: Object.freeze({}), completed: Object.freeze({}), stopped: Object.freeze({}), reconciliation_required: Object.freeze({}),

--- a/src/effects/automation/controller-run.ts
+++ b/src/effects/automation/controller-run.ts
@@ -1,0 +1,134 @@
+import { canonicalMessageDigest } from '../../core/messages/mechanics';
+import { workEnvelopeSha256, type EngineerPrincipalV1 } from '../../core/engineers/principal-claim';
+import type { AutomationControllerCurrentV1, AutomationControllerOperation, AutomationControllerStepReceiptV1 } from '../../core/automation/controller';
+import {
+  AutomationBudgetStoreError,
+  appendAutomationUsage,
+  readAutomationBudgetStatus,
+  reserveAutomationBudget,
+} from './budget-store';
+import {
+  appendAutomationControllerEvent,
+  readAutomationControllerStatus,
+} from './controller-store';
+import { resolveEngineerPrincipal } from '../engineers/principal';
+import { acquireNextScheduledEngineerTask, type AcquireNextScheduledEngineerTaskResult } from '../engineers/scheduling-acquire-next';
+import { dispatchDelegatedRun, type DelegatedRunStatus } from '../engineers/delegated-run-store';
+import { repoHarnessAuthorizationRevision } from '../repo-registry';
+
+export interface StepAutomationControllerInput {
+  readonly repo_root: string;
+  readonly run_id: string;
+  readonly idempotency_key: string;
+  readonly dispatch_id?: string;
+  readonly max_selection_attempts?: number;
+}
+
+export interface AutomationControllerStepResult {
+  readonly run_id: string;
+  readonly current: AutomationControllerCurrentV1;
+  readonly acquisition: AcquireNextScheduledEngineerTaskResult | null;
+  readonly dispatch: DelegatedRunStatus | null;
+  readonly steps_executed: number;
+}
+
+export interface AutomationControllerRunDependencies {
+  readonly now: () => Date;
+  readonly resolvePrincipal: typeof resolveEngineerPrincipal;
+  readonly authorizationRevision: typeof repoHarnessAuthorizationRevision;
+  readonly acquireNext: typeof acquireNextScheduledEngineerTask;
+  readonly dispatch: typeof dispatchDelegatedRun;
+  readonly readBudget: typeof readAutomationBudgetStatus;
+  readonly reserveBudget: typeof reserveAutomationBudget;
+  readonly appendUsage: typeof appendAutomationUsage;
+}
+
+const defaultDependencies: AutomationControllerRunDependencies = {
+  now: () => new Date(),
+  resolvePrincipal: resolveEngineerPrincipal,
+  authorizationRevision: repoHarnessAuthorizationRevision,
+  acquireNext: acquireNextScheduledEngineerTask,
+  dispatch: dispatchDelegatedRun,
+  readBudget: readAutomationBudgetStatus,
+  reserveBudget: reserveAutomationBudget,
+  appendUsage: appendAutomationUsage,
+};
+
+function exactPrincipal(expected: ReturnType<typeof readAutomationControllerStatus>['run']['principal'], observed: EngineerPrincipalV1, authorizationRevision: number): void {
+  if (observed.repository_id === '' || observed.engineer_id !== expected.engineer_id
+    || observed.binding_id !== expected.binding_id || observed.binding_generation !== expected.binding_generation
+    || observed.engineer_contract_revision !== expected.engineer_contract_revision
+    || observed.auth_subject !== expected.authorization_id || authorizationRevision !== expected.authorization_revision) {
+    throw new Error('controller principal, Binding or authorization revision is stale');
+  }
+}
+
+function evidence(runId: string, sha256: string) { return Object.freeze([{ ref: `controller-run:${runId}`, sha256 }]); }
+function receipt(operation: AutomationControllerOperation, outcome: string, extra: Partial<AutomationControllerStepReceiptV1> = {}): AutomationControllerStepReceiptV1 {
+  return Object.freeze({ operation, outcome, work_package_id: null, task_id: null, claim_id: null, lease_generation: null, work_envelope_sha256: null, dispatch_id: null, runtime_effect_id: null, evidence_refs: [], ...extra });
+}
+
+function append(repoRoot: string, runId: string, current: AutomationControllerCurrentV1, key: string, operation: AutomationControllerOperation, observedAt: string, stepReceipt: AutomationControllerStepReceiptV1, attentionOwner: 'none' | 'user' | 'operator' = 'none', blocker: string | null = null, retryAt: string | null = null): AutomationControllerCurrentV1 {
+  return appendAutomationControllerEvent({ repo_root: repoRoot, run_id: runId, expected_current_sha256: current.current_sha256, idempotency_key: key, operation, attention_owner: attentionOwner, blocker, retry_at: retryAt, receipt: stepReceipt, observed_at: observedAt }).current;
+}
+
+function budgetRefusal(repoRoot: string, runId: string, current: AutomationControllerCurrentV1, key: string, error: AutomationBudgetStoreError, observedAt: string): AutomationControllerCurrentV1 {
+  const exhausted = error.code === 'automation_budget_refused' && (error.refusal?.refusal_code === 'budget_limit_exceeded' || error.refusal?.refusal_code === 'budget_expired');
+  const operation = exhausted ? 'exhaust_budget' : 'require_reconciliation';
+  return append(repoRoot, runId, current, `${key}:budget-refusal`, operation, observedAt, receipt(operation, error.code, { evidence_refs: [`automation-budget:${error.code}`] }), exhausted ? 'user' : 'operator', error.refusal?.refusal_code ?? error.code);
+}
+
+export function stepAutomationController(input: StepAutomationControllerInput, overrides: Partial<AutomationControllerRunDependencies> = {}): AutomationControllerStepResult {
+  const deps = { ...defaultDependencies, ...overrides }; const status = readAutomationControllerStatus(input.repo_root, input.run_id); const run = status.run;
+  const startedAt = deps.now().getTime(); let current = status.current; let steps = 0; let acquisition: AcquireNextScheduledEngineerTaskResult | null = null; let dispatched: DelegatedRunStatus | null = null;
+  const observedPrincipal = deps.resolvePrincipal({ repo_root: input.repo_root, authorization_id: run.principal.authorization_id });
+  exactPrincipal(run.principal, observedPrincipal, deps.authorizationRevision());
+  const budget = deps.readBudget(input.repo_root, run.run_id);
+  if (budget.budget.budget_sha256 !== run.budget_sha256 || !budget.budget.unattended || budget.budget.engineer_id !== run.principal.engineer_id) throw new Error('controller budget does not authorize this exact unattended Engineer run');
+  const room = () => steps < run.policy.maximum_steps_per_invocation && deps.now().getTime() - startedAt < run.policy.maximum_duration_ms;
+  const at = () => deps.now().toISOString();
+
+  if (current.state === 'created' && room()) { current = append(input.repo_root, run.run_id, current, `${input.idempotency_key}:observe`, 'observe', at(), receipt('observe', 'ready')); steps += 1; }
+  if (current.state === 'acquiring' || current.state === 'waiting_for_evidence') {
+    current = append(input.repo_root, run.run_id, current, `${input.idempotency_key}:uncertain`, 'require_reconciliation', at(), receipt('require_reconciliation', 'unresolved_side_effect'), 'operator', 'controller_reconciliation_required'); steps += 1;
+    return Object.freeze({ run_id: run.run_id, current, acquisition, dispatch: dispatched, steps_executed: steps });
+  }
+  if (current.state === 'observing' && room()) {
+    let reservation;
+    try { reservation = deps.reserveBudget({ repo_root: input.repo_root, automation_run_id: run.run_id, expected_budget_sha256: run.budget_sha256, idempotency_key: `${input.idempotency_key}:acquisition`, operation: 'acquisition', unit_kind: 'execute', unit_id: run.run_id, attempt: 1, provider: null }); }
+    catch (error) { if (error instanceof AutomationBudgetStoreError) { current = budgetRefusal(input.repo_root, run.run_id, current, input.idempotency_key, error, at()); return Object.freeze({ run_id: run.run_id, current, acquisition, dispatch: dispatched, steps_executed: steps + 1 }); } throw error; }
+    current = append(input.repo_root, run.run_id, current, `${input.idempotency_key}:begin-acquire`, 'begin_acquire', at(), receipt('begin_acquire', 'reserved', { evidence_refs: [reservation.reservation_sha256] })); steps += 1;
+    try { acquisition = deps.acquireNext({ repo_root: input.repo_root, principal: observedPrincipal, idempotency_key: `${input.idempotency_key}:acquire-next`, max_selection_attempts: input.max_selection_attempts }); }
+    catch (error) { current = append(input.repo_root, run.run_id, current, `${input.idempotency_key}:acquire-unknown`, 'require_reconciliation', at(), receipt('require_reconciliation', 'acquisition_outcome_unknown'), 'operator', 'controller_reconciliation_required'); throw error; }
+    const acquisitionEvidence = evidence(run.run_id, current.current_event_sha256);
+    const usage = deps.appendUsage({ repo_root: input.repo_root, reservation, outcome: acquisition.ok ? 'progress' : 'no_progress', evidence_refs: acquisitionEvidence });
+    if (acquisition.ok) {
+      const envelopeSha = workEnvelopeSha256(acquisition.envelope);
+      current = append(input.repo_root, run.run_id, current, `${input.idempotency_key}:acquired`, 'acquired', at(), receipt('acquired', 'acquired', { work_package_id: acquisition.offer.work_package_id, task_id: acquisition.envelope.task_id, claim_id: acquisition.envelope.claim_id, lease_generation: acquisition.envelope.generation, work_envelope_sha256: envelopeSha, evidence_refs: [acquisition.receipt.receipt_sha256, usage.event.event_sha256] })); steps += 1;
+    } else if (acquisition.error === 'engineer_no_eligible_offer') {
+      current = append(input.repo_root, run.run_id, current, `${input.idempotency_key}:no-offer`, 'retry_wait', at(), receipt('retry_wait', 'no_eligible_offer', { evidence_refs: [usage.event.event_sha256] }), 'none', null, new Date(deps.now().getTime() + run.policy.initial_backoff_ms).toISOString()); steps += 1;
+    } else {
+      current = append(input.repo_root, run.run_id, current, `${input.idempotency_key}:acquire-failed`, 'require_reconciliation', at(), receipt('require_reconciliation', acquisition.error, { evidence_refs: [usage.event.event_sha256] }), 'operator', acquisition.error); steps += 1;
+    }
+  }
+  if (current.state === 'executing' && room()) {
+    if (!input.dispatch_id) return Object.freeze({ run_id: run.run_id, current, acquisition, dispatch: dispatched, steps_executed: steps });
+    let reservation;
+    try { reservation = deps.reserveBudget({ repo_root: input.repo_root, automation_run_id: run.run_id, expected_budget_sha256: run.budget_sha256, idempotency_key: `${input.idempotency_key}:dispatch`, operation: 'dispatch', unit_kind: 'execute', unit_id: run.run_id, attempt: 1, provider: null }); }
+    catch (error) { if (error instanceof AutomationBudgetStoreError) { current = budgetRefusal(input.repo_root, run.run_id, current, input.idempotency_key, error, at()); return Object.freeze({ run_id: run.run_id, current, acquisition, dispatch: dispatched, steps_executed: steps + 1 }); } throw error; }
+    current = append(input.repo_root, run.run_id, current, `${input.idempotency_key}:begin-dispatch`, 'begin_dispatch', at(), receipt('begin_dispatch', 'reserved', { dispatch_id: input.dispatch_id, evidence_refs: [reservation.reservation_sha256] })); steps += 1;
+    try { dispatched = deps.dispatch({ repo_root: input.repo_root, dispatch_id: input.dispatch_id, observed_at: at(), protected_paths: run.protected_paths }); }
+    catch (error) { current = append(input.repo_root, run.run_id, current, `${input.idempotency_key}:dispatch-unknown`, 'require_reconciliation', at(), receipt('require_reconciliation', 'dispatch_outcome_unknown', { dispatch_id: input.dispatch_id }), 'operator', 'controller_reconciliation_required'); throw error; }
+    const outcome = dispatched.current.state === 'completed' ? 'progress' : dispatched.current.state === 'failed' ? 'provider_failure' : 'no_progress';
+    const usage = deps.appendUsage({ repo_root: input.repo_root, reservation, outcome, evidence_refs: evidence(run.run_id, current.current_event_sha256) });
+    if (dispatched.current.state === 'completed') {
+      current = append(input.repo_root, run.run_id, current, `${input.idempotency_key}:dispatch-started`, 'dispatch_started', at(), receipt('dispatch_started', 'completed', { dispatch_id: input.dispatch_id, evidence_refs: [dispatched.current.observation_sha256, usage.event.event_sha256] })); steps += 1;
+      if (room()) { current = append(input.repo_root, run.run_id, current, `${input.idempotency_key}:outcome`, 'outcome_observed', at(), receipt('outcome_observed', 'progress', { dispatch_id: input.dispatch_id, evidence_refs: [dispatched.current.observation_sha256] })); steps += 1; }
+    } else {
+      current = append(input.repo_root, run.run_id, current, `${input.idempotency_key}:dispatch-observed`, 'require_reconciliation', at(), receipt('require_reconciliation', dispatched.current.state, { dispatch_id: input.dispatch_id, evidence_refs: [dispatched.current.observation_sha256, usage.event.event_sha256] }), 'operator', 'controller_reconciliation_required'); steps += 1;
+    }
+  }
+  return Object.freeze({ run_id: run.run_id, current, acquisition, dispatch: dispatched, steps_executed: steps });
+}
+
+export function controllerRunId(input: { readonly repository_id: string; readonly engineer_id: string; readonly budget_sha256: string; readonly idempotency_key: string }): string { return canonicalMessageDigest(input); }

--- a/src/effects/automation/controller-run.ts
+++ b/src/effects/automation/controller-run.ts
@@ -78,8 +78,10 @@ export function startBoundedAutomationController(input: StartBoundedAutomationCo
   const deps = { ...defaultDependencies, ...overrides };
   const principal = deps.resolvePrincipal({ repo_root: input.repo_root, authorization_id: input.authorization_id });
   const authorizationRevision = deps.authorizationRevision();
-  const budget = deps.readBudget(input.repo_root, input.automation_run_id).budget;
+  const budgetStatus = deps.readBudget(input.repo_root, input.automation_run_id);
+  const budget = budgetStatus.budget;
   if (!budget.unattended || budget.automation_run_id !== input.automation_run_id || budget.repository_id !== principal.repository_id || budget.engineer_id !== principal.engineer_id) throw new Error('automation budget does not authorize this exact unattended Engineer controller');
+  if (budgetStatus.current.state !== 'active' || budgetStatus.stop_receipt !== null) throw new Error('automation budget is not active');
   const observedAt = deps.now().toISOString();
   const run = buildAutomationControllerRun({ run_id: input.automation_run_id, repository_id: principal.repository_id, principal: { authorization_id: input.authorization_id, engineer_id: principal.engineer_id, binding_id: principal.binding_id, binding_generation: principal.binding_generation, engineer_contract_revision: principal.engineer_contract_revision, authorization_revision: authorizationRevision }, budget_sha256: budget.budget_sha256, policy: input.policy, protected_paths: input.protected_paths, created_at: observedAt });
   return startAutomationControllerRun({ repo_root: input.repo_root, run, idempotency_key: input.idempotency_key, observed_at: observedAt });

--- a/src/effects/automation/controller-run.ts
+++ b/src/effects/automation/controller-run.ts
@@ -1,4 +1,5 @@
 import { canonicalMessageDigest } from '../../core/messages/mechanics';
+import { buildAutomationControllerRun, type AutomationControllerPolicyV1 } from '../../core/automation/controller';
 import { workEnvelopeSha256, type EngineerPrincipalV1 } from '../../core/engineers/principal-claim';
 import type { AutomationControllerCurrentV1, AutomationControllerOperation, AutomationControllerStepReceiptV1 } from '../../core/automation/controller';
 import {
@@ -10,6 +11,7 @@ import {
 import {
   appendAutomationControllerEvent,
   readAutomationControllerStatus,
+  startAutomationControllerRun,
 } from './controller-store';
 import { resolveEngineerPrincipal } from '../engineers/principal';
 import { acquireNextScheduledEngineerTask, type AcquireNextScheduledEngineerTaskResult } from '../engineers/scheduling-acquire-next';
@@ -43,6 +45,15 @@ export interface AutomationControllerRunDependencies {
   readonly appendUsage: typeof appendAutomationUsage;
 }
 
+export interface StartBoundedAutomationControllerInput {
+  readonly repo_root: string;
+  readonly automation_run_id: string;
+  readonly authorization_id: string;
+  readonly idempotency_key: string;
+  readonly policy: AutomationControllerPolicyV1;
+  readonly protected_paths: readonly string[];
+}
+
 const defaultDependencies: AutomationControllerRunDependencies = {
   now: () => new Date(),
   resolvePrincipal: resolveEngineerPrincipal,
@@ -54,13 +65,41 @@ const defaultDependencies: AutomationControllerRunDependencies = {
   appendUsage: appendAutomationUsage,
 };
 
-function exactPrincipal(expected: ReturnType<typeof readAutomationControllerStatus>['run']['principal'], observed: EngineerPrincipalV1, authorizationRevision: number): void {
-  if (observed.repository_id === '' || observed.engineer_id !== expected.engineer_id
+function exactPrincipal(repositoryId: string, expected: ReturnType<typeof readAutomationControllerStatus>['run']['principal'], observed: EngineerPrincipalV1, authorizationRevision: number): void {
+  if (observed.repository_id !== repositoryId || observed.engineer_id !== expected.engineer_id
     || observed.binding_id !== expected.binding_id || observed.binding_generation !== expected.binding_generation
     || observed.engineer_contract_revision !== expected.engineer_contract_revision
     || observed.auth_subject !== expected.authorization_id || authorizationRevision !== expected.authorization_revision) {
     throw new Error('controller principal, Binding or authorization revision is stale');
   }
+}
+
+export function startBoundedAutomationController(input: StartBoundedAutomationControllerInput, overrides: Partial<AutomationControllerRunDependencies> = {}) {
+  const deps = { ...defaultDependencies, ...overrides };
+  const principal = deps.resolvePrincipal({ repo_root: input.repo_root, authorization_id: input.authorization_id });
+  const authorizationRevision = deps.authorizationRevision();
+  const budget = deps.readBudget(input.repo_root, input.automation_run_id).budget;
+  if (!budget.unattended || budget.automation_run_id !== input.automation_run_id || budget.repository_id !== principal.repository_id || budget.engineer_id !== principal.engineer_id) throw new Error('automation budget does not authorize this exact unattended Engineer controller');
+  const observedAt = deps.now().toISOString();
+  const run = buildAutomationControllerRun({ run_id: input.automation_run_id, repository_id: principal.repository_id, principal: { authorization_id: input.authorization_id, engineer_id: principal.engineer_id, binding_id: principal.binding_id, binding_generation: principal.binding_generation, engineer_contract_revision: principal.engineer_contract_revision, authorization_revision: authorizationRevision }, budget_sha256: budget.budget_sha256, policy: input.policy, protected_paths: input.protected_paths, created_at: observedAt });
+  return startAutomationControllerRun({ repo_root: input.repo_root, run, idempotency_key: input.idempotency_key, observed_at: observedAt });
+}
+
+export function stopAutomationController(repoRoot: string, runId: string, idempotencyKey: string, overrides: Partial<AutomationControllerRunDependencies> = {}) {
+  const deps = { ...defaultDependencies, ...overrides }; const status = readAutomationControllerStatus(repoRoot, runId); let current = status.current;
+  if (['blocked', 'budget_exhausted', 'completed', 'stopped', 'reconciliation_required'].includes(current.state)) return status;
+  const observedAt = deps.now().toISOString();
+  if (current.state !== 'stopping') current = append(repoRoot, runId, current, `${idempotencyKey}:request`, 'request_stop', observedAt, receipt('request_stop', 'requested'));
+  current = append(repoRoot, runId, current, `${idempotencyKey}:stopped`, 'stop', observedAt, receipt('stop', 'stopped'));
+  return Object.freeze({ run: status.run, current });
+}
+
+export function reconcileAutomationController(repoRoot: string, runId: string, idempotencyKey: string, evidenceRefs: readonly string[], overrides: Partial<AutomationControllerRunDependencies> = {}) {
+  const deps = { ...defaultDependencies, ...overrides }; const status = readAutomationControllerStatus(repoRoot, runId); const current = status.current;
+  if (current.state !== 'acquiring' && current.state !== 'waiting_for_evidence' && current.state !== 'executing') return status;
+  if (evidenceRefs.length === 0) throw new Error('controller reconciliation requires exact evidence');
+  const next = append(repoRoot, runId, current, `${idempotencyKey}:reconcile`, 'require_reconciliation', deps.now().toISOString(), receipt('require_reconciliation', 'evidence_requires_operator', { evidence_refs: evidenceRefs }), 'operator', 'controller_reconciliation_required');
+  return Object.freeze({ run: status.run, current: next });
 }
 
 function evidence(runId: string, sha256: string) { return Object.freeze([{ ref: `controller-run:${runId}`, sha256 }]); }
@@ -78,17 +117,24 @@ function budgetRefusal(repoRoot: string, runId: string, current: AutomationContr
   return append(repoRoot, runId, current, `${key}:budget-refusal`, operation, observedAt, receipt(operation, error.code, { evidence_refs: [`automation-budget:${error.code}`] }), exhausted ? 'user' : 'operator', error.refusal?.refusal_code ?? error.code);
 }
 
+function transientAcquisition(result: AcquireNextScheduledEngineerTaskResult): boolean {
+  return !result.ok && (result.error === 'engineer_offer_stale' || result.error === 'engineer_concurrency_unavailable'
+    || (result.error === 'fleet_acquire_failed' && result.fleet?.ok === false && result.fleet.error === 'fleet_acquire_failed'
+      && result.fleet.fleet?.ok === false && (result.fleet.fleet.error === 'offer_stale' || result.fleet.fleet.error === 'claim_failed')));
+}
+
 export function stepAutomationController(input: StepAutomationControllerInput, overrides: Partial<AutomationControllerRunDependencies> = {}): AutomationControllerStepResult {
   const deps = { ...defaultDependencies, ...overrides }; const status = readAutomationControllerStatus(input.repo_root, input.run_id); const run = status.run;
   const startedAt = deps.now().getTime(); let current = status.current; let steps = 0; let acquisition: AcquireNextScheduledEngineerTaskResult | null = null; let dispatched: DelegatedRunStatus | null = null;
   const observedPrincipal = deps.resolvePrincipal({ repo_root: input.repo_root, authorization_id: run.principal.authorization_id });
-  exactPrincipal(run.principal, observedPrincipal, deps.authorizationRevision());
+  exactPrincipal(run.repository_id, run.principal, observedPrincipal, deps.authorizationRevision());
   const budget = deps.readBudget(input.repo_root, run.run_id);
   if (budget.budget.budget_sha256 !== run.budget_sha256 || !budget.budget.unattended || budget.budget.engineer_id !== run.principal.engineer_id) throw new Error('controller budget does not authorize this exact unattended Engineer run');
   const room = () => steps < run.policy.maximum_steps_per_invocation && deps.now().getTime() - startedAt < run.policy.maximum_duration_ms;
   const at = () => deps.now().toISOString();
 
   if (current.state === 'created' && room()) { current = append(input.repo_root, run.run_id, current, `${input.idempotency_key}:observe`, 'observe', at(), receipt('observe', 'ready')); steps += 1; }
+  if (current.state === 'observing' && current.retry_at !== null && Date.parse(current.retry_at) > deps.now().getTime()) return Object.freeze({ run_id: run.run_id, current, acquisition, dispatch: dispatched, steps_executed: steps });
   if (current.state === 'acquiring' || current.state === 'waiting_for_evidence') {
     current = append(input.repo_root, run.run_id, current, `${input.idempotency_key}:uncertain`, 'require_reconciliation', at(), receipt('require_reconciliation', 'unresolved_side_effect'), 'operator', 'controller_reconciliation_required'); steps += 1;
     return Object.freeze({ run_id: run.run_id, current, acquisition, dispatch: dispatched, steps_executed: steps });
@@ -106,7 +152,15 @@ export function stepAutomationController(input: StepAutomationControllerInput, o
       const envelopeSha = workEnvelopeSha256(acquisition.envelope);
       current = append(input.repo_root, run.run_id, current, `${input.idempotency_key}:acquired`, 'acquired', at(), receipt('acquired', 'acquired', { work_package_id: acquisition.offer.work_package_id, task_id: acquisition.envelope.task_id, claim_id: acquisition.envelope.claim_id, lease_generation: acquisition.envelope.generation, work_envelope_sha256: envelopeSha, evidence_refs: [acquisition.receipt.receipt_sha256, usage.event.event_sha256] })); steps += 1;
     } else if (acquisition.error === 'engineer_no_eligible_offer') {
-      current = append(input.repo_root, run.run_id, current, `${input.idempotency_key}:no-offer`, 'retry_wait', at(), receipt('retry_wait', 'no_eligible_offer', { evidence_refs: [usage.event.event_sha256] }), 'none', null, new Date(deps.now().getTime() + run.policy.initial_backoff_ms).toISOString()); steps += 1;
+      current = append(input.repo_root, run.run_id, current, `${input.idempotency_key}:no-offer`, 'no_offer', at(), receipt('no_offer', 'no_eligible_offer', { evidence_refs: [usage.event.event_sha256] })); steps += 1;
+    } else if (transientAcquisition(acquisition)) {
+      const nextAttempt = current.consecutive_transient_failures + 1;
+      if (nextAttempt > run.policy.maximum_transient_retries) current = append(input.repo_root, run.run_id, current, `${input.idempotency_key}:retry-exhausted`, 'block', at(), receipt('block', 'transient_retry_exhausted', { evidence_refs: [usage.event.event_sha256] }), 'operator', 'transient_retry_exhausted');
+      else {
+        const delay = Math.min(run.policy.maximum_backoff_ms, run.policy.initial_backoff_ms * (2 ** (nextAttempt - 1)));
+        current = append(input.repo_root, run.run_id, current, `${input.idempotency_key}:retry-${nextAttempt}`, 'retry_wait', at(), receipt('retry_wait', acquisition.error, { evidence_refs: [usage.event.event_sha256] }), 'none', null, new Date(deps.now().getTime() + delay).toISOString());
+      }
+      steps += 1;
     } else {
       current = append(input.repo_root, run.run_id, current, `${input.idempotency_key}:acquire-failed`, 'require_reconciliation', at(), receipt('require_reconciliation', acquisition.error, { evidence_refs: [usage.event.event_sha256] }), 'operator', acquisition.error); steps += 1;
     }

--- a/src/effects/automation/controller-store.ts
+++ b/src/effects/automation/controller-store.ts
@@ -53,6 +53,15 @@ function parse<T>(path: string, validate: (value: unknown) => T, canonical: (val
   if (!raw.equals(Buffer.from(`${canonical(value)}\n`, 'utf8'))) fail('automation_controller_conflict', `${path} is not canonical`); return value;
 }
 function current(value: ReturnType<typeof paths>): AutomationControllerCurrentV1 | null { return existsSync(value.current) ? parse(value.current, validateAutomationControllerCurrent, canonicalAutomationControllerCurrentBytes) : null; }
+function assertNoUnfoldedEvent(value: ReturnType<typeof paths>, runId: string, previous: AutomationControllerCurrentV1 | null): void {
+  const directory = join(value.root, 'events');
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    if (!entry.isFile() || !/^[0-9a-f]{64}\.json$/u.test(entry.name)) fail('automation_controller_unsafe_path', `unexpected controller event entry: ${entry.name}`);
+    const event = parse(join(directory, entry.name), validateAutomationControllerEvent, canonicalAutomationControllerEventBytes);
+    if (event.run_id === runId && event.previous_event_sha256 === (previous?.current_event_sha256 ?? null)
+      && event.event_sha256 !== previous?.current_event_sha256) fail('automation_controller_persistence_failed', 'controller has a durable event not folded into current; replay its exact idempotency key');
+  }
+}
 
 export interface AppendAutomationControllerEventInput {
   readonly repo_root: string;
@@ -85,6 +94,7 @@ function appendLocked(value: ReturnType<typeof paths>, run: AutomationController
   }
   const expected = previous?.current_sha256 ?? null;
   if (input.expected_current_sha256 !== expected) fail('automation_controller_conflict', `controller current changed: expected ${input.expected_current_sha256 ?? 'absent'}, found ${expected ?? 'absent'}`);
+  assertNoUnfoldedEvent(value, run.run_id, previous);
   const event = buildAutomationControllerEvent({ run_id: run.run_id, revision: (previous?.revision ?? 0) + 1, idempotency_key: input.idempotency_key, operation: input.operation, previous_state: previous?.state ?? null, attention_owner: input.attention_owner, blocker: input.blocker, retry_at: input.retry_at, receipt: input.receipt, observed_at: input.observed_at, previous_event_sha256: previous?.current_event_sha256 ?? null });
   const bytes = Buffer.from(`${canonicalAutomationControllerEventBytes(event)}\n`, 'utf8'); immutable(join(value.root, 'events', `${shaName(event.event_sha256)}.json`), bytes); immutable(transitionPath, bytes); input.crash_hook?.('after_event_fsync');
   const next = foldAutomationControllerCurrent(run, previous, event); atomic(value.current, Buffer.from(`${canonicalAutomationControllerCurrentBytes(next)}\n`, 'utf8')); input.crash_hook?.('after_current_fsync'); return Object.freeze({ event, current: next });
@@ -114,10 +124,14 @@ export function appendAutomationControllerEvent(input: AppendAutomationControlle
 }
 
 export function readAutomationControllerStatus(repoRootInput: string, runId: string): { readonly run: AutomationControllerRunV1; readonly current: AutomationControllerCurrentV1 } {
-  const value = paths(resolve(repoRootInput), runId); if (!existsSync(value.definition) || !existsSync(value.current)) fail('automation_controller_not_found', 'controller run is missing'); return Object.freeze({ run: parse(value.definition, validateAutomationControllerRun, canonicalAutomationControllerRunBytes), current: current(value)! });
+  const value = paths(resolve(repoRootInput), runId); if (!existsSync(value.definition) || !existsSync(value.current)) fail('automation_controller_not_found', 'controller run is missing');
+  const run = parse(value.definition, validateAutomationControllerRun, canonicalAutomationControllerRunBytes); const projection = current(value)!;
+  if (projection.run_id !== run.run_id || projection.run_sha256 !== run.run_sha256 || !existsSync(join(value.root, 'events', `${shaName(projection.current_event_sha256)}.json`))) fail('automation_controller_conflict', 'controller current does not resolve to its exact run and durable event');
+  return Object.freeze({ run, current: projection });
 }
 
 export function listAutomationControllerRuns(repoRootInput: string): readonly ReturnType<typeof readAutomationControllerStatus>[] {
   const repoRoot = resolve(repoRootInput); const root = join(resolveGitCommonDirectory(repoRoot), ROOT, 'runs'); if (!existsSync(root)) return Object.freeze([]);
-  return Object.freeze(readdirSync(root, { withFileTypes: true }).filter((entry) => entry.isDirectory() && /^[0-9a-f]{64}$/u.test(entry.name)).map((entry) => readAutomationControllerStatus(repoRoot, `sha256:${entry.name}`)).sort((left, right) => left.run.created_at.localeCompare(right.run.created_at) || left.run.run_id.localeCompare(right.run.run_id)));
+  const entries = readdirSync(root, { withFileTypes: true }); if (entries.some((entry) => !entry.isDirectory() || !/^[0-9a-f]{64}$/u.test(entry.name))) fail('automation_controller_unsafe_path', 'controller run store contains an unexpected entry');
+  return Object.freeze(entries.map((entry) => readAutomationControllerStatus(repoRoot, `sha256:${entry.name}`)).sort((left, right) => left.run.created_at.localeCompare(right.run.created_at) || left.run.run_id.localeCompare(right.run.run_id)));
 }

--- a/src/effects/automation/controller-store.ts
+++ b/src/effects/automation/controller-store.ts
@@ -1,0 +1,116 @@
+import { createHash, randomUUID } from 'crypto';
+import { closeSync, constants, existsSync, fsyncSync, lstatSync, mkdirSync, openSync, readFileSync, readdirSync, renameSync, writeSync } from 'fs';
+import { dirname, join, resolve } from 'path';
+
+import {
+  buildAutomationControllerEvent,
+  canonicalAutomationControllerCurrentBytes,
+  canonicalAutomationControllerEventBytes,
+  canonicalAutomationControllerRunBytes,
+  foldAutomationControllerCurrent,
+  validateAutomationControllerCurrent,
+  validateAutomationControllerEvent,
+  validateAutomationControllerRun,
+  type AutomationControllerAttentionOwner,
+  type AutomationControllerCurrentV1,
+  type AutomationControllerEventV1,
+  type AutomationControllerOperation,
+  type AutomationControllerRunV1,
+  type AutomationControllerStepReceiptV1,
+} from '../../core/automation/controller';
+import { resolveGitCommonDirectory } from '../git/common-directory';
+import { withExclusiveDirectoryLock } from '../locking/exclusive-directory-lock';
+
+const ROOT = 'repo-harness/automation-controllers/v1';
+const RUN_ID = /^sha256:[0-9a-f]{64}$/u;
+
+export class AutomationControllerStoreError extends Error {
+  constructor(readonly code: 'automation_controller_not_found' | 'automation_controller_conflict' | 'automation_controller_unsafe_path' | 'automation_controller_persistence_failed', message: string, readonly cause?: unknown) {
+    super(message); this.name = 'AutomationControllerStoreError';
+  }
+}
+
+function fail(code: AutomationControllerStoreError['code'], message: string, cause?: unknown): never { throw new AutomationControllerStoreError(code, message, cause); }
+function safeRunId(value: string): string { if (!RUN_ID.test(value)) fail('automation_controller_unsafe_path', 'controller run_id is invalid'); return value; }
+function fileKey(value: string): string { return createHash('sha256').update(value, 'utf8').digest('hex'); }
+function shaName(value: string): string { if (!/^sha256:[0-9a-f]{64}$/u.test(value)) fail('automation_controller_unsafe_path', 'digest is invalid'); return value.slice(7); }
+function paths(repoRoot: string, runId: string) {
+  const common = resolveGitCommonDirectory(repoRoot); const root = join(common, ROOT); const name = safeRunId(runId).slice(7); const run = join(root, 'runs', name);
+  return { common, root, run, definition: join(run, 'run.json'), current: join(run, 'current.json'), lock: `${ROOT}/locks/runs/${name}.lock` };
+}
+function ensure(path: string): void { mkdirSync(path, { recursive: true, mode: 0o700 }); const stat = lstatSync(path); if (!stat.isDirectory() || stat.isSymbolicLink()) fail('automation_controller_unsafe_path', `unsafe controller directory: ${path}`); }
+function prepare(value: ReturnType<typeof paths>): void { for (const path of [value.root, join(value.root, 'runs'), join(value.root, 'events'), join(value.root, 'transitions'), join(value.root, 'engineers'), value.run]) ensure(path); }
+function regular(path: string): Buffer { const stat = lstatSync(path); if (!stat.isFile() || stat.isSymbolicLink()) fail('automation_controller_unsafe_path', `unsafe controller file: ${path}`); return readFileSync(path); }
+function atomic(path: string, bytes: Buffer): void {
+  ensure(dirname(path)); const temp = join(dirname(path), `.${process.pid}.${randomUUID()}.tmp`); let fd: number;
+  try { fd = openSync(temp, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY | constants.O_NOFOLLOW, 0o600); } catch (error) { return fail('automation_controller_persistence_failed', `cannot create controller temporary for ${path}`, error); }
+  try { let offset = 0; while (offset < bytes.length) offset += writeSync(fd, bytes, offset, bytes.length - offset); fsyncSync(fd); } finally { closeSync(fd); }
+  try { renameSync(temp, path); const directory = openSync(dirname(path), constants.O_RDONLY); try { fsyncSync(directory); } finally { closeSync(directory); } } catch (error) { fail('automation_controller_persistence_failed', `cannot publish controller file ${path}`, error); }
+}
+function immutable(path: string, bytes: Buffer): void { if (existsSync(path)) { if (!regular(path).equals(bytes)) fail('automation_controller_conflict', `${path} names different immutable bytes`); return; } atomic(path, bytes); }
+function parse<T>(path: string, validate: (value: unknown) => T, canonical: (value: T) => string): T {
+  const raw = regular(path); let value: T; try { value = validate(JSON.parse(raw.toString('utf8'))); } catch (error) { return fail('automation_controller_conflict', `${path} is invalid`, error); }
+  if (!raw.equals(Buffer.from(`${canonical(value)}\n`, 'utf8'))) fail('automation_controller_conflict', `${path} is not canonical`); return value;
+}
+function current(value: ReturnType<typeof paths>): AutomationControllerCurrentV1 | null { return existsSync(value.current) ? parse(value.current, validateAutomationControllerCurrent, canonicalAutomationControllerCurrentBytes) : null; }
+
+export interface AppendAutomationControllerEventInput {
+  readonly repo_root: string;
+  readonly run_id: string;
+  readonly expected_current_sha256: string | null;
+  readonly idempotency_key: string;
+  readonly operation: AutomationControllerOperation;
+  readonly attention_owner: AutomationControllerAttentionOwner;
+  readonly blocker: string | null;
+  readonly retry_at: string | null;
+  readonly receipt: AutomationControllerStepReceiptV1;
+  readonly observed_at: string;
+  readonly crash_hook?: (boundary: 'after_event_fsync' | 'after_current_fsync') => void;
+}
+
+function appendLocked(value: ReturnType<typeof paths>, run: AutomationControllerRunV1, input: AppendAutomationControllerEventInput): { readonly event: AutomationControllerEventV1; readonly current: AutomationControllerCurrentV1 } {
+  prepare(value); const previous = current(value); const transitionPath = join(value.root, 'transitions', `${fileKey(`${run.run_id}\0${input.idempotency_key}`)}.json`);
+  if (existsSync(transitionPath)) {
+    const stored = parse(transitionPath, validateAutomationControllerEvent, canonicalAutomationControllerEventBytes);
+    const candidate = buildAutomationControllerEvent({ run_id: run.run_id, revision: stored.revision, idempotency_key: input.idempotency_key, operation: input.operation, previous_state: stored.previous_state, attention_owner: input.attention_owner, blocker: input.blocker, retry_at: input.retry_at, receipt: input.receipt, observed_at: input.observed_at, previous_event_sha256: stored.previous_event_sha256 });
+    if (candidate.event_sha256 !== stored.event_sha256) fail('automation_controller_conflict', 'controller idempotency key names another operation');
+    if (previous?.current_event_sha256 === stored.event_sha256) return Object.freeze({ event: stored, current: previous });
+    if ((previous?.current_sha256 ?? null) === input.expected_current_sha256
+      && stored.previous_event_sha256 === (previous?.current_event_sha256 ?? null)) {
+      const repaired = foldAutomationControllerCurrent(run, previous, stored);
+      atomic(value.current, Buffer.from(`${canonicalAutomationControllerCurrentBytes(repaired)}\n`, 'utf8'));
+      return Object.freeze({ event: stored, current: repaired });
+    }
+    fail('automation_controller_conflict', 'persisted controller event is not the current chain head');
+  }
+  const expected = previous?.current_sha256 ?? null;
+  if (input.expected_current_sha256 !== expected) fail('automation_controller_conflict', `controller current changed: expected ${input.expected_current_sha256 ?? 'absent'}, found ${expected ?? 'absent'}`);
+  const event = buildAutomationControllerEvent({ run_id: run.run_id, revision: (previous?.revision ?? 0) + 1, idempotency_key: input.idempotency_key, operation: input.operation, previous_state: previous?.state ?? null, attention_owner: input.attention_owner, blocker: input.blocker, retry_at: input.retry_at, receipt: input.receipt, observed_at: input.observed_at, previous_event_sha256: previous?.current_event_sha256 ?? null });
+  const bytes = Buffer.from(`${canonicalAutomationControllerEventBytes(event)}\n`, 'utf8'); immutable(join(value.root, 'events', `${shaName(event.event_sha256)}.json`), bytes); immutable(transitionPath, bytes); input.crash_hook?.('after_event_fsync');
+  const next = foldAutomationControllerCurrent(run, previous, event); atomic(value.current, Buffer.from(`${canonicalAutomationControllerCurrentBytes(next)}\n`, 'utf8')); input.crash_hook?.('after_current_fsync'); return Object.freeze({ event, current: next });
+}
+
+export function startAutomationControllerRun(input: { readonly repo_root: string; readonly run: AutomationControllerRunV1; readonly idempotency_key: string; readonly observed_at: string; readonly crash_hook?: AppendAutomationControllerEventInput['crash_hook'] }): { readonly run: AutomationControllerRunV1; readonly event: AutomationControllerEventV1; readonly current: AutomationControllerCurrentV1 } {
+  const repoRoot = resolve(input.repo_root); const run = validateAutomationControllerRun(input.run); const value = paths(repoRoot, run.run_id);
+  return withExclusiveDirectoryLock(value.common, `${ROOT}/locks/engineers/${fileKey(run.principal.engineer_id)}.lock`, () => withExclusiveDirectoryLock(value.common, value.lock, () => {
+    prepare(value); const bytes = Buffer.from(`${canonicalAutomationControllerRunBytes(run)}\n`, 'utf8'); immutable(value.definition, bytes);
+    const pointer = join(value.root, 'engineers', `${fileKey(run.principal.engineer_id)}.json`);
+    if (existsSync(pointer)) { const active = regular(pointer).toString('utf8').trim(); if (active !== run.run_id) fail('automation_controller_conflict', `Engineer already has controller run ${active}`); } else atomic(pointer, Buffer.from(`${run.run_id}\n`, 'utf8'));
+    const result = appendLocked(value, run, { repo_root: repoRoot, run_id: run.run_id, expected_current_sha256: null, idempotency_key: input.idempotency_key, operation: 'start', attention_owner: 'none', blocker: null, retry_at: null, receipt: { operation: 'start', outcome: 'created', work_package_id: null, task_id: null, claim_id: null, lease_generation: null, work_envelope_sha256: null, dispatch_id: null, runtime_effect_id: null, evidence_refs: [] }, observed_at: input.observed_at, crash_hook: input.crash_hook });
+    return Object.freeze({ run, ...result });
+  }, { reclaimStaleEmptyDirectory: true, reclaimStaleOwner: true }), { reclaimStaleEmptyDirectory: true, reclaimStaleOwner: true });
+}
+
+export function appendAutomationControllerEvent(input: AppendAutomationControllerEventInput): { readonly run: AutomationControllerRunV1; readonly event: AutomationControllerEventV1; readonly current: AutomationControllerCurrentV1 } {
+  const repoRoot = resolve(input.repo_root); const value = paths(repoRoot, input.run_id);
+  return withExclusiveDirectoryLock(value.common, value.lock, () => { if (!existsSync(value.definition)) fail('automation_controller_not_found', 'controller run is missing'); const run = parse(value.definition, validateAutomationControllerRun, canonicalAutomationControllerRunBytes); return Object.freeze({ run, ...appendLocked(value, run, input) }); }, { reclaimStaleEmptyDirectory: true, reclaimStaleOwner: true });
+}
+
+export function readAutomationControllerStatus(repoRootInput: string, runId: string): { readonly run: AutomationControllerRunV1; readonly current: AutomationControllerCurrentV1 } {
+  const value = paths(resolve(repoRootInput), runId); if (!existsSync(value.definition) || !existsSync(value.current)) fail('automation_controller_not_found', 'controller run is missing'); return Object.freeze({ run: parse(value.definition, validateAutomationControllerRun, canonicalAutomationControllerRunBytes), current: current(value)! });
+}
+
+export function listAutomationControllerRuns(repoRootInput: string): readonly ReturnType<typeof readAutomationControllerStatus>[] {
+  const repoRoot = resolve(repoRootInput); const root = join(resolveGitCommonDirectory(repoRoot), ROOT, 'runs'); if (!existsSync(root)) return Object.freeze([]);
+  return Object.freeze(readdirSync(root, { withFileTypes: true }).filter((entry) => entry.isDirectory() && /^[0-9a-f]{64}$/u.test(entry.name)).map((entry) => readAutomationControllerStatus(repoRoot, `sha256:${entry.name}`)).sort((left, right) => left.run.created_at.localeCompare(right.run.created_at) || left.run.run_id.localeCompare(right.run.run_id)));
+}

--- a/src/effects/automation/controller-store.ts
+++ b/src/effects/automation/controller-store.ts
@@ -95,7 +95,14 @@ export function startAutomationControllerRun(input: { readonly repo_root: string
   return withExclusiveDirectoryLock(value.common, `${ROOT}/locks/engineers/${fileKey(run.principal.engineer_id)}.lock`, () => withExclusiveDirectoryLock(value.common, value.lock, () => {
     prepare(value); const bytes = Buffer.from(`${canonicalAutomationControllerRunBytes(run)}\n`, 'utf8'); immutable(value.definition, bytes);
     const pointer = join(value.root, 'engineers', `${fileKey(run.principal.engineer_id)}.json`);
-    if (existsSync(pointer)) { const active = regular(pointer).toString('utf8').trim(); if (active !== run.run_id) fail('automation_controller_conflict', `Engineer already has controller run ${active}`); } else atomic(pointer, Buffer.from(`${run.run_id}\n`, 'utf8'));
+    if (existsSync(pointer)) {
+      const active = regular(pointer).toString('utf8').trim();
+      if (active !== run.run_id) {
+        const prior = readAutomationControllerStatus(repoRoot, active);
+        if (!['blocked', 'budget_exhausted', 'completed', 'stopped', 'reconciliation_required'].includes(prior.current.state)) fail('automation_controller_conflict', `Engineer already has controller run ${active}`);
+        atomic(pointer, Buffer.from(`${run.run_id}\n`, 'utf8'));
+      }
+    } else atomic(pointer, Buffer.from(`${run.run_id}\n`, 'utf8'));
     const result = appendLocked(value, run, { repo_root: repoRoot, run_id: run.run_id, expected_current_sha256: null, idempotency_key: input.idempotency_key, operation: 'start', attention_owner: 'none', blocker: null, retry_at: null, receipt: { operation: 'start', outcome: 'created', work_package_id: null, task_id: null, claim_id: null, lease_generation: null, work_envelope_sha256: null, dispatch_id: null, runtime_effect_id: null, evidence_refs: [] }, observed_at: input.observed_at, crash_hook: input.crash_hook });
     return Object.freeze({ run, ...result });
   }, { reclaimStaleEmptyDirectory: true, reclaimStaleOwner: true }), { reclaimStaleEmptyDirectory: true, reclaimStaleOwner: true });

--- a/tasks/waivers/20260904-issue-279-controller.json
+++ b/tasks/waivers/20260904-issue-279-controller.json
@@ -1,0 +1,25 @@
+{
+  "protocol": 1,
+  "kind": "repo-harness-substantive-change-waiver",
+  "substantive_change_sha256": "sha256:2db29e25cac199834d23e640afec55a70aa1ab50fdde9574796128997e9704ac",
+  "reason": "Issue #279 is a zero-ceremony bounded controller implementation with complete source, architecture and test evidence but no work-package plan or contract; this waiver binds the exact final substantive diff required by the repository sync gate.",
+  "owner": "ancienttwo",
+  "scope": [
+    ".archcontext/model/flows/flow.automation-controller.acquire-dispatch.yaml",
+    ".archcontext/model/nodes/capability.runtime-harness.automation-budget.yaml",
+    ".archcontext/model/nodes/component.automation-controller.journal.yaml",
+    ".archcontext/model/relations/relation.automation-controller.journal.yaml",
+    "docs/architecture/modules/runtime-harness/automation-budget.md",
+    "src/cli/commands/automation.ts",
+    "src/core/automation/controller.ts",
+    "src/effects/automation/controller-run.ts",
+    "src/effects/automation/controller-store.ts",
+    "tests/architecture-projection-e2e.test.ts",
+    "tests/cli/automation-controller.test.ts",
+    "tests/unit/collaboration-authority-baseline.test.ts",
+    "tests/unit/issue-279-automation-controller-core.test.ts",
+    "tests/unit/issue-279-automation-controller-run.test.ts",
+    "tests/unit/issue-279-automation-controller-store.test.ts"
+  ],
+  "revisit_trigger": "Issue #279 or PR #303 is reopened because its controller contract lacks durable workflow evidence"
+}

--- a/tests/architecture-projection-e2e.test.ts
+++ b/tests/architecture-projection-e2e.test.ts
@@ -27,15 +27,15 @@ describe("AXR7 repo-harness architecture consumer", () => {
     const flows = yamlFiles(join(modelRoot, "flows"));
 
     expect(capabilities).toHaveLength(25);
-    expect(components).toHaveLength(25);
+    expect(components).toHaveLength(26);
     // C4 declared the collaboration -> delegated-runs relation and the
     // delegated-contribution flow; C6 adds the collaboration -> bound-task-freezes
     // relation its read-time succession proof crosses, and the context-delivery
     // flow. Both counts are inventory pins: a legitimate model addition is a red
     // test until the pin moves with it, which is the point. Multiple flows per
     // capability was already the norm.
-    expect(relations).toHaveLength(49);
-    expect(flows).toHaveLength(31);
+    expect(relations).toHaveLength(50);
+    expect(flows).toHaveLength(32);
     expect(flows.every((flow) => flow.schemaVersion === "archcontext.flow/v1")).toBe(true);
     expect(flows.every((flow) => flow.applicability === "required")).toBe(true);
     expect(new Set(flows.map((flow) => flow.capabilityId))).toEqual(new Set(capabilities.map((node) => node.id)));

--- a/tests/cli/automation-controller.test.ts
+++ b/tests/cli/automation-controller.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { spawnSync } from 'child_process';
+
+const ROOT = join(import.meta.dir, '../..');
+const CLI = join(ROOT, 'src/cli/index.ts');
+function repo(): string { const root = mkdtempSync(join(tmpdir(), 'controller-cli-')); spawnSync('git', ['init', '-q'], { cwd: root }); return root; }
+
+describe('automation controller CLI', () => {
+  test('exposes the bounded start, step, status, stop and reconcile surface', () => {
+    const result = spawnSync('bun', [CLI, 'automation', 'controller', '--help'], { cwd: ROOT, encoding: 'utf8' });
+    expect(result.status).toBe(0);
+    for (const command of ['start', 'step', 'status', 'stop', 'reconcile']) expect(result.stdout).toContain(command);
+  });
+
+  test('status list is JSON and an unknown exact run fails with a typed JSON error', () => {
+    const root = repo();
+    try {
+      const list = spawnSync('bun', [CLI, 'automation', 'controller', 'status'], { cwd: root, encoding: 'utf8' });
+      expect(list.status).toBe(0); expect(JSON.parse(list.stdout)).toEqual([]);
+      const missing = spawnSync('bun', [CLI, 'automation', 'controller', 'status', '--run', `sha256:${'a'.repeat(64)}`], { cwd: root, encoding: 'utf8' });
+      expect(missing.status).toBe(1); expect(JSON.parse(missing.stderr).error).toBe('automation_controller_not_found');
+    } finally { rmSync(root, { recursive: true, force: true }); }
+  });
+});

--- a/tests/unit/collaboration-authority-baseline.test.ts
+++ b/tests/unit/collaboration-authority-baseline.test.ts
@@ -346,6 +346,11 @@ interface ExcludedModule {
  */
 const DELIBERATELY_EXCLUDED: readonly ExcludedModule[] = [
   {
+    module: 'src/core/automation/controller.ts',
+    fails: ['C-1', 'C-2'],
+    evidence: 'automation orchestration evidence plane (issue #279): journals bounded observations and calls existing acquire/dispatch authorities, but grants no claim, moves no lease generation, and publishes or accepts nothing',
+  },
+  {
     /**
      * The automation cost plane (issue #282). It fails C-1 because a budget is
      * none of the five planes C0 froze: it owns spend, not Task/Claim, Lease,

--- a/tests/unit/issue-279-automation-controller-core.test.ts
+++ b/tests/unit/issue-279-automation-controller-core.test.ts
@@ -30,6 +30,7 @@ function run() {
       initial_backoff_ms: 500,
       maximum_backoff_ms: 8_000,
     },
+    protected_paths: ['plans', 'tasks'],
     created_at: '2026-09-04T00:00:00.000Z',
   });
 }

--- a/tests/unit/issue-279-automation-controller-core.test.ts
+++ b/tests/unit/issue-279-automation-controller-core.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  AutomationControllerError,
+  buildAutomationControllerEvent,
+  buildAutomationControllerRun,
+  foldAutomationControllerCurrent,
+  nextAutomationControllerState,
+} from '../../src/core/automation/controller';
+
+const SHA = `sha256:${'a'.repeat(64)}`;
+const RUN_ID = `sha256:${'b'.repeat(64)}`;
+
+function run() {
+  return buildAutomationControllerRun({
+    run_id: RUN_ID,
+    repository_id: 'repo_0123456789abcdef',
+    principal: {
+      authorization_id: 'authorization-1',
+      engineer_id: 'engineer:capability.runtime-harness.automation',
+      binding_id: '11111111-1111-4111-8111-111111111111',
+      binding_generation: 3,
+      engineer_contract_revision: SHA,
+      authorization_revision: 7,
+    },
+    budget_sha256: SHA,
+    policy: {
+      maximum_steps_per_invocation: 8,
+      maximum_duration_ms: 60_000,
+      maximum_transient_retries: 3,
+      initial_backoff_ms: 500,
+      maximum_backoff_ms: 8_000,
+    },
+    created_at: '2026-09-04T00:00:00.000Z',
+  });
+}
+
+function event(
+  operation: Parameters<typeof buildAutomationControllerEvent>[0]['operation'],
+  revision: number,
+  previous: ReturnType<typeof foldAutomationControllerCurrent> | null,
+  extra: Partial<Parameters<typeof buildAutomationControllerEvent>[0]> = {},
+) {
+  return buildAutomationControllerEvent({
+    run_id: RUN_ID,
+    revision,
+    idempotency_key: `step-${revision}`,
+    operation,
+    previous_state: previous?.state ?? null,
+    attention_owner: 'none',
+    blocker: null,
+    retry_at: null,
+    receipt: {
+      operation,
+      outcome: 'ok',
+      work_package_id: null,
+      task_id: null,
+      claim_id: null,
+      lease_generation: null,
+      work_envelope_sha256: null,
+      dispatch_id: null,
+      runtime_effect_id: null,
+      evidence_refs: [],
+    },
+    observed_at: `2026-09-04T00:00:0${revision}.000Z`,
+    previous_event_sha256: previous?.current_event_sha256 ?? null,
+    ...extra,
+  });
+}
+
+describe('issue #279 automation controller core', () => {
+  test('freezes the principal, budget and bounded invocation policy', () => {
+    const value = run();
+    expect(value.run_sha256).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(value.policy.maximum_steps_per_invocation).toBe(8);
+    expect(() => buildAutomationControllerRun({ ...value, policy: { ...value.policy, maximum_steps_per_invocation: 65 } })).toThrow('<= 64');
+    expect(() => buildAutomationControllerRun({ ...value, policy: { ...value.policy, maximum_backoff_ms: 100 } })).toThrow('must be >=');
+  });
+
+  test('walks observation through one exact acquisition and dispatch evidence boundary', () => {
+    const definition = run();
+    let current = foldAutomationControllerCurrent(definition, null, event('start', 1, null));
+    current = foldAutomationControllerCurrent(definition, current, event('observe', 2, current));
+    current = foldAutomationControllerCurrent(definition, current, event('begin_acquire', 3, current));
+    const acquired = event('acquired', 4, current, {
+      receipt: {
+        operation: 'acquired', outcome: 'acquired', work_package_id: 'wp-1', task_id: 'c'.repeat(64),
+        claim_id: '22222222-2222-4222-8222-222222222222', lease_generation: 1,
+        work_envelope_sha256: SHA, dispatch_id: null, runtime_effect_id: null, evidence_refs: [`work-envelope:${SHA}`],
+      },
+    });
+    current = foldAutomationControllerCurrent(definition, current, acquired);
+    expect(current.state).toBe('executing');
+    current = foldAutomationControllerCurrent(definition, current, event('dispatch_started', 5, current, {
+      receipt: { ...acquired.receipt, operation: 'dispatch_started', outcome: 'started', dispatch_id: SHA },
+    }));
+    expect(current.state).toBe('waiting_for_evidence');
+  });
+
+  test('user blockers terminate without entering a retry state', () => {
+    const definition = run();
+    let current = foldAutomationControllerCurrent(definition, null, event('start', 1, null));
+    current = foldAutomationControllerCurrent(definition, current, event('observe', 2, current));
+    current = foldAutomationControllerCurrent(definition, current, event('block', 3, current, {
+      attention_owner: 'user', blocker: 'approval_required', receipt: {
+        operation: 'block', outcome: 'user_blocked', work_package_id: null, task_id: null,
+        claim_id: null, lease_generation: null, work_envelope_sha256: null, dispatch_id: null,
+        runtime_effect_id: null, evidence_refs: ['blocker:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'],
+      },
+    }));
+    expect(current.state).toBe('blocked');
+    expect(() => nextAutomationControllerState('blocked', 'retry_wait')).toThrow(AutomationControllerError);
+  });
+
+  test('explicit stop cannot silently discard an uncertain side effect', () => {
+    expect(nextAutomationControllerState('observing', 'request_stop')).toBe('stopping');
+    expect(nextAutomationControllerState('stopping', 'stop')).toBe('stopped');
+    expect(nextAutomationControllerState('executing', 'request_stop')).toBe('stopping');
+    expect(nextAutomationControllerState('executing', 'require_reconciliation')).toBe('reconciliation_required');
+    expect(() => nextAutomationControllerState('executing', 'stop')).toThrow('cannot stop');
+  });
+
+  test('folding rejects a stale or forked event chain', () => {
+    const definition = run();
+    const first = foldAutomationControllerCurrent(definition, null, event('start', 1, null));
+    expect(() => foldAutomationControllerCurrent(definition, first, event('observe', 3, first))).toThrow('does not extend');
+  });
+});

--- a/tests/unit/issue-279-automation-controller-run.test.ts
+++ b/tests/unit/issue-279-automation-controller-run.test.ts
@@ -6,7 +6,7 @@ import { spawnSync } from 'child_process';
 
 import { buildAutomationControllerRun } from '../../src/core/automation/controller';
 import { startAutomationControllerRun } from '../../src/effects/automation/controller-store';
-import { stepAutomationController } from '../../src/effects/automation/controller-run';
+import { stepAutomationController, stopAutomationController } from '../../src/effects/automation/controller-run';
 
 const SHA = `sha256:${'a'.repeat(64)}`;
 const RUN_ID = `sha256:${'b'.repeat(64)}`;
@@ -63,6 +63,34 @@ describe('issue #279 bounded controller orchestration', () => {
       expect((error as Error).message).toContain('crash');
       const recovered = stepAutomationController({ repo_root: root, run_id: RUN_ID, idempotency_key: 'step-2' }, dependencies({ ok: false }));
       expect(recovered.current.state).toBe('reconciliation_required');
+    } finally { rmSync(root, { recursive: true, force: true }); }
+  });
+
+  test('transient acquisition failures persist deterministic bounded backoff and then stop', () => {
+    const { root } = setup(); let now = 1_000; let calls = 0; let reservation = 0;
+    const deps = {
+      ...dependencies({ ok: false }), now: () => new Date(Date.parse('2026-09-04T00:00:00.000Z') + now),
+      acquireNext: () => { calls += 1; return { ok: false, error: 'engineer_concurrency_unavailable', message: 'busy' } as never; },
+      reserveBudget: () => ({ reservation_sha256: `sha256:${String(++reservation).padStart(64, '0')}` }) as never,
+    };
+    try {
+      const first = stepAutomationController({ repo_root: root, run_id: RUN_ID, idempotency_key: 'retry-1' }, deps);
+      expect(first.current.state).toBe('observing'); expect(first.current.consecutive_transient_failures).toBe(1); expect(calls).toBe(1);
+      stepAutomationController({ repo_root: root, run_id: RUN_ID, idempotency_key: 'too-early' }, deps); expect(calls).toBe(1);
+      now += 100;
+      const second = stepAutomationController({ repo_root: root, run_id: RUN_ID, idempotency_key: 'retry-2' }, deps); expect(second.current.consecutive_transient_failures).toBe(2);
+      now += 200;
+      const third = stepAutomationController({ repo_root: root, run_id: RUN_ID, idempotency_key: 'retry-3' }, deps); expect(third.current.state).toBe('blocked'); expect(third.current.blocker).toBe('transient_retry_exhausted');
+    } finally { rmSync(root, { recursive: true, force: true }); }
+  });
+
+  test('explicit stop prevents later acquisition without releasing work authority', () => {
+    const { root } = setup(); let calls = 0;
+    try {
+      const stopped = stopAutomationController(root, RUN_ID, 'stop-1', { now: () => new Date('2026-09-04T00:00:02.000Z') });
+      expect(stopped.current.state).toBe('stopped');
+      const result = stepAutomationController({ repo_root: root, run_id: RUN_ID, idempotency_key: 'after-stop' }, { ...dependencies({ ok: false }), acquireNext: () => { calls += 1; return { ok: false } as never; } });
+      expect(result.current.state).toBe('stopped'); expect(calls).toBe(0);
     } finally { rmSync(root, { recursive: true, force: true }); }
   });
 });

--- a/tests/unit/issue-279-automation-controller-run.test.ts
+++ b/tests/unit/issue-279-automation-controller-run.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { spawnSync } from 'child_process';
+
+import { buildAutomationControllerRun } from '../../src/core/automation/controller';
+import { startAutomationControllerRun } from '../../src/effects/automation/controller-store';
+import { stepAutomationController } from '../../src/effects/automation/controller-run';
+
+const SHA = `sha256:${'a'.repeat(64)}`;
+const RUN_ID = `sha256:${'b'.repeat(64)}`;
+const principal = {
+  protocol: 1, kind: 'repo-harness-engineer-principal', repository_id: 'repo_0123456789abcdef',
+  engineer_id: 'engineer:capability.runtime-harness.automation', binding_id: '11111111-1111-4111-8111-111111111111',
+  binding_generation: 1, engineer_contract_revision: SHA, carrier: 'mcp_oauth', auth_subject: 'authorization-1',
+  provider: 'tmux-cli-agent', provider_thread_id: null,
+} as const;
+
+function setup() {
+  const root = mkdtempSync(join(tmpdir(), 'controller-run-')); spawnSync('git', ['init', '-q'], { cwd: root });
+  const run = buildAutomationControllerRun({ run_id: RUN_ID, repository_id: principal.repository_id,
+    principal: { authorization_id: principal.auth_subject, engineer_id: principal.engineer_id, binding_id: principal.binding_id, binding_generation: 1, engineer_contract_revision: SHA, authorization_revision: 7 }, budget_sha256: SHA,
+    policy: { maximum_steps_per_invocation: 8, maximum_duration_ms: 10_000, maximum_transient_retries: 2, initial_backoff_ms: 100, maximum_backoff_ms: 1_000 }, protected_paths: ['plans', 'tasks'], created_at: '2026-09-04T00:00:00.000Z' });
+  startAutomationControllerRun({ repo_root: root, run, idempotency_key: 'start', observed_at: run.created_at }); return { root, run };
+}
+
+function dependencies(acquire: unknown, dispatch: unknown = null) {
+  let reservation = 0;
+  return {
+    now: () => new Date('2026-09-04T00:00:01.000Z'), resolvePrincipal: () => principal as never,
+    authorizationRevision: () => 7,
+    readBudget: () => ({ budget: { budget_sha256: SHA, unattended: true, engineer_id: principal.engineer_id }, current: {}, stored_current: {}, stop_receipt: null, drift: 'none', latest_record_at: null }) as never,
+    reserveBudget: () => ({ reservation_sha256: `sha256:${String(++reservation).padStart(64, '0')}` }) as never,
+    appendUsage: () => ({ event: { event_sha256: `sha256:${'e'.repeat(64)}` }, current: {}, stop_receipt: null }) as never,
+    acquireNext: () => acquire as never, dispatch: () => dispatch as never,
+  };
+}
+
+describe('issue #279 bounded controller orchestration', () => {
+  test('persists acquisition before consuming a real WorkEnvelope and dispatches only through the fenced dependency', () => {
+    const { root } = setup();
+    try {
+      const acquired = { ok: true, offer: { work_package_id: 'wp-1' }, envelope: { protocol: 1, kind: 'repo-harness-work-envelope', repo_id: principal.repository_id, task_id: 'c'.repeat(64), task_revision: 'd'.repeat(64), sprint_path: 'plans/sprints/test.sprint.md', claim_id: '22222222-2222-4222-8222-222222222222', generation: 1, worktree_path: root, branch: 'codex/test', unit_ref: 'unit', authorization_revision: 7, offer_revision: SHA, canonical_target: {}, plan: {}, claim_token: {} }, receipt: { receipt_sha256: SHA } };
+      const first = stepAutomationController({ repo_root: root, run_id: RUN_ID, idempotency_key: 'step-1' }, dependencies(acquired));
+      expect(first.current.state).toBe('executing');
+      expect(first.acquisition?.ok).toBe(true);
+      let dispatchCalls = 0;
+      const dispatched = { current: { state: 'completed', observation_sha256: SHA } };
+      const second = stepAutomationController({ repo_root: root, run_id: RUN_ID, idempotency_key: 'step-2', dispatch_id: SHA }, { ...dependencies(acquired, dispatched), dispatch: () => { dispatchCalls += 1; return dispatched as never; } });
+      expect(dispatchCalls).toBe(1);
+      expect(second.current.state).toBe('observing');
+    } finally { rmSync(root, { recursive: true, force: true }); }
+  });
+
+  test('an unresolved persisted acquisition boundary becomes reconciliation_required instead of claiming twice', () => {
+    const { root } = setup();
+    try {
+      const deps = dependencies({ ok: false, error: 'engineer_no_eligible_offer', message: 'none' });
+      const first = stepAutomationController({ repo_root: root, run_id: RUN_ID, idempotency_key: 'step-1' }, { ...deps, acquireNext: () => { throw new Error('crash after side effect boundary'); } });
+      expect(first).toBeUndefined();
+    } catch (error) {
+      expect((error as Error).message).toContain('crash');
+      const recovered = stepAutomationController({ repo_root: root, run_id: RUN_ID, idempotency_key: 'step-2' }, dependencies({ ok: false }));
+      expect(recovered.current.state).toBe('reconciliation_required');
+    } finally { rmSync(root, { recursive: true, force: true }); }
+  });
+});

--- a/tests/unit/issue-279-automation-controller-run.test.ts
+++ b/tests/unit/issue-279-automation-controller-run.test.ts
@@ -30,7 +30,7 @@ function dependencies(acquire: unknown, dispatch: unknown = null) {
   return {
     now: () => new Date('2026-09-04T00:00:01.000Z'), resolvePrincipal: () => principal as never,
     authorizationRevision: () => 7,
-    readBudget: () => ({ budget: { budget_sha256: SHA, unattended: true, engineer_id: principal.engineer_id }, current: {}, stored_current: {}, stop_receipt: null, drift: 'none', latest_record_at: null }) as never,
+    readBudget: () => ({ budget: { budget_sha256: SHA, unattended: true, engineer_id: principal.engineer_id }, current: { state: 'active' }, stored_current: {}, stop_receipt: null, drift: 'none', latest_record_at: null }) as never,
     reserveBudget: () => ({ reservation_sha256: `sha256:${String(++reservation).padStart(64, '0')}` }) as never,
     appendUsage: () => ({ event: { event_sha256: `sha256:${'e'.repeat(64)}` }, current: {}, stop_receipt: null }) as never,
     acquireNext: () => acquire as never, dispatch: () => dispatch as never,

--- a/tests/unit/issue-279-automation-controller-store.test.ts
+++ b/tests/unit/issue-279-automation-controller-store.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { spawnSync } from 'child_process';
+
+import { buildAutomationControllerRun } from '../../src/core/automation/controller';
+import {
+  AutomationControllerStoreError,
+  appendAutomationControllerEvent,
+  readAutomationControllerStatus,
+  startAutomationControllerRun,
+} from '../../src/effects/automation/controller-store';
+
+const SHA = `sha256:${'a'.repeat(64)}`;
+function fixture(): string { const root = mkdtempSync(join(tmpdir(), 'controller-store-')); spawnSync('git', ['init', '-q'], { cwd: root }); return root; }
+function definition(runId = `sha256:${'b'.repeat(64)}`) {
+  return buildAutomationControllerRun({
+    run_id: runId, repository_id: 'repo_0123456789abcdef',
+    principal: { authorization_id: 'authorization-1', engineer_id: 'engineer:capability.runtime-harness.automation', binding_id: '11111111-1111-4111-8111-111111111111', binding_generation: 1, engineer_contract_revision: SHA, authorization_revision: 1 },
+    budget_sha256: SHA,
+    policy: { maximum_steps_per_invocation: 4, maximum_duration_ms: 10_000, maximum_transient_retries: 2, initial_backoff_ms: 100, maximum_backoff_ms: 1_000 },
+    created_at: '2026-09-04T00:00:00.000Z',
+  });
+}
+function emptyReceipt(operation: 'observe') { return { operation, outcome: 'observed', work_package_id: null, task_id: null, claim_id: null, lease_generation: null, work_envelope_sha256: null, dispatch_id: null, runtime_effect_id: null, evidence_refs: [] } as const; }
+
+describe('issue #279 automation controller store', () => {
+  test('same-key start is idempotent and one Engineer has one current controller', () => {
+    const root = fixture();
+    try {
+      const first = startAutomationControllerRun({ repo_root: root, run: definition(), idempotency_key: 'start-1', observed_at: '2026-09-04T00:00:00.000Z' });
+      const replay = startAutomationControllerRun({ repo_root: root, run: definition(), idempotency_key: 'start-1', observed_at: '2026-09-04T00:00:00.000Z' });
+      expect(replay.current.current_sha256).toBe(first.current.current_sha256);
+      expect(() => startAutomationControllerRun({ repo_root: root, run: definition(`sha256:${'c'.repeat(64)}`), idempotency_key: 'start-2', observed_at: '2026-09-04T00:00:01.000Z' })).toThrow(AutomationControllerStoreError);
+    } finally { rmSync(root, { recursive: true, force: true }); }
+  });
+
+  test('event-first crash repairs the same exact chain and stale CAS cannot fork it', () => {
+    const root = fixture();
+    try {
+      const started = startAutomationControllerRun({ repo_root: root, run: definition(), idempotency_key: 'start-1', observed_at: '2026-09-04T00:00:00.000Z' });
+      const input = { repo_root: root, run_id: started.run.run_id, expected_current_sha256: started.current.current_sha256, idempotency_key: 'observe-1', operation: 'observe' as const, attention_owner: 'none' as const, blocker: null, retry_at: null, receipt: emptyReceipt('observe'), observed_at: '2026-09-04T00:00:01.000Z' };
+      expect(() => appendAutomationControllerEvent({ ...input, crash_hook: (point) => { if (point === 'after_event_fsync') throw new Error('crash'); } })).toThrow('crash');
+      expect(readAutomationControllerStatus(root, started.run.run_id).current.state).toBe('created');
+      const repaired = appendAutomationControllerEvent(input);
+      expect(repaired.current.state).toBe('observing');
+      expect(appendAutomationControllerEvent(input).current.current_sha256).toBe(repaired.current.current_sha256);
+      expect(() => appendAutomationControllerEvent({ ...input, idempotency_key: 'observe-2' })).toThrow('controller current changed');
+    } finally { rmSync(root, { recursive: true, force: true }); }
+  });
+});

--- a/tests/unit/issue-279-automation-controller-store.test.ts
+++ b/tests/unit/issue-279-automation-controller-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { mkdtempSync, rmSync } from 'fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { spawnSync } from 'child_process';
@@ -34,6 +34,19 @@ describe('issue #279 automation controller store', () => {
       const replay = startAutomationControllerRun({ repo_root: root, run: definition(), idempotency_key: 'start-1', observed_at: '2026-09-04T00:00:00.000Z' });
       expect(replay.current.current_sha256).toBe(first.current.current_sha256);
       expect(() => startAutomationControllerRun({ repo_root: root, run: definition(`sha256:${'c'.repeat(64)}`), idempotency_key: 'start-2', observed_at: '2026-09-04T00:00:01.000Z' })).toThrow(AutomationControllerStoreError);
+    } finally { rmSync(root, { recursive: true, force: true }); }
+  });
+
+  test('two processes starting controllers for one Engineer elect exactly one run', async () => {
+    const root = fixture();
+    try {
+      const modulePath = join(import.meta.dir, '../../src/effects/automation/controller-store.ts');
+      const inputPaths = [definition(), definition(`sha256:${'c'.repeat(64)}`)].map((run, index) => {
+        const path = join(root, `input-${index}.json`); writeFileSync(path, JSON.stringify({ repo_root: root, run, idempotency_key: `start-${index}`, observed_at: '2026-09-04T00:00:00.000Z' })); return path;
+      });
+      const script = `import {readFileSync} from 'fs'; import {startAutomationControllerRun} from ${JSON.stringify(modulePath)}; try { startAutomationControllerRun(JSON.parse(readFileSync(process.argv[1],'utf8'))); process.stdout.write('won'); } catch (e) { process.stdout.write('lost'); }`;
+      const results = await Promise.all(inputPaths.map(async (path) => { const child = Bun.spawn(['bun', '-e', script, path], { stdout: 'pipe', stderr: 'pipe' }); return { code: await child.exited, text: await new Response(child.stdout).text() }; }));
+      expect(results.map((result) => result.text).sort()).toEqual(['lost', 'won']);
     } finally { rmSync(root, { recursive: true, force: true }); }
   });
 

--- a/tests/unit/issue-279-automation-controller-store.test.ts
+++ b/tests/unit/issue-279-automation-controller-store.test.ts
@@ -57,6 +57,7 @@ describe('issue #279 automation controller store', () => {
       const input = { repo_root: root, run_id: started.run.run_id, expected_current_sha256: started.current.current_sha256, idempotency_key: 'observe-1', operation: 'observe' as const, attention_owner: 'none' as const, blocker: null, retry_at: null, receipt: emptyReceipt('observe'), observed_at: '2026-09-04T00:00:01.000Z' };
       expect(() => appendAutomationControllerEvent({ ...input, crash_hook: (point) => { if (point === 'after_event_fsync') throw new Error('crash'); } })).toThrow('crash');
       expect(readAutomationControllerStatus(root, started.run.run_id).current.state).toBe('created');
+      expect(() => appendAutomationControllerEvent({ ...input, idempotency_key: 'observe-2' })).toThrow('durable event not folded');
       const repaired = appendAutomationControllerEvent(input);
       expect(repaired.current.state).toBe('observing');
       expect(appendAutomationControllerEvent(input).current.current_sha256).toBe(repaired.current.current_sha256);

--- a/tests/unit/issue-279-automation-controller-store.test.ts
+++ b/tests/unit/issue-279-automation-controller-store.test.ts
@@ -20,6 +20,7 @@ function definition(runId = `sha256:${'b'.repeat(64)}`) {
     principal: { authorization_id: 'authorization-1', engineer_id: 'engineer:capability.runtime-harness.automation', binding_id: '11111111-1111-4111-8111-111111111111', binding_generation: 1, engineer_contract_revision: SHA, authorization_revision: 1 },
     budget_sha256: SHA,
     policy: { maximum_steps_per_invocation: 4, maximum_duration_ms: 10_000, maximum_transient_retries: 2, initial_backoff_ms: 100, maximum_backoff_ms: 1_000 },
+    protected_paths: ['plans', 'tasks'],
     created_at: '2026-09-04T00:00:00.000Z',
   });
 }


### PR DESCRIPTION
Adds a repository-owned bounded controller over the existing Engineer offer, Fleet acquisition, WorkEnvelope, delegated-run, and automation-budget authorities.

The controller persists a canonical append-only journal with CAS/idempotency, exact principal and budget fences, bounded transient backoff, explicit stop/reconciliation states, and crash-safe event-first recovery. The CLI exposes `automation controller start|step|status|stop|reconcile` as JSON adapters.

Validation:
- 18 focused controller, CLI, and architecture tests pass
- `bunx tsc --noEmit`
- architecture, workflow, SQL-order, project-state, and init dry-run checks pass

Closes #279
