### PR TITLE
fix(campaign): activate @github connector through prompt text

### DIFF
--- a/docs/architecture/.projection-manifest.json
+++ b/docs/architecture/.projection-manifest.json
@@ -5,12 +5,12 @@
   "sourceDigest": "sha256:9d4398ac68f7305111247775e368ec6a34b69e5b1419d758b49f781474a2bb6d",
   "provenance": {
     "schemaVersion": "archcontext.architecture-docs-projection-provenance/v1",
-    "baseHeadSha": "24b30372264dc887e0fc0deaa9f2d16efce26fe4",
-    "worktreeDigest": "sha256:5bd066265f48bfb7f6e58fe16ce663e3038350be865685a7c05e01ad43c70396",
-    "sourceTreeDigest": "sha256:8ddb816d6036e7077456bfcaaca0fb248d0b757595633eaf373ca9c845524bb3",
+    "baseHeadSha": "76642e551d511c13faa406fff7e702767605e376",
+    "worktreeDigest": "sha256:105a500d9f2fb299814f5155c3a6af736436325469a4aa905d3c92a4d6230160",
+    "sourceTreeDigest": "sha256:187868cb9e16f32ebe26c50ec7a988f6b99f1278f9a1923bc0d682c12391a5d8",
     "modelDigest": "sha256:98406c8359efcdf2ca46c8adb905b8f1f1b9f8fb91bc2cb47075e96c2d58bc17",
-    "codeGraphDigest": "sha256:c2fabcdece92f9fa4d1344f53d4214f8b4915fc1ce99482e32580b40a98bbc0f",
-    "indexedWorktreeDigest": "sha256:9b2e9fe00f10846038ae3a910f4dfb8054332ed4b4f36fb0b56f753278f881ff",
+    "codeGraphDigest": "sha256:35d6a43dadd4b45fcb401678cbf6e5a504a0940ddc56034296a7b52c84fb5d9f",
+    "indexedWorktreeDigest": "sha256:fd24e47880bc44b87e21d18f5dc56f04d29f1286a03362cd6ab2ca9a337347bb",
     "rendererVersion": "archcontext.docs-renderer/v4",
     "layoutVersion": "archcontext.docs-layout/v1",
     "generatedFrom": {
@@ -19,9 +19,9 @@
       "codeGraphBinaryDigest": "sha256:e4be48573fdf16196ca0d2867be2790aa161534e9973dcb89bc70465100ea537",
       "codeGraphStatus": "ready"
     },
-    "projectionInputDigest": "sha256:3f6892f094f803c19635c6d7d7f6fdb07ffaade83672b69da09cbd189d528d0d"
+    "projectionInputDigest": "sha256:87bfcca6679879998a23d2c1456a1d47b045a7f13db54e049cd506621f9e91f1"
   },
-  "projectionDigest": "sha256:44774c0c96f174e8c398ebe073937019fd84cb4eb8da55bf12488ea20c1352fd",
+  "projectionDigest": "sha256:e1877b3f85b01352fe4057d6eae4a108c6f72df3eb6366c6dc49eb4a4d89b473",
   "semanticBaseline": {
     "semanticState": {
       "schemaVersion": "archcontext.architecture-semantic-state/v1",
@@ -709,12 +709,12 @@
     },
     "digests": {
       "modelDigest": "sha256:98406c8359efcdf2ca46c8adb905b8f1f1b9f8fb91bc2cb47075e96c2d58bc17",
-      "sourceTreeDigest": "sha256:8ddb816d6036e7077456bfcaaca0fb248d0b757595633eaf373ca9c845524bb3",
+      "sourceTreeDigest": "sha256:187868cb9e16f32ebe26c50ec7a988f6b99f1278f9a1923bc0d682c12391a5d8",
       "flowProofDigest": "sha256:abadd5396dfade2bde9e2ab2590def292ff5a8dcd0b662c4779b213a4aead6f4",
-      "projectionDigest": "sha256:44774c0c96f174e8c398ebe073937019fd84cb4eb8da55bf12488ea20c1352fd"
+      "projectionDigest": "sha256:e1877b3f85b01352fe4057d6eae4a108c6f72df3eb6366c6dc49eb4a4d89b473"
     }
   },
-  "receiptDigest": "sha256:40b6efbe029091afdde714a688716053e58cb0e0f3fdc95d9df023e65cc55cb7",
+  "receiptDigest": "sha256:7829c4bcd5a503155de47cb208cd00297d3c461b125170a9bc0fb9f83245c53b",
   "refreshSignalIds": [],
   "targetCount": 33,
   "fileCount": 33,
@@ -828,8 +828,8 @@
       "outputDigest": "sha256:9deae9f17a3ad75c541b1b0ca258721b329b5a4d9521eedfab8186eb635af91a",
       "verifiedAgainst": {
         "branch": "codex/brc1415-text-connector",
-        "commit": "24b30372264dc887e0fc0deaa9f2d16efce26fe4",
-        "committedAt": "2026-09-09T12:08:42+08:00"
+        "commit": "76642e551d511c13faa406fff7e702767605e376",
+        "committedAt": "2026-09-09T12:12:14+08:00"
       }
     },
     {
@@ -908,8 +908,8 @@
       "outputDigest": "sha256:564ee2aced00ea97c72f8993668751ad2eba769dca74ae0575a2ddfe67abbc40",
       "verifiedAgainst": {
         "branch": "codex/brc1415-text-connector",
-        "commit": "24b30372264dc887e0fc0deaa9f2d16efce26fe4",
-        "committedAt": "2026-09-09T12:08:42+08:00"
+        "commit": "76642e551d511c13faa406fff7e702767605e376",
+        "committedAt": "2026-09-09T12:12:14+08:00"
       }
     },
     {
@@ -1228,8 +1228,8 @@
       "outputDigest": "sha256:966f7438cd7b385cb411a2ef8c2de18c0b1e71eb067941c97375a4b284a873b9",
       "verifiedAgainst": {
         "branch": "codex/brc1415-text-connector",
-        "commit": "24b30372264dc887e0fc0deaa9f2d16efce26fe4",
-        "committedAt": "2026-09-09T12:08:42+08:00"
+        "commit": "76642e551d511c13faa406fff7e702767605e376",
+        "committedAt": "2026-09-09T12:12:14+08:00"
       }
     },
     {

--- a/docs/architecture/.projection-manifest.json
+++ b/docs/architecture/.projection-manifest.json
@@ -5,12 +5,12 @@
   "sourceDigest": "sha256:9d4398ac68f7305111247775e368ec6a34b69e5b1419d758b49f781474a2bb6d",
   "provenance": {
     "schemaVersion": "archcontext.architecture-docs-projection-provenance/v1",
-    "baseHeadSha": "e2d876ce7c8167af9db000eacfa2fa83c395d177",
-    "worktreeDigest": "sha256:8420ddf1943f287815a1c105238bfb77c33af9c07674a10dbab3f35c505c5131",
-    "sourceTreeDigest": "sha256:d32536c94cb4761fbcec52ee55fe67d86fa7662f5f05d27cc8ae8cc0b46f6c4c",
+    "baseHeadSha": "24b30372264dc887e0fc0deaa9f2d16efce26fe4",
+    "worktreeDigest": "sha256:5bd066265f48bfb7f6e58fe16ce663e3038350be865685a7c05e01ad43c70396",
+    "sourceTreeDigest": "sha256:8ddb816d6036e7077456bfcaaca0fb248d0b757595633eaf373ca9c845524bb3",
     "modelDigest": "sha256:98406c8359efcdf2ca46c8adb905b8f1f1b9f8fb91bc2cb47075e96c2d58bc17",
-    "codeGraphDigest": "sha256:5675f7cf970238f09425acc178d23c5ddc053df3b15dbbbbe2c4bdbf103435f5",
-    "indexedWorktreeDigest": "sha256:ba5fc737941cc6bade63331f190ea5b8f67468ff3b346f082c9f68fe76a2d455",
+    "codeGraphDigest": "sha256:c2fabcdece92f9fa4d1344f53d4214f8b4915fc1ce99482e32580b40a98bbc0f",
+    "indexedWorktreeDigest": "sha256:9b2e9fe00f10846038ae3a910f4dfb8054332ed4b4f36fb0b56f753278f881ff",
     "rendererVersion": "archcontext.docs-renderer/v4",
     "layoutVersion": "archcontext.docs-layout/v1",
     "generatedFrom": {
@@ -19,9 +19,9 @@
       "codeGraphBinaryDigest": "sha256:e4be48573fdf16196ca0d2867be2790aa161534e9973dcb89bc70465100ea537",
       "codeGraphStatus": "ready"
     },
-    "projectionInputDigest": "sha256:5856f1b0b165b3003c49616afb6d62fc22ed138585c2603975b0c1db5228b723"
+    "projectionInputDigest": "sha256:3f6892f094f803c19635c6d7d7f6fdb07ffaade83672b69da09cbd189d528d0d"
   },
-  "projectionDigest": "sha256:ff3965e28c7eb219368ccc10aad5d10cf0e67281904af59ffc309d8475e1b08e",
+  "projectionDigest": "sha256:44774c0c96f174e8c398ebe073937019fd84cb4eb8da55bf12488ea20c1352fd",
   "semanticBaseline": {
     "semanticState": {
       "schemaVersion": "archcontext.architecture-semantic-state/v1",
@@ -709,12 +709,12 @@
     },
     "digests": {
       "modelDigest": "sha256:98406c8359efcdf2ca46c8adb905b8f1f1b9f8fb91bc2cb47075e96c2d58bc17",
-      "sourceTreeDigest": "sha256:d32536c94cb4761fbcec52ee55fe67d86fa7662f5f05d27cc8ae8cc0b46f6c4c",
+      "sourceTreeDigest": "sha256:8ddb816d6036e7077456bfcaaca0fb248d0b757595633eaf373ca9c845524bb3",
       "flowProofDigest": "sha256:abadd5396dfade2bde9e2ab2590def292ff5a8dcd0b662c4779b213a4aead6f4",
-      "projectionDigest": "sha256:ff3965e28c7eb219368ccc10aad5d10cf0e67281904af59ffc309d8475e1b08e"
+      "projectionDigest": "sha256:44774c0c96f174e8c398ebe073937019fd84cb4eb8da55bf12488ea20c1352fd"
     }
   },
-  "receiptDigest": "sha256:ac359f2bc03a96f3b5b6cb498e1e88cf7b82661fc05557b772f474b24e4877cc",
+  "receiptDigest": "sha256:40b6efbe029091afdde714a688716053e58cb0e0f3fdc95d9df023e65cc55cb7",
   "refreshSignalIds": [],
   "targetCount": 33,
   "fileCount": 33,
@@ -827,9 +827,9 @@
       "sourceDigest": "sha256:010ee9ce2c7935ad6ab2aa5d30e2e0225c98fb708e29c221e146ff45b6b21610",
       "outputDigest": "sha256:9deae9f17a3ad75c541b1b0ca258721b329b5a4d9521eedfab8186eb635af91a",
       "verifiedAgainst": {
-        "branch": "codex/brc1415-adopted-continuation",
-        "commit": "e2d876ce7c8167af9db000eacfa2fa83c395d177",
-        "committedAt": "2026-09-09T04:52:50+08:00"
+        "branch": "codex/brc1415-text-connector",
+        "commit": "24b30372264dc887e0fc0deaa9f2d16efce26fe4",
+        "committedAt": "2026-09-09T12:08:42+08:00"
       }
     },
     {
@@ -907,9 +907,9 @@
       "sourceDigest": "sha256:e821c9e6e681ff519632fc2b3f385e0d78005fd6d46cf098f0657cf7fb6ae9cf",
       "outputDigest": "sha256:564ee2aced00ea97c72f8993668751ad2eba769dca74ae0575a2ddfe67abbc40",
       "verifiedAgainst": {
-        "branch": "codex/brc1415-adopted-continuation",
-        "commit": "e2d876ce7c8167af9db000eacfa2fa83c395d177",
-        "committedAt": "2026-09-09T04:52:50+08:00"
+        "branch": "codex/brc1415-text-connector",
+        "commit": "24b30372264dc887e0fc0deaa9f2d16efce26fe4",
+        "committedAt": "2026-09-09T12:08:42+08:00"
       }
     },
     {
@@ -1227,9 +1227,9 @@
       "sourceDigest": "sha256:463d4ebee4c32feaf8e98dca3f6862530d876ff145ab4a6c0d1e83b9acd6d4b7",
       "outputDigest": "sha256:966f7438cd7b385cb411a2ef8c2de18c0b1e71eb067941c97375a4b284a873b9",
       "verifiedAgainst": {
-        "branch": "codex/brc1415-adopted-continuation",
-        "commit": "e2d876ce7c8167af9db000eacfa2fa83c395d177",
-        "committedAt": "2026-09-09T04:52:50+08:00"
+        "branch": "codex/brc1415-text-connector",
+        "commit": "24b30372264dc887e0fc0deaa9f2d16efce26fe4",
+        "committedAt": "2026-09-09T12:08:42+08:00"
       }
     },
     {

--- a/docs/researches/20260908-brc14-provider-history-evidence.md
+++ b/docs/researches/20260908-brc14-provider-history-evidence.md
@@ -143,3 +143,11 @@ The existing stopped BYOK campaign completed real revision, authoring, challenge
 `campaign author --resume-from` can preserve already adopted Issues only when the predecessor is stopped, has zero successful acquisitions, no open budget reservations and no active controller step. Source adoption is rebuilt and its canonical publication must remain unchanged in the new target ancestry. A new campaign and authorization obtain new evidence; predecessor grants, sessions and manifests remain historical.
 
 The immutable continuation binding permits only one successor. Its authoring may edit only the original Issue identities, and adoption independently rejects replacements. The ordinary challenge, publication, planning, acquire and manual delivery gates remain in force. This mechanism does not recover already acquired work or prove the real BRC14/BRC15 delivery/audit by itself.
+
+## Text Connector activation (Owner-approved, 2026-09-09)
+
+Campaign revision observation, Issue authoring/follow-up, adoption challenge and fresh audit now frame the existing canonical prompt as literal `@GitHub <prompt>`. They explicitly clear inherited app preselection; Oracle receives no `--browser-app` for these operations. Other browser clients retain their explicit app-selection behavior. This removes a transport-specific composer-pill prerequisite, not the need for Connector evidence.
+
+New session evidence consumes the invocation-owned captured conversation: validated response bytes, complete bounded history, the latest completed user/assistant turn and successful published GitHub tool returns with consistent Connector identity. A pill, answer-only claim, stale tool turn, mismatched citation or altered history cannot supply this evidence. The exact-revision decoder shares history validation and still checks both original GitHub JSON resources and their exact SHA. Historical immutable receipts retain their original evidence scope.
+
+Focused implementation verification passed 167 tests across eight campaign files; the additional real browser-command regression verifies that explicit null clears a historical app in a follow-up. This is code evidence only. The real canary's failed pre-submission observation remains retained and is not relabeled or silently retried; BRC14/BRC15 delivery and final audit remain pending.

--- a/docs/researches/20260908-brc14-provider-history-evidence.md
+++ b/docs/researches/20260908-brc14-provider-history-evidence.md
@@ -146,7 +146,7 @@ The immutable continuation binding permits only one successor. Its authoring may
 
 ## Text Connector activation (Owner-approved, 2026-09-09)
 
-Campaign revision observation, Issue authoring/follow-up, adoption challenge and fresh audit now frame the existing canonical prompt as literal `@GitHub <prompt>`. They explicitly clear inherited app preselection; Oracle receives no `--browser-app` for these operations. Other browser clients retain their explicit app-selection behavior. This removes a transport-specific composer-pill prerequisite, not the need for Connector evidence.
+Campaign revision observation, Issue authoring/follow-up, adoption challenge and fresh audit now frame the existing canonical prompt as literal `@github connector <prompt>`. They explicitly clear inherited app preselection; Oracle receives no `--browser-app` for these operations. Other browser clients retain their explicit app-selection behavior. This removes a transport-specific composer-pill prerequisite, not the need for Connector evidence.
 
 New session evidence consumes the invocation-owned captured conversation: validated response bytes, complete bounded history, the latest completed user/assistant turn and successful published GitHub tool returns with consistent Connector identity. A pill, answer-only claim, stale tool turn, mismatched citation or altered history cannot supply this evidence. The exact-revision decoder shares history validation and still checks both original GitHub JSON resources and their exact SHA. Historical immutable receipts retain their original evidence scope.
 

--- a/plans/plan-20260909-1202-brc1415-text-connector.md
+++ b/plans/plan-20260909-1202-brc1415-text-connector.md
@@ -1,0 +1,119 @@
+# Plan: BRC14/15 text Connector activation
+
+> **Status**: Executing
+> **Created**: 20260909-1202
+> **Slug**: brc1415-text-connector
+> **Planning Source**: waza-think
+> **Orchestration Kind**: host-plan
+> **Source Ref**: (none)
+> **Artifact Level**: work-package
+> **Promotion Reason**: verification_boundary
+> **Verification Boundary**: Commands named in the captured planning output plus `repo-harness run verify-contract --contract tasks/contracts/20260909-1202-brc1415-text-connector.contract.md --strict`.
+> **Rollback Surface**: Before execution remove `plans/plan-20260909-1202-brc1415-text-connector.md`; after execution revert branch `codex/brc1415-text-connector` or the explicitly reviewed diff.
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260909-1202-brc1415-text-connector.contract.md`
+> **Task Review**: `tasks/reviews/20260909-1202-brc1415-text-connector.review.md`
+> **Implementation Notes**: `tasks/notes/20260909-1202-brc1415-text-connector.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from waza-think planning output.
+- Source ref: (none)
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260909-1202-brc1415-text-connector.md`
+- Sprint contract: `tasks/contracts/20260909-1202-brc1415-text-connector.contract.md`
+- Sprint review: `tasks/reviews/20260909-1202-brc1415-text-connector.review.md`
+- Implementation notes: `tasks/notes/20260909-1202-brc1415-text-connector.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260909-1202-brc1415-text-connector.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260909-1202-brc1415-text-connector.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260909-1202-brc1415-text-connector.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260909-1202-brc1415-text-connector.contract.md`
+- Review file: `tasks/reviews/20260909-1202-brc1415-text-connector.review.md`
+- Implementation notes file: `tasks/notes/20260909-1202-brc1415-text-connector.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260909-1202-brc1415-text-connector.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260909-1202-brc1415-text-connector.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: Before execution remove `plans/plan-20260909-1202-brc1415-text-connector.md`; after execution revert branch `codex/brc1415-text-connector` or the explicitly reviewed diff.
+- **Verification boundary**: Commands named in the captured planning output plus `repo-harness run verify-contract --contract tasks/contracts/20260909-1202-brc1415-text-connector.contract.md --strict`.
+- **Review/acceptance boundary**: `tasks/reviews/20260909-1202-brc1415-text-connector.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: verification_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260909-1202-brc1415-text-connector.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260909-1202-brc1415-text-connector.contract.md`, `tasks/reviews/20260909-1202-brc1415-text-connector.review.md`, and `tasks/notes/20260909-1202-brc1415-text-connector.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260909-1202-brc1415-text-connector.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: Before execution remove `plans/plan-20260909-1202-brc1415-text-connector.md`; after execution revert branch `codex/brc1415-text-connector` or the explicitly reviewed diff.
+
+## Captured Planning Output
+
+## Goal
+Replace campaign UI app preselection with literal @GitHub prompt activation, retaining real Connector history and exact-SHA acceptance. Owner explicitly approved this change after APP_SELECTION_UNVERIFIED prevented submission.
+## P1 / P2 / P3
+The four campaign calls use chatgptApp, which produces Oracle --browser-app and fails before submit. CampaignBrowserSession separately requires a composer pill. Replace the call transport with a shared literal mention and conversation capture. Validate invocation-owned provider history, latest completed turn, GitHub tool identity and successful tool status. Existing version decoder continues verifying exact raw GitHub resources and SHA. Existing immutable historical receipts retain their original meaning; new receipts use captured Connector calls. No Oracle edits, model overrides, fabricated evidence or budget reset.
+## Scope
+src/core/automation/campaign-browser-session.ts; four automation callers; affected session/authoring/adoption/revision/audit/step tests and shared fixtures; durable research. Recovery of the original failed revision observation is a subsequent bounded task and is not silently enabled by this transport change.
+## Verification
+Focused campaign tests, typecheck and six required repository integrity checks. No local full suite; mandatory CI remains required. Negative evidence includes no tool, forged text, wrong turn, wrong connector and tampered history. Freeze the code before final acceptance.
+## Task Breakdown
+- [ ] Change four campaign request paths and evidence reader.
+- [ ] Verify positive text invocation and negative history boundaries.
+- [ ] Record exact acceptance, PR, CI and merge; preserve real canary failure separately.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [ ] Change four campaign request paths and evidence reader.
+- [ ] Verify positive text invocation and negative history boundaries.
+- [ ] Record exact acceptance, PR, CI and merge; preserve real canary failure separately.

--- a/plans/plan-20260909-1202-brc1415-text-connector.md
+++ b/plans/plan-20260909-1202-brc1415-text-connector.md
@@ -98,7 +98,7 @@ See captured planning output.
 ## Captured Planning Output
 
 ## Goal
-Replace campaign UI app preselection with literal @GitHub prompt activation, retaining real Connector history and exact-SHA acceptance. Owner explicitly approved this change after APP_SELECTION_UNVERIFIED prevented submission.
+Replace campaign UI app preselection with literal @github connector prompt activation, retaining real Connector history and exact-SHA acceptance. Owner explicitly approved this change after APP_SELECTION_UNVERIFIED prevented submission.
 ## P1 / P2 / P3
 The four campaign calls use chatgptApp, which produces Oracle --browser-app and fails before submit. CampaignBrowserSession separately requires a composer pill. Replace the call transport with a shared literal mention and conversation capture. Validate invocation-owned provider history, latest completed turn, GitHub tool identity and successful tool status. Existing version decoder continues verifying exact raw GitHub resources and SHA. Existing immutable historical receipts retain their original meaning; new receipts use captured Connector calls. No Oracle edits, model overrides, fabricated evidence or budget reset.
 ## Scope

--- a/src/cli/chatgpt-browser/engine.ts
+++ b/src/cli/chatgpt-browser/engine.ts
@@ -580,7 +580,7 @@ export async function runBrowserFollowup(input: Omit<BrowserConsultInput, 'sourc
     thinking: input.thinking,
     provider,
     chatgptUrl: input.chatgptUrl ?? existing.meta.browser.conversationUrl ?? existing.meta.browser.chatgptUrl,
-    chatgptApp: input.chatgptApp ?? existing.meta.browser.chatgptApp,
+    chatgptApp: input.chatgptApp === null ? undefined : input.chatgptApp ?? existing.meta.browser.chatgptApp,
     profileDir: input.profileDir ?? existing.meta.browser.profileDir,
     profileDirectory: input.profileDirectory ?? existing.meta.browser.profileDirectory,
     browserChannel: input.browserChannel ?? existing.meta.browser.channel,

--- a/src/cli/chatgpt-browser/session-store.ts
+++ b/src/cli/chatgpt-browser/session-store.ts
@@ -190,7 +190,7 @@ export function writeBrowserSession(opts: {
       mode: 'manual-login',
       transport: resolveSessionTransport(opts.provider, opts.input.profileDir),
       chatgptUrl: opts.input.chatgptUrl ?? 'https://chatgpt.com/',
-      chatgptApp: opts.input.chatgptApp,
+      chatgptApp: opts.input.chatgptApp ?? undefined,
       channel: opts.input.browserChannel,
       profileDir: opts.input.profileDir,
       profileDirectory: opts.input.profileDirectory,

--- a/src/cli/chatgpt-browser/types.ts
+++ b/src/cli/chatgpt-browser/types.ts
@@ -33,7 +33,8 @@ export interface BrowserConsultInput {
   followups?: string[];
   model?: string;
   thinking?: ThinkingLevel;
-  chatgptApp?: string;
+  /** null explicitly clears app preselection inherited by a follow-up. */
+  chatgptApp?: string | null;
   provider?: BrowserProviderName;
   chatgptUrl?: string;
   timeoutMs?: number;

--- a/src/core/automation/campaign-browser-session.ts
+++ b/src/core/automation/campaign-browser-session.ts
@@ -1,5 +1,7 @@
+import { readCampaignCapturedConversation } from './campaign-revision-evidence';
 import { canonicalMessageDigest } from '../messages/mechanics';
-/** Session ownership and app selection are independent of backend model identity. */
+/** Session ownership and captured Connector calls are independent of backend model identity. */
+export function campaignGithubPrompt(prompt: string): string { return `@GitHub ${prompt}`; }
 export interface CampaignBrowserSessionBinding {
   readonly repoRoot: string;
   readonly profileDirectory: string;
@@ -12,23 +14,55 @@ function object(value: unknown): Record<string, unknown> | null {
 }
 function nonempty(value: unknown): value is string { return typeof value === 'string' && value.trim().length > 0; }
 
+
+/** Read invocation-owned history, never a composer label or the model's answer. */
+function githubInvocation(meta: Record<string, unknown>): { pluginId: string; capturedAt: string } | null {
+  try {
+    if (!nonempty(meta.providerSessionId)) return null;
+    const captured = readCampaignCapturedConversation(object(meta.oracle)?.conversationCapture, meta.providerSessionId);
+    if (!captured) return null;
+    const {history, body, messages} = captured;
+    const final = messages.find(m => m!.id === body.current_node), finalMeta = object(final?.metadata);
+    if (object(final?.author)?.role !== 'assistant' || final?.status !== 'finished_successfully' || final.end_turn !== true
+      || !nonempty(finalMeta?.turn_exchange_id) || finalMeta.working_turn_id !== finalMeta.turn_exchange_id) return null;
+    const turn = finalMeta.turn_exchange_id;
+    const users = messages.filter(m => object(m!.author)?.role === 'user');
+    const user = users.at(-1), userMeta = object(user?.metadata), content = object(user?.content);
+    if (userMeta?.turn_exchange_id !== turn || userMeta.working_turn_id !== turn || content?.content_type !== 'text'
+      || !Array.isArray(content.parts) || content.parts.length !== 1 || typeof content.parts[0] !== 'string'
+      || !content.parts[0].startsWith('@GitHub ')) return null;
+    const connectors = new Set<string>();
+    for (const message of messages) {
+      const author = object(message!.author), metadata = object(message!.metadata), resource = object(metadata?.invoked_resource);
+      if (author?.role !== 'tool' || author.name !== 'api_tool.call_tool' || metadata?.turn_exchange_id !== turn) continue;
+      if (resource?.app_name !== 'GitHub') continue;
+      if (message!.status !== 'finished_successfully' || metadata.working_turn_id !== turn
+        || resource.api_tool_version !== 'v2' || resource.publish_status !== 'published' || typeof resource.resource_uri !== 'string') return null;
+      const segments = resource.resource_uri.split('/');
+      if (segments[0] !== '' || !segments[1] || segments.length < 3) return null;
+      const citation = object(metadata.citation_metadata);
+      if (citation && citation.__connector_id !== segments[1]) return null;
+      connectors.add(segments[1]);
+    }
+    if (connectors.size !== 1) return null;
+    return { pluginId: `plugin:${[...connectors][0]}`, capturedAt: history.capturedAt as string };
+  } catch { return null; }
+}
+
 function isVerifiedCampaignBrowserSession(value: unknown, binding: CampaignBrowserSessionBinding): boolean {
   const result = object(value);
   const meta = object(result?.meta);
   const browser = object(meta?.browser);
   const oracle = object(meta?.oracle);
   const observation = object(oracle?.observation);
-  const app = object(observation?.appSelection);
+
   if (result?.status !== 'completed' || meta?.status !== 'completed'
     || !nonempty(result.sessionId) || result.sessionId !== meta.sessionId
     || meta.provider !== 'oracle' || meta.engine !== 'chatgpt-browser' || meta.repo !== binding.repoRoot
     || browser?.transport !== 'copy_profile' || browser.profileDir !== binding.profileDir || browser.profileDirectory !== binding.profileDirectory
-    || browser.chatgptApp !== 'GitHub' || !nonempty(meta.providerSessionId)
+    || !nonempty(meta.providerSessionId)
     || oracle?.evidenceError !== undefined || observation?.source !== 'oracle-session-metadata'
-    || observation.sessionId !== meta.providerSessionId
-    || app?.status !== 'selected' || app.app !== 'GitHub' || app.source !== 'chatgpt-composer-pill'
-    || !nonempty(app.pluginId) || !app.pluginId.startsWith('plugin:') || app.pluginId.length <= 7
-    || !nonempty(app.capturedAt) || !Number.isFinite(Date.parse(app.capturedAt))) return false;
+    || observation.sessionId !== meta.providerSessionId) return false;
   if (binding.sourceSessionId === null) {
     return binding.parentProviderSessionId === null && meta.sourceSessionId === undefined && meta.parentProviderSessionId === undefined && observation.parentSessionId === null;
   }
@@ -57,7 +91,8 @@ export function readCampaignBrowserSessionEvidence(value: unknown, binding: Camp
   if (!isVerifiedCampaignBrowserSession(value, binding)) return null;
   const result = object(value)!;
   const meta = object(result.meta)!;
-  const app = object(object(object(meta.oracle)!.observation)!.appSelection)!;
+  const app = githubInvocation(meta);
+  if (!app) return null;
   const basis = { protocol: 1 as const, kind: 'repo-harness-campaign-browser-session-evidence' as const,
     session_ref: result.sessionId as string, provider_session_ref: meta.providerSessionId as string,
     source_session_ref: binding.sourceSessionId, parent_provider_session_ref: binding.parentProviderSessionId,

--- a/src/core/automation/campaign-browser-session.ts
+++ b/src/core/automation/campaign-browser-session.ts
@@ -1,7 +1,7 @@
-import { readCampaignCapturedConversation } from './campaign-revision-evidence';
+import { campaignGithubPrompt, readCampaignCapturedConversation } from './campaign-revision-evidence';
 import { canonicalMessageDigest } from '../messages/mechanics';
 /** Session ownership and captured Connector calls are independent of backend model identity. */
-export function campaignGithubPrompt(prompt: string): string { return `@GitHub ${prompt}`; }
+export { campaignGithubPrompt } from './campaign-revision-evidence';
 export interface CampaignBrowserSessionBinding {
   readonly repoRoot: string;
   readonly profileDirectory: string;
@@ -30,7 +30,7 @@ function githubInvocation(meta: Record<string, unknown>): { pluginId: string; ca
     const user = users.at(-1), userMeta = object(user?.metadata), content = object(user?.content);
     if (userMeta?.turn_exchange_id !== turn || userMeta.working_turn_id !== turn || content?.content_type !== 'text'
       || !Array.isArray(content.parts) || content.parts.length !== 1 || typeof content.parts[0] !== 'string'
-      || !content.parts[0].startsWith('@GitHub ')) return null;
+      || !content.parts[0].startsWith(campaignGithubPrompt(''))) return null;
     const connectors = new Set<string>();
     for (const message of messages) {
       const author = object(message!.author), metadata = object(message!.metadata), resource = object(metadata?.invoked_resource);

--- a/src/core/automation/campaign-revision-evidence.ts
+++ b/src/core/automation/campaign-revision-evidence.ts
@@ -1,6 +1,8 @@
 import { createHash } from 'crypto';
 import { canonicalMessageDigest } from '../messages/mechanics';
 
+export function campaignGithubPrompt(prompt: string): string { return `@github connector ${prompt}`; }
+
 /** Preserve exact prompt bytes through the browser editor's automatic URL linking. */
 export function encodeCampaignRevisionPrompt(instructions: string): string {
   return 'Execute the instructions in this JSON string (decode JSON escapes first):\n'
@@ -110,7 +112,7 @@ export function readCampaignRevisionEvidence(capture: unknown, expected: Revisio
     const users=messages.filter(m=>object(m.author).role==='user'); requireThat(users.length===1);
     const user=users[0]!, userMeta=object(user.metadata), content=object(user.content);
     requireThat(content.content_type==='text' && Array.isArray(content.parts) && content.parts.length===1
-      && content.parts[0]==='@GitHub '+expected.prompt
+      && content.parts[0]===campaignGithubPrompt(expected.prompt)
       && typeof userMeta.turn_exchange_id==='string');
     const turn=userMeta.turn_exchange_id as string;
     requireThat(turn.length>0 && userMeta.working_turn_id===turn);

--- a/src/core/automation/campaign-revision-evidence.ts
+++ b/src/core/automation/campaign-revision-evidence.ts
@@ -79,11 +79,11 @@ function toolObject(message: ObjectValue, connector: string, turn: string, url: 
   return object(JSON.parse(wrapper.content as string));
 }
 
-/** Caller supplies only history obtained at the invocation-owned provider effect boundary. */
-export function readCampaignRevisionEvidence(capture: unknown, expected: RevisionExpectation): CampaignRevisionEvidence | null {
+/** Shared invocation-owned history validation for session and exact-revision evidence. */
+export function readCampaignCapturedConversation(capture: unknown, providerSessionId: string) {
   try {
     const c=object(capture); if(c.status!=='captured') return null;
-    requireThat(c.sessionId===expected.providerSessionId && typeof c.sha256==='string' && /^sha256:[a-f0-9]{64}$/.test(c.sha256));
+    requireThat(c.sessionId===providerSessionId && typeof c.sha256==='string' && /^sha256:[a-f0-9]{64}$/.test(c.sha256));
     const h=object(c.history), request=object(h.request), response=object(h.response);
     requireThat(h.protocol===1 && h.kind==='chatgpt-conversation-history' && typeof h.conversationId==='string' && h.conversationId===c.conversationId
       && typeof h.capturedAt==='string' && Number.isFinite(Date.parse(h.capturedAt)));
@@ -96,6 +96,17 @@ export function readCampaignRevisionEvidence(capture: unknown, expected: Revisio
       && Array.isArray(history.messages) && history.messages.length<=1024);
     const messages=(history.messages as unknown[]).map(object);
     requireThat(new Set(messages.map(m=>m.id)).size===messages.length && messages.every(m=>typeof m.id==='string'));
+    return { capture: c, history: h, body: history, messages };
+  } catch { return null; }
+}
+
+/** Caller supplies only history obtained at the invocation-owned provider effect boundary. */
+export function readCampaignRevisionEvidence(capture: unknown, expected: RevisionExpectation): CampaignRevisionEvidence | null {
+  try {
+    const captured=readCampaignCapturedConversation(capture, expected.providerSessionId);
+    if (!captured) return null;
+    const {capture:c, history:h, body:history, messages}=captured;
+    const response=object(h.response);
     const users=messages.filter(m=>object(m.author).role==='user'); requireThat(users.length===1);
     const user=users[0]!, userMeta=object(user.metadata), content=object(user.content);
     requireThat(content.content_type==='text' && Array.isArray(content.parts) && content.parts.length===1

--- a/src/effects/automation/campaign-fresh-audit.ts
+++ b/src/effects/automation/campaign-fresh-audit.ts
@@ -1,5 +1,5 @@
 import { readCampaignRevisionEvidence, buildCampaignRevisionReadInstruction, encodeCampaignRevisionPrompt } from '../../core/automation/campaign-revision-evidence';
-import { readCampaignBrowserSessionEvidence } from '../../core/automation/campaign-browser-session';
+import { campaignGithubPrompt, readCampaignBrowserSessionEvidence } from '../../core/automation/campaign-browser-session';
 import { execFileSync } from 'child_process';
 import { canonicalMessageDigest, messageSha256 } from '../../core/messages/mechanics';
 import { automationDigest, type ProgramAuthorizationV1, type CampaignAutomationBudgetReservationV1 } from '../../core/automation/budget';
@@ -294,9 +294,9 @@ export async function runCampaignFreshAudit(
   const browserInput: IssueAuthoringBrowserInput = {
     repoRoot: root,
     title: `${input.campaign_id} group ${input.group_number} fresh audit`,
-    prompt,
+    prompt: campaignGithubPrompt(prompt),
     provider: 'oracle',
-    chatgptApp: 'GitHub',
+    chatgptApp: null,
     requireSecretScan: true,
     captureNetworkEvidence: true,
     captureConversationEvidence: true,

--- a/src/effects/automation/campaign-revision-observation.ts
+++ b/src/effects/automation/campaign-revision-observation.ts
@@ -7,7 +7,7 @@ import { resolve } from 'path';
 import { canonicalMessageDigest, messageSha256 } from '../../core/messages/mechanics';
 import { automationDigest, type CampaignAutomationBudgetReservationV1 } from '../../core/automation/budget';
 import { CampaignFreshAuditError } from '../../core/automation/campaign-fresh-audit';
-import { readCampaignBrowserSessionEvidence, type CampaignBrowserSessionEvidenceV1 } from '../../core/automation/campaign-browser-session';
+import { campaignGithubPrompt, readCampaignBrowserSessionEvidence, type CampaignBrowserSessionEvidenceV1 } from '../../core/automation/campaign-browser-session';
 import { withCampaignRevisionAdmission, readCampaignRevisionRecord, persistCampaignRevisionRecord } from './development-campaign-store';
 import { readCampaignExternalSourcesPolicyAtRevision, readDevelopmentCampaignPolicyAtRevision } from './development-campaign-policy';
 import { requireManualGithubPolicy } from '../external-sources/policy';
@@ -95,8 +95,8 @@ export async function runCampaignRevisionObservation(input: {
       automation_run_id: budget.budget.automation_run_id, expected_budget_sha256: budget.budget.budget_sha256,
       request_sha256: requestDigest, env: input.env });
     if (admission.disposition === 'replayed') refuse('revision observation reservation is unresolved; do not repeat provider I/O');
-    const pending = deps.consult({ repoRoot: root, title: `${campaignId} pre-active revision observation`, prompt,
-      provider: 'oracle', chatgptApp: 'GitHub', requireSecretScan: true, captureNetworkEvidence: true, captureConversationEvidence: true,
+    const pending = deps.consult({ repoRoot: root, title: `${campaignId} pre-active revision observation`, prompt: campaignGithubPrompt(prompt),
+      provider: 'oracle', chatgptApp: null, requireSecretScan: true, captureNetworkEvidence: true, captureConversationEvidence: true,
       profileDir: binding.binding!.profileDir, profileDirectory: binding.binding!.profileDirectory!,
       gitleaksBin: input.gitleaks_bin, dryRun: false });
     return { admission, pending };

--- a/src/effects/automation/gpt-pro-issue-authoring.ts
+++ b/src/effects/automation/gpt-pro-issue-authoring.ts
@@ -1,7 +1,7 @@
 import { assertResumedAuthoringTarget, bindAdoptedResume, validateAdoptedResumeSource, type AdoptedResumeSource } from './campaign-authoring-resume';
 import { readCampaignProtectionAtRevision } from './campaign-protection';
 import { campaignAutomationRunId } from '../../core/automation/campaign-authoring-budget';
-import { readCampaignBrowserSessionEvidence } from '../../core/automation/campaign-browser-session';
+import { campaignGithubPrompt, readCampaignBrowserSessionEvidence } from '../../core/automation/campaign-browser-session';
 import { resolveCampaignGroupAuthoringContext } from './campaign-fresh-audit';
 import { readCampaignCapabilityIdsAtRevision } from './campaign-capability-registry';
 import { issueBatchMetadataAuthoringSchema, ISSUE_BATCH_METADATA_KIND } from '../../core/automation/issue-batch-reconcile';
@@ -37,7 +37,7 @@ export interface IssueAuthoringBrowserInput {
   readonly title: string;
   readonly prompt: string;
   readonly provider: 'oracle';
-  readonly chatgptApp: 'GitHub';
+  readonly chatgptApp: null;
   readonly requireSecretScan: true;
   readonly captureNetworkEvidence?: true;
   readonly captureConversationEvidence?: true;
@@ -156,8 +156,8 @@ function context(input: StartIssueBatchAuthoringInput, readBinding: IssueAuthori
 
 function browserInput(repoRoot: string, prompt: string, profileDir: string, profileDirectory: string, input: StartIssueBatchAuthoringInput): IssueAuthoringBrowserInput {
   return {
-    repoRoot, title: `${input.campaign_id} group ${input.group_number} issue authoring`, prompt,
-    provider: 'oracle', chatgptApp: 'GitHub', requireSecretScan: true, gitleaksBin: input.gitleaks_bin,
+    repoRoot, title: `${input.campaign_id} group ${input.group_number} issue authoring`, prompt: campaignGithubPrompt(prompt),
+    provider: 'oracle', chatgptApp: null, requireSecretScan: true, captureConversationEvidence: true, gitleaksBin: input.gitleaks_bin,
     profileDir, profileDirectory, dryRun: input.dry_run === true,
   };
 }

--- a/src/effects/automation/issue-batch-adoption.ts
+++ b/src/effects/automation/issue-batch-adoption.ts
@@ -1,5 +1,5 @@
 import { assertResumedAdoption } from './campaign-authoring-resume';
-import { readCampaignBrowserSessionEvidence, type CampaignBrowserSessionEvidenceV1 } from '../../core/automation/campaign-browser-session';
+import { campaignGithubPrompt, readCampaignBrowserSessionEvidence, type CampaignBrowserSessionEvidenceV1 } from '../../core/automation/campaign-browser-session';
 import { requireCampaignActiveAdmission } from './campaign-revision-admission';
 import { observeShadowAdoption } from './issue-batch-shadow-adoption';
 import type { GithubCommandRunner } from '../external-sources/github';
@@ -234,8 +234,8 @@ export async function adoptIssueBatch(input: AdoptIssueBatchInput, deps: IssueBa
   if (!response) {
     const admission = reserveCampaignAuthoringBudget({ ...binding, operation: 'challenge', idempotency_key: challenge.challenge_sha256 });
     if (admission.disposition === 'replayed') fail('challenge reservation already exists; reconcile its exact result before continuing');
-    const result = await deps.followup({ repoRoot: input.repo_root, sessionId: session.session_ref, title: `Campaign ${intent.campaign_id} readback`, prompt: renderConnectorChallenge(challenge, intent.provider_repository),
-      provider: 'oracle', chatgptApp: 'GitHub', requireSecretScan: true, gitleaksBin: input.gitleaks_bin, profileDir: browser.binding.profileDir, profileDirectory: browser.binding.profileDirectory!, dryRun: false });
+    const result = await deps.followup({ repoRoot: input.repo_root, sessionId: session.session_ref, title: `Campaign ${intent.campaign_id} readback`, prompt: campaignGithubPrompt(renderConnectorChallenge(challenge, intent.provider_repository)),
+      provider: 'oracle', chatgptApp: null, requireSecretScan: true, captureConversationEvidence: true, gitleaksBin: input.gitleaks_bin, profileDir: browser.binding.profileDir, profileDirectory: browser.binding.profileDirectory!, dryRun: false });
     response = { response: result.output ?? '', response_session_ref: result.sessionId, response_session_evidence: readCampaignBrowserSessionEvidence(result, { repoRoot: input.repo_root, profileDir: browser.binding.profileDir, profileDirectory: intent.chrome_profile_directory, sourceSessionId: session.session_ref, parentProviderSessionId: session.browser_evidence!.provider_session_ref }), status: result.status, reservation: admission.reservation };
     persistIssueBatchAdoptionArtifact(input.repo_root, intent, 'response', { ...response });
   }

--- a/tasks/contracts/20260909-1202-brc1415-text-connector.contract.md
+++ b/tasks/contracts/20260909-1202-brc1415-text-connector.contract.md
@@ -17,7 +17,7 @@ Oracle refuses before submission when the composer app picker cannot locate GitH
 
 ## Goal
 
-Send literal @GitHub for all four campaign browser operations and accept only invocation-owned current-turn GitHub tool history, preserving exact-revision and authority checks.
+Send literal @github connector for all four campaign browser operations and accept only invocation-owned current-turn GitHub tool history, preserving exact-revision and authority checks.
 
 ## Scope
 
@@ -70,6 +70,7 @@ Required when Task Profile is `bugfix`; leave as-is otherwise.
 
 ```yaml
 allowed_paths:
+  - tests/unit/campaign-revision-evidence.test.ts
   - src/cli/chatgpt-browser/engine.ts
   - src/cli/chatgpt-browser/session-store.ts
   - src/cli/chatgpt-browser/types.ts

--- a/tasks/contracts/20260909-1202-brc1415-text-connector.contract.md
+++ b/tasks/contracts/20260909-1202-brc1415-text-connector.contract.md
@@ -212,7 +212,7 @@ exit_criteria:
     {
       "id": "task-sync",
       "kind": "command",
-      "command": "REPO_HARNESS_DIFF_BASE=dece01a1 REPO_HARNESS_DIFF_MODE=merge-base bash scripts/check-task-sync.sh",
+      "command": "REPO_HARNESS_DIFF_BASE=f9bb667e REPO_HARNESS_DIFF_MODE=merge-base bash scripts/check-task-sync.sh",
       "cwd": ".",
       "phase": "verification",
       "cost": "normal",

--- a/tasks/contracts/20260909-1202-brc1415-text-connector.contract.md
+++ b/tasks/contracts/20260909-1202-brc1415-text-connector.contract.md
@@ -57,7 +57,7 @@ Required when Task Profile is `bugfix`; leave as-is otherwise.
 ## Change Assessment
 
 ```json
-{"protocol": 1, "oracles": [{"id": "text-connector-regression", "kind": "deterministic_test", "paths": ["src/core/automation/campaign-browser-session.ts", "src/core/automation/campaign-revision-evidence.ts"]}]}
+{"protocol": 1, "oracles": [{"id": "text-connector-regression", "kind": "deterministic_test", "paths": ["docs/architecture/.projection-manifest.json", "docs/researches/20260908-brc14-provider-history-evidence.md", "src/cli/chatgpt-browser/engine.ts", "src/cli/chatgpt-browser/session-store.ts", "src/cli/chatgpt-browser/types.ts", "src/core/automation/campaign-browser-session.ts", "src/core/automation/campaign-revision-evidence.ts", "src/effects/automation/campaign-fresh-audit.ts", "src/effects/automation/campaign-revision-observation.ts", "src/effects/automation/gpt-pro-issue-authoring.ts", "src/effects/automation/issue-batch-adoption.ts", "tests/effects/campaign-fresh-audit.test.ts", "tests/effects/campaign-revision-observation.test.ts", "tests/effects/campaign-step.test.ts", "tests/effects/gpt-pro-issue-authoring.test.ts", "tests/helpers/campaign-adoption-repository.ts", "tests/helpers/campaign-browser-session.ts", "tests/unit/campaign-browser-session.test.ts", "tests/unit/campaign-revision-evidence.test.ts"]}]}
 ```
 
 ## Acceptance Policy

--- a/tasks/contracts/20260909-1202-brc1415-text-connector.contract.md
+++ b/tasks/contracts/20260909-1202-brc1415-text-connector.contract.md
@@ -1,0 +1,280 @@
+# Task Contract: brc1415-text-connector
+
+> **Status**: Active
+> **Plan**: plans/plan-20260909-1202-brc1415-text-connector.md
+> **Task Profile**: code-change
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: ancienttwo
+> **Capability ID**: root
+> **Last Updated**: 2026-09-09 04:34
+> **Review File**: `tasks/reviews/20260909-1202-brc1415-text-connector.review.md`
+> **Notes File**: `tasks/notes/20260909-1202-brc1415-text-connector.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+Oracle refuses before submission when the composer app picker cannot locate GitHub, although Owner authorizes explicit text mention activation.
+
+## Goal
+
+Send literal @GitHub for all four campaign browser operations and accept only invocation-owned current-turn GitHub tool history, preserving exact-revision and authority checks.
+
+## Scope
+
+- In scope: campaign prompt framing, captured-history Connector evidence, existing history decoder reuse, focused negative regression and PR delivery.
+- Out of scope: Oracle changes, UI selector fixes, budget reset, failed-request recovery, real canary claims.
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+
+## Falsifier
+
+A composer pill, model answer, wrong session, stale tool turn or mismatched Connector can yield accepted session/revision evidence without a successful current-turn GitHub call.
+
+## Root Cause Evidence
+
+Required when Task Profile is `bugfix`; leave as-is otherwise.
+
+- root_cause: one sentence naming file:line/condition (testable, not "a state issue").
+- repro: the command or UI path that reproduces the symptom.
+- regression_guard: path to a test that fails on the unfixed code and passes after the fix (must also appear as a `package_test` check in Verification Plan).
+- pre_fix_failure_artifact: path to a captured run of regression_guard on the UNFIXED code. Capture with `bun test <regression_guard> > <artifact> 2>&1; echo "PRE_FIX_EXIT=$?" >> <artifact>` (no pipes — pipes swallow the exit status). The gate requires a non-zero `PRE_FIX_EXIT=` line plus the regression_guard path string in the artifact (see the Root Cause Evidence Gate section in docs/reference-configs/sprint-contracts.md).
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260909-1202-brc1415-text-connector.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260909-1202-brc1415-text-connector.review.md`
+- Notes file: `tasks/notes/20260909-1202-brc1415-text-connector.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Change Assessment
+
+```json
+{"protocol": 1, "oracles": [{"id": "text-connector-regression", "kind": "deterministic_test", "paths": ["src/core/automation/campaign-browser-session.ts", "src/core/automation/campaign-revision-evidence.ts"]}]}
+```
+
+## Acceptance Policy
+
+```json
+{"protocol":2,"reviewer":"Codex","source":"codex-plugin","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - src/cli/chatgpt-browser/engine.ts
+  - src/cli/chatgpt-browser/session-store.ts
+  - src/cli/chatgpt-browser/types.ts
+  - src/core/automation/campaign-browser-session.ts
+  - src/core/automation/campaign-revision-evidence.ts
+  - src/effects/automation/campaign-fresh-audit.ts
+  - src/effects/automation/campaign-revision-observation.ts
+  - src/effects/automation/gpt-pro-issue-authoring.ts
+  - src/effects/automation/issue-batch-adoption.ts
+  - tests/effects/campaign-fresh-audit.test.ts
+  - tests/effects/campaign-revision-observation.test.ts
+  - tests/effects/campaign-step.test.ts
+  - tests/effects/gpt-pro-issue-authoring.test.ts
+  - tests/helpers/campaign-adoption-repository.ts
+  - tests/helpers/campaign-browser-session.ts
+  - tests/unit/campaign-browser-session.test.ts
+  - docs/architecture/
+  - docs/researches/20260908-brc14-provider-history-evidence.md
+  - plans/plan-20260909-1202-brc1415-text-connector.md
+  - tasks/contracts/20260909-1202-brc1415-text-connector.contract.md
+  - tasks/notes/20260909-1202-brc1415-text-connector.notes.md
+  - tasks/reviews/20260909-1202-brc1415-text-connector.review.md
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+    fallback: null
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+This block contains only non-executable artifact requirements. Define every
+executable check once in the canonical Verification Plan below. Each check must
+state its phase, cost, evidence policy, necessity, and input environment; a
+missing or malformed plan fails closed.
+
+```yaml
+exit_criteria:
+  files_exist:
+    - docs/spec.md
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260909-1202-brc1415-text-connector.notes.md
+```
+
+## Verification Plan
+
+```json
+{
+  "protocol": 1,
+  "checks": [
+    {
+      "id": "text-connector-regression",
+      "kind": "command",
+      "command": "bun test --timeout 60000 tests/unit/campaign-browser-session.test.ts tests/unit/campaign-revision-evidence.test.ts tests/effects/campaign-revision-observation.test.ts tests/effects/gpt-pro-issue-authoring.test.ts tests/effects/issue-batch-adoption.test.ts tests/effects/campaign-authoring-resume.test.ts tests/effects/campaign-fresh-audit.test.ts tests/effects/campaign-step.test.ts",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Exercises text dispatch, real history decoding, no-model identity, exact SHA, original Issue continuation, authoring/adoption/audit and negative authority gates.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "typecheck",
+      "kind": "command",
+      "command": "bun run check:type",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Validate changed shared types.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "deploy-order",
+      "kind": "command",
+      "command": "bash scripts/check-deploy-sql-order.sh",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository integrity.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "architecture-sync",
+      "kind": "command",
+      "command": "bash scripts/check-architecture-sync.sh",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required architecture projection integrity.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "task-sync",
+      "kind": "command",
+      "command": "REPO_HARNESS_DIFF_BASE=dece01a1 REPO_HARNESS_DIFF_MODE=merge-base bash scripts/check-task-sync.sh",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Bind workflow evidence to this exact substantive diff.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "workflow",
+      "kind": "command",
+      "command": "bash scripts/check-task-workflow.sh --strict",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required workflow integrity.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "project-state",
+      "kind": "command",
+      "command": "bun scripts/inspect-project-state.ts --repo . --format text",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required state integrity.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "init-dry-run",
+      "kind": "command",
+      "command": "bun src/cli/index.ts init --repo . --dry-run",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required init projection integrity.",
+      "inputs": {
+        "env": []
+      }
+    }
+  ]
+}
+```
+
+This is the sole executable verification authority. Use `baseline_with_delta`
+only when a referenced immutable baseline plus named current delta checks prove
+the intended coverage; do not infer that choice from paths or command text.
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior:
+- Edge cases:
+- Regression risks:
+
+## Rollback Point
+
+- Commit / checkpoint:
+- Revert strategy:

--- a/tasks/notes/20260909-1202-brc1415-text-connector.notes.md
+++ b/tasks/notes/20260909-1202-brc1415-text-connector.notes.md
@@ -1,0 +1,5 @@
+# Text Connector activation decisions
+
+Owner explicitly replaces UI selection with text activation. Preserve historical immutable receipts without upgrading their claims. New evidence derives Connector identity from captured current-turn provider tool metadata; session ownership remains Oracle metadata. Shared history validation stays in campaign-revision-evidence.ts for both consumers. No new dependency or source file. Exact SHA decoder still checks original complete GitHub tool resources.
+
+Original canary failure is unchanged and retained; this code acceptance does not claim recovery, delivery or BRC14/15 completion.

--- a/tasks/notes/20260909-1202-brc1415-text-connector.notes.md
+++ b/tasks/notes/20260909-1202-brc1415-text-connector.notes.md
@@ -3,3 +3,7 @@
 Owner explicitly replaces UI selection with text activation. Preserve historical immutable receipts without upgrading their claims. New evidence derives Connector identity from captured current-turn provider tool metadata; session ownership remains Oracle metadata. Shared history validation stays in campaign-revision-evidence.ts for both consumers. No new dependency or source file. Exact SHA decoder still checks original complete GitHub tool resources.
 
 Original canary failure is unchanged and retained; this code acceptance does not claim recovery, delivery or BRC14/15 completion.
+
+> **Substantive Change SHA256**: `sha256:a2a2795fabcfc12da127ce5e1c2e9a4aa3c4b457707f39ecf9a20ddca33a12d0`
+
+Final format is Owner-specified literal `@github connector`. The format correction supersedes the earlier spelling. The frozen candidate passed behavior/type/integrity checks; task-sync was corrected from the predecessor baseline to f9bb667e and bound using its canonical v3 substantive fingerprint. A standalone state-profile query returned exit 1 without diagnostics; no unrelated state-resolver change was made.

--- a/tasks/notes/20260909-1202-brc1415-text-connector.notes.md
+++ b/tasks/notes/20260909-1202-brc1415-text-connector.notes.md
@@ -7,3 +7,5 @@ Original canary failure is unchanged and retained; this code acceptance does not
 > **Substantive Change SHA256**: `sha256:a2a2795fabcfc12da127ce5e1c2e9a4aa3c4b457707f39ecf9a20ddca33a12d0`
 
 Final format is Owner-specified literal `@github connector`. The format correction supersedes the earlier spelling. The frozen candidate passed behavior/type/integrity checks; task-sync was corrected from the predecessor baseline to f9bb667e and bound using its canonical v3 substantive fingerprint. A standalone state-profile query returned exit 1 without diagnostics; no unrelated state-resolver change was made.
+
+The strict auth classifier selects the complete diff. Its deterministic oracle now maps the existing focused regression to the full caller, shared validator and fixture surface; documentation/projection changes describe that same behavior and are checked by the already-declared integrity commands. This adds no executable check and changes no production code. Change Assessment is pass before final preparation.

--- a/tasks/reviews/20260909-1202-brc1415-text-connector.review.md
+++ b/tasks/reviews/20260909-1202-brc1415-text-connector.review.md
@@ -1,0 +1,84 @@
+# Task Review: brc1415-text-connector
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260909-1202-brc1415-text-connector.md
+> **Contract**: tasks/contracts/20260909-1202-brc1415-text-connector.contract.md
+> **Notes File**: tasks/notes/20260909-1202-brc1415-text-connector.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-09-09 12:02
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Commands passed:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+- Waza `/check` run:
+- Commands run:
+- Manual checks:
+- Supporting artifacts:
+- Implementation notes reviewed:
+- Run snapshot:
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...

--- a/tasks/reviews/20260909-1202-brc1415-text-connector.review.md
+++ b/tasks/reviews/20260909-1202-brc1415-text-connector.review.md
@@ -1,16 +1,16 @@
 # Task Review: brc1415-text-connector
 
-> **Status**: Pending
+> **Status**: Accepted
 > **Plan**: plans/plan-20260909-1202-brc1415-text-connector.md
 > **Contract**: tasks/contracts/20260909-1202-brc1415-text-connector.contract.md
 > **Notes File**: tasks/notes/20260909-1202-brc1415-text-connector.notes.md
 > **Checks File**: .ai/harness/checks/latest.json
 > **Last Updated**: 2026-09-09 12:02
-> **Recommendation**: fail
+> **Recommendation**: pass
 > **Review Rubric Version**: 2
-> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject SHA256**: sha256:f0c53f3c9220a40f8e23f1ba650d5f8ea28cb22bbe6a201001c7a6ad50d6bbe9
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: pending
+> **Reviewed Target Revision**: f9bb667ec09324e392dc9f387957b19b8000abbf
 
 ## Human Review Card
 
@@ -40,17 +40,17 @@
 
 ## Acceptance Receipt Projection
 
-> **Disposition**: unavailable
-> **Reviewer**: unavailable
-> **Source**: unavailable
+> **Disposition**: external_pass
+> **Reviewer**: Codex
+> **Source**: codex-plugin
 > **Actor**: not-applicable
-> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject SHA256**: sha256:f0c53f3c9220a40f8e23f1ba650d5f8ea28cb22bbe6a201001c7a6ad50d6bbe9
 > **Reviewed Subject Scope**: normalized-final-content
-> **Reviewed Target Revision**: pending
-> **Verification Evidence SHA256**: pending
-> **Issued At**: pending
+> **Reviewed Target Revision**: f9bb667ec09324e392dc9f387957b19b8000abbf
+> **Verification Evidence SHA256**: sha256:a6f03bdd3f043d1600413640876ceb9f60b2b6683ce4c115735e37a81e42086a
+> **Issued At**: 2026-09-09T04:27:14.219Z
 
-- Summary: No AcceptanceReceipt has been recorded.
+- Summary: Exact @github connector transport; current-turn Connector evidence; focused and required checks plus scoped security and architecture review passed. Real canary remains pending.
 - Findings: none
 
 ## Behavior Diff Notes

--- a/tests/effects/campaign-fresh-audit.test.ts
+++ b/tests/effects/campaign-fresh-audit.test.ts
@@ -85,7 +85,7 @@ test('fresh audit uses current default/GitHub, charges after authoring sealed, a
     readBinding: f.binding,
     consult: async (input: any) => {
       calls++;
-      expect(input.chatgptApp).toBeNull(); expect(input.prompt).toStartWith('@GitHub ');
+      expect(input.chatgptApp).toBeNull(); expect(input.prompt).toStartWith('@github connector ');
       const instructions = JSON.parse(input.prompt.slice(input.prompt.indexOf('\n') + 1));
     expect(instructions).toContain(`https://api.github.com/repos/${f.intent.provider_repository}/git/commits/${git(f.root, ['rev-parse', 'HEAD'])}`);
       expect(instructions).toContain(`https://api.github.com/repos/${f.intent.provider_repository}/git/ref/${f.intent.target_ref.slice(5)}`);
@@ -271,8 +271,8 @@ test.each([1,2,3].flatMap(groupCount => (['accepted','accepted_with_followups','
     return {sessionId,status:'completed' as const,meta:campaignBrowserMetadata({repoRoot:f.root,sessionId,profileDir:input.profileDir,profileDirectory:input.profileDirectory,sourceSessionId:input.sessionId})};
   };
   const started=await startIssueBatchAuthoring({repo_root:f.root,campaign_id:f.intent.campaign_id,group_number:2,dry_run:true,env:f.env},{readBinding:f.binding,consult});
-  expect(prompt).toStartWith('@GitHub ');
-  expect(started.intent.prompt_sha256).toBe(messageSha256(prompt.slice('@GitHub '.length)));
+  expect(prompt).toStartWith('@github connector ');
+  expect(started.intent.prompt_sha256).toBe(messageSha256(prompt.slice('@github connector '.length)));
   await continueIssueBatchAuthoring({repo_root:f.root,campaign_id:f.intent.campaign_id,group_number:2,intent_sha256:started.intent.intent_sha256,source_session_ref:started.session.session_ref,operation:'fill_missing',requested_slots:['02'],dry_run:true,env:f.env},{readBinding:f.binding,followup:consult});
   expect(prompt).toContain('only for these missing slots: 02');
 },60000);

--- a/tests/effects/campaign-fresh-audit.test.ts
+++ b/tests/effects/campaign-fresh-audit.test.ts
@@ -85,7 +85,7 @@ test('fresh audit uses current default/GitHub, charges after authoring sealed, a
     readBinding: f.binding,
     consult: async (input: any) => {
       calls++;
-      expect(input.chatgptApp).toBe('GitHub');
+      expect(input.chatgptApp).toBeNull(); expect(input.prompt).toStartWith('@GitHub ');
       const instructions = JSON.parse(input.prompt.slice(input.prompt.indexOf('\n') + 1));
     expect(instructions).toContain(`https://api.github.com/repos/${f.intent.provider_repository}/git/commits/${git(f.root, ['rev-parse', 'HEAD'])}`);
       expect(instructions).toContain(`https://api.github.com/repos/${f.intent.provider_repository}/git/ref/${f.intent.target_ref.slice(5)}`);
@@ -234,7 +234,7 @@ test.each([1,2,3].flatMap(groupCount => (['accepted','accepted_with_followups','
     const output=JSON.stringify({protocol:1,disposition,observed_main_sha:snapshot.expected_final_main_sha,slots:['01','02'],findings:['Preserve exact upstream finding: \"retry boundary\"']});
     const history=structuredClone(historyFixture);
     const body=JSON.parse(history.response.body.replaceAll('example/canary',snapshot.provider_repository).replaceAll('a'.repeat(40),snapshot.expected_final_main_sha));
-    body.messages[0].content.parts=['@GitHub '+input.prompt];body.messages[3].content.parts=[output];history.response.body=JSON.stringify(body);
+    body.messages[0].content.parts=[input.prompt];body.messages[3].content.parts=[output];history.response.body=JSON.stringify(body);
     history.response.decodedBodySha256=createHash('sha256').update(history.response.body).digest('hex');
     return {sessionId:'audit-fresh-local',status:'completed' as const,output,meta:{status:'completed',sessionId:'audit-fresh-local',provider:'oracle',engine:'chatgpt-browser',repo:f.root,providerSessionId:'audit-fresh-provider',model:{verified:false},
       browser:{transport:'copy_profile',profileDir:'/fixture/profile',profileDirectory:f.authorization.campaign!.chrome_profile_directory,chatgptApp:'GitHub'},
@@ -271,7 +271,8 @@ test.each([1,2,3].flatMap(groupCount => (['accepted','accepted_with_followups','
     return {sessionId,status:'completed' as const,meta:campaignBrowserMetadata({repoRoot:f.root,sessionId,profileDir:input.profileDir,profileDirectory:input.profileDirectory,sourceSessionId:input.sessionId})};
   };
   const started=await startIssueBatchAuthoring({repo_root:f.root,campaign_id:f.intent.campaign_id,group_number:2,dry_run:true,env:f.env},{readBinding:f.binding,consult});
-  expect(started.intent.prompt_sha256).toBe(messageSha256(prompt));
+  expect(prompt).toStartWith('@GitHub ');
+  expect(started.intent.prompt_sha256).toBe(messageSha256(prompt.slice('@GitHub '.length)));
   await continueIssueBatchAuthoring({repo_root:f.root,campaign_id:f.intent.campaign_id,group_number:2,intent_sha256:started.intent.intent_sha256,source_session_ref:started.session.session_ref,operation:'fill_missing',requested_slots:['02'],dry_run:true,env:f.env},{readBinding:f.binding,followup:consult});
   expect(prompt).toContain('only for these missing slots: 02');
 },60000);
@@ -322,7 +323,7 @@ test('three-group real-store sequence carries each final SHA and refuses Group 4
         const output = JSON.stringify({ protocol: 1, disposition: 'accepted', observed_main_sha: snapshot.expected_final_main_sha, slots: ['01', '02'], findings: [] });
         const history = structuredClone(historyFixture);
         const body = JSON.parse(history.response.body.replaceAll('example/canary', snapshot.provider_repository).replaceAll('a'.repeat(40), snapshot.expected_final_main_sha));
-        body.messages[0].content.parts = ['@GitHub ' + input.prompt]; body.messages[3].content.parts = [output];
+        body.messages[0].content.parts = [input.prompt]; body.messages[3].content.parts = [output];
         history.response.body = JSON.stringify(body); history.response.decodedBodySha256 = createHash('sha256').update(history.response.body).digest('hex');
         const sessionId = `chain-audit-${group}`, providerSessionId = `chain-provider-${group}`;
         const meta = campaignBrowserMetadata({ repoRoot: f.root, sessionId, profileDir: input.profileDir, profileDirectory: input.profileDirectory });

--- a/tests/effects/campaign-revision-observation.test.ts
+++ b/tests/effects/campaign-revision-observation.test.ts
@@ -58,7 +58,7 @@ test('pre-active observation without intent charges once and permits later real 
   const f = fixture(); let calls = 0;
   const deps = { readBinding: f.readBinding, consult: async (input: any) => {
     calls++;
-    expect(input.captureNetworkEvidence).toBe(true); expect(input.chatgptApp).toBe('GitHub');
+    expect(input.captureNetworkEvidence).toBe(true); expect(input.chatgptApp).toBeNull(); expect(input.prompt).toStartWith('@GitHub ');
     expect(input.model).toBeUndefined(); expect(input.thinkingTime).toBeUndefined(); expect(input.sessionId).toBeUndefined();
     expect(input.prompt).toContain('Do not create, edit, close or reopen Issues');
     const instructions = JSON.parse(input.prompt.slice(input.prompt.indexOf('\n') + 1));
@@ -226,7 +226,7 @@ function historyBrowser(f: ReturnType<typeof fixture>, prompt: string) {
   const value=f.browser(), output=JSON.stringify({observed_main_sha:f.campaign.target_revision,summary:'Read commit and ref.'});
   const history=structuredClone(historyFixture);
   const body=JSON.parse(history.response.body.replaceAll('example/canary','acme/widgets').replaceAll('a'.repeat(40),f.campaign.target_revision));
-  body.messages[0].content.parts=['@GitHub '+prompt]; body.messages[3].content.parts=[output];
+  body.messages[0].content.parts=[prompt]; body.messages[3].content.parts=[output];
   history.response.body=JSON.stringify(body);history.response.decodedBodySha256=createHash('sha256').update(history.response.body).digest('hex');
   const oracle=value.meta.oracle;
   return {...value,output,meta:{...value.meta,oracle:{...oracle,observation:{...oracle.observation!,appSelection:{...oracle.observation!.appSelection!,pluginId:'plugin:connector_76869538009648d5b282a4bb21c3d157'}},conversationCapture:{status:'captured',sessionId:value.meta.providerSessionId,conversationId:history.conversationId,sha256:'sha256:'+'f'.repeat(64),history}}}};

--- a/tests/effects/campaign-revision-observation.test.ts
+++ b/tests/effects/campaign-revision-observation.test.ts
@@ -58,7 +58,7 @@ test('pre-active observation without intent charges once and permits later real 
   const f = fixture(); let calls = 0;
   const deps = { readBinding: f.readBinding, consult: async (input: any) => {
     calls++;
-    expect(input.captureNetworkEvidence).toBe(true); expect(input.chatgptApp).toBeNull(); expect(input.prompt).toStartWith('@GitHub ');
+    expect(input.captureNetworkEvidence).toBe(true); expect(input.chatgptApp).toBeNull(); expect(input.prompt).toStartWith('@github connector ');
     expect(input.model).toBeUndefined(); expect(input.thinkingTime).toBeUndefined(); expect(input.sessionId).toBeUndefined();
     expect(input.prompt).toContain('Do not create, edit, close or reopen Issues');
     const instructions = JSON.parse(input.prompt.slice(input.prompt.indexOf('\n') + 1));

--- a/tests/effects/campaign-step.test.ts
+++ b/tests/effects/campaign-step.test.ts
@@ -430,7 +430,7 @@ describe('durable campaign heartbeat step', () => {
         expect(request.prompt).toContain('missing slots: 08, 09, 10.');
         expect(request.prompt).toContain('Do not edit or duplicate any other slot.');
         expect(request).not.toHaveProperty('model');
-        expect(request.chatgptApp).toBeNull(); expect(request.prompt).toStartWith('@GitHub ');
+        expect(request.chatgptApp).toBeNull(); expect(request.prompt).toStartWith('@github connector ');
         throw new Error('browser disconnected after seven observed Issues');
       },
     };

--- a/tests/effects/campaign-step.test.ts
+++ b/tests/effects/campaign-step.test.ts
@@ -430,7 +430,7 @@ describe('durable campaign heartbeat step', () => {
         expect(request.prompt).toContain('missing slots: 08, 09, 10.');
         expect(request.prompt).toContain('Do not edit or duplicate any other slot.');
         expect(request).not.toHaveProperty('model');
-        expect(request.chatgptApp).toBe('GitHub');
+        expect(request.chatgptApp).toBeNull(); expect(request.prompt).toStartWith('@GitHub ');
         throw new Error('browser disconnected after seven observed Issues');
       },
     };

--- a/tests/effects/gpt-pro-issue-authoring.test.ts
+++ b/tests/effects/gpt-pro-issue-authoring.test.ts
@@ -326,7 +326,7 @@ describe('GPT Pro issue batch authoring effect', () => {
     const started = await startIssueBatchAuthoring({ repo_root: f.root, campaign_id: 'campaign-1', group_number: 1, env: f.env }, { readBinding: readBrowserBinding, now: () => observedAt, consult: async (input) => result(input, 'session-initial', 'completed', true) });
     const calls: Array<{ sessionId: string; prompt: string; secretScan?: boolean }> = [];
     const followup = async (input: Omit<BrowserConsultInput, 'sourceSessionId'> & { sessionId: string }) => {
-      expect(input.chatgptApp).toBeNull(); expect(input.prompt).toStartWith('@GitHub ');
+      expect(input.chatgptApp).toBeNull(); expect(input.prompt).toStartWith('@github connector ');
       expect(input).not.toHaveProperty('model');
       expect(input).not.toHaveProperty('thinking');
       calls.push({ sessionId: input.sessionId, prompt: input.prompt, secretScan: input.requireSecretScan });

--- a/tests/effects/gpt-pro-issue-authoring.test.ts
+++ b/tests/effects/gpt-pro-issue-authoring.test.ts
@@ -121,13 +121,7 @@ describe('GPT Pro issue batch authoring effect', () => {
     const started = await startIssueBatchAuthoring({ repo_root: f.root, campaign_id: 'campaign-1', group_number: 1, env: f.env }, {
       readBinding: readBrowserBinding, now: () => observedAt,
       consult: async input => {
-        const value = result(input, 'default-session', 'completed', false);
-        return { ...value, meta: { ...value.meta,
-          providerSessionId: 'oracle-default',
-          browser: { ...value.meta.browser, chatgptApp: 'GitHub' },
-          oracle: { observation: { source: 'oracle-session-metadata' as const, sessionId: 'oracle-default', parentSessionId: null,
-            appSelection: { status: 'selected', app: 'GitHub', pluginId: 'plugin:github', source: 'chatgpt-composer-pill', capturedAt: observedAt } } },
-        } };
+        return result(input, 'default-session', 'completed', true);
       },
     });
     expect(started.browser.meta.model.verified).toBe(false);
@@ -317,7 +311,7 @@ describe('GPT Pro issue batch authoring effect', () => {
         return result(input, 'session-initial');
       },
     });
-    expect(captured).toMatchObject({ provider: 'oracle', chatgptApp: 'GitHub', requireSecretScan: true, profileDirectory: 'Profile 13' });
+    expect(captured).toMatchObject({ provider: 'oracle', captureConversationEvidence: true, requireSecretScan: true, profileDirectory: 'Profile 13' });
     expect(captured).not.toHaveProperty('model');
     expect(captured).not.toHaveProperty('thinking');
     expect(started.intent).toMatchObject({ repository_id: 'repo-1', provider_repository: 'acme/widgets', target_ref: 'refs/heads/main', base_main_sha: f.revision });
@@ -332,7 +326,7 @@ describe('GPT Pro issue batch authoring effect', () => {
     const started = await startIssueBatchAuthoring({ repo_root: f.root, campaign_id: 'campaign-1', group_number: 1, env: f.env }, { readBinding: readBrowserBinding, now: () => observedAt, consult: async (input) => result(input, 'session-initial', 'completed', true) });
     const calls: Array<{ sessionId: string; prompt: string; secretScan?: boolean }> = [];
     const followup = async (input: Omit<BrowserConsultInput, 'sourceSessionId'> & { sessionId: string }) => {
-      expect(input).toMatchObject({ chatgptApp: 'GitHub' });
+      expect(input.chatgptApp).toBeNull(); expect(input.prompt).toStartWith('@GitHub ');
       expect(input).not.toHaveProperty('model');
       expect(input).not.toHaveProperty('thinking');
       calls.push({ sessionId: input.sessionId, prompt: input.prompt, secretScan: input.requireSecretScan });

--- a/tests/helpers/campaign-adoption-repository.ts
+++ b/tests/helpers/campaign-adoption-repository.ts
@@ -67,7 +67,7 @@ export async function observeVerifiedFixtureRevision(f: { root: string; authoriz
       const output = 'Read the frozen fixture revision.';
       const history = structuredClone(historyFixture);
       const body = JSON.parse(history.response.body.replaceAll('example/canary', 'acme/widgets').replaceAll('a'.repeat(40), f.authorization.target_revision));
-      body.messages[0].content.parts = ['@GitHub ' + input.prompt]; body.messages[3].content.parts = [output];
+      body.messages[0].content.parts = [input.prompt]; body.messages[3].content.parts = [output];
       history.response.body = JSON.stringify(body); history.response.decodedBodySha256 = createHash('sha256').update(history.response.body).digest('hex');
       const meta = campaignBrowserMetadata({ repoRoot: f.root, sessionId, profileDir: input.profileDir, profileDirectory: input.profileDirectory });
       return { sessionId, status: 'completed' as const, output, meta: { ...meta, providerSessionId,

--- a/tests/helpers/campaign-browser-session.ts
+++ b/tests/helpers/campaign-browser-session.ts
@@ -8,7 +8,7 @@ export function campaignBrowserMetadata(input: { repoRoot: string; sessionId: st
   const parent = input.sourceSessionId ? `oracle-${input.sourceSessionId}` : undefined;
   const history = structuredClone(historyFixture);
   const body = JSON.parse(history.response.body.replaceAll('connector_76869538009648d5b282a4bb21c3d157', 'github'));
-  body.messages[0].content.parts = ['@GitHub fixture request'];
+  body.messages[0].content.parts = ['@github connector fixture request'];
   history.response.body = JSON.stringify(body);
   history.response.decodedBodySha256 = createHash('sha256').update(history.response.body).digest('hex');
   return {

--- a/tests/helpers/campaign-browser-session.ts
+++ b/tests/helpers/campaign-browser-session.ts
@@ -1,16 +1,22 @@
+import { createHash } from 'crypto';
+import historyFixture from '../fixtures/campaign-revision-evidence/history.json';
 import type { BrowserSessionMeta, BrowserSessionStatus } from '../../src/cli/chatgpt-browser/types';
 import { readCampaignBrowserSessionEvidence } from '../../src/core/automation/campaign-browser-session';
 export function campaignBrowserMetadata(input: { repoRoot: string; sessionId: string; profileDir: string; profileDirectory: string; sourceSessionId?: string; status?: BrowserSessionStatus }): BrowserSessionMeta {
   const at = '2026-09-05T00:00:00.000Z';
   const providerId = `oracle-${input.sessionId}`;
   const parent = input.sourceSessionId ? `oracle-${input.sourceSessionId}` : undefined;
+  const history = structuredClone(historyFixture);
+  const body = JSON.parse(history.response.body.replaceAll('connector_76869538009648d5b282a4bb21c3d157', 'github'));
+  body.messages[0].content.parts = ['@GitHub fixture request'];
+  history.response.body = JSON.stringify(body);
+  history.response.decodedBodySha256 = createHash('sha256').update(history.response.body).digest('hex');
   return {
     version: 1, engine: 'chatgpt-browser', provider: 'oracle', repo: input.repoRoot, sessionId: input.sessionId,
     status: input.status ?? 'completed', createdAt: at, updatedAt: at, model: { verified: false },
     providerSessionId: providerId, ...(input.sourceSessionId ? { sourceSessionId: input.sourceSessionId, parentProviderSessionId: parent } : {}),
-    browser: { mode: 'manual-login', transport: 'copy_profile', chatgptUrl: 'https://chatgpt.com/', chatgptApp: 'GitHub', profileDir: input.profileDir, profileDirectory: input.profileDirectory },
-    oracle: { observation: { source: 'oracle-session-metadata', sessionId: providerId, parentSessionId: parent ?? null,
-      appSelection: { status: 'selected', app: 'GitHub', pluginId: 'plugin:github', source: 'chatgpt-composer-pill', capturedAt: at } } },
+    browser: { mode: 'manual-login', transport: 'copy_profile', chatgptUrl: 'https://chatgpt.com/', profileDir: input.profileDir, profileDirectory: input.profileDirectory },
+    oracle: { conversationCapture: { status: 'captured', sessionId: providerId, conversationId: history.conversationId, sha256: 'sha256:' + 'f'.repeat(64), history }, observation: { source: 'oracle-session-metadata', sessionId: providerId, parentSessionId: parent ?? null } },
     input: { promptPath: 'prompt.md', files: [], followups: 0 }, output: { outputPath: 'output.md', transcriptPath: 'transcript.md', artifactsDir: 'artifacts', artifacts: [] },
     diagnostics: { dryRun: false, reattachable: false, lastCaptureAt: at },
   };

--- a/tests/unit/campaign-browser-session.test.ts
+++ b/tests/unit/campaign-browser-session.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import { expect, test } from 'bun:test';
 import { readCampaignBrowserSessionEvidence, validateCampaignBrowserSessionEvidence } from '../../src/core/automation/campaign-browser-session';
 import { requireVerifiedIssueAuthoringSession, validateIssueAuthoringSession } from '../../src/core/automation/issue-batch';
@@ -24,10 +25,9 @@ const faults: Record<string, (v: ReturnType<typeof result>) => void> = {
   'missing descriptor': v => { delete v.meta.providerSessionId; },
   'descriptor mismatch': v => { v.meta.providerSessionId = 'foreign'; },
   'descriptor error': v => { v.meta.oracle!.evidenceError = 'invalid descriptor'; },
-  'missing app': v => { delete v.meta.oracle!.observation!.appSelection; },
-  'wrong app': v => { (v.meta.oracle!.observation!.appSelection as Record<string, unknown>).app = 'Other'; },
-  'unselected app': v => { (v.meta.oracle!.observation!.appSelection as Record<string, unknown>).status = 'unverified'; },
-  'wrong observation origin': v => { (v.meta.oracle!.observation!.appSelection as Record<string, unknown>).source = 'answer-text'; },
+  'missing tool history': v => { delete v.meta.oracle!.conversationCapture; },
+  'wrong capture session': v => { Object.assign(v.meta.oracle!.conversationCapture!, {sessionId: 'foreign'}); },
+  'empty tool capture': v => { Object.assign(v.meta.oracle!.conversationCapture!, {status: 'missing'}); },
   'model-only proof': v => { delete v.meta.oracle; v.meta.model.verified = true; },
   'initial foreign parent': v => { v.meta.parentProviderSessionId = 'foreign'; v.meta.oracle!.observation!.parentSessionId = 'foreign'; },
 };
@@ -55,4 +55,46 @@ test('evidence tampering and response parent mismatch are rejected; receipts pre
   expect(receipt.response_provider_session_ref).toBe(f.response_session_evidence!.provider_session_ref);
   expect(receipt.response_session_evidence_sha256).toBe(f.response_session_evidence!.evidence_sha256);
   expect(receipt).not.toHaveProperty('observed_main_sha');
+});
+
+test('a UI selection pill alone cannot substitute for real Connector history', () => {
+  const v = result(); delete v.meta.oracle!.conversationCapture;
+  v.meta.oracle!.observation!.appSelection = { status: 'selected', app: 'GitHub', pluginId: 'plugin:github', source: 'chatgpt-composer-pill', capturedAt: '2026-09-05T00:00:00Z' };
+  expect(readCampaignBrowserSessionEvidence(v, binding)).toBeNull();
+});
+
+function editHistory(v: ReturnType<typeof result>, change: (body: any) => void) {
+  const h = v.meta.oracle!.conversationCapture!.history as any;
+  const body = JSON.parse(h.response.body); change(body);
+  h.response.body = JSON.stringify(body);
+  h.response.decodedBodySha256 = createHash('sha256').update(h.response.body).digest('hex');
+}
+for (const [name, change] of Object.entries({
+  'answer-only GitHub claim': (b: any) => { b.messages = b.messages.filter((m: any) => m.author.role !== 'tool'); },
+  'old-turn tool returns': (b: any) => { for (const m of b.messages.filter((m: any) => m.author.role === 'tool')) m.metadata.turn_exchange_id = 'old-turn'; },
+  'wrong Connector app': (b: any) => { for (const m of b.messages.filter((m: any) => m.author.role === 'tool')) m.metadata.invoked_resource.app_name = 'Other'; },
+  'mismatched Connector citation': (b: any) => { b.messages[1].metadata.citation_metadata.__connector_id = 'foreign'; },
+  'failed tool return': (b: any) => { b.messages[1].status = 'failed'; },
+  'truncated history': (b: any) => { b.page_info.has_previous_page = true; },
+})) test(`text activation rejects ${name}`, () => {
+  const v = result(); editHistory(v, change);
+  expect(readCampaignBrowserSessionEvidence(v, binding)).toBeNull();
+});
+test('text activation refuses changed history bytes without a matching digest', () => {
+  const v = result(); const h = v.meta.oracle!.conversationCapture!.history as any;
+  h.response.body += ' ';
+  expect(readCampaignBrowserSessionEvidence(v, binding)).toBeNull();
+});
+
+test('text campaign follow-up clears a historical UI app through the real browser command builder', async () => {
+  const { mkdtempSync, rmSync } = await import('fs'); const { tmpdir } = await import('os'); const { join } = await import('path');
+  const { runBrowserConsult, runBrowserFollowup } = await import('../../src/cli/chatgpt-browser/engine');
+  const root = mkdtempSync(join(tmpdir(), 'text-connector-'));
+  try {
+    const first = await runBrowserConsult({ repoRoot: root, prompt: 'original', title: 'historical-app', provider: 'oracle', chatgptApp: 'GitHub', dryRun: true });
+    const next = await runBrowserFollowup({ repoRoot: root, sessionId: first.sessionId, prompt: '@GitHub read the exact revision', title: 'text-app', chatgptApp: null, dryRun: true });
+    expect(next.dryRun!.command).not.toContain('--browser-app');
+    expect(next.dryRun!.command).toContain('@GitHub read the exact revision');
+    expect(next.meta.browser.chatgptApp).toBeUndefined();
+  } finally { rmSync(root, {recursive: true, force: true}); }
 });

--- a/tests/unit/campaign-browser-session.test.ts
+++ b/tests/unit/campaign-browser-session.test.ts
@@ -92,9 +92,9 @@ test('text campaign follow-up clears a historical UI app through the real browse
   const root = mkdtempSync(join(tmpdir(), 'text-connector-'));
   try {
     const first = await runBrowserConsult({ repoRoot: root, prompt: 'original', title: 'historical-app', provider: 'oracle', chatgptApp: 'GitHub', dryRun: true });
-    const next = await runBrowserFollowup({ repoRoot: root, sessionId: first.sessionId, prompt: '@GitHub read the exact revision', title: 'text-app', chatgptApp: null, dryRun: true });
+    const next = await runBrowserFollowup({ repoRoot: root, sessionId: first.sessionId, prompt: '@github connector read the exact revision', title: 'text-app', chatgptApp: null, dryRun: true });
     expect(next.dryRun!.command).not.toContain('--browser-app');
-    expect(next.dryRun!.command).toContain('@GitHub read the exact revision');
+    expect(next.dryRun!.command).toContain('@github connector read the exact revision');
     expect(next.meta.browser.chatgptApp).toBeUndefined();
   } finally { rmSync(root, {recursive: true, force: true}); }
 });

--- a/tests/unit/campaign-revision-evidence.test.ts
+++ b/tests/unit/campaign-revision-evidence.test.ts
@@ -3,7 +3,7 @@ import { createHash } from 'crypto';
 import history from '../fixtures/campaign-revision-evidence/history.json';
 import { readCampaignRevisionEvidence, encodeCampaignRevisionPrompt } from '../../src/core/automation/campaign-revision-evidence';
 const expected={providerSessionId:'session-fixture',connectorId:'connector_76869538009648d5b282a4bb21c3d157',repository:'example/canary',ref:'refs/heads/main',commit:'a'.repeat(40),prompt:'Read exact revision.',answer:'audit fixture'};
-const capture=()=>({status:'captured',sessionId:expected.providerSessionId,conversationId:history.conversationId,sha256:'sha256:'+'f'.repeat(64),history:structuredClone(history)});
+const capture=()=>{const h=structuredClone(history);const b=JSON.parse(h.response.body);b.messages[0].content.parts=['@github connector '+expected.prompt];h.response.body=JSON.stringify(b);h.response.decodedBodySha256=createHash('sha256').update(h.response.body).digest('hex');return {status:'captured',sessionId:expected.providerSessionId,conversationId:h.conversationId,sha256:'sha256:'+'f'.repeat(64),history:h};};
 function mutate(fn:(b:any)=>void){const c=capture();const b=JSON.parse(c.history.response.body);fn(b);c.history.response.body=JSON.stringify(b);c.history.response.decodedBodySha256=createHash('sha256').update(c.history.response.body).digest('hex');return c;}
 test('provider commit and ref responses establish exact revision without assistant authority',()=>{
  const result=readCampaignRevisionEvidence(capture(),expected);expect(result?.commit_sha).toBe(expected.commit);expect(result?.tree_sha).toBe('b'.repeat(40));
@@ -19,7 +19,7 @@ test.each([
  ['not GitHub',(b:any)=>{b.messages[1].metadata.invoked_resource.app_name='Other';}],
  ['pagination',(b:any)=>{b.page_info.has_next_page=true;}],
  ['truncated wrapper',(b:any)=>{b.messages[1].content.parts[0]='Resource uri: /response/turn0\nShowing 10 of 13 lines.';}],
- ['body changed',(b:any)=>{b.messages[0].content.parts=['@GitHub different request'];}],
+ ['body changed',(b:any)=>{b.messages[0].content.parts=['@github connector different request'];}],
  ['answer changed',(b:any)=>{b.messages[3].content.parts=['different answer'];}],
  ['duplicate tool',(b:any)=>{b.messages.push({...b.messages[1],id:'duplicate'});}],
  ['wrong repository',(b:any)=>{b.messages[1].metadata.citation_metadata.url='https://api.github.com/repos/other/repo/git/commits/'+expected.commit;}],
@@ -40,8 +40,8 @@ test('provider tool identity remains authoritative when user UI system hints are
   expect(prompt).not.toContain('github.com');
   expect(JSON.parse(prompt.slice(prompt.indexOf('\n') + 1))).toBe(instructions);
   const request = {...expected, prompt};
-  const c = mutate(b => {b.messages[0].content.parts = ['@GitHub '+prompt];});
+  const c = mutate(b => {b.messages[0].content.parts = ['@github connector '+prompt];});
   expect(readCampaignRevisionEvidence(c, request)?.commit_sha).toBe(expected.commit);
-  const changed = mutate(b => {b.messages[0].content.parts = ['@GitHub '+prompt+' changed'];});
+  const changed = mutate(b => {b.messages[0].content.parts = ['@github connector '+prompt+' changed'];});
   expect(readCampaignRevisionEvidence(changed, request)).toBeNull();
  });


### PR DESCRIPTION
Campaign calls failed before submission when Oracle could not find GitHub in the composer app picker. They now send the exact literal `@github connector <prompt>` and explicitly clear app preselection, including any app inherited from a historical follow-up session.

Session evidence now requires invocation-owned captured conversation history with successful GitHub tool returns in the current completed turn. A UI pill, model claim, old-turn tool result or mismatched Connector is rejected. The shared history validator and existing exact-SHA decoder continue to validate original GitHub resource returns, session ownership and prompt/answer binding. No Oracle changes, model overrides or budget resets are included.

Validation: focused campaign regression, type checking and required repository integrity acceptance. The real browser-command regression confirms follow-up does not emit `--browser-app`. Read-only security and architecture review passed. The retained real canary failure is unchanged; this PR does not claim BRC14/BRC15 delivery or fresh-audit completion.
