### PR TITLE
feat(operator): scope board to selected repository

### DIFF
--- a/docs/researches/operator-repository-selection.md
+++ b/docs/researches/operator-repository-selection.md
@@ -1,0 +1,31 @@
+# Operator repository selection
+
+The operator board displays one repository at a time. Its top-bar selector uses
+the server-projected directory basename as the display name and the canonical
+repository ID as the selection/request identity. Duplicate names include their
+IDs in the selector. Full filesystem paths remain outside the browser payload.
+
+The operator transport is protocol 5 with a required `display_name`; the source
+Fleet transport is unchanged. Deploy the UI bundle and operator server together.
+The decoder rejects older or nameless payloads rather than guessing names.
+
+The worklist, filter counts, stage matrix and repository health use only the
+selected repository. The full Fleet snapshot remains authoritative: filtering
+does not manufacture another snapshot/digest or relax the existing write gates.
+Top-bar Fleet health and notices still describe the full collection.
+
+The first repository is selected initially. Browser storage remembers the
+selection; refresh preserves a surviving ID. If that repository disappears,
+the board requests an explicit new selection instead of showing another repo's
+tasks automatically. An empty registry retains its existing empty-state view.
+
+Changing repository resets worklist filters, closes the task pane and unmounts
+its composer/diff, aborts the obsolete collaboration read, and returns the
+collaboration pane to idle. Existing per-task draft recovery stays keyed by
+repository and task; a draft is never retargeted to the newly selected repo.
+
+Verification covers projection/decoder contracts, per-repo counts, persistence,
+refresh/removal, duplicate-name disambiguation, collaboration cancellation and
+late response isolation, composer fences, desktop/mobile rendering and the
+actual operator server route. No registry or task execution state is changed by
+selecting a repository.

--- a/plans/archive/plan-20260911-operator-repo-selector.md
+++ b/plans/archive/plan-20260911-operator-repo-selector.md
@@ -41,7 +41,7 @@ Focused operator-web interaction/SSR/types, operator fleet projection and serve 
 - **Stop condition**: Focused/integrity checks pass and browser interaction matches the request.
 - **Rollback surface**: Revert the scoped UI and transport commit together; no live repository state changes.
 
-> **Substantive Change SHA256**: `sha256:b7ffabf3f57f0cb3cd80323ee6b44a6551aaf12f2cc9d5172c6b0a934b787497`
+> **Substantive Change SHA256**: `sha256:53e353e671c12d61ac1f870ac12ce36d91311bb7f1c15436fa4d13320804b998`
 
 ## Acceptance Notes
 

--- a/plans/archive/plan-20260911-operator-repo-selector.md
+++ b/plans/archive/plan-20260911-operator-repo-selector.md
@@ -1,0 +1,53 @@
+# Plan: Repository-scoped operator board
+
+> **Status**: Done
+> **Artifact Level**: work-package
+> **Promotion Reason**: verification_boundary
+
+## Scope / P1 / P2 / P3
+
+Owner requests a top-bar repo switcher and no mixed-repository task queue. Isolated branch codex/operator-repo-selector from 8fc92c08. Standard workflow; this plan is the execution artifact.
+
+P1: App.tsx owns worklist filters, selected task, composer and collaboration reads. Core operator snapshot redacts repo_root; browser decoder owns closed transport validation. Fleet authority remains unchanged.
+
+P2: Fleet snapshot -> redacted operator response -> decoder -> selected repo -> worklist/counts/overview -> task details. Existing App consumes all repositories at once; no repo selection exists. Add server-projected display_name from canonical repo_root basename, never expose full paths. Keep repo ID as selection/request identity, with ID disambiguation for duplicate names.
+
+P3: Operator transport moves atomically to protocol 5 for required display_name, with no old-payload fallback. Top bar retains explicitly labeled fleet health; scope only rendering, not authority or write gates. Default first repo; persist explicit/default selection in browser storage. If selected repo disappears, show a choose-repository state instead of silently switching. Switch clears task/draft/collaboration and resets worklist filters; refreshing preserves a surviving selection. No all-repository task mode, new scheduler, registry mutations or fixes to other repositories. At 10x repos the native selector grows; avoid adding search infrastructure without need.
+
+## Task Breakdown
+
+- [x] Add transport name and repo selection with scoped presentation.
+- [x] Test switching, persistence, refresh/removal, duplicate names, stale detail/collaboration isolation and transport rejection.
+- [x] Build and inspect desktop/mobile browser UI; run required integrity checks and record delivery.
+
+## Verification
+
+Focused operator-web interaction/SSR/types, operator fleet projection and serve tests; check:type; build:operator-web; browser smoke using built assets and controlled fixtures. Required hook/helper, deployment SQL, architecture, task-sync, strict workflow, project inspection and init dry-run checks. No full suite: changed boundary is the operator projection/UI; named tests cover it.
+
+## Promotion Gate
+
+- **Merge/PR unit**: Per-repository operator UI plus atomic name transport.
+- **Rollback surface**: Revert UI/protocol change together.
+- **Verification boundary**: Projection/decoder tests, interaction tests and actual browser rendering.
+- **Review/acceptance boundary**: Frozen scoped diff and recorded focused checks.
+- **High-risk surface**: Selection must never retarget a message or relax fleet write gates.
+- **Why not checklist row**: Independent UI behavior and transport compatibility boundary.
+
+## Evidence Contract
+
+- **State/progress path**: This plan's Task Breakdown.
+- **Verification evidence**: Commands above and acceptance notes below.
+- **Evaluator rubric**: Single-repo tasks/counts/details, clear human names, preserved authority and no cross-repo stale state.
+- **Stop condition**: Focused/integrity checks pass and browser interaction matches the request.
+- **Rollback surface**: Revert the scoped UI and transport commit together; no live repository state changes.
+
+> **Substantive Change SHA256**: `sha256:b7ffabf3f57f0cb3cd80323ee6b44a6551aaf12f2cc9d5172c6b0a934b787497`
+
+## Acceptance Notes
+
+- Operator-web interaction/SSR/task-diff/collaboration, payload decoder and projection tests: 215 pass. Operator serve CLI tests: 28 pass. Typecheck passes. Adjusted pre-existing cross-repo tests to explicitly switch repos and assert scoped counts; retained composer/late-response guards.
+- Required integrity checks pass, including final diff-bound task-sync and strict workflow. No full suite for the scoped reasons above. Parent read the final UI/transport diff against unchanged write gates, task identity and snapshot provenance.
+- Final build: build:operator-web passes, JS index-B8ckyb8w.js and CSS index-BpvUpmy-.css.
+- Actual Chrome preview on port 4319: 10 named repos. repo-harness selection displays only its 17 tasks; BYOK canary selection displays only its 18 tasks. Desktop screenshot and 390x844 responsive screenshot show a usable top-bar selector without horizontal overflow. Temporary viewport reset afterward. Preview retained for user inspection; original port 4318 untouched.
+- Protocol 5 is an atomic browser/server boundary; source Fleet protocol remains unchanged. Full paths remain redacted. Durable semantics recorded in docs/researches/operator-repository-selection.md.
+- No registry writes, task messages, campaign execution, global install or release performed. Existing two repo_board_unavailable observations remain outside this slice.

--- a/scripts/check-tarball-install-smoke.sh
+++ b/scripts/check-tarball-install-smoke.sh
@@ -182,18 +182,21 @@ if (!asset.ok || (await asset.arrayBuffer()).byteLength === 0) fail('operator st
 const snapshot = await fetch(`${baseUrl}/api/v1/fleet/snapshot`);
 if (!snapshot.ok) fail(`operator Fleet API returned ${snapshot.status}`);
 const payload = await snapshot.json();
-// payload.protocol tracks FLEET_BOARD_PROTOCOL (src/core/fleet/board.ts), not the /healthz route protocol above.
-if (payload?.protocol !== 4 || payload?.kind !== 'operator_fleet_snapshot' || !Array.isArray(payload?.repositories)
+// The operator browser payload versions itself separately from FLEET_BOARD_PROTOCOL
+// (src/core/fleet/board.ts) and from the /healthz route protocol above. Read the
+// installed package's own constant rather than restating it, so a protocol bump
+// cannot pass its own tests here while this smoke asserts a stale literal.
+const { decodeOperatorFleetSnapshot, OPERATOR_FLEET_PAYLOAD_PROTOCOL } = await import(`${process.cwd()}/node_modules/repo-harness/src/operator-web/types.ts`);
+if (payload?.protocol !== OPERATOR_FLEET_PAYLOAD_PROTOCOL || payload?.kind !== 'operator_fleet_snapshot' || !Array.isArray(payload?.repositories)
   || typeof payload?.source_snapshot_sha256 !== 'string') {
   fail('operator Fleet API did not return OperatorFleetSnapshotV1');
 }
-const { decodeOperatorFleetSnapshot } = await import(`${process.cwd()}/node_modules/repo-harness/src/operator-web/types.ts`);
 const { stableSnapshot } = await import(`${process.cwd()}/node_modules/repo-harness/src/operator-web/fixture.ts`);
 decodeOperatorFleetSnapshot(payload);
 const fixture = decodeOperatorFleetSnapshot(stableSnapshot);
 const evidence = fixture.repositories.flatMap((repo) => repo.cards).find((card) => card.inbox.delivery_evidence?.candidate_count === 1)?.inbox.delivery_evidence;
 if (!evidence?.latest || !/^sha256:[0-9a-f]{64}$/.test(evidence.latest.observation_sha256)) {
-  fail('installed protocol 4 consumer did not preserve nonempty notification evidence');
+  fail('installed operator payload consumer did not preserve nonempty notification evidence');
 }
 const serialized = JSON.stringify(payload);
 for (const forbidden of ['repo_root', 'cause', 'stderr', 'stack', isolatedHome]) {

--- a/src/core/operator/fleet-snapshot.ts
+++ b/src/core/operator/fleet-snapshot.ts
@@ -1,3 +1,4 @@
+import { basename } from 'path';
 import {
   FLEET_BOARD_PROTOCOL,
   fleetBoardErrorMessage,
@@ -33,6 +34,7 @@ export type OperatorFleetCardV1 = FleetBoardCardV1;
 
 export interface OperatorFleetRepositoryV1 {
   readonly repository_id: string;
+  readonly display_name: string;
   readonly access_mode: 'read_only' | 'read_write';
   readonly status: FleetRepositoryStatus;
   readonly snapshot_consistency: OperatorFleetSnapshotConsistency;
@@ -40,7 +42,8 @@ export interface OperatorFleetRepositoryV1 {
   readonly error: OperatorFleetErrorV1 | null;
 }
 
-export interface OperatorFleetSnapshotV1 extends Omit<FleetBoardSnapshotV1, 'kind' | 'repositories' | 'snapshot_sha256'> {
+export interface OperatorFleetSnapshotV1 extends Omit<FleetBoardSnapshotV1, 'protocol' | 'kind' | 'repositories' | 'snapshot_sha256'> {
+  readonly protocol: 5;
   readonly kind: 'operator_fleet_snapshot';
   readonly repositories: readonly OperatorFleetRepositoryV1[];
   /** Digest of the canonical source snapshot, not of this redacted document. */
@@ -116,6 +119,7 @@ function projectRepository(repository: FleetRepositoryBoardV1): OperatorFleetRep
   const error = repository.error;
   return Object.freeze({
     repository_id: repository.repository_id,
+    display_name: basename(repository.repo_root),
     access_mode: repository.access_mode,
     status: repository.status,
     snapshot_consistency: repository.snapshot_consistency,
@@ -133,7 +137,7 @@ function projectRepository(repository: FleetRepositoryBoardV1): OperatorFleetRep
  * Project the canonical Fleet read model into a browser-safe document.
  *
  * This function deliberately does not classify cards, recalculate counts, or
- * derive attention from labels.  The output keeps the Fleet protocol and
+ * derive attention from labels.  The output versions its browser contract separately and keeps the Fleet
  * digest so consumers can correlate the transport view with the source read
  * model while absolute paths and diagnostic causes stay server-side.
  */
@@ -147,7 +151,7 @@ export function projectOperatorFleetSnapshot(
   const repositories = Object.freeze(snapshot.repositories.map(projectRepository));
   const sourceSnapshotSha256 = snapshot.snapshot_sha256;
   return Object.freeze({
-    protocol: snapshot.protocol,
+    protocol: 5,
     kind: 'operator_fleet_snapshot',
     registry_revision: snapshot.registry_revision,
     sequence: snapshot.sequence,

--- a/src/operator-web/App.tsx
+++ b/src/operator-web/App.tsx
@@ -241,7 +241,7 @@ export interface WorklistGroup {
   readonly count: number;
 }
 
-export function groupWorklist(snapshot: OperatorFleetSnapshotV1): readonly WorklistGroup[] {
+export function groupWorklist(snapshot: Pick<OperatorFleetSnapshotV1, 'repositories'>): readonly WorklistGroup[] {
   const buckets = new Map<WorklistGroupId, OperatorFleetCardV1[]>(
     WORKLIST_GROUP_ORDER.map((id) => [id, []]),
   );
@@ -356,9 +356,13 @@ function StatusBar({
   locale,
   onLocale,
   onRefresh,
+  repositoryId,
+  onRepository,
   t,
 }: {
   readonly snapshot: OperatorFleetSnapshotV1 | null;
+  readonly repositoryId: string;
+  readonly onRepository: (id: string) => void;
   readonly stale: boolean;
   readonly busy: boolean;
   readonly locale: OperatorLocale;
@@ -394,6 +398,17 @@ function StatusBar({
         </span>
       </div>
       <div className="operator-statusbar__actions">
+        <label className="repository-switch">
+          <span>{t('field.repository')}</span>
+          <select aria-label={t('repository.select')} value={repositoryId} onChange={(event) => onRepository(event.target.value)} disabled={!snapshot?.repositories.length}>
+            <option value="" disabled>{t('repository.select')}</option>
+            {snapshot?.repositories.map((repo) => (
+              <option key={repo.repository_id} value={repo.repository_id}>
+                {repo.display_name}{snapshot.repositories.filter((other) => other.display_name === repo.display_name).length > 1 ? ` · ${repo.repository_id}` : ''}
+              </option>
+            ))}
+          </select>
+        </label>
         <button className="operator-button operator-button--secondary" type="button" onClick={onRefresh} disabled={busy}>
           <Icon name="refresh" size={15} />
           <span>{busy ? t('status.refreshing') : t('status.refresh')}</span>
@@ -586,7 +601,7 @@ function Worklist({
   onSelect,
   t,
 }: {
-  readonly snapshot: OperatorFleetSnapshotV1;
+  readonly snapshot: Pick<OperatorFleetSnapshotV1, 'repositories'>;
   readonly selectedKey: string | null;
   readonly onSelect: (card: OperatorFleetCardV1) => void;
   readonly t: OperatorTranslate;
@@ -693,7 +708,7 @@ function Worklist({
   );
 }
 
-function StageMatrix({ snapshot, t }: { readonly snapshot: OperatorFleetSnapshotV1; readonly t: OperatorTranslate }) {
+function StageMatrix({ snapshot, t }: { readonly snapshot: Pick<OperatorFleetSnapshotV1, 'repositories'>; readonly t: OperatorTranslate }) {
   return (
     <div className="stage-matrix__scroll">
       <table className="stage-matrix">
@@ -707,7 +722,7 @@ function StageMatrix({ snapshot, t }: { readonly snapshot: OperatorFleetSnapshot
         <tbody>
           {snapshot.repositories.map((repository) => (
             <tr key={repository.repository_id}>
-              <th scope="row">{repository.repository_id}</th>
+              <th scope="row">{repository.display_name}</th>
               {OPERATOR_COLUMNS.map((column) => (
                 <td key={column.id}>{repository.cards.filter((card) => card.column === column.id).length}</td>
               ))}
@@ -723,7 +738,7 @@ function RepositoryHealth({
   snapshot,
   t,
 }: {
-  readonly snapshot: OperatorFleetSnapshotV1;
+  readonly snapshot: Pick<OperatorFleetSnapshotV1, 'repositories'>;
   readonly t: OperatorTranslate;
 }) {
   return (
@@ -733,7 +748,7 @@ function RepositoryHealth({
         return (
           <article className={`repository-row repository-row--${repoStatus}`} key={repository.repository_id}>
             <div className="repository-row__main">
-              <strong>{repository.repository_id}</strong>
+              <strong>{repository.display_name}</strong>
               <span>
                 {t(`repo.accessMode.${repository.access_mode}` as OperatorMessageKey)} · {t('repo.tasks', { count: repository.cards.length })}
               </span>
@@ -1816,6 +1831,7 @@ function useWideLayout(): boolean {
 
 function DetailPane({
   snapshot,
+  visibleRepositories,
   card,
   repository,
   collaboration,
@@ -1828,6 +1844,7 @@ function DetailPane({
   t,
 }: {
   readonly snapshot: OperatorFleetSnapshotV1 | null;
+  readonly visibleRepositories: readonly OperatorFleetRepositoryV1[];
   readonly card: OperatorFleetCardV1 | null;
   readonly repository: OperatorFleetRepositoryV1 | null;
   readonly collaboration: CollaborationViewState;
@@ -1944,10 +1961,10 @@ function DetailPane({
           ) : snapshot ? (
             <>
               <p className="detail-quiet">{t('detail.overviewHint')}</p>
-              <StageMatrix snapshot={snapshot} t={t} />
+              <StageMatrix snapshot={{ repositories: visibleRepositories }} t={t} />
               <section className="detail-block" aria-labelledby="detail-health-heading">
                 <h3 className="detail-eyebrow" id="detail-health-heading">{t('detail.repositoryHealth')}</h3>
-                <RepositoryHealth snapshot={snapshot} t={t} />
+                <RepositoryHealth snapshot={{ repositories: visibleRepositories }} t={t} />
               </section>
             </>
           ) : null}
@@ -2007,6 +2024,8 @@ function FatalState({ error, onRetry, t }: { readonly error: OperatorApiErrorV1;
   );
 }
 
+export const OPERATOR_REPOSITORY_STORAGE_KEY = 'repo-harness:operator-repository';
+
 interface Selection {
   readonly key: string;
   readonly revision: string;
@@ -2023,6 +2042,10 @@ export function OperatorApp({
 }: OperatorAppProps) {
   const initial = initialState ?? (initialSnapshot ? stateFromSnapshot(initialSnapshot) : { kind: 'loading', previous: null } as const);
   const [state, setState] = useState<OperatorSnapshotViewState>(initial);
+  const [repositoryId, setRepositoryId] = useState<string | null>(() => {
+    if (typeof window === 'undefined') return null;
+    try { return localStorage.getItem(OPERATOR_REPOSITORY_STORAGE_KEY); } catch { return null; }
+  });
   const [selection, setSelection] = useState<Selection | null>(null);
   const [collaboration, setCollaboration] = useState<CollaborationViewState>(
     initialCollaboration ?? { kind: 'idle' },
@@ -2034,6 +2057,19 @@ export function OperatorApp({
   const refreshQueued = useRef(false);
   const stateRef = useRef<OperatorSnapshotViewState>(initial);
   const snapshot = snapshotForState(state);
+  const activeRepositoryId = repositoryId ?? snapshot?.repositories[0]?.repository_id ?? '';
+  const activeRepository = snapshot?.repositories.find((repo) => repo.repository_id === activeRepositoryId) ?? null;
+  const visibleRepositories = useMemo(() => activeRepository ? [activeRepository] : [], [activeRepository]);
+  useEffect(() => {
+    if (!activeRepository) return;
+    setRepositoryId(activeRepository.repository_id);
+    try { localStorage.setItem(OPERATOR_REPOSITORY_STORAGE_KEY, activeRepository.repository_id); } catch { /* Browser storage is optional UI preference. */ }
+  }, [activeRepository]);
+  const switchRepository = (id: string) => {
+    setRepositoryId(id);
+    setSelection(null);
+    setCollaboration({ kind: 'idle' });
+  };
   const busy = state.kind === 'loading';
   const stateKind = state.kind;
 
@@ -2084,7 +2120,7 @@ export function OperatorApp({
   }, []);
 
   const selectedCard = selection && snapshot
-    ? allCards(snapshot).find((card) => taskKey(card) === selection.key) ?? null
+    ? activeRepository?.cards.find((card) => taskKey(card) === selection.key) ?? null
     : null;
   const revisionChangedFrom = selectedCard && selection && selectedCard.task_revision !== selection.revision
     ? selection.revision
@@ -2157,6 +2193,8 @@ export function OperatorApp({
     >
       <StatusBar
         snapshot={snapshot}
+        repositoryId={activeRepository?.repository_id ?? ''}
+        onRepository={switchRepository}
         stale={stateKind === 'stale'}
         busy={busy}
         locale={locale}
@@ -2172,8 +2210,10 @@ export function OperatorApp({
               : snapshot ? (
                 snapshotViewKind(snapshot) === 'empty'
                   ? <EmptyFleet t={t} />
+                  : !activeRepository ? <p role="status">{t('repository.select')}</p>
                   : <Worklist
-                    snapshot={snapshot}
+                    key={activeRepository.repository_id}
+                    snapshot={{ repositories: visibleRepositories }}
                     selectedKey={selection?.key ?? null}
                     onSelect={selectCard}
                     t={t}
@@ -2182,7 +2222,9 @@ export function OperatorApp({
         </main>
         {(wideLayout || selectedCard) && state.kind !== 'fatal' && (
           <DetailPane
+            key={activeRepository?.repository_id ?? 'none'}
             snapshot={snapshot}
+            visibleRepositories={visibleRepositories}
             card={selectedCard}
             repository={selectedRepository}
             collaboration={collaboration}

--- a/src/operator-web/fixture.ts
+++ b/src/operator-web/fixture.ts
@@ -132,6 +132,7 @@ function repository(
 ): OperatorFleetRepositoryV1 {
   return {
     repository_id: repositoryId,
+    display_name: repositoryId,
     access_mode: 'read_write',
     status: 'ok',
     snapshot_consistency: 'stable',
@@ -194,7 +195,7 @@ const stableRepositories: readonly OperatorFleetRepositoryV1[] = [
 ];
 
 export const stableSnapshot: OperatorFleetSnapshotV1 = {
-  protocol: 4,
+  protocol: 5,
   kind: 'operator_fleet_snapshot',
   registry_revision: `sha256:${'e'.repeat(64)}`,
   sequence: 18,

--- a/src/operator-web/i18n.ts
+++ b/src/operator-web/i18n.ts
@@ -54,7 +54,7 @@ const en = {
   'status.consistency.stable': 'stable',
   'status.consistency.changed_during_read': 'changed during read',
   'status.consistency.degraded': 'degraded',
-  'status.repositories': '{count} repos',
+  'status.repositories': 'Fleet · {count} repos',
   'status.unreadable': '{count} unreadable',
   'status.refresh': 'Refresh',
   'status.refreshing': 'Refreshing',
@@ -116,7 +116,7 @@ const en = {
   'execution.inline_ready': 'inline ready',
   'execution.unsupported': 'unsupported',
 
-  'detail.overviewTitle': 'Fleet overview',
+  'detail.overviewTitle': 'Repository overview',
   'detail.overviewHint': 'Select a task to see why it needs a decision.',
   'detail.matrixTitle': 'Tasks by repository and stage',
   'detail.matrixRepository': 'repository',
@@ -164,6 +164,7 @@ const en = {
   'detail.changedDuringRead': 'This task changed while the snapshot was read. Re-observe before acting.',
 
   'field.taskId': 'task id',
+  'repository.select': 'Select repository',
   'field.repository': 'repository',
   'field.revision': 'revision',
   'field.claim': 'claim',
@@ -496,7 +497,7 @@ const zh: Readonly<Record<OperatorMessageKey, string>> = {
   'status.consistency.stable': '稳定',
   'status.consistency.changed_during_read': '读取期间有变化',
   'status.consistency.degraded': '降级',
-  'status.repositories': '{count} 个仓库',
+  'status.repositories': 'Fleet · {count} 个仓库',
   'status.unreadable': '{count} 个读不到',
   'status.refresh': '刷新',
   'status.refreshing': '刷新中',
@@ -558,7 +559,7 @@ const zh: Readonly<Record<OperatorMessageKey, string>> = {
   'execution.inline_ready': '可内联执行',
   'execution.unsupported': '不支持',
 
-  'detail.overviewTitle': '舰队总览',
+  'detail.overviewTitle': '仓库总览',
   'detail.overviewHint': '选一个任务，看它为什么排在这里。',
   'detail.matrixTitle': '各仓库按阶段的任务数',
   'detail.matrixRepository': '仓库',
@@ -606,6 +607,7 @@ const zh: Readonly<Record<OperatorMessageKey, string>> = {
   'detail.changedDuringRead': '读快照的时候这个任务变过。动手之前先重新读一次。',
 
   'field.taskId': '任务 id',
+  'repository.select': '选择仓库',
   'field.repository': '仓库',
   'field.revision': 'revision',
   'field.claim': 'claim',

--- a/src/operator-web/styles.css
+++ b/src/operator-web/styles.css
@@ -109,6 +109,14 @@ code, .mono-value { font-family: var(--font-mono); }
 .statusbar-fact--age { font-family: var(--font-mono); }
 .statusbar-fact--age.is-stale { color: var(--danger-text); font-weight: 500; }
 .operator-statusbar__actions { display: flex; align-items: center; gap: 10px; margin-left: auto; }
+.repository-switch { display: flex; align-items: center; gap: 8px; min-width: 0; color: var(--text-muted); font-size: 12px; }
+.repository-switch select { width: clamp(150px, 19vw, 300px); max-width: 100%; min-height: 36px; padding: 6px 28px 6px 10px; border: 1px solid var(--border-default); border-radius: var(--radius-md); color: var(--text-strong); background: var(--surface-card); font: inherit; }
+.repository-switch select:focus-visible { outline: none; box-shadow: var(--ring); }
+@media (max-width: 600px) {
+  .operator-statusbar__actions { width: 100%; flex-wrap: wrap; margin-left: 0; }
+  .repository-switch { flex: 1 1 100%; }
+  .repository-switch select { flex: 1; width: 0; }
+}
 .locale-switch { display: inline-flex; overflow: hidden; border: 1px solid var(--border-default); border-radius: var(--radius-md); background: var(--surface-card); }
 .locale-switch button { min-height: 36px; padding: 0 11px; border: 0; color: var(--text-muted); background: transparent; cursor: pointer; font-family: var(--font-mono); font-size: 12px; }
 .locale-switch button + button { border-left: 1px solid var(--border-subtle); }

--- a/src/operator-web/types.ts
+++ b/src/operator-web/types.ts
@@ -49,7 +49,7 @@ import type {
  * module's literal type, so a drift from the core constant fails typecheck
  * here rather than at runtime.
  */
-export const OPERATOR_FLEET_PAYLOAD_PROTOCOL: OperatorFleetSnapshotV1['protocol'] = 4;
+export const OPERATOR_FLEET_PAYLOAD_PROTOCOL: OperatorFleetSnapshotV1['protocol'] = 5;
 
 /**
  * The collaboration protocol the browser transport accepts, restated for the
@@ -235,7 +235,7 @@ export function projectSnapshotViewState(snapshot: OperatorFleetSnapshotV1): Ope
   return { kind, snapshot } as OperatorSnapshotViewState;
 }
 
-export function allCards(snapshot: OperatorFleetSnapshotV1): readonly OperatorFleetCardV1[] {
+export function allCards(snapshot: Pick<OperatorFleetSnapshotV1, 'repositories'>): readonly OperatorFleetCardV1[] {
   return snapshot.repositories.flatMap((repository) => repository.cards);
 }
 
@@ -538,6 +538,7 @@ function decodeCard(value: unknown, repositoryId: string): OperatorFleetCardV1 {
 function decodeRepository(value: unknown): OperatorFleetRepositoryV1 {
   const repository = requireRecord(value);
   const repositoryId = requireString(repository.repository_id);
+  const displayName = requireString(repository.display_name);
   const accessMode = requireOneOf(repository.access_mode, ['read_only', 'read_write'] as const);
   const status = requireOneOf(repository.status, ['ok', 'unreadable'] as const);
   const snapshotConsistency = requireOneOf(repository.snapshot_consistency, SNAPSHOT_CONSISTENCIES);
@@ -550,6 +551,7 @@ function decodeRepository(value: unknown): OperatorFleetRepositoryV1 {
   if (cardChanged && snapshotConsistency === 'stable') throw new OperatorPayloadError();
   return Object.freeze({
     repository_id: repositoryId,
+    display_name: displayName,
     access_mode: accessMode,
     status,
     snapshot_consistency: snapshotConsistency,

--- a/tests/cli/operator-serve.test.ts
+++ b/tests/cli/operator-serve.test.ts
@@ -191,7 +191,7 @@ describe('operator serve command and HTTP boundary', () => {
       expect(second.status).toBe(200);
       expect(collectCalls).toBe(1);
       const payload = await first.json() as Record<string, unknown>;
-      expect(payload).toMatchObject({ protocol: 4, kind: 'operator_fleet_snapshot', sequence: 1 });
+      expect(payload).toMatchObject({ protocol: 5, kind: 'operator_fleet_snapshot', sequence: 1 });
       expect(await second.json()).toMatchObject({ sequence: 1 });
       expect(JSON.stringify(payload)).not.toContain('repo_root');
 

--- a/tests/operator-web/operator-collaboration.test.tsx
+++ b/tests/operator-web/operator-collaboration.test.tsx
@@ -73,6 +73,12 @@ async function mount(node: React.ReactElement): Promise<void> {
   await act(async () => root?.render(node));
 }
 
+async function selectRepository(id: string): Promise<void> {
+  const select = document.querySelector<HTMLSelectElement>('.repository-switch select');
+  if (!select) throw new Error('repository selector missing');
+  await act(async () => { select.value = id; select.dispatchEvent(new Event('change', { bubbles: true })); });
+}
+
 function buttonWithText(text: string): HTMLButtonElement {
   const button = Array.from(document.querySelectorAll('button')).find((candidate) =>
     candidate.textContent?.includes(text),
@@ -501,6 +507,7 @@ describe('operator collaboration read', () => {
     expect(asked).toEqual([]);
     expect(paneText()).toContain('Select a task to read its repository collaboration lanes.');
 
+    await selectRepository('repo-console');
     await act(async () => buttonWithText(fixtureTasks.console.task_label).click());
     expect(asked).toEqual(['repo-console']);
     expect(paneText()).toContain('repository repo-console');
@@ -513,6 +520,7 @@ describe('operator collaboration read', () => {
     expect(paneText()).toContain('repository repo-console');
 
     // Selecting a task in another repository moves the scope.
+    await selectRepository('repo-harness');
     await act(async () => buttonWithText(fixtureTasks.blocked.task_label).click());
     expect(asked).toEqual(['repo-console', 'repo-console', 'repo-harness']);
     expect(paneText()).toContain('repository repo-harness');
@@ -533,6 +541,7 @@ describe('operator collaboration read', () => {
       />,
     );
 
+    await selectRepository('repo-harness');
     await act(async () => buttonWithText(fixtureTasks.blocked.task_label).click());
     expect(paneText()).toContain('The collaboration store cannot be read');
     expect(paneText()).not.toContain('No lane has a signal in this snapshot.');
@@ -569,6 +578,7 @@ describe('operator collaboration read', () => {
       />,
     );
 
+    await selectRepository('repo-harness');
     await act(async () => buttonWithText(fixtureTasks.blocked.task_label).click());
     expect(asked).toEqual(['repo-harness']);
     expect(paneText()).toContain('The collaboration store cannot be read');
@@ -594,7 +604,9 @@ describe('operator collaboration read', () => {
         fetchCollaboration={fetchCollaboration}
       />,
     );
+    await selectRepository('repo-console');
     await act(async () => buttonWithText(fixtureTasks.console.task_label).click());
+    await selectRepository('repo-harness');
     await act(async () => buttonWithText(fixtureTasks.blocked.task_label).click());
     expect(paneText()).toContain('repository repo-harness');
 
@@ -633,7 +645,9 @@ describe('operator collaboration read', () => {
         fetchCollaboration={fetchCollaboration}
       />,
     );
+    await selectRepository('repo-console');
     await act(async () => buttonWithText(fixtureTasks.console.task_label).click());
+    await selectRepository('repo-harness');
     await act(async () => buttonWithText(fixtureTasks.blocked.task_label).click());
 
     expect(requests.map((request) => request.repositoryId)).toEqual(['repo-console', 'repo-harness']);
@@ -655,6 +669,7 @@ describe('operator collaboration read', () => {
         }}
       />,
     );
+    await selectRepository('repo-harness');
     await act(async () => buttonWithText(fixtureTasks.blocked.task_label).click());
     expect(observed.signal?.aborted).toBe(false);
 
@@ -691,6 +706,7 @@ describe('operator collaboration read', () => {
         fetchCollaboration={fetchCollaboration}
       />,
     );
+    await selectRepository('repo-harness');
     await act(async () => buttonWithText(fixtureTasks.blocked.task_label).click());
     expect(signals).toHaveLength(1);
 
@@ -783,6 +799,7 @@ describe('operator collaboration read', () => {
         fetchCollaboration={async () => ({ ...collaborationSnapshot, repository_id: otherRepository })}
       />,
     );
+    await selectRepository('repo-harness');
     await act(async () => buttonWithText(fixtureTasks.blocked.task_label).click());
     expect(paneText()).toContain('does not match the requested repository');
     expect(paneText()).not.toContain('hotspot 87');

--- a/tests/operator-web/operator-interactions.test.tsx
+++ b/tests/operator-web/operator-interactions.test.tsx
@@ -11,6 +11,7 @@ import {
   fetchOperatorSnapshot,
   groupWorklist,
   OperatorApp,
+  OPERATOR_REPOSITORY_STORAGE_KEY,
   primaryCause,
   TASK_MESSAGE_BODY_LIMIT_BYTES,
   type TaskMessageRequestV1,
@@ -85,6 +86,12 @@ function installDom(wide = false): void {
     KeyboardEvent: window.KeyboardEvent,
     IS_REACT_ACT_ENVIRONMENT: true,
   });
+}
+
+async function selectRepository(id: string): Promise<void> {
+  const select = document.querySelector<HTMLSelectElement>('.repository-switch select');
+  if (!select) throw new Error('repository selector missing');
+  await act(async () => { select.value = id; select.dispatchEvent(new Event('change', { bubbles: true })); });
 }
 
 function buttonWithText(text: string): HTMLButtonElement {
@@ -275,13 +282,46 @@ describe('operator web worklist projection', () => {
 });
 
 describe('operator web interactions', () => {
+  test('repository switch scopes counts and detail, persists across reload and refuses a removed selection', async () => {
+    installDom(true);
+    let next = stableSnapshot;
+    await mount(<OperatorApp initialSnapshot={stableSnapshot} initialLocale="en" fetchSnapshot={async () => next} />);
+    expect(filterChipCount('All')).toBe(stableSnapshot.repositories[0]!.cards.length);
+    await act(async () => buttonWithText(fixtureTasks.blocked.task_label).click());
+    expect(paneText()).toContain(fixtureTasks.blocked.task_label);
+    await selectRepository('repo-console');
+    expect(paneText()).not.toContain(fixtureTasks.blocked.task_label);
+    expect(filterChipCount('All')).toBe(stableSnapshot.repositories[1]!.cards.length);
+    expect(document.querySelector('.worklist')?.textContent).not.toContain(fixtureTasks.blocked.task_label);
+    expect(window.localStorage.getItem(OPERATOR_REPOSITORY_STORAGE_KEY)).toBe('repo-console');
+    await act(async () => root?.unmount()); root = null;
+    await mount(<OperatorApp initialSnapshot={stableSnapshot} initialLocale="en" fetchSnapshot={async () => next} />);
+    expect(document.querySelector<HTMLSelectElement>('.repository-switch select')?.value).toBe('repo-console');
+    await act(async () => buttonWithText('Refresh').click());
+    expect(filterChipCount('All')).toBe(stableSnapshot.repositories[1]!.cards.length);
+    next = { ...stableSnapshot, repositories: [stableSnapshot.repositories[0]!] };
+    await act(async () => buttonWithText('Refresh').click());
+    expect(document.querySelector('.worklist')).toBeNull();
+    expect(document.querySelector<HTMLSelectElement>('.repository-switch select')?.value).toBe('');
+    expect(document.querySelector('main')?.textContent).toContain('Select repository');
+  });
+
+  test('duplicate display names remain distinguishable and names never become request identities', async () => {
+    const snapshot = { ...stableSnapshot, repositories: stableSnapshot.repositories.map(repo => ({ ...repo, display_name: 'shared-name' })) };
+    await mount(<OperatorApp initialSnapshot={snapshot} initialLocale="en" />);
+    const options = Array.from(document.querySelectorAll<HTMLOptionElement>('.repository-switch option')).filter(option => option.value);
+    expect(options.map(option => option.textContent?.trim())).toEqual(['shared-name · repo-harness', 'shared-name · repo-console']);
+    await selectRepository('repo-console');
+    expect(filterChipCount('All')).toBe(snapshot.repositories[1]!.cards.length);
+  });
+
   test('renders the plain-language cause with its raw code and expands a collapsed group on demand', async () => {
     await mount(<OperatorApp initialState={projectSnapshotViewState(stableSnapshot)} initialLocale="en" />);
 
     const worklist = document.querySelector('.worklist')?.textContent ?? '';
     expect(worklist).toContain('The base branch moved after verification');
     expect(worklist).toContain('base_moved_since_verification');
-    expect(worklist).toContain('no progress');
+    expect(worklist).not.toContain('no progress');
     expect(worklist).not.toContain(fixtureTasks.review.task_label);
 
     await act(async () => buttonWithText('External').click());
@@ -320,6 +360,7 @@ describe('operator web interactions', () => {
 
     installDom(true);
     await mount(<OperatorApp initialState={projectSnapshotViewState(runtimeEffectFailure)} initialLocale="en" />);
+    await selectRepository('repo-unreadable');
     await act(async () => buttonWithText('Unreadable repos').click());
     const english = document.querySelector('.worklist')?.textContent ?? '';
     expect(english).toContain('Agent Runtime effect evidence is unavailable');
@@ -378,6 +419,7 @@ describe('operator web interactions', () => {
     const close = document.querySelector<HTMLButtonElement>('.detail-pane [aria-label="Close task details"]');
     if (!close) throw new Error('close button not found');
     await act(async () => close.click());
+    await selectRepository('repo-console');
     await act(async () => buttonWithText(fixtureTasks.console.task_label).click());
     const consolePane = paneText();
     expect(consolePane).toContain('Feedback reports no progress');
@@ -697,7 +739,7 @@ describe('operator web interactions', () => {
     expect(translate('zh', 'status.observedAgo', { age: '2 分钟' })).toBe('2 分钟前读到的快照');
   });
 
-  test('keeps a persistent complementary pane on wide layouts and a fleet overview until a task is picked', async () => {
+  test('keeps a persistent complementary pane on wide layouts and a repository overview until a task is picked', async () => {
     installDom(true);
     await mount(<OperatorApp initialState={projectSnapshotViewState(stableSnapshot)} initialLocale="en" />);
 
@@ -705,11 +747,11 @@ describe('operator web interactions', () => {
     expect(overview?.getAttribute('aria-modal')).toBeNull();
     expect(overview?.getAttribute('aria-labelledby')).toBe('detail-pane-title');
     expect(document.querySelector('[role="dialog"]')).toBeNull();
-    expect(paneText()).toContain('Fleet overview');
+    expect(paneText()).toContain('Repository overview');
     expect(paneText()).toContain('Tasks by repository and stage');
     expect(paneText()).toContain('Repository health');
-    expect(paneText()).toContain('read only');
-    expect(document.querySelectorAll('.stage-matrix tbody tr').length).toBe(stableSnapshot.repositories.length);
+    expect(paneText()).toContain('read write');
+    expect(document.querySelectorAll('.stage-matrix tbody tr').length).toBe(1);
 
     const trigger = buttonWithText(fixtureTasks.blocked.task_label);
     trigger.focus();
@@ -784,7 +826,7 @@ describe('operator web interactions', () => {
     installDom(true);
     await mount(<OperatorApp initialState={projectSnapshotViewState(degradedSnapshot)} initialLocale="en" />);
 
-    const cards = degradedSnapshot.repositories.flatMap((repository) => repository.cards).length;
+    const cards = degradedSnapshot.repositories[0]!.cards.length;
     const unreadable = degradedSnapshot.repositories.filter((repository) => repository.status === 'unreadable').length;
     expect(cards).toBeGreaterThan(0);
     expect(unreadable).toBeGreaterThan(0);
@@ -792,6 +834,9 @@ describe('operator web interactions', () => {
     // The All chip used to sum repositories into the card total, so a fleet
     // with many unreadable repositories reported hundreds of phantom tasks.
     expect(filterChipCount('All')).toBe(cards);
+    expect(filterChipCount('Unreadable repos')).toBe(0);
+    await selectRepository('repo-unreadable');
+    expect(filterChipCount('All')).toBe(0);
     expect(filterChipCount('Unreadable repos')).toBe(unreadable);
     expect(document.querySelector('.operator-statusbar [data-fact="repositories"]')?.textContent)
       .toContain(`${degradedSnapshot.counts.unreadable} unreadable`);
@@ -873,6 +918,9 @@ describe('operator web task message composer', () => {
     await mount(
       <OperatorApp initialState={projectSnapshotViewState(snapshot)} initialLocale="en" {...props} />,
     );
+    const repository = snapshot.repositories.find((repo) => repo.cards.some((card) => card.task_label === task));
+    if (!repository) throw new Error('fixture task missing');
+    await selectRepository(repository.repository_id);
     await act(async () => buttonWithText(task).click());
     await act(async () => composerToggle().click());
   }
@@ -979,6 +1027,7 @@ describe('operator web task message composer', () => {
         })),
       } : stableSnapshot;
       await mount(<OperatorApp initialState={projectSnapshotViewState(snapshot)} initialLocale="en" />);
+      await selectRepository(snapshot.repositories[0]!.repository_id);
       await act(async () => buttonWithText(differentRepository ? fixtureTasks.blocked.task_label : fixtureTasks.available.task_label).click());
       expect(composerToggle().getAttribute('aria-expanded')).toBe('false');
       await act(async () => composerToggle().click());
@@ -989,6 +1038,7 @@ describe('operator web task message composer', () => {
     await act(async () => root?.unmount());
     root = null;
     await mount(<OperatorApp initialState={projectSnapshotViewState(stableSnapshot)} initialLocale="en" />);
+    await selectRepository('repo-harness');
     await act(async () => buttonWithText(fixtureTasks.blocked.task_label).click());
     expect((document.querySelector('#composer-body') as HTMLTextAreaElement).value).toBe('keep in this repository and task');
     await typeMessage('');

--- a/tests/operator-web/operator-ui.test.tsx
+++ b/tests/operator-web/operator-ui.test.tsx
@@ -47,7 +47,7 @@ describe('operator web control board', () => {
       'External',
       'Done',
     )).toBe(true);
-    expect(markup).toContain('protocol 4');
+    expect(markup).toContain('protocol 5');
     expect(markup).toContain('observe-only · one write: task message');
   });
 
@@ -56,7 +56,8 @@ describe('operator web control board', () => {
 
     expect(markup).toContain(fixtureTasks.available.task_label);
     expect(markup).toContain(fixtureTasks.blocked.task_label);
-    expect(markup).toContain(fixtureTasks.console.task_label);
+    expect(markup).not.toContain(fixtureTasks.console.task_label);
+    expect(renderStable({ ...stableSnapshot, repositories: [...stableSnapshot.repositories].reverse() })).toContain(fixtureTasks.console.task_label);
     expect(markup).not.toContain(fixtureTasks.available.task_id);
     expect(markup).not.toContain(fixtureTasks.blocked.task_id);
   });
@@ -77,9 +78,10 @@ describe('operator web control board', () => {
 
     expect(markup).toContain('The base branch moved after verification');
     expect(markup).toContain('base_moved_since_verification');
-    expect(markup).toContain('no progress');
+    const consoleMarkup = renderStable({ ...stableSnapshot, repositories: [...stableSnapshot.repositories].reverse() });
+    expect(consoleMarkup).toContain('no progress');
     expect(markup).toContain('1 unread');
-    expect(markup).toContain('2 unread');
+    expect(consoleMarkup).toContain('2 unread');
   });
 
   // `available` carries no blocker and no stall, so unread is its primary cause;
@@ -160,7 +162,7 @@ describe('operator web control board', () => {
     );
 
     expect(markup).toContain('protocol — · sequence —');
-    expect(markup).not.toContain('protocol 4');
+    expect(markup).not.toContain('protocol 5');
   });
 
   test('keeps empty, changed-during-read, and repo-degraded semantics explicit', () => {

--- a/tests/unit/operator-fleet-snapshot.test.ts
+++ b/tests/unit/operator-fleet-snapshot.test.ts
@@ -64,7 +64,7 @@ describe('OperatorFleetSnapshotV1 browser projection', () => {
     const projected = projectOperatorFleetSnapshot(source);
 
     expect(projected).toMatchObject({
-      protocol: source.protocol,
+      protocol: 5,
       kind: 'operator_fleet_snapshot',
       registry_revision: source.registry_revision,
       sequence: source.sequence,
@@ -74,6 +74,7 @@ describe('OperatorFleetSnapshotV1 browser projection', () => {
       source_snapshot_sha256: source.snapshot_sha256,
     });
     expect(projected.repositories[0]?.cards).toEqual(source.repositories[0]?.cards);
+    expect(projected.repositories[0]?.display_name).toBe('repo-a');
     expect(JSON.stringify(projected)).not.toContain('repo_root');
     expect(JSON.stringify(projected)).not.toContain('/private/workspaces');
     expect(JSON.stringify(projected)).not.toContain('provider stderr');
@@ -216,7 +217,7 @@ describe('OperatorFleetSnapshotV1 browser projection', () => {
       'repositories', 'sequence', 'snapshot_consistency', 'source_snapshot_sha256',
     ]);
     expect(Object.keys(projected.repositories[0] ?? {}).sort()).toEqual([
-      'access_mode', 'cards', 'error', 'repository_id', 'snapshot_consistency', 'status',
+      'access_mode', 'cards', 'display_name', 'error', 'repository_id', 'snapshot_consistency', 'status',
     ]);
     expect(Object.keys(projected.repositories[0]?.cards[0] ?? {}).sort()).toEqual([
       'attention_owner', 'blocker_codes', 'claim_id', 'column', 'error', 'execution_readiness',

--- a/tests/unit/operator-web-types.test.ts
+++ b/tests/unit/operator-web-types.test.ts
@@ -21,7 +21,7 @@ const snapshotDigest = `sha256:${'c'.repeat(64)}`;
 
 function validFleetPayload(): Record<string, unknown> {
   return {
-    protocol: 4,
+    protocol: 5,
     kind: 'operator_fleet_snapshot',
     registry_revision: `sha256:${'d'.repeat(64)}`,
     sequence: 1,
@@ -29,6 +29,7 @@ function validFleetPayload(): Record<string, unknown> {
     snapshot_consistency: 'stable',
     repositories: [{
       repository_id: 'repo-1',
+      display_name: 'repo-1',
       access_mode: 'read_write',
       status: 'ok',
       snapshot_consistency: 'stable',
@@ -96,6 +97,14 @@ function validCollaborationPayload(): Record<string, unknown> {
 }
 
 describe('operator browser payload contracts', () => {
+  test('requires the named-repository protocol without accepting old or missing display names', () => {
+    expect(() => decodeOperatorFleetSnapshot({ ...validFleetPayload(), protocol: 4 })).toThrow();
+    const payload = validFleetPayload();
+    const repos = payload.repositories as Record<string, unknown>[];
+    delete repos[0]!.display_name;
+    expect(() => decodeOperatorFleetSnapshot(payload)).toThrow();
+    expect(decodeOperatorFleetSnapshot(validFleetPayload()).repositories[0]?.display_name).toBe('repo-1');
+  });
   test('accepts an addressable task and claim fence', () => {
     const decoded = decodeOperatorFleetSnapshot(validFleetPayload());
     const card = decoded.repositories[0]?.cards[0];


### PR DESCRIPTION
Operator board 加上倉庫選擇器，看板資料按選中的 repo 範圍化，不再把多倉庫狀態混在同一面。

- `src/core/operator/fleet-snapshot.ts` 帶出 repo 維度
- `src/operator-web/` App/types/i18n/styles 支援選擇與切換
- fixture 同步更新

測試：`tests/operator-web/*`、`tests/unit/operator-fleet-snapshot.test.ts`、`tests/unit/operator-web-types.test.ts`、`tests/cli/operator-serve.test.ts`