### PR TITLE
refactor(tooling): single-source the herdr runtime pin

### DIFF
--- a/.ai/harness/policy.json
+++ b/.ai/harness/policy.json
@@ -501,6 +501,15 @@
       "model_dir": ".archcontext/model",
       "nodes_dir": ".archcontext/model/nodes",
       "capability_source_key": ".ai/harness/policy.json#context.capability_source"
+    },
+    "herdr": {
+      "min_version": "0.9.0",
+      "release_assets": {
+        "linux-x86_64": {
+          "url": "https://github.com/herdrdev/herdr/releases/download/v0.9.0/herdr-linux-x86_64",
+          "sha256": "4fa1a01158dd8043da92d31b270780b0dcc10603038d9b61cac4d81ab63fb71f"
+        }
+      }
     }
   },
   "agentic_development": {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,16 @@ jobs:
 
       - name: Install pinned Herdr runtime
         run: |
-          curl --fail --location --retry 3 https://github.com/herdrdev/herdr/releases/download/v0.9.0/herdr-linux-x86_64 --output "$RUNNER_TEMP/herdr"
-          echo "4fa1a01158dd8043da92d31b270780b0dcc10603038d9b61cac4d81ab63fb71f  $RUNNER_TEMP/herdr" | sha256sum --check
+          set -euo pipefail
+          pin=".ai/harness/policy.json"
+          version="$(jq -er '.external_tooling.herdr.min_version' "$pin")"
+          url="$(jq -er '.external_tooling.herdr.release_assets["linux-x86_64"].url' "$pin")"
+          sha256="$(jq -er '.external_tooling.herdr.release_assets["linux-x86_64"].sha256' "$pin")"
+          curl --fail --location --retry 3 "$url" --output "$RUNNER_TEMP/herdr"
+          echo "$sha256  $RUNNER_TEMP/herdr" | sha256sum --check
           sudo install -m 755 "$RUNNER_TEMP/herdr" /usr/local/bin/herdr
           herdr --version
+          test "$(herdr --version)" = "herdr $version"
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/assets/reference-configs/external-tooling.md
+++ b/assets/reference-configs/external-tooling.md
@@ -326,7 +326,7 @@ boundary explicit:
 
 | Capability | Owner | Required for |
 |---|---|---|
-| `herdr` | user install (herdr.dev) | required, version >=0.9.0; peer terminals and persistent task reviewer hosting |
+| `herdr` | user install (herdr.dev) | required at the version pinned in `.ai/harness/policy.json#external_tooling.herdr`; peer terminals and persistent task reviewer hosting |
 | `bun` | repo-harness | repo-harness-owned global installs, local dependency install, tests, and runtime execution |
 | `bash` | repo-harness | helper scripts, migration, setup checks, and contract verification wrappers; Git-for-Windows Bash is the Windows platform contract |
 | `npm` | npm registry | registry readbacks, publish gates, and opt-in update checks; not repo-harness-owned global install repair |
@@ -334,10 +334,12 @@ boundary explicit:
 | `rsync` | platform filesystem | Waza staging-to-Codex sync and installed-copy runtime mirroring |
 | `symlink` | platform filesystem | link-mode aliases; copy mode is the fallback |
 
-Install herdr through its official installer or platform package manager and verify
-`herdr --version` reports version 0.9.0 or newer. `check-agent-tooling.sh
---strict-readiness` fails if it is missing or unusable; `setup check` projects
-`runtime.herdr`. Repo-harness does not install it or edit user Herdr config.
+`.ai/harness/policy.json#external_tooling.herdr` is the single herdr pin: it owns
+the `min_version` floor and the checksum-verified `release_assets` entry that CI
+installs. Install herdr through its official installer or platform package manager
+and verify `herdr --version` reports at least that pinned `min_version`.
+`check-agent-tooling.sh --strict-readiness` reads the same key and fails if herdr is
+missing, unusable, or older than the pin; `setup check` projects `runtime.herdr`. Repo-harness does not install it or edit user Herdr config.
 The persistent reviewer still requires POSIX process groups: use macOS/Linux or
 WSL. Native Windows review lifecycle support is not implied by Herdr support.
 Drain old tmux reviewers with the previous repo-harness version before upgrading.

--- a/assets/templates/helpers/check-agent-tooling.sh
+++ b/assets/templates/helpers/check-agent-tooling.sh
@@ -142,6 +142,7 @@ const ARCHCTX_CONTRACTS_PACKAGE = "archctx-contracts";
 const ARCHCTX_MODEL_DIR = ".archcontext/model";
 const ARCHCTX_NODES_DIR = ".archcontext/model/nodes";
 const ARCHCTX_CAPABILITY_SOURCE_KEY = ".ai/harness/policy.json#context.capability_source";
+const HERDR_PIN_KEY = ".ai/harness/policy.json#external_tooling.herdr";
 const WAZA_STAGING_ROOT = path.join(HOME, ".agents");
 const WAZA_STAGING_DIR = path.join(WAZA_STAGING_ROOT, "skills");
 const WAZA_STAGING_RULES_DIR = path.join(WAZA_STAGING_ROOT, "rules");
@@ -794,13 +795,39 @@ function detectWaza() {
   };
 }
 
+/**
+ * Reads the single herdr runtime pin. The version floor, the release URL, and
+ * the release checksum are one datum owned by
+ * `.ai/harness/policy.json#external_tooling.herdr`; CI installs from the same
+ * key. A missing or malformed pin fails closed instead of assuming a floor.
+ */
+function herdrMinVersion() {
+  const policy = readJson(path.join(REPO_ROOT, ".ai/harness/policy.json"));
+  const pinned = policy?.external_tooling?.herdr?.min_version;
+  return typeof pinned === "string" && /^\d+\.\d+\.\d+$/.test(pinned) ? pinned : null;
+}
+
+function versionAtLeast(actual, minimum) {
+  const parse = (value) => /^(\d+)\.(\d+)\.(\d+)$/.exec(value)?.slice(1, 4).map(Number) ?? null;
+  const left = parse(actual);
+  const right = parse(minimum);
+  if (!left || !right) return false;
+  for (let index = 0; index < 3; index += 1) {
+    if (left[index] !== right[index]) return left[index] > right[index];
+  }
+  return true;
+}
+
 function detectRuntimeCapabilities(waza) {
   const herdr = commandCapability("herdr", "persistent agent terminals, peer collaboration and task-scoped Claude acceptance review", "platform-runtime", true);
+  const minVersion = herdrMinVersion();
+  herdr.min_version = minVersion;
+  herdr.min_version_source = HERDR_PIN_KEY;
   if (herdr.path) {
     try {
       herdr.version = execFileSync(herdr.path, ["--version"], { encoding: "utf8", timeout: 5000, stdio: ["ignore", "pipe", "pipe"] }).trim();
-      const version = /^herdr (\d+)\.(\d+)\.(\d+)$/.exec(herdr.version);
-      if (!version || (Number(version[1]) === 0 && Number(version[2]) < 9)) herdr.status = "unavailable";
+      const reported = /^herdr (\d+\.\d+\.\d+)$/.exec(herdr.version)?.[1] ?? null;
+      if (!minVersion || !reported || !versionAtLeast(reported, minVersion)) herdr.status = "unavailable";
     } catch (_) { herdr.status = "unavailable"; }
   }
   return {
@@ -1977,7 +2004,9 @@ const report = {
 
 const strictFailures = [];
 if (strictReadiness && report.runtime_capabilities.herdr.status !== "present") {
-  strictFailures.push(`herdr runtime is ${report.runtime_capabilities.herdr.status}; install herdr >=0.9.0 and verify herdr --version`);
+  const pinned = report.runtime_capabilities.herdr.min_version;
+  const floor = pinned ? `>=${pinned}` : `the version pinned in ${HERDR_PIN_KEY} (pin missing or malformed)`;
+  strictFailures.push(`herdr runtime is ${report.runtime_capabilities.herdr.status}; install herdr ${floor} and verify herdr --version`);
 }
 if (strictReadiness && ["missing", "partial"].includes(report.tools.codegraph.status)) {
   strictFailures.push(`CodeGraph readiness is ${report.tools.codegraph.status}: ${report.tools.codegraph.reason}`);

--- a/assets/templates/helpers/check-agent-tooling.sh
+++ b/assets/templates/helpers/check-agent-tooling.sh
@@ -2005,8 +2005,8 @@ const report = {
 const strictFailures = [];
 if (strictReadiness && report.runtime_capabilities.herdr.status !== "present") {
   const pinned = report.runtime_capabilities.herdr.min_version;
-  const floor = pinned ? `>=${pinned}` : `the version pinned in ${HERDR_PIN_KEY} (pin missing or malformed)`;
-  strictFailures.push(`herdr runtime is ${report.runtime_capabilities.herdr.status}; install herdr ${floor} and verify herdr --version`);
+  const floor = pinned ? `herdr >=${pinned}` : `the herdr version pinned in ${HERDR_PIN_KEY} (pin missing or malformed)`;
+  strictFailures.push(`herdr runtime is ${report.runtime_capabilities.herdr.status}; install ${floor} and verify herdr --version`);
 }
 if (strictReadiness && ["missing", "partial"].includes(report.tools.codegraph.status)) {
   strictFailures.push(`CodeGraph readiness is ${report.tools.codegraph.status}: ${report.tools.codegraph.reason}`);

--- a/assets/templates/helpers/ensure-task-workflow.sh
+++ b/assets/templates/helpers/ensure-task-workflow.sh
@@ -1273,6 +1273,15 @@ ARCHITECTURE_INDEX_EOF
       "model_dir": ".archcontext/model",
       "nodes_dir": ".archcontext/model/nodes",
       "capability_source_key": ".ai/harness/policy.json#context.capability_source"
+    },
+    "herdr": {
+      "min_version": "0.9.0",
+      "release_assets": {
+        "linux-x86_64": {
+          "url": "https://github.com/herdrdev/herdr/releases/download/v0.9.0/herdr-linux-x86_64",
+          "sha256": "4fa1a01158dd8043da92d31b270780b0dcc10603038d9b61cac4d81ab63fb71f"
+        }
+      }
     }
   },
   "agentic_development": {

--- a/docs/reference-configs/external-tooling.md
+++ b/docs/reference-configs/external-tooling.md
@@ -326,7 +326,7 @@ boundary explicit:
 
 | Capability | Owner | Required for |
 |---|---|---|
-| `herdr` | user install (herdr.dev) | required, version >=0.9.0; peer terminals and persistent task reviewer hosting |
+| `herdr` | user install (herdr.dev) | required at the version pinned in `.ai/harness/policy.json#external_tooling.herdr`; peer terminals and persistent task reviewer hosting |
 | `bun` | repo-harness | repo-harness-owned global installs, local dependency install, tests, and runtime execution |
 | `bash` | repo-harness | helper scripts, migration, setup checks, and contract verification wrappers; Git-for-Windows Bash is the Windows platform contract |
 | `npm` | npm registry | registry readbacks, publish gates, and opt-in update checks; not repo-harness-owned global install repair |
@@ -334,10 +334,12 @@ boundary explicit:
 | `rsync` | platform filesystem | Waza staging-to-Codex sync and installed-copy runtime mirroring |
 | `symlink` | platform filesystem | link-mode aliases; copy mode is the fallback |
 
-Install herdr through its official installer or platform package manager and verify
-`herdr --version` reports version 0.9.0 or newer. `check-agent-tooling.sh
---strict-readiness` fails if it is missing or unusable; `setup check` projects
-`runtime.herdr`. Repo-harness does not install it or edit user Herdr config.
+`.ai/harness/policy.json#external_tooling.herdr` is the single herdr pin: it owns
+the `min_version` floor and the checksum-verified `release_assets` entry that CI
+installs. Install herdr through its official installer or platform package manager
+and verify `herdr --version` reports at least that pinned `min_version`.
+`check-agent-tooling.sh --strict-readiness` reads the same key and fails if herdr is
+missing, unusable, or older than the pin; `setup check` projects `runtime.herdr`. Repo-harness does not install it or edit user Herdr config.
 The persistent reviewer still requires POSIX process groups: use macOS/Linux or
 WSL. Native Windows review lifecycle support is not implied by Herdr support.
 Drain old tmux reviewers with the previous repo-harness version before upgrading.

--- a/plans/plan-20260909-1731-herdr-pin-source.md
+++ b/plans/plan-20260909-1731-herdr-pin-source.md
@@ -95,7 +95,7 @@ See captured planning output.
 - **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
 - **Rollback surface**: Single commit revert restores the previous literals
 
-> **Substantive Change SHA256**: `sha256:a67d8a267c287d8959b0e515658c9d1eedb2a3ab4d8f127b4266926d147f9d15`
+> **Substantive Change SHA256**: `sha256:dc4f0d7d724901012784589f5695ee234066b4404c6a2e71cf2b0c37c1a84560`
 
 ## Captured Planning Output
 

--- a/plans/plan-20260909-1731-herdr-pin-source.md
+++ b/plans/plan-20260909-1731-herdr-pin-source.md
@@ -1,0 +1,159 @@
+# Plan: Single-source the herdr runtime pin
+
+> **Status**: Executing
+> **Created**: 20260909-1731
+> **Slug**: herdr-pin-source
+> **Planning Source**: repo-harness-plan
+> **Orchestration Kind**: host-plan
+> **Source Ref**: (none)
+> **Artifact Level**: work-package
+> **Promotion Reason**: verification_boundary
+> **Verification Boundary**: Drift test plus CI install-step behavior must be verified independently of the rest of the tree
+> **Rollback Surface**: Single commit revert restores the previous literals
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260909-1731-herdr-pin-source.contract.md`
+> **Task Review**: `tasks/reviews/20260909-1731-herdr-pin-source.review.md`
+> **Implementation Notes**: `tasks/notes/20260909-1731-herdr-pin-source.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from repo-harness-plan planning output.
+- Source ref: (none)
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260909-1731-herdr-pin-source.md`
+- Sprint contract: `tasks/contracts/20260909-1731-herdr-pin-source.contract.md`
+- Sprint review: `tasks/reviews/20260909-1731-herdr-pin-source.review.md`
+- Implementation notes: `tasks/notes/20260909-1731-herdr-pin-source.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260909-1731-herdr-pin-source.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260909-1731-herdr-pin-source.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260909-1731-herdr-pin-source.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260909-1731-herdr-pin-source.contract.md`
+- Review file: `tasks/reviews/20260909-1731-herdr-pin-source.review.md`
+- Implementation notes file: `tasks/notes/20260909-1731-herdr-pin-source.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260909-1731-herdr-pin-source.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260909-1731-herdr-pin-source.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: Single commit revert restores the previous literals
+- **Verification boundary**: Drift test plus CI install-step behavior must be verified independently of the rest of the tree
+- **Review/acceptance boundary**: `tasks/reviews/20260909-1731-herdr-pin-source.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: verification_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260909-1731-herdr-pin-source.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260909-1731-herdr-pin-source.contract.md`, `tasks/reviews/20260909-1731-herdr-pin-source.review.md`, and `tasks/notes/20260909-1731-herdr-pin-source.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260909-1731-herdr-pin-source.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: Single commit revert restores the previous literals
+
+> **Substantive Change SHA256**: `sha256:a67d8a267c287d8959b0e515658c9d1eedb2a3ab4d8f127b4266926d147f9d15`
+
+## Captured Planning Output
+
+## Problem
+
+The herdr runtime requirement is stated three times: `.github/workflows/ci.yml`
+hardcodes the release tag, asset URL, and sha256; `scripts/check-agent-tooling.sh`
+hand-codes the floor as a `minor < 9` regex plus a `>=0.9.0` literal in its strict
+failure message; `docs/reference-configs/external-tooling.md` restates the number in
+prose. Any version move requires four coordinated edits with no drift check.
+
+## Decision
+
+`.ai/harness/policy.json#external_tooling.herdr` becomes the single herdr pin,
+owning `min_version` and the checksum-verified `release_assets` entry. It is chosen
+over a new `.ai/harness/runtime-pins.json` because policy.json is the repo's
+machine-readable workflow contract, already holds a per-tool block for every other
+external tool (`waza`, `codegraph`, `archctx`, `agent_fleet`), and — unlike a
+self-host-only file — already exists in every downstream repo, which matters because
+`scripts/check-agent-tooling.sh` is mirrored verbatim into downstream repos through
+`assets/templates/helpers/`.
+
+Readers become projections: CI extracts version/url/sha with `jq` and asserts the
+installed `herdr --version` equals the pin; the readiness script reads `min_version`
+and semver-compares, failing closed when the pin is missing or malformed; docs name
+the key instead of restating the number. The downstream policy seed
+(`scripts/lib/project-init-lib.sh` and the `ensure-task-workflow.sh` pair) carries the
+same block so downstream readiness keeps working, and `tests/herdr-runtime-pin.test.ts`
+is the drift check over all four readers.
+
+## Task Breakdown
+
+- [x] Add `external_tooling.herdr` to `.ai/harness/policy.json`
+- [x] Rewrite the CI install step to read the pin via `jq` and assert the reported version
+- [x] Read the pin in `scripts/check-agent-tooling.sh` (plus asset mirror), removing the `<9` regex and the literal message
+- [x] Point `docs/reference-configs/external-tooling.md` (plus asset mirror) at the key
+- [x] Seed the pin into the downstream policy defaults
+- [x] Add `tests/herdr-runtime-pin.test.ts` drift coverage
+
+## Verification
+
+- `bun test tests/herdr-runtime-pin.test.ts`
+- `bun test tests/check-agent-tooling.test.ts`
+- `bash scripts/check-agent-tooling.sh --host both`
+- CI step simulation: `jq` extraction compared byte-for-byte against the removed literals
+- Repository integrity checks
+
+## Rollback
+
+Revert the commit; the previous literals are restored in place and no state is migrated.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [x] Add `external_tooling.herdr` to `.ai/harness/policy.json`
+- [x] Rewrite the CI install step to read the pin via `jq` and assert the reported version
+- [x] Read the pin in `scripts/check-agent-tooling.sh` (plus asset mirror), removing the `<9` regex and the literal message
+- [x] Point `docs/reference-configs/external-tooling.md` (plus asset mirror) at the key
+- [x] Seed the pin into the downstream policy defaults
+- [x] Add `tests/herdr-runtime-pin.test.ts` drift coverage

--- a/plans/plan-20260909-1731-herdr-pin-source.md
+++ b/plans/plan-20260909-1731-herdr-pin-source.md
@@ -95,7 +95,7 @@ See captured planning output.
 - **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
 - **Rollback surface**: Single commit revert restores the previous literals
 
-> **Substantive Change SHA256**: `sha256:dc4f0d7d724901012784589f5695ee234066b4404c6a2e71cf2b0c37c1a84560`
+> **Substantive Change SHA256**: `sha256:aeff53c3a6b23b76f28ab8cd61d09d3481ebdf0c49263f0f93ecce899803cca3`
 
 ## Captured Planning Output
 

--- a/scripts/check-agent-tooling.sh
+++ b/scripts/check-agent-tooling.sh
@@ -142,6 +142,7 @@ const ARCHCTX_CONTRACTS_PACKAGE = "archctx-contracts";
 const ARCHCTX_MODEL_DIR = ".archcontext/model";
 const ARCHCTX_NODES_DIR = ".archcontext/model/nodes";
 const ARCHCTX_CAPABILITY_SOURCE_KEY = ".ai/harness/policy.json#context.capability_source";
+const HERDR_PIN_KEY = ".ai/harness/policy.json#external_tooling.herdr";
 const WAZA_STAGING_ROOT = path.join(HOME, ".agents");
 const WAZA_STAGING_DIR = path.join(WAZA_STAGING_ROOT, "skills");
 const WAZA_STAGING_RULES_DIR = path.join(WAZA_STAGING_ROOT, "rules");
@@ -794,13 +795,39 @@ function detectWaza() {
   };
 }
 
+/**
+ * Reads the single herdr runtime pin. The version floor, the release URL, and
+ * the release checksum are one datum owned by
+ * `.ai/harness/policy.json#external_tooling.herdr`; CI installs from the same
+ * key. A missing or malformed pin fails closed instead of assuming a floor.
+ */
+function herdrMinVersion() {
+  const policy = readJson(path.join(REPO_ROOT, ".ai/harness/policy.json"));
+  const pinned = policy?.external_tooling?.herdr?.min_version;
+  return typeof pinned === "string" && /^\d+\.\d+\.\d+$/.test(pinned) ? pinned : null;
+}
+
+function versionAtLeast(actual, minimum) {
+  const parse = (value) => /^(\d+)\.(\d+)\.(\d+)$/.exec(value)?.slice(1, 4).map(Number) ?? null;
+  const left = parse(actual);
+  const right = parse(minimum);
+  if (!left || !right) return false;
+  for (let index = 0; index < 3; index += 1) {
+    if (left[index] !== right[index]) return left[index] > right[index];
+  }
+  return true;
+}
+
 function detectRuntimeCapabilities(waza) {
   const herdr = commandCapability("herdr", "persistent agent terminals, peer collaboration and task-scoped Claude acceptance review", "platform-runtime", true);
+  const minVersion = herdrMinVersion();
+  herdr.min_version = minVersion;
+  herdr.min_version_source = HERDR_PIN_KEY;
   if (herdr.path) {
     try {
       herdr.version = execFileSync(herdr.path, ["--version"], { encoding: "utf8", timeout: 5000, stdio: ["ignore", "pipe", "pipe"] }).trim();
-      const version = /^herdr (\d+)\.(\d+)\.(\d+)$/.exec(herdr.version);
-      if (!version || (Number(version[1]) === 0 && Number(version[2]) < 9)) herdr.status = "unavailable";
+      const reported = /^herdr (\d+\.\d+\.\d+)$/.exec(herdr.version)?.[1] ?? null;
+      if (!minVersion || !reported || !versionAtLeast(reported, minVersion)) herdr.status = "unavailable";
     } catch (_) { herdr.status = "unavailable"; }
   }
   return {
@@ -1977,7 +2004,9 @@ const report = {
 
 const strictFailures = [];
 if (strictReadiness && report.runtime_capabilities.herdr.status !== "present") {
-  strictFailures.push(`herdr runtime is ${report.runtime_capabilities.herdr.status}; install herdr >=0.9.0 and verify herdr --version`);
+  const pinned = report.runtime_capabilities.herdr.min_version;
+  const floor = pinned ? `>=${pinned}` : `the version pinned in ${HERDR_PIN_KEY} (pin missing or malformed)`;
+  strictFailures.push(`herdr runtime is ${report.runtime_capabilities.herdr.status}; install herdr ${floor} and verify herdr --version`);
 }
 if (strictReadiness && ["missing", "partial"].includes(report.tools.codegraph.status)) {
   strictFailures.push(`CodeGraph readiness is ${report.tools.codegraph.status}: ${report.tools.codegraph.reason}`);

--- a/scripts/check-agent-tooling.sh
+++ b/scripts/check-agent-tooling.sh
@@ -2005,8 +2005,8 @@ const report = {
 const strictFailures = [];
 if (strictReadiness && report.runtime_capabilities.herdr.status !== "present") {
   const pinned = report.runtime_capabilities.herdr.min_version;
-  const floor = pinned ? `>=${pinned}` : `the version pinned in ${HERDR_PIN_KEY} (pin missing or malformed)`;
-  strictFailures.push(`herdr runtime is ${report.runtime_capabilities.herdr.status}; install herdr ${floor} and verify herdr --version`);
+  const floor = pinned ? `herdr >=${pinned}` : `the herdr version pinned in ${HERDR_PIN_KEY} (pin missing or malformed)`;
+  strictFailures.push(`herdr runtime is ${report.runtime_capabilities.herdr.status}; install ${floor} and verify herdr --version`);
 }
 if (strictReadiness && ["missing", "partial"].includes(report.tools.codegraph.status)) {
   strictFailures.push(`CodeGraph readiness is ${report.tools.codegraph.status}: ${report.tools.codegraph.reason}`);

--- a/scripts/ensure-task-workflow.sh
+++ b/scripts/ensure-task-workflow.sh
@@ -1273,6 +1273,15 @@ ARCHITECTURE_INDEX_EOF
       "model_dir": ".archcontext/model",
       "nodes_dir": ".archcontext/model/nodes",
       "capability_source_key": ".ai/harness/policy.json#context.capability_source"
+    },
+    "herdr": {
+      "min_version": "0.9.0",
+      "release_assets": {
+        "linux-x86_64": {
+          "url": "https://github.com/herdrdev/herdr/releases/download/v0.9.0/herdr-linux-x86_64",
+          "sha256": "4fa1a01158dd8043da92d31b270780b0dcc10603038d9b61cac4d81ab63fb71f"
+        }
+      }
     }
   },
   "agentic_development": {

--- a/scripts/lib/project-init-lib.sh
+++ b/scripts/lib/project-init-lib.sh
@@ -1821,6 +1821,15 @@ pi_write_harness_policy() {
       "model_dir": ".archcontext/model",
       "nodes_dir": ".archcontext/model/nodes",
       "capability_source_key": ".ai/harness/policy.json#context.capability_source"
+    },
+    "herdr": {
+      "min_version": "0.9.0",
+      "release_assets": {
+        "linux-x86_64": {
+          "url": "https://github.com/herdrdev/herdr/releases/download/v0.9.0/herdr-linux-x86_64",
+          "sha256": "4fa1a01158dd8043da92d31b270780b0dcc10603038d9b61cac4d81ab63fb71f"
+        }
+      }
     }
   },
   "agentic_development": {

--- a/tasks/contracts/20260909-1731-herdr-pin-source.contract.md
+++ b/tasks/contracts/20260909-1731-herdr-pin-source.contract.md
@@ -1,0 +1,187 @@
+# Task Contract: herdr-pin-source
+
+> **Status**: Active
+> **Plan**: plans/plan-20260909-1731-herdr-pin-source.md
+> **Task Profile**: code-change
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: ancienttwo
+> **Capability ID**: root
+> **Last Updated**: 2026-09-09 17:31
+> **Review File**: `tasks/reviews/20260909-1731-herdr-pin-source.review.md`
+> **Notes File**: `tasks/notes/20260909-1731-herdr-pin-source.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+Why this task matters and what breaks downstream if it ships wrong or is skipped.
+
+## Goal
+
+Describe the exact outcome this task must deliver.
+
+## Scope
+
+- In scope:
+- Out of scope:
+- Taste constraints: <!-- advisory only, no run gate; default style/taste lives in AGENTS.md and the minimal-change policy, use this to record a per-task override -->
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+
+## Falsifier
+
+What observable evidence would prove this task's direction wrong, and the cheapest proof point to check first. Leave as-is if not applicable.
+
+## Root Cause Evidence
+
+Required when Task Profile is `bugfix`; leave as-is otherwise.
+
+- root_cause: one sentence naming file:line/condition (testable, not "a state issue").
+- repro: the command or UI path that reproduces the symptom.
+- regression_guard: path to a test that fails on the unfixed code and passes after the fix (must also appear as a `package_test` check in Verification Plan).
+- pre_fix_failure_artifact: path to a captured run of regression_guard on the UNFIXED code. Capture with `bun test <regression_guard> > <artifact> 2>&1; echo "PRE_FIX_EXIT=$?" >> <artifact>` (no pipes — pipes swallow the exit status). The gate requires a non-zero `PRE_FIX_EXIT=` line plus the regression_guard path string in the artifact (see the Root Cause Evidence Gate section in docs/reference-configs/sprint-contracts.md).
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260909-1731-herdr-pin-source.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260909-1731-herdr-pin-source.review.md`
+- Notes file: `tasks/notes/20260909-1731-herdr-pin-source.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Change Assessment
+
+```json
+{"protocol":1,"oracles":[]}
+```
+
+## Acceptance Policy
+
+```json
+{"protocol":2,"reviewer":"Codex","source":"codex-plugin","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - docs/spec.md
+  - plans/
+  - tasks/todos.md
+  - tasks/contracts/20260909-1731-herdr-pin-source.contract.md
+  - tasks/reviews/20260909-1731-herdr-pin-source.review.md
+  - tasks/notes/20260909-1731-herdr-pin-source.notes.md
+  - .ai/context/capabilities.json
+  - .claude/templates/
+  - src/
+  - tests/
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+    fallback: null
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+This block contains only non-executable artifact requirements. Define every
+executable check once in the canonical Verification Plan below. Each check must
+state its phase, cost, evidence policy, necessity, and input environment; a
+missing or malformed plan fails closed.
+
+```yaml
+exit_criteria:
+  files_exist:
+    - docs/spec.md
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260909-1731-herdr-pin-source.notes.md
+```
+
+## Verification Plan
+
+```json
+{
+  "protocol": 1,
+  "checks": [
+    {
+      "id": "focused-regression",
+      "kind": "package_test",
+      "path": "tests/unit/herdr-pin-source.test.ts",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Covers the changed behavior named by this contract.",
+      "inputs": { "env": [] }
+    },
+    {
+      "id": "typecheck",
+      "kind": "command",
+      "command": "bun run check:type",
+      "cwd": ".",
+      "phase": "preflight",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Checks TypeScript contracts before behavioral verification.",
+      "inputs": { "env": [] }
+    }
+  ]
+}
+```
+
+This is the sole executable verification authority. Use `baseline_with_delta`
+only when a referenced immutable baseline plus named current delta checks prove
+the intended coverage; do not infer that choice from paths or command text.
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior:
+- Edge cases:
+- Regression risks:
+
+## Rollback Point
+
+- Commit / checkpoint:
+- Revert strategy:

--- a/tasks/contracts/20260909-1731-herdr-pin-source.contract.md
+++ b/tasks/contracts/20260909-1731-herdr-pin-source.contract.md
@@ -13,17 +13,34 @@
 
 ## Why
 
-Why this task matters and what breaks downstream if it ships wrong or is skipped.
+The herdr runtime version was pinned in four independent places: the CI install step
+hard-coded `v0.9.0` plus its checksum, `scripts/check-agent-tooling.sh` hard-coded the
+`0.9` floor in a regex comparison, the reference docs restated `>=0.9.0`, and downstream
+repos got none of it. Bumping herdr therefore meant editing several unrelated files, and
+missing one silently produced a CI runner and a readiness check that disagreed about which
+herdr version is required.
 
 ## Goal
 
-Describe the exact outcome this task must deliver.
+Make `.ai/harness/policy.json#external_tooling.herdr` the single source of truth for the
+herdr runtime pin (`min_version` plus the checksum-verified `release_assets` entry), and
+turn every other mention into a deterministic projection of that key: CI installs and
+version-asserts from it via `jq`, `check-agent-tooling.sh` reads it for the strict-readiness
+floor and reports `min_version`/`min_version_source`, the reference docs point at the key
+instead of restating the number, and the downstream policy seeds carry the same block.
+Drift tests keep the projections honest.
 
 ## Scope
 
-- In scope:
-- Out of scope:
-- Taste constraints: <!-- advisory only, no run gate; default style/taste lives in AGENTS.md and the minimal-change policy, use this to record a per-task override -->
+- In scope: `.ai/harness/policy.json` herdr block; `.github/workflows/ci.yml` pinned-install
+  step; `scripts/check-agent-tooling.sh` pin read plus semver comparison; the downstream
+  policy seeds in `scripts/ensure-task-workflow.sh` and `scripts/lib/project-init-lib.sh`;
+  the `assets/templates/helpers/` and `assets/reference-configs/` mirrors;
+  `docs/reference-configs/external-tooling.md`; drift/pin tests under `tests/`.
+- Out of scope: installing or upgrading herdr itself, bumping the pinned version, adding
+  release assets for platforms other than `linux-x86_64`, and any change to herdr's role in
+  the reviewer lifecycle.
+- Taste constraints: no default-floor fallback — a missing or malformed pin fails closed. <!-- advisory only, no run gate; default style/taste lives in AGENTS.md and the minimal-change policy, use this to record a per-task override -->
 
 ## Stop Conditions
 
@@ -78,7 +95,12 @@ allowed_paths:
   - tasks/reviews/20260909-1731-herdr-pin-source.review.md
   - tasks/notes/20260909-1731-herdr-pin-source.notes.md
   - .ai/context/capabilities.json
+  - .ai/harness/policy.json
+  - .github/workflows/ci.yml
   - .claude/templates/
+  - assets/
+  - docs/reference-configs/
+  - scripts/
   - src/
   - tests/
 ```

--- a/tasks/notes/20260909-1731-herdr-pin-source.notes.md
+++ b/tasks/notes/20260909-1731-herdr-pin-source.notes.md
@@ -1,0 +1,41 @@
+# Implementation Notes: herdr-pin-source
+
+> **Status**: Active
+> **Plan**: plans/plan-20260909-1731-herdr-pin-source.md
+> **Contract**: tasks/contracts/20260909-1731-herdr-pin-source.contract.md
+> **Review**: tasks/reviews/20260909-1731-herdr-pin-source.review.md
+> **Last Updated**: 2026-09-09 17:31
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- ...
+
+## Deviations From Plan Or Spec
+
+- None recorded.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| ... | ... | ... |
+
+## Open Questions
+
+- None.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/notes/20260909-1731-herdr-pin-source.notes.md
+++ b/tasks/notes/20260909-1731-herdr-pin-source.notes.md
@@ -9,7 +9,20 @@
 
 ## Design Decisions
 
-- ...
+- A missing or malformed `external_tooling.herdr.min_version` fails closed rather than
+  falling back to the previously hard-coded `0.9.0` floor: `herdrMinVersion()` returns
+  `null`, `detectRuntimeCapabilities` marks herdr `unavailable`, and strict readiness fails
+  with a message naming the pin key. A default floor would let a repo with a broken pin
+  report a green readiness check against a version nobody declared, which is exactly the
+  silent CI/readiness disagreement this task removes.
+- The pin lives in `.ai/harness/policy.json#external_tooling.herdr` rather than a new
+  `runtime-pins.json`. Every other external tool (`codegraph`, `archctx`, waza) already has
+  an `external_tooling` block there, and `scripts/check-agent-tooling.sh` is shipped
+  downstream as a byte-identical mirror of
+  `assets/templates/helpers/check-agent-tooling.sh` — so whatever file the script reads must
+  also exist in generated repos. Adding the block to the downstream policy seeds
+  (`ensure-task-workflow.sh`, `project-init-lib.sh`) was cheaper and less duplicative than
+  introducing a second runtime-config file plus its own seeding and drift checks.
 
 ## Deviations From Plan Or Spec
 
@@ -19,7 +32,10 @@
 
 | Option | Decision | Reason |
 |--------|----------|--------|
-| ... | ... | ... |
+| Fall back to a built-in `0.9.0` floor when the pin is missing/malformed | Rejected | Reintroduces a second authority for the version and can report readiness green against an undeclared version; fail-closed keeps one source of truth. |
+| New `runtime-pins.json` for runtime version pins | Rejected | `external_tooling` in `policy.json` already owns every other tool pin, and the downstream-mirrored tooling script would need a new file seeded into generated repos. |
+| Pin in `policy.json#external_tooling.herdr`, projected into CI/script/docs/seeds | Chosen | One datum, all other mentions are deterministic projections guarded by drift tests. |
+| Keep the `linux-x86_64` release asset only | Chosen | CI is the only consumer that downloads a binary; other hosts install herdr themselves and are checked against `min_version`. |
 
 ## Open Questions
 

--- a/tasks/reviews/20260909-1731-herdr-pin-source.review.md
+++ b/tasks/reviews/20260909-1731-herdr-pin-source.review.md
@@ -1,0 +1,84 @@
+# Task Review: herdr-pin-source
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260909-1731-herdr-pin-source.md
+> **Contract**: tasks/contracts/20260909-1731-herdr-pin-source.contract.md
+> **Notes File**: tasks/notes/20260909-1731-herdr-pin-source.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-09-09 17:31
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Commands passed:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+- Waza `/check` run:
+- Commands run:
+- Manual checks:
+- Supporting artifacts:
+- Implementation notes reviewed:
+- Run snapshot:
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -1,7 +1,7 @@
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: 2026-09-09 03:05
+> **Updated**: 2026-09-09 17:31
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.

--- a/tests/check-agent-tooling.test.ts
+++ b/tests/check-agent-tooling.test.ts
@@ -351,12 +351,24 @@ function writeFakeCurl(fakeBin: string, version: string, logFile?: string) {
   );
 }
 
-function writeArchctxRepo(repoRoot: string, capabilitySource: "registry" | "archcontext") {
+const HERDR_PIN = JSON.parse(readFileSync(join(ROOT, ".ai/harness/policy.json"), "utf8")).external_tooling.herdr;
+
+/**
+ * Strict readiness reads the herdr floor from
+ * `.ai/harness/policy.json#external_tooling.herdr`, so a fixture repo that stands
+ * in for a ready repo must carry the same pin this repo publishes.
+ */
+function writeFixturePolicy(repoRoot: string, policy: Record<string, unknown> = {}) {
   mkdirSync(join(repoRoot, ".ai/harness"), { recursive: true });
+  const externalTooling = { ...((policy.external_tooling as Record<string, unknown>) ?? {}), herdr: HERDR_PIN };
   writeFileSync(
     join(repoRoot, ".ai/harness/policy.json"),
-    JSON.stringify({ version: 1, context: { capability_source: capabilitySource } }, null, 2)
+    `${JSON.stringify({ ...policy, external_tooling: externalTooling }, null, 2)}\n`
   );
+}
+
+function writeArchctxRepo(repoRoot: string, capabilitySource: "registry" | "archcontext") {
+  writeFixturePolicy(repoRoot, { version: 1, context: { capability_source: capabilitySource } });
   writeFileSync(
     join(repoRoot, "package.json"),
     JSON.stringify({ devDependencies: { "archctx-contracts": "0.3.0" } }, null, 2)
@@ -1105,6 +1117,7 @@ describe("check-agent-tooling", () => {
     ]) {
       const envRoot = setupFakeEnvironment(`check-agent-tooling-role-${testCase.evidenceStatus}`);
       try {
+        writeFixturePolicy(envRoot.root);
         mkdirSync(join(envRoot.home, ".codex", "agents"), { recursive: true });
         writeFileSync(
           join(envRoot.home, ".codex", "config.toml"),
@@ -1194,8 +1207,7 @@ describe("check-agent-tooling", () => {
   test("accepts the top-level evidence pointer written by a real SubagentStart handler", () => {
     const envRoot = setupFakeEnvironment("check-agent-tooling-hook-e2e");
     try {
-      mkdirSync(join(envRoot.root, ".ai", "harness"), { recursive: true });
-      writeFileSync(join(envRoot.root, ".ai", "harness", "policy.json"), "{}\n");
+      writeFixturePolicy(envRoot.root);
       mkdirSync(join(envRoot.home, ".codex", "agents"), { recursive: true });
       writeFileSync(
         join(envRoot.home, ".codex", "config.toml"),

--- a/tests/herdr-runtime-pin.test.ts
+++ b/tests/herdr-runtime-pin.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+/**
+ * `.ai/harness/policy.json#external_tooling.herdr` is the single herdr runtime
+ * pin. These are drift checks for its readers: CI, the readiness script, and the
+ * downstream policy seed must derive the floor, URL, and checksum from that key
+ * instead of restating them.
+ */
+const ROOT = join(import.meta.dir, "..");
+const POLICY_PATH = join(ROOT, ".ai/harness/policy.json");
+const CI_PATH = join(ROOT, ".github/workflows/ci.yml");
+const SCRIPT_PATH = join(ROOT, "scripts/check-agent-tooling.sh");
+const SEED_PATHS = [
+  join(ROOT, "scripts/lib/project-init-lib.sh"),
+  join(ROOT, "scripts/ensure-task-workflow.sh"),
+  join(ROOT, "assets/templates/helpers/ensure-task-workflow.sh"),
+];
+
+function readPolicy() {
+  return JSON.parse(readFileSync(POLICY_PATH, "utf8"));
+}
+
+function herdrInstallStep() {
+  const workflow = readFileSync(CI_PATH, "utf8");
+  const start = workflow.indexOf("      - name: Install pinned Herdr runtime\n");
+  expect(start).toBeGreaterThanOrEqual(0);
+  const next = workflow.indexOf("\n      - name: ", start + 1);
+  return workflow.slice(start, next === -1 ? undefined : next);
+}
+
+describe("herdr runtime pin has one source of truth", () => {
+  test("the pin parses and its release URL embeds the pinned version", () => {
+    const herdr = readPolicy().external_tooling?.herdr;
+    expect(herdr).toBeDefined();
+    expect(herdr.min_version).toMatch(/^\d+\.\d+\.\d+$/);
+    const asset = herdr.release_assets?.["linux-x86_64"];
+    expect(asset?.sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(asset?.url).toContain(`/v${herdr.min_version}/`);
+  });
+
+  test("the CI install step reads the pin instead of restating it", () => {
+    const step = herdrInstallStep();
+    expect(step).toContain(".ai/harness/policy.json");
+    expect(step).toContain(".external_tooling.herdr.min_version");
+    expect(step).toContain("sha256sum --check");
+    expect(step).toContain("herdr --version");
+    // No hardcoded version, release tag, or checksum may survive in the step.
+    expect(step).not.toMatch(/v?\d+\.\d+\.\d+/);
+    expect(step).not.toMatch(/[0-9a-f]{64}/);
+  });
+
+  test("check-agent-tooling.sh carries no hand-coded herdr version floor", () => {
+    const script = readFileSync(SCRIPT_PATH, "utf8");
+    expect(script).toContain('".ai/harness/policy.json#external_tooling.herdr"');
+    expect(script).toContain("external_tooling?.herdr?.min_version");
+    const herdrLines = script.split("\n").filter((line) => /herdr/i.test(line));
+    expect(herdrLines.length).toBeGreaterThan(0);
+    for (const line of herdrLines) {
+      expect(line).not.toMatch(/\d+\.\d+\.\d+/);
+      expect(line).not.toMatch(/minor\s*[<>]=?\s*\d|\[2\]\)\s*[<>]/);
+    }
+  });
+
+  test("the downstream policy seed projects the same pin", () => {
+    const herdr = readPolicy().external_tooling.herdr;
+    const expected = JSON.stringify(herdr, null, 2)
+      .split("\n")
+      .map((line) => line.trim());
+    for (const seedPath of SEED_PATHS) {
+      const seed = readFileSync(seedPath, "utf8");
+      const start = seed.indexOf('    "herdr": {');
+      expect(start, seedPath).toBeGreaterThanOrEqual(0);
+      const block = seed
+        .slice(start, seed.indexOf("\n    }\n", start) + "\n    }".length)
+        .split("\n")
+        .map((line) => line.trim());
+      expect(block.slice(1), seedPath).toEqual(expected.slice(1));
+    }
+  });
+});


### PR DESCRIPTION
## Problem

The herdr runtime requirement was stated in three places with no drift check:

- `.github/workflows/ci.yml` hardcoded `v0.9.0`, the release asset URL, and its sha256.
- `scripts/check-agent-tooling.sh` hand-coded the floor as `major === 0 && minor < 9`, plus a `>=0.9.0` literal in the strict-readiness failure message.
- `docs/reference-configs/external-tooling.md` restated `>=0.9.0` in prose twice.

## Chosen pin file: `.ai/harness/policy.json#external_tooling.herdr`

Picked over a new `.ai/harness/runtime-pins.json` because:

1. policy.json is already the repo's machine-readable workflow contract and already carries a per-tool block for every other external tool (`waza`, `hai_stack`, `agent_fleet`, `codegraph`, `archctx`). herdr was the odd one out.
2. `scripts/check-agent-tooling.sh` is a byte-identical mirror of `assets/templates/helpers/check-agent-tooling.sh` and ships verbatim into generated downstream repos. A self-host-only pin file would make every downstream strict-readiness run fail closed on a missing pin; policy.json exists in every downstream repo.

The block holds the floor and the artifact as one datum, since a version without its verified download is what drifted apart in the first place:

```json
"herdr": {
  "min_version": "0.9.0",
  "release_assets": {
    "linux-x86_64": {
      "url": "https://github.com/herdrdev/herdr/releases/download/v0.9.0/herdr-linux-x86_64",
      "sha256": "4fa1a01158dd8043da92d31b270780b0dcc10603038d9b61cac4d81ab63fb71f"
    }
  }
}
```

## Readers are now projections

- **CI** extracts version/url/sha with `jq -er` (jq is installed by the preceding step), keeps `sha256sum --check` and the `herdr --version` echo, and additionally asserts `herdr --version` equals `herdr $version`.
- **`check-agent-tooling.sh`** reads `min_version`, semver-compares the reported version, and surfaces `min_version` / `min_version_source` in the JSON report. A missing or malformed pin fails closed (`status: unavailable`) rather than assuming a floor; the strict failure message names the key.
- **Docs** name `.ai/harness/policy.json#external_tooling.herdr` instead of restating the number. No test asserted those doc strings (checked before editing).
- **Downstream seed** (`scripts/lib/project-init-lib.sh`, `scripts/ensure-task-workflow.sh` and its asset mirror) emits the same block so generated repos keep a working readiness gate.

The version is unchanged: `0.9.0`.

## Drift check

`tests/herdr-runtime-pin.test.ts` (4 tests) asserts the CI step contains no `x.y.z` version and no 64-hex checksum while still referencing the pin key and keeping checksum verification; no herdr-mentioning line in the readiness script carries a version literal or a hand-coded minor comparison; the pin parses and its URL embeds `v<min_version>`; and each seed file's herdr block deep-equals the policy block. Negative-checked by mutating `min_version` — 2 of the 4 tests fail as intended.

## Verification

- `bun test tests/herdr-runtime-pin.test.ts` — 4 pass / 0 fail
- `bun test tests/check-agent-tooling.test.ts` — 29 pass / 1 fail, identical to the `origin/main` baseline (the failing `native-role-routing` test is pre-existing). Fixture repos that stand in for a ready repo now seed the pin through a `writeFixturePolicy` helper that reads the real pin.
- `bun test tests/create-project-dirs.runtime.test.ts tests/bootstrap-files.test.ts tests/output-parity.test.ts` — one pre-existing failure (`Codex fleet subagent TOML definitions`), also red on `origin/main`.
- `bash scripts/check-agent-tooling.sh --host both` — herdr `present`, `herdr 0.9.0`, `min_version: 0.9.0`.
- CI step simulated locally: the `jq` extraction returns the URL and sha256 byte-for-byte identical to the removed literals, and the version assertion passes against the local herdr.
- Six repository integrity checks: all green (`check-deploy-sql-order`, `check-architecture-sync`, `check-task-sync` with `REPO_HARNESS_DIFF_BASE=origin/main REPO_HARNESS_DIFF_MODE=merge-base`, `check-task-workflow --strict`, `inspect-project-state`, `init --repo . --dry-run`).

No full suite; no dependency added.