### PR TITLE
feat(fleet): add explicit stale registry pruning

### DIFF
--- a/docs/researches/registry-prune.md
+++ b/docs/researches/registry-prune.md
@@ -1,0 +1,40 @@
+# Removing stale repository registrations
+
+The Kanban enumerates the account registry, including unavailable repositories.
+It must not silently hide missing authority. Deleting a test repository or
+worktree does not itself unregister its path.
+
+Preview explicitly:
+
+```sh
+repo-harness fleet prune
+```
+
+The JSON contains `registry_revision`, `candidates`, `skipped` and
+`remaining_count`. Only paths whose `lstat` returns `ENOENT` are candidates.
+Existing files/directories and all other errors remain registered. Check that
+missing paths are obsolete rather than temporarily unmounted or moved.
+
+Apply using the revision from that preview:
+
+```sh
+repo-harness fleet prune --apply --expected-revision sha256:REPLACE_WITH_PREVIEW_DIGEST
+```
+
+Use `--repo-id <id...>` on preview and apply to select specific registrations.
+Apply rejects changed registry bytes or unknown IDs, rechecks paths while
+holding the existing registry mutation lock, and atomically removes only the
+selected absent entries. It increments authorizationRevision once for an actual
+change; a no-op preserves the registry bytes and revision. The returned
+`registry_revision` identifies the input snapshot; preview again after a change.
+
+This command removes registry rows only. It neither deletes repository files
+nor writes a backup. Cleanup is never automatic on startup or board refresh.
+An unavailable board in a directory that still exists requires separate
+diagnosis and must not be removed by treating every UI error as stale state.
+
+Historical init test leaks have a producer-side guard in
+`tests/cli/init.test.ts` (`npx cache sources keep process.env as the constructed
+command env base`). The current `initCommandEnv` preserves caller isolation.
+This command handles old residue and repositories removed after valid
+registration without introducing test-name heuristics into product logic.

--- a/plans/archive/plan-20260911-registry-prune.md
+++ b/plans/archive/plan-20260911-registry-prune.md
@@ -41,7 +41,7 @@ Focused: registry prune CLI tests, registry authority tests, init environment re
 - **Stop condition**: Live cleanup readback and named tests/checks pass.
 - **Rollback surface**: Code revert; user explicitly declines a live registry backup.
 
-> **Substantive Change SHA256**: `sha256:c9ca8ea886607fef2b906205fc7e16ea00a16ae26720685ce1ae3828906591c0`
+> **Substantive Change SHA256**: `sha256:0138335adc28c4adcc00fd15494d48b489cebbbe138cb43485715b2feeff416e`
 
 ## Acceptance Notes
 

--- a/plans/archive/plan-20260911-registry-prune.md
+++ b/plans/archive/plan-20260911-registry-prune.md
@@ -1,0 +1,52 @@
+# Plan: Explicit stale registry cleanup
+
+> **Status**: Done
+> **Artifact Level**: work-package
+> **Promotion Reason**: verification_boundary
+
+## Scope and authorization
+
+Owner requests removal of obsolete test registrations and a logic fix or cleanup command; explicitly declines backup. Preserve repository files and valid/uncertain registrations. Isolated branch codex/registry-prune from 8a33faed. Standard workflow: this plan owns progress; no separate contract/notes scaffolding.
+
+## P1 / P2 / P3
+
+- Map: src/effects/repo-registry.ts owns strict authority parsing, mutation locking, atomic writes and authorizationRevision. src/cli/commands/fleet.ts owns fleet operator commands; the board reads all registered rows.
+- Trace: historical init test subprocess environment lost HOME/REPO_HARNESS_HOME, registering temporary repos in real home. Deleted paths persist in registry and fail board lstat. Existing init regression guard covers that producer bug. Live inventory: 1039 registrations, 1029 absent paths, all source init.
+- Decision: add fleet prune with read-only default, explicit --apply and expected registry revision, optional exact repo-id scope. Only ENOENT is removable; present paths and other probe errors remain. Reprobe under the existing registry mutation lock, atomically write retained entries and bump authorization revision once. No backup, repo deletion, hidden board filtering, automatic cleanup or change to init semantics. At 10x registry size synchronous path probing is the first limit; this bounded operator action adds no background service.
+
+## Task Breakdown
+
+- [x] Add prune effect/CLI and focused regression tests.
+- [x] Preview and apply only confirmed missing temporary registrations; read back registry and board.
+- [x] Run focused and required integrity checks; record durable result and delivery state.
+
+## Verification
+
+Focused: registry prune CLI tests, registry authority tests, init environment regression, fleet board tests; check:type. Required: check:hooks, check:helpers, check-deploy-sql-order, check-architecture-sync, check-task-sync, check-task-workflow --strict, inspect-project-state and init --dry-run. No full suite: named registry/board/init tests cover the affected shared authority. Test no-op byte preservation, stale revision refusal, invalid registry refusal, exact scoped removal, one revision bump and non-ENOENT preservation.
+
+## Promotion Gate
+
+- **Merge/PR unit**: Explicit registry pruning command and safety tests.
+- **Rollback surface**: Revert new command/effect; no existing repository files are modified by prune.
+- **Verification boundary**: Disposable registry mutation and real operator cleanup readback.
+- **Review/acceptance boundary**: Frozen scoped diff and focused/integrity evidence.
+- **High-risk surface**: Account registry authorization; preserve locks, strict parsing and revision fence.
+- **Why not checklist row**: Independent operator mutation with a bounded validation surface.
+
+## Evidence Contract
+
+- **State/progress path**: This plan's Task Breakdown.
+- **Verification evidence**: Commands above and acceptance notes below.
+- **Evaluator rubric**: Only confirmed absent selected records are removed, no repo data deletion or backup, unknown/present paths retained, malformed/stale authority rejected.
+- **Stop condition**: Live cleanup readback and named tests/checks pass.
+- **Rollback surface**: Code revert; user explicitly declines a live registry backup.
+
+> **Substantive Change SHA256**: `sha256:c9ca8ea886607fef2b906205fc7e16ea00a16ae26720685ce1ae3828906591c0`
+
+## Acceptance Notes
+
+- `bun test tests/cli/registry-prune.test.ts tests/cli/registry.test.ts`: 21 pass. Fleet board tests: 15 pass. Existing init npx environment regression: 1 pass. New tests rerun after a literal-type correction: 3 pass. Typecheck passes.
+- Required integrity checks pass; task-sync bound to final substantive digest. Full suite not run for the scoped reason above. Parent reviewed the final CLI/effect diff against lock, strict parsing, revision and no-op invariants.
+- Live cleanup used the tested CLI with exact selected IDs and preview revision. Removed 1028 absent temporary init registrations, then one absent arch-context worktree after confirming it was not a registered Git worktree. Registry now retains 10 existing paths and zero absent paths. No backup per Owner instruction; no repository files deleted.
+- Live Operator HTTP readback at /api/v1/fleet/snapshot: sequence 3, 10 repositories, 2 unreadable. The remaining arch-context and salesko-new failures are repo_board_unavailable; their existing directories were retained. These are separate board-observation faults, not stale registrations, and were not fixed in this slice.
+- Durable operator semantics: docs/researches/registry-prune.md. The new command is committed on the isolated branch; no global installation or release is claimed.

--- a/src/cli/commands/fleet.ts
+++ b/src/cli/commands/fleet.ts
@@ -1,4 +1,5 @@
 import { Command } from 'commander';
+import { pruneRepoHarnessRegistry } from '../../effects/repo-registry';
 import { randomUUID } from 'crypto';
 import { lstatSync, realpathSync, readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
@@ -358,6 +359,18 @@ function outputAcquireResult(result: ReturnType<typeof acquireFleetTask>): void 
 
 export function buildFleetCommand(): Command {
   const fleet = new Command('fleet').description('Project fleet workflow views and task acquisition');
+  fleet.command('prune')
+    .description('Preview missing repository registrations; --apply removes registry rows only, without backup')
+    .option('--apply', 'Remove confirmed absent paths under the registry mutation lock')
+    .option('--expected-revision <digest>', 'Exact registry_revision from the preview; required with --apply')
+    .option('--repo-id <id...>', 'Limit inspection/removal to these registered repository IDs')
+    .action(options => {
+      try {
+        const result = pruneRepoHarnessRegistry({ apply: options.apply,
+          expectedRevision: options.expectedRevision, repoIds: options.repoId });
+        process.stdout.write(`${JSON.stringify({ ok: true, ...result }, null, 2)}\n`);
+      } catch (error) { outputFeedbackValidation(error); }
+    });
   fleet
     .command('ready')
     .description('Aggregate current reviewing publications in canonical sprint row order')

--- a/src/effects/repo-registry.ts
+++ b/src/effects/repo-registry.ts
@@ -672,3 +672,48 @@ export function restoreRepoHarnessRegistryEntries(
   };
   return opts.dryRun ? apply() : withRegistryMutationLock(repoHarnessRegisteredReposPath(opts.env), apply);
 }
+
+/** Explicit operator cleanup; unreadable paths are not proof of absence. */
+export function pruneRepoHarnessRegistry(opts: {
+  readonly env?: NodeJS.ProcessEnv;
+  readonly apply?: boolean;
+  readonly expectedRevision?: string;
+  readonly repoIds?: readonly string[];
+} = {}) {
+  if (opts.apply && !/^sha256:[0-9a-f]{64}$/.test(opts.expectedRevision ?? '')) {
+    throw new Error('--apply requires --expected-revision from the preview');
+  }
+  const inspect = (snapshot: RepoHarnessRegistryStrictSnapshot) => {
+    if (opts.expectedRevision !== undefined && opts.expectedRevision !== snapshot.registryRevision) {
+      throw new Error('registry revision changed; preview again before applying');
+    }
+    const selected = opts.repoIds === undefined ? null : new Set(opts.repoIds);
+    for (const id of selected ?? []) {
+      if (!snapshot.repos.some(repo => repo.id === id)) throw new Error(`unknown registered repo id: ${id}`);
+    }
+    const candidates: RepoHarnessRegisteredRepo[] = [];
+    const skipped: { id: string; path: string; reason: string }[] = [];
+    for (const repo of snapshot.repos) {
+      if (selected !== null && !selected.has(repo.id)) continue;
+      try {
+        lstatSync(repo.path);
+        skipped.push({ id: repo.id, path: repo.path, reason: 'path_present' });
+      } catch (error) {
+        if (isNodeError(error) && error.code === 'ENOENT') candidates.push(repo);
+        else skipped.push({ id: repo.id, path: repo.path, reason: isNodeError(error) ? error.code ?? 'probe_failed' : 'probe_failed' });
+      }
+    }
+    const removed = opts.apply ? candidates : [];
+    const ids = new Set(removed.map(repo => repo.id));
+    const authorizationRevision = snapshot.authorizationRevision + (removed.length > 0 ? 1 : 0);
+    if (removed.length > 0) {
+      writeRegistryFile(snapshot.registryPath, snapshot.repos.filter(repo => !ids.has(repo.id)), authorizationRevision);
+    }
+    return { registry_path: snapshot.registryPath, registry_revision: snapshot.registryRevision,
+      applied: opts.apply === true, authorization_revision: authorizationRevision,
+      candidates, removed, skipped, remaining_count: snapshot.repos.length - removed.length };
+  };
+  return opts.apply
+    ? withRepoHarnessRegistryAuthorizationLock({ env: opts.env }, inspect)
+    : inspect(readRepoHarnessRegistryStrictSnapshot({ env: opts.env, adoptedOnly: false }));
+}

--- a/tests/cli/registry-prune.test.ts
+++ b/tests/cli/registry-prune.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { pruneRepoHarnessRegistry, readRepoHarnessRegistryStrictSnapshot, repoHarnessRepoIdFor } from '../../src/effects/repo-registry';
+
+const roots: string[] = [];
+afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }); });
+function fixture() {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), 'registry-prune-')));
+  roots.push(root);
+  const env = { ...process.env, HOME: root, REPO_HARNESS_HOME: join(root, 'home') };
+  mkdirSync(env.REPO_HARNESS_HOME);
+  const present = join(root, 'present'); mkdirSync(present);
+  const file = join(root, 'file'); writeFileSync(file, 'preserve');
+  const paths = [present, join(root, 'missing'), join(root, 'other-missing'), join(file, 'child')];
+  const repos = paths.map(path => ({ id: repoHarnessRepoIdFor(path), path, accessMode: 'read_only' as const,
+    source: 'init' as const, registeredAt: '2026-09-11T00:00:00.000Z', lastSeenAt: '2026-09-11T00:00:00.000Z' }));
+  const registry = join(env.REPO_HARNESS_HOME, 'registered-repos.json');
+  writeFileSync(registry, JSON.stringify({ version: 1, authorizationRevision: 5, repos }));
+  const cli = (...args: string[]) => spawnSync(process.execPath, [resolve(import.meta.dir, '../../src/cli/index.ts'), 'fleet', 'prune', ...args], { env, encoding: 'utf8' });
+  return { root, env, repos, registry, cli };
+}
+
+test('CLI defaults to preview, applies exact selected IDs with a revision fence and preserves other rows/files', () => {
+  const f = fixture(); const before = readFileSync(f.registry, 'utf8');
+  const preview = f.cli(); expect(preview.status).toBe(0);
+  const plan = JSON.parse(preview.stdout);
+  expect(plan.candidates.map((repo: { path: string }) => repo.path).sort()).toEqual([f.repos[1]!.path, f.repos[2]!.path].sort());
+  expect(plan.skipped).toContainEqual({ id: f.repos[3]!.id, path: f.repos[3]!.path, reason: 'ENOTDIR' });
+  expect(readFileSync(f.registry, 'utf8')).toBe(before);
+  expect(f.cli('--apply').status).toBe(2);
+  expect(readFileSync(f.registry, 'utf8')).toBe(before);
+  const apply = f.cli('--apply', '--expected-revision', plan.registry_revision, '--repo-id', f.repos[1]!.id);
+  expect(apply.status).toBe(0);
+  expect(JSON.parse(apply.stdout).removed).toEqual([f.repos[1]]);
+  const state = readRepoHarnessRegistryStrictSnapshot({ env: f.env });
+  expect(state.authorizationRevision).toBe(6);
+  expect(state.repos).toEqual(f.repos.filter((_, i) => i !== 1).sort((a, b) => a.id.localeCompare(b.id)));
+  expect(readFileSync(join(f.root, 'file'), 'utf8')).toBe('preserve');
+  const current = readFileSync(f.registry, 'utf8');
+  expect(f.cli('--apply', '--expected-revision', plan.registry_revision).status).toBe(2);
+  expect(readFileSync(f.registry, 'utf8')).toBe(current);
+});
+
+test('apply reprobes filesystem and no-op preserves bytes and revision', () => {
+  const f = fixture(); const before = readFileSync(f.registry, 'utf8');
+  const plan = pruneRepoHarnessRegistry({ env: f.env });
+  mkdirSync(f.repos[1]!.path); mkdirSync(f.repos[2]!.path);
+  const result = pruneRepoHarnessRegistry({ env: f.env, apply: true, expectedRevision: plan.registry_revision });
+  expect(result.removed).toEqual([]); expect(result.authorization_revision).toBe(5);
+  expect(readFileSync(f.registry, 'utf8')).toBe(before);
+});
+
+test('malformed registry and unknown scope fail without changing authority', () => {
+  const f = fixture(); const before = readFileSync(f.registry, 'utf8');
+  const plan = pruneRepoHarnessRegistry({ env: f.env });
+  expect(() => pruneRepoHarnessRegistry({ env: f.env, apply: true, expectedRevision: plan.registry_revision, repoIds: ['unknown'] })).toThrow('unknown');
+  expect(readFileSync(f.registry, 'utf8')).toBe(before);
+  writeFileSync(f.registry, '{bad');
+  expect(f.cli().status).toBe(2);
+  expect(f.cli('--apply', '--expected-revision', plan.registry_revision).status).toBe(2);
+  expect(readFileSync(f.registry, 'utf8')).toBe('{bad');
+});


### PR DESCRIPTION
新增顯式的 repo registry 清理路徑，讓過期條目由操作員主動剪除，而不是靠隱式失效。

- `src/effects/repo-registry.ts` 提供 prune 行為
- `src/cli/commands/fleet.ts` 暴露對應子命令
- `docs/researches/registry-prune.md` 記錄判定條件

測試：`tests/cli/registry-prune.test.ts`