### PR TITLE
test(agents): align positive routing fixtures with Astra fleet

### DIFF
--- a/tasks/waivers/20260909-agents-astra-test-fixtures.json
+++ b/tasks/waivers/20260909-agents-astra-test-fixtures.json
@@ -1,0 +1,13 @@
+{
+  "protocol": 1,
+  "kind": "repo-harness-substantive-change-waiver",
+  "substantive_change_sha256": "sha256:1b7c2628c00c86691c9da9949062aaaf6c83c9bc873ae9d4f3a805f2b660b1b4",
+  "reason": "Tests-only alignment of positive routing fixtures with the Codex fleet TOML authority changed by bc2328db (fast-worker, deep-worker and gatekeeper moved to gpt-6-astra). main CI is red on these five assertions; no runtime, hook, or workflow semantics change. Negative identity-mismatch fixtures are untouched.",
+  "owner": "ancienttwo",
+  "scope": [
+    "tests/bootstrap-files.test.ts",
+    "tests/check-agent-tooling.test.ts",
+    "tests/subagent-handler.test.ts"
+  ],
+  "revisit_trigger": "Fleet agent TOML model or effort changes again, or bootstrap fixtures start reading .codex/agents/*.toml as the single source instead of a literal spec table"
+}

--- a/tests/bootstrap-files.test.ts
+++ b/tests/bootstrap-files.test.ts
@@ -77,9 +77,9 @@ describe("Bootstrap Script Contracts", () => {
     const specs: Array<{ name: string; model: string; effort: string; sandboxMode?: string }> = [
       { name: "explorer", model: "gpt-5.6-luna", effort: "high", sandboxMode: "read-only" },
       { name: "deep-reasoner", model: "gpt-5.6-terra", effort: "xhigh", sandboxMode: "read-only" },
-      { name: "fast-worker", model: "gpt-5.6-terra", effort: "high", sandboxMode: "workspace-write" },
-      { name: "deep-worker", model: "gpt-5.6-sol", effort: "medium", sandboxMode: "workspace-write" },
-      { name: "gatekeeper", model: "gpt-5.6-terra", effort: "xhigh", sandboxMode: "read-only" },
+      { name: "fast-worker", model: "gpt-6-astra", effort: "low", sandboxMode: "workspace-write" },
+      { name: "deep-worker", model: "gpt-6-astra", effort: "medium", sandboxMode: "workspace-write" },
+      { name: "gatekeeper", model: "gpt-6-astra", effort: "medium", sandboxMode: "read-only" },
       { name: "root-cause-prover", model: "gpt-5.6-terra", effort: "high", sandboxMode: "workspace-write" },
       { name: "harness-evaluator", model: "gpt-5.6-terra", effort: "high", sandboxMode: "workspace-write" },
     ];

--- a/tests/check-agent-tooling.test.ts
+++ b/tests/check-agent-tooling.test.ts
@@ -1223,7 +1223,7 @@ describe("check-agent-tooling", () => {
           turn_id: "turn-hook-e2e",
           agent_id: "agent-hook-e2e",
           agent_type: "fast-worker",
-          model: "gpt-5.6-terra",
+          model: "gpt-6-astra",
         }),
       });
       expect(hook.exitCode).toBe(0);
@@ -1245,7 +1245,7 @@ describe("check-agent-tooling", () => {
       expect(report.tools.agent_fleet.native_role_routing.observations).toEqual([
         expect.objectContaining({
           agent_type: "fast-worker",
-          observed_model: "gpt-5.6-terra",
+          observed_model: "gpt-6-astra",
           reasoning_effort_status: "configured_unverified",
         }),
       ]);

--- a/tests/subagent-handler.test.ts
+++ b/tests/subagent-handler.test.ts
@@ -816,7 +816,7 @@ describe('typed subagent hook handlers', () => {
       const home = tempRepo();
       try {
         const contract = seedActiveContract(repoRoot);
-        const stack = composedChildStack(repoRoot, 'fast-worker', 'gpt-5.6-terra', codexEnv({ HOME: home }));
+        const stack = composedChildStack(repoRoot, 'fast-worker', 'gpt-6-astra', codexEnv({ HOME: home }));
         expect(stack.startContext).toContain('[repo-harness:native-role-routing] verified');
         expect(occurrences(stack.composed, BOUNDARY_MARKER)).toBe(1);
         expect(occurrences(stack.composed, BOUNDARY_SENTENCE)).toBe(1);
@@ -852,7 +852,7 @@ describe('typed subagent hook handlers', () => {
       const repoRoot = tempRepo();
       const home = tempRepo();
       try {
-        const stack = composedChildStack(repoRoot, 'fast-worker', 'gpt-5.6-terra', codexEnv({ HOME: home }));
+        const stack = composedChildStack(repoRoot, 'fast-worker', 'gpt-6-astra', codexEnv({ HOME: home }));
         expect(stack.startContext).toContain('[repo-harness:native-role-routing] verified');
         expect(occurrences(stack.composed, BOUNDARY_MARKER)).toBe(0);
         expect(occurrences(stack.composed, BOUNDARY_SENTENCE)).toBe(0);
@@ -918,7 +918,7 @@ describe('typed subagent hook handlers', () => {
           turn_id: 'turn-sandbox-evidence',
           agent_id: 'agent-sandbox-evidence',
           agent_type: 'gatekeeper',
-          model: 'gpt-5.6-terra',
+          model: 'gpt-6-astra',
         }, codexEnv({ HOME: home }));
         expect(output.exitCode).toBe(0);
         expect(readRoutingObservations(repoRoot)[0]).toMatchObject({


### PR DESCRIPTION
## Summary

main is red since bc2328db moved fast-worker, deep-worker and gatekeeper to `gpt-6-astra` while three tests still assert `gpt-5.6-terra` as the correct-identity expectation. This aligns only the positive fixtures with the current `.codex/agents/*.toml` authority.

- `tests/bootstrap-files.test.ts` spec table: fast-worker astra/low, deep-worker astra/medium, gatekeeper astra/medium
- `tests/subagent-handler.test.ts` composed native-child positive cases and the gatekeeper sandbox-evidence case observe `gpt-6-astra`
- `tests/check-agent-tooling.test.ts` real SubagentStart evidence pointer case observes `gpt-6-astra`

Negative identity-mismatch fixtures (observed `gpt-5.6-sol`, self-contained fake TOML strings) are untouched. Workflow evidence is waived via `tasks/waivers/20260909-agents-astra-test-fixtures.json` (tests-only, no semantics change).

## Verification

- `bun test --timeout 60000 tests/bootstrap-files.test.ts tests/check-agent-tooling.test.ts tests/subagent-handler.test.ts` → 65 pass / 0 fail (baseline on clean main: 60 pass / 5 fail)
- `bun test --timeout 60000 tests/install-agent-fleet.test.ts` → 21 pass
- `bash scripts/check-task-workflow.sh --strict` → OK
- `REPO_HARNESS_DIFF_BASE=origin/main REPO_HARNESS_DIFF_MODE=merge-base bash scripts/check-task-sync.sh` → OK

Unblocks #374, whose Required / CI fails on the same five pre-existing assertions.