### PR TITLE
fix(install): honor installation ownership on upgrade and seed the Herdr pin

### DIFF
--- a/.ai/harness/handoff/brc1415-paused-20260910-2310.md
+++ b/.ai/harness/handoff/brc1415-paused-20260910-2310.md
@@ -1,0 +1,230 @@
+> **CLOSED — 2026-09-11 00:20 HKT（Claude 主循環，Owner 授權）**：BRC14/BRC15 以 scope amendment 收口，不是驗收通過。最終狀態：
+> - campaign `byok-brc1415-20260910-host-verification` → `stopped` rev 4（event `sha256:4a402198a483fccd58f37c7a5f4d10b1489a53fee4e477ec04934398bfe78452`，`2026-09-10T15:26:03.277Z`）；#177 lease（claim `0aa1f52a…`）released；dispatch 未 retire；immutable preparation 保留。證據：canary `.canary-scratch/brc177-recovery-evidence/host-verification/{release-177,stop,stop-request}.json`。
+> - byok-sdk：PR #182 人工 squash 合進 `codex/brc1415-canary`（`b7645e4a2174c55aaf8de30732b6731217ee38a5`，CI 46/46）；#177 CLOSED/completed；#178 CLOSED/not planned；canonical canary 已 ff 到 `b7645e4a`。這些都不是 campaign 驗收。
+> - repo-harness：PR #398 `codex/brc1415-closeout`（sprint Status → Done、BRC14/BRC15 unmet-item 表、`docs/researches/20260910-brc1415-canary3-closeout.md`、todos 兩條 deferred goal、lessons 一段）等 CI 後 squash merge。
+> - 0.19.0 已發布：merge `a8b56203`（#396）、tag `v0.19.0`（tag object `03b5eae2`）、npm latest 0.19.0（shasum `94ca3e05…`）、`check:release-published` OK、全域 runtime 0.19.0、record commit `7a272b8e`（admin bypass，未跑 Required/CI）。
+> - Owner 2026-09-11 立場：Codex 五步全鏈路驗收不必全走；真用 campaign 時再補 0.19.x（宿主機執行證據契約 → Canary 1 故障矩陣 → 其餘等真實 group）。入口在 `tasks/todos.md` 的兩條 BRC deferred goal。
+> - 殘留未清：byok canary 9 個 worktree、`repo-harness-wt-campaign-preparation-retry`（容器 retry WIP）、`/tmp/campaign-reconciliation-recovery/`、主 checkout 16f6581f + 其他 session 的 17 個髒項。
+> 以下原文為暫停時狀態，只作歷史。
+
+# BRC14/BRC15 handoff — 已暂停，禁止自动续跑
+
+更新时间：2026-09-10 23:10 HKT。交接人：Codex，parent session `01a089b3-6b92-72e2-ba20-da48ab37c465`。
+
+## 先读这个边界
+
+用户明确拒绝容器，范围包括 worker、verifier、测试和构建。此前把测试移到宿主机、仍用容器运行模型的解释是错误执行方向，已被用户否决。
+
+用户随后指出消耗了三十几的周额度却没有收口。当前承诺是停止后台研究和后续执行，保留已有改动，不自行续跑。本次请求仅为“给我 handoff”，不授权恢复工作。更早的“批准”“延长并做完”不能覆盖最新暂停状态。
+
+- 不启动 Docker、模型、测试、provider、grant 延期/替换、campaign transition 或其他执行。
+- 不继续容器 preparation retry 修复；已有 WIP 保留供检查，不是获准交付方向。
+- 不改写、删除或伪造 immutable preparation/reconciliation/usage/final/receipt。
+- 不因期限将到自动续期、停止、释放 claim 或 mint 新 grant。
+- 不把源码绿色检查、PR CI、历史 receipt 当作当前 BRC acceptance。
+- 不操作 SDK main、npm 发布或生产环境。
+- 不使用 raw CDP 探测 Oracle；此前这种探测曾中断 Oracle 会话。
+
+本次 handoff 仅做本地只读核对与交接文件写入，没有新测试、模型调用、GitHub 写入或 campaign 状态写入。
+
+## 结论与实际剩余工作
+
+**BRC14/BRC15 未验收完成，#177/#178 未在本链收口。**
+
+已经有 #177 的两个产品文件修复、历史源码验证和绿色 PR CI，但本次 successor 没有 completed passing worker final，也没有当前 source AcceptanceReceipt、publication/merge/cleanup 或最终 fresh audit。#178 已找到原有覆盖，并曾在前一 campaign 做过正式 not_reproducible 证据；新 campaign 仍需要绑定自身身份的决策与 receipt。
+
+真正的方向冲突：当前 BRC 实现把 managed Codex invocation 和终止证据绑定到容器；普通 contract-run 支持宿主机命令，但不能因此绕过 campaign 的监督证据门禁。**尚未设计、实现或验证合法的纯宿主机 BRC 路径。不要承诺只换一个参数即可收口。**
+
+本轮直接源码证据（均相对于后述 preparation-retry worktree）：
+
+- `scripts/contract-run.ts:181-183,234-239`：campaign provider 只允许 `codex-exec`，排除命令/runner override。
+- `src/effects/automation/campaign-worker.ts:140`：新 campaign launch 要求 supervised codex-exec。
+- `src/core/automation/campaign-runtime.ts:20-21,51-73`：invocation 的严格 schema 要求 container/probe 信息。
+- `src/effects/automation/campaign-runtime.ts:28-91,110-131`：实际准备和运行使用容器，terminal proof 消费容器 receipt。
+
+原生宿主机路径的只读研究已被打断，没有最终设计结论。不得把一般进程退出、临时工作目录或人为 JSON 替代当前门禁要求的运行证据。
+
+## 本次直接核对的本地状态
+
+| 工作区 | HEAD / 状态 | 用途 |
+|---|---|---|
+| `/Users/ancienttwo/Projects/byok-brc1415-canary` | `87ad369119efd2a0d54bc270d58c4e5af1df6bc5`，clean | canonical canary；尚未包含 #177 两文件修复 |
+| `/Users/ancienttwo/Projects/byok-brc1415-canary-wt-brc177-host-verification` | 同上，clean；coordination 目录为空 | 本次 acquired worktree，没有 worker-ready 或 host-result |
+| `/Users/ancienttwo/Projects/byok-brc1415-canary-wt-brc177-readme-delivery` | `98eaae33c46105433955c76b5b87dc5b52ac21a5`，clean | 已有源码修复 / PR182 的来源 |
+| `/Users/ancienttwo/Projects/repo-harness-wt-campaign-preparation-retry` | `9cc12bac18084293dda466364b02bd1c3734f21c` + 未提交 WIP | 已暂停的容器准备重试修复 |
+| `/tmp/campaign-reconciliation-recovery/approved-runtime` | 此前冻结于 `9cc12bac18084293dda466364b02bd1c3734f21c` | 旧操作脚本固定的 harness runtime；不要原地改动 |
+
+进程查询 `pgrep -fl 'launch-host-worker.ts|watch-host-verification.ts|contract-run.ts run'` 无匹配。协作状态核对：`acceptance_gate_trace` 为 interrupted，另外两位研究/审查 agent completed，没有后台子 agent 继续执行。
+
+GitHub 状态在本次 handoff 未重新查询。下文 PR/CI/Issue 状态是本会话此前保存的最后 readback，不应被当作 handoff 时刻的远端刷新。
+
+## #177 已有产品成果
+
+PR：<https://github.com/Ancienttwo/byok-sdk/pull/182>，最后 readback 为 OPEN / DRAFT，base `codex/brc1415-canary`，head `98eaae33c46105433955c76b5b87dc5b52ac21a5`。
+
+产品差异仅两文件：
+
+1. `packages/sdk/README.md`：六个 namespace 改为七个；补 `uiRuntime` import 与说明，保留 keys 的独立边界。
+2. `packages/sdk/src/readme.test.ts`：capture 使用 `example![1]!`，修复 TS2532；没有删除或弱化 README assertions。
+
+本次重新读取并核对的裸 SHA256：
+
+```text
+packages/sdk/README.md
+7c65c87fa1817269a0937b21c6a539960ca7e25989839561d99ea6f3236cc8a2
+packages/sdk/src/readme.test.ts
+4eb58b428fa44da938ea3f6f3fc3f1683fff05bc4066a4e97afb1f52979f93eb
+```
+
+历史证据：push CI `34478545552` 与 PR CI `34478640026` 均 23/23 PASS。源码准备时 build、typecheck、workspace tests、API surface、version authority 通过；完整 tests 当时运行约 100698ms。历史 aggregate 曾因 plan 文档缺段失败，后续严格 workflow 检查通过；不要把那个失败 aggregate 改称通过，也不要把旧 subject 说成本次 successor 通过。详见源码 worktree 中 `20260910-2029-brc177-readme-delivery` plan/contract/review/notes 与 `tasks/evidence/brc177-readme-delivery-pre-fix.log`。
+
+不要为恢复重新实现这两个文件；若将来获准并确定路径，已有精确 blobs 可复用，但不能把旧工作流元数据整包 cherry-pick 成新 campaign 的身份与证据。
+
+## 最新 campaign 与不可变准备记录
+
+这是会话此前最后一次 live 状态，加上本次读取的原始 selector/exit 日志；本次未调用会写状态的 live CLI。Lease/liveness、预算余额、远端和时间有效性在未来恢复前都需要重新只读确认。
+
+```text
+campaign: byok-brc1415-20260910-host-verification
+group: 1
+authorization: cf6d772a9b3b4d2f1ad8e04d358751bac16c830150c7e200839119e54de00b31
+parent host: codex
+parent session: 01a089b3-6b92-72e2-ba20-da48ab37c465
+intent: sha256:171639391acd04176f12acef27020c9a45dda7ab4ed76712ba85e62e88a6522f
+dispatch: sha256:f7b161eb7af21163d326020a632a25a3de1d615c257218f34f47a8e1bb0710d8
+task177: 918bc42ec95f5a62bda72af70b17a2b9b797bc21564deada976f0d7ba4244bea
+task177 revision: b7058fc0d27dd307629b76b1751ff169f741034daefaea05f848f4fdcdb5ec57
+claim: 0aa1f52a-4bf6-4994-aa33-d2bb8c92c9e9
+lease generation: 1
+binding generation: 1
+acquired_at: 2026-09-10T14:48:52.245Z
+contract: tasks/contracts/20260910-2243-brc177-host-verification.contract.md
+contract sha256: c1141a8bf8ebb5c3615e11cf8a5e66acfe761fb1e618ebb9ac1aa6fbe1f14d37
+plan sha256: a1da6a408f4e2a5ca29462d5a849703426a0e5d88edcf11dde97baf2a4989a07
+```
+
+最后正式 lifecycle 为 `group_running` revision 3。新 grant 只沿用前次剩余额度，起始余量 25 agent turns / 26 runner invocations，其他余量见原始 grant；一次 acquisition 已使用。这不是当前余额刷新。
+
+两个不同期限必须区分：
+
+- 已持久化 worker preparation 原始 `deadline_ms = 1789054453741`，即 **2026-09-10 23:34:13.741 HKT**。
+- grant 到期 **2026-09-11 01:23:10.982 HKT**（`2026-09-10T17:23:10.982Z`）。
+
+期限不是恢复授权；不得改时钟、改记录、延长 preparation deadline，或因到期临近而启动被用户禁止的容器。
+
+### 这一次具体为什么失败
+
+`launch-host-worker.ts` 错把测试固定 PATH 同时用于 controller，遗漏 Docker 所在 `/usr/local/bin`。`worker-run.log` 唯一错误为：
+
+```text
+Executable not found in $PATH: "docker"
+```
+
+`worker-run.exit.json`：exit 1，`2026-09-10T14:49:15.869Z`。`host-watch.exit.json`：SIGTERM，`2026-09-10T14:49:15.871Z`。
+
+harness 先持久化不可变 preparation，之后才检查 Docker context；因此没有模型启动、测试启动或 version/workload journal，却留下 preparation。旧代码随后无条件拒绝重试。此前只读核对 worker intent/started/terminal、launch/final、attempt reservation 均未产生；本次新 acquired worktree 仍 clean、handshake 目录为空也与此一致。
+
+这次 PATH 错误是父代理操作失误。更关键的是整个容器 worker 方向已被用户否决；**补 PATH 不是可执行的下一步**。
+
+## 已暂停的 harness WIP
+
+位置：`/Users/ancienttwo/Projects/repo-harness-wt-campaign-preparation-retry`，branch `codex/campaign-preparation-retry`，base `9cc12bac...`。没有 commit、PR、acceptance 或正式运行时切换。
+
+改动：
+
+- `src/effects/automation/campaign-runtime.ts`：新增 `assertCampaignPreparationRetryable`，以 `lstatSync` 检查 version/workload 两个确定性 journal 均不存在；非 ENOENT 拒绝。
+- `src/effects/automation/campaign-worker.ts`：仅允许尚无后续记录或 attempt reservation 的 worker preparation 重入；核对 identity，沿用原 deadline；更晚 caller bound 不延长保存的期限，更早不兼容 bound 拒绝。原 exclusive journal mkdir 保留。
+- `tests/effects/campaign-worker.test.ts`：新增三个 regression cases，mock provider 的 pre-journal 失败，不运行容器。
+- `tasks/todos.md`：capture-plan 带来的本地任务关联改动。
+- 未追踪 plan、contract、notes、review：stem `20260910-2258-campaign-preparation-retry`。
+- 未追踪 `tasks/evidence/campaign-preparation-retry-pre-fix.log`：实际未修复运行 0 pass / 3 fail，`PRE_FIX_EXIT=1`。
+
+开发期实际 red/green 命令：
+
+```text
+bun test tests/effects/campaign-worker.test.ts --test-name-pattern 'pre-journal preparation|existing .* journal' --timeout 60000
+```
+
+修复后一次运行 3 pass / 0 fail、18 expects、17.05s（会话 unified exec 55485）；**之后又加了一行 candidate deadline safe-integer 检查，尚未重测，所以不是最终 WIP 全部验证通过**。
+
+尚未做：完整 focused/边界覆盖、check:type、required integrity checks、正式 prepare/receipt/验收。生成 contract 仍是模板，Goal/Scope/Allowed Paths/Verification Plan 尚未填写成实际任务；不能拿来执行。没有创建计划中的 durable research 文档。
+
+研究 agent 的 deadline 建议与父代理实现不完全相同：agent 建议输入 deadline 必须完全相同；父代理实现允许新 caller 给更晚上界，但 runtime 仍只收旧 deadline。这一取舍没有经过最终验收。不要把已完成的 agent 根因调查称为该最终 diff 的 PASS。
+
+此 WIP 解决的是容器准备重试，与用户现在要求的纯宿主机路径不同；保留，不继续、不合并。
+
+## 前一轮真实尝试与 #178
+
+前一 campaign `byok-brc1415-20260910-completion` 的真实容器 worker 已应用两文件修复，README 3/3；canonical verify 在执行 criteria 之前失败，因为 temporary index 的 git add 仍要写被只读挂载的 common Git，shared verification locks 也需要真实 common Git 写权限。verifier 正确返回 fail；immutable final 是 `permanent_failure / verifier_rejected`。不是成功尝试，不得 relabel。
+
+它已正式 stopped revision 4；旧 dispatch 已 retired、claim 已 released、open reservations 0。旧 worktree `/Users/ancienttwo/Projects/byok-brc1415-canary-wt-brc177-completion` 保存两文件 WIP，不触碰。
+
+#178 的 alleged gap 已由 `scripts/release/pack-and-smoke.mjs` 覆盖：10-package pack/install graph，并验证 SDK 七 namespace / 无 keys。历史 baseline `ce48120507bb51360d48aa2ab3a2ffbe4be67951` 的 CI `34468443838` 三平台 pack/install jobs 通过；该 aggregate 曾因另一 TypeScript 错误失败，不能称全部 CI 通过。
+
+前一 campaign 的 `20260910-2154-brc178-completion` 已有真实 codex-plugin review、typed receipt 与正式 verify-sprint finalize，已提交到旧身份的元数据。新 campaign 的 #178 task 是 `161307648a9b0689ea61f69c6ee91f0e3aa963766301b3935bd37c21953781a3`；尚无新 planning job/decision/receipt。
+
+**不要先关闭 #178。** `close-not-planned` 会先落 immutable campaign-closeout-intent；任意该 intent 会阻断当前两 slot 的 stopped-resume。#177 成功前不要制造这一不可逆状态。
+
+## 早前已修复的故障，不要重做
+
+此前 harness PR <https://github.com/Ancienttwo/repo-harness/pull/395> 已合入 `9cc12bac18084293dda466364b02bd1c3734f21c`，解决 reconciliation 先持久化后验证与已到期终态停止/恢复相关问题。旧 poisoned reservation 已通过真实 repair receipt 结算，原 immutable 文件保留；历史 CI 和 source acceptance 已通过。详见旧 handoff 的开头与 PR，而不是再修改原始账本。
+
+最初 archctx 0.5.9 的依赖在隔离 runtime/worktree 安装中已同步；本次 handoff 没有重查全局 daemon 版本，不把它当作当前未查证的 blocker 或完成证明。
+
+## 文件入口与过期脚本
+
+主要原始操作证据目录：
+
+`/Users/ancienttwo/Projects/byok-brc1415-canary/.canary-scratch/brc177-recovery-evidence/host-verification/`
+
+优先读取 `grant.json`、`approval-and-basis.json`、`acquire-177.json`、`worker-selector.json`、`worker-run.log`、`worker-run.exit.json`、`host-watch.exit.json`。这些是保存的操作结果；当前 live store 仍在 canonical Git common/runtime store，应使用对应只读 API 核对，不能反向改 JSON 作为 live authority。
+
+旧操作目录 `/tmp/campaign-reconciliation-recovery/` 中：
+
+- `launch-host-worker.ts`：**禁止执行**；旧容器路线且含 PATH 错误，输出使用 wx；不是原生宿主机 launcher。
+- `watch-host-verification.ts`：**禁止自行执行**；等待旧容器 worker-ready 协议，未跑过本次 host verification。
+- `host-op.ts` / `host-transition.ts`：包含真实 provider/campaign 写入入口，不因看见脚本就执行。
+- `fill-host-contract.py`：旧方向的模板生成器；不得改写已 admitted 的 contract。
+- `brc177-bin/repo-harness`：旧 host 检查的 runtime wrapper。
+
+旧契约把 host verification 固定到 Node22.22.0、Bun1.4.0、harness9cc12bac 和特定 PATH；同环境证据不能随便重绑定。它同时写明容器 worker/verifier 协议，因此也不是用户新方向下可以直接续用的契约。
+
+旧累计 handoff（仅历史，不是续跑授权）：
+
+- `/tmp/campaign-reconciliation-recovery/handoff.md`
+- `/Users/ancienttwo/Projects/byok-brc1415-canary/.canary-scratch/brc1415-recovery-20260910.md`
+
+这些旧文档中“启动容器”“立即 acquire”“续跑”“不允许宿主机测试”等指示已被后续用户消息覆盖，以本文件顶部约束为准。
+
+## 不属于本任务的共享 WIP
+
+共享 `/Users/ancienttwo/Projects/repo-harness` 本次核对仍有其他 session 的改动。不要 checkout/reset/stash/commit 或吸收它们：
+
+```text
+assets/templates/helpers/recovery-view-cli.ts
+docs/architecture/.projection-manifest.json
+docs/researches/20260901-operator-board-audit-hardening.md
+docs/researches/20260910-checkpoint-cache-retention.md (untracked)
+plans/archive/plan-20260910-1608-operator-composer-draft.md (untracked)
+scripts/recovery-view-cli.ts
+scripts/sync-helper-sources.ts
+src/effects/evidence/checkpoint-store.ts
+src/effects/evidence/checkpoint-snapshot.ts (untracked)
+src/operator-web/App.tsx
+src/operator-web/i18n.ts
+tests/evidence-checkpoint.test.ts
+tests/evidence-recovery-materializer.test.ts
+tests/helper-scripts.test.ts
+tests/operator-web/operator-interactions.test.tsx
+tests/unit/helper-projection-drift.test.ts
+```
+
+共享 repo 的自动 `.ai/harness/handoff/current.md` 正在投影其他工作，不能作为本 BRC 的当前状态，也不要覆盖。本文件使用独立 handoff 路径。
+
+## 未来获准恢复后的第一步
+
+先向用户准确说明 **纯宿主机执行与现有 BRC 容器证据契约的冲突**，在现有代码中确认最小、明确的宿主机执行/验收工作边界和实际成本；不要先启动模型、重跑全套、换 grant、补 Docker PATH 或扩大基础设施修复。
+
+若用户日后明确恢复并接受具体方向，随后才核对 live grant/Lease/immutable state 与远端 PR。合法流程仍需依次拿到 #177 当前真实 execution/verification/receipt、publication 和绿色 CI、canary merge/cleanup、#178 当前身份的 not-planned closeout、精确最终 revision 的 fresh audit。普通 host tests 只能证明源码行为，不能伪装成上述链路已经完成。
+
+当前无可靠剩余时间估算；不得再用“差一点”“再二三十分钟”替代尚未定界的事实。交接状态：**暂停，等待用户明确后续指令**。

--- a/assets/templates/helpers/check-agent-tooling.sh
+++ b/assets/templates/helpers/check-agent-tooling.sh
@@ -827,8 +827,12 @@ function detectRuntimeCapabilities(waza) {
     try {
       herdr.version = execFileSync(herdr.path, ["--version"], { encoding: "utf8", timeout: 5000, stdio: ["ignore", "pipe", "pipe"] }).trim();
       const reported = /^herdr (\d+\.\d+\.\d+)$/.exec(herdr.version)?.[1] ?? null;
-      if (!minVersion || !reported || !versionAtLeast(reported, minVersion)) herdr.status = "unavailable";
+      if (!reported || (minVersion && !versionAtLeast(reported, minVersion))) herdr.status = "unavailable";
     } catch (_) { herdr.status = "unavailable"; }
+  }
+  if (!minVersion) {
+    herdr.status = "configuration-error";
+    herdr.reason = `${HERDR_PIN_KEY}.min_version is missing or malformed; run repo-harness init --repo . to merge repository policy defaults, then verify the declared version requirement`;
   }
   return {
     herdr,
@@ -2005,8 +2009,8 @@ const report = {
 const strictFailures = [];
 if (strictReadiness && report.runtime_capabilities.herdr.status !== "present") {
   const pinned = report.runtime_capabilities.herdr.min_version;
-  const floor = pinned ? `herdr >=${pinned}` : `the herdr version pinned in ${HERDR_PIN_KEY} (pin missing or malformed)`;
-  strictFailures.push(`herdr runtime is ${report.runtime_capabilities.herdr.status}; install ${floor} and verify herdr --version`);
+  if (!pinned) strictFailures.push(`herdr configuration error: ${report.runtime_capabilities.herdr.reason}`);
+  else strictFailures.push(`herdr runtime is ${report.runtime_capabilities.herdr.status}; install herdr >=${pinned} and verify herdr --version`);
 }
 if (strictReadiness && ["missing", "partial"].includes(report.tools.codegraph.status)) {
   strictFailures.push(`CodeGraph readiness is ${report.tools.codegraph.status}: ${report.tools.codegraph.reason}`);

--- a/assets/templates/helpers/install-agent-fleet.sh
+++ b/assets/templates/helpers/install-agent-fleet.sh
@@ -107,6 +107,10 @@ const CLAUDE_TARGET_DIR = path.join(HOME, ".claude", "agents");
 const CODEX_TARGET_DIR = path.join(HOME, ".codex", "agents");
 const USER_MANAGED_RECEIPT_PATH = path.join(HOME, ".repo-harness", "agent-fleet-user-managed.json");
 const SOURCE_DIR = process.env.REPO_HARNESS_AGENT_FLEET_SOURCE_DIR;
+const { readInstalledProfile, managedInstallSurfaceIsCurrent } = require(
+  path.join(SOURCE_DIR, "../../src/cli/installer/install-profile.ts"),
+);
+const installedProfile = readInstalledProfile();
 
 // A generated persona carries role identity only. The anti-extras execution
 // boundary belongs to the runtime task packet (SubagentStart context in
@@ -363,6 +367,13 @@ function compareAndWrite(targetPath, content, acceptedHash) {
   }
 
   if (acceptedHash === sha256(existing)) return "user-managed";
+
+  const owned = installedProfile?.ownership_manifest.find((surface) =>
+    surface.path === targetPath && surface.type === "managed-file");
+  if (owned && managedInstallSurfaceIsCurrent(owned)) {
+    fs.writeFileSync(targetPath, content);
+    return "installed";
+  }
 
   return "drift";
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this skill are documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Fleet and bundled cross-review upgrades honor installation ownership.**
+  Unchanged files recorded in the installation manifest can now upgrade to a
+  newer package; unowned or user-modified content remains protected. Bundled
+  skills synchronize their entire trees, including updated and retired
+  references, with rollback on copy failure. `deep-worker` is included in
+  installation transaction capture and fleet completeness checks.
+- **Herdr repository configuration is seeded and diagnosed correctly.**
+  TypeScript repository adoption now supplies the canonical Herdr version pin.
+  Missing or malformed `external_tooling.herdr.min_version` reports
+  `configuration-error` instead of runtime `unavailable`, while strict readiness
+  still fails closed. After upgrading, run `repo-harness init --repo .` in an
+  affected repository to fill missing defaults; explicit malformed values must
+  be corrected deliberately. Global runtime refresh alone does not update
+  repository policy.
+
 ## [0.19.0] - 2026-09-10
 
 The release grows a second layer on top of the file-backed session contract:

--- a/docs/researches/20260911-install-019-owned-upgrade.md
+++ b/docs/researches/20260911-install-019-owned-upgrade.md
@@ -1,0 +1,24 @@
+# 0.19 installed runtime upgrade and Herdr policy repair
+
+## Root cause evidence
+
+- Observed behavior: fleet compares installed role bytes only with the candidate package; bundled cross-review compares only SKILL.md. A legitimate older package is refused as drift, while reference-only changes are silently skipped.
+- Owning boundary: `scripts/install-agent-fleet.sh#compareAndWrite`, `src/cli/commands/init.ts#syncBundledItemsAtHome`; both omitted the existing protocol-2 installation ownership ledger. `installProfileHostMutationPaths` also omitted deep-worker.
+- Reproduction: receipt-owned old role content fails upgrade with exit 1 on the original helper; original bundled sync leaves retired references present. New regression cases exercise both Claude and Codex, SKILL.md changes, reference-only changes, and subsequent user edits.
+- Resolution: reuse `readInstalledProfile` and `managedInstallSurfaceIsCurrent`; update only recorded, unchanged files/trees. Compare entire skill trees and replace old trees through the existing compensating transaction. Include deep-worker in transaction capture and complete-fleet evidence. Unknown or edited content still fails closed; no force flag or ownership inference is added.
+
+## Herdr configuration boundary
+
+The shell policy seeds already declare the Herdr pin, but the active TypeScript adoption defaults omitted it. Standard adoption now projects the canonical `.ai/harness/policy.json#external_tooling.herdr` pin, guarded by the existing pin drift test. Repository-specific explicit values remain authoritative.
+
+The tooling checker reports a missing/malformed floor as `configuration-error`, retaining the observed CLI version and failing strict readiness with a repository-init instruction. It does not infer a version requirement from the installed executable, claim server failure, or change global runtime refresh into a repository mutation.
+
+For a missing declaration, run the repaired `repo-harness init --repo .` in the affected repository. A malformed explicit declaration must be corrected deliberately; merging defaults does not override it.
+
+## Verification and limits
+
+- Red/green run: original fleet helper rejects the receipt-owned upgrade; repaired helper passes. Herdr missing/malformed cases originally report unavailable, and the original adoption plan omits the pin; all new regression cases pass after repair.
+- Focused coverage: fleet installer, bundled init, global runtime init, install profiles, adoption plan/apply, tooling checker, Herdr pin drift. The seven initial profile-fixture failures were obsolete six-role fixtures; after adding deep-worker, all 63 tests in the affected installer/profile/bundled-runtime selection passed.
+- Package verification: `npm pack` builds both runtime artifacts; extracted package scripts and projected helper independently resolve their packaged TypeScript ownership reader. A disposable HOME fresh install and receipt-owned upgrade reproduce all 14 role files without producer module links. Archive contains the required modules and no Python cache artifacts.
+- No new production dependency or abstraction. The one new test helper serializes a protocol-2 ownership fixture for two regression consumers; this prevents tests from requiring unrelated full-profile tools. This research file preserves the verified upgrade boundary.
+- No full-suite trigger: changes are covered by the named installer, policy, and detector suites plus repository integrity checks. No release or live user configuration mutation is claimed. Installations without valid ownership evidence remain blocked rather than being silently adopted.

--- a/plans/plan-20260911-0100-install-owned-upgrade.md
+++ b/plans/plan-20260911-0100-install-owned-upgrade.md
@@ -1,0 +1,41 @@
+> **Status**: Executing
+> **Created**: 20260911-0100
+> **Slug**: install-owned-upgrade
+> **Planning Source**: codex-plan
+> **Orchestration Kind**: host-plan
+> **Artifact Level**: work-package
+> **Promotion Reason**: merge_boundary
+> **Verification Boundary**: Focused installer/adoption/detector suites plus repository integrity checks
+> **Rollback Surface**: Scoped source revert; no published artifact or live host mutation
+> **Workflow Profile**: standard
+> **Execution Mode**: worktree
+> **Substantive Change SHA256**: `sha256:94e7e29bc8c6d8d5e67c077dceaf544668d509cfe8e2f1b1505b84c2d3c398ff`
+
+# Honor installation ownership on 0.19 upgrade and seed the Herdr pin
+
+## Scope and decision
+Installed fleet roles and bundled cross-review trees refused legitimate package upgrades because both compared candidate bytes only, ignoring the existing protocol-2 ownership ledger. Separately, TypeScript adoption omitted the canonical Herdr version pin the shell seeds already declared, so a missing floor surfaced as runtime `unavailable` instead of a configuration error.
+
+P1: `scripts/install-agent-fleet.sh#compareAndWrite` and `src/cli/commands/init.ts#syncBundledItemsAtHome` own installed-host writes; `src/core/adoption/standard-plan.ts` owns repository policy defaults; `scripts/check-agent-tooling.sh` owns readiness classification.
+P2: package upgrade -> ownership receipt lookup -> unchanged-owned file/tree replacement -> transaction capture -> readiness probe. The pressure point is that ownership evidence existed but was never read on either write path.
+P3: reuse `readInstalledProfile` and `managedInstallSurfaceIsCurrent` rather than adding a force flag or inferring ownership. Unknown or user-edited content still fails closed. A malformed explicit Herdr declaration stays authoritative and must be corrected deliberately; defaults never override it.
+
+## Scope paths
+`scripts/` and `assets/templates/helpers/` fleet and tooling helpers, `src/cli/commands/init.ts`, `src/cli/installer/install-profile.ts`, `src/core/adoption/standard-plan.ts`, the fleet contract asset, the named regression tests and their ownership fixture helper, `docs/researches/20260911-install-019-owned-upgrade.md`, `docs/CHANGELOG.md`, this plan, and the archived BRC14/BRC15 pause handoff.
+
+## Task Breakdown
+- [x] Read installation ownership on both write paths and include deep-worker in transaction capture.
+- [x] Synchronize entire bundled skill trees with rollback on copy failure.
+- [x] Seed the canonical Herdr pin in TypeScript adoption and report a missing or malformed floor as `configuration-error`.
+- [x] Cover both hosts, reference-only changes, and subsequent user edits with regression tests.
+- [x] Record the release note and the verified boundary; preserve the BRC14/BRC15 pause handoff as history.
+
+## Promotion Gate
+- Merge/PR unit: the installer ownership repair plus the Herdr policy seed ship as one revertible commit.
+- Rollback surface: revert the scoped source commit. Nothing is published and no live host configuration is mutated.
+- Verification boundary: focused installer, adoption, bundled-runtime and detector suites, plus the repository integrity checks and required remote CI.
+- Review/acceptance boundary: `docs/researches/20260911-install-019-owned-upgrade.md` holds the root-cause evidence and coverage rationale.
+
+## Verification
+- `bun run check:hooks`, `bun run check:helpers`, `bash scripts/check-deploy-sql-order.sh`, `bash scripts/check-architecture-sync.sh`, `bash scripts/check-task-sync.sh`, `bash scripts/check-task-workflow.sh --strict`, `bun scripts/inspect-project-state.ts --repo . --format text`, `bun src/cli/index.ts init --repo . --dry-run`.
+- Focused suites named in the research file. No full-suite trigger: required CI owns the branch-wide run.

--- a/scripts/check-agent-tooling.sh
+++ b/scripts/check-agent-tooling.sh
@@ -827,8 +827,12 @@ function detectRuntimeCapabilities(waza) {
     try {
       herdr.version = execFileSync(herdr.path, ["--version"], { encoding: "utf8", timeout: 5000, stdio: ["ignore", "pipe", "pipe"] }).trim();
       const reported = /^herdr (\d+\.\d+\.\d+)$/.exec(herdr.version)?.[1] ?? null;
-      if (!minVersion || !reported || !versionAtLeast(reported, minVersion)) herdr.status = "unavailable";
+      if (!reported || (minVersion && !versionAtLeast(reported, minVersion))) herdr.status = "unavailable";
     } catch (_) { herdr.status = "unavailable"; }
+  }
+  if (!minVersion) {
+    herdr.status = "configuration-error";
+    herdr.reason = `${HERDR_PIN_KEY}.min_version is missing or malformed; run repo-harness init --repo . to merge repository policy defaults, then verify the declared version requirement`;
   }
   return {
     herdr,
@@ -2005,8 +2009,8 @@ const report = {
 const strictFailures = [];
 if (strictReadiness && report.runtime_capabilities.herdr.status !== "present") {
   const pinned = report.runtime_capabilities.herdr.min_version;
-  const floor = pinned ? `herdr >=${pinned}` : `the herdr version pinned in ${HERDR_PIN_KEY} (pin missing or malformed)`;
-  strictFailures.push(`herdr runtime is ${report.runtime_capabilities.herdr.status}; install ${floor} and verify herdr --version`);
+  if (!pinned) strictFailures.push(`herdr configuration error: ${report.runtime_capabilities.herdr.reason}`);
+  else strictFailures.push(`herdr runtime is ${report.runtime_capabilities.herdr.status}; install herdr >=${pinned} and verify herdr --version`);
 }
 if (strictReadiness && ["missing", "partial"].includes(report.tools.codegraph.status)) {
   strictFailures.push(`CodeGraph readiness is ${report.tools.codegraph.status}: ${report.tools.codegraph.reason}`);

--- a/scripts/install-agent-fleet.sh
+++ b/scripts/install-agent-fleet.sh
@@ -107,6 +107,10 @@ const CLAUDE_TARGET_DIR = path.join(HOME, ".claude", "agents");
 const CODEX_TARGET_DIR = path.join(HOME, ".codex", "agents");
 const USER_MANAGED_RECEIPT_PATH = path.join(HOME, ".repo-harness", "agent-fleet-user-managed.json");
 const SOURCE_DIR = process.env.REPO_HARNESS_AGENT_FLEET_SOURCE_DIR;
+const { readInstalledProfile, managedInstallSurfaceIsCurrent } = require(
+  path.join(SOURCE_DIR, "../../src/cli/installer/install-profile.ts"),
+);
+const installedProfile = readInstalledProfile();
 
 // A generated persona carries role identity only. The anti-extras execution
 // boundary belongs to the runtime task packet (SubagentStart context in
@@ -363,6 +367,13 @@ function compareAndWrite(targetPath, content, acceptedHash) {
   }
 
   if (acceptedHash === sha256(existing)) return "user-managed";
+
+  const owned = installedProfile?.ownership_manifest.find((surface) =>
+    surface.path === targetPath && surface.type === "managed-file");
+  if (owned && managedInstallSurfaceIsCurrent(owned)) {
+    fs.writeFileSync(targetPath, content);
+    return "installed";
+  }
 
   return "drift";
 }

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -17,6 +17,7 @@ import {
   copyFileSync,
   existsSync,
   mkdirSync,
+  lstatSync,
   readFileSync,
   realpathSync,
   rmSync,
@@ -33,7 +34,8 @@ import {
   probeExpectations as catalogProbeExpectations,
   type SkillSurfaceCatalog,
 } from "../../core/skill-surface/catalog";
-import { PROFILE_COMPONENTS } from "../installer/install-profile";
+import { skillTreeSha256 } from "../../effects/skill-tree-integrity";
+import { beginInstallHostTransaction, commitInstallHostTransaction, rollbackInstallHostTransaction, managedInstallSurfaceIsCurrent, readInstalledProfile, PROFILE_COMPONENTS } from "../installer/install-profile";
 import {
   defaultBrainRootChoice,
   discoverBrainRootChoices,
@@ -444,8 +446,10 @@ function syncBundledItemsAtHome(
   home: string | null,
   skills: ReadonlyArray<BundledHostSkill>,
   agents: ReadonlyArray<BundledHostAgent>,
+  env?: NodeJS.ProcessEnv,
 ): InitStep[] {
   const steps: InitStep[] = [];
+  const installed = home ? readInstalledProfile({ ...env, HOME: home }) : null;
   for (const { skill, host, step } of skills) {
     if (target !== "both" && target !== host) continue;
     if (!home) {
@@ -465,17 +469,29 @@ function syncBundledItemsAtHome(
     if (
       existsSync(dest) &&
       (samePath(source, dest) ||
-        (existsSync(destSkill) && readFileSync(destSkill, "utf-8") === readFileSync(srcSkill, "utf-8")))
+        (existsSync(destSkill) && lstatSync(dest).isDirectory() && skillTreeSha256(dest) === skillTreeSha256(source)))
     ) {
       steps.push({ step, status: "ok", detail: "already present" });
       continue;
     }
     if (existsSync(dest)) {
-      steps.push({
-        step,
-        status: "failed",
-        detail: `refusing to overwrite unowned or modified skill at ${dest}`,
-      });
+      const owned = installed?.ownership_manifest.find(surface =>
+        surface.path === dest && surface.type === "directory-copy");
+      if (!owned || !managedInstallSurfaceIsCurrent(owned)) {
+        steps.push({ step, status: "failed", detail: `refusing to overwrite unowned or modified skill at ${dest}` });
+        continue;
+      }
+      const transaction = beginInstallHostTransaction([dest], { HOME: home });
+      try {
+        // Replace the verified old tree so retired references cannot survive an upgrade.
+        rmSync(dest, { recursive: true });
+        cpSync(source, dest, { recursive: true });
+        commitInstallHostTransaction(transaction);
+        steps.push({ step, status: "ok", detail: `synced ${dest}` });
+      } catch (error) {
+        rollbackInstallHostTransaction(transaction);
+        steps.push({ step, status: "failed", detail: `cannot update bundled skill ${dest}: ${String(error)}` });
+      }
       continue;
     }
     cpSync(source, dest, { recursive: true });
@@ -515,7 +531,7 @@ export function syncCrossReviewSkills(
   env?: NodeJS.ProcessEnv,
 ): InitStep[] {
   const catalog = loadSkillSurfaceCatalog(sourceRoot);
-  const steps = syncBundledItemsAtHome(sourceRoot, target, homeDir(env), crossReviewSkillsFromCatalog(catalog), []);
+  const steps = syncBundledItemsAtHome(sourceRoot, target, homeDir(env), crossReviewSkillsFromCatalog(catalog), [], env);
   if (target === "codex" || target === "both") steps.push(ensureOfficialCodexPlugin(sourceRoot, env));
   return steps;
 }

--- a/src/cli/installer/install-profile.ts
+++ b/src/cli/installer/install-profile.ts
@@ -508,7 +508,7 @@ export function installProfileHostMutationPaths(env: NodeJS.ProcessEnv = process
   const home = env.HOME ?? homedir();
   const bunRoot = env.BUN_INSTALL ?? join(home, '.bun');
   const { repoHarnessSkills: skills, externalSkills } = catalogMutationPathSkillNames(loadSkillSurfaceCatalog());
-  const agents = ['explorer', 'deep-reasoner', 'fast-worker', 'gatekeeper', 'root-cause-prover', 'harness-evaluator'];
+  const agents = ['explorer', 'deep-reasoner', 'fast-worker', 'deep-worker', 'gatekeeper', 'root-cause-prover', 'harness-evaluator'];
   const paths = [
     join(bunRoot, 'bin', 'repo-harness'),
     join(bunRoot, 'bin', 'codegraph'),
@@ -626,7 +626,7 @@ function componentsForTransactionPath(path: string): readonly InstallComponent[]
       ? ['cross-model-acceptance']
       : ['planning-integrations'];
   }
-  if (/\/(?:\.codex|\.claude)\/agents\/(?:explorer|deep-reasoner|fast-worker|gatekeeper|root-cause-prover|harness-evaluator)\.(?:toml|md)$/.test(normalized)) {
+  if (/\/(?:\.codex|\.claude)\/agents\/(?:explorer|deep-reasoner|fast-worker|deep-worker|gatekeeper|root-cause-prover|harness-evaluator)\.(?:toml|md)$/.test(normalized)) {
     return name.startsWith('gatekeeper.') ? ['agent-fleet', 'verifier'] : ['agent-fleet'];
   }
   if (/\/(?:\.agents|\.codex|\.claude)\/rules\/(?:anti-patterns|chinese|durable-context|english)\.md$/.test(normalized)) {
@@ -951,7 +951,7 @@ function completeHostSkillSetEvidence(home: string, names: readonly string[]): s
 }
 
 function completeAgentFleetEvidence(home: string): string[] {
-  const agents = ['explorer', 'deep-reasoner', 'fast-worker', 'gatekeeper', 'root-cause-prover', 'harness-evaluator'];
+  const agents = ['explorer', 'deep-reasoner', 'fast-worker', 'deep-worker', 'gatekeeper', 'root-cause-prover', 'harness-evaluator'];
   for (const [root, extension] of [[join(home, '.codex', 'agents'), '.toml'], [join(home, '.claude', 'agents'), '.md']] as const) {
     const paths = agents.map((agent) => join(root, `${agent}${extension}`));
     if (paths.every(existsSync)) return paths;

--- a/src/core/adoption/standard-plan.ts
+++ b/src/core/adoption/standard-plan.ts
@@ -376,6 +376,16 @@ export function defaultPolicy(documentationProfile: string, documentationLanguag
       reference_resolver: "repo-harness docs path <doc-id>",
     },
     external_tooling: {
+      // Projection of the canonical repository pin; herdr-runtime-pin tests guard drift.
+      herdr: {
+        "min_version": "0.9.0",
+        "release_assets": {
+          "linux-x86_64": {
+            "url": "https://github.com/herdrdev/herdr/releases/download/v0.9.0/herdr-linux-x86_64",
+            "sha256": "4fa1a01158dd8043da92d31b270780b0dcc10603038d9b61cac4d81ab63fb71f"
+          }
+        }
+      },
       routing: {
         simple: "waza",
       },

--- a/tasks/workstreams/workflow-engine/contract-assets/agent-fleet-specialists.md
+++ b/tasks/workstreams/workflow-engine/contract-assets/agent-fleet-specialists.md
@@ -28,3 +28,11 @@ Track durable multi-session progress for `workflow-engine-contract-assets` witho
 
 - Project the current slice into `tasks/todos.md` for a single session.
 - Keep architecture facts in `docs/architecture/modules/workflow-engine/contract-assets.md`; keep execution progress here.
+
+## 2026-09-11 installation repair
+
+- Completed receipt-owned fleet and bundled cross-review upgrades, deep-worker transaction coverage, and the missing Herdr adoption pin/configuration diagnostic.
+- Durable evidence and operational boundary: `docs/researches/20260911-install-019-owned-upgrade.md`.
+- Verification: targeted installer/profile/init/adoption/tooling regressions and extracted npm-package fleet smoke; repository integrity checks are required before integration. Publication remains a separate release boundary.
+
+> **Substantive Change SHA256**: `sha256:de07ea6f9c95bd3da0540cad55047a15dd80eb45e1ebbcbc8f250f52558fa2f4`

--- a/tests/check-agent-tooling.test.ts
+++ b/tests/check-agent-tooling.test.ts
@@ -1755,3 +1755,20 @@ test.each(['present', 'missing', 'unavailable'])('herdr is a required runtime ca
     }
   } finally { rmSync(fixture.root, { recursive: true, force: true }); }
 }, 20_000);
+
+test.each([undefined, "invalid"])("Herdr missing or malformed version policy is a configuration error: %s", pin => {
+  const fixture = setupFakeEnvironment("herdr-policy-error");
+  try {
+    mkdirSync(join(fixture.root, ".ai/harness"), { recursive: true });
+    writeFileSync(join(fixture.root, ".ai/harness/policy.json"), JSON.stringify({ external_tooling: { herdr: { min_version: pin } } }));
+    const result = spawnSync("/bin/bash", [SCRIPT, "--json", "--strict-readiness", "--host", "claude"], {
+      cwd: fixture.root, encoding: "utf8", env: { ...process.env, HOME: fixture.home, PATH: `${fixture.fakeBin}:${process.env.PATH}` }, timeout: 15000,
+    });
+    const herdr = JSON.parse(result.stdout).runtime_capabilities.herdr;
+    expect(herdr.status).toBe("configuration-error");
+    expect(herdr.version).toBe("herdr 0.9.0");
+    expect(herdr.reason).toContain("min_version");
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("repo-harness init --repo .");
+  } finally { rmSync(fixture.root, { recursive: true, force: true }); }
+}, 20000);

--- a/tests/cli/adoption-plan.test.ts
+++ b/tests/cli/adoption-plan.test.ts
@@ -21,6 +21,27 @@ function cleanup(path: string): void {
 }
 
 describe("canonical adoption plan", () => {
+  test("adoption supplies the Herdr pin to old repositories and preserves explicit floors", () => {
+    const repo = tempRepo();
+    const pin = JSON.parse(readFileSync(join(ROOT, ".ai/harness/policy.json"), "utf8")).external_tooling.herdr;
+    try {
+      mkdirSync(join(repo, ".ai/harness"), { recursive: true });
+      writeFileSync(join(repo, ".ai/harness/policy.json"), JSON.stringify({ external_tooling: { routing: { custom: "kept" } } }));
+      const plan = planAdoption({ repoRoot: repo, mode: "standard", apply: true });
+      const operation = plan.operations.find(op => op.path === ".ai/harness/policy.json");
+      if (!operation || operation.kind !== "writeFile") throw new Error("policy operation missing");
+      expect(JSON.parse(operation.content).external_tooling.herdr).toEqual(pin);
+      expect(applyAdoptionPlan(plan).ok).toBe(true);
+      const policy = JSON.parse(readFileSync(join(repo, ".ai/harness/policy.json"), "utf8"));
+      expect(policy.external_tooling.herdr).toEqual(pin);
+      policy.external_tooling.herdr.min_version = "99.0.0";
+      writeFileSync(join(repo, ".ai/harness/policy.json"), JSON.stringify(policy));
+      const next = planAdoption({ repoRoot: repo, mode: "standard" }).operations.find(op => op.path === ".ai/harness/policy.json");
+      if (!next || next.kind !== "writeFile") throw new Error("policy operation missing");
+      expect(JSON.parse(next.content).external_tooling.herdr.min_version).toBe("99.0.0");
+    } finally { cleanup(repo); }
+  });
+
   test("standard plan is a complete repo-local projection and does not install root helpers", () => {
     const repo = tempRepo();
     try {

--- a/tests/cli/init.test.ts
+++ b/tests/cli/init.test.ts
@@ -1,3 +1,4 @@
+import { recordInstallOwnership } from "../helpers/install-ownership";
 import { describe, expect, test } from "bun:test";
 import {
   existsSync,
@@ -1246,6 +1247,40 @@ describe("bundled host runtimes", () => {
       "---\nname: claude-plan\n---\n",
     );
   }
+
+  test.each(["skill", "reference"])("upgrades owned bundled trees (%s) and rejects user drift", change => {
+    const tmp = join(tmpdir(), `cross-review-owned-${Date.now()}`);
+    const source = join(tmp, "source"), home = join(tmp, "home");
+    const env: NodeJS.ProcessEnv = { ...process.env, HOME: home };
+    try {
+      makeSource(source);
+      mkdirSync(home, { recursive: true });
+      const fakeBin = join(tmp, "bin");
+      mkdirSync(fakeBin, { recursive: true });
+      env.REPO_HARNESS_CLAUDE_EXECUTABLE = writeReadyOfficialCodexPluginCli(fakeBin, home);
+      const reference = join(source, "assets/skills/repo-harness-cross-review/reference.md");
+      writeFileSync(reference, "old reference");
+      expect(syncCrossReviewSkills(source, "both", env).every(step => step.status === "ok")).toBe(true);
+      const paths = [".claude", ".codex"].map(host => join(home, host, "skills/repo-harness-cross-review"));
+      recordInstallOwnership(paths, env);
+      if (change === "skill") writeFileSync(join(source, "assets/skills/repo-harness-cross-review/SKILL.md"), "---\nname: repo-harness-cross-review\n---\nUpdated instructions\n");
+      rmSync(reference);
+      writeFileSync(join(source, "assets/skills/repo-harness-cross-review/new-reference.md"), "new reference");
+      expect(syncCrossReviewSkills(source, "both", env).every(step => step.status === "ok")).toBe(true);
+      recordInstallOwnership(paths, env);
+      for (const host of [".claude", ".codex"]) {
+        const dest = join(home, host, "skills/repo-harness-cross-review");
+        expect(existsSync(join(dest, "reference.md"))).toBe(false);
+        expect(readFileSync(join(dest, "new-reference.md"), "utf8")).toBe("new reference");
+        writeFileSync(join(dest, "new-reference.md"), "user edit");
+      }
+      const blocked = syncCrossReviewSkills(source, "both", env);
+      expect(blocked.filter(step => step.status === "failed")).toHaveLength(2);
+      for (const host of [".claude", ".codex"]) {
+        expect(readFileSync(join(home, host, "skills/repo-harness-cross-review/new-reference.md"), "utf8")).toBe("user edit");
+      }
+    } finally { rmSync(tmp, { recursive: true, force: true }); }
+  });
 
   test("installs repo-harness-cross-review on both hosts; claude-plan stays Codex-only", () => {
     const tmp = join(tmpdir(), `cross-review-both-${Date.now()}`);

--- a/tests/helpers/install-ownership.ts
+++ b/tests/helpers/install-ownership.ts
@@ -1,0 +1,38 @@
+import { createHash } from 'crypto';
+import { lstatSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'fs';
+import { dirname, join, relative } from 'path';
+import { installProfileStatePath, PROFILE_COMPONENTS } from '../../src/cli/installer/install-profile';
+
+/** Seed the persisted protocol, independently of unrelated full-profile probes. */
+export function recordInstallOwnership(paths: string[], env: NodeJS.ProcessEnv): void {
+  const ownership_manifest = paths.map(path => {
+    const directory = lstatSync(path).isDirectory();
+    const hash = createHash('sha256');
+    if (directory) {
+      const files: string[] = [];
+      const visit = (root: string) => {
+        for (const entry of readdirSync(root, { withFileTypes: true })) {
+          if (entry.isDirectory()) visit(join(root, entry.name));
+          else files.push(relative(path, join(root, entry.name)));
+        }
+      };
+      visit(path);
+      for (const file of files.sort()) {
+        hash.update(`F\0${file}\0`);
+        hash.update(readFileSync(join(path, file)));
+        hash.update('\0');
+      }
+    } else hash.update(readFileSync(path));
+    return {
+      path, components: [directory ? 'cross-model-acceptance' : 'agent-fleet'],
+      authority: 'repo-harness-install-transaction', removal: 'managed-surfaces-only',
+      type: directory ? 'directory-copy' : 'managed-file',
+      managed_marker: directory ? 'transaction-created-directory' : 'transaction-created-file',
+      content_hash: `sha256:${hash.digest('hex')}`, symlink_target: null,
+    };
+  });
+  const statePath = installProfileStatePath(env);
+  mkdirSync(dirname(statePath), { recursive: true });
+  writeFileSync(statePath, JSON.stringify({ protocol: 2, profile: 'full', components: PROFILE_COMPONENTS.full,
+    transaction_id: 'owned-upgrade-fixture', applied_at: new Date().toISOString(), ownership_manifest, previous: null }));
+}

--- a/tests/herdr-runtime-pin.test.ts
+++ b/tests/herdr-runtime-pin.test.ts
@@ -1,3 +1,4 @@
+import { defaultPolicy } from "../src/core/adoption/standard-plan";
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "fs";
 import { join } from "path";
@@ -65,6 +66,7 @@ describe("herdr runtime pin has one source of truth", () => {
 
   test("the downstream policy seed projects the same pin", () => {
     const herdr = readPolicy().external_tooling.herdr;
+    expect((defaultPolicy("minimal-agentic", "en").external_tooling as Record<string, unknown>).herdr).toEqual(herdr);
     const expected = JSON.stringify(herdr, null, 2)
       .split("\n")
       .map((line) => line.trim());

--- a/tests/install-agent-fleet.test.ts
+++ b/tests/install-agent-fleet.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { chmodSync, cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { chmodSync, cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { dirname, join } from "path";
 import { spawnSync } from "child_process";
+
+import { installProfileHostMutationPaths } from "../src/cli/installer/install-profile";
+
+import { recordInstallOwnership } from "./helpers/install-ownership";
 
 const ROOT = join(import.meta.dir, "..");
 const SCRIPT = join(ROOT, "scripts/install-agent-fleet.sh");
@@ -95,6 +99,7 @@ function prepareInstallerRuntime(home: string, sourceDir: string) {
   mkdirSync(join(packageRoot, "scripts"), { recursive: true });
   mkdirSync(join(packageRoot, "agents"), { recursive: true });
   cpSync(SCRIPT, runtimeScript);
+  symlinkSync(join(ROOT, "src"), join(packageRoot, "src"), "dir");
   chmodSync(runtimeScript, 0o755);
   cpSync(sourceDir, join(packageRoot, "agents/fleet"), { recursive: true });
   return { packageRoot, runtimeScript };
@@ -119,6 +124,35 @@ function runInstaller(
 }
 
 describe("install-agent-fleet", () => {
+  test("upgrades receipt-owned fleet files and preserves subsequent user edits", () => {
+    const { root, home } = setupFakeHome("fleet-owned-upgrade");
+    const env = { ...process.env, HOME: home };
+    try {
+      expect(runInstaller(home, FLEET_SOURCE_DIR).status).toBe(0);
+      const paths = AGENTS.flatMap(agent => [join(home, ".claude/agents", `${agent}.md`), join(home, ".codex/agents", `${agent}.toml`)]);
+      recordInstallOwnership(paths, env);
+      for (const path of paths) expect(installProfileHostMutationPaths(env)).toContain(path);
+      const next = join(root, "next");
+      cpSync(FLEET_SOURCE_DIR, next, { recursive: true });
+      for (const agent of AGENTS) {
+        const file = join(next, `${agent}.md`);
+        writeFileSync(file, readFileSync(file, "utf8") + "\nUpdated role instruction.\n");
+      }
+      const result = runInstaller(home, next);
+      expect(result.status).toBe(0);
+      recordInstallOwnership(paths, env);
+      for (const host of [".claude", ".codex"]) {
+        const file = join(home, host, "agents", `deep-worker.${host === ".claude" ? "md" : "toml"}`);
+        expect(readFileSync(file, "utf8")).toContain("Updated role instruction.");
+        writeFileSync(file, readFileSync(file, "utf8") + "\n# User edit\n");
+      }
+      const blocked = runInstaller(home, FLEET_SOURCE_DIR);
+      expect(blocked.status).toBe(1);
+      expect(blocked.stdout).toContain("deep-worker.md: drift");
+      expect(blocked.stdout).toContain("deep-worker.toml: drift");
+    } finally { rmSync(root, { recursive: true, force: true }); }
+  });
+
   test("fresh install writes claude .md byte-identical to source and codex .toml byte-identical to golden", () => {
     const { root, home } = setupFakeHome("install-agent-fleet-fresh");
     try {

--- a/tests/install-profiles.test.ts
+++ b/tests/install-profiles.test.ts
@@ -82,7 +82,7 @@ function writeManagedHostSurfaces(
     writePath(join(source, 'scripts/verify-sprint.sh'), '# managed\n');
     writePath(join(source, 'scripts/ship-worktrees.sh'), '# managed\n');
     writePath(join(home, '.bun', 'bin', 'codegraph'), '#!/bin/sh\n');
-    for (const agent of ['explorer', 'deep-reasoner', 'fast-worker', 'gatekeeper', 'root-cause-prover', 'harness-evaluator']) {
+    for (const agent of ['explorer', 'deep-reasoner', 'fast-worker', 'deep-worker', 'gatekeeper', 'root-cause-prover', 'harness-evaluator']) {
       writePath(join(home, '.codex', 'agents', `${agent}.toml`), '# managed\n');
     }
     writePath(join(home, '.codex', 'skills', 'repo-harness-cross-review', 'SKILL.md'), '# external\n');
@@ -816,7 +816,7 @@ describe('install profiles', () => {
     writePath(join(source, 'scripts/verify-sprint.sh'), '# managed\n');
     writePath(join(source, 'scripts/ship-worktrees.sh'), '# managed\n');
     writePath(join(env.HOME!, '.bun', 'bin', 'codegraph'), '#!/bin/sh\n');
-    for (const agent of ['explorer', 'deep-reasoner', 'fast-worker', 'gatekeeper', 'root-cause-prover', 'harness-evaluator']) {
+    for (const agent of ['explorer', 'deep-reasoner', 'fast-worker', 'deep-worker', 'gatekeeper', 'root-cause-prover', 'harness-evaluator']) {
       writePath(join(env.HOME!, '.codex', 'agents', `${agent}.toml`), '# managed\n');
     }
     writePath(join(env.HOME!, '.codex', 'skills', 'repo-harness-cross-review', 'SKILL.md'), '# external\n');


### PR DESCRIPTION
## What changed

Installed fleet roles and bundled cross-review trees refused legitimate package upgrades because both write paths compared candidate bytes only and never read the existing protocol-2 ownership ledger. Unchanged files recorded in the installation manifest now upgrade; unowned or user-modified content still fails closed. Bundled skills synchronize their entire trees, including updated and retired references, with rollback on copy failure. `deep-worker` joins installation transaction capture and fleet completeness checks.

TypeScript repository adoption now projects the canonical Herdr version pin that the shell seeds already declared. A missing or malformed `external_tooling.herdr.min_version` reports `configuration-error` instead of runtime `unavailable`, while strict readiness still fails closed. Explicit repository values remain authoritative — defaults never override a malformed declaration.

The second commit binds the slice to `plans/plan-20260911-0100-install-owned-upgrade.md`, adds the Unreleased release note, and preserves the BRC14/BRC15 pause handoff as history now that the campaign closed by scope amendment.

## Verification

- `bun test tests/install-agent-fleet.test.ts tests/install-profiles.test.ts tests/check-agent-tooling.test.ts tests/cli/adoption-plan.test.ts tests/cli/init.test.ts tests/herdr-runtime-pin.test.ts` — 158 pass, 0 fail
- `bun run check:hooks`, `bun run check:helpers`, `bash scripts/check-deploy-sql-order.sh`, `bash scripts/check-architecture-sync.sh`, `bash scripts/check-task-sync.sh`, `bash scripts/check-task-workflow.sh --strict`, `bun scripts/inspect-project-state.ts --repo . --format text`, `bun src/cli/index.ts init --repo . --dry-run` — all green
- Root-cause evidence and coverage rationale: `docs/researches/20260911-install-019-owned-upgrade.md`

No full-suite trigger locally; required CI owns the branch-wide run.