### PR TITLE
docs(workflow): require helper and hook projection drift checks locally

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,9 +61,13 @@ This repository self-hosts the `repo-harness` contract; the former `repo-harness
 Verification is risk-scoped. The active task contract's JSON `Verification Plan`
 owns executable checks; `exit_criteria` owns artifact requirements. Run focused
 tests for every changed behavior. The following repository-integrity checks are required for
-substantive repository changes:
+substantive repository changes; `check:hooks` and `check:helpers` catch a
+projection edited without its authoring source in `scripts/`, so that drift fails
+here instead of only in `scripts/check-ci.sh governance`:
 
 ```bash
+bun run check:hooks
+bun run check:helpers
 bash scripts/check-deploy-sql-order.sh
 bash scripts/check-architecture-sync.sh
 bash scripts/check-task-sync.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,9 +61,13 @@ This repository self-hosts the `repo-harness` contract; the former `repo-harness
 Verification is risk-scoped. The active task contract's JSON `Verification Plan`
 owns executable checks; `exit_criteria` owns artifact requirements. Run focused
 tests for every changed behavior. The following repository-integrity checks are required for
-substantive repository changes:
+substantive repository changes; `check:hooks` and `check:helpers` catch a
+projection edited without its authoring source in `scripts/`, so that drift fails
+here instead of only in `scripts/check-ci.sh governance`:
 
 ```bash
+bun run check:hooks
+bun run check:helpers
 bash scripts/check-deploy-sql-order.sh
 bash scripts/check-architecture-sync.sh
 bash scripts/check-task-sync.sh


### PR DESCRIPTION
Projection drift (`assets/templates/helpers/*`, hook adapters edited without their authoring source in `scripts/`) only failed in `scripts/check-ci.sh governance` — it slipped through twice during PR #386 rounds 2 and 3.

Adds `bun run check:hooks` and `bun run check:helpers` to the root `## Required Checks` block in `CLAUDE.md` and `AGENTS.md` (kept byte-identical), mirroring the governance lane's own order.

Proof the gate bites: appending a line to `assets/templates/helpers/check-deploy-sql-order.sh` makes `check:helpers` report `content drift` and exit 1; reverting restores `projection OK: 58 helpers`.

Verified: `check:hooks`, `check:helpers`, `check:type`, `check-deploy-sql-order.sh`, `check-architecture-sync.sh`, `check-task-sync.sh`, `check-task-workflow.sh --strict`, `inspect-project-state.ts`, `init --dry-run`, `bun test tests/bootstrap-files.test.ts`, and `check-ci.sh governance` (with `REPO_HARNESS_DIFF_BASE=origin/main REPO_HARNESS_DIFF_MODE=merge-base`) all pass.