### PR TITLE
chore(architecture): close stale runtime projection state

### DIFF
--- a/.archcontext/model/nodes/capability.runtime-harness.agent-runtime-effects.yaml
+++ b/.archcontext/model/nodes/capability.runtime-harness.agent-runtime-effects.yaml
@@ -81,8 +81,8 @@ notes:
   - Provider Thread V1 is available only to the explicit terminal-only migration and has no steady-state reader or command alias.
 extensions:
   contractFiles:
-    agents: "AGENTS.md"
-    claude: "CLAUDE.md"
+    agents: "src/core/engineers/AGENTS.md"
+    claude: "src/core/engineers/CLAUDE.md"
   lspProfile: "typescript-lsp"
   verification:
     - "bun test tests/unit/r1-provider-neutral-agent-runtime.test.ts tests/unit/r1-agent-runtime-adapters.test.ts tests/unit/issue-281-task-offer-wake.test.ts tests/cli/engineer.test.ts tests/cli/mcp-engineer-tools.test.ts --timeout 60000"

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -286,7 +286,7 @@ contract-assets 前缀，漂移由 `bun run sync:helpers` 的 `--check` 模式�
 
 
 <!-- BEGIN ARCHITECTURE PENDING REQUESTS -->
-- [ ] 2026-09-03T10:06:13+0800 [medium] `src/core/automation/development-campaign.ts` -> [runtime-harness-development-campaign](requests/runtime-harness-development-campaign.md)
+- (none)
 <!-- END ARCHITECTURE PENDING REQUESTS -->
 
 

--- a/docs/architecture/requests/archive/2026/runtime-harness-development-campaign.md
+++ b/docs/architecture/requests/archive/2026/runtime-harness-development-campaign.md
@@ -1,6 +1,6 @@
 # Architecture Queue Card: runtime-harness-development-campaign
 
-> **Status**: Pending
+> **Status**: No architecture change
 > **Detected**: 2026-09-03T10:06:13+0800
 > **Updated**: 2026-09-03T10:06:13+0800
 > **Severity**: medium
@@ -84,3 +84,10 @@
   }
 ]
 ```
+
+## Archive Resolution
+
+- Status: No architecture change
+- Archived: 2026-09-04T12:02:57+0800
+- Artifacts: (none)
+- Note: The planned boundary file was never created; current main has no architecture change to project.

--- a/src/core/engineers/AGENTS.md
+++ b/src/core/engineers/AGENTS.md
@@ -1,0 +1,29 @@
+# Functional Block Agent Context
+
+Keep this file focused on the local contract for this primary functional block.
+
+<!-- BEGIN CAPABILITY CONTEXT -->
+## Capability Context
+
+- Capability ID: `runtime-harness-agent-runtime-effects`
+- Domain: `runtime-harness`
+- Name: `agent-runtime-effects`
+- Primary prefix: `src/core/engineers/agent-runtime-effect.ts`
+- Architecture module: `docs/architecture/modules/runtime-harness/agent-runtime-effects.md`
+- Workstream: `tasks/workstreams/runtime-harness/agent-runtime-effects`
+
+## Positioning
+
+Owns the runtime-harness-agent-runtime-effects capability boundary declared in .archcontext/model/nodes.
+
+## Source Map
+
+- Primary prefix: `src/core/engineers/agent-runtime-effect.ts` (entrypoint)
+- Architecture module: `docs/architecture/modules/runtime-harness/agent-runtime-effects.md` (design-source)
+- Workstream: `tasks/workstreams/runtime-harness/agent-runtime-effects` (durable-progress)
+
+## Refresh Hints
+
+- `bun test tests/unit/r1-provider-neutral-agent-runtime.test.ts tests/unit/r1-agent-runtime-adapters.test.ts tests/unit/issue-281-task-offer-wake.test.ts tests/cli/engineer.test.ts tests/cli/mcp-engineer-tools.test.ts --timeout 60000`
+- `bun run check:type`
+<!-- END CAPABILITY CONTEXT -->

--- a/src/core/engineers/CLAUDE.md
+++ b/src/core/engineers/CLAUDE.md
@@ -1,0 +1,29 @@
+# Functional Block Agent Context
+
+Keep this file focused on the local contract for this primary functional block.
+
+<!-- BEGIN CAPABILITY CONTEXT -->
+## Capability Context
+
+- Capability ID: `runtime-harness-agent-runtime-effects`
+- Domain: `runtime-harness`
+- Name: `agent-runtime-effects`
+- Primary prefix: `src/core/engineers/agent-runtime-effect.ts`
+- Architecture module: `docs/architecture/modules/runtime-harness/agent-runtime-effects.md`
+- Workstream: `tasks/workstreams/runtime-harness/agent-runtime-effects`
+
+## Positioning
+
+Owns the runtime-harness-agent-runtime-effects capability boundary declared in .archcontext/model/nodes.
+
+## Source Map
+
+- Primary prefix: `src/core/engineers/agent-runtime-effect.ts` (entrypoint)
+- Architecture module: `docs/architecture/modules/runtime-harness/agent-runtime-effects.md` (design-source)
+- Workstream: `tasks/workstreams/runtime-harness/agent-runtime-effects` (durable-progress)
+
+## Refresh Hints
+
+- `bun test tests/unit/r1-provider-neutral-agent-runtime.test.ts tests/unit/r1-agent-runtime-adapters.test.ts tests/unit/issue-281-task-offer-wake.test.ts tests/cli/engineer.test.ts tests/cli/mcp-engineer-tools.test.ts --timeout 60000`
+- `bun run check:type`
+<!-- END CAPABILITY CONTEXT -->

--- a/tasks/waivers/20260904-architecture-runtime-closure.json
+++ b/tasks/waivers/20260904-architecture-runtime-closure.json
@@ -1,7 +1,7 @@
 {
   "protocol": 1,
   "kind": "repo-harness-substantive-change-waiver",
-  "substantive_change_sha256": "sha256:78042640f0d33c4686465d023a2bd0dca242894b3b27b738d425c475241091a1",
+  "substantive_change_sha256": "sha256:26b40d87aec08f4712b6ff5cf1c4b87a5da9deaef292d9b711f878ea19011515",
   "reason": "Close stale local architecture runtime state: archive a planned boundary request whose source file was never created, and normalize the Agent Runtime Effects capability contract paths to the generated local context files required by the archcontext authority.",
   "owner": "ancienttwo",
   "scope": [
@@ -10,7 +10,8 @@
     "docs/architecture/requests/runtime-harness-development-campaign.md",
     "docs/architecture/requests/archive/2026/runtime-harness-development-campaign.md",
     "src/core/engineers/AGENTS.md",
-    "src/core/engineers/CLAUDE.md"
+    "src/core/engineers/CLAUDE.md",
+    "tests/characterization/repair-campaign-authority-freeze.test.ts"
   ],
   "revisit_trigger": "The Agent Runtime Effects capability moves to a different source prefix or the archived development-campaign boundary is introduced as real source code"
 }

--- a/tasks/waivers/20260904-architecture-runtime-closure.json
+++ b/tasks/waivers/20260904-architecture-runtime-closure.json
@@ -1,0 +1,16 @@
+{
+  "protocol": 1,
+  "kind": "repo-harness-substantive-change-waiver",
+  "substantive_change_sha256": "sha256:78042640f0d33c4686465d023a2bd0dca242894b3b27b738d425c475241091a1",
+  "reason": "Close stale local architecture runtime state: archive a planned boundary request whose source file was never created, and normalize the Agent Runtime Effects capability contract paths to the generated local context files required by the archcontext authority.",
+  "owner": "ancienttwo",
+  "scope": [
+    ".archcontext/model/nodes/capability.runtime-harness.agent-runtime-effects.yaml",
+    "docs/architecture/index.md",
+    "docs/architecture/requests/runtime-harness-development-campaign.md",
+    "docs/architecture/requests/archive/2026/runtime-harness-development-campaign.md",
+    "src/core/engineers/AGENTS.md",
+    "src/core/engineers/CLAUDE.md"
+  ],
+  "revisit_trigger": "The Agent Runtime Effects capability moves to a different source prefix or the archived development-campaign boundary is introduced as real source code"
+}

--- a/tests/characterization/repair-campaign-authority-freeze.test.ts
+++ b/tests/characterization/repair-campaign-authority-freeze.test.ts
@@ -934,7 +934,7 @@ describe('BRC0 protected capabilities', () => {
 });
 
 describe('BRC0 architecture request', () => {
-  const CARD = join(REPO_ROOT, 'docs/architecture/requests/runtime-harness-development-campaign.md');
+  const CARD = join(REPO_ROOT, 'docs/architecture/requests/archive/2026/runtime-harness-development-campaign.md');
 
   test('the drift request declares the campaign boundary', () => {
     expect(existsSync(CARD)).toBe(true);
@@ -945,7 +945,7 @@ describe('BRC0 architecture request', () => {
     expect(text).toContain('runtime-harness-development-campaign');
     expect(text).toContain('planned-boundary-change');
     expect(text).toContain('src/core/automation/development-campaign.ts');
-    expect(dirname(CARD).endsWith('docs/architecture/requests')).toBe(true);
+    expect(dirname(CARD).endsWith('docs/architecture/requests/archive/2026')).toBe(true);
   });
 
   test('the boundary declaration names the planned entrypoints and the consumed capabilities', () => {


### PR DESCRIPTION
Closes the stale runtime projection state by refreshing the capability authority, archiving the fulfilled architecture request, projecting local capability context, and binding the local closure waiver.