### PR TITLE
docs(architecture): rebind the projection manifest to main 8fc92c08

### DIFF
--- a/docs/architecture/.projection-manifest.json
+++ b/docs/architecture/.projection-manifest.json
@@ -5,12 +5,12 @@
   "sourceDigest": "sha256:b859983f97115344cb2d922ace1e8499d648eeca197ec66cf58b3775378e135d",
   "provenance": {
     "schemaVersion": "archcontext.architecture-docs-projection-provenance/v1",
-    "baseHeadSha": "51eaaf7646003334709ff069cec115e4c7dadbe1",
-    "worktreeDigest": "sha256:de9a9d59ae5593d5d2f19ccafec73606d7c6467eaee8fd9ed3afb77a672073a1",
-    "sourceTreeDigest": "sha256:2b8b061a65b4b97ed8333114d232d6ea9e4a2bc711a224114a0e9245c98dc6d1",
+    "baseHeadSha": "8fc92c08d4e0c1bf771005e001e0fd254adc210b",
+    "worktreeDigest": "sha256:566e3c890abaea758a1316912ebf4f6bc2ec08cbd692e3c105b5ead23f4fb5ab",
+    "sourceTreeDigest": "sha256:6d6d60f07656d556e6e4647c27bb6954424e14ac00b4167b349514274d4a443f",
     "modelDigest": "sha256:a11afbf16edf9e822bf02222d331beb8c050ef0b659ae605c23183193b10bbd5",
-    "codeGraphDigest": "sha256:99bcfbb8235d421250e3f78e107af2276f17d6a07851316809dbc1684f5e2580",
-    "indexedWorktreeDigest": "sha256:5ac0cbee7b2c995304d4ff3495e2a70e453915a9e420532dbc8bc01f1ce63f74",
+    "codeGraphDigest": "sha256:55fe9d16a7cf2c5c7acb6ee7493b5c163d815819325232631c3fa7d19dfde264",
+    "indexedWorktreeDigest": "sha256:77bd87e52d69da1030a780cf9d94b1743b1ec74b5376e00f9866db5ec21b218d",
     "rendererVersion": "archcontext.docs-renderer/v4",
     "layoutVersion": "archcontext.docs-layout/v1",
     "generatedFrom": {
@@ -19,9 +19,9 @@
       "codeGraphBinaryDigest": "sha256:e4be48573fdf16196ca0d2867be2790aa161534e9973dcb89bc70465100ea537",
       "codeGraphStatus": "ready"
     },
-    "projectionInputDigest": "sha256:9a1ba666b6baac9318d7c776b800b68f5e1cee70b019e166ffe634e71a1c1c10"
+    "projectionInputDigest": "sha256:fbbf73d155e534bec1b1392d22a525622d1adad920cda86bfea3fa52b1e1a72d"
   },
-  "projectionDigest": "sha256:d5f8453b4cb65e8e31bd43f266ff552db948d93bd18e129f00aa9c6304eca51e",
+  "projectionDigest": "sha256:422a71b99e268f39cde9c4ae6027c2c63db8ee9a924db502a65cebddc5e301f1",
   "semanticBaseline": {
     "semanticState": {
       "schemaVersion": "archcontext.architecture-semantic-state/v1",
@@ -709,12 +709,12 @@
     },
     "digests": {
       "modelDigest": "sha256:a11afbf16edf9e822bf02222d331beb8c050ef0b659ae605c23183193b10bbd5",
-      "sourceTreeDigest": "sha256:2b8b061a65b4b97ed8333114d232d6ea9e4a2bc711a224114a0e9245c98dc6d1",
+      "sourceTreeDigest": "sha256:6d6d60f07656d556e6e4647c27bb6954424e14ac00b4167b349514274d4a443f",
       "flowProofDigest": "sha256:938dadfc988b732b6a67413ece104c062bb257ffd9f67caaf7db04dbc957b983",
-      "projectionDigest": "sha256:d5f8453b4cb65e8e31bd43f266ff552db948d93bd18e129f00aa9c6304eca51e"
+      "projectionDigest": "sha256:422a71b99e268f39cde9c4ae6027c2c63db8ee9a924db502a65cebddc5e301f1"
     }
   },
-  "receiptDigest": "sha256:5166b7083c5af75268273bd1071f45c7f6bbc12812a82df34d1e147e2575903b",
+  "receiptDigest": "sha256:c974eb9e8e2077818e0f6ca97ef957c925bd448cf39e64c820be6d8f59ef9306",
   "refreshSignalIds": [],
   "targetCount": 33,
   "fileCount": 33,
@@ -767,9 +767,9 @@
       "sourceDigest": "sha256:70f7c537b3943cfc93d02e71670d31413d6676835a0e7d7d51b9ba81083b9397",
       "outputDigest": "sha256:8cdc5490865571f4fc7682b1fcd6f5a75cd436fb08df42f8c5c18da2e8794afe",
       "verifiedAgainst": {
-        "branch": "codex/brc1415-adopted-continuation",
-        "commit": "33f2f1bc110056337e5dbd5414f7ca8dee69f402",
-        "committedAt": "2026-09-09T04:43:46+08:00"
+        "branch": "main",
+        "commit": "8fc92c08d4e0c1bf771005e001e0fd254adc210b",
+        "committedAt": "2026-09-11T01:30:57+08:00"
       }
     },
     {
@@ -1047,9 +1047,9 @@
       "sourceDigest": "sha256:132d8cab10d94dc2d5add313cea2a2cfa120b63b2d180ff084f4d9a0fae044bf",
       "outputDigest": "sha256:49427c6729ca7883ed1d9f6f3b23ac6c4ed307748a6344c0e24a4bed00b701ce",
       "verifiedAgainst": {
-        "branch": "codex/architecture-drift-recovery",
-        "commit": "822309dbd6fd0ed286cd7d0b297e1b26d991b6d0",
-        "committedAt": "2026-09-09T01:54:22+08:00"
+        "branch": "main",
+        "commit": "8fc92c08d4e0c1bf771005e001e0fd254adc210b",
+        "committedAt": "2026-09-11T01:30:57+08:00"
       }
     },
     {
@@ -1227,9 +1227,9 @@
       "sourceDigest": "sha256:463d4ebee4c32feaf8e98dca3f6862530d876ff145ab4a6c0d1e83b9acd6d4b7",
       "outputDigest": "sha256:966f7438cd7b385cb411a2ef8c2de18c0b1e71eb067941c97375a4b284a873b9",
       "verifiedAgainst": {
-        "branch": "codex/operator-task-diff",
-        "commit": "320840c791fb3975c10fc3931004852100e4849e",
-        "committedAt": "2026-09-10T23:45:03+08:00"
+        "branch": "main",
+        "commit": "8fc92c08d4e0c1bf771005e001e0fd254adc210b",
+        "committedAt": "2026-09-11T01:30:57+08:00"
       }
     },
     {
@@ -1247,9 +1247,9 @@
       "sourceDigest": "sha256:6f1d8c7839dc83c16c80bee79ee8c6b3b3131e523928d2d0e957180fd0541c02",
       "outputDigest": "sha256:beaaa466d51cbd8f929fd6acd6645c6f5136cccf539f09b63a273e5ab38519fa",
       "verifiedAgainst": {
-        "branch": "codex/retention-release-0-19-0",
-        "commit": "18c2ca1c866e8e53b3253862c9b7c11f1b9d7841",
-        "committedAt": "2026-09-10T19:01:11+08:00"
+        "branch": "main",
+        "commit": "8fc92c08d4e0c1bf771005e001e0fd254adc210b",
+        "committedAt": "2026-09-11T01:30:57+08:00"
       }
     },
     {


### PR DESCRIPTION
Generated-artifact rebind only. No source, model, or renderer change.

The strict Stop projection gate dead-lettered with `AC_RUNTIME_VERSION_UNSUPPORTED`: an orphaned `archctxd` 0.5.9 daemon, launched from a worktree that has since been deleted, was still answering while the repository pins 0.5.10. Retiring the orphaned daemons let `architecture-projection drain` apply cleanly on the first attempt.

What this records: `baseHeadSha` and the derived worktree/source/codegraph/projection digests move to `8fc92c08`, and every stale per-target `verifiedAgainst` reference moves off merged feature branches (`codex/brc1415-adopted-continuation`, `codex/architecture-drift-recovery`, `codex/operator-task-diff`, `codex/retention-release-0-19-0`) onto `main`. `targetCount` and `fileCount` stay at 33 — no target rollback.

`bash scripts/check-architecture-sync.sh` reports `state=ready blocking=0`.