### PR TITLE
fix(ci): repair the Linux deadline fixture and self-host task-sync resolution

### DIFF
--- a/assets/templates/helpers/check-task-sync.sh
+++ b/assets/templates/helpers/check-task-sync.sh
@@ -335,7 +335,18 @@ fi
 # The state resolver owns risk and ceremony policy. Pass the complete diff
 # inventory, including base-only and documentation paths, so a clean HEAD or
 # the substantive-path filter cannot hide strict-category signals.
-if ! command -v repo-harness >/dev/null 2>&1; then
+# The repo-harness source checkout resolves through its own CLI source, the
+# same selection check-architecture-sync.sh makes; every other repo uses the
+# installed CLI.
+repo_root="$(git rev-parse --show-toplevel)"
+repo_harness_cli=()
+if [[ -f "$repo_root/src/cli/index.ts" ]] \
+  && grep -Eq '^  "name": "repo-harness",$' "$repo_root/package.json" 2>/dev/null \
+  && command -v bun >/dev/null 2>&1; then
+  repo_harness_cli=(bun "$repo_root/src/cli/index.ts")
+elif command -v repo-harness >/dev/null 2>&1; then
+  repo_harness_cli=(repo-harness)
+else
   echo "[task-sync] Workflow profile resolution failed: repo-harness is required." >&2
   exit 1
 fi
@@ -343,7 +354,7 @@ profile_paths=()
 for file in "${changed_files[@]}"; do
   profile_paths+=("./$file")
 done
-if ! workflow_profile="$(repo-harness state resolve --json --field workflow_profile --target-path "${profile_paths[@]}")"; then
+if ! workflow_profile="$("${repo_harness_cli[@]}" state resolve --json --field workflow_profile --target-path "${profile_paths[@]}")"; then
   echo "[task-sync] Workflow profile resolution failed; no lite exemption admitted." >&2
   exit 1
 fi

--- a/scripts/check-task-sync.sh
+++ b/scripts/check-task-sync.sh
@@ -335,7 +335,18 @@ fi
 # The state resolver owns risk and ceremony policy. Pass the complete diff
 # inventory, including base-only and documentation paths, so a clean HEAD or
 # the substantive-path filter cannot hide strict-category signals.
-if ! command -v repo-harness >/dev/null 2>&1; then
+# The repo-harness source checkout resolves through its own CLI source, the
+# same selection check-architecture-sync.sh makes; every other repo uses the
+# installed CLI.
+repo_root="$(git rev-parse --show-toplevel)"
+repo_harness_cli=()
+if [[ -f "$repo_root/src/cli/index.ts" ]] \
+  && grep -Eq '^  "name": "repo-harness",$' "$repo_root/package.json" 2>/dev/null \
+  && command -v bun >/dev/null 2>&1; then
+  repo_harness_cli=(bun "$repo_root/src/cli/index.ts")
+elif command -v repo-harness >/dev/null 2>&1; then
+  repo_harness_cli=(repo-harness)
+else
   echo "[task-sync] Workflow profile resolution failed: repo-harness is required." >&2
   exit 1
 fi
@@ -343,7 +354,7 @@ profile_paths=()
 for file in "${changed_files[@]}"; do
   profile_paths+=("./$file")
 done
-if ! workflow_profile="$(repo-harness state resolve --json --field workflow_profile --target-path "${profile_paths[@]}")"; then
+if ! workflow_profile="$("${repo_harness_cli[@]}" state resolve --json --field workflow_profile --target-path "${profile_paths[@]}")"; then
   echo "[task-sync] Workflow profile resolution failed; no lite exemption admitted." >&2
   exit 1
 fi

--- a/tasks/notes/20260905-ci-gate-linux-repair.notes.md
+++ b/tasks/notes/20260905-ci-gate-linux-repair.notes.md
@@ -1,0 +1,10 @@
+# CI gate repair: Linux deadline fixture and source-checkout task-sync resolution
+
+> **Substantive Change SHA256**: `sha256:1098bba847b301aa497c4a911edcb2b604a65348c696f781832c2366ae1260a6`
+
+Two faults kept `Required / CI` red on `main` from `7fe02beb` onward; the first masked the second because `check:ci` stops at the first failing test file.
+
+- `tests/architecture-projection-provider.test.ts` ran its slow-node probe under `PATH=''`. Under dash a bare `sleep` is not found, the script echoes its version immediately, and runtime selection succeeds before the deadline. macOS only passed because bun's cold supervisor start exceeded the 100 ms deadline first. The probe now calls `/bin/sleep`, and a scratch mutation removing the deadline re-check at `archctx-provider.ts:161` still fails the corrected test.
+- `scripts/check-task-sync.sh` resolved the workflow profile only through an installed `repo-harness` binary, which CI never installs. The self-host checkout now resolves through `bun src/cli/index.ts` when `package.json` names `repo-harness`, the same selection `check-architecture-sync.sh` already makes; every other repo keeps the installed CLI. The helper projection under `assets/templates/helpers/` is regenerated from the script.
+
+Verification: provider test 23/23 on macOS and 3/3 native Linux (`oven/bun:1.4.0`); `tests/check-task-sync.test.ts` and `tests/helper-scripts.test.ts` 181/181; `check-task-sync.sh` resolves the profile with `repo-harness` absent from `PATH`.

--- a/tests/architecture-projection-provider.test.ts
+++ b/tests/architecture-projection-provider.test.ts
@@ -248,7 +248,7 @@ describe('package-local ArchContext projection provider', () => {
   test('charges Node runtime selection to the caller deadline', () => {
     const f = fixture();
     const slowNode = join(f.root, 'slow-node');
-    writeFileSync(slowNode, '#!/bin/sh\nsleep 2\necho v24.18.0\n');
+    writeFileSync(slowNode, '#!/bin/sh\n/bin/sleep 2\necho v24.18.0\n');
     chmodSync(slowNode, 0o755);
     const providerModule = join(import.meta.dir, '..', 'src', 'effects', 'architecture', 'archctx-provider.ts');
     const script = join(f.root, 'node-deadline.ts');
@@ -260,7 +260,7 @@ describe('package-local ArchContext projection provider', () => {
       `} catch (error) { console.log(String(error)); }`,
       '',
     ].join('\n'));
-    const result = spawnSync(process.execPath, [script], { cwd: f.repoRoot, encoding: 'utf8', timeout: 3_500, killSignal: 'SIGKILL' });
+    const result = spawnSync(process.execPath, [script], { cwd: f.repoRoot, encoding: 'utf8', timeout: 4_000, killSignal: 'SIGKILL' });
     expect((result.error as NodeJS.ErrnoException | undefined)?.code).not.toBe('ETIMEDOUT');
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('architecture projection timeout before Node runtime selection');


### PR DESCRIPTION
## Summary

`Required / CI` has been red on `main` since `7fe02beb`. Two independent faults; the first masked the second because `check:ci` stops at the first failing test file.

- **Deadline fixture** (`tests/architecture-projection-provider.test.ts`): the slow-node probe runs under `PATH=''`, so dash cannot resolve a bare `sleep`; the script prints its version immediately, runtime selection succeeds before the 100 ms deadline, and the child exits 2. macOS passed only because bun's cold supervisor start exceeded the deadline first. The probe now calls `/bin/sleep`; the child timeout matches the sibling test. A scratch mutation removing the deadline re-check at `archctx-provider.ts:161` still fails the corrected test, so the guard keeps its teeth.
- **Task-sync CLI resolution** (`scripts/check-task-sync.sh`): the workflow profile resolved only through an installed `repo-harness` binary, which CI never installs. The self-host checkout now resolves through `bun src/cli/index.ts` when `package.json` names `repo-harness`, the same selection `check-architecture-sync.sh` already makes; every other repo keeps the installed CLI. Helper projection regenerated.

No product runtime behavior changes.

## Verification

- macOS: `bun test --timeout 60000 tests/architecture-projection-provider.test.ts` 23/23; `tests/check-task-sync.test.ts` + `tests/helper-scripts.test.ts` 181/181
- Native Linux (`oven/bun:1.4.0`, 3 runs): deadline test 1/1 each
- `check-task-sync.sh` resolves `standard` with `repo-harness` absent from `PATH`; merge-base digest bound in `tasks/notes/20260905-ci-gate-linux-repair.notes.md`
- `check-task-workflow.sh --strict`, `check:helpers`: pass