### PR TITLE
fix(contract): record the shape discriminator and the paths the work touched

### DIFF
--- a/assets/reference-configs/hook-operations.md
+++ b/assets/reference-configs/hook-operations.md
@@ -131,8 +131,8 @@ registry with `bun test` and `repo-harness init --repo . --dry-run`.
 
 ## Evidence Retention
 
-`.ai/harness/runs/` has four record writers plus assorted operator reports, and
-only one shape is disposable history:
+`.ai/harness/runs/` holds four record shapes from five writers, and only one of
+them is disposable history:
 
 | File | Writer | Retention owner |
 | --- | --- | --- |
@@ -146,7 +146,8 @@ Evidence checkpoints under `.ai/harness/evidence/checkpoints/` are owned by
 `checkpoint-store.ts`, which keeps only the checkpoint the published marker
 names and prunes inside every successful publish.
 
-The two unowned classes are durable evidence, not leaks. A frozen acceptance
+The three unowned rows are not leaks. Operator reports own their own files; the
+other two are durable evidence. A frozen acceptance
 snapshot shares Stop's `run-` prefix, and a missing verification record makes
 `readValidRunResult` report an absent baseline, which fails a
 `baseline_with_delta` criterion permanently because a rerun only mints a new

--- a/docs/reference-configs/hook-operations.md
+++ b/docs/reference-configs/hook-operations.md
@@ -131,8 +131,8 @@ registry with `bun test` and `repo-harness init --repo . --dry-run`.
 
 ## Evidence Retention
 
-`.ai/harness/runs/` has four record writers plus assorted operator reports, and
-only one shape is disposable history:
+`.ai/harness/runs/` holds four record shapes from five writers, and only one of
+them is disposable history:
 
 | File | Writer | Retention owner |
 | --- | --- | --- |
@@ -146,7 +146,8 @@ Evidence checkpoints under `.ai/harness/evidence/checkpoints/` are owned by
 `checkpoint-store.ts`, which keeps only the checkpoint the published marker
 names and prunes inside every successful publish.
 
-The two unowned classes are durable evidence, not leaks. A frozen acceptance
+The three unowned rows are not leaks. Operator reports own their own files; the
+other two are durable evidence. A frozen acceptance
 snapshot shares Stop's `run-` prefix, and a missing verification record makes
 `readValidRunResult` report an absent baseline, which fails a
 `baseline_with_delta` criterion permanently because a rerun only mints a new

--- a/tasks/contracts/20260911-0202-evidence-gc-retention.contract.md
+++ b/tasks/contracts/20260911-0202-evidence-gc-retention.contract.md
@@ -34,9 +34,11 @@ Bound Stop run-summary growth at the writer, and give operators one command that
 reclaims obsolete evidence in a repo the Stop path can no longer heal.
 
 1. `src/effects/run-summary-retention.ts` owns one retention policy: delete only
-   records carrying Stop's own `reason: "session-stop"` marker, keeping the
-   newest `RUN_SUMMARY_RETENTION_COUNT` by mtime. Every other shape in the
-   directory belongs to its own owner and is never a candidate.
+   records with the run-summary shape -- a non-empty `run_id` plus string
+   `checks_file`, `handoff_file`, `policy_file`, and `context_map_file` -- keeping
+   the newest `RUN_SUMMARY_RETENTION_COUNT` by mtime. The discriminator is the
+   shape, not `reason`: that field is free-form operator text. Every other shape
+   in the directory belongs to its own owner and is never a candidate.
 2. `stop-handler.ts` applies that sweep after its own run-summary write, fail-open
    so a sweep fault never fails Stop.
 3. `repo-harness run evidence-gc [--dry-run] [--repo <path>]` applies the same
@@ -53,7 +55,9 @@ reclaims obsolete evidence in a repo the Stop path can no longer heal.
   `assets/reference-configs/`. Also `workflow_write_run_summary`'s jq-less
   branch in `assets/hooks/lib/workflow-state.sh`: it writes the same record this
   contract now identifies by shape, and its short fallback would make every
-  jq-less host's summaries permanently unreclaimable.
+  jq-less host's summaries permanently unreclaimable. Also the root `CLAUDE.md`
+  and `AGENTS.md` `Required Checks` block, which omitted `check:reference-configs`
+  -- the third member of the projection-drift family this contract trips.
 - Out of scope: `src/effects/hook-event-log.ts` retention constants. The 256 MB /
   32-segment archive cap is already bounded and works as designed; the operator
   decided this round not to change it. Also out of scope: any change to the
@@ -71,16 +75,28 @@ reclaims obsolete evidence in a repo the Stop path can no longer heal.
 
 ## Falsifier
 
-The direction is wrong if any file in `harness.runs_dir` that a reader depends on
-can carry Stop's `reason: "session-stop"` marker, or if Stop's own summaries can
-lack it. Cheapest proof point: grep every `runs_dir` / `run_file` consumer in
-`src/` and `scripts/`, and for each writer confirm the record shape it emits.
+The direction is wrong if a file in `harness.runs_dir` that some reader depends
+on can carry the run-summary shape, or if a genuine run summary can lack one of
+its four path fields and so become permanently unreclaimable. Cheapest proof
+point: enumerate every writer into `runs_dir` across `src/`, `scripts/`, and
+`assets/hooks/`, and for each one read the record shape it emits on every branch.
 
-Executed. Three writers: `stop-handler.ts:467` (marker present, disposable),
-`verify-sprint.sh:1009` (`schema: repo-harness-run-trace.v1`, read back at
-finalization), and `verification-execution.ts:919-921` (`kind:
-verification_execution_record`, ledger-bound by sha256, read at
-`readValidRunResult:507-510`). Only the first carries the marker.
+Executed. Four writers of a `${runId}.json`-style record:
+
+- `stop-handler.ts:470-482` -- the disposable run summary, all eleven fields.
+- `workflow_write_run_summary` (`assets/hooks/lib/workflow-state.sh:1314`) --
+  the same eleven fields and the larger producer by volume. Its jq-less branch
+  emitted only five; this contract fixes that, because a short branch would make
+  every jq-less host's summaries permanently unreclaimable.
+- `verify-sprint.sh:1009` -- `schema: repo-harness-run-trace.v1`, read back at
+  finalization (`:913-937`). Carries `run_id`, none of the four path fields.
+- `verification-execution.ts:919-921` -- `kind: verification_execution_record`,
+  ledger-bound by sha256, read at `readValidRunResult:507-510`. No `run_id` at
+  all, so the discriminator rejects it on its first test.
+
+Operator reports in the same directory carry neither `run_id` nor the path
+fields. Measured on this repository's live directory: 5898 run summaries, 33
+verify-sprint traces, 12 operator reports, zero partial-shape records.
 
 ## Root Cause Evidence
 
@@ -131,8 +147,13 @@ allowed_paths:
   - scripts/
   - assets/workflow-contract.v1.json
   - assets/templates/helpers/
+  - assets/hooks/
+  - assets/reference-configs/
+  - .ai/hooks/
   - .ai/harness/workflow-contract.json
   - docs/
+  - CLAUDE.md
+  - AGENTS.md
 ```
 
 ## Evidence Requirements

--- a/tasks/notes/20260911-0202-evidence-gc-retention.notes.md
+++ b/tasks/notes/20260911-0202-evidence-gc-retention.notes.md
@@ -104,4 +104,4 @@ of the `check:hooks` / `check:helpers` family and was missing from the root
 `Required Checks` block; it is now listed there in both `CLAUDE.md` and
 `AGENTS.md`.
 
-> **Substantive Change SHA256**: `sha256:9ca9180d9fe3216e4eb50bb3701040326130a5e5f76577bbbc5932918d31ae60`
+> **Substantive Change SHA256**: `sha256:80dd845324279a2cb1ce1620525c6d7bc058d79f884a67f1c66cc14e315d9539`

--- a/tests/workflow-state-lib.test.ts
+++ b/tests/workflow-state-lib.test.ts
@@ -668,6 +668,7 @@ describe("run summary shape is one authoring contract", () => {
 
   function writeRunSummary(withJq: boolean): Record<string, unknown> {
     const cwd = mkdtempSync(join(tmpdir(), "run-summary-shape-"));
+    let bin: string | null = null;
     try {
       mkdirSync(join(cwd, ".ai/harness/runs"), { recursive: true });
       writeFileSync(join(cwd, ".ai/harness/policy.json"), "{}\n");
@@ -676,7 +677,7 @@ describe("run summary shape is one authoring contract", () => {
       if (!withJq) {
         // A PATH holding only the coreutils the fallback branch needs proves
         // the branch actually runs, instead of silently taking the jq path.
-        const bin = mkdtempSync(join(tmpdir(), "run-summary-bin-"));
+        bin = mkdtempSync(join(tmpdir(), "run-summary-bin-"));
         for (const tool of ["date", "cat", "mkdir", "rm", "dirname", "basename", "sed", "grep", "awk", "head", "tail", "printf", "ls", "tr", "id", "uname", "mktemp", "stat", "sort", "find", "wc"]) {
           const resolved = spawnSync("command", ["-v", tool], { shell: true, encoding: "utf-8" }).stdout.trim();
           if (resolved) symlinkSync(resolved, join(bin, tool));
@@ -697,6 +698,7 @@ describe("run summary shape is one authoring contract", () => {
       return JSON.parse(readFileSync(join(cwd, ".ai/harness/runs", files[0]!), "utf-8")) as Record<string, unknown>;
     } finally {
       rmSync(cwd, { recursive: true, force: true });
+      if (bin) rmSync(bin, { recursive: true, force: true });
     }
   }
 


### PR DESCRIPTION
#405 合入時，它的驗收記錄描述的是一條程式碼刻意推翻的規則。

contract 的 Goal 與 Falsifier 還寫著早期的 `reason: "session-stop"` 標記判準。實際上 `run-summary-retention.ts` 用的是記錄形狀，因為 `reason` 是自由文字——本 repo 歷史裡有約 190 種值。照標記規則，shell writer 寫出的那些 `reason` 全都匹配不到，那正是那一輪修掉的 bug；記錄留著會把它重新引回來。

`allowed_paths` 也沒隨那輪放寬，`assets/hooks/`、`.ai/hooks/`、`assets/reference-configs/`、`CLAUDE.md`、`AGENTS.md` 都在範圍外。`verify-contract` 不檢查這個區塊，所以它過了，但 `verify-sprint` 的 scope guard 會 fail closed。

另外兩處：docs 表格多了第三列無 owner 的記錄，底下那段還寫著「兩類」；shell run-summary 測試的 PATH shim 暫存目錄每跑一次漏一個。

驗證：`check:type`、`check:reference-configs`、`check:hooks`、`check:helpers`、`check-task-workflow.sh --strict`、`tests/workflow-state-lib.test.ts`（15 pass）全綠，scope guard 重算後 0 個路徑出界。