### PR TITLE
fix(ci): discover .test.tsx files in isolate mode

### DIFF
--- a/plans/plan-20260906-0233-ci-isolate-discover-tsx.md
+++ b/plans/plan-20260906-0233-ci-isolate-discover-tsx.md
@@ -146,9 +146,3 @@ Make the isolate-mode CI test loop discover `*.test.tsx` files so the three `tes
 ## Annotations
 
 - None.
-
-## Task Breakdown
-- [x] RED: add the tsx-discovery case; capture `bun test <guard> > <artifact> 2>&1; echo "PRE_FIX_EXIT=$?" >> <artifact>`.
-- [x] GREEN: change the find predicate.
-- [x] Fill the contract (Task Profile bugfix, Root Cause Evidence, Allowed Paths, Exit Criteria, Change Assessment oracles as `{id,kind,paths}` objects with `deterministic_test` and `runtime_readback`), clear `[NOTE]` placeholders, tick boxes.
-- [x] Verification: the guard + `tests/bootstrap-files.test.ts`; runtime readback `BUN_TEST_ISOLATE_FILES=1 bash -c 'set -euo pipefail; source scripts/lib/ci-run-tests.sh; run_bun_tests'` is too slow for a readback (whole suite) — instead readback the discovery alone: `find tests -type f \( -name '*.test.ts' -o -name '*.test.tsx' \) | LC_ALL=C sort | wc -l` equals the count bun reports in `bun test --timeout 60000` (`Ran N tests across M files`), and the three operator-web tsx paths appear in the sorted list; six repository-integrity checks; CI-mode `check-task-sync` digest bound; one full `bun test --timeout 60000`.

--- a/plans/plan-20260906-0233-ci-isolate-discover-tsx.md
+++ b/plans/plan-20260906-0233-ci-isolate-discover-tsx.md
@@ -1,0 +1,154 @@
+# Plan: CI isolate loop discovers .test.tsx files
+
+> **Status**: Executing
+> **Created**: 20260906-0233
+> **Slug**: ci-isolate-discover-tsx
+> **Planning Source**: repo-harness-plan
+> **Orchestration Kind**: host-plan
+> **Source Ref**: (none)
+> **Artifact Level**: work-package
+> **Promotion Reason**: verification_boundary
+> **Verification Boundary**: tsx-discovery guard, discovery count readback against bun, repository-integrity checks, one full suite run
+> **Rollback Surface**: Revert the discovery predicate and the guard case together
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260906-0233-ci-isolate-discover-tsx.contract.md`
+> **Task Review**: `tasks/reviews/20260906-0233-ci-isolate-discover-tsx.review.md`
+> **Implementation Notes**: `tasks/notes/20260906-0233-ci-isolate-discover-tsx.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from repo-harness-plan planning output.
+- Source ref: (none)
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260906-0233-ci-isolate-discover-tsx.md`
+- Sprint contract: `tasks/contracts/20260906-0233-ci-isolate-discover-tsx.contract.md`
+- Sprint review: `tasks/reviews/20260906-0233-ci-isolate-discover-tsx.review.md`
+- Implementation notes: `tasks/notes/20260906-0233-ci-isolate-discover-tsx.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260906-0233-ci-isolate-discover-tsx.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260906-0233-ci-isolate-discover-tsx.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260906-0233-ci-isolate-discover-tsx.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260906-0233-ci-isolate-discover-tsx.contract.md`
+- Review file: `tasks/reviews/20260906-0233-ci-isolate-discover-tsx.review.md`
+- Implementation notes file: `tasks/notes/20260906-0233-ci-isolate-discover-tsx.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260906-0233-ci-isolate-discover-tsx.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260906-0233-ci-isolate-discover-tsx.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: Revert the discovery predicate and the guard case together
+- **Verification boundary**: tsx-discovery guard, discovery count readback against bun, repository-integrity checks, one full suite run
+- **Review/acceptance boundary**: `tasks/reviews/20260906-0233-ci-isolate-discover-tsx.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: verification_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260906-0233-ci-isolate-discover-tsx.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260906-0233-ci-isolate-discover-tsx.contract.md`, `tasks/reviews/20260906-0233-ci-isolate-discover-tsx.review.md`, and `tasks/notes/20260906-0233-ci-isolate-discover-tsx.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260906-0233-ci-isolate-discover-tsx.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: Revert the discovery predicate and the guard case together
+
+## Captured Planning Output
+
+## Goal
+
+Make the isolate-mode CI test loop discover `*.test.tsx` files so the three `tests/operator-web/*.test.tsx` suites run in CI's `Test` job, matching bun's own discovery.
+
+## P1 Map
+
+- `scripts/lib/ci-run-tests.sh` owns isolate-mode discovery: `find tests -type f -name '*.test.ts' | LC_ALL=C sort` (used by `scripts/check-ci.sh` under `BUN_TEST_ISOLATE_FILES=1`, the `.github/workflows/ci.yml` `Test` job setting).
+- Non-isolate `bun test` discovers `.test.ts` and `.test.tsx`; at main 02385612 it ran 361 files while the isolate loop ran 358 — the delta is exactly `tests/operator-web/operator-{collaboration,interactions,ui}.test.tsx`.
+- `tests/check-ci-isolate-aggregation.test.ts` guards the loop's aggregation behaviour; `tests/bootstrap-files.test.ts` pins `check-ci` literals.
+
+## P2 Trace
+
+`run_bun_tests` (isolate) → `find tests -type f -name '*.test.ts'` → tsx files never enter the loop → CI never executes them → any regression in the operator-web suites is invisible to CI while passing locally under plain `bun test`.
+
+## P3 Decision
+
+- Change the discovery predicate to `\( -name '*.test.ts' -o -name '*.test.tsx' \)` (keep `-type f`, keep `LC_ALL=C sort`). No other behaviour change. `BUN_TEST_FILES` explicit selection unchanged.
+- Guard: extend `tests/check-ci-isolate-aggregation.test.ts` with one case that creates a temp `tests`-shaped dir containing a `.test.ts` and a `.test.tsx` file (both passing), runs `run_bun_tests` in isolate mode WITHOUT `BUN_TEST_FILES` from that temp root (the lib finds under `tests` relative to cwd, so `cd` into the temp root and create `tests/` there), and asserts both `[ci] test` lines appear. On the unfixed lib the tsx line is absent (RED).
+- Out of scope: any other discovery root, file-name pattern, sort order, concurrency, timeouts, workflow YAML.
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `scripts/lib/ci-run-tests.sh` | Modify | discovery predicate includes `*.test.tsx` |
+| `tests/check-ci-isolate-aggregation.test.ts` | Modify | add tsx-discovery case |
+
+## Task Breakdown
+
+- [x] RED: add the tsx-discovery case; capture `bun test <guard> > <artifact> 2>&1; echo "PRE_FIX_EXIT=$?" >> <artifact>`.
+- [x] GREEN: change the find predicate.
+- [x] Fill the contract (Task Profile bugfix, Root Cause Evidence, Allowed Paths, Exit Criteria, Change Assessment oracles as `{id,kind,paths}` objects with `deterministic_test` and `runtime_readback`), clear `[NOTE]` placeholders, tick boxes.
+- [x] Verification: the guard + `tests/bootstrap-files.test.ts`; runtime readback `BUN_TEST_ISOLATE_FILES=1 bash -c 'set -euo pipefail; source scripts/lib/ci-run-tests.sh; run_bun_tests'` is too slow for a readback (whole suite) — instead readback the discovery alone: `find tests -type f \( -name '*.test.ts' -o -name '*.test.tsx' \) | LC_ALL=C sort | wc -l` equals the count bun reports in `bun test --timeout 60000` (`Ran N tests across M files`), and the three operator-web tsx paths appear in the sorted list; six repository-integrity checks; CI-mode `check-task-sync` digest bound; one full `bun test --timeout 60000`.
+
+## Allowed Paths
+
+- `scripts/lib/ci-run-tests.sh`
+- `tests/check-ci-isolate-aggregation.test.ts`
+- plan, contract, review, notes files of this work package
+
+## Verification
+
+- `bun test --timeout 60000 tests/check-ci-isolate-aggregation.test.ts tests/bootstrap-files.test.ts`
+- `bash scripts/check-deploy-sql-order.sh && bash scripts/check-architecture-sync.sh && bash scripts/check-task-sync.sh && bash scripts/check-task-workflow.sh --strict && bun scripts/inspect-project-state.ts --repo . --format text && bun src/cli/index.ts init --repo . --dry-run`
+- `bun test --timeout 60000` (full, once, logged)
+
+## Annotations
+
+- None.
+
+## Task Breakdown
+- [x] RED: add the tsx-discovery case; capture `bun test <guard> > <artifact> 2>&1; echo "PRE_FIX_EXIT=$?" >> <artifact>`.
+- [x] GREEN: change the find predicate.
+- [x] Fill the contract (Task Profile bugfix, Root Cause Evidence, Allowed Paths, Exit Criteria, Change Assessment oracles as `{id,kind,paths}` objects with `deterministic_test` and `runtime_readback`), clear `[NOTE]` placeholders, tick boxes.
+- [x] Verification: the guard + `tests/bootstrap-files.test.ts`; runtime readback `BUN_TEST_ISOLATE_FILES=1 bash -c 'set -euo pipefail; source scripts/lib/ci-run-tests.sh; run_bun_tests'` is too slow for a readback (whole suite) — instead readback the discovery alone: `find tests -type f \( -name '*.test.ts' -o -name '*.test.tsx' \) | LC_ALL=C sort | wc -l` equals the count bun reports in `bun test --timeout 60000` (`Ran N tests across M files`), and the three operator-web tsx paths appear in the sorted list; six repository-integrity checks; CI-mode `check-task-sync` digest bound; one full `bun test --timeout 60000`.

--- a/scripts/lib/ci-run-tests.sh
+++ b/scripts/lib/ci-run-tests.sh
@@ -41,7 +41,7 @@ run_bun_tests() {
         failed_count=$((failed_count + 1))
         failed_list+="  $file (exit $status)"$'\n'
       fi
-    done < <(find tests -type f -name '*.test.ts' | LC_ALL=C sort)
+    done < <(find tests -type f \( -name '*.test.ts' -o -name '*.test.tsx' \) | LC_ALL=C sort)
   fi
 
   if [[ "$found" != "1" ]]; then

--- a/tasks/contracts/20260906-0233-ci-isolate-discover-tsx.contract.md
+++ b/tasks/contracts/20260906-0233-ci-isolate-discover-tsx.contract.md
@@ -1,0 +1,186 @@
+# Task Contract: ci-isolate-discover-tsx
+
+> **Status**: Fulfilled
+> **Plan**: plans/plan-20260906-0233-ci-isolate-discover-tsx.md
+> **Task Profile**: bugfix
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: ancienttwo
+> **Capability ID**: root
+> **Last Updated**: 2026-09-06 02:33
+> **Review File**: `tasks/reviews/20260906-0233-ci-isolate-discover-tsx.review.md`
+> **Notes File**: `tasks/notes/20260906-0233-ci-isolate-discover-tsx.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+> **Substantive Change SHA256**: `sha256:ce7464205e19886cbe0afa7357a5f949d1c4df0ea43a9acdff9a73fb376a9ac5`
+
+## Why
+
+CI's `Test` job runs the isolate loop, whose own file discovery is narrower than
+bun's. The three `tests/operator-web/*.test.tsx` suites therefore never execute
+in CI: a regression in them stays green on every PR while passing locally under
+plain `bun test`.
+
+## Goal
+
+The isolate-mode loop in `scripts/lib/ci-run-tests.sh` discovers `*.test.tsx`
+alongside `*.test.ts`, so its discovered file count matches bun's own, and a
+guard case pins that behaviour.
+
+## Scope
+
+- In scope:
+  - `scripts/lib/ci-run-tests.sh`: widen the isolate-mode `find` predicate to include `*.test.tsx`.
+  - `tests/check-ci-isolate-aggregation.test.ts`: add the tsx-discovery guard case.
+- Out of scope:
+  - any other discovery root, file-name pattern, sort order, concurrency, timeouts, workflow YAML.
+  - the explicit `BUN_TEST_FILES` selection branch, which is unchanged.
+- Taste constraints: minimal predicate change only; no restructuring of the loop.
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+
+## Falsifier
+
+If the discovered file count from the widened predicate does not equal the
+`across M files` figure bun reports for the full suite, the predicate is still
+not equivalent to bun's discovery and this direction is wrong. Cheapest proof:
+compare `find tests -type f \( -name '*.test.ts' -o -name '*.test.tsx' \) | wc -l`
+against the full-suite summary line.
+
+## Root Cause Evidence
+
+- root_cause: `scripts/lib/ci-run-tests.sh:44` discovers isolate-mode files with `find tests -type f -name '*.test.ts'`, a predicate that omits `*.test.tsx`, so the three `tests/operator-web/*.test.tsx` suites never enter the CI loop.
+- repro: from a `tests`-shaped root containing `tests/a.test.ts` and `tests/b.test.tsx`, run `BUN_TEST_ISOLATE_FILES=1 bash -c 'set -euo pipefail; source <abs>/scripts/lib/ci-run-tests.sh; run_bun_tests'` with `BUN_TEST_FILES` unset; only `[ci] test tests/a.test.ts` is printed.
+- regression_guard: tests/check-ci-isolate-aggregation.test.ts
+- pre_fix_failure_artifact: .ai/harness/evidence/pre-fix/check-ci-isolate-discover-tsx.log
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260906-0233-ci-isolate-discover-tsx.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260906-0233-ci-isolate-discover-tsx.review.md`
+- Notes file: `tasks/notes/20260906-0233-ci-isolate-discover-tsx.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Change Assessment
+
+```json
+{"protocol":1,"oracles":[{"id":"ci-isolate-discover-tsx-deterministic","kind":"deterministic_test","paths":["scripts/lib/ci-run-tests.sh","tests/check-ci-isolate-aggregation.test.ts"]},{"id":"ci-isolate-discover-tsx-readback","kind":"runtime_readback","paths":["scripts/lib/ci-run-tests.sh"]}]}
+```
+
+## Acceptance Policy
+
+```json
+{"protocol":2,"reviewer":"Codex","source":"codex-review","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - scripts/lib/ci-run-tests.sh
+  - tests/check-ci-isolate-aggregation.test.ts
+  - plans/plan-20260906-0233-ci-isolate-discover-tsx.md
+  - tasks/todos.md
+  - tasks/contracts/20260906-0233-ci-isolate-discover-tsx.contract.md
+  - tasks/reviews/20260906-0233-ci-isolate-discover-tsx.review.md
+  - tasks/notes/20260906-0233-ci-isolate-discover-tsx.notes.md
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+    fallback: null
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+Choose the smallest checks that cover the changed behavior. Add a full suite
+only for an explicit release requirement or an observed cross-module coverage
+gap; state that reason and expected cost in Acceptance Notes. Do not duplicate
+coverage between `tests_pass` and `commands_succeed`. Before the first run,
+list eligible deterministic criteria in `criterion_reuse`; eligibility requires
+all inputs to be bound by the frozen subject/toolchain context. Leave external
+or mutable-state criteria ineligible. The canonical acceptance runner owns the
+expensive execution; workers and reviewers consume its evidence.
+
+If a full suite already passed before a bounded follow-up edit, preserve its
+run identity as baseline evidence and choose focused checks for the actual delta.
+The parent revises these criteria and records the baseline plus coverage rationale
+in Acceptance Notes, unless an explicit user/release requirement still requires
+a full run on the new subject. A cache miss alone does not justify another full
+suite; never label the old subject's pass as a full pass for the new subject.
+
+```yaml
+exit_criteria:
+  files_exist:
+    - scripts/lib/ci-run-tests.sh
+    - tests/check-ci-isolate-aggregation.test.ts
+  artifacts_exist:
+    - tasks/notes/20260906-0233-ci-isolate-discover-tsx.notes.md
+  tests_pass:
+    - path: tests/check-ci-isolate-aggregation.test.ts
+    - path: tests/bootstrap-files.test.ts
+  commands_succeed:
+    - test "$(find tests -type f \( -name '*.test.ts' -o -name '*.test.tsx' \) | LC_ALL=C sort | wc -l | tr -d ' ')" = "361"
+    - bash scripts/check-deploy-sql-order.sh
+    - bash scripts/check-architecture-sync.sh
+    - bash scripts/check-task-sync.sh
+    - bash scripts/check-task-workflow.sh --strict
+    - bun scripts/inspect-project-state.ts --repo . --format text
+    - bun src/cli/index.ts init --repo . --dry-run
+criterion_reuse:
+  tests_pass: []
+  commands_succeed: []
+```
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior: isolate-mode discovery now matches bun's own file set (361 files), so the three `tests/operator-web/*.test.tsx` suites run in CI's `Test` job.
+- Edge cases: the explicit `BUN_TEST_FILES` branch is untouched; the `no test files matched` guard and `LC_ALL=C sort` ordering are unchanged.
+- Regression risks: the CI `Test` job now executes three additional suites, lengthening the job; a pre-existing failure in those suites would surface as a new CI red.
+- Coverage rationale: one full `bun test --timeout 60000` run supplies the `across M files` figure the discovery readback is compared against, so the full suite is both the coverage check and the readback source.
+
+## Rollback Point
+
+- Commit / checkpoint: base main 29b3fd12
+- Revert strategy: revert the discovery predicate in `scripts/lib/ci-run-tests.sh` and the guard case in `tests/check-ci-isolate-aggregation.test.ts` together.

--- a/tasks/contracts/20260906-0233-ci-isolate-discover-tsx.contract.md
+++ b/tasks/contracts/20260906-0233-ci-isolate-discover-tsx.contract.md
@@ -161,7 +161,8 @@ exit_criteria:
     - path: tests/check-ci-isolate-aggregation.test.ts
     - path: tests/bootstrap-files.test.ts
   commands_succeed:
-    - test "$(find tests -type f \( -name '*.test.ts' -o -name '*.test.tsx' \) | LC_ALL=C sort | wc -l | tr -d ' ')" = "361"
+    - list="$(find tests -type f \( -name '*.test.ts' -o -name '*.test.tsx' \) | LC_ALL=C sort)"; for p in tests/operator-web/operator-collaboration.test.tsx tests/operator-web/operator-interactions.test.tsx tests/operator-web/operator-ui.test.tsx; do printf '%s\n' "$list" | grep -qxF "$p" || exit 1; done
+    - test "$(find tests -type f -name '*.test.tsx' | LC_ALL=C sort | wc -l | tr -d ' ')" -gt 0
     - bash scripts/check-deploy-sql-order.sh
     - bash scripts/check-architecture-sync.sh
     - bash scripts/check-task-sync.sh
@@ -176,6 +177,7 @@ criterion_reuse:
 ## Acceptance Notes (Human Review)
 
 - Functional behavior: isolate-mode discovery now matches bun's own file set (361 files), so the three `tests/operator-web/*.test.tsx` suites run in CI's `Test` job.
+- Recorded count evidence (head 86139c45): the discovery list held 361 files, equal to the `Ran 4471 tests across 361 files` figure from the full `bun test --timeout 60000` run. The count is recorded here rather than pinned in an exit criterion, because any new test file on main would change it without indicating a discovery regression.
 - Edge cases: the explicit `BUN_TEST_FILES` branch is untouched; the `no test files matched` guard and `LC_ALL=C sort` ordering are unchanged.
 - Regression risks: the CI `Test` job now executes three additional suites, lengthening the job; a pre-existing failure in those suites would surface as a new CI red.
 - Coverage rationale: one full `bun test --timeout 60000` run supplies the `across M files` figure the discovery readback is compared against, so the full suite is both the coverage check and the readback source.

--- a/tasks/notes/20260906-0233-ci-isolate-discover-tsx.notes.md
+++ b/tasks/notes/20260906-0233-ci-isolate-discover-tsx.notes.md
@@ -1,0 +1,45 @@
+# Implementation Notes: ci-isolate-discover-tsx
+
+> **Status**: Active
+> **Plan**: plans/plan-20260906-0233-ci-isolate-discover-tsx.md
+> **Contract**: tasks/contracts/20260906-0233-ci-isolate-discover-tsx.contract.md
+> **Review**: tasks/reviews/20260906-0233-ci-isolate-discover-tsx.review.md
+> **Last Updated**: 2026-09-06 02:33
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- The guard runs the loop from a throwaway `tests`-shaped root instead of the repo root: the library is sourced by absolute path (`REPO_HARNESS_CI_RUN_TESTS_LIB` already resolves it that way) while `find tests` resolves against the working directory, so discovery is observable without executing the repo's own suite.
+- The discovery branch is reached only by leaving `BUN_TEST_FILES` empty. The existing cases pass an explicit file list, so the new case sets `BUN_TEST_FILES: ""` rather than relying on it being absent from the inherited environment.
+- The readback compares the predicate's file count with the `across M files` figure from the full-suite run rather than executing `run_bun_tests` in isolate mode, which would re-run the whole suite file by file.
+
+## Deviations From Plan Or Spec
+
+- None recorded.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| Widen the `find` predicate | Chosen | Smallest change that makes loop discovery equal bun's discovery |
+| Delegate discovery to `bun test --list`-style enumeration | Rejected | Adds a second discovery authority and a bun-version dependency for no behaviour gain |
+
+## Open Questions
+
+- None.
+
+## Evidence Links
+
+- Pre-fix artifact: `.ai/harness/evidence/pre-fix/check-ci-isolate-discover-tsx.log` (`PRE_FIX_EXIT=1`); the path is under a gitignored root, so it exists only in this worktree.
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/reviews/20260906-0233-ci-isolate-discover-tsx.review.md
+++ b/tasks/reviews/20260906-0233-ci-isolate-discover-tsx.review.md
@@ -1,24 +1,24 @@
 # Task Review: ci-isolate-discover-tsx
 
-> **Status**: Pending
+> **Status**: Complete
 > **Plan**: plans/plan-20260906-0233-ci-isolate-discover-tsx.md
 > **Contract**: tasks/contracts/20260906-0233-ci-isolate-discover-tsx.contract.md
 > **Notes File**: tasks/notes/20260906-0233-ci-isolate-discover-tsx.notes.md
 > **Checks File**: .ai/harness/checks/latest.json
 > **Last Updated**: 2026-09-06 02:33
-> **Recommendation**: fail
+> **Recommendation**: pass
 > **Review Rubric Version**: 2
 > **Reviewed Subject SHA256**: pending
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: pending
+> **Reviewed Target Revision**: 86139c45
 
 ## Human Review Card
 
-- Verdict: pending
+- Verdict: pass
 - Change type: bugfix
 - Intended files changed: `scripts/lib/ci-run-tests.sh`, `tests/check-ci-isolate-aggregation.test.ts`, plus this work package's plan/contract/review/notes and `tasks/todos.md`
 - Actual files changed: `scripts/lib/ci-run-tests.sh`, `tests/check-ci-isolate-aggregation.test.ts`, `plans/plan-20260906-0233-ci-isolate-discover-tsx.md`, `tasks/contracts/20260906-0233-ci-isolate-discover-tsx.contract.md`, `tasks/reviews/20260906-0233-ci-isolate-discover-tsx.review.md`, `tasks/notes/20260906-0233-ci-isolate-discover-tsx.notes.md`, `tasks/todos.md`
-- Commands passed: `bun test --timeout 60000 tests/check-ci-isolate-aggregation.test.ts tests/bootstrap-files.test.ts` (18 pass / 0 fail); `verify-contract --strict` (total=22 failed=0); the six repository-integrity checks; `bun run check:helpers`; one full `bun test --timeout 60000`
+- Commands passed: `bun test --timeout 60000 tests/check-ci-isolate-aggregation.test.ts tests/bootstrap-files.test.ts` (18 pass / 0 fail); `verify-contract --strict` (total=22 failed=0); the six repository-integrity checks (all exit 0); CI-mode `check-task-sync` bound `sha256:ce746420...`; `bun run check:helpers` OK; one full `bun test --timeout 60000` (4467 pass / 4 skip / 0 fail across 361 files); `git merge-tree` clean against main 29b3fd12
 - Residual risks: the CI `Test` job now runs three additional `tests/operator-web/*.test.tsx` suites, so the job gets longer and any pre-existing failure there surfaces as a new CI red
 - Reviewer action required: inspect diff and card
 - Rollback: revert the discovery predicate and the guard case together (base main 29b3fd12)
@@ -32,7 +32,7 @@
 ## Verification Evidence
 
 - Waza `/check` run: not run; acceptance is owned by the ship gate
-- Commands run: guard + `tests/bootstrap-files.test.ts`; discovery readback (`361` files, including the three `tests/operator-web/*.test.tsx` paths); `bun run check:helpers`; `check-deploy-sql-order`, `check-architecture-sync`, `check-task-sync`, `check-task-workflow --strict`, `inspect-project-state`, `init --dry-run`; CI-mode `check-task-sync` with the digest bound; one full `bun test --timeout 60000`
+- Commands run: guard + `tests/bootstrap-files.test.ts` (18/18); discovery readback (`361` files with the widened predicate against `358` for the old one, including the three `tests/operator-web/*.test.tsx` paths); a bash 3.2 runtime probe of the isolate loop printing both the `.test.ts` and the `.test.tsx` line; `bun run check:helpers`; `check-deploy-sql-order`, `check-architecture-sync`, `check-task-sync`, `check-task-workflow --strict`, `inspect-project-state`, `init --dry-run`; CI-mode `check-task-sync` bound `sha256:ce746420...`; `verify-contract --strict` (22/22); one full `bun test --timeout 60000` (4467 pass / 4 skip / 0 fail across 361 files); `git merge-tree` clean against main 29b3fd12
 - Manual checks: no packaged mirror of `scripts/lib/ci-run-tests.sh` exists (`check:helpers` OK, repo-wide `run_bun_tests` scan finds only the lib and `scripts/check-ci.sh`)
 - Supporting artifacts: `/tmp/rh-tb/tsx/full.log`, `/tmp/rh-tb/tsx/discovered.txt`, `.ai/harness/evidence/pre-fix/check-ci-isolate-discover-tsx.log`
 - Implementation notes reviewed: `tasks/notes/20260906-0233-ci-isolate-discover-tsx.notes.md`
@@ -60,16 +60,17 @@
 
 ## Residual Risks / Follow-ups
 
+- The CI `Test` job now runs three more suites, so it takes longer and a latent `tests/operator-web` failure would surface as a new red.
 - The pre-fix artifact lives under the gitignored `.ai/harness/evidence/` root, so it is worktree-local and not reviewable from the PR diff.
 
 ## Scorecard
 
 | Dimension | Score | Notes |
 |-----------|-------|-------|
-| Functionality | 0/10 | |
-| Product depth | 0/10 | |
-| Design quality | 0/10 | |
-| Code quality | 0/10 | |
+| Functionality | 9/10 | Widened predicate discovers 361 files against 358 before; the three `tests/operator-web/*.test.tsx` paths appear in the readback and the bash 3.2 runtime probe prints both loop lines. |
+| Product depth | 8/10 | Closes the CI blind spot at its source and pins it with a guard case; the full suite (4467 pass / 4 skip / 0 fail across 361 files) confirms the newly discovered suites are green. |
+| Design quality | 8/10 | One-line predicate change inside the existing loop; sort order, `BUN_TEST_FILES` branch, aggregation, and the empty-match guard are untouched. |
+| Code quality | 9/10 | Guard 18/18 with `tests/bootstrap-files.test.ts`; `check:helpers` OK, six integrity checks exit 0, `verify-contract --strict` 22/22, CI-mode task-sync bound `sha256:ce746420...`, merge-tree clean vs main 29b3fd12. |
 
 ## Failing Items
 
@@ -82,4 +83,4 @@
 
 ## Summary
 
-- The isolate-mode CI loop now discovers `*.test.tsx`, closing the gap that hid the three `tests/operator-web` suites from CI. Verdict is left pending for the ship gate.
+- The isolate-mode CI loop now discovers `*.test.tsx`, closing the gap that hid the three `tests/operator-web` suites from CI. The ship gate passed at 86139c45; verdict is pass.

--- a/tasks/reviews/20260906-0233-ci-isolate-discover-tsx.review.md
+++ b/tasks/reviews/20260906-0233-ci-isolate-discover-tsx.review.md
@@ -1,0 +1,85 @@
+# Task Review: ci-isolate-discover-tsx
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260906-0233-ci-isolate-discover-tsx.md
+> **Contract**: tasks/contracts/20260906-0233-ci-isolate-discover-tsx.contract.md
+> **Notes File**: tasks/notes/20260906-0233-ci-isolate-discover-tsx.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-09-06 02:33
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: bugfix
+- Intended files changed: `scripts/lib/ci-run-tests.sh`, `tests/check-ci-isolate-aggregation.test.ts`, plus this work package's plan/contract/review/notes and `tasks/todos.md`
+- Actual files changed: `scripts/lib/ci-run-tests.sh`, `tests/check-ci-isolate-aggregation.test.ts`, `plans/plan-20260906-0233-ci-isolate-discover-tsx.md`, `tasks/contracts/20260906-0233-ci-isolate-discover-tsx.contract.md`, `tasks/reviews/20260906-0233-ci-isolate-discover-tsx.review.md`, `tasks/notes/20260906-0233-ci-isolate-discover-tsx.notes.md`, `tasks/todos.md`
+- Commands passed: `bun test --timeout 60000 tests/check-ci-isolate-aggregation.test.ts tests/bootstrap-files.test.ts` (18 pass / 0 fail); `verify-contract --strict` (total=22 failed=0); the six repository-integrity checks; `bun run check:helpers`; one full `bun test --timeout 60000`
+- Residual risks: the CI `Test` job now runs three additional `tests/operator-web/*.test.tsx` suites, so the job gets longer and any pre-existing failure there surfaces as a new CI red
+- Reviewer action required: inspect diff and card
+- Rollback: revert the discovery predicate and the guard case together (base main 29b3fd12)
+
+## Mode Evidence
+
+- Selected route: planning -> contract execution in an isolated worktree
+- P1/P2/P3 evidence: `plans/plan-20260906-0233-ci-isolate-discover-tsx.md` `## Captured Planning Output`
+- Root cause or plan evidence: `scripts/lib/ci-run-tests.sh:44` discovered only `-name '*.test.ts'`; pre-fix capture in `.ai/harness/evidence/pre-fix/check-ci-isolate-discover-tsx.log` (`PRE_FIX_EXIT=1`, missing `[ci] test tests/b.test.tsx`)
+
+## Verification Evidence
+
+- Waza `/check` run: not run; acceptance is owned by the ship gate
+- Commands run: guard + `tests/bootstrap-files.test.ts`; discovery readback (`361` files, including the three `tests/operator-web/*.test.tsx` paths); `bun run check:helpers`; `check-deploy-sql-order`, `check-architecture-sync`, `check-task-sync`, `check-task-workflow --strict`, `inspect-project-state`, `init --dry-run`; CI-mode `check-task-sync` with the digest bound; one full `bun test --timeout 60000`
+- Manual checks: no packaged mirror of `scripts/lib/ci-run-tests.sh` exists (`check:helpers` OK, repo-wide `run_bun_tests` scan finds only the lib and `scripts/check-ci.sh`)
+- Supporting artifacts: `/tmp/rh-tb/tsx/full.log`, `/tmp/rh-tb/tsx/discovered.txt`, `.ai/harness/evidence/pre-fix/check-ci-isolate-discover-tsx.log`
+- Implementation notes reviewed: `tasks/notes/20260906-0233-ci-isolate-discover-tsx.notes.md`
+- Run snapshot: `.ai/harness/runs/`
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- Isolate-mode discovery went from `find tests -type f -name '*.test.ts'` to `find tests -type f \( -name '*.test.ts' -o -name '*.test.tsx' \)`; the sort, the `BUN_TEST_FILES` branch, the failure aggregation, and the `no test files matched` guard are unchanged.
+- Discovered file count is now 361, equal to the `across ... files` figure bun reports for the full suite.
+
+## Residual Risks / Follow-ups
+
+- The pre-fix artifact lives under the gitignored `.ai/harness/evidence/` root, so it is worktree-local and not reviewable from the PR diff.
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- None.
+
+## Retest Steps
+
+- Re-run: `bun test --timeout 60000 tests/check-ci-isolate-aggregation.test.ts tests/bootstrap-files.test.ts`
+- Re-check: `find tests -type f \( -name '*.test.ts' -o -name '*.test.tsx' \) | LC_ALL=C sort | wc -l` equals the full suite's `across M files` figure
+
+## Summary
+
+- The isolate-mode CI loop now discovers `*.test.tsx`, closing the gap that hid the three `tests/operator-web` suites from CI. Verdict is left pending for the ship gate.

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -1,7 +1,7 @@
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: (archive-workflow)
+> **Updated**: 2026-09-06 02:33
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.

--- a/tests/check-ci-isolate-aggregation.test.ts
+++ b/tests/check-ci-isolate-aggregation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -40,6 +40,29 @@ function runIsolatedGate(files: string[]): RunResult {
       ...process.env,
       BUN_TEST_ISOLATE_FILES: "1",
       BUN_TEST_FILES: files.join(" "),
+      BUN_TEST_TIMEOUT_MS: "60000",
+      BUN_TEST_MAX_CONCURRENCY: "1",
+    },
+  });
+  return {
+    status: typeof result.status === "number" ? result.status : -1,
+    output: `${result.stdout ?? ""}${result.stderr ?? ""}`,
+  };
+}
+
+// Discovery mode drops BUN_TEST_FILES so the loop falls through to the lib's
+// own `find tests` scan. That scan is relative to the working directory, so the
+// gate is exercised from a throwaway `tests`-shaped root while the library is
+// still sourced by absolute path.
+function runDiscoveredGate(cwd: string): RunResult {
+  const script = `set -euo pipefail; source ${JSON.stringify(LIB_PATH)}; run_bun_tests`;
+  const result = spawnSync("bash", ["-c", script], {
+    cwd,
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      BUN_TEST_ISOLATE_FILES: "1",
+      BUN_TEST_FILES: "",
       BUN_TEST_TIMEOUT_MS: "60000",
       BUN_TEST_MAX_CONCURRENCY: "1",
     },
@@ -101,6 +124,26 @@ describe("ci isolate-mode test loop", () => {
       expect(result.status).toBe(0);
     } finally {
       rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("discovers .test.tsx files alongside .test.ts files", () => {
+    const root = mkdtempSync(join(tmpdir(), "rh-ci-discover-"));
+    try {
+      const testsDir = join(root, "tests");
+      mkdirSync(testsDir);
+      writeTestFile(testsDir, "a.test.ts", true);
+      writeTestFile(testsDir, "b.test.tsx", true);
+
+      const result = runDiscoveredGate(root);
+
+      expect(result.output).toContain("[ci] test tests/a.test.ts");
+      // bun discovers .test.tsx on its own, so a loop that skips it hides those
+      // suites from the gate while they still pass locally.
+      expect(result.output).toContain("[ci] test tests/b.test.tsx");
+      expect(result.status).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
The isolate-mode CI test loop discovered its files with `find tests -type f -name '*.test.ts'`, a predicate narrower than bun's own discovery. The three `tests/operator-web/*.test.tsx` suites therefore never entered the loop: the `Test` job ran 358 files where plain `bun test` runs 361, so a regression in those suites stayed green on every PR while failing only locally.

The predicate now reads `\( -name '*.test.ts' -o -name '*.test.tsx' \)`, matching bun's discovery. `-type f`, the `LC_ALL=C sort` ordering, the explicit `BUN_TEST_FILES` selection branch, the failure aggregation, and the `no test files matched` guard are all unchanged.

`tests/check-ci-isolate-aggregation.test.ts` gains one guard case: it builds a throwaway `tests`-shaped root holding a `.test.ts` and a `.test.tsx` file, runs the loop in isolate mode with `BUN_TEST_FILES` empty so discovery is exercised, and asserts both `[ci] test` lines appear. The case fails on the old predicate.

## Verification

- `bun test --timeout 60000 tests/check-ci-isolate-aggregation.test.ts tests/bootstrap-files.test.ts` — 18 pass / 0 fail
- Discovery readback — 361 files with the widened predicate against 358 with the old one; the three `tests/operator-web/*.test.tsx` paths present
- bash 3.2 runtime probe of the loop from a temp root — both the `.test.ts` and the `.test.tsx` line printed, exit 0
- `bun run check:helpers` — projection OK, 56 helpers
- Six repository-integrity checks — all exit 0
- `verify-contract --strict` — 23 criteria, 0 failed
- Full `bun test --timeout 60000` — 4467 pass / 4 skip / 0 fail across 361 files

## Residual risk

The `Test` job now executes three additional suites, so it takes longer, and any latent failure in `tests/operator-web` will surface as a new CI red rather than staying hidden.
