### PR TITLE
fix(campaign): retry preparation before any runtime effect

### DIFF
--- a/plans/plan-20260910-2258-campaign-preparation-retry.md
+++ b/plans/plan-20260910-2258-campaign-preparation-retry.md
@@ -1,0 +1,116 @@
+# Plan: Retry campaign preparation before any runtime effect
+
+> **Status**: Executing
+> **Created**: 20260910-2258
+> **Slug**: campaign-preparation-retry
+> **Planning Source**: codex-plan
+> **Orchestration Kind**: host-plan
+> **Source Ref**: (none)
+> **Artifact Level**: work-package
+> **Promotion Reason**: verification_boundary
+> **Verification Boundary**: Preserved identity and deadline before any container journal or launch
+> **Rollback Surface**: Revert two bounded runtime source changes
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260910-2258-campaign-preparation-retry.contract.md`
+> **Task Review**: `tasks/reviews/20260910-2258-campaign-preparation-retry.review.md`
+> **Implementation Notes**: `tasks/notes/20260910-2258-campaign-preparation-retry.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from codex-plan planning output.
+- Source ref: (none)
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260910-2258-campaign-preparation-retry.md`
+- Sprint contract: `tasks/contracts/20260910-2258-campaign-preparation-retry.contract.md`
+- Sprint review: `tasks/reviews/20260910-2258-campaign-preparation-retry.review.md`
+- Implementation notes: `tasks/notes/20260910-2258-campaign-preparation-retry.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260910-2258-campaign-preparation-retry.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260910-2258-campaign-preparation-retry.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260910-2258-campaign-preparation-retry.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260910-2258-campaign-preparation-retry.contract.md`
+- Review file: `tasks/reviews/20260910-2258-campaign-preparation-retry.review.md`
+- Implementation notes file: `tasks/notes/20260910-2258-campaign-preparation-retry.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260910-2258-campaign-preparation-retry.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260910-2258-campaign-preparation-retry.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: Revert two bounded runtime source changes
+- **Verification boundary**: Preserved identity and deadline before any container journal or launch
+- **Review/acceptance boundary**: `tasks/reviews/20260910-2258-campaign-preparation-retry.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: verification_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260910-2258-campaign-preparation-retry.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260910-2258-campaign-preparation-retry.contract.md`, `tasks/reviews/20260910-2258-campaign-preparation-retry.review.md`, and `tasks/notes/20260910-2258-campaign-preparation-retry.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260910-2258-campaign-preparation-retry.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: Revert two bounded runtime source changes
+
+## Captured Planning Output
+
+P1 Map: campaign-worker owns immutable child admission, launch and budget reservation. campaign-runtime assembles the pinned provider invocation. campaign-container owns the protected account journal and exclusive pre-create directory fence. The existing execution worktree and handoff are unchanged.
+
+P2 Trace: prepareChild persists preparation before prepareCampaignCodexInvocation. A missing Docker executable fails in the first context inspection before either deterministic container journal is created. Re-entry unconditionally rejects the persisted preparation, so a failure with no provider/runtime effect wedges the acquired task. The observed live dispatch has preparation only; no invocation, started, launch, final or reservation.
+
+P3 Decision: Permit retry of preparation only when its identity matches the current handoff, its original deadline is still valid and no later runtime/admission evidence or either protected journal exists. The original stored deadline remains the only effect deadline; a new caller upper bound never extends it and an earlier incompatible bound rejects. Keep the immutable record, exact contract/claim validation and the lower mkdirSync exclusive fence. A journal, including empty or symlink state, remains a reconciliation boundary. At ten times concurrent retries the exclusive directory fence allows at most one create. No retry after launch, no budget reset, no container request reconstruction or deletion, no extra provider/carrier.
+
+Implementation paths: src/effects/automation/campaign-worker.ts, src/effects/automation/campaign-runtime.ts, tests/effects/campaign-worker.test.ts. Record durable boundary and pre-fix evidence in docs/researches/20260910-campaign-preparation-retry.md and tasks/evidence/campaign-preparation-retry-pre-fix.log; maintain required architecture projections only if the existing sync gate identifies those exact changed source paths.
+
+Verification: First observe the new regression fail on the unchanged implementation. Run focused campaign-worker, BRC10 lifecycle and campaign containment model tests on the host; no BRC_TEST_CONTAINER_IMAGE is supplied and no test container is created. Run the repository's required integrity checks and typecheck. The changed admission window is covered by named positive retry, preserved deadline, existing journal, later effect, identity and existing launch/final refusal cases; a full suite is not justified for this bounded change. Reuse final evidence after code freeze. Then resume the existing prepared dispatch through normal contract-run with the controller's Docker PATH repaired; test/build production remains on pinned host verification runtime9cc12bac.
+
+Rollback: Revert the bounded source fix. Preserve all live immutable preparation, grant, counters and runtime journals. Stop rather than widen retry when any journal/effect exists or the original deadline expires.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [ ] Execute captured plan: Retry campaign preparation before any runtime effect

--- a/src/effects/automation/campaign-runtime.ts
+++ b/src/effects/automation/campaign-runtime.ts
@@ -157,6 +157,18 @@ export interface CampaignCodexPreparation {
   identity: CampaignRuntimeIdentity;
   deadline_ms: number;
 }
+/** Journal creation is the exclusive fence before any container create request. */
+export function assertCampaignPreparationRetryable(preparation: CampaignCodexPreparation, worktree: string): void {
+  const common = commonDirectory(worktree, preparation.deadline_ms);
+  for (const identity of [{ ...preparation.identity, phase: 'version' }, preparation.identity]) {
+    try { lstatSync(campaignContainerDirectory(common, identity)); }
+    catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') continue;
+      throw error;
+    }
+    throw new Error('campaign preparation has a container journal; reconciliation required');
+  }
+}
 /** Preparation may have a probe alone or probe plus an unstarted workload. */
 export async function reconcileCampaignCodexPreparation(preparation: CampaignCodexPreparation, worktree: string) {
   const common = commonDirectory(worktree, Date.now() + 5000);

--- a/src/effects/automation/campaign-worker.ts
+++ b/src/effects/automation/campaign-worker.ts
@@ -22,7 +22,7 @@ import { LeaseLivenessStoreError, readLeaseLiveness, renewLeaseLiveness } from '
 
 import { campaignRuntimeRecordKey, type CampaignCodexInvocation } from '../../core/automation/campaign-runtime';
 import { campaignAttemptOutcome } from '../../core/automation/campaign-runtime';
-import { prepareCampaignCodexInvocation, assertCampaignInvocationExecutable, observeCampaignCodexTerminal, observeCampaignCodexInterruption, parseCampaignVerifierResponse, observeCampaignCodexPreparationInterruption, type CampaignCodexPreparation } from './campaign-runtime';
+import { prepareCampaignCodexInvocation, assertCampaignPreparationRetryable, assertCampaignInvocationExecutable, observeCampaignCodexTerminal, observeCampaignCodexInterruption, parseCampaignVerifierResponse, observeCampaignCodexPreparationInterruption, type CampaignCodexPreparation } from './campaign-runtime';
 
 type Acquisition = Extract<ScheduledEngineerAcquireResult, { ok: true }>;
 export interface CampaignWorkerSelector {
@@ -175,12 +175,31 @@ export function bindCampaignWorker(input: {
     async prepareChild(role: 'worker' | 'verifier', prompt: string, deadline: number): Promise<CampaignCodexInvocation> {
       if (input.provider !== 'codex-exec') throw new Error('campaign provider mode is not selected');
       validate();
-      const preparation = { deadline_ms: Math.min(deadline, Date.parse(budget.deadline_at)),
+      const candidate = { deadline_ms: Math.min(deadline, Date.parse(budget.deadline_at)),
         identity: { dispatch_id: selector.dispatch_id, role, task_id: work.task_id, task_revision: work.task_revision, claim_id: work.claim_id, lease_generation: work.generation, binding_generation: offer.binding_generation } };
-      withCampaignPlanningLock(root, intent, () => {
+      const preparation = withCampaignPlanningLock(root, intent, () => {
         assertNotRetired();
-        if (readPlanningRecord(root, intent, runtimeKey(role, 'preparation'))) throw new Error('campaign preparation already admitted; reconciliation required');
-        persistPlanningRecord(root, intent, runtimeKey(role, 'preparation'), preparation);
+        const prior = readPlanningRecord<CampaignCodexPreparation>(root, intent, runtimeKey(role, 'preparation'));
+        if (prior) {
+          if (role !== 'worker' || read('launch') || read('final') || read('child-worker') || read('child-verifier')
+            || readPlanningRecord(root, intent, runtimeKey('verifier', 'preparation'))
+            || (['worker', 'verifier'] as const).some(child => (['intent', 'started', 'terminal'] as const).some(phase => readPlanningRecord(root, intent, runtimeKey(child, phase))))
+            || readAutomationReservationByKey(root, budget.automation_run_id, key(selector.dispatch_id, 'attempt'), input.env)) {
+            throw new Error('campaign preparation already admitted; reconciliation required');
+          }
+          if (!exact(Object.keys(prior).sort(), ['deadline_ms', 'identity']) || !exact(prior.identity, candidate.identity)) {
+            throw new Error('campaign preparation identity differs');
+          }
+          // A retry's caller bound cannot replace or extend the immutable effect window.
+          if (!Number.isSafeInteger(prior.deadline_ms) || !Number.isSafeInteger(candidate.deadline_ms)
+            || prior.deadline_ms <= Date.now() || prior.deadline_ms > candidate.deadline_ms) {
+            throw new Error('campaign original preparation deadline is expired or outside the caller bound');
+          }
+          assertCampaignPreparationRetryable(prior, work.worktree_path);
+          return prior;
+        }
+        persistPlanningRecord(root, intent, runtimeKey(role, 'preparation'), candidate);
+        return candidate;
       });
       const invocation = await prepareCampaignCodexInvocation({ ...preparation, repo_root: root, worktree: work.worktree_path, prompt_path: prompt, env: input.env });
       withCampaignPlanningLock(root, intent, () => {

--- a/tasks/contracts/20260910-2258-campaign-preparation-retry.contract.md
+++ b/tasks/contracts/20260910-2258-campaign-preparation-retry.contract.md
@@ -2,28 +2,28 @@
 
 > **Status**: Active
 > **Plan**: plans/plan-20260910-2258-campaign-preparation-retry.md
-> **Task Profile**: code-change
+> **Task Profile**: bugfix
 > <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
 > **Owner**: ancienttwo
 > **Capability ID**: root
-> **Last Updated**: 2026-09-10 22:58
+> **Last Updated**: 2026-09-11 03:30
 > **Review File**: `tasks/reviews/20260910-2258-campaign-preparation-retry.review.md`
 > **Notes File**: `tasks/notes/20260910-2258-campaign-preparation-retry.notes.md`
 > **Exemplar**: `docs/reference-configs/contract-brief-example.md`
 
 ## Why
 
-Why this task matters and what breaks downstream if it ships wrong or is skipped.
+`prepareChild` persists the preparation planning record before it calls `prepareCampaignCodexInvocation`, and re-entry rejected that record unconditionally. A first attempt that dies inside the provider's initial context inspection — a missing or misconfigured Docker executable is the observed case — therefore leaves an acquired campaign task with a preparation record, no container journal, and no legal next move: the record blocks the retry, and reconciliation has nothing to reconcile against. The live dispatch found in this state holds a claim, a lease and a budget reservation that nothing releases, so the wedge costs a whole acquisition. Skipping the fix means every controller-side environment fault before journal creation converts into a stranded task.
 
 ## Goal
 
-Describe the exact outcome this task must deliver.
+`prepareChild` retries against an existing preparation record when that record's attempt provably produced no effect, and rejects otherwise. The retry must reuse the stored preparation unchanged: same identity, same `deadline_ms`. A caller bound may narrow the retry but may never replace or extend the original effect window, and an already-expired stored deadline rejects. Retry is refused outright once any later evidence exists — non-worker role, launch, final, either child record, verifier preparation, any downstream phase record, an attempt reservation, or a container journal for either the version probe or the workload identity.
 
 ## Scope
 
-- In scope:
-- Out of scope:
-- Taste constraints: <!-- advisory only, no run gate; default style/taste lives in AGENTS.md and the minimal-change policy, use this to record a per-task override -->
+- In scope: the retry admission window in `prepareChild` (`src/effects/automation/campaign-worker.ts`); `assertCampaignPreparationRetryable` as the exclusive pre-create journal fence (`src/effects/automation/campaign-runtime.ts`); the retry, preserved-deadline, journal-blocked, later-effect, identity and refusal cases in `tests/effects/campaign-worker.test.ts`.
+- Out of scope: retry after launch; resetting or re-charging budget; reconstructing or deleting a container request; adding a provider or carrier; changing the immutable record, the contract/claim validation, or the lower `mkdirSync` exclusive fence; restarting the stopped campaign or reusing an old grant.
+- Taste constraints: the stored record stays the single authority for the effect window — the retry path reads it and never rewrites it. <!-- advisory only, no run gate; default style/taste lives in AGENTS.md and the minimal-change policy, use this to record a per-task override -->
 
 ## Stop Conditions
 
@@ -33,16 +33,16 @@ Describe the exact outcome this task must deliver.
 
 ## Falsifier
 
-What observable evidence would prove this task's direction wrong, and the cheapest proof point to check first. Leave as-is if not applicable.
+The direction is wrong if a failure inside `prepareCampaignCodexInvocation` can reach the runtime before the container journal exists — then "no journal" would no longer imply "no effect", and retry would have to become reconciliation. Cheapest proof point: the journal-blocked cases in `tests/effects/campaign-worker.test.ts` assert `prepareCampaignCodexInvocation` was called exactly once and the pre-created directory survives, so a second provider call or a mutated journal falsifies the fence directly. The second falsifier is deadline drift: `calls` must equal `[deadline, deadline]` across a retry issued with a wider caller bound; any other pair means the effect window was renewed.
 
 ## Root Cause Evidence
 
 Required when Task Profile is `bugfix`; leave as-is otherwise.
 
-- root_cause: one sentence naming file:line/condition (testable, not "a state issue").
-- repro: the command or UI path that reproduces the symptom.
-- regression_guard: path to a test that fails on the unfixed code and passes after the fix (must also appear as a `package_test` check in Verification Plan).
-- pre_fix_failure_artifact: path to a captured run of regression_guard on the UNFIXED code. Capture with `bun test <regression_guard> > <artifact> 2>&1; echo "PRE_FIX_EXIT=$?" >> <artifact>` (no pipes — pipes swallow the exit status). The gate requires a non-zero `PRE_FIX_EXIT=` line plus the regression_guard path string in the artifact (see the Root Cause Evidence Gate section in docs/reference-configs/sprint-contracts.md).
+- root_cause: `src/effects/automation/campaign-worker.ts:182` (pre-fix, `origin/main`) rejected re-entry whenever `readPlanningRecord(root, intent, runtimeKey(role, 'preparation'))` returned a record, so a first attempt that threw before any container journal was created could never be retried.
+- repro: `bun test tests/effects/campaign-worker.test.ts --test-name-pattern 'pre-journal preparation failure can retry'` on the unfixed code — the second `prepareChild` call throws `campaign preparation already admitted; reconciliation required` instead of reaching the provider.
+- regression_guard: tests/effects/campaign-worker.test.ts
+- pre_fix_failure_artifact: tasks/evidence/campaign-preparation-retry-pre-fix.log
 
 ## Workflow Inventory
 
@@ -71,16 +71,15 @@ Required when Task Profile is `bugfix`; leave as-is otherwise.
 
 ```yaml
 allowed_paths:
-  - docs/spec.md
-  - plans/
-  - tasks/todos.md
+  - src/effects/automation/campaign-worker.ts
+  - src/effects/automation/campaign-runtime.ts
+  - tests/effects/campaign-worker.test.ts
+  - tasks/evidence/campaign-preparation-retry-pre-fix.log
+  - plans/plan-20260910-2258-campaign-preparation-retry.md
   - tasks/contracts/20260910-2258-campaign-preparation-retry.contract.md
   - tasks/reviews/20260910-2258-campaign-preparation-retry.review.md
   - tasks/notes/20260910-2258-campaign-preparation-retry.notes.md
-  - .ai/context/capabilities.json
-  - .claude/templates/
-  - src/
-  - tests/
+  - tasks/todos.md
 ```
 
 ## Evidence Requirements
@@ -132,10 +131,12 @@ missing or malformed plan fails closed.
 
 ```yaml
 exit_criteria:
-  files_exist:
-    - docs/spec.md
+  files_contain:
+    - path: src/effects/automation/campaign-runtime.ts
+      pattern: "assertCampaignPreparationRetryable"
   artifacts_exist:
     - .ai/harness/checks/latest.json
+    - tasks/evidence/campaign-preparation-retry-pre-fix.log
     - tasks/notes/20260910-2258-campaign-preparation-retry.notes.md
 ```
 
@@ -146,14 +147,36 @@ exit_criteria:
   "protocol": 1,
   "checks": [
     {
-      "id": "focused-regression",
+      "id": "campaign-worker-retry-regression",
       "kind": "package_test",
-      "path": "tests/unit/campaign-preparation-retry.test.ts",
+      "path": "tests/effects/campaign-worker.test.ts",
       "cwd": ".",
       "phase": "verification",
       "cost": "normal",
       "evidence_policy": "current_exact",
-      "necessity": "Covers the changed behavior named by this contract.",
+      "necessity": "Root Cause Evidence regression_guard: covers the retry, preserved-deadline, journal-blocked, later-effect and refusal cases that define the changed admission window.",
+      "inputs": { "env": [] }
+    },
+    {
+      "id": "brc10-lifecycle",
+      "kind": "package_test",
+      "path": "tests/effects/brc10-lifecycle.test.ts",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "prepareChild sits inside the supervised dispatch lifecycle; this proves the retry window did not move claim, lease or budget behavior.",
+      "inputs": { "env": [] }
+    },
+    {
+      "id": "campaign-containment",
+      "kind": "package_test",
+      "path": "tests/effects/campaign-containment.test.ts",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "assertCampaignPreparationRetryable reads the container journal the containment model owns; this proves the new fence agrees with that owner.",
       "inputs": { "env": [] }
     },
     {
@@ -166,6 +189,39 @@ exit_criteria:
       "evidence_policy": "current_exact",
       "necessity": "Checks TypeScript contracts before behavioral verification.",
       "inputs": { "env": [] }
+    },
+    {
+      "id": "hook-projection-drift",
+      "kind": "command",
+      "command": "bun run check:hooks",
+      "cwd": ".",
+      "phase": "preflight",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository-integrity check: catches a hook projection edited without its authoring source.",
+      "inputs": { "env": [] }
+    },
+    {
+      "id": "helper-projection-drift",
+      "kind": "command",
+      "command": "bun run check:helpers",
+      "cwd": ".",
+      "phase": "preflight",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository-integrity check: catches a helper projection edited without its authoring source.",
+      "inputs": { "env": [] }
+    },
+    {
+      "id": "task-workflow-strict",
+      "kind": "command",
+      "command": "bash scripts/check-task-workflow.sh --strict",
+      "cwd": ".",
+      "phase": "preflight",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository-integrity check: this contract's own plan/contract/review/notes set must stay internally consistent.",
+      "inputs": { "env": [] }
     }
   ]
 }
@@ -177,11 +233,13 @@ the intended coverage; do not infer that choice from paths or command text.
 
 ## Acceptance Notes (Human Review)
 
-- Functional behavior:
-- Edge cases:
-- Regression risks:
+- Functional behavior: a `prepareChild` attempt that fails before any container journal exists can be retried against its stored preparation record. The retry reuses the stored `deadline_ms` verbatim, so a wider caller bound does not extend the effect window and a narrower bound below the stored deadline rejects. Everything else still refuses: verifier role, any launch/final/child/verifier-preparation/downstream-phase record, an attempt reservation, or a container journal for the version probe or the workload identity.
+- Edge cases: an expired stored deadline rejects rather than retries; a non-safe-integer deadline on either side rejects; an identity or record-shape difference rejects before the journal fence is consulted; an empty or symlinked journal directory still counts as a journal, so it routes to reconciliation. Under concurrent retries the lower `mkdirSync` exclusive fence still admits at most one create.
+- Regression risks: the retry path widens an admission window that used to be strictly single-shot, so the risk is a missed effect signal letting a second provider call through. The journal-blocked cases pin `prepareCampaignCodexInvocation` to exactly one call and assert the pre-created directory survives untouched; the retry case pins the deadline pair to `[deadline, deadline]` and asserts budget status and the launch/intent records are unchanged.
+- Verification scope: coverage is the three focused test files declared above plus typecheck and the projection-drift checks. Also run once on this branch and green, but not declared as replayable criteria: `bash scripts/check-deploy-sql-order.sh` (no SQL in scope), `bash scripts/check-task-sync.sh` and `bash scripts/check-architecture-sync.sh` (both read live git and daemon state, so they belong to CI at the merge boundary rather than a frozen acceptance replay). A full suite is not justified: the change is two bounded functions in one module pair, and the admission window is covered by named positive and refusal cases.
+- Environment note: `check-architecture-sync.sh` was red in this worktree until `bun install` brought its `node_modules` archctx from 0.5.9 up to the 0.5.10 the rebased `package.json` pins. That was stale worktree state, not a repository defect.
 
 ## Rollback Point
 
-- Commit / checkpoint:
-- Revert strategy:
+- Commit / checkpoint: `09e4a4d0` (merge-base with `origin/main`)
+- Revert strategy: revert the single commit. The change is confined to two functions in `campaign-worker.ts` and `campaign-runtime.ts` and reverting restores the unconditional rejection; no data migration, and every live immutable preparation, grant, counter and runtime journal is untouched either way.

--- a/tasks/contracts/20260910-2258-campaign-preparation-retry.contract.md
+++ b/tasks/contracts/20260910-2258-campaign-preparation-retry.contract.md
@@ -1,0 +1,187 @@
+# Task Contract: campaign-preparation-retry
+
+> **Status**: Active
+> **Plan**: plans/plan-20260910-2258-campaign-preparation-retry.md
+> **Task Profile**: code-change
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: ancienttwo
+> **Capability ID**: root
+> **Last Updated**: 2026-09-10 22:58
+> **Review File**: `tasks/reviews/20260910-2258-campaign-preparation-retry.review.md`
+> **Notes File**: `tasks/notes/20260910-2258-campaign-preparation-retry.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+Why this task matters and what breaks downstream if it ships wrong or is skipped.
+
+## Goal
+
+Describe the exact outcome this task must deliver.
+
+## Scope
+
+- In scope:
+- Out of scope:
+- Taste constraints: <!-- advisory only, no run gate; default style/taste lives in AGENTS.md and the minimal-change policy, use this to record a per-task override -->
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+
+## Falsifier
+
+What observable evidence would prove this task's direction wrong, and the cheapest proof point to check first. Leave as-is if not applicable.
+
+## Root Cause Evidence
+
+Required when Task Profile is `bugfix`; leave as-is otherwise.
+
+- root_cause: one sentence naming file:line/condition (testable, not "a state issue").
+- repro: the command or UI path that reproduces the symptom.
+- regression_guard: path to a test that fails on the unfixed code and passes after the fix (must also appear as a `package_test` check in Verification Plan).
+- pre_fix_failure_artifact: path to a captured run of regression_guard on the UNFIXED code. Capture with `bun test <regression_guard> > <artifact> 2>&1; echo "PRE_FIX_EXIT=$?" >> <artifact>` (no pipes — pipes swallow the exit status). The gate requires a non-zero `PRE_FIX_EXIT=` line plus the regression_guard path string in the artifact (see the Root Cause Evidence Gate section in docs/reference-configs/sprint-contracts.md).
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260910-2258-campaign-preparation-retry.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260910-2258-campaign-preparation-retry.review.md`
+- Notes file: `tasks/notes/20260910-2258-campaign-preparation-retry.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Change Assessment
+
+```json
+{"protocol":1,"oracles":[]}
+```
+
+## Acceptance Policy
+
+```json
+{"protocol":2,"reviewer":"Codex","source":"codex-plugin","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - docs/spec.md
+  - plans/
+  - tasks/todos.md
+  - tasks/contracts/20260910-2258-campaign-preparation-retry.contract.md
+  - tasks/reviews/20260910-2258-campaign-preparation-retry.review.md
+  - tasks/notes/20260910-2258-campaign-preparation-retry.notes.md
+  - .ai/context/capabilities.json
+  - .claude/templates/
+  - src/
+  - tests/
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+    fallback: null
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+This block contains only non-executable artifact requirements. Define every
+executable check once in the canonical Verification Plan below. Each check must
+state its phase, cost, evidence policy, necessity, and input environment; a
+missing or malformed plan fails closed.
+
+```yaml
+exit_criteria:
+  files_exist:
+    - docs/spec.md
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260910-2258-campaign-preparation-retry.notes.md
+```
+
+## Verification Plan
+
+```json
+{
+  "protocol": 1,
+  "checks": [
+    {
+      "id": "focused-regression",
+      "kind": "package_test",
+      "path": "tests/unit/campaign-preparation-retry.test.ts",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Covers the changed behavior named by this contract.",
+      "inputs": { "env": [] }
+    },
+    {
+      "id": "typecheck",
+      "kind": "command",
+      "command": "bun run check:type",
+      "cwd": ".",
+      "phase": "preflight",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Checks TypeScript contracts before behavioral verification.",
+      "inputs": { "env": [] }
+    }
+  ]
+}
+```
+
+This is the sole executable verification authority. Use `baseline_with_delta`
+only when a referenced immutable baseline plus named current delta checks prove
+the intended coverage; do not infer that choice from paths or command text.
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior:
+- Edge cases:
+- Regression risks:
+
+## Rollback Point
+
+- Commit / checkpoint:
+- Revert strategy:

--- a/tasks/evidence/campaign-preparation-retry-pre-fix.log
+++ b/tasks/evidence/campaign-preparation-retry-pre-fix.log
@@ -1,0 +1,53 @@
+bun test v1.4.0 (34cbb9a40)
+
+tests/effects/campaign-worker.test.ts:
+48 |     const deadline = Date.now() + 30000;
+49 |     await expect(worker.prepareChild('worker', 'prompt.md', deadline)).rejects.toThrow('transport unavailable');
+50 |     const recordKey = campaignRuntimeRecordKey(f.result.worker_handoff.dispatch_id, 'worker', 'preparation');
+51 |     const original = readPlanningRecord(f.root, f.intent, recordKey);
+52 |     expect(original).not.toBeNull();
+53 |     await expect(worker.prepareChild('worker', 'prompt.md', deadline + 30000)).rejects.toThrow('transport unavailable');
+                                                                                            ^
+error: expect(received).toThrow(expected)
+
+Expected substring: "transport unavailable"
+Received message: "campaign preparation already admitted; reconciliation required"
+
+      at <anonymous> (/Users/ancienttwo/Projects/repo-harness-wt-campaign-preparation-retry/tests/effects/campaign-worker.test.ts:53:88)
+(fail) pre-journal preparation failure can retry without extending its deadline or charging an attempt [5812.82ms]
+77 |     const stored = readPlanningRecord<campaignRuntime.CampaignCodexPreparation>(f.root, f.intent,
+78 |       campaignRuntimeRecordKey(f.result.worker_handoff.dispatch_id, 'worker', 'preparation'))!;
+79 |     const common = resolveGitCommonDirectory(f.worktree);
+80 |     const directory = campaignContainerDirectory(common, phase === 'version' ? { ...stored.identity, phase } : stored.identity);
+81 |     mkdirSync(directory);
+82 |     await expect(worker.prepareChild('worker', 'prompt.md', deadline)).rejects.toThrow('journal');
+                                                                                    ^
+error: expect(received).toThrow(expected)
+
+Expected substring: "journal"
+Received message: "campaign preparation already admitted; reconciliation required"
+
+      at <anonymous> (/Users/ancienttwo/Projects/repo-harness-wt-campaign-preparation-retry/tests/effects/campaign-worker.test.ts:82:80)
+(fail) an existing version journal blocks preparation retry before any provider call [5531.64ms]
+77 |     const stored = readPlanningRecord<campaignRuntime.CampaignCodexPreparation>(f.root, f.intent,
+78 |       campaignRuntimeRecordKey(f.result.worker_handoff.dispatch_id, 'worker', 'preparation'))!;
+79 |     const common = resolveGitCommonDirectory(f.worktree);
+80 |     const directory = campaignContainerDirectory(common, phase === 'version' ? { ...stored.identity, phase } : stored.identity);
+81 |     mkdirSync(directory);
+82 |     await expect(worker.prepareChild('worker', 'prompt.md', deadline)).rejects.toThrow('journal');
+                                                                                    ^
+error: expect(received).toThrow(expected)
+
+Expected substring: "journal"
+Received message: "campaign preparation already admitted; reconciliation required"
+
+      at <anonymous> (/Users/ancienttwo/Projects/repo-harness-wt-campaign-preparation-retry/tests/effects/campaign-worker.test.ts:82:80)
+(fail) an existing worker journal blocks preparation retry before any provider call [5004.35ms]
+
+ 0 pass
+ 12 filtered out
+ 3 fail
+ 7 expect() calls
+Ran 3 tests across 1 file. [16.42s]
+
+PRE_FIX_EXIT=1

--- a/tasks/notes/20260910-2258-campaign-preparation-retry.notes.md
+++ b/tasks/notes/20260910-2258-campaign-preparation-retry.notes.md
@@ -1,0 +1,41 @@
+# Implementation Notes: campaign-preparation-retry
+
+> **Status**: Active
+> **Plan**: plans/plan-20260910-2258-campaign-preparation-retry.md
+> **Contract**: tasks/contracts/20260910-2258-campaign-preparation-retry.contract.md
+> **Review**: tasks/reviews/20260910-2258-campaign-preparation-retry.review.md
+> **Last Updated**: 2026-09-10 22:58
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- ...
+
+## Deviations From Plan Or Spec
+
+- None recorded.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| ... | ... | ... |
+
+## Open Questions
+
+- None.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/notes/20260910-2258-campaign-preparation-retry.notes.md
+++ b/tasks/notes/20260910-2258-campaign-preparation-retry.notes.md
@@ -4,26 +4,36 @@
 > **Plan**: plans/plan-20260910-2258-campaign-preparation-retry.md
 > **Contract**: tasks/contracts/20260910-2258-campaign-preparation-retry.contract.md
 > **Review**: tasks/reviews/20260910-2258-campaign-preparation-retry.review.md
-> **Last Updated**: 2026-09-10 22:58
+> **Last Updated**: 2026-09-11 03:30
 > **Lifecycle**: notes
 
 ## Design Decisions
 
-- ...
+- The stored preparation record stays the single authority for the effect window. The retry path reads it and returns it; it never rewrites it. That is why `prepareChild` now returns the record out of `withCampaignPlanningLock` instead of discarding the lock's result — the caller downstream must use the stored deadline, not the one it was invoked with.
+- The caller's bound may narrow but never widen. `prior.deadline_ms > candidate.deadline_ms` rejects, so a retry issued under a tighter bound is refused rather than silently clamped, and a retry issued under a looser bound cannot renew the window. `prior.deadline_ms <= Date.now()` rejects for the same reason: an expired window is a reconciliation boundary, not a retryable one.
+- Container-journal existence is the effect signal, not provider return status. `assertCampaignPreparationRetryable` lives in `campaign-runtime.ts` beside `reconcileCampaignCodexPreparation`, which already owns the journal path derivation, so the fence and the reconciler cannot drift apart on where a journal lives.
+- Both identities are checked, version probe first. The probe journal is created before the workload journal, so checking only the workload identity would let a retry through after the probe had already reached the runtime.
+- Retry is worker-only. A verifier preparation implies the worker already terminated, which is later evidence by construction; allowing verifier retry would mean reasoning about which of the two children owns the window.
+- Record shape is compared, not just identity. `exact(Object.keys(prior).sort(), ['deadline_ms', 'identity'])` rejects a record written by a different version of this code rather than retrying against a shape whose semantics are unknown.
 
 ## Deviations From Plan Or Spec
 
-- None recorded.
+- The plan named `docs/researches/20260910-campaign-preparation-retry.md` as the durable boundary record. Not written: the boundary is one invariant about one admission window, and it is stated in this contract's Goal and in these notes. Promote to `docs/researches/` only if a second admission window needs the same rule.
+- `Task Profile` was captured as `code-change` and is now `bugfix`. The pre-fix failure artifact and root-cause evidence the plan called for only gate under the `bugfix` profile, so the original value would have left them unverified.
 
 ## Tradeoffs Considered
 
 | Option | Decision | Reason |
 |--------|----------|--------|
-| ... | ... | ... |
+| Delete the preparation record on a pre-journal failure, so the next call takes the fresh path | Rejected | The record is the only durable trace that an attempt was made; deleting it would let a retry mint a new deadline and defeat the immutable effect window. |
+| Treat provider error type (transport vs. runtime) as the retry signal | Rejected | Error text is provider-owned and unversioned. Journal existence is a fact this repository writes and can prove. |
+| Allow the retry to extend the deadline when the caller's bound is later | Rejected | The stored deadline bounds an effect that may already be in flight from the operator's point of view; extending it converts a bounded attempt into an open-ended one. |
+| Put the journal fence inside `prepareCampaignCodexInvocation` | Rejected | That function already creates the journal; a fence inside it could not distinguish "about to create" from "created by the prior attempt". |
 
 ## Open Questions
 
-- None.
+- The pre-fix log was captured against a controller whose Docker PATH was broken. Resuming the stranded dispatch through normal `contract-run` still needs that PATH repaired; the fix removes the wedge, not the environment fault that produced it.
+- `check-architecture-sync.sh` failed in this worktree purely because its `node_modules` still held archctx 0.5.9 against the 0.5.10 pin the rebase brought in. Worth watching whether other long-lived worktrees hit the same stale-install gate after a pin bump.
 
 ## Evidence Links
 
@@ -39,3 +49,5 @@ Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset 
 - Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
 - Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
 - Promote to harness asset files only after verification across more than one task or fixture.
+
+> **Substantive Change SHA256**: `sha256:ca856a49fc5a8d88bc1184086d46e26055617cbfaf95f756a43a524e9dbfd5f0`

--- a/tasks/reviews/20260910-2258-campaign-preparation-retry.review.md
+++ b/tasks/reviews/20260910-2258-campaign-preparation-retry.review.md
@@ -1,0 +1,84 @@
+# Task Review: campaign-preparation-retry
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260910-2258-campaign-preparation-retry.md
+> **Contract**: tasks/contracts/20260910-2258-campaign-preparation-retry.contract.md
+> **Notes File**: tasks/notes/20260910-2258-campaign-preparation-retry.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-09-10 22:58
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Commands passed:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+- Waza `/check` run:
+- Commands run:
+- Manual checks:
+- Supporting artifacts:
+- Implementation notes reviewed:
+- Run snapshot:
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...

--- a/tasks/reviews/20260910-2258-campaign-preparation-retry.review.md
+++ b/tasks/reviews/20260910-2258-campaign-preparation-retry.review.md
@@ -5,7 +5,7 @@
 > **Contract**: tasks/contracts/20260910-2258-campaign-preparation-retry.contract.md
 > **Notes File**: tasks/notes/20260910-2258-campaign-preparation-retry.notes.md
 > **Checks File**: .ai/harness/checks/latest.json
-> **Last Updated**: 2026-09-10 22:58
+> **Last Updated**: 2026-09-11 03:30
 > **Recommendation**: fail
 > **Review Rubric Version**: 2
 > **Reviewed Subject SHA256**: pending
@@ -15,28 +15,37 @@
 ## Human Review Card
 
 - Verdict: pending
-- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
-- Intended files changed:
-- Actual files changed:
-- Commands passed:
-- Residual risks:
+- Change type: code-change
+- Intended files changed: `src/effects/automation/campaign-worker.ts`, `src/effects/automation/campaign-runtime.ts`, `tests/effects/campaign-worker.test.ts`, plus this task's plan/contract/notes/review and `tasks/evidence/campaign-preparation-retry-pre-fix.log`
+- Actual files changed: exactly that set — `plans/plan-20260910-2258-campaign-preparation-retry.md`, `src/effects/automation/campaign-runtime.ts`, `src/effects/automation/campaign-worker.ts`, `tasks/contracts/20260910-2258-campaign-preparation-retry.contract.md`, `tasks/evidence/campaign-preparation-retry-pre-fix.log`, `tasks/notes/20260910-2258-campaign-preparation-retry.notes.md`, `tasks/reviews/20260910-2258-campaign-preparation-retry.review.md`, `tests/effects/campaign-worker.test.ts`. No path outside `allowed_paths`.
+- Commands passed: see Verification Evidence below.
+- Residual risks: the retry widens a previously single-shot admission window; a missed effect signal would let a second provider call through. Pinned by the journal-blocked cases asserting `prepareCampaignCodexInvocation` was called exactly once and the pre-created directory is untouched.
 - Reviewer action required: inspect diff and card
-- Rollback:
+- Rollback: revert the single commit on top of `09e4a4d0`; no data migration, live immutable preparation/grant/counter/journal state untouched either way.
 
 ## Mode Evidence
 
-- Selected route:
-- P1/P2/P3 evidence:
-- Root cause or plan evidence:
+- Selected route: planning — captured Codex Plan output in `plans/plan-20260910-2258-campaign-preparation-retry.md`.
+- P1/P2/P3 evidence: recorded in that plan's `## Captured Planning Output`. P2 names the pressure point: `prepareChild` persists the preparation record before `prepareCampaignCodexInvocation`, and re-entry rejected that record unconditionally.
+- Root cause or plan evidence: `## Root Cause Evidence` in the contract — `src/effects/automation/campaign-worker.ts:182` on `origin/main`, with the pre-fix failure captured in `tasks/evidence/campaign-preparation-retry-pre-fix.log` (`PRE_FIX_EXIT=1`, 3 fail / 0 pass).
 
 ## Verification Evidence
 
-- Waza `/check` run:
+- Waza `/check` run: not run; this contract's acceptance policy routes review to Codex via AcceptanceReceipt.
 - Commands run:
-- Manual checks:
-- Supporting artifacts:
-- Implementation notes reviewed:
-- Run snapshot:
+  - `bun test tests/effects/campaign-worker.test.ts tests/effects/brc10-lifecycle.test.ts tests/effects/campaign-containment.test.ts --timeout 60000` → 40 pass, 4 skip, 0 fail, 239 assertions, 151.44s
+  - `bun run check:type` → clean (fixed two untyped `readPlanningRecord` call sites in the new test)
+  - `bun run check:hooks` → projection OK, 3 files
+  - `bun run check:helpers` → projection OK, 58 helpers
+  - `bash scripts/check-task-workflow.sh --strict` → OK
+  - `bash scripts/check-task-sync.sh` → no changes detected
+  - `bash scripts/check-deploy-sql-order.sh` → OK
+  - `bash scripts/check-architecture-sync.sh` → OK after `bun install` (see Manual checks)
+  - `repo-harness run contract-run preflight --contract tasks/contracts/20260910-2258-campaign-preparation-retry.contract.md` → preflight_pass
+- Manual checks: `check-architecture-sync.sh` failed strict in this worktree with `state=mismatch` until `bun install` raised its `node_modules` archctx from 0.5.9 to the 0.5.10 pinned by the rebased `package.json`. The same check was green on the `main` checkout throughout, confirming stale worktree install rather than a repository defect.
+- Supporting artifacts: `tasks/evidence/campaign-preparation-retry-pre-fix.log`
+- Implementation notes reviewed: `tasks/notes/20260910-2258-campaign-preparation-retry.notes.md`
+- Run snapshot: `.ai/harness/runs/`
 
 ## Acceptance Receipt Projection
 
@@ -55,11 +64,15 @@
 
 ## Behavior Diff Notes
 
-- ...
+- Before: any second `prepareChild` call with an existing preparation record threw `campaign preparation already admitted; reconciliation required`.
+- After: that message is reserved for cases with real later evidence — non-worker role, a launch/final/child/verifier-preparation/downstream-phase record, or an attempt reservation. A worker retry with none of those proceeds against the stored record.
+- New refusals with distinct messages: `campaign preparation identity differs` (identity or record shape changed), `campaign original preparation deadline is expired or outside the caller bound` (stored deadline expired, non-safe-integer, or wider than the caller's bound), and `campaign preparation has a container journal; reconciliation required` (journal exists for the version probe or the workload identity).
+- `prepareChild` now uses the record returned from `withCampaignPlanningLock` rather than the locally built candidate, so a retry runs against the stored deadline instead of the one it was invoked with.
 
 ## Residual Risks / Follow-ups
 
-- ...
+- The stranded dispatch this fix unblocks still needs the controller's Docker PATH repaired before it can resume through normal `contract-run`. The fix removes the wedge, not the environment fault.
+- Long-lived worktrees can fail `check-architecture-sync.sh` strict after an archctx pin bump until `bun install` runs there. Not caused by this change; worth watching if it recurs.
 
 ## Scorecard
 
@@ -76,9 +89,10 @@
 
 ## Retest Steps
 
-- Re-run:
-- Re-check:
+- Re-run: `bun test tests/effects/campaign-worker.test.ts tests/effects/brc10-lifecycle.test.ts tests/effects/campaign-containment.test.ts --timeout 60000`, then `bun run check:type`.
+- Re-check: `repo-harness run contract-run preflight --contract tasks/contracts/20260910-2258-campaign-preparation-retry.contract.md` and `bash scripts/check-task-workflow.sh --strict`. If `check-architecture-sync.sh` reports `state=mismatch`, run `bun install` in the worktree before treating it as a finding.
 
 ## Summary
 
-- ...
+- Implementation and evidence are complete; the verdict is not. Contract, notes and this card were authored by the implementer, so `Status` stays `Pending` and `Recommendation` stays `fail` until an AcceptanceReceipt is recorded under this contract's acceptance policy (`reviewer: Codex`, `source: codex-plugin`).
+- What a reviewer should attack first: whether container-journal absence really implies no runtime effect. That is the load-bearing assumption; the contract's `## Falsifier` names it and the journal-blocked cases are the cheapest place to disprove it.

--- a/tests/effects/campaign-worker.test.ts
+++ b/tests/effects/campaign-worker.test.ts
@@ -48,11 +48,11 @@ test('pre-journal preparation failure can retry without extending its deadline o
     const deadline = Date.now() + 30000;
     await expect(worker.prepareChild('worker', 'prompt.md', deadline)).rejects.toThrow('transport unavailable');
     const recordKey = campaignRuntimeRecordKey(f.result.worker_handoff.dispatch_id, 'worker', 'preparation');
-    const original = readPlanningRecord(f.root, f.intent, recordKey);
+    const original = readPlanningRecord<campaignRuntime.CampaignCodexPreparation>(f.root, f.intent, recordKey);
     expect(original).not.toBeNull();
     await expect(worker.prepareChild('worker', 'prompt.md', deadline + 30000)).rejects.toThrow('transport unavailable');
     expect(calls).toEqual([deadline, deadline]);
-    expect(readPlanningRecord(f.root, f.intent, recordKey)).toEqual(original);
+    expect(readPlanningRecord<campaignRuntime.CampaignCodexPreparation>(f.root, f.intent, recordKey)).toEqual(original);
     expect(budgetStatus(f)).toEqual(before);
     expect(readPlanningRecord(f.root, f.intent, canonicalMessageDigest({ dispatch: f.result.worker_handoff.dispatch_id, part: 'launch' }).slice(7))).toBeNull();
     expect(readPlanningRecord(f.root, f.intent, campaignRuntimeRecordKey(f.result.worker_handoff.dispatch_id, 'worker', 'intent'))).toBeNull();

--- a/tests/effects/campaign-worker.test.ts
+++ b/tests/effects/campaign-worker.test.ts
@@ -1,7 +1,8 @@
 import * as revisionAdmission from '../../src/effects/automation/campaign-revision-admission';
+import * as campaignRuntime from '../../src/effects/automation/campaign-runtime';
 import { afterEach, expect, test, spyOn } from 'bun:test';
 import { spawnSync } from 'child_process';
-import { existsSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { historicalPlanningFixture, installHistoricalBoundDispatch, installHistoricalAttempt, installHistoricalFinal } from '../helpers/historical-campaign-lifecycle';
 import { ensureCampaignAuthoringBudget, readAutomationBudgetStatus, appendAutomationUsage, readAutomationUsageForResult } from '../../src/effects/automation/budget-store';
@@ -13,6 +14,9 @@ import { issueBatchGroupStoreRoot } from '../../src/effects/automation/issue-bat
 import { canonicalMessageBytes, canonicalMessageDigest } from '../../src/core/messages/mechanics';
 import { processSprintDependencies, releaseSprintCommand } from '../../src/effects/state/coordination-sprint';
 import { readLease } from '../../src/effects/state/coordination-lease-store';
+import { campaignRuntimeRecordKey } from '../../src/core/automation/campaign-runtime';
+import { campaignContainerDirectory } from '../../src/effects/automation/campaign-container';
+import { resolveGitCommonDirectory } from '../../src/effects/git/common-directory';
 const roots: string[] = [];
 afterEach(() => roots.splice(0).forEach(root => rmSync(root, { recursive: true, force: true })));
 async function acquired() {
@@ -28,6 +32,61 @@ function budgetStatus(f: Awaited<ReturnType<typeof acquired>>) {
   const budget = ensureCampaignAuthoringBudget({ repo_root: f.root, authorization: f.authorization, env: f.env }).budget;
   return readAutomationBudgetStatus(f.root, budget.automation_run_id, f.env).current;
 }
+
+test('pre-journal preparation failure can retry without extending its deadline or charging an attempt', async () => {
+  const f = await acquired(); const before = budgetStatus(f);
+  const admission = spyOn(revisionAdmission, 'requireCampaignActiveAdmission').mockImplementation(() => {});
+  const calls: number[] = [];
+  const prepare = spyOn(campaignRuntime, 'prepareCampaignCodexInvocation').mockImplementation(async input => {
+    calls.push(input.deadline_ms);
+    throw new Error('Docker context transport unavailable before journal creation');
+  });
+  const previousHome = process.env.REPO_HARNESS_HOME;
+  process.env.REPO_HARNESS_HOME = f.home;
+  try {
+    const worker = bindCampaignWorker({ ...workerInput(f), provider: 'codex-exec' });
+    const deadline = Date.now() + 30000;
+    await expect(worker.prepareChild('worker', 'prompt.md', deadline)).rejects.toThrow('transport unavailable');
+    const recordKey = campaignRuntimeRecordKey(f.result.worker_handoff.dispatch_id, 'worker', 'preparation');
+    const original = readPlanningRecord(f.root, f.intent, recordKey);
+    expect(original).not.toBeNull();
+    await expect(worker.prepareChild('worker', 'prompt.md', deadline + 30000)).rejects.toThrow('transport unavailable');
+    expect(calls).toEqual([deadline, deadline]);
+    expect(readPlanningRecord(f.root, f.intent, recordKey)).toEqual(original);
+    expect(budgetStatus(f)).toEqual(before);
+    expect(readPlanningRecord(f.root, f.intent, canonicalMessageDigest({ dispatch: f.result.worker_handoff.dispatch_id, part: 'launch' }).slice(7))).toBeNull();
+    expect(readPlanningRecord(f.root, f.intent, campaignRuntimeRecordKey(f.result.worker_handoff.dispatch_id, 'worker', 'intent'))).toBeNull();
+    await expect(worker.prepareChild('worker', 'prompt.md', deadline - 1)).rejects.toThrow('deadline');
+    expect(calls).toHaveLength(2);
+  } finally {
+    admission.mockRestore(); prepare.mockRestore();
+    if (previousHome === undefined) delete process.env.REPO_HARNESS_HOME; else process.env.REPO_HARNESS_HOME = previousHome;
+  }
+});
+
+test.each(['version', 'worker'] as const)('an existing %s journal blocks preparation retry before any provider call', async phase => {
+  const f = await acquired();
+  const admission = spyOn(revisionAdmission, 'requireCampaignActiveAdmission').mockImplementation(() => {});
+  const prepare = spyOn(campaignRuntime, 'prepareCampaignCodexInvocation').mockRejectedValue(new Error('pre-journal failure'));
+  const previousHome = process.env.REPO_HARNESS_HOME;
+  process.env.REPO_HARNESS_HOME = f.home;
+  try {
+    const worker = bindCampaignWorker({ ...workerInput(f), provider: 'codex-exec' });
+    const deadline = Date.now() + 30000;
+    await expect(worker.prepareChild('worker', 'prompt.md', deadline)).rejects.toThrow('pre-journal failure');
+    const stored = readPlanningRecord<campaignRuntime.CampaignCodexPreparation>(f.root, f.intent,
+      campaignRuntimeRecordKey(f.result.worker_handoff.dispatch_id, 'worker', 'preparation'))!;
+    const common = resolveGitCommonDirectory(f.worktree);
+    const directory = campaignContainerDirectory(common, phase === 'version' ? { ...stored.identity, phase } : stored.identity);
+    mkdirSync(directory);
+    await expect(worker.prepareChild('worker', 'prompt.md', deadline)).rejects.toThrow('journal');
+    expect(prepare).toHaveBeenCalledTimes(1);
+    expect(existsSync(directory)).toBe(true);
+  } finally {
+    admission.mockRestore(); prepare.mockRestore();
+    if (previousHome === undefined) delete process.env.REPO_HARNESS_HOME; else process.env.REPO_HARNESS_HOME = previousHome;
+  }
+});
 
 test('historical Claim cannot authorize a new handoff, launch, reservation or attempt', async () => {
   const f = await acquired(); const before = budgetStatus(f);


### PR DESCRIPTION
preparation 記錄只允許被 admit 一次，第二次呼叫直接丟 `campaign preparation already admitted`。worker 若在「寫下記錄」與「建立容器」之間被中斷，就沒有出口：記錄擋住重試，而容器 journal 又不存在，reconcile 也無從下手。

`prepareChild` 現在會讀回既有記錄，並且只在該次嘗試可證明沒有產生任何 effect 時才允許重試——限 worker role，且不得存在 launch、final、child、verifier preparation、下游 phase 記錄或 attempt reservation。重試必須帶完全相同的 identity；呼叫端的 bound 不得取代或延長原本的 deadline，所以那個不可變的 effect window 是被保留而不是被續期。

`assertCampaignPreparationRetryable` 是容器 create 請求之前的唯一柵欄：version probe 或 workload identity 任一存在容器 journal，就代表這次嘗試已經觸及 runtime，此時唯一出口是 reconcile，不是重試。

驗證：`bun test tests/effects/campaign-worker.test.ts --timeout 60000` → 15 pass / 0 fail。

**合入前仍待補**：`tasks/contracts/`、`tasks/notes/`、`tasks/reviews/` 三份工作流檔案目前還是未填寫的模板（review 為 `Pending / fail`），需要補齊後再走 merge gate。