### PR TITLE
ci: run the context-files scan in check-ci

### DIFF
--- a/plans/plan-20260906-0338-context-files-ci-step.md
+++ b/plans/plan-20260906-0338-context-files-ci-step.md
@@ -1,0 +1,171 @@
+# Plan: Run context-files scan in check-ci
+
+> **Status**: Executing
+> **Created**: 20260906-0338
+> **Slug**: context-files-ci-step
+> **Planning Source**: repo-harness-plan
+> **Orchestration Kind**: host-plan
+> **Source Ref**: (none)
+> **Artifact Level**: work-package
+> **Promotion Reason**: verification_boundary
+> **Verification Boundary**: check-ci syntax, the scan itself, bootstrap tests, integrity checks
+> **Rollback Surface**: Revert only codex/context-files-ci-step
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260906-0338-context-files-ci-step.contract.md`
+> **Task Review**: `tasks/reviews/20260906-0338-context-files-ci-step.review.md`
+> **Implementation Notes**: `tasks/notes/20260906-0338-context-files-ci-step.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from repo-harness-plan planning output.
+- Source ref: (none)
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260906-0338-context-files-ci-step.md`
+- Sprint contract: `tasks/contracts/20260906-0338-context-files-ci-step.contract.md`
+- Sprint review: `tasks/reviews/20260906-0338-context-files-ci-step.review.md`
+- Implementation notes: `tasks/notes/20260906-0338-context-files-ci-step.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260906-0338-context-files-ci-step.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260906-0338-context-files-ci-step.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260906-0338-context-files-ci-step.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260906-0338-context-files-ci-step.contract.md`
+- Review file: `tasks/reviews/20260906-0338-context-files-ci-step.review.md`
+- Implementation notes file: `tasks/notes/20260906-0338-context-files-ci-step.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260906-0338-context-files-ci-step.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260906-0338-context-files-ci-step.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: Revert only codex/context-files-ci-step
+- **Verification boundary**: check-ci syntax, the scan itself, bootstrap tests, integrity checks
+- **Review/acceptance boundary**: `tasks/reviews/20260906-0338-context-files-ci-step.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: verification_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260906-0338-context-files-ci-step.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260906-0338-context-files-ci-step.contract.md`, `tasks/reviews/20260906-0338-context-files-ci-step.review.md`, and `tasks/notes/20260906-0338-context-files-ci-step.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260906-0338-context-files-ci-step.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: Revert only codex/context-files-ci-step
+
+## Captured Planning Output
+
+## Goal
+`scripts/check-context-files.sh` (prompt-injection and secret-exfiltration scan over agent context files) runs as a named `[ci] context files` step inside the workflow-checks block of `scripts/check-ci.sh`, so the security scan no longer depends on an operator remembering `check:context-files`.
+
+## P1 Map
+`scripts/check-context-files.sh` is a projected helper (listed in `assets/workflow-contract.v1.json#helpers.scripts`, asserted by `tests/bootstrap-files.test.ts:286`), exposed as `package.json#check:context-files` via `repo-harness run check-context-files`. `scripts/check-ci.sh` is the CI chain; its workflow-checks block calls sibling helpers directly with `bash scripts/<helper>.sh`. `.github/workflows` invokes `bun run check:ci`. On current `main` the scan reports `[ContextScan] SAFE` in under one second.
+
+## P2 Trace
+A context file (`CLAUDE.md`, `AGENTS.md`, nested contracts, skill docs) gains an injected instruction or a secret; today nothing in the PR path runs the scan, so it merges. After this change `check-ci.sh` fails at the named step with the scan's own output.
+
+## P3 Decision
+Add exactly one line pair (`echo "[ci] context files"` + `bash scripts/check-context-files.sh`) in the workflow-checks block of `scripts/check-ci.sh`, after `bash scripts/check-deploy-sql-order.sh` and before `bash scripts/check-architecture-sync.sh`, matching the sibling invocation style. No new script, no package.json change, no flag. Tradeoff: none material; the scan is sub-second and already a required helper.
+
+## Scope
+`scripts/check-ci.sh`; `tests/bootstrap-files.test.ts` only if it asserts the step list; this plan.
+
+## Task Breakdown
+- [x] Add the named step to scripts/check-ci.sh in the workflow-checks block.
+- [x] Run the verification commands and record outcomes.
+
+## Promotion Gate
+
+- **Merge/PR unit**: one-line CI wiring PR.
+- **Rollback surface**: revert the branch.
+- **Verification boundary**: `bash -n scripts/check-ci.sh`, the scan itself, `tests/bootstrap-files.test.ts`, integrity checks.
+- **Review/acceptance boundary**: gatekeeper diff review.
+- **High-risk surface**: none; a false-positive scan would red CI, which is the intended behavior.
+- **Why not checklist row**: no active plan owns check-ci.sh wiring; task-sync binding needs a plan artifact.
+
+## Evidence Contract
+
+- **State/progress path**: this plan's Task Breakdown.
+- **Verification evidence**: Verification Results below.
+- **Evaluator rubric**: `scripts/check-ci.sh` contains the step in the workflow-checks block; `bash scripts/check-context-files.sh` exits 0 on the branch; bootstrap tests pass.
+- **Stop condition**: verification commands pass.
+- **Rollback surface**: revert only this branch.
+
+## Verification Commands
+
+```bash
+bash -n scripts/check-ci.sh
+bash scripts/check-context-files.sh
+bun test tests/bootstrap-files.test.ts --timeout 60000
+bash scripts/check-deploy-sql-order.sh
+bash scripts/check-architecture-sync.sh
+bash scripts/check-task-sync.sh
+bash scripts/check-task-workflow.sh --strict
+bun scripts/inspect-project-state.ts --repo . --format text
+bun src/cli/index.ts init --repo . --dry-run
+```
+
+## Verification Results
+
+| Command | Outcome |
+|---------|---------|
+| `bash -n scripts/check-ci.sh` | pass (no syntax errors) |
+| `bash scripts/check-context-files.sh` | pass — `[ContextScan] SAFE` |
+| `bun test tests/bootstrap-files.test.ts --timeout 60000` | pass — 15 pass, 0 fail, 459 expect() |
+| `bash scripts/check-deploy-sql-order.sh` | pass — `[deploy-sql] OK` |
+| `bash scripts/check-architecture-sync.sh` | pass — blocking=0, projection state=ready |
+| `REPO_HARNESS_DIFF_BASE=origin/main REPO_HARNESS_DIFF_MODE=merge-base bash scripts/check-task-sync.sh` | pass — lite profile resolved, no stale digest |
+| `bash scripts/check-task-workflow.sh --strict` | pass — `[workflow] OK` |
+| `bun scripts/inspect-project-state.ts --repo . --format text` | pass — no drift signals |
+| `bun src/cli/index.ts init --repo . --dry-run` | pass — 0 operations (source checkout owns its surfaces) |
+
+`tests/bootstrap-files.test.ts` needed no change: it asserts the prepare-handoff -> resume -> check-task-workflow ordering, not an exhaustive step list, and the new step sits above that window.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [x] Add the named step to scripts/check-ci.sh in the workflow-checks block.
+- [x] Run the verification commands and record outcomes.

--- a/scripts/check-ci.sh
+++ b/scripts/check-ci.sh
@@ -33,6 +33,8 @@ run_bun_tests
 
 echo "[ci] workflow checks"
 bash scripts/check-deploy-sql-order.sh
+echo "[ci] context files"
+bash scripts/check-context-files.sh
 bash scripts/check-architecture-sync.sh
 if [[ "${GITHUB_ACTIONS:-}" == "true" && -z "${REPO_HARNESS_DIFF_BASE:-}" ]]; then
   echo "[ci] GitHub Actions must provide REPO_HARNESS_DIFF_BASE for diff-bound workflow evidence." >&2

--- a/tasks/contracts/20260906-0338-context-files-ci-step.contract.md
+++ b/tasks/contracts/20260906-0338-context-files-ci-step.contract.md
@@ -1,0 +1,170 @@
+# Task Contract: context-files-ci-step
+
+> **Status**: Active
+> **Plan**: plans/plan-20260906-0338-context-files-ci-step.md
+> **Task Profile**: code-change
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: ancienttwo
+> **Capability ID**: root
+> **Last Updated**: 2026-09-06 03:38
+> **Review File**: `tasks/reviews/20260906-0338-context-files-ci-step.review.md`
+> **Notes File**: `tasks/notes/20260906-0338-context-files-ci-step.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+The prompt-injection and secret scan over agent context files runs only when an operator remembers `check:context-files`. Nothing on the PR path executes it, so an injected instruction or secret in a context file merges silently.
+
+## Goal
+
+`scripts/check-ci.sh` runs `bash scripts/check-context-files.sh` as a named `[ci] context files` step in the workflow-checks block, after deploy-sql-order and before architecture-sync; the scan exits 0 on this branch.
+
+## Scope
+
+- In scope: the two-line step in `scripts/check-ci.sh`; `tests/bootstrap-files.test.ts` only if it asserts the step list.
+- Out of scope: changing the scan, package.json, workflow YAML, or any other check.
+- Taste constraints: <!-- advisory only, no run gate; default style/taste lives in AGENTS.md and the minimal-change policy, use this to record a per-task override -->
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+
+## Falsifier
+
+What observable evidence would prove this task's direction wrong, and the cheapest proof point to check first. Leave as-is if not applicable.
+
+## Root Cause Evidence
+
+Required when Task Profile is `bugfix`; leave as-is otherwise.
+
+- root_cause: one sentence naming file:line/condition (testable, not "a state issue").
+- repro: the command or UI path that reproduces the symptom.
+- regression_guard: path to a test that fails on the unfixed code and passes after the fix (must also appear under exit_criteria.tests_pass).
+- pre_fix_failure_artifact: path to a captured run of regression_guard on the UNFIXED code. Capture with `bun test <regression_guard> > <artifact> 2>&1; echo "PRE_FIX_EXIT=$?" >> <artifact>` (no pipes — pipes swallow the exit status). The gate requires a non-zero `PRE_FIX_EXIT=` line plus the regression_guard path string in the artifact (see the Root Cause Evidence Gate section in docs/reference-configs/sprint-contracts.md).
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260906-0338-context-files-ci-step.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260906-0338-context-files-ci-step.review.md`
+- Notes file: `tasks/notes/20260906-0338-context-files-ci-step.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Change Assessment
+
+```json
+{"protocol":1,"oracles":[{"id":"ci-step-wiring","kind":"deterministic_test","paths":["scripts/check-ci.sh","tests/bootstrap-files.test.ts"]}]}
+```
+
+## Acceptance Policy
+
+```json
+{"protocol":2,"reviewer":"Codex","source":"codex-review","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - plans/plan-20260906-0338-context-files-ci-step.md
+  - tasks/contracts/20260906-0338-context-files-ci-step.contract.md
+  - tasks/reviews/20260906-0338-context-files-ci-step.review.md
+  - tasks/notes/20260906-0338-context-files-ci-step.notes.md
+  - tasks/todos.md
+  - scripts/check-ci.sh
+  - tests/bootstrap-files.test.ts
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+    fallback: null
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+Choose the smallest checks that cover the changed behavior. Add a full suite
+only for an explicit release requirement or an observed cross-module coverage
+gap; state that reason and expected cost in Acceptance Notes. Do not duplicate
+coverage between `tests_pass` and `commands_succeed`. Before the first run,
+list eligible deterministic criteria in `criterion_reuse`; eligibility requires
+all inputs to be bound by the frozen subject/toolchain context. Leave external
+or mutable-state criteria ineligible. The canonical acceptance runner owns the
+expensive execution; workers and reviewers consume its evidence.
+
+If a full suite already passed before a bounded follow-up edit, preserve its
+run identity as baseline evidence and choose focused checks for the actual delta.
+The parent revises these criteria and records the baseline plus coverage rationale
+in Acceptance Notes, unless an explicit user/release requirement still requires
+a full run on the new subject. A cache miss alone does not justify another full
+suite; never label the old subject's pass as a full pass for the new subject.
+
+```yaml
+exit_criteria:
+  files_exist:
+    - scripts/check-ci.sh
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260906-0338-context-files-ci-step.notes.md
+  tests_pass:
+    - path: tests/bootstrap-files.test.ts
+  commands_succeed:
+    - bash -n scripts/check-ci.sh
+    - bash scripts/check-context-files.sh
+criterion_reuse:
+  tests_pass:
+    - path: tests/bootstrap-files.test.ts
+  commands_succeed:
+    - bash -n scripts/check-ci.sh
+    - bash scripts/check-context-files.sh
+```
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior:
+- Edge cases:
+- Regression risks:
+
+## Rollback Point
+
+- Commit / checkpoint:
+- Revert strategy:

--- a/tasks/notes/20260906-0338-context-files-ci-step.notes.md
+++ b/tasks/notes/20260906-0338-context-files-ci-step.notes.md
@@ -1,0 +1,41 @@
+# Implementation Notes: context-files-ci-step
+
+> **Status**: Active
+> **Plan**: plans/plan-20260906-0338-context-files-ci-step.md
+> **Contract**: tasks/contracts/20260906-0338-context-files-ci-step.contract.md
+> **Review**: tasks/reviews/20260906-0338-context-files-ci-step.review.md
+> **Last Updated**: 2026-09-06 03:38
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- ...
+
+## Deviations From Plan Or Spec
+
+- None recorded.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| ... | ... | ... |
+
+## Open Questions
+
+- None.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/reviews/20260906-0338-context-files-ci-step.review.md
+++ b/tasks/reviews/20260906-0338-context-files-ci-step.review.md
@@ -1,0 +1,84 @@
+# Task Review: context-files-ci-step
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260906-0338-context-files-ci-step.md
+> **Contract**: tasks/contracts/20260906-0338-context-files-ci-step.contract.md
+> **Notes File**: tasks/notes/20260906-0338-context-files-ci-step.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-09-06 03:38
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Commands passed:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+- Waza `/check` run:
+- Commands run:
+- Manual checks:
+- Supporting artifacts:
+- Implementation notes reviewed:
+- Run snapshot:
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...


### PR DESCRIPTION
## What

`scripts/check-ci.sh` now runs `bash scripts/check-context-files.sh` as a named `[ci] context files` step in the workflow-checks block, after deploy-sql-order and before architecture-sync.

## Why

The prompt-injection and secret scan over agent context files was only reachable through `check:context-files`, which nothing on the PR path invoked. An injected instruction or secret in a context file merged silently. The scan is sub-second and already a required projected helper.

## Verification

- `bash -n scripts/check-ci.sh` — OK
- `bash scripts/check-context-files.sh` — `[ContextScan] SAFE`
- `tests/bootstrap-files.test.ts` — 15 pass
- integrity checks (deploy-sql, architecture-sync, task-sync merge-base, task-workflow strict, inspect-project-state, init dry-run) — pass

Plan: `plans/plan-20260906-0338-context-files-ci-step.md`