### PR TITLE
test(state): regenerate effective-state goldens for updated profile guidance

### DIFF
--- a/tests/state/fixtures/corrupt-cache-reconstruction.json
+++ b/tests/state/fixtures/corrupt-cache-reconstruction.json
@@ -51,7 +51,7 @@
       "tests/effective-state.test.ts"
     ],
     "next_action": "implement resolver",
-    "guidance": "at most one active plan artifact; no contract, notes, or todos scaffolding beyond it",
+    "guidance": "at most one active plan artifact; no contract, notes, or todos scaffolding beyond it. This is a state snapshot, not a session-wide restriction; re-resolve for the proposed edit and current diff when scope changes. Current edit-time requirements supersede earlier snapshot guidance.",
     "blockers": [],
     "stale_sources": [
       "checks",

--- a/tests/state/fixtures/deleted-cache-reconstruction.json
+++ b/tests/state/fixtures/deleted-cache-reconstruction.json
@@ -51,7 +51,7 @@
       "tests/effective-state.test.ts"
     ],
     "next_action": "implement resolver",
-    "guidance": "at most one active plan artifact; no contract, notes, or todos scaffolding beyond it",
+    "guidance": "at most one active plan artifact; no contract, notes, or todos scaffolding beyond it. This is a state snapshot, not a session-wide restriction; re-resolve for the proposed edit and current diff when scope changes. Current edit-time requirements supersede earlier snapshot guidance.",
     "blockers": [],
     "stale_sources": [
       "checks",

--- a/tests/state/fixtures/executing-fresh-evidence.json
+++ b/tests/state/fixtures/executing-fresh-evidence.json
@@ -51,7 +51,7 @@
       "tests/effective-state.test.ts"
     ],
     "next_action": "implement resolver",
-    "guidance": "at most one active plan artifact; no contract, notes, or todos scaffolding beyond it",
+    "guidance": "at most one active plan artifact; no contract, notes, or todos scaffolding beyond it. This is a state snapshot, not a session-wide restriction; re-resolve for the proposed edit and current diff when scope changes. Current edit-time requirements supersede earlier snapshot guidance.",
     "blockers": [],
     "stale_sources": [],
     "conflicting_sources": [],

--- a/tests/state/fixtures/explicit-strict-without-path-signals.json
+++ b/tests/state/fixtures/explicit-strict-without-path-signals.json
@@ -51,7 +51,7 @@
       "tests/effective-state.test.ts"
     ],
     "next_action": "implement resolver",
-    "guidance": "full envelope: plan, contract, notes, and checks as required",
+    "guidance": "full envelope: plan, contract, notes, and checks as required. This is a state snapshot, not a session-wide restriction; re-resolve for the proposed edit and current diff when scope changes. Current edit-time requirements supersede earlier snapshot guidance.",
     "blockers": [],
     "stale_sources": [
       "checks",

--- a/tests/state/fixtures/foreign-worktree-owner.json
+++ b/tests/state/fixtures/foreign-worktree-owner.json
@@ -40,7 +40,7 @@
     },
     "allowed_paths": [],
     "next_action": "resolve blockers",
-    "guidance": "at most one active plan artifact; no contract, notes, or todos scaffolding beyond it",
+    "guidance": "at most one active plan artifact; no contract, notes, or todos scaffolding beyond it. This is a state snapshot, not a session-wide restriction; re-resolve for the proposed edit and current diff when scope changes. Current edit-time requirements supersede earlier snapshot guidance.",
     "blockers": [
       "conflict:worktree_owner"
     ],

--- a/tests/state/fixtures/idle-inspect.json
+++ b/tests/state/fixtures/idle-inspect.json
@@ -40,7 +40,7 @@
     },
     "allowed_paths": [],
     "next_action": null,
-    "guidance": "brief -> edit -> targeted test; do not author plan, contract, notes, todos, or checks files (zero ceremony)",
+    "guidance": "brief -> edit -> targeted test; no workflow artifacts are required for the currently observed scope. User-requested planning is allowed. This is a state snapshot, not a session-wide restriction; re-resolve for the proposed edit and current diff when scope changes. Current edit-time requirements supersede earlier snapshot guidance.",
     "blockers": [],
     "stale_sources": [
       "checks",

--- a/tests/state/fixtures/invalid-capability-registry.json
+++ b/tests/state/fixtures/invalid-capability-registry.json
@@ -52,7 +52,7 @@
       "tests/effective-state.test.ts"
     ],
     "next_action": "resolve blockers",
-    "guidance": "at most one active plan artifact; no contract, notes, or todos scaffolding beyond it",
+    "guidance": "at most one active plan artifact; no contract, notes, or todos scaffolding beyond it. This is a state snapshot, not a session-wide restriction; re-resolve for the proposed edit and current diff when scope changes. Current edit-time requirements supersede earlier snapshot guidance.",
     "blockers": [
       "capability_registry:invalid"
     ],

--- a/tests/state/fixtures/live-lock-waits-for-release.json
+++ b/tests/state/fixtures/live-lock-waits-for-release.json
@@ -51,7 +51,7 @@
       "tests/effective-state.test.ts"
     ],
     "next_action": "implement resolver",
-    "guidance": "at most one active plan artifact; no contract, notes, or todos scaffolding beyond it",
+    "guidance": "at most one active plan artifact; no contract, notes, or todos scaffolding beyond it. This is a state snapshot, not a session-wide restriction; re-resolve for the proposed edit and current diff when scope changes. Current edit-time requirements supersede earlier snapshot guidance.",
     "blockers": [],
     "stale_sources": [
       "checks",

--- a/tests/state/fixtures/missing-contract.json
+++ b/tests/state/fixtures/missing-contract.json
@@ -43,7 +43,7 @@
     },
     "allowed_paths": [],
     "next_action": "implement resolver",
-    "guidance": "at most one active plan artifact; no contract, notes, or todos scaffolding beyond it",
+    "guidance": "at most one active plan artifact; no contract, notes, or todos scaffolding beyond it. This is a state snapshot, not a session-wide restriction; re-resolve for the proposed edit and current diff when scope changes. Current edit-time requirements supersede earlier snapshot guidance.",
     "blockers": [],
     "stale_sources": [
       "checks",

--- a/tests/state/fixtures/stale-dead-lock-reclaimed.json
+++ b/tests/state/fixtures/stale-dead-lock-reclaimed.json
@@ -51,7 +51,7 @@
       "tests/effective-state.test.ts"
     ],
     "next_action": "implement resolver",
-    "guidance": "at most one active plan artifact; no contract, notes, or todos scaffolding beyond it",
+    "guidance": "at most one active plan artifact; no contract, notes, or todos scaffolding beyond it. This is a state snapshot, not a session-wide restriction; re-resolve for the proposed edit and current diff when scope changes. Current edit-time requirements supersede earlier snapshot guidance.",
     "blockers": [],
     "stale_sources": [
       "checks",

--- a/tests/state/fixtures/stale-projections.json
+++ b/tests/state/fixtures/stale-projections.json
@@ -51,7 +51,7 @@
       "tests/effective-state.test.ts"
     ],
     "next_action": "implement resolver",
-    "guidance": "at most one active plan artifact; no contract, notes, or todos scaffolding beyond it",
+    "guidance": "at most one active plan artifact; no contract, notes, or todos scaffolding beyond it. This is a state snapshot, not a session-wide restriction; re-resolve for the proposed edit and current diff when scope changes. Current edit-time requirements supersede earlier snapshot guidance.",
     "blockers": [],
     "stale_sources": [
       "active_sprint",


### PR DESCRIPTION
Commit 6c19234e changed the workflow-profile guidance strings in `src/core/state/project-effective-state.ts` without refreshing `tests/state/fixtures/*.json`, so `tests/state/cli-state-golden.test.ts` has been red on main and on every open PR since.

Regenerated with `UPDATE_EFFECTIVE_STATE_GOLDENS=1`; the diff is only the `guidance` string in 11 fixtures.

Local: `bun test tests/state/cli-state-golden.test.ts` → 13 pass, 0 fail.