### PR TITLE
feat(skills): add bounded auto-campaign standard turn

### DIFF
--- a/assets/skill-commands/manifest.json
+++ b/assets/skill-commands/manifest.json
@@ -160,6 +160,25 @@
       "retirementCandidate": null
     },
     {
+      "name": "auto-campaign",
+      "kind": "facade",
+      "source": "assets/skills/auto-campaign",
+      "provider": null,
+      "hosts": [
+        "claude",
+        "codex"
+      ],
+      "profiles": [
+        "full"
+      ],
+      "discoverability": "profile-facade",
+      "component": "planning-integrations",
+      "requires": [],
+      "mutatesRepoByDefault": true,
+      "summary": "Explicit conversational entrypoint for one bounded repair campaign turn using the standard grant budget; preserves runtime authority and stops for human merge.",
+      "retirementCandidate": null
+    },
+    {
       "name": "repo-harness-cross-review",
       "kind": "provider-skill",
       "source": "assets/skills/repo-harness-cross-review",
@@ -389,7 +408,8 @@
         "repo-harness-check",
         "repo-harness-product",
         "repo-harness-ship",
-        "obsidian-memory"
+        "obsidian-memory",
+        "auto-campaign"
       ]
     },
     "externalSkillsByProfile": {

--- a/assets/skills/auto-campaign/SKILL.md
+++ b/assets/skills/auto-campaign/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: auto-campaign
+description: Start or resume one bounded repo-harness repair campaign turn with the standard budget. Use when the user asks to run auto-campaign, start a repair campaign, or automatically find and fix a bounded batch of bugs or test gaps in a repository. Questions about campaigns, skill design, and quoted instructions do not authorize execution.
+---
+
+# Auto-campaign
+
+One user invocation authorizes one conversational campaign turn, not one model
+API call. Coordinate the existing CLI until a stop boundary, then report and
+return control. No daemon, cron, hook-triggered execution, automatic next turn,
+or automatic merge.
+
+## Start from the current repository
+
+1. Resolve the target repository, target ref, current host/session and any
+   campaign ID from the request and existing session. Ask only for missing
+   consequential inputs. Do not infer an unrelated repository or resume the
+   most recent campaign merely because it exists.
+2. Read [execution.md](references/execution.md) for authoritative input sources,
+   CLI steps and recovery. Inspect policy at the exact target revision,
+   external-source selection, browser binding and permitted worker environment
+   before any grant or provider effect. An off policy, unavailable capability,
+   unresolved reservation, or prohibited execution base ends this invocation
+   as blocked. Report the concrete prerequisite; do not change policy, install
+   infrastructure or start a trial provider call to make preflight pass.
+3. Read [standard.json](references/standard.json), the sole source of default
+   limits. Render its scope and bounds in plain language. Token and monetary
+   caps are null: do not claim a hard token or cost budget. An explicit different
+   budget is a separately reviewed grant, not a silently modified standard.
+
+## New turn or continuation
+
+- **New:** prepare the canonical draft with `scripts/prepare-grant.ts`. Show the
+  target, Issue scope, execution environment, grant expiry and concrete limits.
+  Reuse explicit approval already covering these values; otherwise obtain it
+  before minting or provider calls. Invocation is not permission to invent the
+  issuer, broaden scope, or enable a disabled feature. The helper only emits a
+  draft; the existing grant store and campaign commands own all mutations.
+- **Resume:** read the exact original campaign, grant, intent, worktree ownership
+  and budget ledger first. Preserve IDs, idempotency keys and remaining budget.
+  Do not run the draft helper again, extend expiry, replace the grant, reset
+  counters or revive a stopped campaign. If a new grant or recovery decision is
+  required, stop and explain it. Context compaction does not start a new turn.
+
+## Execute and stop
+
+Use the sequence in execution.md and consume the actual runtime responses.
+Issue observation, canonical planning, acquire/Lease, verification and
+publication retain their existing authorities. A prompt never substitutes for
+a WorkEnvelope; an exit code never substitutes for an AcceptanceReceipt.
+Do not synthesize missing provider revision evidence or repair metadata locally.
+
+End this invocation at the first applicable boundary:
+
+- The authorized group reaches its verified terminal outcome.
+- A prepared PR requires human merge. Report the PR and preserve the campaign;
+  after the user merges, a later explicit continuation may finish cleanup/audit
+  under the original unexpired grant. Do not silently mark the group accepted.
+- Budget or deadline is exhausted. Report remaining/unsettled work without
+  rolling over to another grant or group.
+- Policy, environment, identity, unknown provider outcome, lost ownership or
+  failed verification blocks progress. Follow only the existing permitted
+  reconciliation path; do not retry unknown external effects.
+
+At a boundary leave no newly detached scheduler or worker running to continue
+the turn. Use the existing cancellation/reconciliation protocol; if inactivity
+cannot be proven, report it and retain ownership fences rather than claiming
+cleanup completed. Persist recovery identifiers in the repository's existing
+handoff surface, not a second campaign state store.
+
+Report: outcome (`completed`, `awaiting_merge`, `budget_exhausted`, or `blocked`),
+campaign/grant identifiers, Issue/PR links, exact verified revision, used and
+remaining authoritative budget, unresolved effects and the next bounded action.
+These are user-facing summaries, not new runtime lifecycle states. A successful
+skill invocation alone is not BRC activation or full-chain acceptance.

--- a/assets/skills/auto-campaign/references/execution.md
+++ b/assets/skills/auto-campaign/references/execution.md
@@ -1,0 +1,93 @@
+# Execution reference
+
+Run commands in the target repository. Read each command's `--help` from the
+selected `repo-harness` runtime before using it. Missing commands or authorities
+are blockers, not reasons to substitute a different controller.
+
+## Preflight and draft inputs
+
+Read `.ai/harness/policy.json` at the exact target Git revision, including
+`development_campaign` and `external_sources`. The campaign must permit active
+execution and every bound in standard.json; the GitHub selector must support
+the complete campaign Issue snapshot. Verify the configured browser binding
+with `repo-harness chatgpt browser-doctor`, mandatory prompt scanner, worker
+execution capability and the user's allowed execution environment. Do not use
+`campaign author`, `adopt --dry-run`, or `observe-revision` as readiness probes:
+they can persist intent or consume provider budget. Shadow/off is not active.
+
+Prepare one input JSON object with exactly these fields:
+
+| Fields | Authority |
+| --- | --- |
+| `repository_id`, `work_graph_revision` | Registered repository's canonical graph, read with `repo-harness sprint graph --sprint <path> --format json`; require the graph at the authorized target. Never hash a label to fabricate a graph revision. |
+| `allowed_work_package_ids` | Explicitly authorized IDs from that graph/scope. Do not authorize unrelated existing work. |
+| `target_ref`, `target_revision` | Authorized full ref and its resolved Git commit; read back the remote target before grant creation. |
+| `authorization_id`, `campaign_id` | New unique identities for this explicitly requested turn, recorded with the draft; never replace existing identities on resume. |
+| `issued_by` | Actual authorizing operator identity from the session or supplied authorization. |
+| `issued_at` | Current UTC timestamp at draft preparation; expired drafts require renewed explicit authorization, not silent refresh. |
+| `local_parent_host` | Actual current host, `codex` or `claude`. |
+| `chrome_profile_directory` | Exact verified profile from the saved browser binding. |
+
+If the canonical graph, committed sprint/publication policy, operator identity,
+or any other prerequisite is unavailable, report the missing prerequisite.
+Do not borrow hashes/IDs from examples or create placeholder authority.
+
+Run `bun <installed-skill>/scripts/prepare-grant.ts <input.json>` and capture
+stdout as the draft. The helper resolves the selected CLI package through
+`repo-harness docs path harness-overview`, then uses that runtime's
+`sealProgramAuthorization` and `canonicalAutomationJson`. It validates shape
+and seals bytes; it does not attest input provenance or grant permission.
+Read standard.json and the complete resulting draft back to the operator in
+plain language. Reuse approval already covering that exact scope and budget.
+Otherwise obtain approval before the following mutating steps.
+
+## New campaign progression
+
+1. `repo-harness automation grant mint --repo <repo> --from <draft.json>`.
+   Keep the returned digest and immutable stored path.
+2. `repo-harness campaign start --repo <repo> --authorization-sha256 <digest>
+   --idempotency-key <stable-key>`. Read the returned current state.
+3. `repo-harness campaign transition --repo <repo> --request <request.json>`
+   with operation `prepare_group`. The exact request contains `campaign_id`,
+   `expected_current_sha256` from the current state, `idempotency_key`,
+   `operation`, `evidence_refs` and `observed_at`. Let the runtime reject stale
+   state. Never advance lifecycle merely to bypass a missing prerequisite.
+4. `repo-harness campaign author --repo <repo> --campaign-id <id>
+   --group-number <group> --gitleaks-bin <verified-path>`. Retain the emitted
+   intent/session identifiers. `campaign step` takes the same campaign/group,
+   `--intent-sha256` and a stable `--idempotency-key`; consume its typed result.
+5. When authoring is actually ready, `campaign adopt` requires those identities
+   plus exact-main `--sprint-path`, `--publication-policy` and `--gitleaks-bin`.
+   Consume the canonical adopted tasks; do not write substitute Tasks/WorkGraph.
+   Subsequent `campaign step` planning uses the owning `--host`, `--session-id`
+   and, when required, the real `--planning-result` and issued Engineer
+   `--authorization-id` (distinct from the program grant).
+6. Follow returned planning/acquisition and worker contracts through the
+   existing runtime. `campaign closeout` consumes the stored worker selector
+   via `--request`, owning `--host` and `--session-id`; it does not accept an
+   invented receipt. Stop as soon as a PR awaits manual merge. For a later
+   explicit continuation, `campaign audit` requires the exact campaign/group,
+   intent, fresh attempt key and scanner. Fresh-main evidence and runtime
+   transition guards determine acceptance/completion, not the skill.
+
+These are state-dependent steps, not a shell loop. Read status and budget
+between effects; never blindly rerun the sequence after a timeout.
+
+## Resume, stop and reporting
+
+Use `campaign status --repo <repo> --campaign-id <id>`, the original stored
+grant (`automation grant list --repo <repo>` lists it), and `automation budget
+show --repo <repo> --run <automation-run-id>` with the runtime's recorded run
+identity. Inspect the existing intent, owner/Lease and unsettled reservations.
+Replay the same logical operation with its recorded idempotency key only when
+the runtime allows it; distinct operations need distinct recorded keys.
+
+A stopped or expired campaign is not an ordinary resume. `prepare-resume` can
+prepare a successor and therefore falls outside this skill's same-grant
+continuation. Stop for a new authorization decision. No automatic successor,
+grant renewal, increased cap, extra group, merge, or detached continuation.
+
+Report the first stop boundary defined in SKILL.md with authoritative evidence.
+Do not mark accepted when fresh audit/receipt evidence is absent. Unresolved
+external outcomes retain their fences and require the existing reconciliation
+protocol. Save only recovery pointers in the existing handoff surface.

--- a/assets/skills/auto-campaign/references/standard.json
+++ b/assets/skills/auto-campaign/references/standard.json
@@ -1,0 +1,36 @@
+{
+  "name": "standard",
+  "merge_mode": "manual",
+  "allowed_merge_method": "squash",
+  "allowed_risk_tiers": ["low"],
+  "contract_scope": "contract_less",
+  "contract_path": null,
+  "budget": {
+    "max_agent_turns": 40,
+    "max_successful_acquisitions": 10,
+    "max_runner_invocations": 20,
+    "max_provider_failures": 3,
+    "max_consecutive_no_progress_steps": 3,
+    "max_repair_cycles": 1,
+    "max_wall_clock_seconds": 5400,
+    "max_input_tokens": null,
+    "max_output_tokens": null,
+    "max_cost_micros": null
+  },
+  "campaign": {
+    "group_count": 1,
+    "issues_per_group": 5,
+    "allowed_issue_kinds": ["bugfix", "test_gap"],
+    "max_parallel_tasks": 2,
+    "max_authoring_rounds_per_group": 2,
+    "max_controller_steps": 40,
+    "max_provider_calls": 32,
+    "transient_retry": {
+      "max_consecutive_failures": 2,
+      "initial_backoff_ms": 1000,
+      "maximum_backoff_ms": 10000
+    },
+    "issue_author": "gpt_pro",
+    "require_fresh_main_audit": true
+  }
+}

--- a/assets/skills/auto-campaign/scripts/prepare-grant.ts
+++ b/assets/skills/auto-campaign/scripts/prepare-grant.ts
@@ -1,0 +1,39 @@
+#!/usr/bin/env bun
+import { execFileSync } from 'node:child_process';
+import { readFileSync, realpathSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+// Discover the selected CLI's package; managed skills may be copied elsewhere.
+const doc = execFileSync('repo-harness', ['docs', 'path', 'harness-overview'], {
+  encoding: 'utf8', timeout: 10000, stdio: ['ignore', 'pipe', 'pipe'],
+}).trim();
+const runtime = resolve(dirname(realpathSync(doc)), '../..');
+const { sealProgramAuthorization, canonicalAutomationJson } = await import(
+  pathToFileURL(join(runtime, 'src/core/automation/budget.ts')).href
+);
+
+if (process.argv.length !== 3) throw new Error('Usage: bun prepare-grant.ts <authoritative-input.json>');
+const input = JSON.parse(readFileSync(process.argv[2]!, 'utf8'));
+const fields = ['authorization_id', 'repository_id', 'target_ref', 'target_revision',
+  'work_graph_revision', 'allowed_work_package_ids', 'issued_by', 'issued_at',
+  'campaign_id', 'local_parent_host', 'chrome_profile_directory'];
+if (!input || typeof input !== 'object' || Array.isArray(input)
+  || JSON.stringify(Object.keys(input).sort()) !== JSON.stringify(fields.sort())) {
+  throw new Error('Supply only the complete authoritative identity fields; budget overrides are not standard');
+}
+const preset = JSON.parse(readFileSync(join(dirname(fileURLToPath(import.meta.url)), '../references/standard.json'), 'utf8'));
+const { campaign_id, local_parent_host, chrome_profile_directory, ...identity } = input;
+const draft = sealProgramAuthorization({
+  ...identity,
+  merge_mode: preset.merge_mode,
+  allowed_merge_method: preset.allowed_merge_method,
+  allowed_risk_tiers: preset.allowed_risk_tiers,
+  contract_scope: preset.contract_scope,
+  contract_path: preset.contract_path,
+  budget: preset.budget,
+  max_repair_cycles: preset.budget.max_repair_cycles,
+  expires_at: new Date(Date.parse(input.issued_at) + preset.budget.max_wall_clock_seconds * 1000).toISOString(),
+  campaign: { ...preset.campaign, campaign_id, local_parent_host, chrome_profile_directory },
+});
+process.stdout.write(`${canonicalAutomationJson(draft)}\n`);

--- a/docs/researches/20260911-auto-campaign-turn.md
+++ b/docs/researches/20260911-auto-campaign-turn.md
@@ -1,0 +1,32 @@
+# Auto-campaign conversational turn
+
+`auto-campaign` is the explicit conversational entrypoint for one bounded repair
+campaign turn. It is included in the full skill installation on Claude and
+Codex. A turn may contain multiple model calls and worker steps; it ends at the
+first verified group outcome, manual merge, exhausted budget/deadline or blocker.
+
+The default authority is
+[`standard.json`](../../assets/skills/auto-campaign/references/standard.json).
+The portable draft helper calls the selected runtime's canonical grant sealer.
+It emits JSON without minting a grant, starting a campaign or contacting a model.
+Input provenance and operator approval remain prerequisites; a valid digest
+alone is not authorization. The existing account-level grant store, budget
+ledger, controller and Lease protocols remain the runtime authorities.
+
+Resume preserves the original campaign, grant, operation identities and ledger.
+It does not replenish budget or extend expiry. A stopped campaign or successor
+grant requires a separate authorization decision. Manual merge returns control
+to the user; subsequent explicit continuation may finish audit under the original
+valid grant. No automatic next group, merge or background scheduler is introduced.
+
+The entrypoint preserves policy and environment gates. Installation does not
+activate campaign mode, enable Refactor Mode or supply host execution containment.
+Missing canonical graph, publication policy, browser/worker capability or allowed
+execution environment stops before provider expenditure. See the
+[`execution reference`](../../assets/skills/auto-campaign/references/execution.md)
+for the current CLI mapping and input authorities.
+
+Verification covers full/minimal managed installation, both host copies,
+relocated draft execution, canonical grant mint/read, invalid identity rejection
+and preset binding in disposable state. These tests do not establish model
+effectiveness, live campaign completion, or BRC14/BRC15 acceptance.

--- a/plans/archive/plan-20260911-0055-auto-campaign-skill.md
+++ b/plans/archive/plan-20260911-0055-auto-campaign-skill.md
@@ -74,7 +74,7 @@ Run focused new skill/helper tests and existing named skill manifest/profile/ins
 - **Stop condition**: Named focused tests/integrity checks pass and one review has no blocking findings.
 - **Rollback surface**: Revert scoped skill/catalog/tests; no grants or provider calls were made outside disposable fixtures.
 
-> **Substantive Change SHA256**: `sha256:d08723e9a22d619c1da0aafe6d18c00723b28d9805ebccb46ceb84038f479fd8`
+> **Substantive Change SHA256**: `sha256:e53e86c4c200c788d7e404f81a0d3e1117e072c24f2407434299c32c6f8f0e2d`
 
 ## Acceptance Notes
 

--- a/plans/archive/plan-20260911-0055-auto-campaign-skill.md
+++ b/plans/archive/plan-20260911-0055-auto-campaign-skill.md
@@ -1,0 +1,89 @@
+# Plan: Auto-campaign single-turn skill with standard budget
+
+> **Status**: Done
+> **Created**: 20260911-0055
+> **Slug**: auto-campaign-skill
+> **Planning Source**: codex-plan
+> **Orchestration Kind**: host-plan
+> **Source Ref**: (none)
+> **Artifact Level**: work-package
+> **Promotion Reason**: verification_boundary
+> **Verification Boundary**: Managed skill installation and canonical grant draft with model-free focused tests
+> **Rollback Surface**: Revert only auto-campaign skill, manifest registration and focused tests; no live grants or runtime state
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+
+## Workflow
+
+Standard profile: this approved plan owns scope and verification. No separate contract, review or notes artifact. Execution is isolated in codex/auto-campaign-skill at base 8a33faed.
+
+## Intent and accepted behavior
+
+Owner requests auto-campaign with standard budget: one explicit invocation starts one bounded product turn, not a single model API turn. Reuse the original campaign/grant/ledger on resume. End at completed group, manual merge, budget exhaustion or a blocker; never mint another grant or group automatically. This implementation creates the conversational entrypoint, not host execution containment or live BRC acceptance. User authorized planning and implementation in the current conversation.
+
+## P1 — Map
+
+assets/skill-commands/manifest.json owns managed skill profile membership and assets/skills owns skill content. Existing global install projection copies complete package directories. src/core/automation/budget.ts owns ProgramAuthorizationV1, its canonical sealing/validation and enforced caps; src/effects/automation/grant-store.ts owns immutable mint/read. Existing campaign CLI owns start/transition/author/step/adopt/audit/closeout. Runtime authority and policy remain unchanged.
+
+## P2 — Trace
+
+Explicit auto-campaign request -> read current target and policy/provider/runtime readiness -> read one preset -> resolve authoritative grant inputs -> prepare canonical draft using installed runtime sealProgramAuthorization -> show scope and concrete bounds and obtain/reuse authorization -> existing grant mint and campaign start -> prepare_group -> author -> step/adopt/planning/acquire/verify/publication until one stop boundary. Status/replay read original durable IDs. Missing/off policy or disallowed execution environment stops before grants/provider effects. A dry run of adopt is not zero-provider and must not be used for preflight.
+
+## P3 — Decision
+
+Skill is the conversational coordinator; it owns no new runtime journal, budget parser or lifecycle. A portable supporting helper resolves the installed package through repo-harness docs path, calls its existing canonical grant sealer, and emits JSON to stdout without mint/start/provider effects. Caller supplies validated authoritative repository/ref/work-graph/issuer/session inputs; no local guessed authority. The preset JSON owns all defaults. No budget overrides in first version; explicit different limits require a separately reviewed grant, not silently widened standard. Token/cost limits remain null and unclaimed. Default policy activation and platform restrictions are not changed. At 10x demand the fixed group and budget stop the turn; no auto rollover or queue controller is added.
+
+## Standard preset
+
+One group, five Issues, bugfix/test_gap only, max_parallel_tasks 2, manual merge (squash), low risk only, contract_less campaign grant with null contract path. Budget: 40 agent turns, 10 successful acquisitions, 20 runner invocations, 3 provider failures, 3 consecutive no-progress steps, 1 repair cycle, 5400 wall-clock seconds, null input/output token and cost caps. Campaign: 2 authoring rounds, 40 controller steps, 32 provider calls; transient retries limited to 2 consecutive failures with 1000/10000 ms initial/maximum backoff. Grant expiry is issued_at plus preset wall-clock seconds. Duplicate required max_repair_cycles fields are derived from the same preset budget value. No model/profile override.
+
+## File scope
+
+- assets/skills/auto-campaign/SKILL.md: triggering, turn semantics, preflight, consent reuse, existing CLI progression, stop/report contract.
+- assets/skills/auto-campaign/references/standard.json: sole preset data.
+- assets/skills/auto-campaign/references/execution.md: authoritative input and current CLI mapping, no guessed receipts/IDs, resume/merge boundary.
+- assets/skills/auto-campaign/scripts/prepare-grant.ts: deterministic zero-effect grant draft via runtime sealer.
+- assets/skill-commands/manifest.json and existing manifest/profile discovery tests or projection metadata proven necessary by surface trace: install for Claude/Codex full profile.
+- tests/auto-campaign-skill.test.ts: preset -> canonical validation/mint in disposable HOME; bad/missing authority and no mint on draft; relocated installed skill resolution; trigger and stop instructions; package manifest discovery.
+- docs/researches/20260911-auto-campaign-turn.md: durable product contract and verified boundary, link preset rather than copy numbers.
+- Active plan itself: task/evidence sync. Additional contract/review/notes only if live workflow profile requires them.
+
+## Verification
+
+Run focused new skill/helper tests and existing named skill manifest/profile/installation checks identified by P1. Verify portable skill content after actual managed installation into disposable HOME; no global runtime changes. Run required integrity checks: check:hooks, check:helpers, check-deploy-sql-order, check-architecture-sync, check-task-sync, strict check-task-workflow, inspect-project-state, init dry-run. One final check review of frozen diff. No full suite or provider-based skill benchmark: no runtime semantics change and focused installed-skill tests cover the changed boundary. Do not claim model effectiveness or BRC acceptance from these checks.
+
+## Task Breakdown
+- [x] Register and author auto-campaign with single standard budget authority and zero-effect canonical draft helper.
+- [x] Verify trigger/stop/resume, canonical budget binding, invalid input rejection and installed skill relocation in disposable fixtures.
+- [x] Run required integrity checks, one final review, promote durable semantics and record exact delivery state.
+
+## Promotion Gate
+
+- **Merge/PR unit**: auto-campaign skill, preset, portable draft helper and managed discovery registration.
+- **Rollback surface**: Revert this skill/catalog/test change; no live runtime mutations.
+- **Verification boundary**: Disposable full/minimal host installation and canonical grant round trip.
+- **Review/acceptance boundary**: One frozen-diff check review and focused/integrity evidence.
+- **High-risk surface**: Draft input provenance and existing authorization gates must remain explicit.
+- **Why not checklist row**: This is a separately installable product entrypoint with its own verification boundary.
+
+## Evidence Contract
+
+- **State/progress path**: This plan's Task Breakdown in codex/auto-campaign-skill.
+- **Verification evidence**: Focused tests and required commands listed above; results recorded below.
+- **Evaluator rubric**: Portable installed skill, sole budget preset, no minted authority from drafting, and no resume budget renewal; runtime gates preserved.
+- **Stop condition**: Named focused tests/integrity checks pass and one review has no blocking findings.
+- **Rollback surface**: Revert scoped skill/catalog/tests; no grants or provider calls were made outside disposable fixtures.
+
+> **Substantive Change SHA256**: `sha256:d08723e9a22d619c1da0aafe6d18c00723b28d9805ebccb46ceb84038f479fd8`
+
+## Acceptance Notes
+
+- Base: 8a33faed74ab65706d4f3df7d03c8f7ccac53b84; isolated branch codex/auto-campaign-skill.
+- `bun test tests/auto-campaign-skill.test.ts`: 3 pass, including actual full/minimal managed installation, both host copies, relocated helper and canonical mint/read in disposable HOME.
+- `bun test tests/skill-surface tests/action-command-skills.test.ts`: 137 pass. Fixed exact live catalog expectations for the new facade; historical discovery baseline unchanged.
+- `bun run check:type`: pass.
+- Required integrity commands listed in Verification: all pass. Task-sync is bound to the substantive digest above; workflow field omissions corrected before acceptance.
+- `npm pack --pack-destination /tmp --json` rebuilt hook/UI assets; tarball SHA1 7e488753baa1950db30bf3a17fc2af4b54d5c2fa. Installed tarball into a temporary package/HOME, projected both host skill copies, invoked the relocated draft helper through installed CLI and proved no grant store was created. All four skill files present; no skill cache/noise files.
+- One Standard check review: parent correctness/package review and conditional security/architecture reviewers PASS, no findings. No second acceptance review.
+- Full suite and provider effectiveness runs omitted: changed boundary is skill packaging and deterministic draft generation; named focused tests plus real package install cover it. No runtime controller, ledger, grant-store or Lease implementation changed. Resume/stop are reviewed skill instructions, not a live model behavior proof.
+- Durable semantics promoted to docs/researches/20260911-auto-campaign-turn.md. Implementation complete; global installation, live campaign, merge and release were not performed.

--- a/tests/action-command-skills.test.ts
+++ b/tests/action-command-skills.test.ts
@@ -34,6 +34,7 @@ const TARGET_CANONICAL_PACKAGES = [
 ];
 
 const TARGET_FACADE_KIND_PACKAGES = [
+  "auto-campaign",
   "repo-harness-setup",
   "repo-harness-plan",
   "repo-harness-check",

--- a/tests/auto-campaign-skill.test.ts
+++ b/tests/auto-campaign-skill.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, expect, test } from 'bun:test';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { automationDigest, canonicalAutomationJson, validateProgramAuthorization } from '../src/core/automation/budget';
+import { listStoredProgramAuthorizations, mintProgramAuthorization, readStoredProgramAuthorization } from '../src/effects/automation/grant-store';
+
+const root = resolve(import.meta.dir, '..');
+const source = join(root, 'assets/skills/auto-campaign');
+const temporary: string[] = [];
+afterEach(() => { for (const path of temporary.splice(0)) rmSync(path, { recursive: true, force: true }); });
+
+function fixture(profile: 'minimal' | 'full') {
+  const dir = mkdtempSync(join(tmpdir(), 'auto-campaign-'));
+  temporary.push(dir);
+  const repo = join(dir, 'repo');
+  mkdirSync(repo);
+  execFileSync('git', ['init', '-q', '-b', 'main', repo]);
+  execFileSync('git', ['-c', 'user.name=Fixture', '-c', 'user.email=fixture@example.invalid', 'commit', '--allow-empty', '-qm', 'fixture'], { cwd: repo });
+  const bin = join(dir, 'bin');
+  mkdirSync(bin);
+  // Select this checkout's actual CLI without touching a global installation.
+  const quote = (value: string) => `'${value.replaceAll("'", "'\\''")}'`;
+  writeFileSync(join(bin, 'repo-harness'), `#!/bin/sh\nexec ${quote(process.execPath)} ${quote(join(root, 'src/cli/index.ts'))} "$@"\n`, { mode: 0o755 });
+  const env = { ...process.env, HOME: dir, REPO_HARNESS_HOME: join(dir, 'runtime'),
+    CODEX_SKILLS_ROOT: join(dir, 'codex-skills'), CLAUDE_SKILLS_ROOT: join(dir, 'claude-skills'),
+    AGENTIC_DEV_SOURCE_ROOT: root, AGENTIC_DEV_LINK_INSTALLED_COPIES: '0',
+    REPO_HARNESS_INSTALL_PROFILE: profile, PATH: `${bin}:${process.env.PATH}` };
+  execFileSync('bash', [join(root, 'scripts/sync-codex-installed-copies.sh')], { env, timeout: 60000, stdio: 'pipe' });
+  const input = { authorization_id: 'fixture-grant', repository_id: 'fixture-repository',
+    target_ref: 'refs/heads/main', target_revision: execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repo, encoding: 'utf8' }).trim(),
+    work_graph_revision: automationDigest({ fixture: 'graph' }), allowed_work_package_ids: ['fixture-package'],
+    issued_by: 'fixture-owner', issued_at: '2026-09-11T00:00:00.000Z', campaign_id: 'fixture-campaign',
+    local_parent_host: 'codex', chrome_profile_directory: 'Profile 1' };
+  function draft(value: unknown) {
+    const path = join(dir, 'input.json');
+    writeFileSync(path, JSON.stringify(value));
+    return spawnSync(process.execPath, [join(env.CODEX_SKILLS_ROOT, 'auto-campaign/scripts/prepare-grant.ts'), path], { cwd: repo, env, encoding: 'utf8', timeout: 15000 });
+  }
+  return { dir, repo, env, input, draft };
+}
+
+test('full installs complete portable skill on both hosts; draft seals and mints through existing authority', () => {
+  const f = fixture('full');
+  for (const host of [f.env.CODEX_SKILLS_ROOT, f.env.CLAUDE_SKILLS_ROOT]) {
+    for (const file of ['SKILL.md', 'references/execution.md', 'references/standard.json', 'scripts/prepare-grant.ts']) {
+      expect(readFileSync(join(host, 'auto-campaign', file), 'utf8')).toBe(readFileSync(join(source, file), 'utf8'));
+    }
+  }
+  const result = f.draft(f.input);
+  expect(result.stderr).toBe('');
+  expect(result.status).toBe(0);
+  const grant = validateProgramAuthorization(JSON.parse(result.stdout));
+  expect(result.stdout).toBe(`${canonicalAutomationJson(grant)}\n`);
+  expect(grant.budget).toEqual(JSON.parse(readFileSync(join(source, 'references/standard.json'), 'utf8')).budget);
+  expect(grant.campaign).toMatchObject({ group_count: 1, issues_per_group: 5, max_parallel_tasks: 2, require_fresh_main_audit: true });
+  expect(grant.merge_mode).toBe('manual');
+  expect(grant.max_repair_cycles).toBe(grant.budget.max_repair_cycles);
+  expect(Date.parse(grant.expires_at) - Date.parse(grant.issued_at)).toBe(grant.budget.max_wall_clock_seconds! * 1000);
+  expect(listStoredProgramAuthorizations(f.repo, f.env)).toEqual([]);
+  const path = mintProgramAuthorization({ repo_root: f.repo, authorization: grant, env: f.env });
+  expect(readStoredProgramAuthorization(f.repo, grant.authorization_sha256, f.env)).toEqual(grant);
+  expect(mintProgramAuthorization({ repo_root: f.repo, authorization: grant, env: f.env })).toBe(path);
+  expect(f.draft(f.input).stdout).toBe(result.stdout);
+  expect(listStoredProgramAuthorizations(f.repo, f.env)).toEqual([grant.authorization_sha256]);
+}, 60000);
+
+test('draft rejects absent authority, malformed identity and nonstandard overrides without minting', () => {
+  const f = fixture('full');
+  const { issued_by: _issuer, ...missingIssuer } = f.input;
+  for (const input of [missingIssuer, { ...f.input, target_revision: 'main' },
+    { ...f.input, work_graph_revision: 'unknown' }, { ...f.input, local_parent_host: 'unknown' },
+    { ...f.input, issued_at: 'unknown' }, { ...f.input, budget: { max_agent_turns: 9999 } }]) {
+    const result = f.draft(input);
+    expect(result.status).not.toBe(0);
+    expect(result.stdout).toBe('');
+  }
+  expect(listStoredProgramAuthorizations(f.repo, f.env)).toEqual([]);
+}, 60000);
+
+test('minimal does not discover or install auto-campaign', () => {
+  const f = fixture('minimal');
+  for (const host of [f.env.CODEX_SKILLS_ROOT, f.env.CLAUDE_SKILLS_ROOT]) {
+    expect(existsSync(join(host, 'auto-campaign'))).toBe(false);
+  }
+}, 60000);

--- a/tests/install-profiles.test.ts
+++ b/tests/install-profiles.test.ts
@@ -23,9 +23,23 @@ import {
   rollbackInstallProfile,
 } from '../src/cli/installer/install-profile';
 import { buildManagedHooks } from '../src/cli/installer/managed-entries';
+import { parseSkillSurfaceCatalog, probeExpectations } from '../src/core/skill-surface/catalog';
 
 const ROOT = join(import.meta.dir, '..');
 const CLI = join(ROOT, 'src/cli/index.ts');
+
+// probeInstalledComponents() derives the planning-integrations evidence set
+// from the catalog, so a fixture that hard-codes one facade's SKILL.md goes
+// stale the moment a second planning facade is declared. Read the same
+// catalog the probe reads.
+const PLANNING_CAPABILITY_PATHS = (() => {
+  const resolution = parseSkillSurfaceCatalog(
+    readFileSync(join(ROOT, 'assets/skill-commands/manifest.json'), 'utf-8'),
+    { declared: true, profileComponents: PROFILE_COMPONENTS },
+  );
+  if (resolution.status !== 'valid') throw new Error('skill-surface manifest is invalid');
+  return probeExpectations(resolution.catalog).planningCapabilityPaths;
+})();
 
 function withHome(run: (env: NodeJS.ProcessEnv) => void): void {
   const home = mkdtempSync(join(tmpdir(), 'repo-harness-profile-'));
@@ -74,7 +88,7 @@ function writeManagedHostSurfaces(
   writePath(join(source, 'src/core/workflow/profile.ts'), '// managed\n');
   writePath(join(source, 'src/cli/tools/codegraph.ts'), '// managed\n');
   if (profile === 'full') {
-    writePath(join(source, 'assets/skills/repo-harness-product/SKILL.md'), '# managed\n');
+    for (const relative of PLANNING_CAPABILITY_PATHS) writePath(join(source, relative), '# managed\n');
     for (const skill of ['think', 'hunt', 'check', 'health', 'mermaid']) {
       writePath(join(home, '.codex', 'skills', skill, 'SKILL.md'), '# external\n');
     }
@@ -808,7 +822,7 @@ describe('install profiles', () => {
     // fixture helper), then upgrade in place without a prior removal step.
     writePath(join(source, 'src/core/workflow/profile.ts'), '// managed\n');
     writePath(join(source, 'src/cli/tools/codegraph.ts'), '// managed\n');
-    writePath(join(source, 'assets/skills/repo-harness-product/SKILL.md'), '# managed\n');
+    for (const relative of PLANNING_CAPABILITY_PATHS) writePath(join(source, relative), '# managed\n');
     for (const skill of ['think', 'hunt', 'check', 'health', 'mermaid']) {
       writePath(join(env.HOME!, '.codex', 'skills', skill, 'SKILL.md'), '# external\n');
     }

--- a/tests/skill-routing-eval.test.ts
+++ b/tests/skill-routing-eval.test.ts
@@ -507,7 +507,7 @@ describe("scripts/run-skill-routing-eval.ts provider mode (run subcommand, SSD-0
       expect(report.metrics.double_trigger).toEqual({ count: 0, denominator: 68, rate: 0 });
       expect(report.metrics.provider_error_count).toBe(0);
       expect(report.discovered_surface.map((d) => d.name).sort()).toEqual(
-        ["obsidian-memory", "repo-harness", "repo-harness-check", "repo-harness-chatgpt", "repo-harness-cross-review", "repo-harness-plan", "repo-harness-product", "repo-harness-ship"].sort(),
+        ["auto-campaign", "obsidian-memory", "repo-harness", "repo-harness-check", "repo-harness-chatgpt", "repo-harness-cross-review", "repo-harness-plan", "repo-harness-product", "repo-harness-ship"].sort(),
       );
     }, 30_000);
 

--- a/tests/skill-surface/catalog.test.ts
+++ b/tests/skill-surface/catalog.test.ts
@@ -335,11 +335,11 @@ describe("skill-surface catalog: the real manifest.json on disk", () => {
   // addition, bringing the live surface to 11 repo-owned + 6 external.
   // obsidian-memory is the second repo-owned addition (a facade projected to
   // both hosts by every profile), bringing it to 12 repo-owned + 6 external.
-  test("covers all 12 repo-owned sources plus the 8 external skills (20 packages)", () => {
+  test("covers all 13 repo-owned sources plus the 8 external skills (21 packages)", () => {
     if (resolution.status !== "valid") throw new Error("expected valid catalog");
-    expect(resolution.catalog.packages.length).toBe(20);
+    expect(resolution.catalog.packages.length).toBe(21);
     const repoOwned = resolution.catalog.packages.filter((p) => p.kind !== "external");
-    expect(repoOwned.length).toBe(12);
+    expect(repoOwned.length).toBe(13);
     const external = resolution.catalog.packages.filter((p) => p.kind === "external");
     expect(external.map((p) => p.name).sort()).toEqual([
       "check", "health", "hunt", "mermaid", "obsidian-cli", "obsidian-markdown", "reverse-skill-router", "think",
@@ -420,7 +420,7 @@ describe("skill-surface catalog: target post-cutover discovery matrix", () => {
       "repo-harness-plan", "repo-harness-check", "obsidian-memory",
     ]);
     expect(facadesForProfile(catalog, "full")).toEqual([
-      "repo-harness-plan", "repo-harness-check", "repo-harness-product", "repo-harness-ship", "obsidian-memory",
+      "repo-harness-plan", "repo-harness-check", "repo-harness-product", "repo-harness-ship", "obsidian-memory", "auto-campaign",
     ]);
   });
 
@@ -535,7 +535,7 @@ describe("skill-surface catalog: target post-cutover discovery matrix", () => {
     const { repoHarnessSkills, externalSkills } = mutationPathSkillNames(catalog);
     expect(repoHarnessSkills).toEqual([
       "repo-harness", "repo-harness-plan", "repo-harness-check", "repo-harness-product", "repo-harness-ship",
-      "obsidian-memory",
+      "obsidian-memory", "auto-campaign",
     ]);
     expect(externalSkills).toEqual([
       "repo-harness-cross-review", "think", "hunt", "check", "health", "mermaid", "reverse-skill-router",
@@ -554,6 +554,7 @@ describe("skill-surface catalog: target post-cutover discovery matrix", () => {
     expect(expectations.planningSkillNames).toEqual(["think", "hunt", "check", "health", "mermaid"]);
     expect(expectations.planningCapabilityPaths).toEqual([
       "assets/skills/repo-harness-product/SKILL.md",
+      "assets/skills/auto-campaign/SKILL.md",
     ]);
     expect(expectations.crossModel).toEqual(["repo-harness-cross-review"]);
   });


### PR DESCRIPTION
新增 `auto-campaign` skill，把 campaign 的一輪標準動作固化成有邊界的流程。

- `assets/skills/auto-campaign/` 提供 SKILL.md、執行參考、standard.json 與 `prepare-grant.ts`
- 註冊進 `assets/skill-commands/manifest.json`，納入 skill catalog
- `docs/researches/20260911-auto-campaign-turn.md` 記錄設計依據

測試：`tests/auto-campaign-skill.test.ts`、`tests/skill-surface/catalog.test.ts`、`tests/action-command-skills.test.ts`