### PR TITLE
fix(state): unify strict worktree readiness and isolate provider fixtures

### DIFF
--- a/docs/researches/20260905-agent-workflow-maintenance.md
+++ b/docs/researches/20260905-agent-workflow-maintenance.md
@@ -1,6 +1,6 @@
 # 跨会话工作流维护：真实任务证据与规则裁剪
 
-本轮把重复流程归入一个 host-local `agent-workflow-audit` Skill，自动化只读取证，修正已漂移的指令与记忆。没有增加 runtime、依赖、调度器或第二套 benchmark。项目内改动均为文档；宿主新增 Python stdlib collector 及其测试。
+首轮维护把重复流程归入一个 host-local `agent-workflow-audit` Skill，自动化只读取证，修正已漂移的指令与记忆。首轮没有增加 runtime、依赖、调度器或第二套 benchmark，项目内改动均为文档；宿主新增 Python stdlib collector 及其测试。随后获批的 strict worktree 运行时修复及其独立验证记录见末节。
 
 ## 证据范围
 
@@ -31,7 +31,7 @@
 | Host writer | 恢复任务 → host 返回 `active writer` / `-32600` → 现场有持有 writer 的进程 | 属于 host 恢复问题。一次人工 TERM 成功不构成可自动 kill 的通用步骤 |
 | 文件/环境 | linked worktree 缺 handoff；某次测试遇到 Python 进程挂住并报告 environment failure | 缺文件和环境故障单独报告，不归为产品失败，也不从旧记忆重建事实 |
 | 指令冲突 | lite profile → 全局“所有规划落文件”与旧“所有 worker 全量”同时注入 | 修正过宽文案，不改变 profile 或测试 gate |
-| Worktree 权限判定 | `state resolve` 在 primary worktree 给 edit allow → StrictWorktreeGuard 要求 linked worktree而拒绝 | `tasks/todos.md` 已有真实复现；本轮定位并保留，修复需跨 Effective State/guard 的独立行为切片 |
+| Worktree 权限判定 | `state resolve` 在 primary worktree 给 edit allow → StrictWorktreeGuard 要求 linked worktree而拒绝 | 首轮定位到既有真实复现；随后获批的 Effective State/guard 修复及回归见末节 |
 | 上下文缺口 | SessionStart 的多个 provider 聚成整体 section 后进入预算裁剪 | 已记录于 `tasks/todos.md`。现场预算证据为 1487/1500 tokens，`worktree-backlog-notice` 被丢弃；不能把这一次观测说成全部上下文丢失 |
 | Stop/安装漂移 | 历史 Stop adapter、candidate handoff 与 archive fingerprint 失效 | 当前源码/提交已修复这些具体问题；不再为它们叠加提醒规则 |
 
@@ -66,7 +66,7 @@
 - 一次独立 forward test 在 `default` native child 路由阶段返回 `native-role-routing unavailable`，没有读取 Skill、没有模型行为覆盖，计为环境阻塞。它不同于 Skill 内容失败，不据此修改角色权限或扩大任务。
 - 同一只读请求随后由可用的 native `explorer` 执行：读取新 Skill，运行 collector，核对限定历史及项目指令，返回有来源的恢复/验证处置候选。结果仍为 155 records / 37 sessions，没有写入项目、配置、记忆，没有清理进程或启动完整测试。这是一次真实使用的有限 forward evidence，不构成跨模型有效性结论。
 
-本轮 repo changed paths：`AGENTS.md`、`CLAUDE.md`、两份 `global-working-rules.md`、`tasks/lessons.md` 和本报告。全部是文档/指令说明；没有改动 product/runtime source、测试基础设施或 machine-executed contract。沿用根风险分级，不跑整个 `bun test`；仍执行行为相关检查和六项 repository-integrity checks。
+首轮维护的 repo changed paths：`AGENTS.md`、`CLAUDE.md`、两份 `global-working-rules.md`、`tasks/lessons.md` 和本报告。全部是文档/指令说明；没有改动 product/runtime source、测试基础设施或 machine-executed contract。首轮沿用根风险分级，不跑整个 `bun test`；仍执行行为相关检查和六项 repository-integrity checks。
 
 ## 样本索引
 
@@ -125,3 +125,20 @@ S=状态/遗漏/收口；R=接手/恢复；I=Issue 批处理；X=含 interrupted
 本地主线集成于 `a0bcf49d`，包含独立的验证范围修复 `6c19234e` 和诊断补丁 `be6e90f8`。合并后的六项 helper 回归全部通过，157 条断言覆盖正常复用、收窄后的增量验证、三种 context 漂移、context 不可用和缺少 contract 时的 canonical state 准入。类型检查、helper/reference 投影与 repository-integrity 检查通过；这些命名检查覆盖实际合并边界，没有重复全套测试，也没有将历史中断结果计为通过。
 
 仍存在一个单独的生命周期缺口：standard 单计划任务已能通过工作流检查，但 `scripts/archive-workflow.sh` 的 `completed_archive_gate` 无条件要求 contract、review 和 AcceptanceReceipt，因此不能按现有入口归档这种已完成计划。应在该边界复现并实现与 canonical profile 一致的收口，再归档计划；不能靠补造严格流程产物或跳过现有 gate 来掩盖冲突。
+## Strict worktree 判定的稳定规则
+
+后续修复把 `isolated_contract_worktree` 定义为两个条件同时成立：当前目录是 Git linked worktree，且 active worktree owner 指向当前目录。owner 匹配本身不证明隔离；linked topology 本身也不证明当前任务拥有这个 worktree。
+
+`src/effects/state/resolve-effective-state.ts` 读取 owner 与 Git 的真实 git/common directories，将组合结果纳入 authority revision 和稳定读取确认；`src/core/state/project-effective-state.ts` 投影 requirement；`src/cli/hook/mutation-guard.ts` 消费同一 requirement。`lite` 的 `worktree_boundary` 仍只表达 owner 边界。这一改动没有增加依赖、配置或第二套判定 API；10 倍 strict resolve 调用量下，额外开销首先表现为每次稳定采样的 Git 子进程成本，查询有 5 秒超时。
+
+四个真实 Git fixture 在同一状态下同时调用 resolver 与 guard：primary/current owner、linked/current owner、linked/missing owner、linked/foreign owner。未修复代码实际失败 2 例，分别暴露过度允许的 readiness 与 guard；修复后的相关 107 个测试通过。完整测试还发现旧 strict-primary golden 需要同步该行为；更新其 hash 断言和期望 fixture 后，golden/guard/projector 共 54 个测试重跑通过。未改变 golden normalizer，也没有删除断言。
+
+首轮完整套件运行 39 分 29 秒，结果为 4,186 pass、4 skip、2 fail、1 error；其中 strict golden 已修正。随后获批排查 Fleet provider 超时，确认了测试 fixture 自身污染 subject，以及 Bun 超时后异步函数继续执行这两个边界，修复与证据见下节。最终完整回归被 SIGTERM 中断，不能据此宣称套件中的 Fleet 超时已闭环。代码仍在独立 worktree 中，尚未合并或更新宿主安装；具体 diff 与验证边界见 `tasks/reviews/20260905-isolated-worktree-readiness.review.md`。这一失败案例支持保留 strict 隔离规则，并要求预检查与写入 guard 使用同一份权威事实；它不支持增加新的确认步骤或扩大 SessionStart/Stop 的职责。
+
+## Fleet fixture 的观察边界与超时清理
+
+fake provider 把计数写进被观察的 Git repo，真实调用后 12 个 Effective State source hashes 中只有 `review_subject` 改变，进而改变 `collectLocal` token。readiness 因而把测试自己制造的变化当成业务输入变化并重复采样。修复把 fixture repo 放到临时 workspace 的 `repo/` 子目录，provider script 与 counter 放在仓库外的 sibling 路径。已有四卡、并发上限 2 的测试新增前后完整 review subject 不变断言：旧布局实际失败，新布局通过，没有删除原断言或放宽 30 秒测试期限。
+
+Bun 的外层 test timeout 不会自动取消 async body；只依赖 `finally`，会使迟到断言越过测试边界。测试结束钩子现在先取消 collection、等待其退出，再恢复环境和删除 fixture。强制 8 秒外层超时的真实 fixture probe 仍有一个预期 timeout failure，但紧邻的清理检查通过：4 个已启动 provider PID 全部退出，环境与目录先于下一测试恢复，没有 between-tests 未处理异常。强制终止时 shell trap 未必执行，因此 counter 只作诊断，实际 PID 存活是清理依据。这条生命周期规则不改变产品 provider 的超时、limiter 或终止实现。
+
+74 项相关测试通过（1,100 assertions），typecheck 通过。最终全套在固定基线和冻结 source/test patch 上运行，被 SIGTERM / exit 143 中断，只有 3,315 pass 与 1 fail 的部分日志，没有完整汇总。新失败位于未修改的 `tests/helper-scripts.test.ts:5165`，报告 verify-sprint 执行期间 authority 改变；根因尚未证明。另一个未闭环点是 standard profile 只需一份计划，但 active-plan workflow checker 仍强制 contract。保留这两个失败边界，不补造 contract、不放宽稳定性检查，也不把 isolated passing retry 当作全套通过。相关实现与日志入口集中在上面的 review 中。

--- a/plans/plan-20260905-1455-isolated-worktree-readiness.md
+++ b/plans/plan-20260905-1455-isolated-worktree-readiness.md
@@ -1,0 +1,68 @@
+# Plan: Strict isolation agreement and Fleet verification lifecycle
+
+> **Status**: Approved
+> **Created**: 20260905-1455
+> **Slug**: isolated-worktree-readiness
+> **Planning Source**: codex-plan
+> **Orchestration Kind**: host-plan
+> **Source Ref**: (none)
+> **Artifact Level**: work-package
+> **Promotion Reason**: verification_boundary
+> **Verification Boundary**: Four real Git cases, Fleet provider lifecycle, final full suite and six integrity checks
+> **Rollback Surface**: Revert only the codex/isolated-worktree-readiness commits
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+
+> **Task Review**: `tasks/reviews/20260905-isolated-worktree-readiness.review.md`
+> **Workflow Profile**: standard
+
+## Goal and approval
+Finish the user-approved strict isolated-worktree readiness fix, including the subsequently approved Fleet provider timeout/teardown regression slice. Approval is the current user's 批准; this captures the accepted work and does not request a new decision.
+
+## P1 Map
+Effective State resolver owns strict isolation; the projector exports the requirement and the mutation guard consumes it. Four real Git fixtures plus the strict golden cover agreement. Fleet's real-provider test owns its temporary repository, provider script/counter, environment and collection lifecycle. Production Fleet containment and limiter work belongs to another active worktree.
+
+## P2 Trace
+The full run failed the stale strict-primary golden and then the 30-second Fleet provider test. The golden is corrected. Bun timeout does not cancel an async test body: a deterministic probe records the next test starting before the timed-out body resumes and throws. Teardown must cancel and drain the collection before restoring environment/removing fixtures. Investigate the in-repo provider counter's effect on local readiness tokens before changing fixture placement.
+
+## P3 Decision
+Keep the strict isolation single authority already implemented. Limit additional edits to the Fleet test fixture and its cancellation lifecycle; do not duplicate the other worktree's product changes or weaken concurrency assertions/time limits. A test-finish hook owns cancellation and draining. Move telemetry outside the observed repo only if a real hash/token probe proves contamination. At 10x observation load the expensive readiness sampling and synchronous Git reads remain the first limit, outside this slice.
+
+## Scope
+Allowed paths: src/cli/hook/mutation-guard.ts; src/core/state/project-effective-state.ts; src/effects/state/resolve-effective-state.ts; tests/mutation-guard.test.ts; tests/state/project-effective-state.test.ts; tests/state/cli-state-golden.test.ts; tests/state/fixtures/explicit-strict-without-path-signals.json; tests/effects/fleet-board.test.ts; docs/researches/20260905-agent-workflow-maintenance.md; tasks/reviews/20260905-isolated-worktree-readiness.review.md; this plan and the derived tasks/current.md snapshot.
+Out of scope: optional maintenance Skill product integration, new schedulers, Fleet production containment/limiter changes, baseline reverse-import repair already owned by another task, host installation/release.
+
+## Verification
+Capture actual failing guard/probe evidence before its fix and run focused Fleet, merge-readiness and strict-state suites. Freeze the candidate before one final bun test --timeout 60000 (historical duration 40 minutes), run typecheck and the six required repository-integrity commands, retain honest failed or inherited evidence, and do not claim a green full suite from isolated reruns.
+
+## Delivery
+Record final root cause, regression evidence and scope in the existing review/research. Commit this worktree; merge into main only when main's actual HEAD and dirty paths permit preserving other work. Archive this plan after completion. No separate contract, implementation notes or todo scaffolding for the standard profile.
+
+## Task Breakdown
+- [x] Unify strict isolation in the resolver/projector/guard and verify four real Git cases.
+- [x] Correct the strict-primary golden without weakening normalization or assertions.
+- [x] Prove Fleet timeout lifecycle and any fixture instability, then fix the verified cause in the existing test.
+- [x] Freeze the candidate, attempt final verification and record its actual diff-bound results.
+- [ ] Resolve the recorded acceptance blockers before claiming a completed full regression or merge.
+- [ ] Commit, safely merge and close the approved slice.
+
+## Evidence Contract
+
+- **State/progress path**: This plan's Task Breakdown.
+- **Verification evidence**: Exact commands/results in `tasks/reviews/20260905-isolated-worktree-readiness.review.md` and temporary raw logs named there.
+- **Evaluator rubric**: Preserve isolation agreement, four real provider cards/concurrency 2, subject stability and timeout failure visibility; final repository checks pass.
+- **Stop condition**: All task items complete and the existing review recommends pass with no unresolved in-scope failure.
+- **Rollback surface**: Revert only the commits from `codex/isolated-worktree-readiness`.
+
+## Promotion Gate
+
+- **Merge/PR unit**: The approved strict-isolation change and its blocking Fleet verification repair form this branch's delivery unit.
+- **Rollback surface**: Revert this branch's commits without altering the separate main worktree's edits.
+- **Verification boundary**: Four real Git fixtures, provider subject stability, timeout lifecycle probe, full suite and required repository checks.
+- **Review/acceptance boundary**: `tasks/reviews/20260905-isolated-worktree-readiness.review.md` binds the exact substantive diff and actual verification limits.
+- **High-risk surface**: Strict edit authorization remains resolver-owned and fail-closed; the Fleet delta is test-only.
+- **Why not checklist row**: The approved runtime permission change has its own verification and rollback boundary.
+
+## Current Blockers
+
+The final full suite was interrupted by SIGTERM / exit 143 after 3,315 passing lines and one `verify-sprint` authority-change failure. Its cause is unproven. The standard active-plan workflow check also still requires a separate contract, contrary to the current profile guidance. The overlapping main-worktree changes belong to another task. Keep this candidate as a local checkpoint; no acceptance, merge or installed-runtime claim. Detailed evidence remains in the existing review and research report.

--- a/src/cli/hook/mutation-guard.ts
+++ b/src/cli/hook/mutation-guard.ts
@@ -639,12 +639,15 @@ function runPerPathGuards(
       );
       exit(2);
     }
-    if (!isLinkedWorktree(ctx.repoRoot)) {
+    const isolation = effective?.readiness?.ok
+      ? effective.readiness.requirements.edit.find((entry) => entry.key === 'isolated_contract_worktree')
+      : null;
+    if (!isolation?.satisfied) {
       out(ctx, `[StrictWorktreeGuard] Strict profile requires an isolated contract worktree for ${filePath}`);
       structuredError(
         ctx,
         'StrictWorktreeGuard',
-        `Strict workflow edit to ${filePath} is not running in a linked contract worktree.`,
+        `Strict workflow edit to ${filePath} requires a linked worktree owned by the active contract.`,
         'Start or enter the contract worktree before editing high-risk implementation paths.',
         'state_violation',
       );

--- a/src/core/state/project-effective-state.ts
+++ b/src/core/state/project-effective-state.ts
@@ -62,6 +62,7 @@ export interface EffectiveStateInputs {
   readonly currentWorktree: string;
   readonly worktreeOwner: string | null;
   readonly worktreeOwnerIsCurrent: boolean;
+  readonly isolatedContractWorktree: boolean;
   readonly handoffPath: string;
   readonly handoffText: string | null;
   readonly resumePath: string;
@@ -311,9 +312,8 @@ export function projectEffectiveState(input: EffectiveStateInputs): EffectiveSta
     ? (() => {
         const satisfiedRequirements: ArtifactRequirementKey[] = [];
         if (input.contractText) satisfiedRequirements.push('separate_contract');
-        if (input.worktreeOwnerIsCurrent) {
-          satisfiedRequirements.push('isolated_contract_worktree', 'worktree_boundary');
-        }
+        if (input.worktreeOwnerIsCurrent) satisfiedRequirements.push('worktree_boundary');
+        if (input.isolatedContractWorktree) satisfiedRequirements.push('isolated_contract_worktree');
         if (reviewFreshness === 'fresh') satisfiedRequirements.push('fresh_review');
         if (externalFreshness === 'fresh') satisfiedRequirements.push('external_acceptance');
         if (checksFreshness === 'fresh') {

--- a/src/effects/state/resolve-effective-state.ts
+++ b/src/effects/state/resolve-effective-state.ts
@@ -1,5 +1,6 @@
-import { readFileSync, readdirSync, statSync } from 'fs';
-import { posix, win32 } from 'path';
+import { readFileSync, readdirSync, realpathSync, statSync } from 'fs';
+import { execFileSync } from 'child_process';
+import { isAbsolute, posix, win32 } from 'path';
 import { buildReviewSubject, isImplementationSurfacePath } from '../review/diff-fingerprint';
 import { resolveWorkflowProfile, type WorkflowProfile } from '../../core/workflow/profile';
 import {
@@ -611,6 +612,21 @@ function resolveEffectiveStateUnlocked(
     explicitOverride: options.risk?.explicitOverride ?? (contractOverride as WorkflowProfile | null) ?? undefined,
   });
 
+  const worktreeOwnerIsCurrent = Boolean(owner && safeRealpath(owner) === currentWorktree);
+  const strictProfile = riskResolution.ok && riskResolution.profile === 'strict';
+  // Ownership alone also matches the primary checkout. Resolve Git isolation
+  // here and bind it to the authority revision consumed by the edit guard.
+  let isolatedContractWorktree = false;
+  if (strictProfile && worktreeOwnerIsCurrent) {
+    const directories = execFileSync('git', [
+      'rev-parse', '--path-format=absolute', '--git-dir', '--git-common-dir',
+    ], { cwd, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 5_000 }).trimEnd().split('\n');
+    if (directories.length !== 2 || directories.some((path) => !isAbsolute(path))) {
+      throw new Error('Git worktree directories are unavailable or malformed');
+    }
+    isolatedContractWorktree = realpathSync(directories[0]!) !== realpathSync(directories[1]!);
+  }
+
   // Capability registry reasons are appended to profile_reasons alongside
   // resolveWorkflowProfile's own reasons rather than folded into the resolver
   // itself -- the risk-floor ranking formula is untouched; only the reason
@@ -655,6 +671,7 @@ function resolveEffectiveStateUnlocked(
     active_sprint_marker: sourceHash(cwd, ACTIVE_SPRINT_MARKER),
     active_sprint_file: sprintPath ? sourceHash(cwd, sprintPath) : sha256('missing:active-sprint-file'),
     task_identity: sha256(taskId ?? 'missing:task-id'),
+    ...(strictProfile ? { isolated_contract_worktree: sha256(String(isolatedContractWorktree)) } : {}),
   });
   const subjectRevision = contentRevision({
     review_subject: reviewSubjectSha256 ?? sha256('unavailable:review-subject'),
@@ -731,7 +748,8 @@ function resolveEffectiveStateUnlocked(
     activeWorktreePath: ACTIVE_WORKTREE_MARKER,
     currentWorktree,
     worktreeOwner: owner,
-    worktreeOwnerIsCurrent: Boolean(owner && safeRealpath(owner) === currentWorktree),
+    worktreeOwnerIsCurrent,
+    isolatedContractWorktree,
     handoffPath: HANDOFF_PATH,
     handoffText,
     resumePath: RESUME_PATH,

--- a/tasks/reviews/20260905-isolated-worktree-readiness.review.md
+++ b/tasks/reviews/20260905-isolated-worktree-readiness.review.md
@@ -1,8 +1,8 @@
 # Review: isolated contract worktree readiness
 
-> **Status**: Blocked
+> **Status**: Pending
 > **Base Revision**: `1a9a5ae19167fd50ab0f0c650105ca8a9a2498eb`
-> **Substantive Change SHA256**: `sha256:6b15f94aaa5cf5f3508e7e573bfaa8d3292defd29b3aa05a8e1250e555557ca3`
+> **Substantive Change SHA256**: `sha256:1cdae848e1f4c0e944af1b5acbcf46b81a33529fe3620b2477a99f7cb4bbdf41`
 > **Review Scope**: eight source/test/fixture files; Waza check self-review
 
 ## Finding and change
@@ -143,3 +143,18 @@ Main has since received a separately verified review-boundary repair containing
 the prior reverse-import fix. Another task still owns uncommitted guard/projector
 changes in main. Preserve those writes and validate any integration seam before
 claiming the candidate is merged or installed.
+
+## Rebase verification (2026-09-05, onto 64953b6f)
+
+Rebased onto main after the verification-scope repair (`6c19234e`), the
+context-diagnostics patch (`be6e90f8`), and the golden refresh (#321). Two
+conflicts resolved: the research note keeps both appended sections, and the
+Fleet provider fixture keeps main's `omit_receipt_for` option together with this
+branch's workspace-root isolation. `tests/state/fixtures/loop-semantics/characterization.json`
+was regenerated because the resolver source hash it pins changed; the diff is
+that single `source_sha256` line.
+
+Focused run: `bun test tests/mutation-guard.test.ts tests/effects/fleet-board.test.ts tests/state/cli-state-golden.test.ts tests/state/project-effective-state.test.ts tests/state/loop-semantics-characterization.test.ts --timeout 60000`
+→ 71 pass, 0 fail. `tsc --noEmit` clean. `check-task-workflow --strict` OK, so
+the earlier active-plan contract gate conflict no longer applies. The full suite
+runs once in PR CI; the earlier interrupted run is not reused as evidence.

--- a/tasks/reviews/20260905-isolated-worktree-readiness.review.md
+++ b/tasks/reviews/20260905-isolated-worktree-readiness.review.md
@@ -1,0 +1,145 @@
+# Review: isolated contract worktree readiness
+
+> **Status**: Blocked
+> **Base Revision**: `1a9a5ae19167fd50ab0f0c650105ca8a9a2498eb`
+> **Substantive Change SHA256**: `sha256:6b15f94aaa5cf5f3508e7e573bfaa8d3292defd29b3aa05a8e1250e555557ca3`
+> **Review Scope**: eight source/test/fixture files; Waza check self-review
+
+## Finding and change
+
+Effective State previously treated a matching owner as an isolated worktree,
+while StrictWorktreeGuard independently tested Git topology. A primary checkout
+with a matching owner therefore reported edit readiness but failed the guard;
+a linked checkout without an owner had the inverse disagreement.
+
+The resolver now requires both current ownership and distinct real Git/common
+directories for strict isolation. This observation participates in the authority
+revision and its stable-read confirmation. The pure projector publishes the
+requirement and StrictWorktreeGuard consumes it. Lite worktree-boundary ownership
+semantics and contract/scope exemptions are unchanged.
+
+No dependency, public setting, compatibility path, or production module was
+added. The new internal boolean carries the single resolver-owned observation
+across the existing effects/core boundary. This review file binds actual
+verification evidence to the substantive diff required by task-sync.
+
+## Evidence
+
+- Actual pre-fix run of the four real Git primary/linked fixtures: 2 pass,
+  2 fail; failures were primary/current-owner readiness and linked/missing-owner
+  guard acceptance. Command: `bun test tests/mutation-guard.test.ts --test-name-pattern 'strict isolated worktree agreement' --timeout 60000`.
+- Post-fix mutation-guard and pure-projector suites: 41 pass, 0 fail.
+- Effective State, adapter parity, stability, loop characterization and hook
+  protocol suites: 66 pass, 0 fail.
+- `bun run check:type`: exit 0. `git diff --check`: exit 0.
+- Same-shape sweep: the lease-ownership arming check, explicit
+  `.claude/.require-worktree` guard, and prompt-side worktree routing implement
+  different contracts; none computes the strict isolation requirement.
+- `bun scripts/check-state-boundaries.ts`: 3 reverse-import violations in
+  unchanged `src/effects/automation/gpt-pro-issue-authoring.ts:17-19`. The same
+  command on the pinned baseline fails identically; logs compare byte-for-byte.
+  This separate issue is not repaired by this diff.
+- `bun run build:hook-bundle`: exit 0; the worktree bundle contains the changed
+  hook source. The installed host package is a separate installation, not this
+  checkout; it has not been updated by this slice.
+- Full `bun test --timeout 60000`: exit 1, 4,186 pass, 4 skip, 2 fail,
+  1 error across 4,192 tests / 349 files, 2,368.69 seconds. The runtime source
+  remained frozen throughout the run. Its original substantive diff was
+  `sha256:8e6749a9a28b3dd57021a1d33fcb0b6732b2d36b89784fc59f6119f17ebba073`.
+- One full-run failure was the old strict-primary golden: its hash assertion
+  omitted the new authority fact, and its readiness fixture still allowed the
+  primary checkout. Only that assertion and fixture changed afterward; the
+  expected isolation fact is independently false because these fixtures are
+  primary Git checkouts. No production code changed and no golden normalizer
+  or assertion was weakened.
+- Final `bun test tests/state/cli-state-golden.test.ts tests/mutation-guard.test.ts tests/state/project-effective-state.test.ts --timeout 60000`:
+  exit 0, 54 pass, 0 fail, 1,021 assertions, 33.20 seconds. Final typecheck
+  and whitespace checks also pass.
+
+## Fleet timeout and fixture root cause
+
+The user approved the Fleet follow-up after the initial full-run failure.
+The production Fleet collector and provider limiter are unchanged by this slice;
+a different worktree owns their containment changes.
+
+- **root_cause**: The fake provider wrote `provider-counter/active` and
+  `provider-counter/maximum` inside the observed Git repo. A real provider call
+  changed only `review_subject` among the 12 Effective State source hashes,
+  changing `collectLocal`'s token and invalidating its stability comparison.
+  Separately, Bun's outer test timeout does not cancel its async body, so a
+  `finally` block alone cannot prevent late assertions or fixture use.
+- **repro**: The source-hash probe is captured in
+  `/tmp/fleet-token-source-hash-probe.log`. The durable regression command is
+  `bun test tests/effects/fleet-board.test.ts --test-name-pattern 'bounds real readiness provider children' --timeout 60000`.
+- **regression_guard**: The existing four-card, concurrency-two test now requires
+  the complete Git review subject to remain unchanged across collection, while
+  retaining its repository/card-count and maximum/active-provider assertions.
+- **pre_fix_failure_artifact**: `/tmp/fleet-provider-subject-red.log`,
+  `PRE_FIX_EXIT=1`: the new assertion failed on the old fixture layout, with only
+  the subject hash changed. The test ran for 15.10 seconds.
+
+The fixture now owns a workspace with `repo/`, provider script and telemetry as
+siblings. `onTestFinished` owns cancellation, collection draining, environment
+restoration and directory removal. The normal test deadline and collector
+budget remain 30 seconds. The hook has a separate 35-second teardown budget,
+covering the provider's existing termination grace and wait; this does not turn
+an outer timeout into a pass. The async outcome is captured so a timed-out body
+cannot emit a late rejection or assert after teardown starts.
+
+Post-fix subject guard: 1 pass, 0 fail, 6 assertions, 13.46 seconds. This single
+wall-time comparison is not evidence of a fixed speedup. The combined Fleet,
+merge-readiness, golden, mutation-guard and projector run passed all 74 tests
+(1,100 assertions, 58.38 seconds); its four-card test took 11.82 seconds.
+Typecheck and whitespace checks pass.
+
+A real-fixture copy with an intentionally shortened 8-second outer timeout
+produced exactly 1 expected timeout failure and 1 next-test pass. Four provider
+PIDs were actually started, zero remained alive after the hook, both environment
+variables were restored, and the temporary root was removed before the next
+test. There was no unhandled-between-tests error. Raw evidence:
+`/tmp/fleet-lifecycle-oracle-8s-probe.log`. The outer timeout may kill a child
+without running its shell trap, so a counter value after forced cancellation is
+diagnostic only; actual PID liveness is the teardown oracle. This fault-injection
+probe is supplementary evidence, not a passing full suite or a second benchmark.
+
+Same-shape sweep: the provider-counter fixture and its trap occur only in this
+one test. Other Fleet cancellation tests exercise injected dependencies or
+pre-aborted signals and do not own real provider children. No product timeout,
+limiter, teardown implementation, or public contract was changed for this fix.
+
+## Final verification and delivery boundary
+
+The final full suite ran against base
+`1a9a5ae19167fd50ab0f0c650105ca8a9a2498eb` with frozen source/test patch SHA-256
+`e8b4ff8f98835e31fe7a2860bd7410d9c156c1951b506bcac04a8c25f0bdb1a1`.
+Raw log: `/tmp/isolated-worktree-fleet-full-final.log`. The exec session ended
+with SIGTERM / exit 143 before Bun emitted its final summary or the wrapper's
+exit footer. The partial log contains 3,315 passing test lines and one failure;
+no process retained the log open afterward. The termination source is unknown.
+This is an interrupted, non-green run. It had not reached the Fleet case, so
+there is no claim that the original suite-context Fleet timeout is closed.
+
+The observed failure was the unchanged
+`tests/helper-scripts.test.ts:5165`,
+`verify-sprint composes executed and reused criteria into frozen acceptance evidence`:
+its first verification reported that source, target, contract, goal or toolchain
+authority changed during execution. This run does not identify which authority
+changed or prove a baseline defect. The main-worktree verification-scope task
+also edits this case; this branch does not duplicate that work. Its failure,
+the active-plan contract gate conflict below, and the interrupted full-run
+boundary prevent acceptance. No second full run was started.
+
+The final source/test patch was compared byte-for-byte with its frozen capture
+and was unchanged.
+
+The source worktree passes deploy SQL order, architecture sync, project
+inspection and init dry-run (zero operations). Task-sync's new exact digest is
+bound in this review and the checker passes. The active-plan workflow check still requires a separate
+contract even for the standard profile; current higher-priority guidance permits
+one plan and forbids additional contract/notes/todo scaffolding. This existing
+conflict is recorded rather than bypassed by fabricating a contract.
+
+Main has since received a separately verified review-boundary repair containing
+the prior reverse-import fix. Another task still owns uncommitted guard/projector
+changes in main. Preserve those writes and validate any integration seam before
+claiming the candidate is merged or installed.

--- a/tests/effects/fleet-board.test.ts
+++ b/tests/effects/fleet-board.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, onTestFinished, test } from 'bun:test';
 import { execFileSync } from 'child_process';
 import { chmodSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
@@ -32,6 +32,7 @@ import {
   type RepoHarnessRegistryStrictSnapshot,
 } from '../../src/effects/repo-registry';
 import { writePublicationReceiptCache } from '../../src/effects/publication/publication-receipt';
+import { buildReviewSubject } from '../../src/effects/review/diff-fingerprint';
 import { resolveRepoIdentity } from '../../src/effects/state/coordination-canonical-source';
 import { createLeaseDirectory, writeLeaseOwnerDurably } from '../../src/effects/state/coordination-lease-store';
 import { fixtureTaskId } from '../helpers/sprint-fixture';
@@ -76,10 +77,12 @@ function shellSingleQuoted(value: string): string {
 }
 
 function createReviewingProviderFixture(
-  root: string,
+  workspaceRoot: string,
   cards: number,
   options: { readonly omit_receipt_for?: number } = {},
 ): { readonly repo: RepoHarnessRegisteredRepo; readonly gh_bin: string; readonly counter_dir: string } {
+  const root = join(workspaceRoot, 'repo');
+  mkdirSync(root);
   const sprintPath = 'plans/sprints/fleet-provider.sprint.md';
   const taskNames = Array.from({ length: cards }, (_, index) => `observe provider card ${index + 1}`);
   git(root, 'init', '-b', 'main');
@@ -150,11 +153,12 @@ function createReviewingProviderFixture(
     });
     providerCases.push(`  ${index + 1}) printf '%s\\n' ${shellSingleQuoted(providerPr)} ;;`);
   }
-  const counterDir = join(root, 'provider-counter');
+  // Provider telemetry must not change the repository subject sampled by readiness.
+  const counterDir = join(workspaceRoot, 'provider-counter');
   mkdirSync(counterDir);
   writeFileSync(join(counterDir, 'active'), '0\n');
   writeFileSync(join(counterDir, 'maximum'), '0\n');
-  const ghBin = join(root, 'fake-gh.sh');
+  const ghBin = join(workspaceRoot, 'fake-gh.sh');
   writeFileSync(ghBin, [
     '#!/bin/sh', 'set -eu', 'counter="${FLEET_PROVIDER_COUNTER_DIR:?}"',
     'lock() { while ! mkdir "$counter/lock" 2>/dev/null; do sleep 0.002; done; }',
@@ -366,26 +370,40 @@ describe('fleet board collector', () => {
     const root = mkdtempSync(join(tmpdir(), 'fleet-board-provider-limit-'));
     const previousGhBin = process.env.REPO_HARNESS_GH_BIN;
     const previousCounter = process.env.FLEET_PROVIDER_COUNTER_DIR;
-    try {
-      const fixture = createReviewingProviderFixture(root, 4);
-      process.env.REPO_HARNESS_GH_BIN = fixture.gh_bin;
-      process.env.FLEET_PROVIDER_COUNTER_DIR = fixture.counter_dir;
-      const dependencies: FleetBoardDependencies = {
-        read_registry: () => registry([fixture.repo]),
-        collect_repository: productionFleetBoardDependencies.collect_repository,
-      };
-      const result = await collectFleetBoard({ max_concurrency: 2, timeout_ms: 30_000 }, dependencies);
-      expect(result.repositories[0]).toMatchObject({ status: 'ok' });
-      expect(result.repositories[0]?.cards).toHaveLength(4);
-      expect(Number.parseInt(readFileSync(join(fixture.counter_dir, 'maximum'), 'utf8'), 10)).toBe(2);
-      expect(readFileSync(join(fixture.counter_dir, 'active'), 'utf8').trim()).toBe('0');
-    } finally {
+    const controller = new AbortController();
+    let collection: Promise<
+      { snapshot: Awaited<ReturnType<typeof collectFleetBoard>> } | { error: unknown }
+    > | undefined;
+    // Bun's test deadline does not cancel the async body. Drain it before
+    // restoring its environment or removing files that provider children use.
+    onTestFinished(async () => {
+      controller.abort();
+      await collection;
       if (previousGhBin === undefined) delete process.env.REPO_HARNESS_GH_BIN;
       else process.env.REPO_HARNESS_GH_BIN = previousGhBin;
       if (previousCounter === undefined) delete process.env.FLEET_PROVIDER_COUNTER_DIR;
       else process.env.FLEET_PROVIDER_COUNTER_DIR = previousCounter;
       rmSync(root, { recursive: true, force: true });
-    }
+    }, 35_000);
+    const fixture = createReviewingProviderFixture(root, 4);
+    const subjectBefore = buildReviewSubject(fixture.repo.path);
+    expect(subjectBefore.status).toBe('ok');
+    process.env.REPO_HARNESS_GH_BIN = fixture.gh_bin;
+    process.env.FLEET_PROVIDER_COUNTER_DIR = fixture.counter_dir;
+    const dependencies: FleetBoardDependencies = {
+      read_registry: () => registry([fixture.repo]),
+      collect_repository: productionFleetBoardDependencies.collect_repository,
+    };
+    collection = collectFleetBoard({ max_concurrency: 2, timeout_ms: 30_000, signal: controller.signal }, dependencies)
+      .then(snapshot => ({ snapshot }), error => ({ error }));
+    const outcome = await collection;
+    if (controller.signal.aborted) return;
+    if ('error' in outcome) throw outcome.error;
+    expect(outcome.snapshot.repositories[0]).toMatchObject({ status: 'ok' });
+    expect(outcome.snapshot.repositories[0]?.cards).toHaveLength(4);
+    expect(Number.parseInt(readFileSync(join(fixture.counter_dir, 'maximum'), 'utf8'), 10)).toBe(2);
+    expect(readFileSync(join(fixture.counter_dir, 'active'), 'utf8').trim()).toBe('0');
+    expect(buildReviewSubject(fixture.repo.path)).toEqual(subjectBefore);
   }, 30_000);
 
   test('does not start a repository observation after the outer signal wins before synchronous collection', async () => {

--- a/tests/mutation-guard.test.ts
+++ b/tests/mutation-guard.test.ts
@@ -575,6 +575,51 @@ describe('HRD-03 guard-by-guard parity: previously-uncovered decision branches',
     }
   }, 30_000);
 
+  test.each([
+    { name: 'primary with matching owner', linked: false, owner: 'current', allowed: false },
+    { name: 'linked with matching owner', linked: true, owner: 'current', allowed: true },
+    { name: 'linked without owner', linked: true, owner: 'missing', allowed: false },
+    { name: 'linked with foreign owner', linked: true, owner: 'foreign', allowed: false },
+  ])('strict isolated worktree agreement: $name', ({ linked, owner, allowed }) => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), 'mutation-guard-isolation-')));
+    const primary = join(root, 'primary');
+    const cwd = linked ? join(root, 'linked') : primary;
+    try {
+      mkdirSync(primary);
+      initRepo(primary);
+      if (linked) git(primary, ['worktree', 'add', '-b', 'codex/isolation-fixture', cwd]);
+      writePolicy(cwd);
+      mkdirSync(join(cwd, 'docs'), { recursive: true });
+      writeFileSync(join(cwd, 'docs/spec.md'), '# Spec\n');
+      const plan = writeActivePlan(cwd, 'Executing');
+      const contract = 'tasks/contracts/20260720-0000-mutation-guard-fixture.contract.md';
+      mkdirSync(join(cwd, 'tasks/contracts'), { recursive: true });
+      writeFileSync(join(cwd, contract), [
+        '# Contract', '> **Status**: Active', `> **Plan**: ${plan}`,
+        '> **Workflow Profile**: strict', '', '## Allowed Paths', '',
+        '```yaml', 'allowed_paths:', '  - src/', '```', '',
+      ].join('\n'));
+      if (owner === 'missing') rmSync(join(cwd, '.ai/harness/active-worktree'));
+      if (owner === 'foreign') writeFileSync(join(cwd, '.ai/harness/active-worktree'), `${primary}\n`);
+
+      const state = resolveEffectiveState(cwd, Date.now(), {
+        targetPaths: ['src/feature.ts'], operationKind: 'edit', explicitOverride: 'strict',
+      });
+      const guard = edit(cwd, 'src/feature.ts', { profile: 'strict' });
+      const readiness = state.readiness;
+      expect(readiness?.ok).toBe(true);
+      if (!readiness?.ok) throw new Error('readiness unavailable');
+      expect(readiness.requirements.edit.find((entry) => entry.key === 'isolated_contract_worktree')?.satisfied).toBe(allowed);
+      expect(readiness.allowedToEdit.decision).toBe(allowed ? 'allow' : 'block');
+      expect(guard.exitCode).toBe(allowed ? 0 : 2);
+      if ((owner === 'current' && !linked) || owner === 'missing') {
+        expect(guard.stdout).toContain('[StrictWorktreeGuard]');
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, 30_000);
+
   test('gate mode off: no SpecGuard, no PlanStatusGuard, edit passes silently through the plan gate', () => {
     const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'mutation-guard-gate-off-')));
     try {

--- a/tests/state/cli-state-golden.test.ts
+++ b/tests/state/cli-state-golden.test.ts
@@ -85,6 +85,9 @@ function assertExactHashContract(state: EffectiveState, cwd: string): void {
       ? sourceHash(cwd, state.active_sprint.path)
       : sha256('missing:active-sprint-file'),
     task_identity: sha256(state.task_id ?? 'missing:task-id'),
+    // These characterization fixtures are primary checkouts, so matching
+    // ownership cannot satisfy strict isolation.
+    ...(state.workflow_profile === 'strict' ? { isolated_contract_worktree: sha256('false') } : {}),
   });
   expect(state.source_hashes.authority_revision).toBe(expectedAuthorityRevision);
   expect(state.authority_revision).toBe(expectedAuthorityRevision);

--- a/tests/state/fixtures/explicit-strict-without-path-signals.json
+++ b/tests/state/fixtures/explicit-strict-without-path-signals.json
@@ -117,7 +117,10 @@
     "readiness": {
       "ok": true,
       "allowedToEdit": {
-        "decision": "allow"
+        "decision": "block",
+        "reasons": [
+          "required_worktree_missing"
+        ]
       },
       "allowedToStop": {
         "decision": "block",
@@ -128,6 +131,7 @@
       "readyToShip": {
         "decision": "block",
         "reasons": [
+          "required_worktree_missing",
           "required_review_missing",
           "required_external_acceptance_missing",
           "required_checks_missing"
@@ -143,7 +147,7 @@
           {
             "key": "isolated_contract_worktree",
             "status": "required",
-            "satisfied": true
+            "satisfied": false
           }
         ],
         "stop": [
@@ -162,7 +166,7 @@
           {
             "key": "isolated_contract_worktree",
             "status": "required",
-            "satisfied": true
+            "satisfied": false
           },
           {
             "key": "fresh_review",

--- a/tests/state/fixtures/loop-semantics/characterization.json
+++ b/tests/state/fixtures/loop-semantics/characterization.json
@@ -30,7 +30,7 @@
     },
     {
       "scenario": "explicit-strict-without-path-signals",
-      "source_sha256": "72c1b49825b1b3f7ed58fe81222c5d5f70a16ea1dd28c7611942474e100cfecc",
+      "source_sha256": "e6a68aa425e4f945311e37d91da967d9a63a7cd8ee87e1acc1f285b4543911bf",
       "baseline": "82550779cdccf0575d674ae53bbc95ba63e44743",
       "cli_exit": 0,
       "workflow_profile": "strict",

--- a/tests/state/project-effective-state.test.ts
+++ b/tests/state/project-effective-state.test.ts
@@ -72,6 +72,7 @@ function input(overrides: Partial<EffectiveStateInputs> = {}): EffectiveStateInp
     currentWorktree: '/repo',
     worktreeOwner: '/repo',
     worktreeOwnerIsCurrent: true,
+    isolatedContractWorktree: false,
     handoffPath: '.ai/harness/handoff/current.md',
     handoffText: null,
     resumePath: '.ai/harness/handoff/resume.md',


### PR DESCRIPTION
Defines `isolated_contract_worktree` as both conditions holding: the current directory is a Git linked worktree and the active worktree owner points at it. The resolver reads the real git/common directories and folds the result into the authority revision consumed by the edit guard, removing the state-allows-but-guard-rejects contradiction reproduced in three recovery rounds.

Also isolates the Fleet provider test fixture so provider telemetry no longer mutates the observed repository subject, and drains the async collection on test finish so Bun's timeout cannot leak late assertions.

Rebased onto main; conflict resolution and verification are recorded in `tasks/reviews/20260905-isolated-worktree-readiness.review.md`.