### PR TITLE
chore(refactor): bind delivery evidence

### DIFF
--- a/tasks/notes/20260904-1209-refactor-discovery-proposal-authoring.notes.md
+++ b/tasks/notes/20260904-1209-refactor-discovery-proposal-authoring.notes.md
@@ -1,6 +1,6 @@
 # Implementation Notes: refactor-discovery-proposal-authoring
 
-> **Substantive Change SHA256**: `sha256:b60b9f51087ac167945fd36437d2b7071f033c61d5c97196c3e56a26a82192d6`
+> **Substantive Change SHA256**: `sha256:30e7aca094a0d5a930d8e691b5630cf753c90d8960493af3e6760a48a969e43b`
 
 > **Status**: Active
 > **Plan**: plans/plan-20260904-1209-refactor-discovery-proposal-authoring.md


### PR DESCRIPTION
## Summary

Bind the merged Refactor Mode delivery to the exact merge-base substantive digest required by the task-sync gate.

## Verification

- merge-base task-sync check passes locally
- this is a canonical evidence-only correction for PR #314