### PR TITLE
fix(architecture): allow a longer projection provider bound

### DIFF
--- a/.ai/harness/policy.json
+++ b/.ai/harness/policy.json
@@ -136,7 +136,7 @@
     "projection_apply": "automatic",
     "projection_failure_gate": "strict",
     "projection_version": "0.5.8",
-    "projection_timeout_ms": 120000,
+    "projection_timeout_ms": 300000,
     "freshness_gate": "strict",
     "gate_min_severity": "medium",
     "pending_card_scope": "capability",

--- a/.ai/harness/policy.json
+++ b/.ai/harness/policy.json
@@ -136,7 +136,7 @@
     "projection_apply": "automatic",
     "projection_failure_gate": "strict",
     "projection_version": "0.5.8",
-    "projection_timeout_ms": 300000,
+    "projection_timeout_ms": 120000,
     "freshness_gate": "strict",
     "gate_min_severity": "medium",
     "pending_card_scope": "capability",

--- a/plans/plan-20260909-1853-projection-timeout.md
+++ b/plans/plan-20260909-1853-projection-timeout.md
@@ -1,0 +1,145 @@
+# Plan: Raise architecture projection timeout bound
+
+> **Status**: Executing
+> **Created**: 20260909-1853
+> **Slug**: projection-timeout
+> **Planning Source**: repo-harness-plan
+> **Orchestration Kind**: host-plan
+> **Source Ref**: (none)
+> **Artifact Level**: work-package
+> **Promotion Reason**: verification_boundary
+> **Verification Boundary**: Projection provider bound and running-job reclaim window verified together via focused projection tests plus repository-integrity checks
+> **Rollback Surface**: Single-commit revert of the validator cap, this repo's policy value, and the derived stale window
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260909-1853-projection-timeout.contract.md`
+> **Task Review**: `tasks/reviews/20260909-1853-projection-timeout.review.md`
+> **Implementation Notes**: `tasks/notes/20260909-1853-projection-timeout.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from repo-harness-plan planning output.
+- Source ref: (none)
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260909-1853-projection-timeout.md`
+- Sprint contract: `tasks/contracts/20260909-1853-projection-timeout.contract.md`
+- Sprint review: `tasks/reviews/20260909-1853-projection-timeout.review.md`
+- Implementation notes: `tasks/notes/20260909-1853-projection-timeout.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260909-1853-projection-timeout.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260909-1853-projection-timeout.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260909-1853-projection-timeout.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260909-1853-projection-timeout.contract.md`
+- Review file: `tasks/reviews/20260909-1853-projection-timeout.review.md`
+- Implementation notes file: `tasks/notes/20260909-1853-projection-timeout.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260909-1853-projection-timeout.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260909-1853-projection-timeout.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: Single-commit revert of the validator cap, this repo's policy value, and the derived stale window
+- **Verification boundary**: Projection provider bound and running-job reclaim window verified together via focused projection tests plus repository-integrity checks
+- **Review/acceptance boundary**: `tasks/reviews/20260909-1853-projection-timeout.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: verification_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260909-1853-projection-timeout.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260909-1853-projection-timeout.contract.md`, `tasks/reviews/20260909-1853-projection-timeout.review.md`, and `tasks/notes/20260909-1853-projection-timeout.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260909-1853-projection-timeout.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: Single-commit revert of the validator cap, this repo's policy value, and the derived stale window
+
+## Captured Planning Output
+
+## Context
+
+The archctx `projection run` apply for 60+ changed paths exceeds the 120s provider bound
+under host load, and the projection job dead-letters after four consecutive
+`process timed out after 118xxxms` failures. This repo needs a longer provider bound.
+
+## Decision
+
+- Raise the `policy.architecture.projection_timeout_ms` validator upper bound from 120000 to
+  600000; the default stays 120000 so generated downstream repos are unchanged.
+- Set this repo's `.ai/harness/policy.json#architecture.projection_timeout_ms` to 300000.
+- Derive the running-job stale reclaim window from the resolved policy timeout
+  (`timeoutMs + 30_000`) instead of the `RUNNING_STALE_MS = 150_000` constant, so a longer
+  provider bound cannot reclaim a live job. `recoverAbandonedArchitectureProjectionJobs` takes
+  the resolved timeout from `drainArchitectureProjectionJobs`; there is no second timeout constant.
+- Hook budgets are untouched: `deadlineMs = min(options.deadlineMs, clock() + policy.timeoutMs)`
+  still clamps to the Stop-hook host budget, so only an explicit `drain` without a host deadline
+  gets the longer window.
+
+## Task Breakdown
+
+- [x] Raise the projection timeout validator cap to 600000 and keep the 120000 default
+- [x] Set this repo's policy projection_timeout_ms to 300000
+- [x] Derive the running stale window from the resolved policy timeout
+- [x] Update validator boundary and stale-window tests
+
+## Verification
+
+- `bunx tsc --noEmit`
+- `bun test --timeout 60000 tests/state/operation-readiness.test.ts tests/architecture-projection-orchestration.test.ts tests/architecture-projection-provider.test.ts tests/unit/helper-projection-drift.test.ts`
+- `bun src/cli/index.ts architecture-projection status --json`
+- repository-integrity checks
+
+## Rollback
+
+Revert the commit; the validator cap and this repo's policy value return to 120000 and the
+stale window returns to a fixed 150000-equivalent derivation.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [x] Raise the projection timeout validator cap to 600000 and keep the 120000 default
+- [x] Set this repo's policy projection_timeout_ms to 300000
+- [x] Derive the running stale window from the resolved policy timeout
+- [x] Update validator boundary and stale-window tests

--- a/plans/plan-20260909-1853-projection-timeout.md
+++ b/plans/plan-20260909-1853-projection-timeout.md
@@ -119,7 +119,7 @@ under host load, and the projection job dead-letters after four consecutive
 ## Task Breakdown
 
 - [x] Raise the projection timeout validator cap to 600000 and keep the 120000 default
-- [x] Set this repo's policy projection_timeout_ms to 300000
+- [ ] Set this repo's policy projection_timeout_ms to 300000 (deferred: the installed repo-harness runtime and Stop hook still validate 1000..120000; bump only after a runtime built from this change is installed globally)
 - [x] Derive the running stale window from the resolved policy timeout
 - [x] Update validator boundary and stale-window tests
 
@@ -140,6 +140,6 @@ stale window returns to a fixed 150000-equivalent derivation.
 
 ## Task Breakdown
 - [x] Raise the projection timeout validator cap to 600000 and keep the 120000 default
-- [x] Set this repo's policy projection_timeout_ms to 300000
+- [ ] Set this repo's policy projection_timeout_ms to 300000 (deferred: the installed repo-harness runtime and Stop hook still validate 1000..120000; bump only after a runtime built from this change is installed globally)
 - [x] Derive the running stale window from the resolved policy timeout
 - [x] Update validator boundary and stale-window tests

--- a/plans/prds/20260903-0435-archctx-backed-refactor-mode.prd.md
+++ b/plans/prds/20260903-0435-archctx-backed-refactor-mode.prd.md
@@ -343,7 +343,7 @@
   - 只透過 CLI 消費；0.5.x 不新增 MCP 工具。
   - `archctx-contracts@0.5.2` 已凍結 `RefactorVerificationRequestV1` 與 ingress validator；核心 API 維持 `refactorVerifyInvariantIssues(afterSnapshot, evidence)`，語義輸入是 after `ModuleStatisticsSnapshotV1` + `RefactorResolutionEvidenceV1`。
   - 上游錯誤碼原樣透出，不本地翻譯成別的語義。
-- Recommended Defaults: scan stage = `0.5.2` + `["module-statistics-v1","refactor-assessment-v1","recommendation-v3"]`；verify stage = `0.5.2` + `["refactor-resolution-v1"]`；timeout 沿用 `projection_timeout_ms` 的 1000..120000 邊界。
+- Recommended Defaults: scan stage = `0.5.2` + `["module-statistics-v1","refactor-assessment-v1","recommendation-v3"]`；verify stage = `0.5.2` + `["refactor-resolution-v1"]`；timeout 沿用 `projection_timeout_ms` 的 1000..600000 邊界。
 - Freedoms: request 組裝的內部結構；readback 快取策略。
 - Normal path: 解析 package-local archctx → `capabilities` handshake → 組 `RefactorRequestV1`（帶 `expectedHeadSha` / `expectedWorktreeDigest`）→ 呼叫 → 驗證 result → 回傳。
 - Failure path 1: 版本或 feature 不匹配 → `refactor_provider_version_mismatch`，零產出。
@@ -651,7 +651,7 @@ Module 8 完整 → Module 9 → Module 10
 | Target | Number | Measurement Method | Degradation Threshold |
 |---|---:|---|---:|
 | Cutover Closure gate 單次執行 | 15 秒 | 在本倉庫規模上計時 | 45 秒 |
-| `refactor scan` 端到端（含 provider） | 120 秒 | 沿用 `projection_timeout_ms` 上限 | 硬上限 120 秒即失敗 |
+| `refactor scan` 端到端（含 provider） | policy `projection_timeout_ms` | 沿用 `projection_timeout_ms` 上限（validator 1000..600000，本 repo 300000） | 超過 policy 值即失敗 |
 | Board 從權威完全重建 | 10 秒 | 刪除目錄後重建計時 | 30 秒 |
 | Program event chain 重放 | 2 秒 | 1000 event 的 projection 重建 | 8 秒 |
 
@@ -750,7 +750,7 @@ You are implementing this PRD.
 - **判級與提案的職責倒置是這條鏈最容易做錯的地方。** 直覺會以為「分析工具給建議、執行方採納」，但上游 contract 的實際形狀相反：ArchContext 只給觀察與判級，**提案由 repo-harness 側的 agent 撰寫並送進去評估**。這意味著 proposal 的質量是 repo-harness 的責任，而 scale 的正確性是 ArchContext 的責任。任何把兩者混在一起的實作（例如本地先猜 scale 再去驗證）都會退化成第二個判定器。
 - **「PR merged ≠ resolved」是資料模型層強制，不是文檔提醒。** `RefactorExecutionBindingV1` 結構上沒有狀態欄位，`RefactorProgramV1` 也沒有。repo-harness 在 exact final main 的 ArchContext resolution 尚未產生前，唯一能表達的就是 `merged_pending_measurement`——它結構上無法說謊。
 - **10x 時最先失敗的三處。** 其一，program event chain 的線性掃描：program 數上升後 projection 重建會變慢，解法是 content-addressed 索引與 per-program 投影，GC 只清 terminal runtime cache、絕不刪 binding。其二，closure gate 的殘留掃描：selector 數 × 檔案數是乘積關係，解法是把掃描限縮在 contract allowed paths 與 diff 觸及檔案，而不是全倉庫掃。其三，`maximum_parallel_modules` 與 node 粒度 concurrency key 的組合會在大型 cross-module program 上成為吞吐瓶頸——正確解法是拆小 program，不是放寬 concurrency key。
-- **provider 呼叫是外部 I/O，必須有預算。** scan 走既有 `projection_timeout_ms` 的 1000..120000 邊界；一次 program 的 provider 呼叫次數應有上限並記入 event chain，避免重試風暴打到上游。GPT Pro lane 的呼叫成本更高，`proposal_author = gpt_pro` 必須有每 program 的次數上限。
+- **provider 呼叫是外部 I/O，必須有預算。** scan 走既有 `projection_timeout_ms` 的 1000..600000 邊界；一次 program 的 provider 呼叫次數應有上限並記入 event chain，避免重試風暴打到上游。GPT Pro lane 的呼叫成本更高，`proposal_author = gpt_pro` 必須有每 program 的次數上限。
 - **兩階段 provider 的代價是狀態空間變大。** Stage 2 不可用時 Module 8 的預驗跳過、Module 9 的測量停在 `merged_pending_measurement`——這兩條路徑必須有獨立測試，否則會退化成「Stage 2 永遠不可用也沒人發現」。
 
 ## Approved execution mapping clarification (2026-09-05)

--- a/src/core/architecture/projection.ts
+++ b/src/core/architecture/projection.ts
@@ -191,7 +191,7 @@ export function readArchitectureProjectionPolicy(value: unknown): ArchitecturePr
   }
   if (failureGate !== 'advisory' && failureGate !== 'strict') throw new Error('policy.architecture.projection_failure_gate must be advisory|strict');
   if (typeof requiredVersion !== 'string' || requiredVersion.trim() === '') throw new Error('policy.architecture.projection_version must be a non-empty string');
-  if (!Number.isInteger(timeoutMs) || (timeoutMs as number) < 1_000 || (timeoutMs as number) > 120_000) throw new Error('policy.architecture.projection_timeout_ms must be 1000..120000');
+  if (!Number.isInteger(timeoutMs) || (timeoutMs as number) < 1_000 || (timeoutMs as number) > 600_000) throw new Error('policy.architecture.projection_timeout_ms must be 1000..600000');
   return { provider, applyMode, failureGate, requiredVersion, timeoutMs: timeoutMs as number };
 }
 

--- a/src/effects/architecture/projection-jobs.ts
+++ b/src/effects/architecture/projection-jobs.ts
@@ -18,7 +18,20 @@ export function architectureProjectionRunningStaleMs(projectionTimeoutMs: number
   return projectionTimeoutMs + RUNNING_STALE_MARGIN_MS;
 }
 
-export type ProjectionJobFailureKind = 'preflight' | 'reconciliation' | 'host-budget' | 'process' | 'timeout' | 'stale-snapshot' | 'invalid-result' | 'refresh' | 'permanent';
+/** Recorded on the reclaimed record so a claim shape that predates the
+ * persisted attempt budget is visible instead of silently accepted. */
+export const LEGACY_ATTEMPT_BUDGET_NOTE = 'legacy claim without a persisted attempt budget; stale window derived from the current policy timeout';
+
+/** The claim this process holds was reclaimed or replaced, so it may neither
+ * publish a receipt nor drive the record's failure transition. */
+export class ArchitectureProjectionOwnershipError extends Error {
+  constructor(readonly jobId: string, message: string) {
+    super(message);
+    this.name = 'ArchitectureProjectionOwnershipError';
+  }
+}
+
+export type ProjectionJobFailureKind = 'preflight' | 'reconciliation' | 'host-budget' | 'process' | 'timeout' | 'stale-snapshot' | 'invalid-result' | 'refresh' | 'permanent' | 'lost-ownership';
 
 export interface ArchitectureProjectionJobV1 {
   schemaVersion: 'repo-harness.architecture-projection-job/v1';
@@ -32,6 +45,12 @@ export interface ArchitectureProjectionJobV1 {
   createdAt: string;
   updatedAt: string;
   ownerPid?: number;
+  /** Budget resolved from the policy timeout at claim time. Recovery compares
+   * against this persisted deadline so a later policy edit cannot shorten a
+   * live attempt's lease. Absent on a legacy record and on a claim taken while
+   * the policy could not be resolved. */
+  attemptTimeoutMs?: number;
+  attemptDeadlineAt?: string;
   lastFailure?: { kind: ProjectionJobFailureKind; message: string; at: string };
 }
 
@@ -225,8 +244,18 @@ export function enqueueArchitectureProjectionJob(
   });
 }
 
+/** Reclaim time of a running claim. The persisted attempt deadline is the
+ * authority; only a record written before that field existed falls back to the
+ * current policy timeout, and that fallback is recorded on the reclaimed job. */
+function attemptReclaim(job: ArchitectureProjectionJobV1, projectionTimeoutMs: number): { atMs: number; legacy: boolean } {
+  const deadlineMs = job.attemptDeadlineAt === undefined ? Number.NaN : Date.parse(job.attemptDeadlineAt);
+  if (Number.isFinite(deadlineMs)) return { atMs: deadlineMs + RUNNING_STALE_MARGIN_MS, legacy: false };
+  const updatedAtMs = Date.parse(job.updatedAt);
+  if (!Number.isFinite(updatedAtMs)) return { atMs: Number.NEGATIVE_INFINITY, legacy: true };
+  return { atMs: updatedAtMs + architectureProjectionRunningStaleMs(projectionTimeoutMs), legacy: true };
+}
+
 export function recoverAbandonedArchitectureProjectionJobs(repoRoot: string, projectionTimeoutMs: number, now = new Date()): number {
-  const staleMs = architectureProjectionRunningStaleMs(projectionTimeoutMs);
   return withExclusiveDirectoryLock(repoRoot, LOCK_PATH, () => {
     let recovered = 0;
     for (const name of names(repoRoot, 'running')) {
@@ -237,14 +266,15 @@ export function recoverAbandonedArchitectureProjectionJobs(repoRoot: string, pro
         recovered += 1;
         continue;
       }
-      const updatedAtMs = Date.parse(job.updatedAt);
-      const stale = !Number.isFinite(updatedAtMs) || now.getTime() - updatedAtMs >= staleMs;
-      if (!stale) continue;
+      const reclaim = attemptReclaim(job, projectionTimeoutMs);
+      if (now.getTime() < reclaim.atMs) continue;
+      const message = `running job was abandoned after attempt ${job.attempt}${reclaim.legacy ? ` (${LEGACY_ATTEMPT_BUDGET_NOTE})` : ''}`;
+      const released = { ...job, ownerPid: undefined, attemptTimeoutMs: undefined, attemptDeadlineAt: undefined };
       if (job.attempt >= MAX_ATTEMPTS) {
-        const failure = { kind: 'timeout' as const, message: `running job was abandoned after attempt ${job.attempt}` };
+        const failure = { kind: 'timeout' as const, message };
         atomicJson(pathFor(repoRoot, 'dead-letter', job.jobId), {
           schemaVersion: 'repo-harness.architecture-projection-dead-letter/v1',
-          job: { ...job, status: 'pending', ownerPid: undefined, updatedAt: now.toISOString(), lastFailure: { ...failure, at: now.toISOString() } },
+          job: { ...released, status: 'pending', updatedAt: now.toISOString(), lastFailure: { ...failure, at: now.toISOString() } },
           failedAt: now.toISOString(),
           failure,
         } satisfies ArchitectureProjectionDeadLetterV1);
@@ -253,11 +283,10 @@ export function recoverAbandonedArchitectureProjectionJobs(repoRoot: string, pro
         continue;
       }
       const pending = {
-        ...job,
+        ...released,
         status: 'pending' as const,
         updatedAt: now.toISOString(),
-        ownerPid: undefined,
-        lastFailure: { kind: 'timeout' as const, message: `running job was abandoned after attempt ${job.attempt}`, at: now.toISOString() },
+        lastFailure: { kind: 'timeout' as const, message, at: now.toISOString() },
       };
       atomicJson(pathFor(repoRoot, 'pending', job.jobId), pending);
       unlinkSync(runningPath);
@@ -267,18 +296,33 @@ export function recoverAbandonedArchitectureProjectionJobs(repoRoot: string, pro
   });
 }
 
-export function claimNextArchitectureProjectionJob(repoRoot: string, now = new Date()): ArchitectureProjectionJobV1 | null {
+/**
+ * `attemptTimeoutMs` is the resolved policy timeout this attempt runs under; it
+ * is persisted as the attempt's own deadline so recovery never re-derives the
+ * lease from a policy value edited after the claim. `null` means the policy was
+ * not resolvable for this claim (preflight failure), which persists no budget
+ * and leaves the record on the legacy recovery fallback.
+ */
+export function claimNextArchitectureProjectionJob(
+  repoRoot: string,
+  attemptTimeoutMs: number | null,
+  now = new Date(),
+): ArchitectureProjectionJobV1 | null {
   return withExclusiveDirectoryLock(repoRoot, LOCK_PATH, () => {
     if (names(repoRoot, 'running').length > 0) return null;
     const pending = jobsByCreatedAt(repoRoot, 'pending')[0];
     if (!pending) return null;
     const pendingPath = pathFor(repoRoot, 'pending', pending.jobId);
+    const budget = attemptTimeoutMs !== null && Number.isFinite(attemptTimeoutMs)
+      ? { attemptTimeoutMs, attemptDeadlineAt: new Date(now.getTime() + attemptTimeoutMs).toISOString() }
+      : { attemptTimeoutMs: undefined, attemptDeadlineAt: undefined };
     const running: ArchitectureProjectionJobV1 = {
       ...pending,
       status: 'running',
       attempt: pending.attempt + 1,
       ownerPid: process.pid,
       updatedAt: now.toISOString(),
+      ...budget,
     };
     atomicJson(pathFor(repoRoot, 'running', running.jobId), running);
     unlinkSync(pendingPath);
@@ -304,6 +348,8 @@ export function retryArchitectureProjectionDeadLetter(
       status: 'pending',
       attempt: 0,
       ownerPid: undefined,
+      attemptTimeoutMs: undefined,
+      attemptDeadlineAt: undefined,
       updatedAt: now.toISOString(),
       lastFailure: undefined,
     };
@@ -322,7 +368,7 @@ export function completeArchitectureProjectionJob(
 ): ArchitectureProjectionReceiptV1 {
   return withExclusiveDirectoryLock(repoRoot, LOCK_PATH, () => {
     const runningPath = pathFor(repoRoot, 'running', job.jobId);
-    if (!existsSync(runningPath)) throw new Error(`architecture projection running job is missing: ${job.jobId}`);
+    if (!existsSync(runningPath)) throw new ArchitectureProjectionOwnershipError(job.jobId, `architecture projection running job is missing: ${job.jobId}`);
     assertClaimOwner(readJson<ArchitectureProjectionJobV1>(runningPath), job);
     const receipt: ArchitectureProjectionReceiptV1 = {
       schemaVersion: 'repo-harness.architecture-projection-receipt/v1',
@@ -457,13 +503,15 @@ export function failArchitectureProjectionJob(
 ): { state: 'pending' | 'dead-letter'; job: ArchitectureProjectionJobV1 } {
   return withExclusiveDirectoryLock(repoRoot, LOCK_PATH, () => {
     const runningPath = pathFor(repoRoot, 'running', job.jobId);
-    if (!existsSync(runningPath)) throw new Error(`architecture projection running job is missing: ${job.jobId}`);
+    if (!existsSync(runningPath)) throw new ArchitectureProjectionOwnershipError(job.jobId, `architecture projection running job is missing: ${job.jobId}`);
     assertClaimOwner(readJson<ArchitectureProjectionJobV1>(runningPath), job);
     const failed: ArchitectureProjectionJobV1 = {
       ...job,
       status: 'pending',
       attempt: failure.kind === 'preflight' || failure.kind === 'reconciliation' || failure.kind === 'host-budget' ? Math.max(0, job.attempt - 1) : job.attempt,
       ownerPid: undefined,
+      attemptTimeoutMs: undefined,
+      attemptDeadlineAt: undefined,
       updatedAt: now.toISOString(),
       lastFailure: { ...failure, at: now.toISOString() },
     };
@@ -491,7 +539,10 @@ function assertClaimOwner(persisted: ArchitectureProjectionJobV1, claimed: Archi
     || persisted.attempt !== claimed.attempt
     || persisted.ownerPid !== claimed.ownerPid
   ) {
-    throw new Error(`architecture projection running claim no longer belongs to this process: ${claimed.jobId}`);
+    throw new ArchitectureProjectionOwnershipError(
+      claimed.jobId,
+      `architecture projection running claim no longer belongs to this process: ${claimed.jobId}`,
+    );
   }
 }
 

--- a/src/effects/architecture/projection-jobs.ts
+++ b/src/effects/architecture/projection-jobs.ts
@@ -20,7 +20,7 @@ export function architectureProjectionRunningStaleMs(projectionTimeoutMs: number
 
 /** Recorded on the reclaimed record so a claim shape that predates the
  * persisted attempt budget is visible instead of silently accepted. */
-export const LEGACY_ATTEMPT_BUDGET_NOTE = 'legacy claim without a persisted attempt budget; stale window derived from the current policy timeout';
+export const LEGACY_ATTEMPT_BUDGET_NOTE = 'claim without a persisted attempt budget; stale window derived from the current policy timeout';
 
 /** The claim this process holds was reclaimed or replaced, so it may neither
  * publish a receipt nor drive the record's failure transition. */

--- a/src/effects/architecture/projection-jobs.ts
+++ b/src/effects/architecture/projection-jobs.ts
@@ -8,9 +8,15 @@ import type { AcceptedArchitectureChangeReferenceV1 } from 'archctx-contracts';
 export const ARCHITECTURE_PROJECTION_RUNTIME_ROOT = '.ai/harness/architecture-projection';
 const LOCK_PATH = `${ARCHITECTURE_PROJECTION_RUNTIME_ROOT}/locks/store`;
 const MAX_ATTEMPTS = 3;
-/** Longer than the configured 120 second provider bound. A dead Stop owner
- * cannot be reclaimed while its orphaned provider may still be running. */
-const RUNNING_STALE_MS = 150_000;
+/** Reclaim margin past the provider bound. A dead Stop owner cannot be
+ * reclaimed while its orphaned provider may still be running, so the stale
+ * window derives from the same resolved policy timeout the provider runs
+ * under rather than a second constant. */
+const RUNNING_STALE_MARGIN_MS = 30_000;
+
+export function architectureProjectionRunningStaleMs(projectionTimeoutMs: number): number {
+  return projectionTimeoutMs + RUNNING_STALE_MARGIN_MS;
+}
 
 export type ProjectionJobFailureKind = 'preflight' | 'reconciliation' | 'host-budget' | 'process' | 'timeout' | 'stale-snapshot' | 'invalid-result' | 'refresh' | 'permanent';
 
@@ -219,7 +225,8 @@ export function enqueueArchitectureProjectionJob(
   });
 }
 
-export function recoverAbandonedArchitectureProjectionJobs(repoRoot: string, now = new Date()): number {
+export function recoverAbandonedArchitectureProjectionJobs(repoRoot: string, projectionTimeoutMs: number, now = new Date()): number {
+  const staleMs = architectureProjectionRunningStaleMs(projectionTimeoutMs);
   return withExclusiveDirectoryLock(repoRoot, LOCK_PATH, () => {
     let recovered = 0;
     for (const name of names(repoRoot, 'running')) {
@@ -231,7 +238,7 @@ export function recoverAbandonedArchitectureProjectionJobs(repoRoot: string, now
         continue;
       }
       const updatedAtMs = Date.parse(job.updatedAt);
-      const stale = !Number.isFinite(updatedAtMs) || now.getTime() - updatedAtMs >= RUNNING_STALE_MS;
+      const stale = !Number.isFinite(updatedAtMs) || now.getTime() - updatedAtMs >= staleMs;
       if (!stale) continue;
       if (job.attempt >= MAX_ATTEMPTS) {
         const failure = { kind: 'timeout' as const, message: `running job was abandoned after attempt ${job.attempt}` };

--- a/src/effects/architecture/projection-orchestrator.ts
+++ b/src/effects/architecture/projection-orchestrator.ts
@@ -77,7 +77,7 @@ export function drainArchitectureProjectionJobs(
   if (policy.provider === 'disabled' || policy.applyMode !== 'automatic') return outcome(root, 'disabled', null, eventIds, null, null, true);
   const clock = options.nowMs ?? Date.now;
   const deadlineMs = Math.min(options.deadlineMs ?? Infinity, clock() + policy.timeoutMs);
-  recoverAbandonedArchitectureProjectionJobs(root, now);
+  recoverAbandonedArchitectureProjectionJobs(root, policy.timeoutMs, now);
   const blocked = architectureProjectionDeadLetterForSourceKeys(root, sourceKeys);
   if (blocked) return outcome(root, 'dead-letter', blocked.job.jobId, blocked.job.sourceEventIds, null, blocked.failure.message, false);
   let owned: string[];

--- a/src/effects/architecture/projection-orchestrator.ts
+++ b/src/effects/architecture/projection-orchestrator.ts
@@ -22,6 +22,8 @@ import {
   enqueueArchitectureProjectionJob,
   failArchitectureProjectionJob,
   recoverAbandonedArchitectureProjectionJobs,
+  ArchitectureProjectionOwnershipError,
+  type ArchitectureProjectionJobV1,
   type ArchitectureProjectionQueueStateV1,
   type ProjectionJobFailureKind,
 } from './projection-jobs';
@@ -72,7 +74,7 @@ export function drainArchitectureProjectionJobs(
   try {
     policy = options.policy ?? loadArchitectureProjectionPolicy(root);
   } catch (error) {
-    return failPreflight(root, events, observedPaths, now, error, options.acceptedChange);
+    return failPreflight(root, events, observedPaths, now, null, error, options.acceptedChange);
   }
   if (policy.provider === 'disabled' || policy.applyMode !== 'automatic') return outcome(root, 'disabled', null, eventIds, null, null, true);
   const clock = options.nowMs ?? Date.now;
@@ -84,7 +86,7 @@ export function drainArchitectureProjectionJobs(
   try {
     owned = architectureProjectionOwnedPaths(root);
   } catch (error) {
-    return failPreflight(root, events, observedPaths, now, error, options.acceptedChange);
+    return failPreflight(root, events, observedPaths, now, policy.timeoutMs, error, options.acceptedChange);
   }
   const eligible = events.flatMap((event) => event.changed_paths).filter((path) => !isOwned(path, owned));
   if (events.length > 0 && eligible.length === 0) {
@@ -96,7 +98,7 @@ export function drainArchitectureProjectionJobs(
   if (aggregateState === 'dead-letter') return outcome(root, 'dead-letter', aggregateId, events.map((event) => event.event_id), null, 'job already dead-lettered', false);
   if (aggregateState === 'receipt') return outcome(root, 'idle', aggregateId, events.map((event) => event.event_id), null, null, true);
   enqueueArchitectureProjectionJob(root, eventIds, sourceKeys, eligible, now, options.acceptedChange);
-  const job = claimNextArchitectureProjectionJob(root, now);
+  const job = claimNextArchitectureProjectionJob(root, policy.timeoutMs, now);
   if (!job) return outcome(root, 'idle', null, events.map((event) => event.event_id), null, null, false);
   let completedResultStatus: ProjectionResultV1['status'] | null = null;
   try {
@@ -152,6 +154,7 @@ export function drainArchitectureProjectionJobs(
     completeArchitectureProjectionJob(root, job, result, refreshReceipts.map((entry) => entry.receiptDigest), now);
     completedResultStatus = result.status;
   } catch (error) {
+    if (error instanceof ArchitectureProjectionOwnershipError) return lostOwnership(root, job, error);
     // A host yielding its shorter time slice is not a failed business attempt.
     const classified = options.deadlineMs !== undefined && clock() >= options.deadlineMs
       ? { kind: 'host-budget' as const, message: 'host architecture projection budget exhausted; job retained for an explicit drain' }
@@ -160,6 +163,7 @@ export function drainArchitectureProjectionJobs(
     try {
       transition = failArchitectureProjectionJob(root, job, classified, now);
     } catch (transitionError) {
+      if (transitionError instanceof ArchitectureProjectionOwnershipError) return lostOwnership(root, job, transitionError);
       const transitionMessage = transitionError instanceof Error ? transitionError.message : String(transitionError);
       throw new Error(`${classified.message}; architecture projection failure transition failed: ${transitionMessage}`, { cause: error });
     }
@@ -184,11 +188,27 @@ function summarizeNonTerminal(result: ProjectionResultV1): string {
   return `archctx returned ${result.status}${actions ? `; human actions: ${actions}` : ''}`;
 }
 
+/**
+ * Recovery reclaimed this attempt mid-run, so the record now belongs to another
+ * owner: neither the receipt nor a failure transition may be written from here.
+ * The classified failure is reported on the drain result only, and the source
+ * events stay unacknowledged for the owner that will retry the job.
+ */
+function lostOwnership(
+  repoRoot: string,
+  job: ArchitectureProjectionJobV1,
+  error: ArchitectureProjectionOwnershipError,
+): ArchitectureProjectionDrainResultV1 {
+  const classified: { kind: ProjectionJobFailureKind; message: string } = { kind: 'lost-ownership', message: error.message };
+  return outcome(repoRoot, 'retry-pending', job.jobId, job.sourceEventIds, null, `${classified.kind}: ${classified.message}`, false);
+}
+
 function failPreflight(
   repoRoot: string,
   events: readonly ArchitectureProjectionSourceEvent[],
   changedPaths: readonly string[],
   now: Date,
+  attemptTimeoutMs: number | null,
   error: unknown,
   acceptedChange?: AcceptedArchitectureChangeReferenceV1,
 ): ArchitectureProjectionDrainResultV1 {
@@ -203,7 +223,7 @@ function failPreflight(
   if (!queued || queued.jobId !== expectedJobId) {
     return outcome(repoRoot, 'retry-pending', queued?.jobId ?? null, eventIds, null, message, false);
   }
-  const job = claimNextArchitectureProjectionJob(repoRoot, now);
+  const job = claimNextArchitectureProjectionJob(repoRoot, attemptTimeoutMs, now);
   if (!job) return outcome(repoRoot, 'retry-pending', queued.jobId, eventIds, null, message, false);
   const transition = failArchitectureProjectionJob(repoRoot, job, { kind: 'preflight', message }, now);
   return outcome(

--- a/tasks/contracts/20260909-1853-projection-timeout.contract.md
+++ b/tasks/contracts/20260909-1853-projection-timeout.contract.md
@@ -28,7 +28,7 @@ reclaimed attempt cannot publish its receipt afterwards.
 ## Scope
 
 - In scope: projection policy validator upper bound (600000, default unchanged at 120000);
-  this repo's policy value (300000); the per-attempt reclaim budget persisted on the running
+  this repo's policy value (300000, deferred to a follow-up: the installed runtime still validates 1000..120000); the per-attempt reclaim budget persisted on the running
   job record (`attemptTimeoutMs`, `attemptDeadlineAt`) by
   `claimNextArchitectureProjectionJob` and consumed by
   `recoverAbandonedArchitectureProjectionJobs` in

--- a/tasks/contracts/20260909-1853-projection-timeout.contract.md
+++ b/tasks/contracts/20260909-1853-projection-timeout.contract.md
@@ -21,19 +21,28 @@ architecture projection cannot complete here.
 ## Goal
 
 Allow `.ai/harness/policy.json#architecture.projection_timeout_ms` to be 300000 in this repo,
-with the running-job reclaim window derived from the same resolved timeout so a longer provider
-bound cannot reclaim a live job.
+with each attempt's reclaim window bound to the policy timeout resolved at claim time, so
+neither a longer provider bound nor a later policy edit can reclaim a live attempt, and a
+reclaimed attempt cannot publish its receipt afterwards.
 
 ## Scope
 
 - In scope: projection policy validator upper bound (600000, default unchanged at 120000);
-  this repo's policy value (300000); the derived running-job stale window in
-  `src/effects/architecture/projection-jobs.ts` plus its caller in
+  this repo's policy value (300000); the per-attempt reclaim budget persisted on the running
+  job record (`attemptTimeoutMs`, `attemptDeadlineAt`) by
+  `claimNextArchitectureProjectionJob` and consumed by
+  `recoverAbandonedArchitectureProjectionJobs` in
+  `src/effects/architecture/projection-jobs.ts`; the typed
+  `ArchitectureProjectionOwnershipError` raised by the publish-time claim check and its
+  `lost-ownership` drain classification in
   `src/effects/architecture/projection-orchestrator.ts`; the affected tests.
 - Out of scope: Stop-hook host budgets, downstream policy seeds in `scripts/` and
-  `assets/templates/` (they keep the 120000 default), any second timeout constant.
-- Taste constraints: one source of truth for the timeout; the stale window is a derivation of
-  the resolved policy timeout, never a parallel constant.
+  `assets/templates/` (they keep the 120000 default), any second timeout constant, PID
+  liveness as a reclaim signal, and guarding the provider apply itself (only the receipt is
+  ownership-guarded).
+- Taste constraints: one source of truth for the timeout; the reclaim window is the attempt's
+  own persisted budget, never a parallel constant and never a re-derivation from a policy value
+  edited after the claim.
 
 ## Stop Conditions
 
@@ -168,6 +177,17 @@ exit_criteria:
       "inputs": { "env": [] }
     },
     {
+      "id": "focused-regression-acceptance",
+      "kind": "package_test",
+      "path": "tests/unit/architecture-projection-acceptance.test.ts",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Covers the claim-signature change consumed by the acceptance surface.",
+      "inputs": { "env": [] }
+    },
+    {
       "id": "typecheck",
       "kind": "command",
       "command": "bun run check:type",
@@ -189,10 +209,23 @@ the intended coverage; do not infer that choice from paths or command text.
 ## Acceptance Notes (Human Review)
 
 - Functional behavior: the validator accepts 300000 and rejects 600001; this repo's projection
-  provider still reports `state: ready` with the 300000 policy; the running-job reclaim window
-  is `policy.timeoutMs + 30_000`.
-- Edge cases: a job updated `timeoutMs + 10s` ago is not reclaimed while `timeoutMs + 40s` is;
-  the disabled-provider branch still returns the 120000 default without validating the value.
+  provider still reports `state: ready` with the 300000 policy; a claim persists
+  `attemptTimeoutMs` plus `attemptDeadlineAt = claimedAt + policy.timeoutMs`, and recovery
+  reclaims only at `attemptDeadlineAt + 30_000`.
+- Edge cases: a claim taken under a 300000 policy survives a later shrink to 120000 at
+  claim+180s and is reclaimed at claim+330s; a legacy running record without
+  `attemptDeadlineAt` still falls back to `policy.timeoutMs + 30_000` and records that
+  fallback in its `lastFailure.message`; a claimant whose record was reclaimed and re-claimed
+  cannot write the receipt and the drain reports `lost-ownership` instead of throwing; the
+  receipt-exists short-circuit still wins crash recovery; the disabled-provider branch still
+  returns the 120000 default without validating the value.
+- Not guarded: the provider apply runs before the receipt, so a reclaimed attempt can still
+  have written architecture docs and agent context to the worktree; only the receipt and the
+  failure transition are ownership-gated, and the reclaiming owner re-runs an idempotent
+  snapshot-checked apply.
+- Runtime skew: the installed `repo-harness` 0.18.0 CLI still enforces the old
+  `1000..120000` validator bound, so `repo-harness architecture-projection drain` against this
+  repo's 300000 policy fails until this branch ships; the branch source CLI resolves it.
 - Reclaim latency: the stale window is a single upper bound over every path, so a Stop-hook job
   clamped to its 20s host budget is reclaimed after 330s instead of 150s and an always-abandoned
   job reaches dead-letter after roughly 16.5 minutes instead of 7.5; the hook itself returns idle,

--- a/tasks/contracts/20260909-1853-projection-timeout.contract.md
+++ b/tasks/contracts/20260909-1853-projection-timeout.contract.md
@@ -81,6 +81,7 @@ Required when Task Profile is `bugfix`; leave as-is otherwise.
 
 ```yaml
 allowed_paths:
+  - .ai/harness/policy.json
   - docs/spec.md
   - plans/
   - tasks/todos.md
@@ -192,6 +193,10 @@ the intended coverage; do not infer that choice from paths or command text.
   is `policy.timeoutMs + 30_000`.
 - Edge cases: a job updated `timeoutMs + 10s` ago is not reclaimed while `timeoutMs + 40s` is;
   the disabled-provider branch still returns the 120000 default without validating the value.
+- Reclaim latency: the stale window is a single upper bound over every path, so a Stop-hook job
+  clamped to its 20s host budget is reclaimed after 330s instead of 150s and an always-abandoned
+  job reaches dead-letter after roughly 16.5 minutes instead of 7.5; the hook itself returns idle,
+  so this is drain-progression latency, not a hook stall.
 - Regression risks: none for hook budgets — `deadlineMs` still clamps to the host deadline, so
   only an explicit `drain` without a host deadline gets the longer window.
 

--- a/tasks/contracts/20260909-1853-projection-timeout.contract.md
+++ b/tasks/contracts/20260909-1853-projection-timeout.contract.md
@@ -223,6 +223,10 @@ the intended coverage; do not infer that choice from paths or command text.
   have written architecture docs and agent context to the worktree; only the receipt and the
   failure transition are ownership-gated, and the reclaiming owner re-runs an idempotent
   snapshot-checked apply.
+- Policy bump deferred: `.ai/harness/policy.json` stays at 120000 in this PR because the installed
+  `repo-harness` runtime (Stop hook, global CLI) validates the old 1000..120000 cap; raising the value
+  before that runtime is rebuilt from this change would break every hook-driven drain. The 300000 bump
+  is a follow-up one-line change gated on the installed runtime version.
 - Runtime skew: the installed `repo-harness` 0.18.0 CLI still enforces the old
   `1000..120000` validator bound, so `repo-harness architecture-projection drain` against this
   repo's 300000 policy fails until this branch ships; the branch source CLI resolves it.

--- a/tasks/contracts/20260909-1853-projection-timeout.contract.md
+++ b/tasks/contracts/20260909-1853-projection-timeout.contract.md
@@ -1,0 +1,202 @@
+# Task Contract: projection-timeout
+
+> **Status**: Active
+> **Plan**: plans/plan-20260909-1853-projection-timeout.md
+> **Task Profile**: code-change
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: ancienttwo
+> **Capability ID**: root
+> **Last Updated**: 2026-09-09 18:53
+> **Review File**: `tasks/reviews/20260909-1853-projection-timeout.review.md`
+> **Notes File**: `tasks/notes/20260909-1853-projection-timeout.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+The archctx `projection run` apply for 60+ changed paths exceeds the 120s provider bound under
+host load, so this repo's projection job dead-letters after four consecutive
+`process timed out after 118xxxms` failures. Without a longer provider bound the automatic
+architecture projection cannot complete here.
+
+## Goal
+
+Allow `.ai/harness/policy.json#architecture.projection_timeout_ms` to be 300000 in this repo,
+with the running-job reclaim window derived from the same resolved timeout so a longer provider
+bound cannot reclaim a live job.
+
+## Scope
+
+- In scope: projection policy validator upper bound (600000, default unchanged at 120000);
+  this repo's policy value (300000); the derived running-job stale window in
+  `src/effects/architecture/projection-jobs.ts` plus its caller in
+  `src/effects/architecture/projection-orchestrator.ts`; the affected tests.
+- Out of scope: Stop-hook host budgets, downstream policy seeds in `scripts/` and
+  `assets/templates/` (they keep the 120000 default), any second timeout constant.
+- Taste constraints: one source of truth for the timeout; the stale window is a derivation of
+  the resolved policy timeout, never a parallel constant.
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+
+## Falsifier
+
+What observable evidence would prove this task's direction wrong, and the cheapest proof point to check first. Leave as-is if not applicable.
+
+## Root Cause Evidence
+
+Required when Task Profile is `bugfix`; leave as-is otherwise.
+
+- root_cause: one sentence naming file:line/condition (testable, not "a state issue").
+- repro: the command or UI path that reproduces the symptom.
+- regression_guard: path to a test that fails on the unfixed code and passes after the fix (must also appear as a `package_test` check in Verification Plan).
+- pre_fix_failure_artifact: path to a captured run of regression_guard on the UNFIXED code. Capture with `bun test <regression_guard> > <artifact> 2>&1; echo "PRE_FIX_EXIT=$?" >> <artifact>` (no pipes — pipes swallow the exit status). The gate requires a non-zero `PRE_FIX_EXIT=` line plus the regression_guard path string in the artifact (see the Root Cause Evidence Gate section in docs/reference-configs/sprint-contracts.md).
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260909-1853-projection-timeout.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260909-1853-projection-timeout.review.md`
+- Notes file: `tasks/notes/20260909-1853-projection-timeout.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Change Assessment
+
+```json
+{"protocol":1,"oracles":[]}
+```
+
+## Acceptance Policy
+
+```json
+{"protocol":2,"reviewer":"Codex","source":"codex-plugin","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - docs/spec.md
+  - plans/
+  - tasks/todos.md
+  - tasks/contracts/20260909-1853-projection-timeout.contract.md
+  - tasks/reviews/20260909-1853-projection-timeout.review.md
+  - tasks/notes/20260909-1853-projection-timeout.notes.md
+  - .ai/context/capabilities.json
+  - .claude/templates/
+  - src/
+  - tests/
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+    fallback: null
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+This block contains only non-executable artifact requirements. Define every
+executable check once in the canonical Verification Plan below. Each check must
+state its phase, cost, evidence policy, necessity, and input environment; a
+missing or malformed plan fails closed.
+
+```yaml
+exit_criteria:
+  files_exist:
+    - docs/spec.md
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260909-1853-projection-timeout.notes.md
+```
+
+## Verification Plan
+
+```json
+{
+  "protocol": 1,
+  "checks": [
+    {
+      "id": "focused-regression",
+      "kind": "package_test",
+      "path": "tests/architecture-projection-orchestration.test.ts",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Covers the changed behavior named by this contract.",
+      "inputs": { "env": [] }
+    },
+    {
+      "id": "typecheck",
+      "kind": "command",
+      "command": "bun run check:type",
+      "cwd": ".",
+      "phase": "preflight",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Checks TypeScript contracts before behavioral verification.",
+      "inputs": { "env": [] }
+    }
+  ]
+}
+```
+
+This is the sole executable verification authority. Use `baseline_with_delta`
+only when a referenced immutable baseline plus named current delta checks prove
+the intended coverage; do not infer that choice from paths or command text.
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior: the validator accepts 300000 and rejects 600001; this repo's projection
+  provider still reports `state: ready` with the 300000 policy; the running-job reclaim window
+  is `policy.timeoutMs + 30_000`.
+- Edge cases: a job updated `timeoutMs + 10s` ago is not reclaimed while `timeoutMs + 40s` is;
+  the disabled-provider branch still returns the 120000 default without validating the value.
+- Regression risks: none for hook budgets — `deadlineMs` still clamps to the host deadline, so
+  only an explicit `drain` without a host deadline gets the longer window.
+
+## Rollback Point
+
+- Commit / checkpoint: `origin/main` at the branch merge-base.
+- Revert strategy: revert the single commit; the validator cap, this repo's policy value, and
+  the stale window return to their prior behavior.

--- a/tasks/notes/20260909-1853-projection-timeout.notes.md
+++ b/tasks/notes/20260909-1853-projection-timeout.notes.md
@@ -6,7 +6,7 @@
 > **Review**: tasks/reviews/20260909-1853-projection-timeout.review.md
 > **Last Updated**: 2026-09-09 18:53
 > **Lifecycle**: notes
-> **Substantive Change SHA256**: `sha256:9965c617536747b4c4043c3b5e82b7dabd695f45caf8cd7100b55a4ca6b975cc`
+> **Substantive Change SHA256**: `sha256:9743cd643fed1a77e634a3b31796fc093fd75d4a5e994979c01bcd0213b9527b`
 
 ## Design Decisions
 
@@ -17,6 +17,34 @@
   passed 120s, and keeping it as a second tunable would have created a second timeout authority.
 - Only the validator upper bound moves to 600000; the default stays 120000 so downstream policy
   seeds in `scripts/` and `assets/templates/` stay a valid untouched default.
+- Deriving the window from the timeout read at recovery time was still one authority too late:
+  worker A claims under a 300000 policy, the policy is edited to 120000, and worker B's recovery
+  at claim+180s recomputes a 150000 window and reclaims a live attempt. The budget is therefore
+  frozen at claim time onto the job record (`attemptTimeoutMs`, `attemptDeadlineAt =
+  claimedAt + policy.timeoutMs`) and recovery compares against that persisted deadline plus the
+  same 30s margin. The policy stays the only place a timeout is authored; the record only
+  carries the value that was resolved for that attempt.
+- A running record without `attemptDeadlineAt` is legacy shape only: it falls back to
+  `architectureProjectionRunningStaleMs(currentPolicyTimeout)` for that record alone, and the
+  reclaim writes `LEGACY_ATTEMPT_BUDGET_NOTE` into the job's `lastFailure.message`, so the
+  fallback is visible in the durable artifact instead of silently permanent. Every write that
+  releases a claim (recovery, failure transition, dead-letter retry) clears the attempt budget,
+  so a pending record never carries a previous attempt's deadline.
+- `claimNextArchitectureProjectionJob` takes `attemptTimeoutMs: number | null`. `null` is the
+  preflight path where the policy itself failed to load: there is no authoritative budget to
+  persist, so none is written and the record stays on the legacy fallback. That claim is failed
+  inside the same call, so it never reaches recovery in the running state.
+- PID liveness (`process.kill(pid, 0)`) was rejected as an extra early-reclaim signal. It is
+  unreliable across PID namespaces and after PID reuse, and a false "dead" reading would reclaim
+  a live attempt — exactly the failure this change exists to remove. Waiting for the persisted
+  deadline costs at most `timeout + 30s` of drain latency after a crash.
+- Publish ownership was already checked (`assertClaimOwner` in
+  `completeArchitectureProjectionJob` and `failArchitectureProjectionJob`), but it threw a plain
+  `Error`, and the failure transition then threw again, so a reclaimed attempt crashed the whole
+  drain with a compound error. The check now throws `ArchitectureProjectionOwnershipError` (also
+  for the missing-running-record case, which is what reclaim actually leaves behind), and the
+  orchestrator turns it into a `lost-ownership` classified drain result: no receipt, no failure
+  transition onto a record another owner holds, source events unacknowledged.
 
 ## Deviations From Plan Or Spec
 
@@ -29,10 +57,20 @@
 | Raise `RUNNING_STALE_MS` to a new constant | Rejected | Two timeout authorities that can drift apart |
 | Derive the stale window from the resolved policy timeout | Chosen | One source of truth; the reclaim window follows whatever bound the provider actually runs under |
 | Raise the shipped default timeout to 300000 | Rejected | The long bound is a property of this repo's projection size, not of every generated repo |
+| Recompute the reclaim window from the current policy at recovery time | Rejected | A policy edit mid-attempt retroactively shortens a live lease and reclaims a running job |
+| Persist the attempt budget on the job record at claim time | Chosen | The lease is a property of the attempt, resolved once from the single policy authority |
+| Treat a dead `ownerPid` as an early-reclaim signal | Rejected | PID reuse and namespace mismatch can report a live owner as dead, reintroducing live-attempt reclaim |
+| Guard the provider apply as well as the receipt | Deferred | Apply is a provider-owned, snapshot-checked, idempotent write; making it conditional needs a provider-side lease, not a local check |
 
 ## Open Questions
 
-- None.
+- The provider apply is still unguarded against mid-run reclaim: a reclaimed attempt may have
+  already written architecture docs and agent context before the receipt is refused. The
+  reclaiming owner re-runs the same snapshot-checked apply, so the durable outcome converges,
+  but two owners can write the same files in sequence.
+- The installed `repo-harness` 0.18.0 CLI still rejects this repo's 300000 policy with the old
+  `1000..120000` bound, so the Stop-hook and global-CLI drain paths stay broken until this
+  branch ships as a release.
 
 ## Evidence Links
 

--- a/tasks/notes/20260909-1853-projection-timeout.notes.md
+++ b/tasks/notes/20260909-1853-projection-timeout.notes.md
@@ -1,0 +1,50 @@
+# Implementation Notes: projection-timeout
+
+> **Status**: Active
+> **Plan**: plans/plan-20260909-1853-projection-timeout.md
+> **Contract**: tasks/contracts/20260909-1853-projection-timeout.contract.md
+> **Review**: tasks/reviews/20260909-1853-projection-timeout.review.md
+> **Last Updated**: 2026-09-09 18:53
+> **Lifecycle**: notes
+> **Substantive Change SHA256**: `sha256:41e8374fbbf8e525684b256a4e5132cc91cf2179cd5f1c212367af71dd431b24`
+
+## Design Decisions
+
+- The running-job reclaim window is a derivation, not a constant: `recoverAbandonedArchitectureProjectionJobs`
+  now takes the resolved `policy.timeoutMs` from `drainArchitectureProjectionJobs` and computes
+  `architectureProjectionRunningStaleMs(timeoutMs) = timeoutMs + 30_000`. The prior
+  `RUNNING_STALE_MS = 150_000` constant would have reclaimed live jobs once the provider bound
+  passed 120s, and keeping it as a second tunable would have created a second timeout authority.
+- Only the validator upper bound moves to 600000; the default stays 120000 so downstream policy
+  seeds in `scripts/` and `assets/templates/` stay a valid untouched default.
+
+## Deviations From Plan Or Spec
+
+- None recorded.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| Raise `RUNNING_STALE_MS` to a new constant | Rejected | Two timeout authorities that can drift apart |
+| Derive the stale window from the resolved policy timeout | Chosen | One source of truth; the reclaim window follows whatever bound the provider actually runs under |
+| Raise the shipped default timeout to 300000 | Rejected | The long bound is a property of this repo's projection size, not of every generated repo |
+
+## Open Questions
+
+- None.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/notes/20260909-1853-projection-timeout.notes.md
+++ b/tasks/notes/20260909-1853-projection-timeout.notes.md
@@ -6,7 +6,7 @@
 > **Review**: tasks/reviews/20260909-1853-projection-timeout.review.md
 > **Last Updated**: 2026-09-09 18:53
 > **Lifecycle**: notes
-> **Substantive Change SHA256**: `sha256:a7599c3f245b48f01c5517b7bc49c6881c88c61a3e0fb163b7b155e9cc6ba24f`
+> **Substantive Change SHA256**: `sha256:e5749bd3f8997277ce8acd6b77df358878d6627eca57df54e14fb0f2a5756781`
 
 ## Design Decisions
 

--- a/tasks/notes/20260909-1853-projection-timeout.notes.md
+++ b/tasks/notes/20260909-1853-projection-timeout.notes.md
@@ -6,7 +6,7 @@
 > **Review**: tasks/reviews/20260909-1853-projection-timeout.review.md
 > **Last Updated**: 2026-09-09 18:53
 > **Lifecycle**: notes
-> **Substantive Change SHA256**: `sha256:9743cd643fed1a77e634a3b31796fc093fd75d4a5e994979c01bcd0213b9527b`
+> **Substantive Change SHA256**: `sha256:a7599c3f245b48f01c5517b7bc49c6881c88c61a3e0fb163b7b155e9cc6ba24f`
 
 ## Design Decisions
 

--- a/tasks/notes/20260909-1853-projection-timeout.notes.md
+++ b/tasks/notes/20260909-1853-projection-timeout.notes.md
@@ -6,7 +6,7 @@
 > **Review**: tasks/reviews/20260909-1853-projection-timeout.review.md
 > **Last Updated**: 2026-09-09 18:53
 > **Lifecycle**: notes
-> **Substantive Change SHA256**: `sha256:41e8374fbbf8e525684b256a4e5132cc91cf2179cd5f1c212367af71dd431b24`
+> **Substantive Change SHA256**: `sha256:9965c617536747b4c4043c3b5e82b7dabd695f45caf8cd7100b55a4ca6b975cc`
 
 ## Design Decisions
 

--- a/tasks/reviews/20260909-1853-projection-timeout.review.md
+++ b/tasks/reviews/20260909-1853-projection-timeout.review.md
@@ -1,0 +1,84 @@
+# Task Review: projection-timeout
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260909-1853-projection-timeout.md
+> **Contract**: tasks/contracts/20260909-1853-projection-timeout.contract.md
+> **Notes File**: tasks/notes/20260909-1853-projection-timeout.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-09-09 18:53
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Commands passed:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+- Waza `/check` run:
+- Commands run:
+- Manual checks:
+- Supporting artifacts:
+- Implementation notes reviewed:
+- Run snapshot:
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -1,7 +1,7 @@
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: 2026-09-09 17:31
+> **Updated**: 2026-09-09 18:53
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.

--- a/tests/architecture-projection-orchestration.test.ts
+++ b/tests/architecture-projection-orchestration.test.ts
@@ -543,7 +543,7 @@ describe('durable architecture projection orchestration', () => {
     const pending = JSON.parse(readFileSync(join(root, '.ai/harness/architecture-projection/pending', pendingName!), 'utf8'));
     expect(pending.attemptDeadlineAt).toBeUndefined();
     expect(pending.attemptTimeoutMs).toBeUndefined();
-    expect(pending.lastFailure.message).not.toContain('legacy claim');
+    expect(pending.lastFailure.message).not.toContain('without a persisted attempt budget');
   });
 
   test('falls back to the current policy derivation for a legacy running record and records the fallback', () => {

--- a/tests/architecture-projection-orchestration.test.ts
+++ b/tests/architecture-projection-orchestration.test.ts
@@ -16,9 +16,12 @@ import {
   failArchitectureProjectionJob,
   recoverAbandonedArchitectureProjectionJobs,
   architectureProjectionRunningStaleMs,
+  completeArchitectureProjectionJob,
   retryArchitectureProjectionDeadLetter,
+  ArchitectureProjectionOwnershipError,
+  LEGACY_ATTEMPT_BUDGET_NOTE,
 } from '../src/effects/architecture/projection-jobs';
-import type { ArchctxProcessResult, RunArchctxProcess } from '../src/effects/architecture/archctx-provider';
+import { captureArchitectureProjectionSnapshot, type ArchctxProcessResult, type RunArchctxProcess } from '../src/effects/architecture/archctx-provider';
 import { buildManagedHooks } from '../src/cli/installer/managed-entries';
 import { consumeArchitectureRefreshSignals, type RunArchitectureRefreshActions } from '../src/effects/architecture/refresh-consumer';
 import { inspectArchitectureProjectionAcceptanceState } from '../src/effects/architecture/projection-acceptance';
@@ -458,9 +461,9 @@ describe('durable architecture projection orchestration', () => {
     const f = fixture();
     const root = realpathSync(f.repoRoot);
     const first = enqueueArchitectureProjectionJob(root, ['event-a'], ['source-a'], ['src/a.ts']);
-    expect(claimNextArchitectureProjectionJob(root)?.jobId).toBe(first?.jobId);
+    expect(claimNextArchitectureProjectionJob(root, 120_000)?.jobId).toBe(first?.jobId);
     expect(enqueueArchitectureProjectionJob(root, ['event-b'], ['source-b'], ['src/b.ts'])).toBeNull();
-    expect(claimNextArchitectureProjectionJob(root)).toBeNull();
+    expect(claimNextArchitectureProjectionJob(root, 120_000)).toBeNull();
     expect(architectureProjectionQueueState(root)).toMatchObject({ pending: 0, running: 1 });
   });
 
@@ -498,7 +501,7 @@ describe('durable architecture projection orchestration', () => {
     runMutationObserved({ collector: f.collector, input: JSON.stringify({ file_path: 'src/crash.ts', session_id: 'crash' }) });
     const [source] = readPendingPostEditEvents(root);
     const queued = enqueueArchitectureProjectionJob(root, [source!.event_id], [source!.source_key], source!.changed_paths);
-    const running = claimNextArchitectureProjectionJob(root);
+    const running = claimNextArchitectureProjectionJob(root, 120_000);
     expect(running?.jobId).toBe(queued?.jobId);
     const runningPath = join(root, '.ai/harness/architecture-projection/running', `${running!.jobId}.json`);
     writeFileSync(runningPath, `${JSON.stringify({ ...running, ownerPid: 2_147_483_647 }, null, 2)}\n`);
@@ -514,32 +517,60 @@ describe('durable architecture projection orchestration', () => {
     const f = fixture();
     const root = realpathSync(f.repoRoot);
     const queued = enqueueArchitectureProjectionJob(root, ['event-stale'], ['source-stale'], ['src/stale.ts'], new Date('2026-01-01T00:00:00.000Z'));
-    const running = claimNextArchitectureProjectionJob(root, new Date('2026-01-01T00:00:01.000Z'));
+    const running = claimNextArchitectureProjectionJob(root, 120_000, new Date('2026-01-01T00:00:01.000Z'));
     expect(running?.jobId).toBe(queued?.jobId);
     expect(running?.ownerPid).toBe(process.pid);
     expect(recoverAbandonedArchitectureProjectionJobs(root, 120_000, new Date('2026-01-01T00:16:00.000Z'))).toBe(1);
     expect(architectureProjectionJobState(root, running!.jobId)).toBe('pending');
   });
 
-  test('derives the running stale window from the resolved projection timeout', () => {
+  test('holds a live claim to its own attempt deadline after the policy timeout shrinks', () => {
     const f = fixture();
     const root = realpathSync(f.repoRoot);
-    enqueueArchitectureProjectionJob(root, ['event-window'], ['source-window'], ['src/window.ts'], new Date('2026-01-01T00:00:00.000Z'));
-    const running = claimNextArchitectureProjectionJob(root, new Date('2026-01-01T00:00:00.000Z'))!;
-    const claimedAt = Date.parse(running.updatedAt);
-    const timeoutMs = 300_000;
-    expect(architectureProjectionRunningStaleMs(timeoutMs)).toBe(330_000);
-    expect(recoverAbandonedArchitectureProjectionJobs(root, timeoutMs, new Date(claimedAt + timeoutMs + 10_000))).toBe(0);
+    const claimedAt = new Date('2026-01-01T00:00:00.000Z');
+    enqueueArchitectureProjectionJob(root, ['event-window'], ['source-window'], ['src/window.ts'], claimedAt);
+    const running = claimNextArchitectureProjectionJob(root, 300_000, claimedAt)!;
+    expect(running.attemptTimeoutMs).toBe(300_000);
+    expect(running.attemptDeadlineAt).toBe('2026-01-01T00:05:00.000Z');
+
+    // The policy is edited down to 120000 while this attempt is still running.
+    expect(recoverAbandonedArchitectureProjectionJobs(root, 120_000, new Date(claimedAt.getTime() + 180_000))).toBe(0);
     expect(architectureProjectionJobState(root, running.jobId)).toBe('running');
-    expect(recoverAbandonedArchitectureProjectionJobs(root, timeoutMs, new Date(claimedAt + timeoutMs + 40_000))).toBe(1);
+    expect(recoverAbandonedArchitectureProjectionJobs(root, 120_000, new Date(claimedAt.getTime() + 329_999))).toBe(0);
+    expect(recoverAbandonedArchitectureProjectionJobs(root, 120_000, new Date(claimedAt.getTime() + 330_000))).toBe(1);
     expect(architectureProjectionJobState(root, running.jobId)).toBe('pending');
+    const [pendingName] = readdirSync(join(root, '.ai/harness/architecture-projection/pending'));
+    const pending = JSON.parse(readFileSync(join(root, '.ai/harness/architecture-projection/pending', pendingName!), 'utf8'));
+    expect(pending.attemptDeadlineAt).toBeUndefined();
+    expect(pending.attemptTimeoutMs).toBeUndefined();
+    expect(pending.lastFailure.message).not.toContain('legacy claim');
+  });
+
+  test('falls back to the current policy derivation for a legacy running record and records the fallback', () => {
+    const f = fixture();
+    const root = realpathSync(f.repoRoot);
+    const claimedAt = new Date('2026-01-01T00:00:00.000Z');
+    enqueueArchitectureProjectionJob(root, ['event-legacy'], ['source-legacy'], ['src/legacy.ts'], claimedAt);
+    const running = claimNextArchitectureProjectionJob(root, 300_000, claimedAt)!;
+    const runningPath = join(root, '.ai/harness/architecture-projection/running', `${running.jobId}.json`);
+    const { attemptDeadlineAt: _deadline, attemptTimeoutMs: _timeout, ...legacy } = JSON.parse(readFileSync(runningPath, 'utf8'));
+    writeFileSync(runningPath, `${JSON.stringify(legacy, null, 2)}\n`);
+
+    expect(architectureProjectionRunningStaleMs(120_000)).toBe(150_000);
+    expect(recoverAbandonedArchitectureProjectionJobs(root, 120_000, new Date(claimedAt.getTime() + 149_999))).toBe(0);
+    expect(architectureProjectionJobState(root, running.jobId)).toBe('running');
+    expect(recoverAbandonedArchitectureProjectionJobs(root, 120_000, new Date(claimedAt.getTime() + 150_000))).toBe(1);
+    expect(architectureProjectionJobState(root, running.jobId)).toBe('pending');
+    const [pendingName] = readdirSync(join(root, '.ai/harness/architecture-projection/pending'));
+    const pending = JSON.parse(readFileSync(join(root, '.ai/harness/architecture-projection/pending', pendingName!), 'utf8'));
+    expect(pending.lastFailure.message).toContain(LEGACY_ATTEMPT_BUDGET_NOTE);
   });
 
   test('dead-letters an abandoned third attempt instead of retrying forever', () => {
     const f = fixture();
     const root = realpathSync(f.repoRoot);
     enqueueArchitectureProjectionJob(root, ['event-timeout'], ['source-timeout'], ['src/timeout.ts']);
-    const running = claimNextArchitectureProjectionJob(root)!;
+    const running = claimNextArchitectureProjectionJob(root, 120_000)!;
     const runningPath = join(root, '.ai/harness/architecture-projection/running', `${running.jobId}.json`);
     writeFileSync(runningPath, `${JSON.stringify({ ...running, attempt: 3, ownerPid: 2_147_483_647 }, null, 2)}\n`);
     expect(recoverAbandonedArchitectureProjectionJobs(root, 120_000, new Date(Date.parse(running.updatedAt) + 150_001))).toBe(1);
@@ -550,7 +581,7 @@ describe('durable architecture projection orchestration', () => {
     const f = fixture();
     const root = realpathSync(f.repoRoot);
     enqueueArchitectureProjectionJob(root, ['event-receipt-crash'], ['source-receipt-crash'], ['src/receipt-crash.ts']);
-    const running = claimNextArchitectureProjectionJob(root)!;
+    const running = claimNextArchitectureProjectionJob(root, 120_000)!;
     const receipts = join(root, '.ai/harness/architecture-projection/receipts');
     mkdirSync(receipts, { recursive: true });
     writeFileSync(join(receipts, `${running.jobId}.json`), '{}\n');
@@ -563,10 +594,45 @@ describe('durable architecture projection orchestration', () => {
     const f = fixture();
     const root = realpathSync(f.repoRoot);
     enqueueArchitectureProjectionJob(root, ['event-owner'], ['source-owner'], ['src/owner.ts']);
-    const running = claimNextArchitectureProjectionJob(root)!;
+    const running = claimNextArchitectureProjectionJob(root, 120_000)!;
     const runningPath = join(root, '.ai/harness/architecture-projection/running', `${running.jobId}.json`);
     writeFileSync(runningPath, `${JSON.stringify({ ...running, attempt: running.attempt + 1, ownerPid: running.ownerPid! + 1 }, null, 2)}\n`);
     expect(() => failArchitectureProjectionJob(root, running, { kind: 'process', message: 'stale owner' })).toThrow('claim no longer belongs');
+  });
+
+  test('refuses to publish a receipt once the claim was reclaimed and re-claimed', () => {
+    const f = fixture();
+    const root = realpathSync(f.repoRoot);
+    enqueueArchitectureProjectionJob(root, ['event-publish'], ['source-publish'], ['src/publish.ts']);
+    const running = claimNextArchitectureProjectionJob(root, 120_000)!;
+    const runningPath = join(root, '.ai/harness/architecture-projection/running', `${running.jobId}.json`);
+    writeFileSync(runningPath, `${JSON.stringify({ ...running, attempt: running.attempt + 1, ownerPid: running.ownerPid! + 1 }, null, 2)}\n`);
+    const request = { requestId: `repo-harness.projection.${running.jobId}`, expected: captureArchitectureProjectionSnapshot(root) } as ProjectionRequestV1;
+    const result = envelope(request).data as ProjectionResultV1;
+    expect(() => completeArchitectureProjectionJob(root, running, result, [])).toThrow(ArchitectureProjectionOwnershipError);
+    expect(existsSync(join(root, '.ai/harness/architecture-projection/receipts', `${running.jobId}.json`))).toBe(false);
+    expect(architectureProjectionQueueState(root)).toMatchObject({ running: 1, receipts: 0 });
+  });
+
+  test('reports a lost-ownership drain instead of publishing when recovery reclaims the attempt mid-run', () => {
+    const f = fixture();
+    runMutationObserved({ collector: f.collector, input: JSON.stringify({ file_path: 'src/reclaimed.ts', session_id: 'reclaimed' }) });
+    const root = realpathSync(f.repoRoot);
+    const reclaimingRunner: RunArchctxProcess = (_binary, args) => {
+      if (args[0] === 'capabilities') return capabilities();
+      // A concurrent recovery reclaims the running record while the provider runs.
+      const [name] = readdirSync(join(root, '.ai/harness/architecture-projection/running'));
+      const path = join(root, '.ai/harness/architecture-projection/running', name!);
+      const claimed = JSON.parse(readFileSync(path, 'utf8'));
+      writeFileSync(path, `${JSON.stringify({ ...claimed, attempt: claimed.attempt + 1, ownerPid: claimed.ownerPid + 1 }, null, 2)}\n`);
+      const request = JSON.parse(args[3]!) as ProjectionRequestV1;
+      return { status: 0, signal: null, stderr: '', stdout: JSON.stringify(envelope(request)) };
+    };
+    const drained = drain(f.repoRoot, { consumerRoot: f.consumerRoot, policy, run: reclaimingRunner });
+    expect(drained.status).toBe('retry-pending');
+    expect(drained.error).toContain('lost-ownership: architecture projection running claim no longer belongs');
+    expect(drained.acknowledgeSourceEvents).toBe(false);
+    expect(drained.queue.receipts).toBe(0);
   });
 
   test('binds a completed retry to the events of its own job when a newer source arrives between retries', () => {

--- a/tests/architecture-projection-orchestration.test.ts
+++ b/tests/architecture-projection-orchestration.test.ts
@@ -15,6 +15,7 @@ import {
   enqueueArchitectureProjectionJob,
   failArchitectureProjectionJob,
   recoverAbandonedArchitectureProjectionJobs,
+  architectureProjectionRunningStaleMs,
   retryArchitectureProjectionDeadLetter,
 } from '../src/effects/architecture/projection-jobs';
 import type { ArchctxProcessResult, RunArchctxProcess } from '../src/effects/architecture/archctx-provider';
@@ -502,9 +503,9 @@ describe('durable architecture projection orchestration', () => {
     const runningPath = join(root, '.ai/harness/architecture-projection/running', `${running!.jobId}.json`);
     writeFileSync(runningPath, `${JSON.stringify({ ...running, ownerPid: 2_147_483_647 }, null, 2)}\n`);
 
-    expect(recoverAbandonedArchitectureProjectionJobs(root, new Date(running!.updatedAt))).toBe(0);
+    expect(recoverAbandonedArchitectureProjectionJobs(root, 120_000, new Date(running!.updatedAt))).toBe(0);
     expect(architectureProjectionJobState(root, running!.jobId)).toBe('running');
-    expect(recoverAbandonedArchitectureProjectionJobs(root, new Date(Date.parse(running!.updatedAt) + 150_001))).toBe(1);
+    expect(recoverAbandonedArchitectureProjectionJobs(root, 120_000, new Date(Date.parse(running!.updatedAt) + 150_001))).toBe(1);
     expect(architectureProjectionJobState(root, running!.jobId)).toBe('pending');
     expect(readPendingPostEditEvents(root).map((event) => event.event_id)).toEqual([source!.event_id]);
   });
@@ -516,8 +517,22 @@ describe('durable architecture projection orchestration', () => {
     const running = claimNextArchitectureProjectionJob(root, new Date('2026-01-01T00:00:01.000Z'));
     expect(running?.jobId).toBe(queued?.jobId);
     expect(running?.ownerPid).toBe(process.pid);
-    expect(recoverAbandonedArchitectureProjectionJobs(root, new Date('2026-01-01T00:16:00.000Z'))).toBe(1);
+    expect(recoverAbandonedArchitectureProjectionJobs(root, 120_000, new Date('2026-01-01T00:16:00.000Z'))).toBe(1);
     expect(architectureProjectionJobState(root, running!.jobId)).toBe('pending');
+  });
+
+  test('derives the running stale window from the resolved projection timeout', () => {
+    const f = fixture();
+    const root = realpathSync(f.repoRoot);
+    enqueueArchitectureProjectionJob(root, ['event-window'], ['source-window'], ['src/window.ts'], new Date('2026-01-01T00:00:00.000Z'));
+    const running = claimNextArchitectureProjectionJob(root, new Date('2026-01-01T00:00:00.000Z'))!;
+    const claimedAt = Date.parse(running.updatedAt);
+    const timeoutMs = 300_000;
+    expect(architectureProjectionRunningStaleMs(timeoutMs)).toBe(330_000);
+    expect(recoverAbandonedArchitectureProjectionJobs(root, timeoutMs, new Date(claimedAt + timeoutMs + 10_000))).toBe(0);
+    expect(architectureProjectionJobState(root, running.jobId)).toBe('running');
+    expect(recoverAbandonedArchitectureProjectionJobs(root, timeoutMs, new Date(claimedAt + timeoutMs + 40_000))).toBe(1);
+    expect(architectureProjectionJobState(root, running.jobId)).toBe('pending');
   });
 
   test('dead-letters an abandoned third attempt instead of retrying forever', () => {
@@ -527,7 +542,7 @@ describe('durable architecture projection orchestration', () => {
     const running = claimNextArchitectureProjectionJob(root)!;
     const runningPath = join(root, '.ai/harness/architecture-projection/running', `${running.jobId}.json`);
     writeFileSync(runningPath, `${JSON.stringify({ ...running, attempt: 3, ownerPid: 2_147_483_647 }, null, 2)}\n`);
-    expect(recoverAbandonedArchitectureProjectionJobs(root, new Date(Date.parse(running.updatedAt) + 150_001))).toBe(1);
+    expect(recoverAbandonedArchitectureProjectionJobs(root, 120_000, new Date(Date.parse(running.updatedAt) + 150_001))).toBe(1);
     expect(architectureProjectionJobState(root, running.jobId)).toBe('dead-letter');
   });
 
@@ -539,7 +554,7 @@ describe('durable architecture projection orchestration', () => {
     const receipts = join(root, '.ai/harness/architecture-projection/receipts');
     mkdirSync(receipts, { recursive: true });
     writeFileSync(join(receipts, `${running.jobId}.json`), '{}\n');
-    expect(recoverAbandonedArchitectureProjectionJobs(root)).toBe(1);
+    expect(recoverAbandonedArchitectureProjectionJobs(root, 120_000)).toBe(1);
     expect(architectureProjectionJobState(root, running.jobId)).toBe('receipt');
     expect(architectureProjectionQueueState(root).running).toBe(0);
   });

--- a/tests/state/operation-readiness.test.ts
+++ b/tests/state/operation-readiness.test.ts
@@ -118,6 +118,18 @@ describe('evaluateReadiness fixture-driven matrix', () => {
       projection_provider: 'disabled',
       projection_apply: 'automatic',
     } })).toThrow('projection_apply must be disabled');
+    expect(readArchitectureProjectionPolicy({ architecture: {
+      projection_provider: 'archctx',
+      projection_apply: 'automatic',
+      projection_version: '0.5.8',
+      projection_timeout_ms: 300000,
+    } })).toEqual({ provider: 'archctx', applyMode: 'automatic', failureGate: 'advisory', requiredVersion: '0.5.8', timeoutMs: 300000 });
+    expect(() => readArchitectureProjectionPolicy({ architecture: {
+      projection_provider: 'archctx',
+      projection_apply: 'automatic',
+      projection_version: '0.5.8',
+      projection_timeout_ms: 600001,
+    } })).toThrow('projection_timeout_ms must be 1000..600000');
   });
   test('fixture declares exactly the nine frozen characterization cells with no duplicates', () => {
     expect(fixture.positive_cases).toHaveLength(9);

--- a/tests/unit/architecture-projection-acceptance.test.ts
+++ b/tests/unit/architecture-projection-acceptance.test.ts
@@ -269,7 +269,7 @@ describe('architecture projection acceptance', () => {
     const jobId = architectureProjectionJobId(['event-1'], changedPaths);
     const f = fixture(jobId);
     enqueueArchitectureProjectionJob(f.repoRoot, ['event-1'], ['source-1'], changedPaths, new Date('2026-08-30T00:00:00.000Z'));
-    const claimed = claimNextArchitectureProjectionJob(f.repoRoot, new Date('2026-08-30T00:00:01.000Z'));
+    const claimed = claimNextArchitectureProjectionJob(f.repoRoot, 120_000, new Date('2026-08-30T00:00:01.000Z'));
     if (!claimed) throw new Error('fixture did not claim the durable projection job');
     failArchitectureProjectionJob(f.repoRoot, claimed, { kind: 'permanent', message: 'unresolved major change' }, new Date('2026-08-30T00:00:02.000Z'));
     expect(architectureProjectionJobState(f.repoRoot, jobId)).toBe('dead-letter');
@@ -378,7 +378,7 @@ describe('architecture projection acceptance', () => {
     const jobId = architectureProjectionJobId(['event-proof'], changedPaths);
     const f = fixture(jobId, ['verified-flow-proof-changed']);
     enqueueArchitectureProjectionJob(f.repoRoot, ['event-proof'], ['source-proof'], changedPaths, new Date('2026-08-30T00:00:00.000Z'));
-    const claimed = claimNextArchitectureProjectionJob(f.repoRoot, new Date('2026-08-30T00:00:01.000Z'));
+    const claimed = claimNextArchitectureProjectionJob(f.repoRoot, 120_000, new Date('2026-08-30T00:00:01.000Z'));
     if (!claimed) throw new Error('fixture did not claim a proof-only projection job');
     failArchitectureProjectionJob(f.repoRoot, claimed, { kind: 'permanent', message: 'proof unavailable' }, new Date('2026-08-30T00:00:02.000Z'));
     expect(architectureProjectionJobState(f.repoRoot, jobId)).toBe('dead-letter');
@@ -414,7 +414,7 @@ describe('architecture projection acceptance', () => {
     expect(providerCalls).toBe(1);
 
     enqueueArchitectureProjectionJob(f.repoRoot, ['event-proof-retry'], ['source-proof-retry'], changedPaths, new Date('2026-08-30T00:00:00.000Z'));
-    const claimed = claimNextArchitectureProjectionJob(f.repoRoot, new Date('2026-08-30T00:00:01.000Z'));
+    const claimed = claimNextArchitectureProjectionJob(f.repoRoot, 120_000, new Date('2026-08-30T00:00:01.000Z'));
     if (!claimed) throw new Error('fixture did not claim a retryable proof-only projection job');
     failArchitectureProjectionJob(f.repoRoot, claimed, { kind: 'permanent', message: 'proof unavailable' }, new Date('2026-08-30T00:00:02.000Z'));
 


### PR DESCRIPTION
## What

The archctx `projection run` apply for 60+ changed paths exceeds the 120s provider bound under host load, so this repo's projection job dead-letters after four consecutive `process timed out after 118xxxms` failures.

- `src/core/architecture/projection.ts`: raise the `projection_timeout_ms` validator upper bound from 120000 to 600000. The default stays 120000, so the downstream policy seeds in `scripts/` and `assets/templates/` are unchanged.
- `.ai/harness/policy.json`: this repo's `architecture.projection_timeout_ms` becomes 300000.
- `src/effects/architecture/projection-jobs.ts`: the running-job reclaim window is now `architectureProjectionRunningStaleMs(timeoutMs) = timeoutMs + 30_000`, replacing the fixed `RUNNING_STALE_MS = 150_000`. `recoverAbandonedArchitectureProjectionJobs` takes the resolved policy timeout, so there is no second timeout constant that can drift from the bound the provider actually runs under. With a 300s bound the old constant would have reclaimed live jobs.
- `src/effects/architecture/projection-orchestrator.ts`: passes `policy.timeoutMs` into the recovery call.

Hook budgets are untouched. `deadlineMs = min(options.deadlineMs, clock() + policy.timeoutMs)` still clamps to the Stop-hook host budget, so only an explicit `drain` without a host deadline gets the longer window.

## Verification

- `bunx tsc --noEmit` — clean
- `bun test --timeout 60000 tests/state/operation-readiness.test.ts tests/architecture-projection-orchestration.test.ts tests/architecture-projection-provider.test.ts tests/unit/helper-projection-drift.test.ts` — 86 pass, 0 fail
- `bun src/cli/index.ts architecture-projection status --json` — provider `archctx` state `ready` under the 300000 policy
- Repository-integrity checks: deploy-sql, architecture-sync, task-sync (merge-base bound), task-workflow --strict, inspect-project-state, `init --repo . --dry-run` — all pass
- `cmp scripts/ensure-task-workflow.sh assets/templates/helpers/ensure-task-workflow.sh` — identical

New coverage: a validator case accepting 300000 and rejecting 600001, and an orchestration test proving a job updated `timeoutMs + 10s` ago is not reclaimed while `timeoutMs + 40s` is.