### PR TITLE
fix(architecture): retire stale projection candidates

### DIFF
--- a/src/cli/commands/architecture-projection.ts
+++ b/src/cli/commands/architecture-projection.ts
@@ -11,6 +11,7 @@ import {
   acceptArchitectureProjectionCandidate,
   inspectArchitectureProjectionAcceptanceState,
   reconcileArchitectureProjectionCandidate,
+  retireStaleArchitectureProjectionCandidate,
   recordArchitectureProjectionAcceptanceCandidates,
 } from '../../effects/architecture/projection-acceptance';
 import { processArchitectureCascade, readPendingPostEditEvents } from '../hook/mutation-observed';
@@ -112,6 +113,16 @@ export function buildArchitectureProjectionCommand(): Command {
     .action((options: { signalId: string }) => {
       try {
         write(reconcileArchitectureProjectionCandidate(repositoryRoot(), options.signalId));
+      } catch (error) { fail(error); }
+    });
+  command.command('retire-stale')
+    .description('Retire one stale semantic candidate after explicit approval and a current deterministic proof check')
+    .requiredOption('--json', 'Output architecture stale retirement receipt JSON')
+    .requiredOption('--signal-id <sha256>', 'Exact stale unresolved-major refresh signal id')
+    .requiredOption('--approval-reference <event-id>', 'Exact external human approval event identity')
+    .action((options: { signalId: string; approvalReference: string }) => {
+      try {
+        write(retireStaleArchitectureProjectionCandidate(repositoryRoot(), options.signalId, options.approvalReference));
       } catch (error) { fail(error); }
     });
   command.command('adopt')

--- a/src/effects/architecture/projection-acceptance.ts
+++ b/src/effects/architecture/projection-acceptance.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, readdirSync, realpathSync, renameSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import {
@@ -16,6 +17,7 @@ import { withExclusiveDirectoryLock } from '../locking/exclusive-directory-lock'
 import { captureArchitectureProjectionSnapshot, runArchitectureProjection, type ArchctxProviderOptions } from './archctx-provider';
 import {
   ARCHITECTURE_PROJECTION_RUNTIME_ROOT,
+  architectureProjectionJobState,
   completeArchitectureProjectionDeadLetterAcceptance,
   completeArchitectureProjectionDeadLetterReconciliation,
 } from './projection-jobs';
@@ -24,10 +26,12 @@ import { consumeArchitectureRefreshSignals, type RunArchitectureRefreshActions }
 const CANDIDATE_VERSION = 'repo-harness.architecture-projection-acceptance-candidate/v1' as const;
 const RECEIPT_VERSION = 'repo-harness.architecture-projection-acceptance-receipt/v1' as const;
 const RECONCILIATION_RECEIPT_VERSION = 'repo-harness.architecture-projection-reconciliation-receipt/v1' as const;
+const STALE_RETIREMENT_RECEIPT_VERSION = 'repo-harness.architecture-projection-stale-retirement-receipt/v1' as const;
 const STATE_VERSION = 'repo-harness.architecture-projection-acceptance-state/v1' as const;
 const CANDIDATES = `${ARCHITECTURE_PROJECTION_RUNTIME_ROOT}/acceptance-candidates`;
 const RECEIPTS = `${ARCHITECTURE_PROJECTION_RUNTIME_ROOT}/acceptance-receipts`;
 const RECONCILIATION_RECEIPTS = `${ARCHITECTURE_PROJECTION_RUNTIME_ROOT}/reconciliation-receipts`;
+const STALE_RETIREMENT_RECEIPTS = `${ARCHITECTURE_PROJECTION_RUNTIME_ROOT}/stale-retirement-receipts`;
 const LOCK_PATH = `${ARCHITECTURE_PROJECTION_RUNTIME_ROOT}/locks/acceptance`;
 const DIGEST = /^sha256:[a-f0-9]{64}$/;
 const APPROVAL_REFERENCE = /^[a-zA-Z0-9_.:-]+$/;
@@ -62,11 +66,23 @@ export interface ArchitectureProjectionReconciliationReceiptV1 {
   readonly receiptDigest: Sha256Digest;
 }
 
+export interface ArchitectureProjectionStaleRetirementReceiptV1 {
+  readonly schemaVersion: typeof STALE_RETIREMENT_RECEIPT_VERSION;
+  readonly signalId: Sha256Digest;
+  readonly approvalReference: string;
+  readonly candidateDigest: Sha256Digest;
+  readonly staleHeadSha: string;
+  readonly request: ProjectionRequestV1;
+  readonly result: ProjectionResultV1;
+  readonly receiptDigest: Sha256Digest;
+}
+
 export interface ArchitectureProjectionAcceptanceStateV1 {
   readonly schemaVersion: typeof STATE_VERSION;
   readonly candidates: number;
   readonly receipts: number;
   readonly reconciliationReceipts: number;
+  readonly staleRetirementReceipts: number;
   readonly unresolvedCandidates: number;
   readonly invalidArtifacts: number;
 }
@@ -121,9 +137,14 @@ export function acceptArchitectureProjectionCandidate(
     const candidate = readCandidate(root, signalId);
     const existingPath = artifactPath(root, RECEIPTS, signalId);
     const reconciliationPath = artifactPath(root, RECONCILIATION_RECEIPTS, signalId);
+    const retirementPath = artifactPath(root, STALE_RETIREMENT_RECEIPTS, signalId);
     if (existsSync(reconciliationPath)) {
       readReconciliationReceiptFile(reconciliationPath, candidate);
       throw new Error(`architecture projection candidate is already resolved by reconciliation: ${signalId}`);
+    }
+    if (existsSync(retirementPath)) {
+      readStaleRetirementReceiptFile(retirementPath, candidate, root);
+      throw new Error(`architecture projection candidate is already resolved by stale retirement: ${signalId}`);
     }
     if (existsSync(existingPath)) {
       const existing = readReceiptFile(existingPath, candidate);
@@ -198,9 +219,14 @@ export function reconcileArchitectureProjectionCandidate(
     const candidate = readCandidate(root, signalId);
     const acceptancePath = artifactPath(root, RECEIPTS, signalId);
     const reconciliationPath = artifactPath(root, RECONCILIATION_RECEIPTS, signalId);
+    const retirementPath = artifactPath(root, STALE_RETIREMENT_RECEIPTS, signalId);
     if (existsSync(acceptancePath)) {
       readReceiptFile(acceptancePath, candidate);
       throw new Error(`architecture projection candidate is already resolved by acceptance: ${signalId}`);
+    }
+    if (existsSync(retirementPath)) {
+      readStaleRetirementReceiptFile(retirementPath, candidate, root);
+      throw new Error(`architecture projection candidate is already resolved by stale retirement: ${signalId}`);
     }
     if (existsSync(reconciliationPath)) {
       const existing = readReconciliationReceiptFile(reconciliationPath, candidate);
@@ -243,14 +269,87 @@ export function reconcileArchitectureProjectionCandidate(
   });
 }
 
+export function retireStaleArchitectureProjectionCandidate(
+  repoRoot: string,
+  signalId: string,
+  approvalReference: string,
+  options: ArchitectureProjectionAcceptanceOptions = {},
+): ArchitectureProjectionStaleRetirementReceiptV1 {
+  assertSignalId(signalId);
+  assertApprovalReference(approvalReference, 'stale retirement');
+  const root = realpathSync(resolve(repoRoot));
+  return withExclusiveDirectoryLock(root, LOCK_PATH, () => {
+    const candidate = readCandidate(root, signalId);
+    const acceptancePath = artifactPath(root, RECEIPTS, signalId);
+    const reconciliationPath = artifactPath(root, RECONCILIATION_RECEIPTS, signalId);
+    const retirementPath = artifactPath(root, STALE_RETIREMENT_RECEIPTS, signalId);
+    if (existsSync(acceptancePath)) {
+      readReceiptFile(acceptancePath, candidate);
+      throw new Error(`architecture projection candidate is already resolved by acceptance: ${signalId}`);
+    }
+    if (existsSync(reconciliationPath)) {
+      readReconciliationReceiptFile(reconciliationPath, candidate);
+      throw new Error(`architecture projection candidate is already resolved by reconciliation: ${signalId}`);
+    }
+    if (existsSync(retirementPath)) {
+      const existing = readStaleRetirementReceiptFile(retirementPath, candidate, root);
+      if (existing.approvalReference !== approvalReference) {
+        throw new Error(`architecture stale retirement already recorded with a different approval reference: ${signalId}`);
+      }
+      return existing;
+    }
+
+    assertSemanticCandidate(candidate);
+    if (candidate.jobId && architectureProjectionJobState(root, candidate.jobId) !== 'receipt') {
+      throw new Error(`architecture stale retirement requires a terminal job receipt: ${candidate.jobId}`);
+    }
+    const current = (options.captureSnapshot ?? captureArchitectureProjectionSnapshot)(root);
+    const staleHeadSha = candidate.request.expected.headSha;
+    assertStrictAncestor(root, staleHeadSha, current.headSha);
+    const request: ProjectionRequestV1 = {
+      schemaVersion: PROJECTION_REQUEST_VERSION,
+      requestId: `repo-harness.retire-stale.${signalId.slice('sha256:'.length, 'sha256:'.length + 24)}`,
+      profile: candidate.request.profile,
+      mode: 'check',
+      targets: [...candidate.request.targets],
+      changedPaths: [...candidate.request.changedPaths],
+      expected: current,
+    };
+    const issues = projectionRequestIssues(request);
+    if (issues.length > 0) throw new Error(`architecture stale retirement request invalid: ${issues.join('; ')}`);
+    const result = options.runProjection
+      ? options.runProjection(request, root)
+      : runArchitectureProjection(request, root, options);
+    assertCleanCurrentProof(request, result);
+    const body = {
+      schemaVersion: STALE_RETIREMENT_RECEIPT_VERSION,
+      signalId: candidate.signalId,
+      approvalReference,
+      candidateDigest: candidate.candidateDigest,
+      staleHeadSha,
+      request,
+      result,
+    };
+    const receipt: ArchitectureProjectionStaleRetirementReceiptV1 = {
+      ...body,
+      receiptDigest: digestProjectionJson(body),
+    };
+    assertStaleRetirementReceipt(receipt, candidate, root);
+    atomicJson(retirementPath, receipt);
+    return receipt;
+  });
+}
+
 export function inspectArchitectureProjectionAcceptanceState(repoRoot: string): ArchitectureProjectionAcceptanceStateV1 {
   const root = realpathSync(resolve(repoRoot));
   return withExclusiveDirectoryLock(root, LOCK_PATH, () => {
     const candidateNames = jsonNames(root, CANDIDATES);
     const receiptNames = jsonNames(root, RECEIPTS);
     const reconciliationNames = jsonNames(root, RECONCILIATION_RECEIPTS);
+    const retirementNames = jsonNames(root, STALE_RETIREMENT_RECEIPTS);
     const receiptSet = new Set(receiptNames);
     const reconciliationSet = new Set(reconciliationNames);
+    const retirementSet = new Set(retirementNames);
     let unresolvedCandidates = 0;
     let invalidArtifacts = 0;
     for (const name of candidateNames) {
@@ -259,29 +358,36 @@ export function inspectArchitectureProjectionAcceptanceState(repoRoot: string): 
         const receiptName = `${candidate.signalId.slice('sha256:'.length)}.json`;
         const hasAcceptance = receiptSet.has(receiptName);
         const hasReconciliation = reconciliationSet.has(receiptName);
-        if (!hasAcceptance && !hasReconciliation) {
+        const hasRetirement = retirementSet.has(receiptName);
+        if (!hasAcceptance && !hasReconciliation && !hasRetirement) {
           unresolvedCandidates += 1;
           continue;
         }
         if (hasAcceptance) receiptSet.delete(receiptName);
         if (hasReconciliation) reconciliationSet.delete(receiptName);
-        if (hasAcceptance === hasReconciliation) throw new Error('architecture projection candidate has conflicting resolution receipts');
+        if (hasRetirement) retirementSet.delete(receiptName);
+        if (Number(hasAcceptance) + Number(hasReconciliation) + Number(hasRetirement) !== 1) {
+          throw new Error('architecture projection candidate has conflicting resolution receipts');
+        }
         if (hasAcceptance) {
           readReceiptFile(join(root, RECEIPTS, receiptName), candidate);
-        } else {
+        } else if (hasReconciliation) {
           readReconciliationReceiptFile(join(root, RECONCILIATION_RECEIPTS, receiptName), candidate);
+        } else {
+          readStaleRetirementReceiptFile(join(root, STALE_RETIREMENT_RECEIPTS, receiptName), candidate, root);
         }
       } catch {
         invalidArtifacts += 1;
         unresolvedCandidates += 1;
       }
     }
-    invalidArtifacts += receiptSet.size + reconciliationSet.size;
+    invalidArtifacts += receiptSet.size + reconciliationSet.size + retirementSet.size;
     return {
       schemaVersion: STATE_VERSION,
       candidates: candidateNames.length,
       receipts: receiptNames.length,
       reconciliationReceipts: reconciliationNames.length,
+      staleRetirementReceipts: retirementNames.length,
       unresolvedCandidates,
       invalidArtifacts,
     };
@@ -312,6 +418,16 @@ function readReconciliationReceiptFile(
 ): ArchitectureProjectionReconciliationReceiptV1 {
   const receipt = JSON.parse(readFileSync(path, 'utf8')) as ArchitectureProjectionReconciliationReceiptV1;
   assertReconciliationReceipt(receipt, candidate);
+  return receipt;
+}
+
+function readStaleRetirementReceiptFile(
+  path: string,
+  candidate: ArchitectureProjectionAcceptanceCandidateV1,
+  repoRoot: string,
+): ArchitectureProjectionStaleRetirementReceiptV1 {
+  const receipt = JSON.parse(readFileSync(path, 'utf8')) as ArchitectureProjectionStaleRetirementReceiptV1;
+  assertStaleRetirementReceipt(receipt, candidate, repoRoot);
   return receipt;
 }
 
@@ -400,10 +516,60 @@ function assertReconciliationReceipt(
   }
 }
 
+function assertStaleRetirementReceipt(
+  receipt: ArchitectureProjectionStaleRetirementReceiptV1,
+  candidate: ArchitectureProjectionAcceptanceCandidateV1,
+  repoRoot: string,
+): void {
+  if (receipt.schemaVersion !== STALE_RETIREMENT_RECEIPT_VERSION) {
+    throw new Error('architecture stale retirement receipt schema mismatch');
+  }
+  if (receipt.signalId !== candidate.signalId || receipt.candidateDigest !== candidate.candidateDigest) {
+    throw new Error('architecture stale retirement receipt candidate binding mismatch');
+  }
+  assertApprovalReference(receipt.approvalReference, 'stale retirement receipt');
+  assertSemanticCandidate(candidate);
+  if (receipt.staleHeadSha !== candidate.request.expected.headSha
+    || projectionRequestIssues(receipt.request).length > 0
+    || receipt.request.profile !== candidate.request.profile
+    || receipt.request.targets.join('\0') !== candidate.request.targets.join('\0')
+    || receipt.request.changedPaths.join('\0') !== candidate.request.changedPaths.join('\0')) {
+    throw new Error('architecture stale retirement receipt request surface mismatch');
+  }
+  assertStrictAncestor(repoRoot, receipt.staleHeadSha, receipt.request.expected.headSha);
+  assertCleanCurrentProof(receipt.request, receipt.result);
+  const { receiptDigest: _digest, ...body } = receipt;
+  if (digestProjectionJson(body) !== receipt.receiptDigest) {
+    throw new Error('architecture stale retirement receipt digest mismatch');
+  }
+}
+
 function assertProofOnlyCandidate(candidate: ArchitectureProjectionAcceptanceCandidateV1): void {
   const reasons = candidateSignal(candidate).reasonCodes;
   if (reasons.length !== 1 || reasons[0] !== 'verified-flow-proof-changed') {
     throw new Error('architecture reconciliation requires an exact verified-flow-proof-changed candidate');
+  }
+}
+
+function assertSemanticCandidate(candidate: ArchitectureProjectionAcceptanceCandidateV1): void {
+  const reasons = candidateSignal(candidate).reasonCodes;
+  if (reasons.length === 1 && reasons[0] === 'verified-flow-proof-changed') {
+    throw new Error('architecture stale retirement requires a semantic candidate; use reconciliation for proof-only candidates');
+  }
+}
+
+function assertStrictAncestor(repoRoot: string, staleHeadSha: string, currentHeadSha: string): void {
+  if (staleHeadSha === currentHeadSha) throw new Error('architecture stale retirement candidate head is current');
+  try {
+    execFileSync('git', ['merge-base', '--is-ancestor', staleHeadSha, currentHeadSha], { cwd: repoRoot, stdio: 'ignore' });
+  } catch {
+    throw new Error('architecture stale retirement candidate head is not an ancestor of current HEAD');
+  }
+}
+
+function assertApprovalReference(approvalReference: string, label: string): void {
+  if (!APPROVAL_REFERENCE.test(approvalReference)) {
+    throw new Error(`architecture ${label} approval reference must be a non-empty event identity containing only letters, digits, . _ : or -`);
   }
 }
 

--- a/tasks/waivers/20260904-stale-projection-candidate-retirement.json
+++ b/tasks/waivers/20260904-stale-projection-candidate-retirement.json
@@ -1,0 +1,14 @@
+{
+  "protocol": 1,
+  "kind": "repo-harness-substantive-change-waiver",
+  "substantive_change_sha256": "sha256:c5ff62cb6f11a4f7013469f76c9d4c11d9bb280488adbe241e950ee7103a940d",
+  "reason": "User-approved operational closure for stale architecture projection candidates. The slice adds a fail-closed receipt protocol and CLI entrypoint so obsolete semantic candidates can be retired without deleting authority artifacts or accepting stale semantics.",
+  "owner": "ancienttwo",
+  "scope": [
+    "src/cli/commands/architecture-projection.ts",
+    "src/effects/architecture/projection-acceptance.ts",
+    "tests/architecture-projection-provider.test.ts",
+    "tests/unit/architecture-projection-acceptance.test.ts"
+  ],
+  "revisit_trigger": "The stale retirement receipt protocol changes or the two approved runtime candidates are no longer the intended closure set"
+}

--- a/tests/architecture-projection-provider.test.ts
+++ b/tests/architecture-projection-provider.test.ts
@@ -207,7 +207,7 @@ function runner(calls: Array<{ binary: string; args: readonly string[] }>, docs:
 }
 
 describe('package-local ArchContext projection provider', () => {
-  test('exposes only signal-bound acceptance and proof-only reconciliation as CLI authorities', () => {
+  test('exposes only signal-bound acceptance, proof reconciliation, and approved stale retirement as CLI authorities', () => {
     const command = buildArchitectureProjectionCommand();
     for (const name of ['check', 'plan', 'apply', 'adopt']) {
       const subcommand = command.commands.find((candidate) => candidate.name() === name);
@@ -229,6 +229,13 @@ describe('package-local ArchContext projection provider', () => {
     expect(reconcile!.options.map((option) => option.long)).toEqual([
       '--json',
       '--signal-id',
+    ]);
+    const retireStale = command.commands.find((candidate) => candidate.name() === 'retire-stale');
+    expect(retireStale).toBeDefined();
+    expect(retireStale!.options.map((option) => option.long)).toEqual([
+      '--json',
+      '--signal-id',
+      '--approval-reference',
     ]);
 
     const invalid = request(fixture().repoRoot);

--- a/tests/unit/architecture-projection-acceptance.test.ts
+++ b/tests/unit/architecture-projection-acceptance.test.ts
@@ -16,6 +16,7 @@ import {
   inspectArchitectureProjectionAcceptanceState,
   reconcileArchitectureProjectionCandidate,
   recordArchitectureProjectionAcceptanceCandidates,
+  retireStaleArchitectureProjectionCandidate,
 } from '../../src/effects/architecture/projection-acceptance';
 import {
   architectureProjectionJobId,
@@ -203,6 +204,7 @@ describe('architecture projection acceptance', () => {
       candidates: 1,
       receipts: 1,
       reconciliationReceipts: 0,
+      staleRetirementReceipts: 0,
       unresolvedCandidates: 0,
       invalidArtifacts: 0,
     });
@@ -290,6 +292,7 @@ describe('architecture projection acceptance', () => {
       candidates: 1,
       receipts: 0,
       reconciliationReceipts: 1,
+      staleRetirementReceipts: 0,
       unresolvedCandidates: 0,
       invalidArtifacts: 0,
     });
@@ -419,5 +422,94 @@ describe('architecture projection acceptance', () => {
       unresolvedCandidates: 1,
       invalidArtifacts: 1,
     });
+  });
+
+  test('retires a stale semantic candidate with explicit approval and current noop proof', () => {
+    const f = fixture();
+    writeFileSync(join(f.repoRoot, 'tracked.txt'), 'new head\n');
+    execFileSync('git', ['add', '.'], { cwd: f.repoRoot });
+    execFileSync('git', ['commit', '-m', 'advance'], { cwd: f.repoRoot, stdio: 'ignore' });
+    const current = {
+      ...f.expected,
+      headSha: execFileSync('git', ['rev-parse', 'HEAD'], { cwd: f.repoRoot, encoding: 'utf8' }).trim(),
+      worktreeDigest: digest('b'),
+    };
+    const observed: ProjectionRequestV1[] = [];
+    const receipt = retireStaleArchitectureProjectionCandidate(
+      f.repoRoot,
+      f.candidate.signalId,
+      'user-approval-20260904-stale-candidate-retirement',
+      {
+        captureSnapshot: () => current,
+        runProjection: (request) => {
+          observed.push(request);
+          return noopProofResult(request);
+        },
+      },
+    );
+
+    expect(observed).toHaveLength(1);
+    expect(observed[0]?.mode).toBe('check');
+    expect(observed[0]?.acceptedChange).toBeUndefined();
+    expect(receipt.staleHeadSha).toBe(f.expected.headSha);
+    expect(receipt.approvalReference).toBe('user-approval-20260904-stale-candidate-retirement');
+    expect(inspectArchitectureProjectionAcceptanceState(f.repoRoot)).toEqual({
+      schemaVersion: 'repo-harness.architecture-projection-acceptance-state/v1',
+      candidates: 1,
+      receipts: 0,
+      reconciliationReceipts: 0,
+      staleRetirementReceipts: 1,
+      unresolvedCandidates: 0,
+      invalidArtifacts: 0,
+    });
+  });
+
+  test('makes stale retirement idempotent for one approval identity', () => {
+    const f = fixture();
+    writeFileSync(join(f.repoRoot, 'tracked.txt'), 'new head\n');
+    execFileSync('git', ['add', '.'], { cwd: f.repoRoot });
+    execFileSync('git', ['commit', '-m', 'advance'], { cwd: f.repoRoot, stdio: 'ignore' });
+    const current = {
+      ...f.expected,
+      headSha: execFileSync('git', ['rev-parse', 'HEAD'], { cwd: f.repoRoot, encoding: 'utf8' }).trim(),
+      worktreeDigest: digest('b'),
+    };
+    let providerCalls = 0;
+    const options = {
+      captureSnapshot: () => current,
+      runProjection: (request: ProjectionRequestV1) => { providerCalls += 1; return noopProofResult(request); },
+    };
+    const first = retireStaleArchitectureProjectionCandidate(f.repoRoot, f.candidate.signalId, 'event.review-retire', options);
+    const second = retireStaleArchitectureProjectionCandidate(f.repoRoot, f.candidate.signalId, 'event.review-retire', options);
+
+    expect(second).toEqual(first);
+    expect(providerCalls).toBe(1);
+    expect(() => retireStaleArchitectureProjectionCandidate(f.repoRoot, f.candidate.signalId, 'event.review-other', options))
+      .toThrow('different approval reference');
+  });
+
+  test('refuses stale retirement for a current, proof-only, or unterminated job candidate', () => {
+    const current = fixture();
+    expect(() => retireStaleArchitectureProjectionCandidate(
+      current.repoRoot,
+      current.candidate.signalId,
+      'event.review-current',
+      { captureSnapshot: () => current.expected },
+    )).toThrow('candidate head is current');
+
+    const proofOnly = fixture(undefined, ['verified-flow-proof-changed']);
+    expect(() => retireStaleArchitectureProjectionCandidate(
+      proofOnly.repoRoot,
+      proofOnly.candidate.signalId,
+      'event.review-proof-only',
+    )).toThrow('use reconciliation for proof-only candidates');
+
+    const jobId = architectureProjectionJobId(['event-stale'], ['src/core/architecture.ts']);
+    const jobBound = fixture(jobId);
+    expect(() => retireStaleArchitectureProjectionCandidate(
+      jobBound.repoRoot,
+      jobBound.candidate.signalId,
+      'event.review-job-not-terminal',
+    )).toThrow('requires a terminal job receipt');
   });
 });


### PR DESCRIPTION
陈旧的 semantic architecture projection candidate 只能被状态门继续计数，既不能接受旧语义，也没有可审计的关闭路径。本变更增加 `retire-stale`：仅在显式 approval、候选 HEAD 是当前 HEAD 的严格祖先、关联 job 已有 terminal receipt（如存在），且当前 ArchContext check 返回完整 noop proof 时写入 digest-bound retirement receipt。

状态检查将 retirement receipt 作为与 acceptance/reconciliation 互斥的第三种关闭证据；候选与既有权威文件保留不删。CLI 和单元测试覆盖幂等、审批身份冲突、当前 HEAD、proof-only candidate 与未终结 job 的 fail-closed 路径。

验证：
- `bun test tests/architecture-projection-provider.test.ts tests/unit/architecture-projection-acceptance.test.ts --timeout 60000`
- `bunx tsc --noEmit`
- `bash scripts/check-deploy-sql-order.sh`
- `bash scripts/check-architecture-sync.sh`
- `bash scripts/check-task-sync.sh`
- `bash scripts/check-task-workflow.sh --strict`
- `bun scripts/inspect-project-state.ts --repo . --format text`
- `bun src/cli/index.ts init --repo . --dry-run`

完整 `bun test --timeout 60000` 在本机跑到既有 `fleet feedback CLI > repair complete writes exactly one completed reaction receipt` 时发生 30 秒超时；本变更相关测试及此前数千项均通过，交由 PR CI 复核完整矩阵。
