### PR TITLE
ci: drop the Google Chrome apt source before installing shell dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,10 @@ jobs:
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Install shell dependencies
-        run: sudo apt-get update && sudo apt-get install -y jq rsync
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/google-chrome*.list /etc/apt/sources.list.d/google-chrome*.sources
+          sudo apt-get update
+          sudo apt-get install -y jq rsync
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -82,7 +85,10 @@ jobs:
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Install shell dependencies
-        run: sudo apt-get update && sudo apt-get install -y jq rsync
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/google-chrome*.list /etc/apt/sources.list.d/google-chrome*.sources
+          sudo apt-get update
+          sudo apt-get install -y jq rsync
 
       - name: Install pinned Herdr runtime
         run: |


### PR DESCRIPTION
On current `ubuntu-latest` images the preinstalled Google Chrome apt source returns `Hash Sum mismatch` for `https://dl.google.com/linux/chrome-stable/deb stable/main amd64 Packages`. `apt-get update` then exits 100, so both the Governance and Test jobs fail at "Install shell dependencies" before any gate runs (PR #386 failed three times identically, e.g. run 34384591497).

Both steps now remove the Google Chrome source list before `apt-get update`. Nothing else in the workflow changes.