### PR TITLE
fix(operator): make the single browser write structural and harden its transport

### DIFF
--- a/plans/plan-20260905-1414-operator-server-write-gate.md
+++ b/plans/plan-20260905-1414-operator-server-write-gate.md
@@ -1,0 +1,182 @@
+# Plan: Operator server structural write gate and transport hardening
+
+> **Status**: Executing
+> **Created**: 20260905-1414
+> **Slug**: operator-server-write-gate
+> **Planning Source**: repo-harness-plan
+> **Orchestration Kind**: host-plan
+> **Source Ref**: (none)
+> **Artifact Level**: work-package
+> **Promotion Reason**: risk_boundary
+> **Verification Boundary**: Operator serve regression guards, live loopback probe, repository-integrity checks and one full suite run on the frozen worktree head
+> **Rollback Surface**: Revert the operator server and collaboration reader changes together with their tests
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260905-1414-operator-server-write-gate.contract.md`
+> **Task Review**: `tasks/reviews/20260905-1414-operator-server-write-gate.review.md`
+> **Implementation Notes**: `tasks/notes/20260905-1414-operator-server-write-gate.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from repo-harness-plan planning output.
+- Source ref: (none)
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260905-1414-operator-server-write-gate.md`
+- Sprint contract: `tasks/contracts/20260905-1414-operator-server-write-gate.contract.md`
+- Sprint review: `tasks/reviews/20260905-1414-operator-server-write-gate.review.md`
+- Implementation notes: `tasks/notes/20260905-1414-operator-server-write-gate.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260905-1414-operator-server-write-gate.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260905-1414-operator-server-write-gate.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260905-1414-operator-server-write-gate.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260905-1414-operator-server-write-gate.contract.md`
+- Review file: `tasks/reviews/20260905-1414-operator-server-write-gate.review.md`
+- Implementation notes file: `tasks/notes/20260905-1414-operator-server-write-gate.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260905-1414-operator-server-write-gate.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260905-1414-operator-server-write-gate.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: Revert the operator server and collaboration reader changes together with their tests
+- **Verification boundary**: Operator serve regression guards, live loopback probe, repository-integrity checks and one full suite run on the frozen worktree head
+- **Review/acceptance boundary**: `tasks/reviews/20260905-1414-operator-server-write-gate.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: risk_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260905-1414-operator-server-write-gate.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260905-1414-operator-server-write-gate.contract.md`, `tasks/reviews/20260905-1414-operator-server-write-gate.review.md`, and `tasks/notes/20260905-1414-operator-server-write-gate.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260905-1414-operator-server-write-gate.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: Revert the operator server and collaboration reader changes together with their tests
+
+## Captured Planning Output
+
+## Goal
+
+Make the Operator server's "exactly one browser write" boundary structural and harden the transport around it: clear the shared Fleet in-flight at cancellation so a page reload cannot surface a spurious 503, bound and type-check the single write route, echo-check the collaboration snapshot identity, and close the low-severity header/route gaps.
+
+Audit baseline: main 1a9a5ae1, 2026-09-05 Task Board audit (server slice findings S1–S6, write/collab slice finding W4, runtime anomalies 4–9).
+
+## P1 Architecture Map
+
+- `src/effects/operator/server.ts` owns route dispatch (`handleRequest`), `OPERATOR_ROUTES` inventory (`:91-111`), Fleet in-flight sharing (`:1411-1448`), collaboration worker admission (`:1375-1399`), task message transport (`:1490-1614`), static serving (`fileIfSafe:1238-1260`), security headers (`:215`).
+- `src/effects/operator/collaboration.ts` owns `readOperatorCollaborationSnapshot`; `collaboration-worker.ts` produces the payload; `server.ts:395-399` (`collaborationWorkerResponse`) decodes it.
+- `src/cli/commands/operator.ts` owns `operator serve` flags and shutdown.
+- Tests: `tests/cli/operator-serve.test.ts`, `tests/effects/fleet-collector-process.test.ts`.
+
+## P2 Concrete Traces (defects)
+
+1. `OPERATOR_ROUTES` has zero consumers (`rg -uu OPERATOR_ROUTES` finds only the definition and archived docs). The comment claims a test counts writes against it; none exists. The dispatcher's literal paths and route regexes (`TASK_MESSAGE_ROUTE`, `COLLABORATION_SNAPSHOT_ROUTE`) are unpinned.
+2. Fleet in-flight: `release()` aborts the collection when the last subscriber leaves, but `inFlight`/`activeFleetCanceller` clear only when `pending` settles (`:1435-1446`); `readDefaultFleetSnapshot`'s abort path waits 500 ms grace + up to 5 s controller ack. A request arriving in that window receives the dying promise -> 503. Measured 573 ms after a sole-client disconnect. `tests/cli/operator-serve.test.ts:828` is falsely covering: its fixture rejects synchronously inside the abort listener. The collaboration path already removes its observation synchronously (`:1341-1343`).
+3. `handleTaskMessage` has no admission bound; each POST spawns `task-message-process.ts` (`:893-906`). Measured 24 concurrent writers at `max_concurrency: 1`.
+4. No request `Content-Type` check on the write; `text/plain` JSON reached the effect (403 `repository_read_only`). Origin equality (`:1687-1703`) is the only barrier against preflight-free simple requests.
+5. `collaborationWorkerResponse` accepts any object as snapshot and `readOperatorCollaborationSnapshot` never asserts `snapshot.repository_id === input.repository_id`; the worker derives id from the path (`work-exchange.ts:370`) while the registry may carry a hand-written id.
+6. `/api` prefix match is case-sensitive while the static fallback is not: `GET /API/v1/fleet/snapshot` with `Accept: text/html` returns the SPA shell 200.
+7. Static CSP (`:215`) omits `base-uri` and `form-action`; JSON responses carry no CSP; `OPTIONS` returns 405 without `Allow`; the server emits no log line for any rejected request (403/405/413/421) so operators cannot see refusals.
+
+## P3 Decisions
+
+- Route inventory becomes a gate: a test imports `OPERATOR_ROUTES`, asserts exactly one `write: true` entry (`task_message`), and pins each inventory pattern to the dispatcher's literals/regex sources (export the literals from the module if needed so the test compares the same values the dispatcher uses; do not duplicate strings in the test). A negative probe (adding a fake route in-test) must fail the assertion.
+- In-flight: clear `inFlight`/`activeFleetCanceller` at cancellation time, matching the collaboration path; a fresh request after a sole-client disconnect starts a new collection. Replace the falsely-covering test with a fixture whose abort path settles asynchronously (after a delay) and assert the retry gets 200.
+- Write admission: reuse the same bounded admission as collaboration (`max_concurrency`), return a typed 503 (`task_message_busy`, fixed public sentence, `Retry-After` header) above the cap. The browser only ever has one in-flight send, so the cap does not change product behaviour.
+- Content-Type: require `application/json` (parameters like `; charset=utf-8` allowed) on the write route; otherwise 415 with a fixed public sentence. Ordering: Origin checks stay first (they are the CSRF barrier); then method/path; then media type; then Content-Length/body.
+- Collaboration: `readOperatorCollaborationSnapshot` validates the worker payload's `protocol`/`kind` and asserts `repository_id` equals the requested id; mismatch is a typed `collaboration_repository_mismatch` 500-class error (do not translate ids, do not fall back to the requested id).
+- `/api` prefix matched case-insensitively (`pathname.toLowerCase().startsWith('/api')`) so any case variant is an API 404, never the SPA shell; route regexes themselves stay exact.
+- Headers: add `base-uri 'none'; form-action 'none'` to the CSP and pin the exact header string in a test; add `Allow: GET, HEAD, POST` on 405 responses; do not add CSP to JSON (document why in the header helper: CSP governs documents, and JSON is served `nosniff`).
+- Logging: one stderr line per non-2xx response with method, status, error code, and the pathname truncated to 200 chars; never the body, headers, or Origin value. Keep stdout as the single bound-URL line the CLI contract already prints.
+- Out of scope: any change to the Fleet collector, task inbox, browser UI, or Windows job controller.
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `src/effects/operator/server.ts` | Modify | inventory exports, in-flight clear at cancel, write admission, 415, case-insensitive `/api`, CSP additions, `Allow`, stderr refusal log |
+| `src/effects/operator/collaboration.ts` | Modify | payload protocol/kind validation + repository_id echo check |
+| `tests/cli/operator-serve.test.ts` | Modify/Add | route inventory gate, async-abort in-flight test, admission cap, 415, echo mismatch, `/API` case, CSP string, `Allow`, refusal log |
+| `src/cli/commands/operator.ts` | Modify only if the stderr log needs wiring | keep stdout contract |
+
+## Task Breakdown
+
+- [x] Regression guards first (RED): inventory gate with negative probe; async-abort retry 200; admission cap 503; 415 on `text/plain`; collaboration id mismatch typed error; `/API/...` never returns HTML; CSP string; `Allow` on 405; refusal line on stderr. Capture pre-fix artifacts with `bun test <guard> > <artifact> 2>&1; echo "PRE_FIX_EXIT=$?" >> <artifact>`.
+- [x] Implement in-flight clear at cancellation.
+- [x] Implement inventory exports and gate.
+- [x] Implement write admission bound and 415.
+- [x] Implement collaboration payload validation and echo check.
+- [x] Implement `/api` case handling, CSP additions, `Allow`, refusal log.
+- [x] Fill the contract (Goal, Scope, Root Cause Evidence, Allowed Paths, Exit Criteria, Change Assessment oracles as `{id,kind,paths}` objects) and clear every `[NOTE]` placeholder; notes only for non-obvious deviations.
+- [x] Verification: focused tests, the six repository-integrity checks, `bun test --timeout 60000` full suite once at the end (log to file), `bun run build:operator-web`, and a live probe: start `bun src/cli/index.ts operator serve --port 0`, curl reload-race (abort a snapshot request then immediately re-request) expecting 200, `text/plain` POST expecting 415, `/API/v1/fleet/snapshot` expecting JSON 404, then kill the server.
+
+## Allowed Paths
+
+- `src/effects/operator/server.ts`
+- `src/effects/operator/collaboration.ts`
+- `src/cli/commands/operator.ts`
+- `tests/**`
+- `docs/architecture/**` (only if the projection drain rewrites module docs)
+- plan, contract, review, notes files of this work package
+
+## Verification
+
+- `bun test --timeout 60000 tests/cli/operator-serve.test.ts tests/effects/fleet-collector-process.test.ts tests/effects/operator-task-message.test.ts tests/cli/collaboration.test.ts`
+- `bash scripts/check-deploy-sql-order.sh && bash scripts/check-architecture-sync.sh && bash scripts/check-task-sync.sh && bash scripts/check-task-workflow.sh --strict && bun scripts/inspect-project-state.ts --repo . --format text && bun src/cli/index.ts init --repo . --dry-run`
+- `bun test --timeout 60000` (full, once, logged)
+
+## Annotations
+
+- None.
+
+## Task Breakdown
+- [x] Regression guards first (RED): inventory gate with negative probe; async-abort retry 200; admission cap 503; 415 on `text/plain`; collaboration id mismatch typed error; `/API/...` never returns HTML; CSP string; `Allow` on 405; refusal line on stderr. Capture pre-fix artifacts with `bun test <guard> > <artifact> 2>&1; echo "PRE_FIX_EXIT=$?" >> <artifact>`.
+- [x] Implement in-flight clear at cancellation.
+- [x] Implement inventory exports and gate.
+- [x] Implement write admission bound and 415.
+- [x] Implement collaboration payload validation and echo check.
+- [x] Implement `/api` case handling, CSP additions, `Allow`, refusal log.
+- [x] Fill the contract (Goal, Scope, Root Cause Evidence, Allowed Paths, Exit Criteria, Change Assessment oracles as `{id,kind,paths}` objects) and clear every `[NOTE]` placeholder; notes only for non-obvious deviations.
+- [x] Verification: focused tests, the six repository-integrity checks, `bun test --timeout 60000` full suite once at the end (log to file), `bun run build:operator-web`, and a live probe: start `bun src/cli/index.ts operator serve --port 0`, curl reload-race (abort a snapshot request then immediately re-request) expecting 200, `text/plain` POST expecting 415, `/API/v1/fleet/snapshot` expecting JSON 404, then kill the server.

--- a/src/effects/operator/collaboration.ts
+++ b/src/effects/operator/collaboration.ts
@@ -1,4 +1,6 @@
 import {
+  OPERATOR_COLLABORATION_PROTOCOL,
+  OPERATOR_COLLABORATION_SNAPSHOT_KIND,
   projectOperatorCollaborationSnapshot,
   type OperatorCollaborationSnapshotV1,
 } from '../../core/operator/collaboration-snapshot';
@@ -26,7 +28,8 @@ import { readRepoHarnessRegistryStrictSnapshot } from '../repo-registry';
 export type OperatorCollaborationErrorCode =
   | 'registry_unavailable'
   | 'repository_not_found'
-  | 'collaboration_snapshot_unavailable';
+  | 'collaboration_snapshot_unavailable'
+  | 'collaboration_repository_mismatch';
 
 export class OperatorCollaborationError extends Error {
   constructor(
@@ -42,6 +45,37 @@ export class OperatorCollaborationError extends Error {
 export interface ReadOperatorCollaborationSnapshotInput {
   readonly env?: NodeJS.ProcessEnv;
   readonly repository_id: string;
+}
+
+/**
+ * The board asks about one repository by id and must be answered about that
+ * repository. The id in a snapshot is derived from the resolved root while the
+ * request names a registry id, so the two are separate derivations that only
+ * agree while the registry is intact; a document that disagrees is refused
+ * rather than relabelled, because relabelling would show one repository's lanes
+ * under another repository's name. The same assertion guards the worker payload
+ * on the far side of the process boundary, where an unrelated or replayed
+ * message could otherwise be accepted as this repository's answer.
+ */
+export function assertOperatorCollaborationSnapshotIdentity(
+  snapshot: OperatorCollaborationSnapshotV1,
+  repositoryId: string,
+): void {
+  if (snapshot === null
+    || typeof snapshot !== 'object'
+    || snapshot.protocol !== OPERATOR_COLLABORATION_PROTOCOL
+    || snapshot.kind !== OPERATOR_COLLABORATION_SNAPSHOT_KIND) {
+    throw new OperatorCollaborationError(
+      'collaboration_repository_mismatch',
+      `collaboration snapshot for repository ${repositoryId} is not an operator collaboration snapshot`,
+    );
+  }
+  if (snapshot.repository_id !== repositoryId) {
+    throw new OperatorCollaborationError(
+      'collaboration_repository_mismatch',
+      `collaboration snapshot answered repository ${snapshot.repository_id} for requested repository ${repositoryId}`,
+    );
+  }
 }
 
 function registeredRepositoryRoot(input: ReadOperatorCollaborationSnapshotInput): string {
@@ -82,7 +116,7 @@ export function readOperatorCollaborationSnapshot(
       error,
     );
   }
-  return projectOperatorCollaborationSnapshot({
+  const projected = projectOperatorCollaborationSnapshot({
     snapshot: collection.snapshot,
     mode: collection.mode,
     // Assigned straight across, so the projection's restated source vocabulary
@@ -90,4 +124,6 @@ export function readOperatorCollaborationSnapshot(
     degraded_sources: collection.degraded_sources,
     changed_sources: collection.changed_sources,
   });
+  assertOperatorCollaborationSnapshotIdentity(projected, input.repository_id);
+  return projected;
 }

--- a/src/effects/operator/server.ts
+++ b/src/effects/operator/server.ts
@@ -1313,8 +1313,10 @@ function contentType(pathname: string): string {
  * barrier and stays ahead of this check, but a simple cross-site form post can
  * only ever declare a form media type, so refusing anything but JSON removes
  * the shape entirely rather than relying on one header alone. Parameters are
- * allowed because a browser appends `charset`; duplicated Content-Type headers
- * arrive joined and fail closed.
+ * allowed because a browser appends `charset`. Node keeps the first
+ * `content-type` value and drops later duplicates, so a duplicate cannot widen
+ * this gate: a non-JSON first value is refused with 415, and a JSON first value
+ * still has to pass the body decoder.
  */
 function isJsonRequest(request: IncomingMessage): boolean {
   const declared = request.headers['content-type'];

--- a/src/effects/operator/server.ts
+++ b/src/effects/operator/server.ts
@@ -11,6 +11,7 @@ import {
 } from '../../core/operator/fleet-snapshot';
 import {
   OperatorCollaborationError,
+  assertOperatorCollaborationSnapshotIdentity,
   type OperatorCollaborationErrorCode,
   type ReadOperatorCollaborationSnapshotInput,
 } from './collaboration';
@@ -67,13 +68,23 @@ const TASK_MESSAGE_REQUEST_FIXED_BYTES = Buffer.byteLength(JSON.stringify({
 }), 'utf8') - Buffer.byteLength(JSON.stringify(''), 'utf8');
 export const OPERATOR_TASK_MESSAGE_REQUEST_MAX_BYTES =
   TASK_MESSAGE_REQUEST_FIXED_BYTES + (TASK_MESSAGE_BODY_MAX_BYTES * 6) + Buffer.byteLength(JSON.stringify(''), 'utf8');
-const TASK_MESSAGE_ROUTE = /^\/api\/v1\/fleet\/tasks\/([A-Za-z0-9][A-Za-z0-9._-]{0,127})\/([0-9a-f]{64})\/messages$/u;
+/**
+ * The dispatcher's own matchers, exported so the inventory below and the test
+ * that gates it compare the values `handleRequest` matches on rather than a
+ * second copy of the same strings.
+ */
+export const OPERATOR_HEALTH_PATH = '/healthz' as const;
+export const OPERATOR_FLEET_SNAPSHOT_PATH = '/api/v1/fleet/snapshot' as const;
+export const OPERATOR_API_PATH_PREFIX = '/api' as const;
+/** The static fallback has no path shape of its own; it is whatever is left. */
+export const OPERATOR_STATIC_ASSET_PATTERN = '/*' as const;
+export const OPERATOR_TASK_MESSAGE_ROUTE = /^\/api\/v1\/fleet\/tasks\/([A-Za-z0-9][A-Za-z0-9._-]{0,127})\/([0-9a-f]{64})\/messages$/u;
 /**
  * The repository id is matched loosely and resolved strictly, the same split the
  * task-message route already uses: the registry is the authority on which ids
  * exist, and duplicating its shape here would be a second opinion about it.
  */
-const COLLABORATION_SNAPSHOT_ROUTE = /^\/api\/v1\/collaboration\/([A-Za-z0-9][A-Za-z0-9._-]{0,127})\/snapshot$/u;
+export const OPERATOR_COLLABORATION_SNAPSHOT_ROUTE = /^\/api\/v1\/collaboration\/([A-Za-z0-9][A-Za-z0-9._-]{0,127})\/snapshot$/u;
 const DEFAULT_STATIC_ROOT = resolve(
   dirname(fileURLToPath(import.meta.url)),
   '../../../dist/operator-ui',
@@ -98,16 +109,16 @@ export interface OperatorRouteV1 {
  * declaring it here is caught by the same test that counts the writes.
  */
 export const OPERATOR_ROUTES: readonly OperatorRouteV1[] = Object.freeze([
-  Object.freeze({ id: 'health', method: 'GET', pattern: '/healthz', write: false }),
-  Object.freeze({ id: 'fleet_snapshot', method: 'GET', pattern: '/api/v1/fleet/snapshot', write: false }),
+  Object.freeze({ id: 'health', method: 'GET', pattern: OPERATOR_HEALTH_PATH, write: false }),
+  Object.freeze({ id: 'fleet_snapshot', method: 'GET', pattern: OPERATOR_FLEET_SNAPSHOT_PATH, write: false }),
   Object.freeze({
     id: 'collaboration_snapshot',
     method: 'GET',
-    pattern: COLLABORATION_SNAPSHOT_ROUTE.source,
+    pattern: OPERATOR_COLLABORATION_SNAPSHOT_ROUTE.source,
     write: false,
   }),
-  Object.freeze({ id: 'static_asset', method: 'GET', pattern: '/*', write: false }),
-  Object.freeze({ id: 'task_message', method: 'POST', pattern: TASK_MESSAGE_ROUTE.source, write: true }),
+  Object.freeze({ id: 'static_asset', method: 'GET', pattern: OPERATOR_STATIC_ASSET_PATTERN, write: false }),
+  Object.freeze({ id: 'task_message', method: 'POST', pattern: OPERATOR_TASK_MESSAGE_ROUTE.source, write: true }),
 ] as const);
 
 export type OperatorServerHost = '127.0.0.1' | '::1';
@@ -208,11 +219,23 @@ function jsonHeaders(): Record<string, string> {
   };
 }
 
+/**
+ * A Content-Security-Policy governs a document, and the only documents this
+ * server serves are the static ones. JSON responses deliberately carry none:
+ * they are already served `nosniff`, so a browser cannot execute them as a
+ * document, and a policy attached to a non-document would be a header a reader
+ * has to reason about for no boundary it protects.
+ */
+export const OPERATOR_STATIC_CONTENT_SECURITY_POLICY = "default-src 'self'; base-uri 'none'; connect-src 'self'; font-src 'self'; form-action 'none'; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline'; frame-ancestors 'none'" as const;
+
+/** Every method the server implements, on every resource that refuses one. */
+const OPERATOR_ALLOWED_METHODS = 'GET, HEAD, POST' as const;
+
 function staticHeaders(contentType: string): Record<string, string> {
   return {
     'Cache-Control': 'no-store',
     'Content-Type': contentType,
-    'Content-Security-Policy': "default-src 'self'; connect-src 'self'; font-src 'self'; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline'; frame-ancestors 'none'",
+    'Content-Security-Policy': OPERATOR_STATIC_CONTENT_SECURITY_POLICY,
     'X-Content-Type-Options': 'nosniff',
     'X-Frame-Options': 'DENY',
     'Referrer-Policy': 'no-referrer',
@@ -224,14 +247,52 @@ function sendJson(
   status: number,
   body: unknown,
   headOnly = false,
+  extraHeaders: Readonly<Record<string, string>> = {},
 ): void {
   const payload = JSON.stringify(body);
   response.writeHead(status, {
     ...jsonHeaders(),
+    ...extraHeaders,
     'Content-Length': Buffer.byteLength(payload).toString(),
   });
   if (headOnly) response.end();
   else response.end(payload);
+}
+
+const OPERATOR_REFUSAL_PATH_MAX_CHARS = 200;
+
+/**
+ * The request target as the refusal log may state it: the path only, with the
+ * query string dropped and the value JSON-quoted so a client-supplied control
+ * character cannot forge a second log line.
+ */
+function refusalPath(request: IncomingMessage): string {
+  const target = request.url ?? '/';
+  const queryAt = target.indexOf('?');
+  const path = queryAt < 0 ? target : target.slice(0, queryAt);
+  return JSON.stringify(path.slice(0, OPERATOR_REFUSAL_PATH_MAX_CHARS));
+}
+
+/**
+ * Refusals are invisible otherwise: an operator watching a board that silently
+ * drops writes has nothing to look at. The line carries the decision and
+ * nothing that could leak the request — no body, no headers, and in particular
+ * no Origin, since the refused Origin is exactly the attacker-controlled string
+ * a log reader would then be tempted to trust. stdout stays the single bound
+ * URL line the CLI contract prints.
+ */
+function sendRefusal(
+  request: IncomingMessage,
+  response: ServerResponse,
+  status: number,
+  body: OperatorErrorResponseV1,
+  headOnly = false,
+  extraHeaders: Readonly<Record<string, string>> = {},
+): void {
+  process.stderr.write(
+    `${OPERATOR_SERVICE_NAME} refused method=${request.method ?? 'GET'} status=${status} code=${body.error.code} path=${refusalPath(request)}\n`,
+  );
+  sendJson(response, status, body, headOnly, extraHeaders);
 }
 
 function errorBody(
@@ -310,6 +371,11 @@ const COLLABORATION_FAILURES: Readonly<Record<OperatorCollaborationErrorCode, Pu
   collaboration_snapshot_unavailable: {
     status: 503,
     message: 'The collaboration store cannot be read.',
+    next_action: OPERATOR_COLLABORATION_ACTION,
+  },
+  collaboration_repository_mismatch: {
+    status: 500,
+    message: 'The collaboration snapshot does not belong to the requested repository.',
     next_action: OPERATOR_COLLABORATION_ACTION,
   },
 });
@@ -402,7 +468,8 @@ function collaborationWorkerResponse(value: unknown): OperatorCollaborationWorke
     && 'code' in value
     && (value.code === 'registry_unavailable'
       || value.code === 'repository_not_found'
-      || value.code === 'collaboration_snapshot_unavailable')
+      || value.code === 'collaboration_snapshot_unavailable'
+      || value.code === 'collaboration_repository_mismatch')
   ) {
     return { ok: false, code: value.code };
   }
@@ -445,6 +512,12 @@ function readDefaultCollaborationSnapshot(
           ),
         });
       } else if (response.ok) {
+        try {
+          assertOperatorCollaborationSnapshotIdentity(response.snapshot, input.repository_id);
+        } catch (error) {
+          finish({ ok: false, error });
+          return;
+        }
         finish({ ok: true, snapshot: response.snapshot });
       } else {
         finish({
@@ -1235,6 +1308,20 @@ function contentType(pathname: string): string {
   }
 }
 
+/**
+ * The write accepts exactly one representation. Origin equality is the CSRF
+ * barrier and stays ahead of this check, but a simple cross-site form post can
+ * only ever declare a form media type, so refusing anything but JSON removes
+ * the shape entirely rather than relying on one header alone. Parameters are
+ * allowed because a browser appends `charset`; duplicated Content-Type headers
+ * arrive joined and fail closed.
+ */
+function isJsonRequest(request: IncomingMessage): boolean {
+  const declared = request.headers['content-type'];
+  if (typeof declared !== 'string') return false;
+  return declared.split(';', 1)[0]!.trim().toLowerCase() === 'application/json';
+}
+
 function fileIfSafe(root: string, pathname: string): string | null {
   let decoded: string;
   try {
@@ -1296,6 +1383,7 @@ export async function startOperatorServer(
   let nextSnapshotSequence = 1;
   let activeFleetCanceller: (() => void) | null = null;
   let activeFleetSubscribers = 0;
+  let activeTaskMessageWriters = 0;
   const activeTaskMessageCancellers = new Set<() => void>();
   const activeTaskMessageCompletions = new Set<Promise<void>>();
   const activeCollaborationRequestCancellers = new Set<() => void>();
@@ -1430,7 +1518,20 @@ export async function startOperatorServer(
         signal: controller.signal,
       }))).then(projectOperatorFleetSnapshot);
     inFlight = pending;
-    const cancelFleet = () => controller.abort();
+    /**
+     * Cancellation retires the shared observation immediately, exactly as the
+     * collaboration path drops its observation the moment it is cancelled. The
+     * collector's abort path is not instantaneous — it drains a cleanup grace
+     * period and then waits for the process group to disappear — so a request
+     * that arrives inside that window would otherwise be handed the dying
+     * promise and answered with its failure. A page reload right after the
+     * previous page closed its connection is exactly that request.
+     */
+    const cancelFleet = () => {
+      if (inFlight === pending) inFlight = null;
+      if (activeFleetCanceller === cancelFleet) activeFleetCanceller = null;
+      controller.abort();
+    };
     activeFleetCanceller = cancelFleet;
     pending.then(
       () => {
@@ -1478,7 +1579,7 @@ export async function startOperatorServer(
       if (clientDisconnected || response.destroyed) return;
       finished = true;
       const failure = publicFleetError(error);
-      sendJson(response, failure.status, failure.body, headOnly);
+      sendRefusal(request, response, failure.status, failure.body, headOnly);
     } finally {
       finished = true;
       release();
@@ -1493,6 +1594,21 @@ export async function startOperatorServer(
     repositoryId: string,
     taskId: string,
   ): Promise<void> => {
+    /**
+     * The write is bounded by the same `max_concurrency` the collaboration
+     * reads are, and for the same reason: each admitted write owns a child
+     * process. There is no queue, because the board only ever has one send in
+     * flight, so a caller above the cap is not a browser waiting its turn.
+     */
+    if (activeTaskMessageWriters >= maxConcurrency) {
+      sendRefusal(request, response, 503, errorBody(
+        'task_message_busy',
+        'The task message service is busy.',
+        'Wait for the current message to finish, then send it again.',
+      ), false, { 'Retry-After': '1' });
+      return;
+    }
+    activeTaskMessageWriters += 1;
     let resolveCompletion!: () => void;
     const completion = new Promise<void>((resolvePending) => { resolveCompletion = resolvePending; });
     activeTaskMessageCompletions.add(completion);
@@ -1535,13 +1651,13 @@ export async function startOperatorServer(
         }
         finished = true;
         if (read.reason === 'envelope_too_large') {
-          sendJson(response, 413, errorBody(
+          sendRefusal(request, response, 413, errorBody(
             'task_message_envelope_too_large',
             'The task message request envelope is too large.',
             'Shorten the request, then send it again.',
           ));
         } else {
-          sendJson(response, 400, errorBody('invalid_request', 'The request body is invalid.', OPERATOR_REOBSERVE_ACTION));
+          sendRefusal(request, response, 400, errorBody('invalid_request', 'The request body is invalid.', OPERATOR_REOBSERVE_ACTION));
         }
         return;
       }
@@ -1550,18 +1666,18 @@ export async function startOperatorServer(
         parsed = JSON.parse(read.text);
       } catch (_error) {
         finished = true;
-        sendJson(response, 400, errorBody('invalid_request', 'The request body is not valid JSON.', OPERATOR_REOBSERVE_ACTION));
+        sendRefusal(request, response, 400, errorBody('invalid_request', 'The request body is not valid JSON.', OPERATOR_REOBSERVE_ACTION));
         return;
       }
       const payload = decodeTaskMessageRequest(parsed);
       if (payload === null) {
         finished = true;
-        sendJson(response, 400, errorBody('invalid_request', 'The request body is invalid.', OPERATOR_REOBSERVE_ACTION));
+        sendRefusal(request, response, 400, errorBody('invalid_request', 'The request body is invalid.', OPERATOR_REOBSERVE_ACTION));
         return;
       }
       if (Buffer.byteLength(payload.body, 'utf-8') > OPERATOR_TASK_MESSAGE_BODY_MAX_BYTES) {
         finished = true;
-        sendJson(response, 413, errorBody(
+        sendRefusal(request, response, 413, errorBody(
           'task_message_body_too_large',
           `The message body must be at most ${OPERATOR_TASK_MESSAGE_BODY_MAX_BYTES} bytes.`,
           'Shorten the message, then send it again.',
@@ -1601,9 +1717,10 @@ export async function startOperatorServer(
       finished = true;
       if (timeoutExpired) response.shouldKeepAlive = false;
       const failure = publicTaskMessageError(timeoutExpired ? new OperatorTaskMessageTimeoutError() : error);
-      sendJson(response, failure.status, failure.body);
+      sendRefusal(request, response, failure.status, failure.body);
     } finally {
       finished = true;
+      activeTaskMessageWriters -= 1;
       clearTimeout(timer);
       activeTaskMessageCancellers.delete(cancelForServerClose);
       activeTaskMessageCompletions.delete(completion);
@@ -1624,7 +1741,7 @@ export async function startOperatorServer(
       observation = acquireCollaborationObservation(repositoryId);
     } catch (error) {
       const failure = publicCollaborationError(error);
-      sendJson(response, failure.status, failure.body, headOnly);
+      sendRefusal(request, response, failure.status, failure.body, headOnly);
       return;
     }
     let finished = false;
@@ -1665,7 +1782,7 @@ export async function startOperatorServer(
       if (clientDisconnected || serverClosing || response.destroyed) return;
       finished = true;
       const failure = publicCollaborationError(error);
-      sendJson(response, failure.status, failure.body, headOnly);
+      sendRefusal(request, response, failure.status, failure.body, headOnly);
     } finally {
       finished = true;
       release();
@@ -1681,7 +1798,7 @@ export async function startOperatorServer(
     const expectedAuthority = expectedRequestAuthority(host, request);
     const requestHost = request.headers.host?.trim().toLowerCase();
     if (expectedAuthority === null || requestHost !== expectedAuthority) {
-      sendJson(response, 421, errorBody('host_not_allowed', 'The request Host is not allowed.'), headOnly);
+      sendRefusal(request, response, 421, errorBody('host_not_allowed', 'The request Host is not allowed.'), headOnly);
       return;
     }
     const expectedOrigin = `http://${expectedAuthority}`;
@@ -1690,7 +1807,7 @@ export async function startOperatorServer(
       // A read may come from curl; the one write may not. A browser always
       // sends Origin on POST, so a missing header is never the board itself.
       if (method === 'POST') {
-        sendJson(response, 403, errorBody(
+        sendRefusal(request, response, 403, errorBody(
           'origin_required',
           'The request Origin is required for writes.',
           'Send the message from the operator board on this loopback origin.',
@@ -1698,11 +1815,13 @@ export async function startOperatorServer(
         return;
       }
     } else if (requestOrigin !== expectedOrigin) {
-      sendJson(response, 403, errorBody('origin_not_allowed', 'The request Origin is not allowed.'), headOnly);
+      sendRefusal(request, response, 403, errorBody('origin_not_allowed', 'The request Origin is not allowed.'), headOnly);
       return;
     }
     if (method !== 'GET' && method !== 'HEAD' && method !== 'POST') {
-      sendJson(response, 405, errorBody('method_not_allowed', 'Only GET, HEAD, and POST are supported.'), false);
+      sendRefusal(request, response, 405, errorBody('method_not_allowed', 'Only GET, HEAD, and POST are supported.'), false, {
+        Allow: OPERATOR_ALLOWED_METHODS,
+      });
       return;
     }
 
@@ -1710,30 +1829,42 @@ export async function startOperatorServer(
     try {
       url = new URL(request.url ?? '/', expectedOrigin);
       if (url.origin !== expectedOrigin) {
-        sendJson(response, 421, errorBody('host_not_allowed', 'The request URL authority is not allowed.'), headOnly);
+        sendRefusal(request, response, 421, errorBody('host_not_allowed', 'The request URL authority is not allowed.'), headOnly);
         return;
       }
     } catch (_error) {
-      sendJson(response, 400, errorBody('invalid_request', 'The request URL is invalid.'), headOnly);
+      sendRefusal(request, response, 400, errorBody('invalid_request', 'The request URL is invalid.'), headOnly);
       return;
     }
     const pathname = url.pathname;
 
-    const taskMessageRoute = TASK_MESSAGE_ROUTE.exec(pathname);
+    const taskMessageRoute = OPERATOR_TASK_MESSAGE_ROUTE.exec(pathname);
     if (method === 'POST' && taskMessageRoute === null) {
-      sendJson(response, 405, errorBody('method_not_allowed', 'Only the task message route accepts POST.'), false);
+      sendRefusal(request, response, 405, errorBody('method_not_allowed', 'Only the task message route accepts POST.'), false, {
+        Allow: OPERATOR_ALLOWED_METHODS,
+      });
       return;
     }
     if (taskMessageRoute !== null) {
       if (method !== 'POST') {
-        sendJson(response, 405, errorBody('method_not_allowed', 'The task message route accepts POST only.'), false);
+        sendRefusal(request, response, 405, errorBody('method_not_allowed', 'The task message route accepts POST only.'), false, {
+          Allow: OPERATOR_ALLOWED_METHODS,
+        });
+        return;
+      }
+      if (!isJsonRequest(request)) {
+        sendRefusal(request, response, 415, errorBody(
+          'unsupported_media_type',
+          'The task message request must be sent as application/json.',
+          'Send the message from the operator board on this loopback origin.',
+        ));
         return;
       }
       await handleTaskMessage(request, response, taskMessageRoute[1]!, taskMessageRoute[2]!);
       return;
     }
 
-    if (pathname === '/healthz') {
+    if (pathname === OPERATOR_HEALTH_PATH) {
       const health: OperatorHealthResponseV1 = {
         ok: true,
         service: OPERATOR_SERVICE_NAME,
@@ -1743,20 +1874,28 @@ export async function startOperatorServer(
       return;
     }
 
-    if (pathname === '/api/v1/fleet/snapshot') {
+    if (pathname === OPERATOR_FLEET_SNAPSHOT_PATH) {
       await handleFleetSnapshot(request, response, headOnly);
       return;
     }
 
-    const collaborationRoute = COLLABORATION_SNAPSHOT_ROUTE.exec(pathname);
+    const collaborationRoute = OPERATOR_COLLABORATION_SNAPSHOT_ROUTE.exec(pathname);
     if (collaborationRoute !== null) {
       // POST reached 405 above; this route reads and nothing else.
       await handleCollaborationSnapshot(request, response, collaborationRoute[1]!, headOnly);
       return;
     }
 
-    if (pathname === '/api' || pathname.startsWith('/api/')) {
-      sendJson(response, 404, errorBody('not_found', 'The requested operator API route does not exist.'), headOnly);
+    /**
+     * The API prefix is claimed case-insensitively while the routes above stay
+     * exact, because the static fallback resolves case-insensitively on macOS
+     * and Windows: `/API/v1/fleet/snapshot` matched no API route, fell through
+     * to the SPA shell, and answered a navigation with 200 HTML. Anything under
+     * the API prefix that reached here is a missing API route and says so.
+     */
+    const apiPathname = pathname.toLowerCase();
+    if (apiPathname === OPERATOR_API_PATH_PREFIX || apiPathname.startsWith(`${OPERATOR_API_PATH_PREFIX}/`)) {
+      sendRefusal(request, response, 404, errorBody('not_found', 'The requested operator API route does not exist.'), headOnly);
       return;
     }
 
@@ -1764,9 +1903,9 @@ export async function startOperatorServer(
     const file = requestedFile ?? (isHtmlNavigation(request, pathname) ? fallbackIndex(staticRoot) : null);
     if (file === null) {
       if (pathname === '/' || isHtmlNavigation(request, pathname)) {
-        sendJson(response, 503, errorBody('operator_assets_unavailable', 'Operator UI assets are unavailable.', OPERATOR_ASSET_ACTION), headOnly);
+        sendRefusal(request, response, 503, errorBody('operator_assets_unavailable', 'Operator UI assets are unavailable.', OPERATOR_ASSET_ACTION), headOnly);
       } else {
-        sendJson(response, 404, errorBody('not_found', 'The requested operator asset does not exist.'), headOnly);
+        sendRefusal(request, response, 404, errorBody('not_found', 'The requested operator asset does not exist.'), headOnly);
       }
       return;
     }
@@ -1775,7 +1914,7 @@ export async function startOperatorServer(
     try {
       body = readFileSync(file);
     } catch (_error) {
-      sendJson(response, 503, errorBody('operator_assets_unavailable', 'Operator UI assets are unavailable.', OPERATOR_ASSET_ACTION), headOnly);
+      sendRefusal(request, response, 503, errorBody('operator_assets_unavailable', 'Operator UI assets are unavailable.', OPERATOR_ASSET_ACTION), headOnly);
       return;
     }
     const headers = {
@@ -1793,7 +1932,7 @@ export async function startOperatorServer(
         response.destroy();
         return;
       }
-      sendJson(response, 500, errorBody('operator_server_unavailable', 'Operator server failed to handle the request.'));
+      sendRefusal(request, response, 500, errorBody('operator_server_unavailable', 'Operator server failed to handle the request.'));
     });
   });
 

--- a/tasks/contracts/20260905-1414-operator-server-write-gate.contract.md
+++ b/tasks/contracts/20260905-1414-operator-server-write-gate.contract.md
@@ -1,0 +1,210 @@
+# Task Contract: operator-server-write-gate
+
+> **Status**: Active
+> **Plan**: plans/plan-20260905-1414-operator-server-write-gate.md
+> **Task Profile**: bugfix
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: ancienttwo
+> **Capability ID**: root
+> **Last Updated**: 2026-09-05 14:14
+> **Review File**: `tasks/reviews/20260905-1414-operator-server-write-gate.review.md`
+> **Notes File**: `tasks/notes/20260905-1414-operator-server-write-gate.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+> **Substantive Change SHA256**: `sha256:b4e68c870f69635d4cb39086be563f819a83beb0147099d224276410de36f302`
+
+## Why
+
+The operator board's standing boundary is that a browser has exactly one write.
+That claim was only ever probed, never structural: `OPERATOR_ROUTES` had zero
+consumers, so a route added without declaring it went uncaught, and the one
+declared write had no admission bound and no media-type check. Around the same
+boundary, a page reload landing inside the Fleet collector's abort drain was
+answered with a spurious 503, a case-variant API path returned the SPA shell
+instead of a JSON 404, and every refusal was silent, so an operator watching a
+board that dropped writes had nothing to look at.
+
+## Goal
+
+Make the single-write boundary structural and harden the transport around it:
+retire the shared Fleet observation at cancellation rather than at settlement,
+gate the route inventory with a test that counts writes against the values the
+dispatcher matches on, bound and type-check the one write route, assert the
+collaboration snapshot echoes the requested repository id, claim the API prefix
+case-insensitively, and close the header and observability gaps.
+
+## Scope
+
+- In scope:
+  - `src/effects/operator/server.ts`: exported route matchers and the inventory
+    built from them, in-flight clear at cancellation, write admission bound,
+    415 on a non-JSON write, case-insensitive API prefix, CSP `base-uri` and
+    `form-action`, `Allow` on 405, one stderr line per refusal.
+  - `src/effects/operator/collaboration.ts`: the exported snapshot identity
+    assertion and its use on both sides of the collaboration worker boundary.
+  - `tests/cli/operator-serve.test.ts` and
+    `tests/effects/operator-write-boundary.test.ts`: the regression guards.
+- Out of scope:
+  - any change to the Fleet collector, task inbox, browser UI, or Windows job controller.
+- Taste constraints: keep every refusal a fixed public sentence; the transport
+  keeps the typed code and drops the diagnostic text, paths, headers, and Origin.
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+
+## Falsifier
+
+If retiring the shared Fleet observation at cancellation let two collections run
+concurrently against one board, the direction is wrong: the point of the shared
+in-flight promise is that concurrent readers coalesce. Cheapest proof point:
+`tests/cli/operator-serve.test.ts` already asserts that two simultaneous
+snapshot requests produce exactly one collector call, and that a third request
+after both settle produces the next sequence. Both still hold, because the
+cancel path only runs when the subscriber count has already reached zero.
+
+## Root Cause Evidence
+
+- root_cause: `src/effects/operator/server.ts` cleared `inFlight` and `activeFleetCanceller` only in the settlement handlers of the shared snapshot promise, so between a sole subscriber's disconnect (which aborts the collection) and that collection actually settling — the collector drains a 500 ms cleanup grace period and then waits up to 5 s for its process group to disappear — every arriving request was handed the dying promise and answered with its failure.
+- repro: `bun src/cli/index.ts operator serve --port 0`, then `curl --max-time 0.15 $URL/api/v1/fleet/snapshot` to abort a started collection and immediately `curl -i $URL/api/v1/fleet/snapshot`; before the fix the second request answered 503 with the first one's failure.
+- regression_guard: tests/cli/operator-serve.test.ts
+- pre_fix_failure_artifact: .ai/harness/evidence/pre-fix/operator-serve.test.log
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260905-1414-operator-server-write-gate.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260905-1414-operator-server-write-gate.review.md`
+- Notes file: `tasks/notes/20260905-1414-operator-server-write-gate.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Change Assessment
+
+```json
+{"protocol":1,"oracles":[{"id":"operator-server-write-gate-deterministic","kind":"deterministic_test","paths":["*"]},{"id":"operator-server-write-gate-loopback-probe","kind":"runtime_readback","paths":["*"]}]}
+```
+
+## Acceptance Policy
+
+```json
+{"protocol":2,"reviewer":"Codex","source":"codex-review","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - plans/plan-20260905-1414-operator-server-write-gate.md
+  - tasks/todos.md
+  - tasks/contracts/20260905-1414-operator-server-write-gate.contract.md
+  - tasks/reviews/20260905-1414-operator-server-write-gate.review.md
+  - tasks/notes/20260905-1414-operator-server-write-gate.notes.md
+  - src/effects/operator/server.ts
+  - src/effects/operator/collaboration.ts
+  - src/cli/commands/operator.ts
+  - tests/
+  - docs/architecture/
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+    fallback: null
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+```yaml
+exit_criteria:
+  files_exist:
+    - src/effects/operator/server.ts
+    - src/effects/operator/collaboration.ts
+  artifacts_exist:
+    - tasks/notes/20260905-1414-operator-server-write-gate.notes.md
+    - .ai/harness/evidence/pre-fix/operator-serve.test.log
+  tests_pass:
+    - path: tests/cli/operator-serve.test.ts
+    - path: tests/effects/operator-write-boundary.test.ts
+    - path: tests/effects/operator-task-message.test.ts
+    - path: tests/effects/fleet-collector-process.test.ts
+    - path: tests/cli/collaboration.test.ts
+  commands_succeed:
+    - bun run check:type
+    - bun run build:operator-web
+    - bash scripts/check-deploy-sql-order.sh
+    - bash scripts/check-architecture-sync.sh
+    - bash scripts/check-task-sync.sh
+    - bash scripts/check-task-workflow.sh --strict
+    - bun scripts/inspect-project-state.ts --repo . --format text
+    - bun src/cli/index.ts init --repo . --dry-run
+# Optional exact-subject reuse is fail-closed and opt-in. List only deterministic
+# criteria whose inputs are fully bound by the frozen subject/toolchain context.
+# criterion_reuse:
+#   tests_pass:
+#     - path/to/deterministic.test.ts
+#   commands_succeed:
+#     - bun test --timeout 60000
+```
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior: a reload arriving inside the collector's abort drain gets
+  a fresh 200 collection; the inventory declares exactly one write and its
+  patterns are the dispatcher's own; a second concurrent write above
+  `max_concurrency` gets 503 `task_message_busy` with `Retry-After`; a non-JSON
+  write gets 415; a collaboration snapshot that does not echo the requested id
+  gets a typed 500; `/API/...` is a JSON 404; the static CSP carries `base-uri`
+  and `form-action`; every 405 carries `Allow`; every non-2xx writes one stderr
+  line and stdout stays the single bound-URL line.
+- Edge cases: Origin checks stay ahead of the media-type check, so a foreign
+  Origin with `text/plain` is still 403 and never 415; a duplicated
+  `Content-Type` header arrives joined and fails closed; the refusal path is
+  JSON-quoted and truncated to 200 characters so a control character in the
+  request target cannot forge a second log line.
+- Regression risks: the write admission bound is new refusal behavior on a route
+  that previously accepted unbounded concurrency; the browser only ever has one
+  send in flight, and the cap defaults to 4.
+
+## Rollback Point
+
+- Commit / checkpoint: main 1a9a5ae1 (branch base)
+- Revert strategy: revert the two commits on `codex/operator-server-write-gate`
+  together; the server change and its guards share one rollback surface.

--- a/tasks/contracts/20260905-1414-operator-server-write-gate.contract.md
+++ b/tasks/contracts/20260905-1414-operator-server-write-gate.contract.md
@@ -1,6 +1,6 @@
 # Task Contract: operator-server-write-gate
 
-> **Status**: Active
+> **Status**: Fulfilled
 > **Plan**: plans/plan-20260905-1414-operator-server-write-gate.md
 > **Task Profile**: bugfix
 > <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
@@ -10,7 +10,7 @@
 > **Review File**: `tasks/reviews/20260905-1414-operator-server-write-gate.review.md`
 > **Notes File**: `tasks/notes/20260905-1414-operator-server-write-gate.notes.md`
 > **Exemplar**: `docs/reference-configs/contract-brief-example.md`
-> **Substantive Change SHA256**: `sha256:b4e68c870f69635d4cb39086be563f819a83beb0147099d224276410de36f302`
+> **Substantive Change SHA256**: `sha256:823b80ff4f808689792de8371a84ff0c4eb6950c5a2c80556aef7393ce2ed6f1`
 
 ## Why
 
@@ -195,8 +195,10 @@ exit_criteria:
   and `form-action`; every 405 carries `Allow`; every non-2xx writes one stderr
   line and stdout stays the single bound-URL line.
 - Edge cases: Origin checks stay ahead of the media-type check, so a foreign
-  Origin with `text/plain` is still 403 and never 415; a duplicated
-  `Content-Type` header arrives joined and fails closed; the refusal path is
+  Origin with `text/plain` is still 403 and never 415; Node keeps the first
+  `content-type` value and drops later duplicates, so a duplicated header cannot
+  widen the gate — a non-JSON first value is refused with 415, and a JSON first
+  value still has to pass the body decoder; the refusal path is
   JSON-quoted and truncated to 200 characters so a control character in the
   request target cannot forge a second log line.
 - Regression risks: the write admission bound is new refusal behavior on a route
@@ -206,5 +208,5 @@ exit_criteria:
 ## Rollback Point
 
 - Commit / checkpoint: main 1a9a5ae1 (branch base)
-- Revert strategy: revert the two commits on `codex/operator-server-write-gate`
+- Revert strategy: revert the branch's commits on `codex/operator-server-write-gate`
   together; the server change and its guards share one rollback surface.

--- a/tasks/notes/20260905-1414-operator-server-write-gate.notes.md
+++ b/tasks/notes/20260905-1414-operator-server-write-gate.notes.md
@@ -21,6 +21,11 @@
 - The write admission bound has no queue. Collaboration queues because several
   repositories can legitimately be observed at once; the board only ever has one
   send in flight, so a caller above the cap is not a browser waiting its turn.
+- Write admission and collaboration admission read the same `max_concurrency`
+  value but keep separate counters, so the aggregate child-process budget is
+  2x `max_concurrency` plus the Fleet collector; that is deliberate, because the
+  browser has at most one write in flight and the two paths bound unrelated
+  workloads.
 
 ## Deviations From Plan Or Spec
 

--- a/tasks/notes/20260905-1414-operator-server-write-gate.notes.md
+++ b/tasks/notes/20260905-1414-operator-server-write-gate.notes.md
@@ -1,0 +1,73 @@
+# Implementation Notes: operator-server-write-gate
+
+> **Status**: Active
+> **Plan**: plans/plan-20260905-1414-operator-server-write-gate.md
+> **Contract**: tasks/contracts/20260905-1414-operator-server-write-gate.contract.md
+> **Review**: tasks/reviews/20260905-1414-operator-server-write-gate.review.md
+> **Last Updated**: 2026-09-05 14:14
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- The collaboration identity assertion is one exported function applied at two
+  call sites: the reader's own projection in `collaboration.ts`, and the worker
+  payload in `server.ts` where the requested id is still in scope. Two call
+  sites, one rule — the alternative was a second copy of the comparison on the
+  transport side, which is exactly the drift the assertion exists to prevent.
+- The refusal log lives in one `sendRefusal()` wrapper rather than inside
+  `sendJson()`. `sendJson()` has no request in scope and also serves the 2xx
+  responses, which must stay silent; routing every non-2xx through a named
+  refusal helper makes the logged set the same set as the refused set.
+- The write admission bound has no queue. Collaboration queues because several
+  repositories can legitimately be observed at once; the board only ever has one
+  send in flight, so a caller above the cap is not a browser waiting its turn.
+
+## Deviations From Plan Or Spec
+
+- The plan sketched the API prefix match as `pathname.toLowerCase().startsWith('/api')`.
+  The implementation keeps the existing prefix boundary and only makes it
+  case-insensitive (`=== '/api'` or `startsWith('/api/')`). The bare prefix
+  would also claim a static asset named `apidocs.html`, which widens the change
+  beyond the stated goal that any case variant is an API 404.
+- The route inventory gate lives in a new `tests/effects/operator-write-boundary.test.ts`
+  rather than in `tests/cli/operator-serve.test.ts`. It is the only guard that
+  needs symbols the fix introduces, so keeping it separate leaves the pre-fix
+  artifact for the transport guards showing real assertion failures instead of a
+  module-resolution error that would have hidden all of them.
+- The collaboration identity mismatch cannot be produced through the registry:
+  `readRepoHarnessRegistryStrictSnapshot()` already refuses an entry whose id is
+  not derived from its canonical path, and the collector derives the snapshot id
+  from that same path. The guard is therefore a direct assertion test plus a
+  transport test that the typed code maps to a 500-class refusal with a fixed
+  public sentence, not an end-to-end forged mismatch.
+- Task Profile was promoted from the scaffold's `code-change` to `bugfix` so the
+  Root Cause Evidence gate actually evaluates the captured pre-fix artifact.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| Clear the shared Fleet observation at cancellation vs. keep it until settlement and let a retry wait | Clear at cancellation | The collector's abort path drains a grace period and then waits for a process group; a reload inside that window is a new reader, not a subscriber to the dying collection. This is what the collaboration path already does. |
+| Attach the refusal log to `sendJson()` vs. a `sendRefusal()` wrapper | Wrapper | `sendJson()` also serves 2xx and has no request in scope; the wrapper makes the logged set exactly the refused set. |
+| Per-resource `Allow` vs. one server-wide value | Server-wide `GET, HEAD, POST` | The approved decision; the refusal already names which route accepts what in its message. |
+
+## Open Questions
+
+- None.
+
+## Evidence Links
+
+- Pre-fix artifacts: `.ai/harness/evidence/pre-fix/operator-serve.test.log`,
+  `.ai/harness/evidence/pre-fix/operator-write-boundary.test.log`
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/reviews/20260905-1414-operator-server-write-gate.review.md
+++ b/tasks/reviews/20260905-1414-operator-server-write-gate.review.md
@@ -15,28 +15,57 @@
 ## Human Review Card
 
 - Verdict: pending
-- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
-- Intended files changed:
-- Actual files changed:
-- Commands passed:
-- Residual risks:
+- Change type: bugfix
+- Intended files changed: `src/effects/operator/server.ts`,
+  `src/effects/operator/collaboration.ts`, `tests/cli/operator-serve.test.ts`,
+  plus the plan, contract, review, and notes of this work package.
+- Actual files changed: the intended set, minus `src/cli/commands/operator.ts`
+  (the refusal log needed no CLI wiring), plus a new
+  `tests/effects/operator-write-boundary.test.ts` and `tasks/todos.md`.
+- Commands passed: `bun run check:type`; `bun run build:operator-web`;
+  `bun test --timeout 60000 tests/cli/operator-serve.test.ts tests/effects/fleet-collector-process.test.ts tests/effects/operator-task-message.test.ts tests/cli/collaboration.test.ts tests/effects/operator-write-boundary.test.ts`
+  (51 pass, 2 skip, 0 fail); the six repository-integrity checks;
+  `bun test --timeout 60000` (4192 pass, 4 skip, 0 fail across 350 files).
+- Residual risks: the write admission bound is new refusal behavior on a route
+  that previously accepted unbounded concurrency.
 - Reviewer action required: inspect diff and card
-- Rollback:
+- Rollback: revert the three commits on `codex/operator-server-write-gate`.
 
 ## Mode Evidence
 
-- Selected route:
-- P1/P2/P3 evidence:
-- Root cause or plan evidence:
+- Selected route: planning (captured work-package plan executed in an isolated
+  contract worktree).
+- P1/P2/P3 evidence: `plans/plan-20260905-1414-operator-server-write-gate.md`
+  `## Captured Planning Output`.
+- Root cause or plan evidence: `## Root Cause Evidence` in the contract, backed
+  by `.ai/harness/evidence/pre-fix/operator-serve.test.log` (`PRE_FIX_EXIT=1`,
+  six failing guards) and
+  `.ai/harness/evidence/pre-fix/operator-write-boundary.test.log`
+  (`PRE_FIX_EXIT=1`).
 
 ## Verification Evidence
 
-- Waza `/check` run:
-- Commands run:
-- Manual checks:
-- Supporting artifacts:
-- Implementation notes reviewed:
-- Run snapshot:
+- Waza `/check` run: not run; this work package was executed and verified
+  directly against the plan's Verification section.
+- Commands run: `bun run check:type`; the focused test set;
+  `bun run build:operator-web`; `bash scripts/check-deploy-sql-order.sh`;
+  `bash scripts/check-architecture-sync.sh`;
+  `REPO_HARNESS_DIFF_BASE=origin/main REPO_HARNESS_DIFF_MODE=merge-base bash scripts/check-task-sync.sh`;
+  `bash scripts/check-task-workflow.sh --strict`;
+  `bun scripts/inspect-project-state.ts --repo . --format text`;
+  `bun src/cli/index.ts init --repo . --dry-run`; `bun test --timeout 60000`.
+- Manual checks: live loopback probe against `bun src/cli/index.ts operator
+  serve --port 0` — an aborted snapshot followed immediately by a re-request
+  answered `HTTP/1.1 200 OK`; a `text/plain` POST answered `415 Unsupported
+  Media Type` with `unsupported_media_type`; `/API/v1/fleet/snapshot` with
+  `Accept: text/html` answered `404 Not Found` as
+  `application/json; charset=utf-8`; `OPTIONS` answered `405` with
+  `Allow: GET, HEAD, POST`; the document carried the pinned
+  `Content-Security-Policy`. A separate run with stdout and stderr split proved
+  stdout stays the single bound-URL line while refusals go to stderr.
+- Supporting artifacts: pre-fix logs under `.ai/harness/evidence/pre-fix/`.
+- Implementation notes reviewed: `tasks/notes/20260905-1414-operator-server-write-gate.notes.md`.
+- Run snapshot: `.ai/harness/runs/`
 
 ## Acceptance Receipt Projection
 
@@ -55,11 +84,24 @@
 
 ## Behavior Diff Notes
 
-- ...
+- A Fleet snapshot request arriving after a sole subscriber disconnected now
+  starts a new collection instead of inheriting the cancelled one's failure.
+- A second concurrent task-message write above `max_concurrency` is refused
+  `503 task_message_busy` with `Retry-After: 1` instead of spawning another
+  child process.
+- A task-message write without an `application/json` media type is refused 415.
+- `/API/...` and other case variants are a JSON 404 instead of the SPA shell.
+- The static CSP gained `base-uri 'none'` and `form-action 'none'`; 405
+  responses gained `Allow`; every non-2xx response writes one stderr line.
 
 ## Residual Risks / Follow-ups
 
-- ...
+- The collaboration identity mismatch is unreachable through the registry today,
+  because the strict registry reader already refuses an entry whose id is not
+  derived from its canonical path. The assertion is a structural guard on the
+  worker boundary, not a live failure mode.
+- `verify-contract --strict` could not be run: the repository-wide
+  `expensive-run.lock` was held throughout by a live peer worktree.
 
 ## Scorecard
 
@@ -72,13 +114,17 @@
 
 ## Failing Items
 
-- ...
+- None.
 
 ## Retest Steps
 
-- Re-run:
-- Re-check:
+- Re-run: `bun test --timeout 60000 tests/cli/operator-serve.test.ts tests/effects/operator-write-boundary.test.ts`
+- Re-check: `bun src/cli/index.ts run verify-contract --contract tasks/contracts/20260905-1414-operator-server-write-gate.contract.md --strict`
 
 ## Summary
 
-- ...
+- The operator board's one-write boundary is now declared as a value and gated
+  by a test that counts writes against the matchers the dispatcher uses, the
+  write itself is bounded and typed, and the transport around it no longer
+  answers a reload with a cancelled collection's failure, leaks the SPA shell
+  through a case-variant API path, or refuses a request silently.

--- a/tasks/reviews/20260905-1414-operator-server-write-gate.review.md
+++ b/tasks/reviews/20260905-1414-operator-server-write-gate.review.md
@@ -1,0 +1,84 @@
+# Task Review: operator-server-write-gate
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260905-1414-operator-server-write-gate.md
+> **Contract**: tasks/contracts/20260905-1414-operator-server-write-gate.contract.md
+> **Notes File**: tasks/notes/20260905-1414-operator-server-write-gate.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-09-05 14:14
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Commands passed:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+- Waza `/check` run:
+- Commands run:
+- Manual checks:
+- Supporting artifacts:
+- Implementation notes reviewed:
+- Run snapshot:
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...

--- a/tasks/reviews/20260905-1414-operator-server-write-gate.review.md
+++ b/tasks/reviews/20260905-1414-operator-server-write-gate.review.md
@@ -1,20 +1,20 @@
 # Task Review: operator-server-write-gate
 
-> **Status**: Pending
+> **Status**: Complete
 > **Plan**: plans/plan-20260905-1414-operator-server-write-gate.md
 > **Contract**: tasks/contracts/20260905-1414-operator-server-write-gate.contract.md
 > **Notes File**: tasks/notes/20260905-1414-operator-server-write-gate.notes.md
 > **Checks File**: .ai/harness/checks/latest.json
 > **Last Updated**: 2026-09-05 14:14
-> **Recommendation**: fail
+> **Recommendation**: pass
 > **Review Rubric Version**: 2
 > **Reviewed Subject SHA256**: pending
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: pending
+> **Reviewed Target Revision**: 27c7de3c
 
 ## Human Review Card
 
-- Verdict: pending
+- Verdict: pass
 - Change type: bugfix
 - Intended files changed: `src/effects/operator/server.ts`,
   `src/effects/operator/collaboration.ts`, `tests/cli/operator-serve.test.ts`,
@@ -29,7 +29,7 @@
 - Residual risks: the write admission bound is new refusal behavior on a route
   that previously accepted unbounded concurrency.
 - Reviewer action required: inspect diff and card
-- Rollback: revert the three commits on `codex/operator-server-write-gate`.
+- Rollback: revert the branch's commits on `codex/operator-server-write-gate` together.
 
 ## Mode Evidence
 
@@ -53,7 +53,9 @@
   `REPO_HARNESS_DIFF_BASE=origin/main REPO_HARNESS_DIFF_MODE=merge-base bash scripts/check-task-sync.sh`;
   `bash scripts/check-task-workflow.sh --strict`;
   `bun scripts/inspect-project-state.ts --repo . --format text`;
-  `bun src/cli/index.ts init --repo . --dry-run`; `bun test --timeout 60000`.
+  `bun src/cli/index.ts init --repo . --dry-run`; `bun test --timeout 60000`;
+  `bun src/cli/index.ts run verify-contract --contract tasks/contracts/20260905-1414-operator-server-write-gate.contract.md --strict`
+  (27/27 Fulfilled).
 - Manual checks: live loopback probe against `bun src/cli/index.ts operator
   serve --port 0` — an aborted snapshot followed immediately by a re-request
   answered `HTTP/1.1 200 OK`; a `text/plain` POST answered `415 Unsupported
@@ -100,17 +102,28 @@
   because the strict registry reader already refuses an entry whose id is not
   derived from its canonical path. The assertion is a structural guard on the
   worker boundary, not a live failure mode.
-- `verify-contract --strict` could not be run: the repository-wide
-  `expensive-run.lock` was held throughout by a live peer worktree.
+- During the collector's abort drain (up to 5.5 s), a reconnect starts a second
+  collector. Nothing but the reload rate bounds how many overlap: the Fleet path
+  has no admission counter of the kind the collaboration path carries.
+- Write admission and collaboration admission read the same `max_concurrency`
+  value but keep separate counters, so the aggregate child-process budget is
+  2x `max_concurrency` plus the Fleet collector.
+- The write admission counter is incremented outside the `try` whose `finally`
+  releases it (`src/effects/operator/server.ts` ~1613 vs ~1643), with the
+  request's cancellation and timeout setup in between. None of those statements
+  throws in practice, so no counter leak is reachable today, but the release is
+  not structurally bound to the acquire.
+- The pre-fix evidence lives under gitignored `.ai/harness/evidence/` and does
+  not travel with the branch; a later reader sees the claim, not the artifact.
 
 ## Scorecard
 
 | Dimension | Score | Notes |
 |-----------|-------|-------|
-| Functionality | 0/10 | |
-| Product depth | 0/10 | |
-| Design quality | 0/10 | |
-| Code quality | 0/10 | |
+| Functionality | 9/10 | All seven plan defects are fixed and each is pinned by a live probe: the reload race answers 200 with sequence 2, `text/plain` with a good Origin is 415 while no Origin is still 403 `origin_required`, `/API/v1/fleet/snapshot` is a JSON 404, `OPTIONS` is 405 with `Allow: GET, HEAD, POST`, the CSP carries `base-uri 'none'` and `form-action 'none'`, and 9 refusals produced 9 stderr lines with stdout holding exactly 1 line. Held back from 10 by the unbounded collector overlap during the abort drain. |
+| Product depth | 8/10 | The refusals are typed, named, and retryable where retry is the right answer (`503 task_message_busy` with `Retry-After: 1`), and the operator-visible surface — one stdout line, one stderr line per refusal — stays legible under load. The child-process budget is still 2x `max_concurrency` across two counters rather than one declared number. |
+| Design quality | 8/10 | One `sendRefusal()` wrapper makes the logged set exactly the refused set, and the identity assertion is one exported rule at two call sites instead of a duplicated comparison. The write admission counter's acquire and release are adjacent by convention rather than structurally paired. |
+| Code quality | 9/10 | `tsc` clean, `vite` operator-web build ok, focused set 51 pass / 2 skip / 0 fail, full suite 4192 pass / 4 skip / 0 fail, the six repository-integrity checks exit 0 plus CI-mode `check-task-sync` exit 0, and `verify-contract --strict` reports 27/27 Fulfilled. |
 
 ## Failing Items
 

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -1,7 +1,7 @@
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: (archive-workflow)
+> **Updated**: 2026-09-05 14:14
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.

--- a/tests/cli/operator-serve.test.ts
+++ b/tests/cli/operator-serve.test.ts
@@ -9,6 +9,7 @@ import { projectFleetBoardSnapshot } from '../../src/core/fleet/board';
 import { TASK_MESSAGE_BODY_MAX_BYTES } from '../../src/core/fleet/task-message';
 import type { OperatorCollaborationSnapshotV1 } from '../../src/core/operator/collaboration-snapshot';
 import { repoHarnessRegisteredReposPath, repoHarnessRepoIdFor } from '../../src/effects/repo-registry';
+import { OperatorCollaborationError } from '../../src/effects/operator/collaboration';
 import {
   OPERATOR_TASK_MESSAGE_BODY_MAX_BYTES,
   OPERATOR_TASK_MESSAGE_REQUEST_MAX_BYTES,
@@ -831,16 +832,23 @@ describe('operator serve command and HTTP boundary', () => {
     let started = false;
     let abortObserved = false;
     let healthy = false;
+    let collectCalls = 0;
     const server = await startOperatorServer({
       port: 0,
       static_root: staticRoot,
       collect_fleet_board: async (options) => {
+        collectCalls += 1;
         if (healthy) return snapshot(options?.sequence ?? 1);
         started = true;
         return new Promise<never>((_resolve, reject) => {
           options?.signal?.addEventListener('abort', () => {
             abortObserved = true;
-            reject(new Error('cancelled Fleet fixture'));
+            // The production collector settles long after the abort signal: it
+            // drains a cleanup grace period and then waits for the collector
+            // process group to disappear. A fixture that rejects inside the
+            // abort listener hides the reload race entirely, because the shared
+            // in-flight promise is already gone by the time a retry arrives.
+            setTimeout(() => reject(new Error('cancelled Fleet fixture')), 300);
           }, { once: true });
         });
       },
@@ -862,8 +870,12 @@ describe('operator serve command and HTTP boundary', () => {
       socket.destroy();
       await waitFor(() => abortObserved, 'Fleet client disconnect did not abort collection');
       healthy = true;
+      // A page reload lands here: the cancelled collection has not settled yet,
+      // so a shared in-flight promise would hand this request the dying one.
       const retry = await fetch(`${server.url}/api/v1/fleet/snapshot`);
       expect(retry.status).toBe(200);
+      expect(await retry.json()).toMatchObject({ kind: 'operator_fleet_snapshot' });
+      expect(collectCalls).toBe(2);
     } finally {
       socket.destroy();
       await server.close();
@@ -1008,6 +1020,192 @@ describe('operator serve command and HTTP boundary', () => {
       await server.close();
       rmSync(staticRoot, { recursive: true, force: true });
       rmSync(outsideRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('bounds concurrent task-message writes and refuses above the admission cap', async () => {
+    const staticRoot = mkdtempSync(join(tmpdir(), 'repo-harness-operator-write-admission-'));
+    writeFileSync(join(staticRoot, 'index.html'), '<!doctype html><main>operator</main>');
+    let started = 0;
+    let releaseFirst!: (result: SendOperatorTaskMessageResult) => void;
+    const server = await startOperatorServer({
+      port: 0,
+      static_root: staticRoot,
+      max_concurrency: 1,
+      collect_fleet_board: async () => snapshot(),
+      send_task_message: () => new Promise<SendOperatorTaskMessageResult>((resolveSend) => {
+        started += 1;
+        releaseFirst = resolveSend;
+      }),
+    });
+    const url = `${server.url}${messagePath('repo-write')}`;
+    const headers = { 'Content-Type': 'application/json', Origin: server.url };
+    const first = fetch(url, { method: 'POST', headers, body: taskMessagePayload() });
+    try {
+      await waitFor(() => started === 1, 'first task-message write did not start');
+      const overloaded = await fetch(url, { method: 'POST', headers, body: taskMessagePayload() });
+      expect(overloaded.status).toBe(503);
+      expect(overloaded.headers.get('retry-after')).toBe('1');
+      expect(await overloaded.json()).toMatchObject({
+        error: {
+          code: 'task_message_busy',
+          message: 'The task message service is busy.',
+        },
+      });
+      expect(started).toBe(1);
+
+      releaseFirst(sendResult());
+      expect((await first).status).toBe(201);
+    } finally {
+      await server.close();
+      rmSync(staticRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('requires an application/json media type on the one write route', async () => {
+    const calls: SendOperatorTaskMessageInput[] = [];
+    const harness = await startWriteServer(async () => sendResult(), calls);
+    const url = `${harness.server.url}${messagePath('repo-write')}`;
+    try {
+      for (const declared of ['text/plain;charset=UTF-8', 'application/x-www-form-urlencoded', 'application/jsonish']) {
+        const refused = await fetch(url, {
+          method: 'POST',
+          headers: { 'Content-Type': declared, Origin: harness.server.url },
+          body: taskMessagePayload(),
+        });
+        expect(refused.status).toBe(415);
+        expect(await refused.json()).toMatchObject({
+          error: {
+            code: 'unsupported_media_type',
+            message: 'The task message request must be sent as application/json.',
+          },
+        });
+      }
+      expect(calls).toEqual([]);
+
+      const parameterized = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'Application/JSON; charset=utf-8', Origin: harness.server.url },
+        body: taskMessagePayload(),
+      });
+      expect(parameterized.status).toBe(201);
+      expect(calls).toHaveLength(1);
+
+      // Origin is the CSRF barrier and stays ahead of the media-type check.
+      const foreignOrigin = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'text/plain', Origin: 'http://attacker.example' },
+        body: taskMessagePayload(),
+      });
+      expect(foreignOrigin.status).toBe(403);
+      expect(await foreignOrigin.json()).toMatchObject({ error: { code: 'origin_not_allowed' } });
+      expect(calls).toHaveLength(1);
+    } finally {
+      await stopWriteServer(harness);
+    }
+  });
+
+  test('turns a collaboration repository identity mismatch into a typed refusal', async () => {
+    const staticRoot = mkdtempSync(join(tmpdir(), 'repo-harness-operator-collaboration-echo-'));
+    writeFileSync(join(staticRoot, 'index.html'), '<!doctype html><main>operator</main>');
+    const server = await startOperatorServer({
+      port: 0,
+      static_root: staticRoot,
+      collect_fleet_board: async () => snapshot(),
+      read_collaboration_snapshot: async () => {
+        throw new OperatorCollaborationError(
+          'collaboration_repository_mismatch',
+          'collaboration snapshot for /private/tmp/other-repo answered repo-other',
+        );
+      },
+    });
+    try {
+      const response = await fetch(`${server.url}/api/v1/collaboration/repo-write/snapshot`);
+      expect(response.status).toBe(500);
+      const body = await response.json() as { error: { code: string; message: string; next_action: string } };
+      expect(body.error.code).toBe('collaboration_repository_mismatch');
+      expect(body.error.message).toBe('The collaboration snapshot does not belong to the requested repository.');
+      expect(body.error.next_action.length).toBeGreaterThan(0);
+      expect(JSON.stringify(body)).not.toContain('/private/tmp/other-repo');
+      expect(JSON.stringify(body)).not.toContain('repo-other');
+    } finally {
+      await server.close();
+      rmSync(staticRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('keeps a case-variant API path off the SPA shell and pins the refusal headers', async () => {
+    const staticRoot = mkdtempSync(join(tmpdir(), 'repo-harness-operator-headers-'));
+    writeFileSync(join(staticRoot, 'index.html'), '<!doctype html><main>operator</main>');
+    const server = await startOperatorServer({
+      port: 0,
+      static_root: staticRoot,
+      collect_fleet_board: async () => snapshot(),
+    });
+    try {
+      for (const variant of ['/API/v1/fleet/snapshot', '/Api/v1/collaboration/repo-write/snapshot', '/API']) {
+        const response = await fetch(`${server.url}${variant}`, { headers: { Accept: 'text/html' } });
+        expect(response.status).toBe(404);
+        expect(response.headers.get('content-type')).toBe('application/json; charset=utf-8');
+        const text = await response.text();
+        expect(text).not.toContain('<main>operator</main>');
+        expect(JSON.parse(text)).toMatchObject({ error: { code: 'not_found' } });
+      }
+
+      const document = await fetch(`${server.url}/`);
+      expect(document.status).toBe(200);
+      expect(document.headers.get('content-security-policy')).toBe(
+        "default-src 'self'; base-uri 'none'; connect-src 'self'; font-src 'self'; form-action 'none'; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline'; frame-ancestors 'none'",
+      );
+
+      const options = await fetch(`${server.url}/api/v1/fleet/snapshot`, { method: 'OPTIONS' });
+      expect(options.status).toBe(405);
+      expect(options.headers.get('allow')).toBe('GET, HEAD, POST');
+      expect(options.headers.get('content-security-policy')).toBeNull();
+      expect(await options.json()).toMatchObject({ error: { code: 'method_not_allowed' } });
+    } finally {
+      await server.close();
+      rmSync(staticRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('logs one stderr line per refusal without the body, headers, or Origin', async () => {
+    const calls: SendOperatorTaskMessageInput[] = [];
+    const harness = await startWriteServer(async () => sendResult(), calls);
+    const url = `${harness.server.url}${messagePath('repo-write')}`;
+    const captured: string[] = [];
+    const originalWrite = process.stderr.write.bind(process.stderr);
+    try {
+      process.stderr.write = ((chunk: unknown) => {
+        captured.push(typeof chunk === 'string' ? chunk : String(chunk));
+        return true;
+      }) as typeof process.stderr.write;
+      try {
+        const refused = await fetch(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'text/plain', Origin: harness.server.url },
+          body: taskMessagePayload('confidential-operator-body'),
+        });
+        expect(refused.status).toBe(415);
+        await waitFor(() => captured.length > 0, 'refusal was not logged');
+        const accepted = await fetch(`${harness.server.url}/healthz`);
+        expect(accepted.status).toBe(200);
+      } finally {
+        process.stderr.write = originalWrite;
+      }
+      const lines = captured.join('').split('\n').filter((line) => line.length > 0);
+      expect(lines).toHaveLength(1);
+      const line = lines[0]!;
+      expect(line).toContain('method=POST');
+      expect(line).toContain('status=415');
+      expect(line).toContain('code=unsupported_media_type');
+      expect(line).toContain(messagePath('repo-write'));
+      expect(line).not.toContain('confidential-operator-body');
+      expect(line).not.toContain(harness.server.url);
+      expect(line).not.toContain('text/plain');
+      expect(calls).toEqual([]);
+    } finally {
+      await stopWriteServer(harness);
     }
   });
 });

--- a/tests/effects/operator-write-boundary.test.ts
+++ b/tests/effects/operator-write-boundary.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  OPERATOR_COLLABORATION_PROTOCOL,
+  OPERATOR_COLLABORATION_SNAPSHOT_KIND,
+  type OperatorCollaborationSnapshotV1,
+} from '../../src/core/operator/collaboration-snapshot';
+import {
+  OperatorCollaborationError,
+  assertOperatorCollaborationSnapshotIdentity,
+} from '../../src/effects/operator/collaboration';
+import {
+  OPERATOR_API_PATH_PREFIX,
+  OPERATOR_COLLABORATION_SNAPSHOT_ROUTE,
+  OPERATOR_FLEET_SNAPSHOT_PATH,
+  OPERATOR_HEALTH_PATH,
+  OPERATOR_ROUTES,
+  OPERATOR_STATIC_ASSET_PATTERN,
+  OPERATOR_TASK_MESSAGE_ROUTE,
+  type OperatorRouteV1,
+} from '../../src/effects/operator/server';
+
+/**
+ * The inventory claim under test is "exactly one browser write". Probing a
+ * running server proves how the routes that exist behave, never which routes
+ * exist, so the gate is applied to the declared inventory as a value.
+ */
+function writeRouteIds(routes: readonly OperatorRouteV1[]): readonly string[] {
+  return routes.filter((route) => route.write).map((route) => route.id);
+}
+
+function collaborationSnapshot(
+  overrides: Partial<OperatorCollaborationSnapshotV1> = {},
+): OperatorCollaborationSnapshotV1 {
+  return {
+    protocol: OPERATOR_COLLABORATION_PROTOCOL,
+    kind: OPERATOR_COLLABORATION_SNAPSHOT_KIND,
+    repository_id: 'repo-a',
+    ...overrides,
+  } as OperatorCollaborationSnapshotV1;
+}
+
+describe('operator structural write boundary', () => {
+  test('declares exactly one write route and the negative probe fails the same assertion', () => {
+    expect(writeRouteIds(OPERATOR_ROUTES)).toEqual(['task_message']);
+
+    const undeclaredWrite: OperatorRouteV1 = {
+      id: 'fake_write',
+      method: 'POST',
+      pattern: '/api/v1/fleet/tasks/anything',
+      write: true,
+    };
+    expect(writeRouteIds([...OPERATOR_ROUTES, undeclaredWrite])).not.toEqual(['task_message']);
+  });
+
+  test('pins every inventory pattern to the value the dispatcher matches on', () => {
+    const patterns = new Map(OPERATOR_ROUTES.map((route) => [route.id, route.pattern]));
+    expect(patterns.size).toBe(OPERATOR_ROUTES.length);
+    expect([...patterns.keys()]).toEqual([
+      'health',
+      'fleet_snapshot',
+      'collaboration_snapshot',
+      'static_asset',
+      'task_message',
+    ]);
+    expect(patterns.get('health')).toBe(OPERATOR_HEALTH_PATH);
+    expect(patterns.get('fleet_snapshot')).toBe(OPERATOR_FLEET_SNAPSHOT_PATH);
+    expect(patterns.get('collaboration_snapshot')).toBe(OPERATOR_COLLABORATION_SNAPSHOT_ROUTE.source);
+    expect(patterns.get('static_asset')).toBe(OPERATOR_STATIC_ASSET_PATTERN);
+    expect(patterns.get('task_message')).toBe(OPERATOR_TASK_MESSAGE_ROUTE.source);
+
+    expect(OPERATOR_FLEET_SNAPSHOT_PATH.startsWith(OPERATOR_API_PATH_PREFIX)).toBe(true);
+    expect(OPERATOR_TASK_MESSAGE_ROUTE.test('/api/v1/fleet/tasks/repo-a/'.concat('b'.repeat(64), '/messages'))).toBe(true);
+    expect(OPERATOR_TASK_MESSAGE_ROUTE.test('/API/v1/fleet/tasks/repo-a/'.concat('b'.repeat(64), '/messages'))).toBe(false);
+  });
+
+  test('refuses a collaboration snapshot that does not echo the requested identity', () => {
+    expect(() => assertOperatorCollaborationSnapshotIdentity(collaborationSnapshot(), 'repo-a')).not.toThrow();
+
+    for (const [snapshot, requested] of [
+      [collaborationSnapshot({ repository_id: 'repo-b' }), 'repo-a'],
+      [collaborationSnapshot({ protocol: 99 as never }), 'repo-a'],
+      [collaborationSnapshot({ kind: 'operator_fleet_snapshot' as never }), 'repo-a'],
+      [{} as OperatorCollaborationSnapshotV1, 'repo-a'],
+    ] as const) {
+      let thrown: unknown;
+      try {
+        assertOperatorCollaborationSnapshotIdentity(snapshot, requested);
+      } catch (error) {
+        thrown = error;
+      }
+      expect(thrown).toBeInstanceOf(OperatorCollaborationError);
+      expect((thrown as OperatorCollaborationError).code).toBe('collaboration_repository_mismatch');
+    }
+  });
+});


### PR DESCRIPTION
The operator board's standing claim is that a browser has exactly one write. That claim was only ever probed, never structural, and the transport around it had a set of low-severity gaps. This makes the boundary structural and closes them.

## Behavior

- **Route inventory is now a gate.** The dispatcher's own matchers are exported and `OPERATOR_ROUTES` is built from them, so the inventory carries the values `handleRequest` matches on rather than a second copy of the same strings. A test asserts exactly one `write: true` entry.
- **The shared Fleet observation is retired at cancellation, not at settlement.** The collector's abort path drains a cleanup grace period and then waits for its process group, so a request arriving inside that window used to be handed the dying promise and answered with its failure. A page reload right after the previous page disconnected is exactly that request; it now starts a fresh collection and gets 200.
- **The one write is bounded.** A second concurrent write above `max_concurrency` is refused `503 task_message_busy` with `Retry-After` and a fixed public sentence, instead of spawning another child process. The board only ever has one send in flight, so the cap does not change product behavior.
- **The write requires `application/json`.** Anything else is 415 with a fixed sentence. Origin equality is the CSRF barrier and stays ahead of the media-type check, so a foreign Origin is still 403 and never 415.
- **The collaboration snapshot must answer the repository it was asked about.** One exported assertion validates `protocol`, `kind`, and `repository_id` on both sides of the worker boundary. A mismatch is a typed `collaboration_repository_mismatch` refusal that states a fixed sentence and never echoes an id.
- **The API prefix is claimed case-insensitively.** `/API/v1/fleet/snapshot` was falling through to the static handler and answering a navigation with the SPA shell; any case variant is now a JSON 404. The route patterns themselves stay exact, and the prefix boundary is preserved so a static asset named `apidocs.html` is still served.
- **Headers and observability.** The static CSP gains `base-uri 'none'` and `form-action 'none'`, pinned verbatim in a test. Every 405 carries `Allow: GET, HEAD, POST`. Every non-2xx writes one stderr line carrying the method, status, error code, and the request path — JSON-quoted and truncated to 200 characters so a control character cannot forge a second line — and never the body, headers, or Origin. 2xx responses log nothing and stdout stays the single bound-URL line.

JSON responses deliberately carry no CSP: a policy governs a document, and JSON is already served `nosniff`.

## Verification

- Focused suite (`operator-serve`, `fleet-collector-process`, `operator-task-message`, `collaboration`, `operator-write-boundary`): 51 pass / 2 skip / 0 fail.
- Full suite on the frozen source head: 4192 pass / 4 skip / 0 fail across 350 files.
- `bun run check:type`, `bun run build:operator-web`, and the six repository-integrity checks: all exit 0, including `check-task-sync` in CI merge-base mode.
- `verify-contract --strict`: 27/27, status Fulfilled.
- Live loopback probe: an aborted snapshot followed immediately by a re-request answers 200; a `text/plain` POST with a same-origin Origin answers 415 while the same POST without an Origin answers 403 `origin_required`, proving the ordering; `/API/v1/fleet/snapshot` with `Accept: text/html` answers a JSON 404; `OPTIONS` answers 405 with `Allow`; the document carries the pinned CSP; a `%0a%0d` path is logged as one escaped line; stdout stays one line.

## Integration notes

- `tests/cli/operator-serve.test.ts` is also touched by `codex/fleet-board-card-containment`, which additionally changes `src/core/operator/fleet-snapshot.ts` — consumed by this server's snapshot projection. Whichever of the two merges second should rebase and re-run that test file.
- `tasks/todos.md` overlaps with #316 on the one-line `Updated:` stamp.
