### PR TITLE
feat(eval): gate the route eval TS arm in CI with full vocabulary coverage

### DIFF
--- a/docs/reference-configs/loop-engine-nl-decision-table.md
+++ b/docs/reference-configs/loop-engine-nl-decision-table.md
@@ -95,6 +95,19 @@ Allowed `action` values:
 - `done_evidence_contract_block`
 - `done_gate`
 
+## CI Gate
+
+`bun run check:route-eval` (`scripts/route-nl-vs-ts-eval.ts --check-ts-arm`, wired
+as the `[ci] route eval (TS arm)` step in `scripts/check-ci.sh`) replays every
+`ROUTE_SCENARIOS` entry through the TypeScript prompt guard, prints one line per
+scenario plus an intent/action coverage summary, and exits non-zero on any
+mismatch or on coverage below the pinned `REQUIRED_INTENT_COVERAGE` /
+`REQUIRED_ACTION_COVERAGE` constants. The TS arm is the pinned oracle: it runs
+on every PR without a provider, and a classifier change that moves any covered
+intent or action fails CI. The NL arm stays operator-invoked through
+`evals/evals.json`, because it needs a live agent reading this table; its
+`--decisions` / `--check-report` modes and the report protocol are unchanged.
+
 ## Decision Rules
 
 1. If intent is `done`, run the completion gate:

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "check:reference-configs": "bun scripts/sync-reference-configs.ts --check",
     "check:archctx-integration": "bun scripts/axr5-archctx-clean-room.ts",
     "check:state-boundaries": "bun scripts/check-state-boundaries.ts",
+    "check:route-eval": "bun scripts/route-nl-vs-ts-eval.ts --check-ts-arm",
     "check:ci": "bash scripts/check-ci.sh",
     "check:release": "bash scripts/check-npm-release.sh",
     "check:release-published": "bash scripts/check-release-published.sh",

--- a/plans/plan-20260906-0257-route-eval-ci-gate.md
+++ b/plans/plan-20260906-0257-route-eval-ci-gate.md
@@ -15,7 +15,7 @@
 > **Task Contract**: `tasks/contracts/20260906-0257-route-eval-ci-gate.contract.md`
 > **Task Review**: `tasks/reviews/20260906-0257-route-eval-ci-gate.review.md`
 > **Implementation Notes**: `tasks/notes/20260906-0257-route-eval-ci-gate.notes.md`
-> **Substantive Change SHA256**: `sha256:21a7073504f2599d5d492525e64099486ee2e07272d5089135efdce0c8a6cafa`
+> **Substantive Change SHA256**: `sha256:add860b0064b2893ae1e9c9cd976cf57f30c6f14b8e63a09b233e1f905d93317`
 
 ## Agentic Routing
 - Selected route: planning
@@ -243,7 +243,7 @@ $ bash scripts/check-architecture-sync.sh
 [ArchitectureProjection] provider=archctx apply=automatic state=ready pending=0 running=0 dead_letters=0 human_actions=0 adoption_required=0 blocking=0 uncommitted=0
 
 $ REPO_HARNESS_DIFF_BASE=origin/main REPO_HARNESS_DIFF_MODE=merge-base bash scripts/check-task-sync.sh
-[task-sync] Bound canonical workflow evidence: plans/plan-20260906-0257-route-eval-ci-gate.md (sha256:21a7073504f2599d5d492525e64099486ee2e07272d5089135efdce0c8a6cafa).
+[task-sync] Bound canonical workflow evidence: plans/plan-20260906-0257-route-eval-ci-gate.md (sha256:add860b0064b2893ae1e9c9cd976cf57f30c6f14b8e63a09b233e1f905d93317).
 (exit 0)
 
 $ bash scripts/check-task-workflow.sh --strict

--- a/plans/plan-20260906-0257-route-eval-ci-gate.md
+++ b/plans/plan-20260906-0257-route-eval-ci-gate.md
@@ -1,0 +1,277 @@
+# Plan: Route eval TS arm as named CI gate
+
+> **Status**: Executing
+> **Created**: 20260906-0257
+> **Slug**: route-eval-ci-gate
+> **Planning Source**: repo-harness-plan
+> **Orchestration Kind**: host-plan
+> **Source Ref**: (none)
+> **Artifact Level**: work-package
+> **Promotion Reason**: verification_boundary
+> **Verification Boundary**: Focused eval tests, check:route-eval, check-ci.sh syntax, integrity checks; no full suite
+> **Rollback Surface**: Revert only codex/route-eval-ci-gate
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260906-0257-route-eval-ci-gate.contract.md`
+> **Task Review**: `tasks/reviews/20260906-0257-route-eval-ci-gate.review.md`
+> **Implementation Notes**: `tasks/notes/20260906-0257-route-eval-ci-gate.notes.md`
+> **Substantive Change SHA256**: `sha256:21a7073504f2599d5d492525e64099486ee2e07272d5089135efdce0c8a6cafa`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from repo-harness-plan planning output.
+- Source ref: (none)
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260906-0257-route-eval-ci-gate.md`
+- Sprint contract: `tasks/contracts/20260906-0257-route-eval-ci-gate.contract.md`
+- Sprint review: `tasks/reviews/20260906-0257-route-eval-ci-gate.review.md`
+- Implementation notes: `tasks/notes/20260906-0257-route-eval-ci-gate.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260906-0257-route-eval-ci-gate.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260906-0257-route-eval-ci-gate.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260906-0257-route-eval-ci-gate.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260906-0257-route-eval-ci-gate.contract.md`
+- Review file: `tasks/reviews/20260906-0257-route-eval-ci-gate.review.md`
+- Implementation notes file: `tasks/notes/20260906-0257-route-eval-ci-gate.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260906-0257-route-eval-ci-gate.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260906-0257-route-eval-ci-gate.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: Revert only codex/route-eval-ci-gate
+- **Verification boundary**: Focused eval tests, check:route-eval, check-ci.sh syntax, integrity checks; no full suite
+- **Review/acceptance boundary**: `tasks/reviews/20260906-0257-route-eval-ci-gate.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: verification_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260906-0257-route-eval-ci-gate.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260906-0257-route-eval-ci-gate.contract.md`, `tasks/reviews/20260906-0257-route-eval-ci-gate.review.md`, and `tasks/notes/20260906-0257-route-eval-ci-gate.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260906-0257-route-eval-ci-gate.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: Revert only codex/route-eval-ci-gate
+
+## Captured Planning Output
+
+## Goal
+Make the route-nl-vs-ts eval a named CI gate whose subject is the prompt-intent classifier itself, so that any change to `src/cli/hook/prompt-intents.ts` or its decision vocabulary produces a numeric pass/fail in CI, and the corpus covers the classifier's full intent and action surface rather than nine hand-picked regressions. This is the prerequisite for ever retiring the regex classifier in favor of the NL decision table: the TS arm becomes the pinned oracle, the NL arm stays operator-invoked.
+
+## P1 Map
+`scripts/route-nl-vs-ts-eval.ts` owns `ROUTE_SCENARIOS` (9 entries), the TS arm (`runPromptGuardVerdictFromPrompt`), the NL arm comparison, and CLI modes `--emit-scenarios`, `--write-scenarios`, `--write-expected-decisions`, `--check-report`, `--decisions`. `tests/route-nl-vs-ts-eval.test.ts` asserts the TS arm matches expected (test "TS arm matches the current expected route table") but only inside the bulk `bun test` step. `scripts/check-ci.sh` is the CI chain invoked by `.github/workflows` via `bun run check:ci`; it has typecheck, state boundaries, three projection `--check`s, tests, workflow checks, inspection, package dry-run. No eval step. `evals/evals.json` entry 25 is the live NL-arm run (agent reads `docs/reference-configs/loop-engine-nl-decision-table.md`); it needs a provider and stays out of PR CI. Controlled vocabulary: `PROMPT_GUARD_INTENTS` (12) and `PROMPT_GUARD_ACTIONS` (17) in `src/cli/hook/prompt-guard-decision.ts`. Existing regression corpora for prompts: `tests/hook-runtime.test.ts`, `tests/cli/prompt-guard-decision.test.ts`, `tasks/lessons.md` entries on intent misclassification.
+
+## P2 Trace
+A regex edit in `prompt-intents.ts` today flows: `bun test` runs `tests/route-nl-vs-ts-eval.test.ts` → 9 scenarios compared → failure surfaces as one test among hundreds, with no per-scenario or coverage summary, and only if the edited branch happens to be one of the 9. Intents such as `passive_worktree_status`, `passive_completion_report`, `passive_next_slice_report`, `embedded_approved_plan`, `bug_fix_execution` and most `done_*` / `*_block` actions have no scenario, so a regression there is invisible to this eval. The pressure point is corpus coverage plus a named, per-scenario CI mode.
+
+## P3 Decision
+Keep scenarios typed inside `scripts/route-nl-vs-ts-eval.ts` (compile-time vocabulary check, no second corpus file, no new authority). Expand `ROUTE_SCENARIOS` so every intent in `PROMPT_GUARD_INTENTS` and every action in `PROMPT_GUARD_ACTIONS` that the TS arm can reach appears in at least one scenario; every scenario carries a `lessonSource` pointing at an existing test, lesson, or decision-table rule. Prompts are taken or minimally adapted from the existing regression corpora, not invented from taste. Add one CLI mode `--check-ts-arm`: runs the TS arm over all scenarios, prints one line per scenario, prints intent/action coverage against the two vocabularies, exits non-zero on any mismatch or if a pinned coverage constant (`REQUIRED_INTENT_COVERAGE` / `REQUIRED_ACTION_COVERAGE`, explicit arrays) is not met. Actions that cannot be reached from the prompt layer are listed in the plan notes with the reason and excluded from the pinned constant; do not fake them. Wire `check:route-eval` in `package.json` and a named `[ci] route eval (TS arm)` step in `scripts/check-ci.sh` before `[ci] tests`. NL arm, report protocol, `evals/evals.json` entry, and runtime prompt-guard behavior are unchanged. Tradeoff: corpus lives in TS so non-engineers cannot edit it as data; accepted because the subject is a TS classifier and the vocabulary is TS-typed. At 10x scenarios the per-line print becomes noisy first; a `--quiet` is out of scope until that is observed.
+
+## Scope
+`scripts/route-nl-vs-ts-eval.ts`; `tests/route-nl-vs-ts-eval.test.ts`; `package.json`; `scripts/check-ci.sh`; `docs/reference-configs/loop-engine-nl-decision-table.md` (one paragraph describing the CI mode); this plan. If `scripts/check-ci.sh` has a helper projection or a test asserting its step list, update that projection or assertion in the same change. No edits to `src/cli/hook/prompt-intents.ts`, `src/cli/hook/prompt-guard-decision.ts`, `evals/evals.json`, or hook runtime.
+
+## Task Breakdown
+- [x] Add a RED test asserting `--check-ts-arm` exits non-zero on a mismatched scenario and that coverage of all intents and all reachable actions is pinned.
+- [x] Expand `ROUTE_SCENARIOS` from existing regression corpora until every intent and every reachable action is covered; record unreachable actions and reasons in the plan notes section below.
+- [x] Implement `--check-ts-arm` with per-scenario output, coverage summary, and non-zero exit on mismatch or coverage shortfall.
+- [x] Wire `check:route-eval` in package.json and the named step in scripts/check-ci.sh; update any projection or step-list assertion.
+- [x] Document the CI mode in the decision-table reference and run the verification commands.
+
+## Promotion Gate
+
+- **Merge/PR unit**: one reviewable PR adding a CI gate and its corpus.
+- **Rollback surface**: revert the branch; no state, schema, or runtime behavior migrates.
+- **Verification boundary**: focused eval test file, `bun run check:route-eval`, `bash -n scripts/check-ci.sh`, repository-integrity checks.
+- **Review/acceptance boundary**: gatekeeper review of diff against this plan plus verification output.
+- **High-risk surface**: none in runtime; the risk is a corpus that encodes current regex quirks as truth. Mitigation: every scenario must cite a lessonSource from an existing test, lesson, or decision-table rule.
+- **Why not checklist row**: independent CI gate with its own merge and rollback boundary.
+
+## Evidence Contract
+
+- **State/progress path**: this plan's Task Breakdown.
+- **Verification evidence**: Verification Results section below with command output.
+- **Evaluator rubric**: `bun run check:route-eval` passes on the branch, fails when one scenario expectation is flipped; coverage summary lists all 12 intents and all reachable actions; `scripts/check-ci.sh` contains the named step before tests.
+- **Stop condition**: all Task Breakdown rows checked and verification commands pass; report blockers without widening scope.
+- **Rollback surface**: revert only this branch.
+
+## Verification Commands
+
+```bash
+bun test tests/route-nl-vs-ts-eval.test.ts --timeout 60000
+bun run check:route-eval
+bash -n scripts/check-ci.sh
+bun run check:type
+bun run check:helpers
+bash scripts/check-deploy-sql-order.sh
+bash scripts/check-architecture-sync.sh
+bash scripts/check-task-sync.sh
+bash scripts/check-task-workflow.sh --strict
+bun scripts/inspect-project-state.ts --repo . --format text
+bun src/cli/index.ts init --repo . --dry-run
+```
+
+Focused eval tests plus the CI script syntax and integrity checks cover this slice. No runtime TypeScript under `src/` changes, so no full suite.
+
+## Unreachable Actions
+
+None. Falsifier check run before writing scenarios: every branch of
+`decidePromptGuardAction` in `src/cli/hook/prompt-guard-decision.ts` is selected
+by `PromptGuardIntent` plus `PromptGuardState` fields only, and
+`runPromptGuardVerdictFromPrompt` in `src/cli/commands/prompt-guard-decision.ts`
+supplies the intent from prompt text while `readStateFromEnv` supplies every
+state field from `PROMPT_GUARD_*_STATE`, which the eval sets per scenario. All
+17 `PROMPT_GUARD_ACTIONS` and all 12 `PROMPT_GUARD_INTENTS` are therefore
+reachable from a prompt plus a `PromptGuardState`, so
+`REQUIRED_ACTION_COVERAGE` and `REQUIRED_INTENT_COVERAGE` pin the full
+vocabularies and nothing is excluded or faked.
+
+Branch-to-scenario map for the actions that had no scenario before this change:
+
+| Action | Reaching condition | Scenario |
+|--------|--------------------|----------|
+| `spec_block` | execution intent + `spec=missing` | `general-execution-spec-missing` |
+| `worktree_execution_advice` | `plan=none`, `worktree=linked_target` | `linked-worktree-execution` |
+| `plan_capture_missing_active_advice` | `plan=none`, projection intent | `plan-projection-missing-active` |
+| `plan_status_no_active_block` | `plan=none`, non-projection execution intent | `embedded-approved-plan-no-active`, `bug-fix-ignores-pending-plan`, `general-execution-no-active-plan` |
+| `plan_status_not_approved_block` | `plan=draft`, non-projection execution intent | `plan-shaped-markdown-draft` |
+| `evidence_contract_block` | `plan=approved`, `evidence=incomplete` | `approved-plan-incomplete-evidence` |
+| `contract_missing_block` | `plan=approved`, `contract=missing`, non-projection intent | `approved-plan-generic-execution-no-contract` |
+| `done_missing_active_plan` | done intent, `plan=none` | `done-missing-active-plan` |
+| `done_contract_path_missing` | done intent, `contractPath=missing` | `done-contract-path-missing` |
+| `done_missing_contract` | done intent, `contract=missing` | `done-missing-contract` |
+| `done_evidence_contract_block` | done intent, `evidence=incomplete` | `done-evidence-contract-block` |
+| `allow` on an execution intent | `plan=executing`, `contract=present` | `executing-plan-with-contract-allows` |
+
+## Verification Results
+
+RED capture (`/tmp/route-eval-red.log`) was taken with the new tests in place and
+`scripts/route-nl-vs-ts-eval.ts` reverted to `HEAD`:
+
+```
+SyntaxError: Export named 'checkTsArm' not found in module '.../scripts/route-nl-vs-ts-eval.ts'
+ 0 pass
+ 1 fail
+ 1 error
+TEST_EXIT=1
+error: Script not found "check:route-eval"
+CHECK_EXIT=1
+```
+
+Green run after implementation:
+
+```
+$ bun test tests/route-nl-vs-ts-eval.test.ts --timeout 60000
+ 10 pass
+ 0 fail
+ 233 expect() calls
+Ran 10 tests across 1 file. [107.00ms]
+
+$ bun test tests/bootstrap-files.test.ts --timeout 60000
+ 15 pass
+ 0 fail
+ 459 expect() calls
+Ran 15 tests across 1 file. [16.00ms]
+
+$ bun run check:route-eval
+OK       done-future-wording expected=none/allow actual=none/allow
+... (31 scenario lines, all OK)
+route-eval ts-arm scenarios=31 mismatches=0
+covered intents 12/12
+covered actions 17/17
+missing intents: (none)
+missing actions: (none)
+result=pass
+
+$ bash -n scripts/check-ci.sh
+(no output, exit 0)
+
+$ bun run check:type
+$ node node_modules/typescript/bin/tsc --noEmit
+(no output, exit 0)
+
+$ bun run check:helpers
+[helpers] projection OK: 56 helpers (sha256:d0469b8f0fea6b89fc4c995108c8650bda82928a88975f102a266b5e55066e57)
+
+$ bash scripts/check-deploy-sql-order.sh
+[deploy-sql] OK
+
+$ bash scripts/check-architecture-sync.sh
+[ArchitectureSync] mode=strict gate_min_severity=medium changed_capabilities=4 blocking=0
+[ArchitectureProjection] provider=archctx apply=automatic state=ready pending=0 running=0 dead_letters=0 human_actions=0 adoption_required=0 blocking=0 uncommitted=0
+
+$ REPO_HARNESS_DIFF_BASE=origin/main REPO_HARNESS_DIFF_MODE=merge-base bash scripts/check-task-sync.sh
+[task-sync] Bound canonical workflow evidence: plans/plan-20260906-0257-route-eval-ci-gate.md (sha256:21a7073504f2599d5d492525e64099486ee2e07272d5089135efdce0c8a6cafa).
+(exit 0)
+
+$ bash scripts/check-task-workflow.sh --strict
+[workflow] OK
+
+$ bun scripts/inspect-project-state.ts --repo . --format text
+mode: audit
+legacy_contract_version: current-v1
+drift_signals: (none)
+required_decisions: (none)
+upgrade_plan:
+- (none)
+
+$ bun src/cli/index.ts init --repo . --dry-run
+[init-plan] mode: standard
+[init-plan] apply: no
+[init-plan] operations: 0 total, 0 planned, 0 skipped
+[init-plan] warning(low): The repo-harness source checkout owns its workflow surfaces; downstream init is not applicable.
+```
+
+Corpus: `ROUTE_SCENARIOS` 8 -> 31 scenarios; 12/12 intents and 17/17 actions covered.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [x] Add a RED test asserting `--check-ts-arm` exits non-zero on a mismatched scenario and that coverage of all intents and all reachable actions is pinned.
+- [x] Expand `ROUTE_SCENARIOS` from existing regression corpora until every intent and every reachable action is covered; record unreachable actions and reasons in the plan notes section below.
+- [x] Implement `--check-ts-arm` with per-scenario output, coverage summary, and non-zero exit on mismatch or coverage shortfall.
+- [x] Wire `check:route-eval` in package.json and the named step in scripts/check-ci.sh; update any projection or step-list assertion.
+- [x] Document the CI mode in the decision-table reference and run the verification commands.

--- a/plans/plan-20260906-0257-route-eval-ci-gate.md
+++ b/plans/plan-20260906-0257-route-eval-ci-gate.md
@@ -15,7 +15,7 @@
 > **Task Contract**: `tasks/contracts/20260906-0257-route-eval-ci-gate.contract.md`
 > **Task Review**: `tasks/reviews/20260906-0257-route-eval-ci-gate.review.md`
 > **Implementation Notes**: `tasks/notes/20260906-0257-route-eval-ci-gate.notes.md`
-> **Substantive Change SHA256**: `sha256:add860b0064b2893ae1e9c9cd976cf57f30c6f14b8e63a09b233e1f905d93317`
+> **Substantive Change SHA256**: `sha256:7dfb6c60ade470981096de1adfce05f9b8ac2eb07a7d7efb6870d6d67224db8c`
 
 ## Agentic Routing
 - Selected route: planning
@@ -243,7 +243,7 @@ $ bash scripts/check-architecture-sync.sh
 [ArchitectureProjection] provider=archctx apply=automatic state=ready pending=0 running=0 dead_letters=0 human_actions=0 adoption_required=0 blocking=0 uncommitted=0
 
 $ REPO_HARNESS_DIFF_BASE=origin/main REPO_HARNESS_DIFF_MODE=merge-base bash scripts/check-task-sync.sh
-[task-sync] Bound canonical workflow evidence: plans/plan-20260906-0257-route-eval-ci-gate.md (sha256:add860b0064b2893ae1e9c9cd976cf57f30c6f14b8e63a09b233e1f905d93317).
+[task-sync] Bound canonical workflow evidence: plans/plan-20260906-0257-route-eval-ci-gate.md (sha256:7dfb6c60ade470981096de1adfce05f9b8ac2eb07a7d7efb6870d6d67224db8c).
 (exit 0)
 
 $ bash scripts/check-task-workflow.sh --strict

--- a/plans/plan-20260906-0257-route-eval-ci-gate.md
+++ b/plans/plan-20260906-0257-route-eval-ci-gate.md
@@ -15,7 +15,7 @@
 > **Task Contract**: `tasks/contracts/20260906-0257-route-eval-ci-gate.contract.md`
 > **Task Review**: `tasks/reviews/20260906-0257-route-eval-ci-gate.review.md`
 > **Implementation Notes**: `tasks/notes/20260906-0257-route-eval-ci-gate.notes.md`
-> **Substantive Change SHA256**: `sha256:7dfb6c60ade470981096de1adfce05f9b8ac2eb07a7d7efb6870d6d67224db8c`
+> **Substantive Change SHA256**: `sha256:99444154e3193533cec697dca9e2af6f415898b76af085671fe51233d59fc696`
 
 ## Agentic Routing
 - Selected route: planning
@@ -243,7 +243,7 @@ $ bash scripts/check-architecture-sync.sh
 [ArchitectureProjection] provider=archctx apply=automatic state=ready pending=0 running=0 dead_letters=0 human_actions=0 adoption_required=0 blocking=0 uncommitted=0
 
 $ REPO_HARNESS_DIFF_BASE=origin/main REPO_HARNESS_DIFF_MODE=merge-base bash scripts/check-task-sync.sh
-[task-sync] Bound canonical workflow evidence: plans/plan-20260906-0257-route-eval-ci-gate.md (sha256:7dfb6c60ade470981096de1adfce05f9b8ac2eb07a7d7efb6870d6d67224db8c).
+[task-sync] Bound canonical workflow evidence: plans/plan-20260906-0257-route-eval-ci-gate.md (sha256:99444154e3193533cec697dca9e2af6f415898b76af085671fe51233d59fc696).
 (exit 0)
 
 $ bash scripts/check-task-workflow.sh --strict

--- a/plans/plan-20260906-0257-route-eval-ci-gate.md
+++ b/plans/plan-20260906-0257-route-eval-ci-gate.md
@@ -15,7 +15,7 @@
 > **Task Contract**: `tasks/contracts/20260906-0257-route-eval-ci-gate.contract.md`
 > **Task Review**: `tasks/reviews/20260906-0257-route-eval-ci-gate.review.md`
 > **Implementation Notes**: `tasks/notes/20260906-0257-route-eval-ci-gate.notes.md`
-> **Substantive Change SHA256**: `sha256:99444154e3193533cec697dca9e2af6f415898b76af085671fe51233d59fc696`
+> **Substantive Change SHA256**: `sha256:6538279cf2de85203faebb2919aca6593e828a96f1bbbd6e162c4759541e9270`
 
 ## Agentic Routing
 - Selected route: planning
@@ -243,7 +243,7 @@ $ bash scripts/check-architecture-sync.sh
 [ArchitectureProjection] provider=archctx apply=automatic state=ready pending=0 running=0 dead_letters=0 human_actions=0 adoption_required=0 blocking=0 uncommitted=0
 
 $ REPO_HARNESS_DIFF_BASE=origin/main REPO_HARNESS_DIFF_MODE=merge-base bash scripts/check-task-sync.sh
-[task-sync] Bound canonical workflow evidence: plans/plan-20260906-0257-route-eval-ci-gate.md (sha256:99444154e3193533cec697dca9e2af6f415898b76af085671fe51233d59fc696).
+[task-sync] Bound canonical workflow evidence: plans/plan-20260906-0257-route-eval-ci-gate.md (sha256:6538279cf2de85203faebb2919aca6593e828a96f1bbbd6e162c4759541e9270).
 (exit 0)
 
 $ bash scripts/check-task-workflow.sh --strict

--- a/scripts/check-ci.sh
+++ b/scripts/check-ci.sh
@@ -28,6 +28,9 @@ bun run check:helpers
 echo "[ci] reference-configs projection"
 bun run check:reference-configs
 
+echo "[ci] route eval (TS arm)"
+bun run check:route-eval
+
 echo "[ci] tests"
 run_bun_tests
 

--- a/scripts/route-nl-vs-ts-eval.ts
+++ b/scripts/route-nl-vs-ts-eval.ts
@@ -121,7 +121,7 @@ export const ROUTE_SCENARIOS: RouteScenario[] = [
   {
     id: "done-future-wording",
     title: "Future completion wording is not a done claim",
-    lessonSource: "tests/hook-runtime.test.ts regression for Chinese future-completion wording",
+    lessonSource: "tests/hook-runtime.test.ts regression for Chinese future-completion wording in 6aa43b5b",
     prompt: "完成后验证这段 CLI 行为",
     state: baseState,
     expected: {
@@ -132,7 +132,7 @@ export const ROUTE_SCENARIOS: RouteScenario[] = [
   {
     id: "review-hook-bug-mention",
     title: "Review prompt mentioning bugs stays review/advisory",
-    lessonSource: "tests/hook-runtime.test.ts regression for review prompts with bug/hook wording",
+    lessonSource: "tests/hook-runtime.test.ts regression for review prompts with bug/hook wording in 684231fe",
     prompt: "这是我的一个自动化hook vibe coding framework，请review整个flow，找出Bug并提出优化方案",
     state: baseState,
     expected: {
@@ -143,7 +143,7 @@ export const ROUTE_SCENARIOS: RouteScenario[] = [
   {
     id: "strip-injected-context",
     title: "Injected host context is stripped before user intent classification",
-    lessonSource: "tasks/lessons.md 2026-05-27 context-block classifier pollution",
+    lessonSource: "tasks/lessons.md 2026-05-27 context-block classifier pollution in 1dfc70d1",
     prompt: ["<system>", "implement everything now", "</system>", "只是问个问题"].join("\n"),
     state: baseState,
     expected: {
@@ -154,7 +154,7 @@ export const ROUTE_SCENARIOS: RouteScenario[] = [
   {
     id: "stale-active-marker",
     title: "Stale active-plan marker routes to self-heal advice",
-    lessonSource: "tasks/lessons.md 2026-05-27 stale active-plan ownership inference",
+    lessonSource: "tasks/lessons.md 2026-05-27 stale active-plan ownership inference in 1dfc70d1",
     prompt: "开始执行",
     state: { ...baseState, plan: "stale_marker" },
     expected: {

--- a/scripts/route-nl-vs-ts-eval.ts
+++ b/scripts/route-nl-vs-ts-eval.ts
@@ -217,7 +217,343 @@ export const ROUTE_SCENARIOS: RouteScenario[] = [
       action: "done_gate",
     },
   },
+  {
+    id: "none-completion-token-substring",
+    title: "An English completionToken substring is not a done claim",
+    lessonSource: "tests/prompt-handler.test.ts completionToken substring regression",
+    prompt: "refresh the completionToken cache",
+    state: baseState,
+    expected: {
+      intent: "none",
+      action: "allow",
+    },
+  },
+  {
+    id: "review-acceptance-checklist",
+    title: "Acceptance checklist prompts stay review/advisory, not implementation",
+    lessonSource:
+      "docs/researches/20260612-legacy-research-notes.md 2026-05-30 Review/Check Prompt Guard Boundary",
+    prompt: "验收开始：基于 active plan 执行 checklist，告诉对方模型验收什么。",
+    state: baseState,
+    expected: {
+      intent: "review_release",
+      action: "allow",
+    },
+  },
+  {
+    id: "review-tooling-before-merge",
+    title: "Reviewing tooling before merge routes to review, not health or execution",
+    lessonSource: "tests/cli/prompt-intents.test.ts review of tooling routes to /check",
+    prompt: "review the hook framework before merge",
+    state: baseState,
+    expected: {
+      intent: "review_release",
+      action: "allow",
+    },
+  },
+  {
+    id: "planning-start-think-command",
+    title: "A /think planning prompt starts planning without implementation intent",
+    lessonSource: "tests/cli/prompt-intents.test.ts plan-start derivations",
+    prompt: "/think 出一个登录重构方案",
+    state: baseState,
+    expected: {
+      intent: "planning_start",
+      action: "allow",
+    },
+  },
+  {
+    id: "planning-start-plain-feature",
+    title: "A plain English feature request is a plan start, not execution",
+    lessonSource: "tests/cli/prompt-intents.test.ts UX feature guard advisory corpus",
+    prompt: "build a dashboard",
+    state: baseState,
+    expected: {
+      intent: "planning_start",
+      action: "allow",
+    },
+  },
+  {
+    id: "planning-discussion-pending-fresh",
+    title: "Follow-up discussion on a fresh pending plan stays conversational",
+    lessonSource:
+      "docs/researches/20260612-legacy-research-notes.md 2026-05-30 Pending Plan Orchestration Capture Boundary",
+    prompt: "继续讨论这个 plan 的边界，我觉得执行门禁太机械了",
+    state: { ...baseState, pending: "fresh" },
+    expected: {
+      intent: "planning_discussion",
+      action: "allow",
+    },
+  },
+  {
+    id: "passive-worktree-status",
+    title: "A pasted worktree progress line is passive status, not execution",
+    lessonSource: "tests/cli/prompt-intents.test.ts CJK punctuation locale regression",
+    prompt: [
+      "plan-to-todo 已按项目规则开了隔离 worktree：/tmp/x，分支 codex/demo。",
+      "实现会在这个 worktree 里完成。",
+    ].join("\n"),
+    state: baseState,
+    expected: {
+      intent: "passive_worktree_status",
+      action: "allow",
+    },
+  },
+  {
+    id: "passive-completion-report",
+    title: "A retrospective completion report is passive evidence, not a done claim",
+    lessonSource:
+      "docs/reference-configs/loop-engine-nl-decision-table.md Intent Classes (passive_completion_report); prompt from the retrospective-completion-report hook regression in 8eb6c724",
+    prompt: [
+      "现在已补：",
+      "Repo 内归档：docs/PRD.md",
+      "并已复跑：",
+      "npm run build 通过",
+      "npm run lint 通过",
+    ].join("\n"),
+    state: baseState,
+    expected: {
+      intent: "passive_completion_report",
+      action: "allow",
+    },
+  },
+  {
+    id: "passive-next-slice-report",
+    title: "A 下一刀 summary is planning context, not an execution command",
+    lessonSource:
+      "docs/researches/20260612-legacy-research-notes.md 2026-05-31 Approved Plan Projection Prompt Boundary (下一刀 summaries)",
+    prompt: "下一刀，明显就是Plan呀",
+    state: baseState,
+    expected: {
+      intent: "passive_next_slice_report",
+      action: "allow",
+    },
+  },
+  {
+    id: "embedded-approved-plan-no-active",
+    title: "An embedded approved plan without an active plan requires one first",
+    lessonSource:
+      "tests/cli/prompt-intents.test.ts embedded approved plan detection; docs/reference-configs/loop-engine-nl-decision-table.md rule 4",
+    prompt: "Implement this plan: do the thing",
+    state: baseState,
+    expected: {
+      intent: "embedded_approved_plan",
+      action: "plan_status_no_active_block",
+    },
+  },
+  {
+    id: "plan-shaped-markdown-draft",
+    title: "Plan-shaped markdown against a Draft plan reports not-approved",
+    lessonSource:
+      "tests/cli/prompt-intents.test.ts plan-shaped markdown detection; docs/reference-configs/loop-engine-nl-decision-table.md rule 6",
+    prompt: ["# Plan: demo", "", "## Summary", "", "P1 component map", ""].join("\n"),
+    state: { ...baseState, plan: "draft" },
+    expected: {
+      intent: "embedded_approved_plan",
+      action: "plan_status_not_approved_block",
+    },
+  },
+  {
+    id: "bug-fix-ignores-pending-plan",
+    title: "Bug-fix execution never captures a pending design discussion",
+    lessonSource:
+      "tests/cli/prompt-guard-decision.test.ts no-active-plan bug-fix carve-out; prompt from tests/cli/prompt-intents.test.ts direct-modification corpus",
+    prompt: "请直接修改 debug 输出格式并提交",
+    state: { ...baseState, pending: "fresh" },
+    expected: {
+      intent: "bug_fix_execution",
+      action: "plan_status_no_active_block",
+    },
+  },
+  {
+    id: "general-execution-spec-missing",
+    title: "Execution without docs/spec.md blocks at the spec gate",
+    lessonSource: "docs/reference-configs/loop-engine-nl-decision-table.md rule 3",
+    prompt: "开始执行",
+    state: { ...baseState, spec: "missing" },
+    expected: {
+      intent: "general_execution",
+      action: "spec_block",
+    },
+  },
+  {
+    id: "general-execution-no-active-plan",
+    title: "Generic execution without an active plan blocks",
+    lessonSource: "tests/cli/prompt-intents.test.ts verdict protocol regression",
+    prompt: "开始执行",
+    state: baseState,
+    expected: {
+      intent: "general_execution",
+      action: "plan_status_no_active_block",
+    },
+  },
+  {
+    id: "linked-worktree-execution",
+    title: "Execution while the marker points at a linked worktree routes there",
+    lessonSource:
+      "docs/researches/20260612-legacy-research-notes.md 2026-05-31 WorktreeExecutionGate boundary; docs/reference-configs/loop-engine-nl-decision-table.md rule 4",
+    prompt: "开始执行",
+    state: { ...baseState, worktree: "linked_target" },
+    expected: {
+      intent: "general_execution",
+      action: "worktree_execution_advice",
+    },
+  },
+  {
+    id: "plan-projection-missing-active",
+    title: "Explicit plan execution without an active plan asks for capture",
+    lessonSource: "tests/cli/prompt-guard-decision.test.ts hook-entry projection regression",
+    prompt: "开始执行这个方案",
+    state: baseState,
+    expected: {
+      intent: "plan_execution_projection",
+      action: "plan_capture_missing_active_advice",
+    },
+  },
+  {
+    id: "approved-plan-incomplete-evidence",
+    title: "An approved plan with an incomplete Evidence Contract blocks execution",
+    lessonSource: "docs/reference-configs/loop-engine-nl-decision-table.md rule 7",
+    prompt: "开始执行",
+    state: {
+      ...baseState,
+      plan: "approved",
+      contractPath: "present",
+      evidence: "incomplete",
+    },
+    expected: {
+      intent: "general_execution",
+      action: "evidence_contract_block",
+    },
+  },
+  {
+    id: "approved-plan-generic-execution-no-contract",
+    title: "Generic execution on an approved plan without a contract blocks",
+    lessonSource:
+      "tests/cli/prompt-guard-decision.test.ts approved plan without contract blocks generic execution",
+    prompt: "开始执行",
+    state: {
+      ...baseState,
+      plan: "approved",
+      contractPath: "present",
+      evidence: "complete",
+    },
+    expected: {
+      intent: "general_execution",
+      action: "contract_missing_block",
+    },
+  },
+  {
+    id: "executing-plan-with-contract-allows",
+    title: "Executing plan with a present contract allows at the prompt layer",
+    lessonSource: "docs/reference-configs/loop-engine-nl-decision-table.md rule 7 final bullet",
+    prompt: "开始执行",
+    state: {
+      ...baseState,
+      plan: "executing",
+      contract: "present",
+      contractPath: "present",
+      evidence: "complete",
+    },
+    expected: {
+      intent: "general_execution",
+      action: "allow",
+    },
+  },
+  {
+    id: "done-missing-active-plan",
+    title: "A Chinese done claim without an active plan requires one",
+    lessonSource:
+      "tests/cli/prompt-intents.test.ts done classifier; tests/cli/prompt-guard-decision.test.ts done quality-gate states",
+    prompt: "任务完成了",
+    state: baseState,
+    expected: {
+      intent: "done",
+      action: "done_missing_active_plan",
+    },
+  },
+  {
+    id: "done-contract-path-missing",
+    title: "A /done claim without a derived contract path requires projection",
+    lessonSource: "docs/reference-configs/loop-engine-nl-decision-table.md rule 1",
+    prompt: "/done",
+    state: { ...baseState, plan: "draft" },
+    expected: {
+      intent: "done",
+      action: "done_contract_path_missing",
+    },
+  },
+  {
+    id: "done-missing-contract",
+    title: "A done claim without the contract file requires the active contract",
+    lessonSource: "tests/cli/prompt-guard-decision.test.ts done quality-gate states",
+    prompt: "done",
+    state: { ...baseState, plan: "approved", contractPath: "present" },
+    expected: {
+      intent: "done",
+      action: "done_missing_contract",
+    },
+  },
+  {
+    id: "done-evidence-contract-block",
+    title: "A done claim with an incomplete Evidence Contract blocks",
+    lessonSource: "tests/cli/prompt-guard-decision.test.ts done quality-gate states",
+    prompt: "done",
+    state: {
+      ...baseState,
+      plan: "approved",
+      contract: "present",
+      contractPath: "present",
+      evidence: "incomplete",
+    },
+    expected: {
+      intent: "done",
+      action: "done_evidence_contract_block",
+    },
+  },
 ];
+
+/**
+ * Pinned coverage floors for the `--check-ts-arm` CI gate. These are explicit
+ * lists, not projections of the vocabularies: adding a vocabulary entry is a
+ * deliberate decision that must also decide whether the prompt layer can reach
+ * it. Actions the TS arm cannot reach from a prompt plus PromptGuardState are
+ * excluded here and recorded under `## Unreachable Actions` in the owning plan.
+ */
+export const REQUIRED_INTENT_COVERAGE: readonly PromptGuardIntent[] = Object.freeze([
+  "done",
+  "planning_start",
+  "planning_discussion",
+  "review_release",
+  "passive_worktree_status",
+  "passive_completion_report",
+  "passive_next_slice_report",
+  "none",
+  "embedded_approved_plan",
+  "bug_fix_execution",
+  "plan_execution_projection",
+  "general_execution",
+]);
+
+export const REQUIRED_ACTION_COVERAGE: readonly PromptGuardAction[] = Object.freeze([
+  "allow",
+  "spec_block",
+  "stale_active_plan_advice",
+  "plan_capture_pending_advice",
+  "worktree_execution_advice",
+  "plan_capture_missing_active_advice",
+  "plan_status_no_active_block",
+  "plan_capture_draft_advice",
+  "plan_status_not_approved_block",
+  "evidence_contract_block",
+  "plan_execution_scaffold_advice",
+  "contract_missing_block",
+  "done_missing_active_plan",
+  "done_contract_path_missing",
+  "done_missing_contract",
+  "done_evidence_contract_block",
+  "done_gate",
+]);
 
 const STATE_ENV: Record<keyof PromptGuardState, string> = {
   spec: "PROMPT_GUARD_SPEC_STATE",
@@ -321,6 +657,75 @@ export function expectedNlDecisions(): RouteNlDecision[] {
 
 export function runTsArm(scenario: RouteScenario): PromptGuardVerdict {
   return withStateEnv(scenario.state, () => runPromptGuardVerdictFromPrompt(scenario.prompt));
+}
+
+export interface TsArmCheckResult {
+  readonly ok: boolean;
+  readonly mismatchCount: number;
+  readonly scenarioLines: string[];
+  readonly summaryLines: string[];
+  readonly coveredIntents: string[];
+  readonly coveredActions: string[];
+  readonly missingIntents: string[];
+  readonly missingActions: string[];
+}
+
+/**
+ * TS-arm CI gate: replay every scenario through the current prompt guard and
+ * compare against the pinned expectation, then assert the corpus still covers
+ * the pinned intent/action floors. Accepts an explicit scenario list so tests
+ * can prove the gate fails on a flipped expectation without mutating the
+ * shipped corpus.
+ */
+export function checkTsArm(scenarios: readonly RouteScenario[] = ROUTE_SCENARIOS): TsArmCheckResult {
+  const scenarioLines: string[] = [];
+  const coveredIntents = new Set<string>();
+  const coveredActions = new Set<string>();
+  let mismatchCount = 0;
+
+  for (const scenario of scenarios) {
+    const verdict = runTsArm(scenario);
+    const matched =
+      verdict.intent === scenario.expected.intent && verdict.action === scenario.expected.action;
+    if (matched) {
+      coveredIntents.add(scenario.expected.intent);
+      coveredActions.add(scenario.expected.action);
+    } else {
+      mismatchCount += 1;
+    }
+    scenarioLines.push(
+      [
+        matched ? "OK      " : "MISMATCH",
+        scenario.id,
+        `expected=${scenario.expected.intent}/${scenario.expected.action}`,
+        `actual=${verdict.intent}/${verdict.action}`,
+      ].join(" "),
+    );
+  }
+
+  const missingIntents = REQUIRED_INTENT_COVERAGE.filter((intent) => !coveredIntents.has(intent));
+  const missingActions = REQUIRED_ACTION_COVERAGE.filter((action) => !coveredActions.has(action));
+  const ok = mismatchCount === 0 && missingIntents.length === 0 && missingActions.length === 0;
+
+  const summaryLines = [
+    `route-eval ts-arm scenarios=${scenarios.length} mismatches=${mismatchCount}`,
+    `covered intents ${REQUIRED_INTENT_COVERAGE.length - missingIntents.length}/${REQUIRED_INTENT_COVERAGE.length}`,
+    `covered actions ${REQUIRED_ACTION_COVERAGE.length - missingActions.length}/${REQUIRED_ACTION_COVERAGE.length}`,
+    `missing intents: ${missingIntents.length === 0 ? "(none)" : missingIntents.join(", ")}`,
+    `missing actions: ${missingActions.length === 0 ? "(none)" : missingActions.join(", ")}`,
+    `result=${ok ? "pass" : "fail"}`,
+  ];
+
+  return {
+    ok,
+    mismatchCount,
+    scenarioLines,
+    summaryLines,
+    coveredIntents: [...coveredIntents],
+    coveredActions: [...coveredActions],
+    missingIntents: [...missingIntents],
+    missingActions: [...missingActions],
+  };
 }
 
 function actionIsAllow(action: string | null): boolean {
@@ -641,6 +1046,15 @@ function main(): void {
 
   if (args["emit-scenarios"]) {
     console.log(JSON.stringify(buildScenarioPack(), null, 2));
+    return;
+  }
+
+  if (args["check-ts-arm"]) {
+    const result = checkTsArm();
+    for (const line of [...result.scenarioLines, ...result.summaryLines]) {
+      console.log(line);
+    }
+    if (!result.ok) process.exitCode = 1;
     return;
   }
 

--- a/tasks/contracts/20260906-0257-route-eval-ci-gate.contract.md
+++ b/tasks/contracts/20260906-0257-route-eval-ci-gate.contract.md
@@ -1,0 +1,178 @@
+# Task Contract: route-eval-ci-gate
+
+> **Status**: Active
+> **Plan**: plans/plan-20260906-0257-route-eval-ci-gate.md
+> **Task Profile**: code-change
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: ancienttwo
+> **Capability ID**: root
+> **Last Updated**: 2026-09-06 02:57
+> **Review File**: `tasks/reviews/20260906-0257-route-eval-ci-gate.review.md`
+> **Notes File**: `tasks/notes/20260906-0257-route-eval-ci-gate.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+`src/cli/hook/prompt-intents.ts` is a 580-line regex intent classifier that re-derives LLM-owned semantics; retiring it needs a numeric oracle. The existing route-nl-vs-ts eval has only 9 scenarios and no named CI step, so a classifier regression on an uncovered intent or action is invisible until a user hits it. Skipping this leaves "delete the regex" as a feeling instead of a number.
+
+## Goal
+
+`bun run check:route-eval` runs the TS arm of `scripts/route-nl-vs-ts-eval.ts` over an expanded `ROUTE_SCENARIOS` corpus that covers every `PROMPT_GUARD_INTENTS` entry and every prompt-layer-reachable `PROMPT_GUARD_ACTIONS` entry, prints one line per scenario plus a coverage summary, exits non-zero on any mismatch or coverage shortfall against pinned constants, and runs as the named `[ci] route eval (TS arm)` step in `scripts/check-ci.sh` before `[ci] tests`. NL arm, report protocol, `evals/evals.json`, and runtime prompt-guard behavior are unchanged.
+
+## Scope
+
+- In scope: `scripts/route-nl-vs-ts-eval.ts` (corpus + `--check-ts-arm` mode), `tests/route-nl-vs-ts-eval.test.ts`, `package.json` script, `scripts/check-ci.sh` step, one paragraph in `docs/reference-configs/loop-engine-nl-decision-table.md`, and `tests/bootstrap-files.test.ts` only if its check-ci step assertions need the new line.
+- Out of scope: any edit to `src/cli/hook/prompt-intents.ts`, `src/cli/hook/prompt-guard-decision.ts`, `evals/evals.json`, hook runtime, or the NL arm. Do not move scenarios into a separate data file. Do not invent prompts from taste: every scenario cites a `lessonSource` from an existing test, `tasks/lessons.md`, or a decision-table rule. Actions unreachable from the prompt layer go into the plan's `## Unreachable Actions` section with a reason, never faked.
+- Taste constraints: <!-- advisory only, no run gate; default style/taste lives in AGENTS.md and the minimal-change policy, use this to record a per-task override -->
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+
+## Falsifier
+
+If the TS arm cannot reach most actions from a prompt plus `PromptGuardState` alone (they depend on filesystem or git state the eval cannot fake), the corpus cannot be the oracle and the slice is wrong. Cheapest check: enumerate the branches of `runPromptGuardVerdictFromPrompt` first and count reachable actions before writing scenarios.
+
+## Root Cause Evidence
+
+Required when Task Profile is `bugfix`; leave as-is otherwise.
+
+- root_cause: one sentence naming file:line/condition (testable, not "a state issue").
+- repro: the command or UI path that reproduces the symptom.
+- regression_guard: path to a test that fails on the unfixed code and passes after the fix (must also appear under exit_criteria.tests_pass).
+- pre_fix_failure_artifact: path to a captured run of regression_guard on the UNFIXED code. Capture with `bun test <regression_guard> > <artifact> 2>&1; echo "PRE_FIX_EXIT=$?" >> <artifact>` (no pipes — pipes swallow the exit status). The gate requires a non-zero `PRE_FIX_EXIT=` line plus the regression_guard path string in the artifact (see the Root Cause Evidence Gate section in docs/reference-configs/sprint-contracts.md).
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260906-0257-route-eval-ci-gate.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260906-0257-route-eval-ci-gate.review.md`
+- Notes file: `tasks/notes/20260906-0257-route-eval-ci-gate.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Change Assessment
+
+```json
+{"protocol":1,"oracles":[{"id":"route-eval-ts-arm","kind":"deterministic_test","paths":["scripts/route-nl-vs-ts-eval.ts","tests/route-nl-vs-ts-eval.test.ts"]},{"id":"ci-chain-wiring","kind":"deterministic_test","paths":["scripts/check-ci.sh","package.json","tests/bootstrap-files.test.ts"]}]}
+```
+
+## Acceptance Policy
+
+```json
+{"protocol":2,"reviewer":"Codex","source":"codex-review","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - plans/plan-20260906-0257-route-eval-ci-gate.md
+  - tasks/contracts/20260906-0257-route-eval-ci-gate.contract.md
+  - tasks/reviews/20260906-0257-route-eval-ci-gate.review.md
+  - tasks/notes/20260906-0257-route-eval-ci-gate.notes.md
+  - scripts/route-nl-vs-ts-eval.ts
+  - scripts/check-ci.sh
+  - package.json
+  - tests/route-nl-vs-ts-eval.test.ts
+  - tests/bootstrap-files.test.ts
+  - docs/reference-configs/loop-engine-nl-decision-table.md
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+    fallback: null
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+Choose the smallest checks that cover the changed behavior. Add a full suite
+only for an explicit release requirement or an observed cross-module coverage
+gap; state that reason and expected cost in Acceptance Notes. Do not duplicate
+coverage between `tests_pass` and `commands_succeed`. Before the first run,
+list eligible deterministic criteria in `criterion_reuse`; eligibility requires
+all inputs to be bound by the frozen subject/toolchain context. Leave external
+or mutable-state criteria ineligible. The canonical acceptance runner owns the
+expensive execution; workers and reviewers consume its evidence.
+
+If a full suite already passed before a bounded follow-up edit, preserve its
+run identity as baseline evidence and choose focused checks for the actual delta.
+The parent revises these criteria and records the baseline plus coverage rationale
+in Acceptance Notes, unless an explicit user/release requirement still requires
+a full run on the new subject. A cache miss alone does not justify another full
+suite; never label the old subject's pass as a full pass for the new subject.
+
+```yaml
+exit_criteria:
+  files_exist:
+    - scripts/route-nl-vs-ts-eval.ts
+    - scripts/check-ci.sh
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260906-0257-route-eval-ci-gate.notes.md
+  tests_pass:
+    - path: tests/route-nl-vs-ts-eval.test.ts
+    - path: tests/bootstrap-files.test.ts
+  commands_succeed:
+    - bun run check:route-eval
+    - bash -n scripts/check-ci.sh
+    - bun run check:type
+criterion_reuse:
+  tests_pass:
+    - path: tests/route-nl-vs-ts-eval.test.ts
+    - path: tests/bootstrap-files.test.ts
+  commands_succeed:
+    - bun run check:route-eval
+    - bash -n scripts/check-ci.sh
+    - bun run check:type
+```
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior:
+- Edge cases:
+- Regression risks:
+
+## Rollback Point
+
+- Commit / checkpoint:
+- Revert strategy:

--- a/tasks/contracts/20260906-0257-route-eval-ci-gate.contract.md
+++ b/tasks/contracts/20260906-0257-route-eval-ci-gate.contract.md
@@ -75,6 +75,7 @@ allowed_paths:
   - tasks/contracts/20260906-0257-route-eval-ci-gate.contract.md
   - tasks/reviews/20260906-0257-route-eval-ci-gate.review.md
   - tasks/notes/20260906-0257-route-eval-ci-gate.notes.md
+  - tasks/todos.md
   - scripts/route-nl-vs-ts-eval.ts
   - scripts/check-ci.sh
   - package.json

--- a/tasks/notes/20260906-0257-route-eval-ci-gate.notes.md
+++ b/tasks/notes/20260906-0257-route-eval-ci-gate.notes.md
@@ -1,0 +1,65 @@
+# Implementation Notes: route-eval-ci-gate
+
+> **Status**: Active
+> **Plan**: plans/plan-20260906-0257-route-eval-ci-gate.md
+> **Contract**: tasks/contracts/20260906-0257-route-eval-ci-gate.contract.md
+> **Review**: tasks/reviews/20260906-0257-route-eval-ci-gate.review.md
+> **Last Updated**: 2026-09-06 02:57
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- Coverage is computed from `expected.intent`/`expected.action` of scenarios that
+  actually matched the TS arm, never from the raw expectation table. A mismatched
+  scenario therefore fails twice (mismatch plus lost coverage) instead of
+  silently claiming a branch it no longer reaches.
+- `REQUIRED_INTENT_COVERAGE` / `REQUIRED_ACTION_COVERAGE` are literal arrays, not
+  projections of `PROMPT_GUARD_INTENTS` / `PROMPT_GUARD_ACTIONS`. Deriving them
+  would make a newly added vocabulary entry auto-required with no scenario, which
+  turns the gate red for the wrong reason; a literal list forces the person who
+  adds an action to decide whether the prompt layer can reach it.
+- `checkTsArm(scenarios = ROUTE_SCENARIOS)` takes the corpus as a parameter only
+  so the flipped-expectation test can prove the gate fails without mutating the
+  shipped corpus or spawning a second process. It is not a second corpus
+  authority: the CLI mode always calls it with the default.
+- `bug-fix-ignores-pending-plan` deliberately sets `pending: "fresh"`. The
+  interesting behavior is the carve-out in `decideNoActivePlanAction` where a
+  bug-fix intent does *not* consume a pending design discussion, so the scenario
+  would be worthless with `pending: "none"`.
+
+## Deviations From Plan Or Spec
+
+- The plan's P1 said `ROUTE_SCENARIOS` had 9 entries; the file had 8. Corpus grew
+  8 -> 31, not 9 -> 31.
+- The plan expected a `## Unreachable Actions` list. The Falsifier check found
+  none: every action is selected by intent plus `PromptGuardState`, and the eval
+  controls both. The section records that enumeration instead of a list.
+- `tests/bootstrap-files.test.ts` needed no change: it asserts individual
+  check-ci lines and their relative order, never an exhaustive step list, so the
+  new step keeps it truthful as written.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| Rewrite the alias test's hardcoded 8-entry decision list vs. keep it | Rewrite as `expectedNlDecisions()` plus an alias/intent override map | The hardcoded list made `nl_compliance == 1` a function of corpus size; every future scenario would have broken an unrelated normalization test |
+| Append new scenarios vs. reorder the corpus by intent | Append after the original 8 | `NL arm mismatches are recorded as no-go evidence` indexes `decisions[0]` and `decisions[3]`; preserving the head order keeps that regression pointed at the same two scenarios |
+
+## Open Questions
+
+- None.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/notes/20260906-0257-route-eval-ci-gate.notes.md
+++ b/tasks/notes/20260906-0257-route-eval-ci-gate.notes.md
@@ -29,6 +29,12 @@
 
 ## Deviations From Plan Or Spec
 
+- The failure exit code is asserted at function level (`checkTsArm(...).ok === false`,
+  including the zero-mismatch coverage-shortfall case); `main()` maps `ok === false` to
+  `process.exitCode = 1` at `scripts/route-nl-vs-ts-eval.ts:1057`. No subprocess failure
+  test exists because `main()` has no scenario-injection point, and adding a test-only
+  flag or env override would be new product surface this contract forbids.
+
 - The plan's P1 said `ROUTE_SCENARIOS` had 9 entries; the file had 8. Corpus grew
   8 -> 31, not 9 -> 31.
 - The plan expected a `## Unreachable Actions` list. The Falsifier check found

--- a/tasks/reviews/20260906-0257-route-eval-ci-gate.review.md
+++ b/tasks/reviews/20260906-0257-route-eval-ci-gate.review.md
@@ -1,0 +1,84 @@
+# Task Review: route-eval-ci-gate
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260906-0257-route-eval-ci-gate.md
+> **Contract**: tasks/contracts/20260906-0257-route-eval-ci-gate.contract.md
+> **Notes File**: tasks/notes/20260906-0257-route-eval-ci-gate.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-09-06 02:57
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Commands passed:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+- Waza `/check` run:
+- Commands run:
+- Manual checks:
+- Supporting artifacts:
+- Implementation notes reviewed:
+- Run snapshot:
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...

--- a/tests/route-nl-vs-ts-eval.test.ts
+++ b/tests/route-nl-vs-ts-eval.test.ts
@@ -91,6 +91,23 @@ describe("route-nl-vs-ts eval", () => {
     }
   });
 
+  test("checkTsArm fails on a coverage shortfall even with zero mismatches", () => {
+    const withoutDoneGate = checkTsArm(
+      ROUTE_SCENARIOS.filter((scenario) => scenario.expected.action !== "done_gate"),
+    );
+    expect(withoutDoneGate.mismatchCount).toBe(0);
+    expect(withoutDoneGate.ok).toBe(false);
+    expect(withoutDoneGate.missingActions).toContain("done_gate");
+    expect(withoutDoneGate.summaryLines.join("\n")).toContain("result=fail");
+
+    const withoutPassiveWorktreeStatus = checkTsArm(
+      ROUTE_SCENARIOS.filter((scenario) => scenario.expected.intent !== "passive_worktree_status"),
+    );
+    expect(withoutPassiveWorktreeStatus.mismatchCount).toBe(0);
+    expect(withoutPassiveWorktreeStatus.ok).toBe(false);
+    expect(withoutPassiveWorktreeStatus.missingIntents).toContain("passive_worktree_status");
+  }, 30_000);
+
   test("every scenario cites a non-empty lessonSource", () => {
     const ids = new Set<string>();
     for (const scenario of ROUTE_SCENARIOS) {

--- a/tests/route-nl-vs-ts-eval.test.ts
+++ b/tests/route-nl-vs-ts-eval.test.ts
@@ -6,8 +6,13 @@ import { spawnSync } from "child_process";
 import {
   buildRouteReport,
   buildScenarioPack,
+  checkTsArm,
   expectedNlDecisions,
   normalizeRouteAction,
+  REQUIRED_ACTION_COVERAGE,
+  REQUIRED_INTENT_COVERAGE,
+  ROUTE_NL_ALLOWED_ACTIONS,
+  ROUTE_NL_ALLOWED_INTENTS,
   ROUTE_SCENARIOS,
   runTsArm,
   validateReport,
@@ -45,6 +50,57 @@ describe("route-nl-vs-ts eval", () => {
     }
   });
 
+  test("--check-ts-arm passes on the shipped corpus and fails on a flipped expectation", () => {
+    const run = spawnSync(process.execPath, [SCRIPT, "--check-ts-arm"], {
+      cwd: ROOT,
+      encoding: "utf-8",
+    });
+    expect(run.stdout + run.stderr).toContain("route-eval ts-arm");
+    expect(run.status).toBe(0);
+    expect(run.stdout).toContain(`covered intents ${REQUIRED_INTENT_COVERAGE.length}/${REQUIRED_INTENT_COVERAGE.length}`);
+    expect(run.stdout).toContain(`covered actions ${REQUIRED_ACTION_COVERAGE.length}/${REQUIRED_ACTION_COVERAGE.length}`);
+    expect(run.stdout).toContain("missing intents: (none)");
+    expect(run.stdout).toContain("missing actions: (none)");
+    expect(run.stdout).not.toContain("MISMATCH");
+
+    const flipped = ROUTE_SCENARIOS.map((scenario, index) =>
+      index === 0
+        ? { ...scenario, expected: { ...scenario.expected, action: "done_gate" as const } }
+        : scenario,
+    );
+    const flippedResult = checkTsArm(flipped);
+    expect(flippedResult.ok).toBe(false);
+    expect(flippedResult.mismatchCount).toBe(1);
+    expect(flippedResult.scenarioLines[0]).toContain("MISMATCH");
+    expect(flippedResult.summaryLines.join("\n")).toContain("result=fail");
+  }, 30_000);
+
+  test("ROUTE_SCENARIOS covers the pinned intent and action floors", () => {
+    const result = checkTsArm();
+
+    expect(result.missingIntents).toEqual([]);
+    expect(result.missingActions).toEqual([]);
+    expect(result.mismatchCount).toBe(0);
+    expect(result.ok).toBe(true);
+
+    for (const intent of REQUIRED_INTENT_COVERAGE) {
+      expect(ROUTE_NL_ALLOWED_INTENTS, intent).toContain(intent);
+    }
+    for (const action of REQUIRED_ACTION_COVERAGE) {
+      expect(ROUTE_NL_ALLOWED_ACTIONS, action).toContain(action);
+    }
+  });
+
+  test("every scenario cites a non-empty lessonSource", () => {
+    const ids = new Set<string>();
+    for (const scenario of ROUTE_SCENARIOS) {
+      expect(scenario.lessonSource.trim().length, scenario.id).toBeGreaterThan(0);
+      expect(scenario.prompt.trim().length, scenario.id).toBeGreaterThan(0);
+      expect(ids.has(scenario.id), scenario.id).toBe(false);
+      ids.add(scenario.id);
+    }
+  });
+
   test("matching NL decisions produce a go report with compliance and token metrics", () => {
     const report = buildRouteReport({
       agent: "unit",
@@ -66,48 +122,26 @@ describe("route-nl-vs-ts eval", () => {
     expect(normalizeRouteAction("capture_pending_plan")).toBe("plan_capture_pending_advice");
     expect(normalizeRouteAction("scaffold_contract")).toBe("plan_execution_scaffold_advice");
 
-    const decisions = [
-      {
-        scenario_id: "done-future-wording",
-        intent: "review_release",
-        action: "allow",
-      },
-      {
-        scenario_id: "review-hook-bug-mention",
-        intent: "review_release",
-        action: "allow",
-      },
-      {
-        scenario_id: "strip-injected-context",
-        intent: "planning_discussion",
-        action: "allow",
-      },
-      {
-        scenario_id: "stale-active-marker",
-        intent: "general_execution",
-        action: "emit_stale_marker_advice",
-      },
-      {
-        scenario_id: "fresh-pending-plan-capture",
-        intent: "plan_execution_projection",
-        action: "capture_pending_plan",
-      },
-      {
-        scenario_id: "draft-plan-approval",
-        intent: "plan_execution_projection",
-        action: "request_plan_capture_approval",
-      },
-      {
-        scenario_id: "approved-plan-missing-contract",
-        intent: "plan_execution_projection",
-        action: "scaffold_contract",
-      },
-      {
-        scenario_id: "done-artifact-gate",
-        intent: "done",
-        action: "enter_done_gate",
-      },
-    ];
+    // Keep this independent of the corpus size: start from the expected route
+    // table and rewrite only the entries whose alias behavior is under test.
+    const actionAliases: Record<string, string> = {
+      "stale-active-marker": "emit_stale_marker_advice",
+      "fresh-pending-plan-capture": "capture_pending_plan",
+      "draft-plan-approval": "request_plan_capture_approval",
+      "approved-plan-missing-contract": "scaffold_contract",
+      "done-artifact-gate": "enter_done_gate",
+    };
+    // Non-execution allow scenarios stay compliant under a different advisory
+    // intent label, which is the leniency the NL arm relies on.
+    const intentOverrides: Record<string, string> = {
+      "done-future-wording": "review_release",
+      "strip-injected-context": "planning_discussion",
+    };
+    const decisions = expectedNlDecisions().map((decision) => ({
+      ...decision,
+      intent: intentOverrides[decision.scenario_id] ?? decision.intent,
+      action: actionAliases[decision.scenario_id] ?? decision.action,
+    }));
 
     const report = buildRouteReport({
       agent: "claude-alias-unit",


### PR DESCRIPTION
## What

`bun run check:route-eval` runs the TS arm of `scripts/route-nl-vs-ts-eval.ts` as a named `[ci] route eval (TS arm)` step in `scripts/check-ci.sh`, before `[ci] tests`. The scenario corpus grows from 8 to 31 and now covers all 12 `PROMPT_GUARD_INTENTS` and all 17 `PROMPT_GUARD_ACTIONS`; the coverage sets are pinned as `REQUIRED_INTENT_COVERAGE` / `REQUIRED_ACTION_COVERAGE`, so the gate fails on any scenario mismatch or on a coverage regression.

Every scenario cites a `lessonSource` from an existing regression test, an archived lessons entry (with originating commit SHA), or a decision-table rule; expectations are derived from `docs/reference-configs/loop-engine-nl-decision-table.md` Decision Rules, not from current regex output.

## Why

`src/cli/hook/prompt-intents.ts` re-derives LLM-owned semantics with regex. Retiring it needs a numeric oracle. This makes the TS arm that oracle in CI; the NL arm stays operator-invoked via `evals/evals.json`.

## Not changed

`src/` runtime, the NL arm, report protocol, `evals/evals.json`, hook behavior.

## Verification

- `bun test tests/route-nl-vs-ts-eval.test.ts` — 11 pass
- `bun test tests/bootstrap-files.test.ts` — 15 pass
- `bun run check:route-eval` — 31 scenarios, 0 mismatches, intents 12/12, actions 17/17
- `check:type`, `check:helpers`, `check-task-workflow --strict`, `check-task-sync` (merge-base vs origin/main), `check-architecture-sync`, inspect-project-state, init dry-run — all pass

Plan: `plans/plan-20260906-0257-route-eval-ci-gate.md`