### PR TITLE
Fix acceptance finalization evidence idempotence

### DIFF
--- a/assets/templates/helpers/verify-sprint.sh
+++ b/assets/templates/helpers/verify-sprint.sh
@@ -913,7 +913,7 @@ fi
 
 finalize_prepared_acceptance() {
   local acceptance_row acceptance_exit acceptance_status acceptance_reviewer acceptance_source acceptance_disposition acceptance_message
-  local finalized_checks change_assessment_file=".ai/harness/checks/change-assessment.latest.json"
+  local finalized_checks prepared_run_file change_assessment_file=".ai/harness/checks/change-assessment.latest.json"
 
   [[ -n "$BUN_BIN" && -x "$BUN_BIN" ]] || { echo "verify-sprint: trusted Bun runtime is unavailable" >&2; return 1; }
   [[ -f "$helper_dir/acceptance-receipt.ts" ]] || { echo "verify-sprint: AcceptanceReceipt helper is missing: $helper_dir/acceptance-receipt.ts" >&2; return 1; }
@@ -942,6 +942,51 @@ finalize_prepared_acceptance() {
     external_pass|user_waiver) ;;
     *) echo "verify-sprint: AcceptanceReceipt disposition is not a closeout state: $acceptance_disposition" >&2; return 1 ;;
   esac
+
+  if jq -e \
+    --arg reviewer "$acceptance_reviewer" \
+    --arg source "$acceptance_source" \
+    --arg disposition "$acceptance_disposition" \
+    '
+      .acceptance_receipt.status == "pass"
+      and .acceptance_receipt.disposition == $disposition
+      and .acceptance_receipt.reviewer == $reviewer
+      and .acceptance_receipt.source == $source
+      and ([.guards[] | select(.name == "acceptance_receipt" and .status == "pass")] | length == 1)
+    ' "$checks_file" >/dev/null 2>&1; then
+    echo "Sprint acceptance already finalized for the receipt-bound evidence"
+    echo "Prepared evidence: $checks_file"
+    return 0
+  fi
+
+  prepared_run_file="$(jq -r '.run_file // empty' "$checks_file")"
+  case "$prepared_run_file" in
+    .ai/harness/runs/*.json) ;;
+    *) echo "verify-sprint: prepared run snapshot path is missing or unsafe" >&2; return 1 ;;
+  esac
+  [[ "$prepared_run_file" != *"/../"* && "$prepared_run_file" != ../* && "$prepared_run_file" != */.. ]] || {
+    echo "verify-sprint: prepared run snapshot path contains traversal" >&2
+    return 1
+  }
+  [[ -f "$prepared_run_file" && ! -L "$prepared_run_file" ]] || {
+    echo "verify-sprint: prepared run snapshot is missing or is a symlink: $prepared_run_file" >&2
+    return 1
+  }
+  jq -e --arg snapshot "$prepared_run_file" --slurpfile prepared "$checks_file" '
+    .source == "verify-sprint"
+    and .status == "pass"
+    and .exit_code == 0
+    and .run_file == $snapshot
+    and .lifecycle.snapshot == $snapshot
+    and .review_subject_sha256 == $prepared[0].review_subject_sha256
+    and .contract.file == $prepared[0].contract.file
+    and .change_assessment == $prepared[0].change_assessment
+    and (.commands | type == "array")
+    and ([.commands[] | select(.status != "pass" or .exit_code != 0)] | length == 0)
+  ' "$prepared_run_file" >/dev/null 2>&1 || {
+    echo "verify-sprint: immutable prepared run snapshot does not match the receipt-bound evidence" >&2
+    return 1
+  }
 
   REPO_HARNESS_TARGET_REPO_ROOT="$(pwd -P)" "$BUN_BIN" "$helper_dir/acceptance-receipt.ts" project \
     --contract "$contract_file" --verification "$checks_file" --review "$review_file" >/dev/null
@@ -974,7 +1019,7 @@ finalize_prepared_acceptance() {
       }
       | .guards = [.guards[] | if .name == "acceptance_receipt" then .status = "pass" else . end]
       | .next_step = "finish contract worktree or archive completed task"
-    ' "$checks_file" > "$finalized_checks"
+    ' "$prepared_run_file" > "$finalized_checks"
   echo "Sprint acceptance finalized without rerunning verification"
   echo "Prepared evidence: $checks_file"
   set +e
@@ -983,7 +1028,13 @@ finalize_prepared_acceptance() {
   set -e
   rm -f "$finalized_checks"
   case "$emit_exit" in
-    0) : ;;
+    0)
+      REPO_HARNESS_TARGET_REPO_ROOT="$(pwd -P)" "$BUN_BIN" "$helper_dir/acceptance-receipt.ts" verify \
+        --contract "$contract_file" --verification "$checks_file" --format row >/dev/null || {
+        echo "verify-sprint: finalized evidence no longer matches the AcceptanceReceipt" >&2
+        return 1
+      }
+      ;;
     3) : ;;
     *) echo "verify-sprint: evidence emission failed" >&2; return 1 ;;
   esac

--- a/plans/plan-20260904-0517-acceptance-redaction-idempotence.md
+++ b/plans/plan-20260904-0517-acceptance-redaction-idempotence.md
@@ -1,0 +1,152 @@
+# Plan: Acceptance redaction idempotence
+
+> **Status**: Executing
+> **Created**: 20260904-0517
+> **Slug**: acceptance-redaction-idempotence
+> **Planning Source**: codex-plan
+> **Orchestration Kind**: host-plan
+> **Source Ref**: (none)
+> **Artifact Level**: work-package
+> **Promotion Reason**: AcceptanceReceipt publication authority is broken across prepare and finalize, directly blocking a verified BYOK release unit.
+> **Verification Boundary**: Focused acceptance-receipt regression plus the repository root required checks on the exact frozen subject.
+> **Rollback Surface**: Revert the command-canonicalization helper, packaged mirror, focused tests, and this workflow package together.
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260904-0517-acceptance-redaction-idempotence.contract.md`
+> **Task Review**: `tasks/reviews/20260904-0517-acceptance-redaction-idempotence.review.md`
+> **Implementation Notes**: `tasks/notes/20260904-0517-acceptance-redaction-idempotence.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from codex-plan planning output.
+- Source ref: (none)
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260904-0517-acceptance-redaction-idempotence.md`
+- Sprint contract: `tasks/contracts/20260904-0517-acceptance-redaction-idempotence.contract.md`
+- Sprint review: `tasks/reviews/20260904-0517-acceptance-redaction-idempotence.review.md`
+- Implementation notes: `tasks/notes/20260904-0517-acceptance-redaction-idempotence.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260904-0517-acceptance-redaction-idempotence.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260904-0517-acceptance-redaction-idempotence.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260904-0517-acceptance-redaction-idempotence.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260904-0517-acceptance-redaction-idempotence.contract.md`
+- Review file: `tasks/reviews/20260904-0517-acceptance-redaction-idempotence.review.md`
+- Implementation notes file: `tasks/notes/20260904-0517-acceptance-redaction-idempotence.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260904-0517-acceptance-redaction-idempotence.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260904-0517-acceptance-redaction-idempotence.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: Revert the command-canonicalization helper, packaged mirror, focused tests, and this workflow package together.
+- **Verification boundary**: Focused acceptance-receipt regression plus the repository root required checks on the exact frozen subject.
+- **Review/acceptance boundary**: `tasks/reviews/20260904-0517-acceptance-redaction-idempotence.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: AcceptanceReceipt publication authority is broken across prepare and finalize, directly blocking a verified BYOK release unit.
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260904-0517-acceptance-redaction-idempotence.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260904-0517-acceptance-redaction-idempotence.contract.md`, `tasks/reviews/20260904-0517-acceptance-redaction-idempotence.review.md`, and `tasks/notes/20260904-0517-acceptance-redaction-idempotence.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260904-0517-acceptance-redaction-idempotence.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: Revert the command-canonicalization helper, packaged mirror, focused tests, and this workflow package together.
+
+## Captured Planning Output
+
+## Goal
+
+Restore AcceptanceReceipt stability when `verify-sprint` finalization re-emits already-redacted command evidence. The same semantic verification run must retain one canonical fingerprint across prepare, receipt record, final verify, archive, and ship.
+
+## P1 Architecture Map
+
+- `src/core/evidence/redaction.ts` owns persisted evidence redaction.
+- `scripts/verify-sprint.sh` prepares and later finalizes acceptance evidence, including materialized command records.
+- `scripts/acceptance-receipt.ts` owns the canonical verification-evidence fingerprint used by receipt freshness checks; its packaged mirror is `assets/templates/helpers/acceptance-receipt.ts`.
+- AcceptanceReceipt freshness is the publication authority. Storage redaction remains security authority and is out of scope unless the regression proves canonicalization cannot solve the issue.
+- Out of scope: weakening secret detection, accepting stale receipts, changing BYOK product code, or adding compatibility/fallback semantics.
+
+## P2 Concrete Trace
+
+1. A focused verifier command containing `real-server-longpoll-stall-dedup` is persisted.
+2. Evidence redaction replaces the high-entropy substring with `sha256:<digest>`.
+3. `acceptance-receipt record` fingerprints the materialized `commands` field containing that marker.
+4. Final `verify-sprint` re-emits the already-materialized checks object.
+5. Redaction hashes the embedded digest again, producing `sha256:sha256:<digest>`.
+6. Receipt verification fingerprints a different command string and rejects the otherwise unchanged subject as stale.
+
+Error boundary: any semantic command change, status change, subject change, or non-redaction evidence change must still invalidate the receipt.
+
+## P3 Decision Rationale
+
+Keep persisted-event redaction and the full AcceptanceReceipt `commands` fingerprint unchanged. Finalization must replay the immutable raw run snapshot referenced by the already receipt-verified projection, validate that snapshot against the frozen subject/contract/assessment, and stop emitting when the same evidence is already finalized. This preserves the existing authorities instead of hiding producer drift in canonicalization.
+
+At 10x scale the first pressure point is command-array volume, but normalization is linear in the already-bounded canonical payload and introduces no additional I/O or authority.
+
+## Allowed Paths
+
+- `scripts/verify-sprint.sh`
+- `assets/templates/helpers/verify-sprint.sh`
+- `tests/evidence-projection-drift.test.ts`
+- plan, contract, review, notes, and generated workflow state for this work-package
+
+## Acceptance Criteria
+
+- A regression test reproduces single-hash to double-hash re-materialization and proves finalization instead replays the raw snapshot to produce the original single-redacted command.
+- Repeated finalization produces no divergent accepted event.
+- The raw snapshot is validated against the receipt-bound subject, contract, and Change Assessment before emission.
+- Source and packaged helper remain byte-aligned through the repository's canonical sync mechanism.
+- Focused tests and all root required checks pass on the exact subject.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [x] Add the repeated-finalization projection regression guard for re-redacted command markers.
+- [x] Implement immutable prepared-snapshot replay and idempotent finalization, then sync the packaged helper mirror.
+- [x] Run focused tests and inspect the exact diff for security-boundary preservation.
+- [x] Run the repository's full required checks and bind acceptance to the frozen subject.
+- [ ] Publish the fix through a reviewed PR, merge it, and use the fixed source-bound harness to unblock BYOK Step 4a publication.

--- a/scripts/verify-sprint.sh
+++ b/scripts/verify-sprint.sh
@@ -913,7 +913,7 @@ fi
 
 finalize_prepared_acceptance() {
   local acceptance_row acceptance_exit acceptance_status acceptance_reviewer acceptance_source acceptance_disposition acceptance_message
-  local finalized_checks change_assessment_file=".ai/harness/checks/change-assessment.latest.json"
+  local finalized_checks prepared_run_file change_assessment_file=".ai/harness/checks/change-assessment.latest.json"
 
   [[ -n "$BUN_BIN" && -x "$BUN_BIN" ]] || { echo "verify-sprint: trusted Bun runtime is unavailable" >&2; return 1; }
   [[ -f "$helper_dir/acceptance-receipt.ts" ]] || { echo "verify-sprint: AcceptanceReceipt helper is missing: $helper_dir/acceptance-receipt.ts" >&2; return 1; }
@@ -942,6 +942,51 @@ finalize_prepared_acceptance() {
     external_pass|user_waiver) ;;
     *) echo "verify-sprint: AcceptanceReceipt disposition is not a closeout state: $acceptance_disposition" >&2; return 1 ;;
   esac
+
+  if jq -e \
+    --arg reviewer "$acceptance_reviewer" \
+    --arg source "$acceptance_source" \
+    --arg disposition "$acceptance_disposition" \
+    '
+      .acceptance_receipt.status == "pass"
+      and .acceptance_receipt.disposition == $disposition
+      and .acceptance_receipt.reviewer == $reviewer
+      and .acceptance_receipt.source == $source
+      and ([.guards[] | select(.name == "acceptance_receipt" and .status == "pass")] | length == 1)
+    ' "$checks_file" >/dev/null 2>&1; then
+    echo "Sprint acceptance already finalized for the receipt-bound evidence"
+    echo "Prepared evidence: $checks_file"
+    return 0
+  fi
+
+  prepared_run_file="$(jq -r '.run_file // empty' "$checks_file")"
+  case "$prepared_run_file" in
+    .ai/harness/runs/*.json) ;;
+    *) echo "verify-sprint: prepared run snapshot path is missing or unsafe" >&2; return 1 ;;
+  esac
+  [[ "$prepared_run_file" != *"/../"* && "$prepared_run_file" != ../* && "$prepared_run_file" != */.. ]] || {
+    echo "verify-sprint: prepared run snapshot path contains traversal" >&2
+    return 1
+  }
+  [[ -f "$prepared_run_file" && ! -L "$prepared_run_file" ]] || {
+    echo "verify-sprint: prepared run snapshot is missing or is a symlink: $prepared_run_file" >&2
+    return 1
+  }
+  jq -e --arg snapshot "$prepared_run_file" --slurpfile prepared "$checks_file" '
+    .source == "verify-sprint"
+    and .status == "pass"
+    and .exit_code == 0
+    and .run_file == $snapshot
+    and .lifecycle.snapshot == $snapshot
+    and .review_subject_sha256 == $prepared[0].review_subject_sha256
+    and .contract.file == $prepared[0].contract.file
+    and .change_assessment == $prepared[0].change_assessment
+    and (.commands | type == "array")
+    and ([.commands[] | select(.status != "pass" or .exit_code != 0)] | length == 0)
+  ' "$prepared_run_file" >/dev/null 2>&1 || {
+    echo "verify-sprint: immutable prepared run snapshot does not match the receipt-bound evidence" >&2
+    return 1
+  }
 
   REPO_HARNESS_TARGET_REPO_ROOT="$(pwd -P)" "$BUN_BIN" "$helper_dir/acceptance-receipt.ts" project \
     --contract "$contract_file" --verification "$checks_file" --review "$review_file" >/dev/null
@@ -974,7 +1019,7 @@ finalize_prepared_acceptance() {
       }
       | .guards = [.guards[] | if .name == "acceptance_receipt" then .status = "pass" else . end]
       | .next_step = "finish contract worktree or archive completed task"
-    ' "$checks_file" > "$finalized_checks"
+    ' "$prepared_run_file" > "$finalized_checks"
   echo "Sprint acceptance finalized without rerunning verification"
   echo "Prepared evidence: $checks_file"
   set +e
@@ -983,7 +1028,13 @@ finalize_prepared_acceptance() {
   set -e
   rm -f "$finalized_checks"
   case "$emit_exit" in
-    0) : ;;
+    0)
+      REPO_HARNESS_TARGET_REPO_ROOT="$(pwd -P)" "$BUN_BIN" "$helper_dir/acceptance-receipt.ts" verify \
+        --contract "$contract_file" --verification "$checks_file" --format row >/dev/null || {
+        echo "verify-sprint: finalized evidence no longer matches the AcceptanceReceipt" >&2
+        return 1
+      }
+      ;;
     3) : ;;
     *) echo "verify-sprint: evidence emission failed" >&2; return 1 ;;
   esac

--- a/tasks/contracts/20260904-0517-acceptance-redaction-idempotence.contract.md
+++ b/tasks/contracts/20260904-0517-acceptance-redaction-idempotence.contract.md
@@ -86,6 +86,7 @@ allowed_paths:
   - assets/templates/helpers/verify-sprint.sh
   - tests/evidence-projection-drift.test.ts
   - tests/helper-scripts.test.ts
+  - docs/architecture/.projection-manifest.json
 ```
 
 ## Evidence Requirements

--- a/tasks/contracts/20260904-0517-acceptance-redaction-idempotence.contract.md
+++ b/tasks/contracts/20260904-0517-acceptance-redaction-idempotence.contract.md
@@ -87,6 +87,13 @@ allowed_paths:
   - tests/evidence-projection-drift.test.ts
   - tests/helper-scripts.test.ts
   - docs/architecture/.projection-manifest.json
+  - docs/architecture/changelog.md
+  - docs/architecture/decisions/index.md
+  - docs/architecture/diagrams/architecture.likec4
+  - docs/architecture/diagrams/architecture.mmd
+  - docs/architecture/diagrams/architecture.structurizr.json
+  - docs/architecture/index.md
+  - docs/architecture/modules/public-surface/root-router.md
 ```
 
 ## Evidence Requirements

--- a/tasks/contracts/20260904-0517-acceptance-redaction-idempotence.contract.md
+++ b/tasks/contracts/20260904-0517-acceptance-redaction-idempotence.contract.md
@@ -154,7 +154,7 @@ exit_criteria:
     - bash scripts/check-deploy-sql-order.sh
     - bash scripts/check-architecture-sync.sh
     - bash scripts/check-task-sync.sh
-    - repo-harness run check-task-workflow --strict
+    - bun src/cli/index.ts run check-task-workflow --strict
     - bun scripts/inspect-project-state.ts --repo . --format text
     - bun src/cli/index.ts init --repo . --dry-run
 # Optional exact-subject reuse is fail-closed and opt-in. List only deterministic

--- a/tasks/contracts/20260904-0517-acceptance-redaction-idempotence.contract.md
+++ b/tasks/contracts/20260904-0517-acceptance-redaction-idempotence.contract.md
@@ -1,0 +1,170 @@
+# Task Contract: acceptance-redaction-idempotence
+
+> **Status**: Active
+> **Plan**: plans/plan-20260904-0517-acceptance-redaction-idempotence.md
+> **Task Profile**: bugfix
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: kito
+> **Capability ID**: root
+> **Last Updated**: 2026-09-04 05:17
+> **Review File**: `tasks/reviews/20260904-0517-acceptance-redaction-idempotence.review.md`
+> **Notes File**: `tasks/notes/20260904-0517-acceptance-redaction-idempotence.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+`verify-sprint` finalization re-emits already-redacted command evidence. The evidence writer then hashes an embedded redaction digest a second time, so an exact frozen subject loses its valid AcceptanceReceipt during the publication path. This currently blocks BYOK Step 4a after its full verification and acceptance have passed.
+
+## Goal
+
+Make `verify-sprint` finalization replay the immutable prepared run snapshot so repeated finalization preserves the exact receipt-bound command semantics and does not re-redact a materialized projection.
+
+## Scope
+
+- In scope:
+  - Resolve and validate the immutable prepared run snapshot referenced by the receipt-verified checks projection.
+  - Build the acceptance overlay from that raw snapshot, not from `.ai/harness/checks/latest.json`.
+  - Make repeated finalization a no-op once the same receipt-bound evidence is already finalized.
+  - Keep the source helper and packaged helper mirror synchronized.
+- Out of scope:
+  - weakening secret detection, accepting stale receipts, changing BYOK product code, or adding compatibility/fallback semantics.
+- Taste constraints: preserve full `commands` in the AcceptanceReceipt fingerprint and preserve persisted-event redaction as the fail-closed security authority.
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+
+## Falsifier
+
+If replaying the raw prepared snapshot cannot reproduce the same materialized command evidence after one redaction pass, this direction is wrong. The cheapest proof is the projection-drift test that runs the shipped finalize overlay through the real event writer/materializer twice.
+
+## Root Cause Evidence
+
+Required when Task Profile is `bugfix`; leave as-is otherwise.
+
+- root_cause: `scripts/verify-sprint.sh:949-981` rebuilds finalized evidence from materialized `.ai/harness/checks/latest.json`; the evidence writer redacts its embedded `sha256:<digest>` command marker again, so `scripts/acceptance-receipt.ts` correctly detects a changed `commands` fingerprint.
+- repro: run the focused repeated-finalize guard in `tests/evidence-projection-drift.test.ts` against the unfixed source; the second materialization changes the command string from one redaction marker to two.
+- regression_guard: tests/evidence-projection-drift.test.ts
+- pre_fix_failure_artifact: .ai/harness/runs/pre-fix-acceptance-redaction-idempotence.log
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260904-0517-acceptance-redaction-idempotence.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260904-0517-acceptance-redaction-idempotence.review.md`
+- Notes file: `tasks/notes/20260904-0517-acceptance-redaction-idempotence.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Change Assessment
+
+```json
+{"protocol":1,"oracles":[{"id":"verify-sprint-finalize-projection-tests","kind":"deterministic_test","paths":["scripts/verify-sprint.sh","assets/templates/helpers/verify-sprint.sh","tests/evidence-projection-drift.test.ts"]}]}
+```
+
+## Acceptance Policy
+
+```json
+{"protocol":2,"reviewer":"Codex","source":"codex-plugin","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - plans/
+  - tasks/contracts/20260904-0517-acceptance-redaction-idempotence.contract.md
+  - tasks/reviews/20260904-0517-acceptance-redaction-idempotence.review.md
+  - tasks/notes/20260904-0517-acceptance-redaction-idempotence.notes.md
+  - .ai/harness/runs/
+  - .ai/harness/checks/latest.json
+  - scripts/verify-sprint.sh
+  - assets/templates/helpers/verify-sprint.sh
+  - tests/evidence-projection-drift.test.ts
+  - tests/helper-scripts.test.ts
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+    fallback: null
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - scripts/verify-sprint.sh
+    - assets/templates/helpers/verify-sprint.sh
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260904-0517-acceptance-redaction-idempotence.notes.md
+  tests_pass:
+    - path: tests/evidence-projection-drift.test.ts
+    - path: tests/helper-scripts.test.ts
+  commands_succeed:
+    - bun test --timeout 60000
+    - bash scripts/check-deploy-sql-order.sh
+    - bash scripts/check-architecture-sync.sh
+    - bash scripts/check-task-sync.sh
+    - repo-harness run check-task-workflow --strict
+    - bun scripts/inspect-project-state.ts --repo . --format text
+    - bun src/cli/index.ts init --repo . --dry-run
+# Optional exact-subject reuse is fail-closed and opt-in. List only deterministic
+# criteria whose inputs are fully bound by the frozen subject/toolchain context.
+# criterion_reuse:
+#   tests_pass:
+#     - path/to/deterministic.test.ts
+#   commands_succeed:
+#     - bun test --timeout 60000
+```
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior: prepare and finalize command evidence materialize the same command identity, and a second finalize emits no divergent event.
+- Edge cases: missing, unsafe, stale, or subject-mismatched run snapshots fail closed.
+- Regression risks: trusting a mutable or unrelated snapshot would weaken the evidence chain, so the source snapshot must be validated against the receipt-verified projection before emission.
+
+## Rollback Point
+
+- Commit / checkpoint: exact branch subject recorded by `verify-sprint --prepare-acceptance`.
+- Revert strategy: revert the helper, packaged mirror, focused test, and workflow artifacts as one unit.

--- a/tasks/contracts/20260904-0517-acceptance-redaction-idempotence.contract.md
+++ b/tasks/contracts/20260904-0517-acceptance-redaction-idempotence.contract.md
@@ -86,14 +86,6 @@ allowed_paths:
   - assets/templates/helpers/verify-sprint.sh
   - tests/evidence-projection-drift.test.ts
   - tests/helper-scripts.test.ts
-  - docs/architecture/.projection-manifest.json
-  - docs/architecture/changelog.md
-  - docs/architecture/decisions/index.md
-  - docs/architecture/diagrams/architecture.likec4
-  - docs/architecture/diagrams/architecture.mmd
-  - docs/architecture/diagrams/architecture.structurizr.json
-  - docs/architecture/index.md
-  - docs/architecture/modules/public-surface/root-router.md
 ```
 
 ## Evidence Requirements

--- a/tasks/notes/20260904-0517-acceptance-redaction-idempotence.notes.md
+++ b/tasks/notes/20260904-0517-acceptance-redaction-idempotence.notes.md
@@ -20,6 +20,7 @@
 - The initial candidate fix normalized redaction markers inside AcceptanceReceipt canonicalization. Root-cause proof falsified that direction because it would hide a real command-identity change; scope moved to the finalization producer.
 - The acceptance preflight refreshed the repository-owned architecture projection manifest after the linked worktree's CodeGraph index became ready. The contract therefore includes that deterministic generated projection in the frozen subject.
 - While publishing, `origin/main` advanced across the reviewed `helper-scripts` and architecture surfaces. The branch was rebased, and the user's task-wide approval was bound as `user.approval-20260904-full-task` to the exact ArchContext signal `sha256:bd58dfc27fa5218745540127764ddf5ef9a77aadfbef538c36b92ce5ae0171d6`; its deterministic architecture-doc projection is included in the refreshed subject.
+- After that rebase, the globally installed `repo-harness` predated `origin/main`'s new workflow schema and falsely reported the new `cutover-closure.ts` helper and schema-v2 sprint tables as missing. Exact-subject verification now invokes the branch-local CLI (`bun src/cli/index.ts run check-task-workflow --strict`), which is the source-bound authority under review.
 
 ## Tradeoffs Considered
 

--- a/tasks/notes/20260904-0517-acceptance-redaction-idempotence.notes.md
+++ b/tasks/notes/20260904-0517-acceptance-redaction-idempotence.notes.md
@@ -18,6 +18,7 @@
 ## Deviations From Plan Or Spec
 
 - The initial candidate fix normalized redaction markers inside AcceptanceReceipt canonicalization. Root-cause proof falsified that direction because it would hide a real command-identity change; scope moved to the finalization producer.
+- The acceptance preflight refreshed the repository-owned architecture projection manifest after the linked worktree's CodeGraph index became ready. The contract therefore includes that deterministic generated projection in the frozen subject.
 
 ## Tradeoffs Considered
 

--- a/tasks/notes/20260904-0517-acceptance-redaction-idempotence.notes.md
+++ b/tasks/notes/20260904-0517-acceptance-redaction-idempotence.notes.md
@@ -18,8 +18,8 @@
 ## Deviations From Plan Or Spec
 
 - The initial candidate fix normalized redaction markers inside AcceptanceReceipt canonicalization. Root-cause proof falsified that direction because it would hide a real command-identity change; scope moved to the finalization producer.
-- The acceptance preflight refreshed the repository-owned architecture projection manifest after the linked worktree's CodeGraph index became ready. The contract therefore includes that deterministic generated projection in the frozen subject.
-- While publishing, `origin/main` advanced across the reviewed `helper-scripts` and architecture surfaces. The branch was rebased, and the user's task-wide approval was bound as `user.approval-20260904-full-task` to the exact ArchContext signal `sha256:bd58dfc27fa5218745540127764ddf5ef9a77aadfbef538c36b92ce5ae0171d6`; its deterministic architecture-doc projection is included in the refreshed subject.
+- The first acceptance preflight needed a worktree-local CodeGraph index before ArchContext could prove the current flow graph.
+- While publishing, `origin/main` advanced across the reviewed `helper-scripts` and architecture surfaces. The branch was rebased, and the user's task-wide approval was bound as `user.approval-20260904-full-task` to the exact ArchContext signal `sha256:bd58dfc27fa5218745540127764ddf5ef9a77aadfbef538c36b92ce5ae0171d6`. A later upstream merge supplied a newer canonical projection, so every generated architecture-doc delta was dropped from this branch rather than carrying a second authority.
 - After that rebase, the globally installed `repo-harness` predated `origin/main`'s new workflow schema and falsely reported the new `cutover-closure.ts` helper and schema-v2 sprint tables as missing. Exact-subject verification now invokes the branch-local CLI (`bun src/cli/index.ts run check-task-workflow --strict`), which is the source-bound authority under review.
 
 ## Tradeoffs Considered
@@ -40,7 +40,7 @@
 - Run snapshots: `.ai/harness/runs/`
 - Pre-fix failure: `.ai/harness/runs/pre-fix-acceptance-redaction-idempotence.log`
 - Focused verification: `bun test tests/evidence-projection-drift.test.ts`; affected finalizer fixture in `tests/helper-scripts.test.ts`.
-- Full repository verification: `bun test --timeout 60000` passed 3,736 tests with 4 platform-specific skips and 0 failures on the implementation worktree.
+- Full repository verification: `bun test --timeout 60000` passed with only platform-specific skips and 0 failures on the implementation worktree.
 - Required checks passed: deploy SQL order, architecture sync, task sync, strict workflow, project-state inspection, init dry-run, helper-source mirror sync, and `git diff --check`.
 
 ## Promotion Filter

--- a/tasks/notes/20260904-0517-acceptance-redaction-idempotence.notes.md
+++ b/tasks/notes/20260904-0517-acceptance-redaction-idempotence.notes.md
@@ -1,0 +1,51 @@
+# Implementation Notes: acceptance-redaction-idempotence
+
+> **Status**: Active
+> **Plan**: plans/plan-20260904-0517-acceptance-redaction-idempotence.md
+> **Contract**: tasks/contracts/20260904-0517-acceptance-redaction-idempotence.contract.md
+> **Review**: tasks/reviews/20260904-0517-acceptance-redaction-idempotence.review.md
+> **Last Updated**: 2026-09-04 06:33
+> **Lifecycle**: notes
+
+> **Substantive Change SHA256**: `sha256:d1596b120fefc5fc2e79b3770570eb3089ddd2df29ba53d8fceb0ca79bcb41fe`
+
+## Design Decisions
+
+- Keep AcceptanceReceipt's full `commands` fingerprint and the evidence redactor unchanged. The regression is in `verify-sprint` finalization re-emitting a materialized projection.
+- Resolve `.run_file` only under `.ai/harness/runs/*.json`, reject traversal/symlinks, and require its subject, contract, Change Assessment, lifecycle pointer, and passing command set to match the receipt-bound projection.
+- Overlay acceptance onto the immutable raw snapshot, then reverify the receipt after materialization. A matching already-finalized projection returns without another event.
+
+## Deviations From Plan Or Spec
+
+- The initial candidate fix normalized redaction markers inside AcceptanceReceipt canonicalization. Root-cause proof falsified that direction because it would hide a real command-identity change; scope moved to the finalization producer.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| Normalize or omit command hashes in AcceptanceReceipt | Reject | Would weaken semantic evidence identity and hide real command changes. |
+| Exempt embedded hashes in global redaction | Reject | Broadens the security exemption beyond this producer bug. |
+| Replay the immutable prepared run snapshot | Use | Preserves both existing authorities and makes the redaction pass occur exactly once per emitted event. |
+
+## Open Questions
+
+- None.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Pre-fix failure: `.ai/harness/runs/pre-fix-acceptance-redaction-idempotence.log`
+- Focused verification: `bun test tests/evidence-projection-drift.test.ts`; affected finalizer fixture in `tests/helper-scripts.test.ts`.
+- Full repository verification: `bun test --timeout 60000` passed 3,736 tests with 4 platform-specific skips and 0 failures on the implementation worktree.
+- Required checks passed: deploy SQL order, architecture sync, task sync, strict workflow, project-state inspection, init dry-run, helper-source mirror sync, and `git diff --check`.
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/notes/20260904-0517-acceptance-redaction-idempotence.notes.md
+++ b/tasks/notes/20260904-0517-acceptance-redaction-idempotence.notes.md
@@ -7,7 +7,7 @@
 > **Last Updated**: 2026-09-04 06:33
 > **Lifecycle**: notes
 
-> **Substantive Change SHA256**: `sha256:d1596b120fefc5fc2e79b3770570eb3089ddd2df29ba53d8fceb0ca79bcb41fe`
+> **Substantive Change SHA256**: `sha256:4bad7e4001c10a7ac6d1be0884d89e1d9e14a8f09afe2e239bde509d13bec2e3`
 
 ## Design Decisions
 

--- a/tasks/notes/20260904-0517-acceptance-redaction-idempotence.notes.md
+++ b/tasks/notes/20260904-0517-acceptance-redaction-idempotence.notes.md
@@ -19,6 +19,7 @@
 
 - The initial candidate fix normalized redaction markers inside AcceptanceReceipt canonicalization. Root-cause proof falsified that direction because it would hide a real command-identity change; scope moved to the finalization producer.
 - The acceptance preflight refreshed the repository-owned architecture projection manifest after the linked worktree's CodeGraph index became ready. The contract therefore includes that deterministic generated projection in the frozen subject.
+- While publishing, `origin/main` advanced across the reviewed `helper-scripts` and architecture surfaces. The branch was rebased, and the user's task-wide approval was bound as `user.approval-20260904-full-task` to the exact ArchContext signal `sha256:bd58dfc27fa5218745540127764ddf5ef9a77aadfbef538c36b92ce5ae0171d6`; its deterministic architecture-doc projection is included in the refreshed subject.
 
 ## Tradeoffs Considered
 

--- a/tasks/reviews/20260904-0517-acceptance-redaction-idempotence.review.md
+++ b/tasks/reviews/20260904-0517-acceptance-redaction-idempotence.review.md
@@ -1,0 +1,84 @@
+# Task Review: acceptance-redaction-idempotence
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260904-0517-acceptance-redaction-idempotence.md
+> **Contract**: tasks/contracts/20260904-0517-acceptance-redaction-idempotence.contract.md
+> **Notes File**: tasks/notes/20260904-0517-acceptance-redaction-idempotence.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-09-04 05:17
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Commands passed:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+- Waza `/check` run:
+- Commands run:
+- Manual checks:
+- Supporting artifacts:
+- Implementation notes reviewed:
+- Run snapshot:
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...

--- a/tasks/reviews/20260904-0517-acceptance-redaction-idempotence.review.md
+++ b/tasks/reviews/20260904-0517-acceptance-redaction-idempotence.review.md
@@ -8,9 +8,9 @@
 > **Last Updated**: 2026-09-04 05:17
 > **Recommendation**: pass
 > **Review Rubric Version**: 2
-> **Reviewed Subject SHA256**: sha256:4c8b78a37e2e1d72bf6232cc4de247ee22c7325071f212321942389032fcc660
+> **Reviewed Subject SHA256**: sha256:fb1641ce9d758b08d5a254ad8e1c67a7f790e3e382051ee497297ac9aebd12ef
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: 1022e100bedc1031c45795d520b35c9c2f7ce7cc
+> **Reviewed Target Revision**: 385be33dbf25da7add32d1665454ef8f718d8adf
 
 ## Human Review Card
 
@@ -44,13 +44,13 @@
 > **Reviewer**: Codex
 > **Source**: codex-plugin
 > **Actor**: not-applicable
-> **Reviewed Subject SHA256**: sha256:4c8b78a37e2e1d72bf6232cc4de247ee22c7325071f212321942389032fcc660
+> **Reviewed Subject SHA256**: sha256:fb1641ce9d758b08d5a254ad8e1c67a7f790e3e382051ee497297ac9aebd12ef
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: 1022e100bedc1031c45795d520b35c9c2f7ce7cc
-> **Verification Evidence SHA256**: sha256:8d286411688e19d442ed287fb65de3f09c35189f09c16e8aad2ddc54d90469b1
-> **Issued At**: 2026-09-03T22:52:21.872Z
+> **Reviewed Target Revision**: 385be33dbf25da7add32d1665454ef8f718d8adf
+> **Verification Evidence SHA256**: sha256:d9fd8b0c48644b7827b5f67bd3ab0fd42904e7f5817802e0c084386c3af5ef54
+> **Issued At**: 2026-09-03T23:33:47.435Z
 
-- Summary: PASS: immutable prepared-snapshot replay preserves receipt-bound command evidence, repeated finalization is idempotent, unsafe or mismatched snapshots fail closed, helper projections match, and exact-subject verification passed 23 of 23 criteria.
+- Summary: PASS: rebased exact subject preserves immutable prepared-snapshot replay, repeat-finalize idempotence, fail-closed snapshot binding, aligned helper projection, and passes all 23 contract criteria against current origin/main.
 - Findings: none
 
 ## Behavior Diff Notes

--- a/tasks/reviews/20260904-0517-acceptance-redaction-idempotence.review.md
+++ b/tasks/reviews/20260904-0517-acceptance-redaction-idempotence.review.md
@@ -1,16 +1,16 @@
 # Task Review: acceptance-redaction-idempotence
 
-> **Status**: Pending
+> **Status**: Accepted
 > **Plan**: plans/plan-20260904-0517-acceptance-redaction-idempotence.md
 > **Contract**: tasks/contracts/20260904-0517-acceptance-redaction-idempotence.contract.md
 > **Notes File**: tasks/notes/20260904-0517-acceptance-redaction-idempotence.notes.md
 > **Checks File**: .ai/harness/checks/latest.json
 > **Last Updated**: 2026-09-04 05:17
-> **Recommendation**: fail
+> **Recommendation**: pass
 > **Review Rubric Version**: 2
-> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject SHA256**: sha256:4c8b78a37e2e1d72bf6232cc4de247ee22c7325071f212321942389032fcc660
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: pending
+> **Reviewed Target Revision**: 1022e100bedc1031c45795d520b35c9c2f7ce7cc
 
 ## Human Review Card
 
@@ -40,17 +40,17 @@
 
 ## Acceptance Receipt Projection
 
-> **Disposition**: unavailable
-> **Reviewer**: unavailable
-> **Source**: unavailable
+> **Disposition**: external_pass
+> **Reviewer**: Codex
+> **Source**: codex-plugin
 > **Actor**: not-applicable
-> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject SHA256**: sha256:4c8b78a37e2e1d72bf6232cc4de247ee22c7325071f212321942389032fcc660
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: pending
-> **Verification Evidence SHA256**: pending
-> **Issued At**: pending
+> **Reviewed Target Revision**: 1022e100bedc1031c45795d520b35c9c2f7ce7cc
+> **Verification Evidence SHA256**: sha256:8d286411688e19d442ed287fb65de3f09c35189f09c16e8aad2ddc54d90469b1
+> **Issued At**: 2026-09-03T22:52:21.872Z
 
-- Summary: No AcceptanceReceipt has been recorded.
+- Summary: PASS: immutable prepared-snapshot replay preserves receipt-bound command evidence, repeated finalization is idempotent, unsafe or mismatched snapshots fail closed, helper projections match, and exact-subject verification passed 23 of 23 criteria.
 - Findings: none
 
 ## Behavior Diff Notes

--- a/tasks/reviews/20260904-0517-acceptance-redaction-idempotence.review.md
+++ b/tasks/reviews/20260904-0517-acceptance-redaction-idempotence.review.md
@@ -8,9 +8,9 @@
 > **Last Updated**: 2026-09-04 05:17
 > **Recommendation**: pass
 > **Review Rubric Version**: 2
-> **Reviewed Subject SHA256**: sha256:fb1641ce9d758b08d5a254ad8e1c67a7f790e3e382051ee497297ac9aebd12ef
+> **Reviewed Subject SHA256**: sha256:526ff73d5950047bc9a6a678756bcab6e016256a3d22662e2e793fd43d6fe93a
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: 385be33dbf25da7add32d1665454ef8f718d8adf
+> **Reviewed Target Revision**: 97fc7c5cc3bd5a077a8478902f52c73968326ed3
 
 ## Human Review Card
 
@@ -44,13 +44,13 @@
 > **Reviewer**: Codex
 > **Source**: codex-plugin
 > **Actor**: not-applicable
-> **Reviewed Subject SHA256**: sha256:fb1641ce9d758b08d5a254ad8e1c67a7f790e3e382051ee497297ac9aebd12ef
+> **Reviewed Subject SHA256**: sha256:526ff73d5950047bc9a6a678756bcab6e016256a3d22662e2e793fd43d6fe93a
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: 385be33dbf25da7add32d1665454ef8f718d8adf
-> **Verification Evidence SHA256**: sha256:d9fd8b0c48644b7827b5f67bd3ab0fd42904e7f5817802e0c084386c3af5ef54
-> **Issued At**: 2026-09-03T23:33:47.435Z
+> **Reviewed Target Revision**: 97fc7c5cc3bd5a077a8478902f52c73968326ed3
+> **Verification Evidence SHA256**: sha256:d37030003bb89a8a810d316ba1cf26542ba3f71b9bc900aad49988a3e106ca16
+> **Issued At**: 2026-09-04T00:44:38.274Z
 
-- Summary: PASS: rebased exact subject preserves immutable prepared-snapshot replay, repeat-finalize idempotence, fail-closed snapshot binding, aligned helper projection, and passes all 23 contract criteria against current origin/main.
+- Summary: PASS: exact source-bound subject preserves immutable snapshot replay and idempotent finalization, retains strict redaction and fingerprint authorities, and passes all 23 contract criteria.
 - Findings: none
 
 ## Behavior Diff Notes

--- a/tests/evidence-projection-drift.test.ts
+++ b/tests/evidence-projection-drift.test.ts
@@ -305,7 +305,7 @@ describe("projection drift: materialized checks/latest", () => {
    */
   function readFinalizeOverlayProgram(): string {
     const source = readFileSync(VERIFY_SPRINT_PATH, "utf-8");
-    const tail = source.indexOf(`' "$checks_file" > "$finalized_checks"`);
+    const tail = source.indexOf(`' "$prepared_run_file" > "$finalized_checks"`);
     expect(tail).toBeGreaterThan(-1);
     const head = source.slice(0, tail);
     const open = head.lastIndexOf("\n    '\n");
@@ -331,6 +331,12 @@ describe("projection drift: materialized checks/latest", () => {
       review_subject_sha256: SUBJECT_A,
       lifecycle: { snapshot: ".ai/harness/runs/run-drift-overlay.json" },
       contract: { file: contractPath, status: "pass" },
+      commands: [{
+        name: "bun test real-server-longpoll-stall-dedup",
+        command: "bun test real-server-longpoll-stall-dedup",
+        status: "pass",
+        exit_code: 0,
+      }],
       guards: [
         { name: "acceptance_receipt", status: "unsatisfied" },
         { name: "allowed_paths_check", status: "pass" },
@@ -354,8 +360,13 @@ describe("projection drift: materialized checks/latest", () => {
     });
   }
 
-  test("the shipped finalize overlay deletes the materializer-owned provenance block before re-emission", () => {
+  test("the shipped finalizer replays the immutable run snapshot and skips an already-finalized receipt", () => {
+    const source = readFileSync(VERIFY_SPRINT_PATH, "utf-8");
     const program = readFinalizeOverlayProgram();
+    expect(source).toContain('prepared_run_file="$(jq -r \'.run_file // empty\' "$checks_file")"');
+    expect(source).toContain('Sprint acceptance already finalized for the receipt-bound evidence');
+    expect(source).toContain('immutable prepared run snapshot does not match the receipt-bound evidence');
+    expect(source).toContain(`' "$prepared_run_file" > "$finalized_checks"`);
     expect(program).toContain("del(.provenance)");
     // The strip must run on the whole document, before the acceptance fields
     // are layered on -- not on some sub-object after the fact.
@@ -378,7 +389,11 @@ describe("projection drift: materialized checks/latest", () => {
       writeFileSync(join(repoRoot, contractPath), contractText);
       const contractHash = `sha256:${createHash("sha256").update(contractText).digest("hex")}`;
       seedGenesis(repoRoot);
-      seedRunTraceEvent(repoRoot, contractHash, preparedRunTrace(contractPath));
+      const rawPrepared = preparedRunTrace(contractPath);
+      seedRunTraceEvent(repoRoot, contractHash, rawPrepared);
+      const rawPreparedPath = join(repoRoot, ".ai/harness/runs/run-drift-overlay.json");
+      mkdirSync(join(repoRoot, ".ai/harness/runs"), { recursive: true });
+      writeFileSync(rawPreparedPath, `${JSON.stringify(rawPrepared, null, 2)}\n`);
 
       const input: MaterializeChecksLatestInput = {
         repoRoot,
@@ -395,7 +410,9 @@ describe("projection drift: materialized checks/latest", () => {
       const preparedPath = join(repoRoot, "prepared-checks.json");
       writeFileSync(preparedPath, `${JSON.stringify(prepared, null, 2)}\n`);
 
-      // 2. The finalize path's own jq overlay, run verbatim from the script.
+      // 2. The finalize path's own jq overlay, run verbatim from the script
+      //    against the immutable raw snapshot rather than the materialized
+      //    projection that already contains redaction output.
       const overlayed = run(
         "jq",
         [
@@ -404,7 +421,7 @@ describe("projection drift: materialized checks/latest", () => {
           "--arg", "disposition", OVERLAY_ARGS.disposition,
           "--arg", "message", OVERLAY_ARGS.message,
           readFinalizeOverlayProgram(),
-          preparedPath,
+          rawPreparedPath,
         ],
         repoRoot,
       );
@@ -434,7 +451,13 @@ describe("projection drift: materialized checks/latest", () => {
       const finalized = buildChecksLatestProjection(input, acceptedFinal, contractText);
       const { provenance, ...consumerFacing } = finalized;
       expect(consumerFacing.acceptance_receipt).toEqual(finalizedRunTrace.acceptance_receipt);
+      expect(consumerFacing.commands).toEqual(prepared.commands);
       expect(contentHashOf(consumerFacing)).toBe(provenance.content_hash);
+
+      seedRunTraceEvent(repoRoot, contractHash, finalizedRunTrace as JsonValue);
+      const { accepted: acceptedRepeated } = readAcceptedEvents(repoRoot);
+      const repeated = buildChecksLatestProjection(input, acceptedRepeated, contractText);
+      expect(repeated.commands).toEqual(prepared.commands);
 
       // Causality lock: the pre-fix shape -- the same overlay output with the
       // previous materialization's provenance still embedded -- reproduces the

--- a/tests/helper-scripts.test.ts
+++ b/tests/helper-scripts.test.ts
@@ -5293,28 +5293,38 @@ describe("Workflow helper scripts", () => {
     };
     try {
       mkdirSync(join(cwd, ".ai/harness/checks"), { recursive: true });
+      mkdirSync(join(cwd, ".ai/harness/runs"), { recursive: true });
       mkdirSync(join(cwd, "tasks/contracts"), { recursive: true });
       mkdirSync(join(cwd, "tasks/reviews"), { recursive: true });
       copyHelpers(cwd);
       writeFileSync(join(cwd, "tasks/contracts/demo.contract.md"), "# Task Contract: demo\n");
       writeFileSync(join(cwd, "tasks/reviews/demo.review.md"), "# Task Review: demo\n");
+      const preparedRunFile = ".ai/harness/runs/run-finalize-fixture.json";
+      const preparedChecks = {
+        schema: "repo-harness-run-trace.v1",
+        status: "pass",
+        source: "verify-sprint",
+        exit_code: 0,
+        run_file: preparedRunFile,
+        lifecycle: { snapshot: preparedRunFile },
+        commands: [],
+        guards: [
+          { name: "contract", status: "pass" },
+          { name: "review", status: "pass" },
+          { name: "acceptance_receipt", status: "pending" },
+          { name: "allowed_paths", status: "pass" },
+          { name: "change_assessment", status: "pass" },
+        ],
+        acceptance_receipt: { status: "pending" },
+        change_assessment: changeAssessment,
+      };
       writeFileSync(
         join(cwd, ".ai/harness/checks/latest.json"),
-        `${JSON.stringify({
-          schema: "repo-harness-run-trace.v1",
-          status: "pass",
-          source: "verify-sprint",
-          exit_code: 0,
-          guards: [
-            { name: "contract", status: "pass" },
-            { name: "review", status: "pass" },
-            { name: "acceptance_receipt", status: "pending" },
-            { name: "allowed_paths", status: "pass" },
-            { name: "change_assessment", status: "pass" },
-          ],
-          acceptance_receipt: { status: "pending" },
-          change_assessment: changeAssessment,
-        }, null, 2)}\n`,
+        `${JSON.stringify(preparedChecks, null, 2)}\n`,
+      );
+      writeFileSync(
+        join(cwd, preparedRunFile),
+        `${JSON.stringify(preparedChecks, null, 2)}\n`,
       );
       writeFileSync(
         join(cwd, ".ai/harness/checks/change-assessment.latest.json"),


### PR DESCRIPTION
Fixes verify-sprint acceptance finalization so it replays the immutable prepared run snapshot instead of re-emitting an already-redacted materialized projection. Repeated finalization is a no-op, snapshot binding fails closed, and source/package helper projections remain aligned.\n\nVerification: 23/23 contract criteria passed, including the full 3,700+ test suite; typed AcceptanceReceipt external_pass is bound to the frozen subject.