### PR TITLE
test(state): refresh effective-state goldens for the current lite guidance

### DIFF
--- a/tasks/notes/20260905-refresh-state-goldens.notes.md
+++ b/tasks/notes/20260905-refresh-state-goldens.notes.md
@@ -1,0 +1,10 @@
+# Effective-state golden refresh after 6c19234e
+
+> **Substantive Change SHA256**: `sha256:920d49a1631e0956dc278fc6e75d696f22445dedc2b58574cfaa9be919034fc4`
+
+`6c19234e` changed the lite-profile guidance text in `project-effective-state.ts` and the `runEditPlanGate` call shape in `mutation-guard.ts` without refreshing the characterization fixtures, so `main` failed at `tests/state/cli-state-golden.test.ts` and would fail next at `loop-semantics-characterization.test.ts`.
+
+- The 11 effective-state goldens were regenerated with `UPDATE_EFFECTIVE_STATE_GOLDENS=1`; the only changed field is `guidance`.
+- The `plan_gate` source-order marker now matches `runEditPlanGate(ctx, filePath, effective);`, and the loop-semantics matrix was regenerated with `UPDATE_LOOP_SEMANTICS_GOLDEN=1`; the only changed fields are the four `esa_goldens` `source_sha256` hashes.
+
+Verification: `tests/state/` 131 pass / 0 fail locally; PR CI ran the full suite to completion before the task-sync gate.

--- a/tests/state/fixtures/corrupt-cache-reconstruction.json
+++ b/tests/state/fixtures/corrupt-cache-reconstruction.json
@@ -51,7 +51,7 @@
       "tests/effective-state.test.ts"
     ],
     "next_action": "implement resolver",
-    "guidance": "at most one active plan artifact; no contract, notes, or todos scaffolding beyond it",
+    "guidance": "at most one active plan artifact; no contract, notes, or todos scaffolding beyond it. This is a state snapshot, not a session-wide restriction; re-resolve for the proposed edit and current diff when scope changes. Current edit-time requirements supersede earlier snapshot guidance.",
     "blockers": [],
     "stale_sources": [
       "checks",

--- a/tests/state/fixtures/deleted-cache-reconstruction.json
+++ b/tests/state/fixtures/deleted-cache-reconstruction.json
@@ -51,7 +51,7 @@
       "tests/effective-state.test.ts"
     ],
     "next_action": "implement resolver",
-    "guidance": "at most one active plan artifact; no contract, notes, or todos scaffolding beyond it",
+    "guidance": "at most one active plan artifact; no contract, notes, or todos scaffolding beyond it. This is a state snapshot, not a session-wide restriction; re-resolve for the proposed edit and current diff when scope changes. Current edit-time requirements supersede earlier snapshot guidance.",
     "blockers": [],
     "stale_sources": [
       "checks",

--- a/tests/state/fixtures/executing-fresh-evidence.json
+++ b/tests/state/fixtures/executing-fresh-evidence.json
@@ -51,7 +51,7 @@
       "tests/effective-state.test.ts"
     ],
     "next_action": "implement resolver",
-    "guidance": "at most one active plan artifact; no contract, notes, or todos scaffolding beyond it",
+    "guidance": "at most one active plan artifact; no contract, notes, or todos scaffolding beyond it. This is a state snapshot, not a session-wide restriction; re-resolve for the proposed edit and current diff when scope changes. Current edit-time requirements supersede earlier snapshot guidance.",
     "blockers": [],
     "stale_sources": [],
     "conflicting_sources": [],

--- a/tests/state/fixtures/explicit-strict-without-path-signals.json
+++ b/tests/state/fixtures/explicit-strict-without-path-signals.json
@@ -51,7 +51,7 @@
       "tests/effective-state.test.ts"
     ],
     "next_action": "implement resolver",
-    "guidance": "full envelope: plan, contract, notes, and checks as required",
+    "guidance": "full envelope: plan, contract, notes, and checks as required. This is a state snapshot, not a session-wide restriction; re-resolve for the proposed edit and current diff when scope changes. Current edit-time requirements supersede earlier snapshot guidance.",
     "blockers": [],
     "stale_sources": [
       "checks",

--- a/tests/state/fixtures/foreign-worktree-owner.json
+++ b/tests/state/fixtures/foreign-worktree-owner.json
@@ -40,7 +40,7 @@
     },
     "allowed_paths": [],
     "next_action": "resolve blockers",
-    "guidance": "at most one active plan artifact; no contract, notes, or todos scaffolding beyond it",
+    "guidance": "at most one active plan artifact; no contract, notes, or todos scaffolding beyond it. This is a state snapshot, not a session-wide restriction; re-resolve for the proposed edit and current diff when scope changes. Current edit-time requirements supersede earlier snapshot guidance.",
     "blockers": [
       "conflict:worktree_owner"
     ],

--- a/tests/state/fixtures/idle-inspect.json
+++ b/tests/state/fixtures/idle-inspect.json
@@ -40,7 +40,7 @@
     },
     "allowed_paths": [],
     "next_action": null,
-    "guidance": "brief -> edit -> targeted test; do not author plan, contract, notes, todos, or checks files (zero ceremony)",
+    "guidance": "brief -> edit -> targeted test; no workflow artifacts are required for the currently observed scope. User-requested planning is allowed. This is a state snapshot, not a session-wide restriction; re-resolve for the proposed edit and current diff when scope changes. Current edit-time requirements supersede earlier snapshot guidance.",
     "blockers": [],
     "stale_sources": [
       "checks",

--- a/tests/state/fixtures/invalid-capability-registry.json
+++ b/tests/state/fixtures/invalid-capability-registry.json
@@ -52,7 +52,7 @@
       "tests/effective-state.test.ts"
     ],
     "next_action": "resolve blockers",
-    "guidance": "at most one active plan artifact; no contract, notes, or todos scaffolding beyond it",
+    "guidance": "at most one active plan artifact; no contract, notes, or todos scaffolding beyond it. This is a state snapshot, not a session-wide restriction; re-resolve for the proposed edit and current diff when scope changes. Current edit-time requirements supersede earlier snapshot guidance.",
     "blockers": [
       "capability_registry:invalid"
     ],

--- a/tests/state/fixtures/live-lock-waits-for-release.json
+++ b/tests/state/fixtures/live-lock-waits-for-release.json
@@ -51,7 +51,7 @@
       "tests/effective-state.test.ts"
     ],
     "next_action": "implement resolver",
-    "guidance": "at most one active plan artifact; no contract, notes, or todos scaffolding beyond it",
+    "guidance": "at most one active plan artifact; no contract, notes, or todos scaffolding beyond it. This is a state snapshot, not a session-wide restriction; re-resolve for the proposed edit and current diff when scope changes. Current edit-time requirements supersede earlier snapshot guidance.",
     "blockers": [],
     "stale_sources": [
       "checks",

--- a/tests/state/fixtures/loop-semantics/characterization.json
+++ b/tests/state/fixtures/loop-semantics/characterization.json
@@ -6,7 +6,7 @@
   "esa_goldens": [
     {
       "scenario": "idle-inspect",
-      "source_sha256": "42755fedaae1d6421e5f013f2236e943d3807a63b24f90abd717bc5c7f6056d4",
+      "source_sha256": "e2be47fec22cd86da0f76d0a37d2b301da341970e2c484d13cde0f420d3ea8b3",
       "baseline": "82550779cdccf0575d674ae53bbc95ba63e44743",
       "cli_exit": 0,
       "workflow_profile": "lite",
@@ -14,7 +14,7 @@
     },
     {
       "scenario": "missing-contract",
-      "source_sha256": "eb632f07283d0577e184520ff237670a8295eff9c592718753cd9b811ceacab8",
+      "source_sha256": "d168f124a429ceb24e19dff0cf74c464a9795bc328ce6e37eb547381d3456cf1",
       "baseline": "82550779cdccf0575d674ae53bbc95ba63e44743",
       "cli_exit": 0,
       "workflow_profile": "standard",
@@ -22,7 +22,7 @@
     },
     {
       "scenario": "executing-fresh-evidence",
-      "source_sha256": "878fabb76d6f9d994654d7449cbf7ca83d7ebd884dbc1c33a4b64b1adac689a7",
+      "source_sha256": "3fd46a92535d8be205d1442a8121be22c0aa5b6848657c70869efa8c9d81b6ae",
       "baseline": "82550779cdccf0575d674ae53bbc95ba63e44743",
       "cli_exit": 0,
       "workflow_profile": "standard",
@@ -30,7 +30,7 @@
     },
     {
       "scenario": "explicit-strict-without-path-signals",
-      "source_sha256": "a4079d7fdcf96ac970909b5bd47cb752ae4ed418a24c03f3735e171458a86ca0",
+      "source_sha256": "72c1b49825b1b3f7ed58fe81222c5d5f70a16ea1dd28c7611942474e100cfecc",
       "baseline": "82550779cdccf0575d674ae53bbc95ba63e44743",
       "cli_exit": 0,
       "workflow_profile": "strict",

--- a/tests/state/fixtures/missing-contract.json
+++ b/tests/state/fixtures/missing-contract.json
@@ -43,7 +43,7 @@
     },
     "allowed_paths": [],
     "next_action": "implement resolver",
-    "guidance": "at most one active plan artifact; no contract, notes, or todos scaffolding beyond it",
+    "guidance": "at most one active plan artifact; no contract, notes, or todos scaffolding beyond it. This is a state snapshot, not a session-wide restriction; re-resolve for the proposed edit and current diff when scope changes. Current edit-time requirements supersede earlier snapshot guidance.",
     "blockers": [],
     "stale_sources": [
       "checks",

--- a/tests/state/fixtures/stale-dead-lock-reclaimed.json
+++ b/tests/state/fixtures/stale-dead-lock-reclaimed.json
@@ -51,7 +51,7 @@
       "tests/effective-state.test.ts"
     ],
     "next_action": "implement resolver",
-    "guidance": "at most one active plan artifact; no contract, notes, or todos scaffolding beyond it",
+    "guidance": "at most one active plan artifact; no contract, notes, or todos scaffolding beyond it. This is a state snapshot, not a session-wide restriction; re-resolve for the proposed edit and current diff when scope changes. Current edit-time requirements supersede earlier snapshot guidance.",
     "blockers": [],
     "stale_sources": [
       "checks",

--- a/tests/state/fixtures/stale-projections.json
+++ b/tests/state/fixtures/stale-projections.json
@@ -51,7 +51,7 @@
       "tests/effective-state.test.ts"
     ],
     "next_action": "implement resolver",
-    "guidance": "at most one active plan artifact; no contract, notes, or todos scaffolding beyond it",
+    "guidance": "at most one active plan artifact; no contract, notes, or todos scaffolding beyond it. This is a state snapshot, not a session-wide restriction; re-resolve for the proposed edit and current diff when scope changes. Current edit-time requirements supersede earlier snapshot guidance.",
     "blockers": [],
     "stale_sources": [
       "active_sprint",

--- a/tests/state/loop-semantics-characterization.test.ts
+++ b/tests/state/loop-semantics-characterization.test.ts
@@ -646,7 +646,7 @@ function captureEdit(profile: Profile): Record<string, unknown> {
       ordering: observedSourceOrder(MUTATION_GUARD_SOURCE, [
         { name: 'resolve_effective_state', marker: 'ctx.collector.getPreEditEffectiveState(allTargetPaths)' },
         { name: 'contract_scope', marker: 'const activeContract = effective?.contract?.path ?? null;' },
-        { name: 'plan_gate', marker: 'runEditPlanGate(ctx, filePath, workflowProfile);' },
+        { name: 'plan_gate', marker: 'runEditPlanGate(ctx, filePath, effective);' },
         { name: 'strict_contract', marker: '[StrictContractGuard] Strict profile requires an active contract for' },
         { name: 'strict_worktree', marker: '[StrictWorktreeGuard] Strict profile requires an isolated contract worktree for' },
       ]),


### PR DESCRIPTION
## Summary

`main` is red at `tests/state/cli-state-golden.test.ts` since `6c19234e`, which changed the lite-profile guidance text in `project-effective-state.ts` and the `runEditPlanGate` call shape in `mutation-guard.ts` without refreshing the characterization fixtures. `check:ci` stops at that file, so the second drift (`loop-semantics-characterization.test.ts` source-order marker) has not surfaced on CI yet.

- Regenerate the 11 effective-state golden fixtures (`UPDATE_EFFECTIVE_STATE_GOLDENS=1`); the only field that changes is `guidance`.
- Update the `plan_gate` source-order marker to the current `runEditPlanGate(ctx, filePath, effective);` call and regenerate the loop-semantics matrix (`UPDATE_LOOP_SEMANTICS_GOLDEN=1`); the only fields that change are the four `esa_goldens` `source_sha256` hashes.

No product code changes.

## Verification

- `bun test --timeout 60000 tests/state/` 131 pass / 0 fail
- Full suite result recorded in the PR conversation once the local run completes