### PR TITLE
chore(release): prepare 0.19.1

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -702,8 +702,8 @@ repositorio adopte la misma política.
 
 ## Versión actual
 
-- Paquete npm: `repo-harness@0.19.0`
-- Sello de workflow generado: `repo-harness@0.19.0+template@0.19.0`
+- Paquete npm: `repo-harness@0.19.1`
+- Sello de workflow generado: `repo-harness@0.19.1+template@0.19.1`
 - Repositorio de GitHub: `Ancienttwo/repo-harness`
 - Notas de versión e historial: [`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -697,8 +697,8 @@ adopte la même policy.
 
 ## Release actuelle
 
-- Package npm : `repo-harness@0.19.0`
-- Generated workflow stamp : `repo-harness@0.19.0+template@0.19.0`
+- Package npm : `repo-harness@0.19.1`
+- Generated workflow stamp : `repo-harness@0.19.1+template@0.19.1`
 - Dépôt GitHub : `Ancienttwo/repo-harness`
 - Notes et historique de release : [`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -694,8 +694,8 @@ commit script や hooks に組み込まないでください。
 
 ## 現在の Release
 
-- npm package：`repo-harness@0.19.0`
-- Generated workflow stamp：`repo-harness@0.19.0+template@0.19.0`
+- npm package：`repo-harness@0.19.1`
+- Generated workflow stamp：`repo-harness@0.19.1+template@0.19.1`
 - GitHub repository：`Ancienttwo/repo-harness`
 - Release notes and history：[`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -660,8 +660,8 @@ repo-harness commit scripts or hooks unless that repo adopts the same policy.
 
 ## Current Release
 
-- npm package: `repo-harness@0.19.0`
-- Generated workflow stamp: `repo-harness@0.19.0+template@0.19.0`
+- npm package: `repo-harness@0.19.1`
+- Generated workflow stamp: `repo-harness@0.19.1+template@0.19.1`
 - GitHub repository: `Ancienttwo/repo-harness`
 - Release notes and history: [`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -630,8 +630,8 @@ commit script 或 hook，除非目标仓库采用同样的 policy。
 
 ## 当前 Release
 
-- npm package：`repo-harness@0.19.0`
-- Generated workflow stamp：`repo-harness@0.19.0+template@0.19.0`
+- npm package：`repo-harness@0.19.1`
+- Generated workflow stamp：`repo-harness@0.19.1+template@0.19.1`
 - GitHub repository：`Ancienttwo/repo-harness`
 - Release notes 和 history：[`docs/CHANGELOG.md`](docs/CHANGELOG.md)
 

--- a/assets/skill-version.json
+++ b/assets/skill-version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.19.0",
-  "templateVersion": "0.19.0",
+  "version": "0.19.1",
+  "templateVersion": "0.19.1",
   "skillName": "repo-harness",
   "contractId": "tasks-first-harness-v1",
   "compatibility": {
@@ -275,6 +275,10 @@
     {
       "version": "0.18.0",
       "description": "Rebuilds the operator control board as an attention-first worklist with a resident detail pane, projecting task_label and task_index through FleetBoardCardV1 at FLEET_BOARD_PROTOCOL 2, and opens the board's single write channel as an authenticated task-message POST with Origin, read_only and 8 KiB gates under sender_kind operator; adds zh/en board i18n and canonical brand marks"
+    },
+    {
+      "version": "0.19.1",
+      "description": "Bounds the two unbounded surfaces under .ai/harness/: Stop run summaries are retained to the newest RUN_SUMMARY_RETENTION_COUNT by record shape, and repo-harness run evidence-gc reclaims superseded evidence checkpoints and over-retention summaries in a repository the Stop path can no longer heal; moves architecture projection execution settings to ~/.repo-harness/config.json#architecture; adds the auto-campaign bounded standard turn, repository-scoped operator board, explicit fleet registry pruning, and proactive measured refactor recommendations behind user approval"
     }
   ],
   "generatedProjectStamp": {

--- a/deploy/release-checklists/260912-repo-harness-0.19.1.md
+++ b/deploy/release-checklists/260912-repo-harness-0.19.1.md
@@ -1,0 +1,72 @@
+# repo-harness 0.19.1 Release Filing
+
+- Date: 2026-09-12
+- Package: `repo-harness@0.19.1`
+- Base release: `v0.19.0` (`a8b5620308a3`)
+- Integration base: `2bea52c1` (`main` after PR #410).
+- Release branch: `codex/release-0-19-1`.
+- Candidate commit: bound by the release PR head and final verification receipt.
+- Release scope: patch, by release-owner decision. The range is additive on top
+  of 0.19.0 rather than a new layer: it bounds the two unbounded surfaces under
+  `.ai/harness/` and adds the operator command that reclaims a backlog the Stop
+  path can no longer reach, moves architecture projection execution settings from
+  repository policy to `~/.repo-harness/config.json#architecture`, and adds the
+  `auto-campaign` bounded standard turn, a repository-scoped operator board,
+  explicit fleet registry pruning, and proactive measured refactor
+  recommendations behind the existing user-approval gates.
+  The range does add public CLI surface (`run evidence-gc`, `fleet` registry
+  pruning) and relocates a settings authority, which a strict semver reading
+  would place in a minor. Recorded here so the next release owner sees the
+  choice rather than inferring the range from the number.
+- Publish status: **pending**.
+
+## Release Content
+
+Merged into `main` since `v0.19.0` (PR order):
+
+| PR | Change |
+| --- | --- |
+| #399 | Installation ownership on upgrade; Herdr repository pin seeding |
+| #400 | Architecture projection manifest rebind |
+| #402 | `auto-campaign` bounded standard turn skill |
+| #403 | Repository-scoped operator board |
+| #404 | Explicit fleet registry pruning |
+| #405 | Stop run summary retention and `repo-harness run evidence-gc` |
+| #406 | Campaign preparation retry before any runtime effect |
+| #407 | BRC native host execution checkpoint (docs) |
+| #401 | Architecture projection as global configuration |
+| #408 | Proactive measured refactor recommendations |
+| #410 | Evidence retention contract record correction |
+
+See `docs/CHANGELOG.md#0191---2026-09-12` for the behavioral detail.
+
+## Upgrade Notes
+
+- **Existing repositories carry an evidence checkpoint backlog.** Checkpoint
+  retention shipped in 0.19.0 but runs only inside a successful publish. After
+  upgrading, the next successful Stop prunes the backlog on its own. Run
+  `repo-harness run evidence-gc --repo . --dry-run` to see the reclaimable bytes,
+  and `repo-harness run evidence-gc --repo .` when that Stop will not come --
+  a repository whose evidence ledger was reset, or one that no longer runs the
+  harness. Measured on the author's machine: 9.7 GB in a single repository,
+  10.5 GB across eight.
+- **Architecture projection settings move to the user level.** Repository `init`
+  removes the retired repository-local execution settings and reports readiness.
+  An explicit `disabled` choice is preserved. Provider versions stay
+  package-owned; nothing to edit by hand.
+- **`runs/verification-*.log` has no retention owner.** Failure diagnostics from
+  `verification-execution.ts` are never retention candidates (not `.json`) and
+  accumulate. They are small and tied to failed checks; left deliberately.
+
+## Verification
+
+- [ ] `bun run check:release` (full release gate, includes `scripts/check-ci.sh`)
+- [ ] `bun run check:hooks`, `check:helpers`, `check:reference-configs`
+- [ ] `bash scripts/check-task-workflow.sh --strict`
+- [ ] `bash scripts/check-task-sync.sh`
+- [ ] `bun src/cli/index.ts init --repo . --dry-run`
+- [ ] Release PR CI green on the candidate head
+- [ ] Tag `v0.19.1` on the merge commit
+- [ ] `npm publish` and `bun run check:release-published`
+- [ ] Bun-global runtime refreshed; `repo-harness --version` reports `0.19.1`
+- [ ] `repo-harness run evidence-gc --dry-run` resolves from the installed runtime

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,86 @@ All notable changes to this skill are documented here.
 
 ## [Unreleased]
 
+## [0.19.1] - 2026-09-12
+
+Two surfaces under `.ai/harness/` grew without an operator exit. This release
+bounds both and adds the command that reclaims a backlog the Stop path can no
+longer reach, alongside architecture-projection configuration moving to the
+user level and four additions on the program layer.
+
+### Changed
+
+- **Architecture projection execution settings are global, not per repository.**
+  They now live once in `~/.repo-harness/config.json#architecture`. Global
+  install and update initialize Archctx automatic projection with an advisory
+  failure gate, preserving an explicit `disabled` choice and unrelated settings.
+  Repository `init` reports readiness and adoption removes the retired
+  repository-local execution settings. Provider versions stay package-owned.
+
+### Added
+
+- **Stop run summaries are bounded.** Stop wrote one `${runId}.json` per session
+  and nothing removed it; a long-running repository reached 5931 files here,
+  the oldest from 2026-05-25. `src/effects/run-summary-retention.ts` retains the
+  newest `RUN_SUMMARY_RETENTION_COUNT` and Stop applies it after its own write,
+  fail-open so a sweep fault never fails Stop.
+
+  A run summary is identified by its record shape -- a `run_id` plus
+  `checks_file`, `handoff_file`, `policy_file`, and `context_map_file`, every one
+  a pointer the next Stop recomputes. Not by filename and not by `reason`:
+  `verify-sprint`'s frozen acceptance snapshot shares the `run-` prefix, and
+  `reason` is free-form operator text. Records carrying results rather than
+  pointers -- that snapshot, and the ledger-bound
+  `verification-${executionId}.json` a `baseline_with_delta` criterion reads --
+  are never candidates, and neither is a shape a future writer adds.
+
+- **`repo-harness run evidence-gc [--dry-run] [--repo <path>]`.** Applies the
+  retention above plus the existing checkpoint prune on demand, reporting
+  reclaimable bytes per class. Checkpoint retention has shipped since 0.19.0 but
+  only runs inside a successful publish, so a repository whose evidence ledger
+  was reset, or one that no longer runs the harness, kept its whole backlog with
+  no way to reclaim it -- 9.7 GB in a single repository measured here. The next
+  successful Stop after upgrading prunes that backlog on its own; this command
+  is for when that Stop will not come.
+
+- **`auto-campaign` skill.** Fixes one standard campaign turn as a bounded
+  procedure: `assets/skills/auto-campaign/` ships `SKILL.md`, an execution
+  reference, `standard.json`, and `prepare-grant.ts`, registered in the skill
+  catalog.
+
+- **Repository-scoped operator board.** The board carries a repository
+  dimension and a selector, so multiple repositories no longer share one
+  undifferentiated surface.
+
+- **`repo-harness fleet` registry pruning.** Stale repository registry entries
+  are removed through an explicit operator command instead of implicit
+  invalidation.
+
+- **Proactive measured refactor recommendations.** Normal Stop reads measured
+  Archctx refactor opportunities and asks the agent to present evidence,
+  inferred benefit, and risk for a proceed/defer/decline choice. Observation
+  never authors or accepts a recommendation, creates a plan or program, enables
+  execution, or builds an index; existing user-approved execution gates stay
+  authoritative. The enable preference is global.
+
 ### Fixed
+
+- **Campaign preparation can retry before any runtime effect.** A worker
+  interrupted between writing the preparation record and creating its container
+  had no exit: the record blocked a retry and the absent container journal left
+  nothing for `reconcile`. `prepareChild` now reads back an existing record and
+  permits a retry only when that attempt is provably effect-free -- worker role
+  only, with no launch, final, child, verifier preparation, downstream phase
+  record, or attempt reservation. The retry must carry identical identity, and
+  the caller's bound neither replaces nor extends the original deadline, so the
+  immutable effect window is preserved rather than renewed.
+
+- **One authoring contract for the run summary record.**
+  `workflow_write_run_summary`'s jq-less branch emitted 5 of the 11 fields.
+  Now that retention identifies a record by its shape, a short branch would have
+  made every jq-less host's summaries permanently unreclaimable. Both branches
+  emit the same fields.
+
 
 - **Fleet and bundled cross-review upgrades honor installation ownership.**
   Unchanged files recorded in the installation manifest can now upgrade to a

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "repo-harness",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Installs, migrates, audits, and repairs repo-local agentic development harnesses",
   "license": "MIT",
   "repository": {

--- a/plans/plan-20260912-1123-release-0-19-1.md
+++ b/plans/plan-20260912-1123-release-0-19-1.md
@@ -1,0 +1,155 @@
+# Plan: Release repo-harness 0.19.1
+
+> **Status**: Executing
+> **Created**: 20260912-1123
+> **Slug**: release-0-19-1
+> **Planning Source**: repo-harness-plan
+> **Orchestration Kind**: host-plan
+> **Source Ref**: (none)
+> **Artifact Level**: work-package
+> **Promotion Reason**: merge_boundary
+> **Verification Boundary**: release gate plus PR CI on the exact candidate
+> **Rollback Surface**: branch and tag before publish; follow-up patch release after
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260912-1123-release-0-19-1.contract.md`
+> **Task Review**: `tasks/reviews/20260912-1123-release-0-19-1.review.md`
+> **Implementation Notes**: `tasks/notes/20260912-1123-release-0-19-1.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from repo-harness-plan planning output.
+- Source ref: (none)
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260912-1123-release-0-19-1.md`
+- Sprint contract: `tasks/contracts/20260912-1123-release-0-19-1.contract.md`
+- Sprint review: `tasks/reviews/20260912-1123-release-0-19-1.review.md`
+- Implementation notes: `tasks/notes/20260912-1123-release-0-19-1.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260912-1123-release-0-19-1.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260912-1123-release-0-19-1.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260912-1123-release-0-19-1.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260912-1123-release-0-19-1.contract.md`
+- Review file: `tasks/reviews/20260912-1123-release-0-19-1.review.md`
+- Implementation notes file: `tasks/notes/20260912-1123-release-0-19-1.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260912-1123-release-0-19-1.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260912-1123-release-0-19-1.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: branch and tag before publish; follow-up patch release after
+- **Verification boundary**: release gate plus PR CI on the exact candidate
+- **Review/acceptance boundary**: `tasks/reviews/20260912-1123-release-0-19-1.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: merge_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260912-1123-release-0-19-1.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260912-1123-release-0-19-1.contract.md`, `tasks/reviews/20260912-1123-release-0-19-1.review.md`, and `tasks/notes/20260912-1123-release-0-19-1.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260912-1123-release-0-19-1.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: branch and tag before publish; follow-up patch release after
+
+## Captured Planning Output
+
+## Problem
+
+`main` carries ten merged PRs since `v0.19.0`, including the two `.ai/harness/`
+retention surfaces and the `evidence-gc` reclaim command. None of it reaches a
+downstream repository: the globally installed runtime is still 0.19.0, so Stop
+never applies run-summary retention and `repo-harness run evidence-gc` does not
+resolve. Checkpoint retention is in 0.19.0 but a repository that cannot reach a
+successful publish has no operator exit until this release ships.
+
+## Decision
+
+Cut 0.19.1 as a patch release off `2bea52c1`, by release-owner decision. No product code changes on this
+branch: it carries the version stamp, the changelog entry, and the release
+filing only. The product tree is byte-identical to `main`, whose CI is green at
+that commit.
+
+The range does add public surface -- `repo-harness run evidence-gc`, `fleet`
+registry pruning, the `auto-campaign` skill, a repository-scoped operator board
+-- and moves architecture projection execution settings from repository policy
+to `~/.repo-harness/config.json`, which a strict semver reading would place in a
+minor. The release owner chose patch: the range is additive on top of 0.19.0
+rather than a new layer. Recorded so the next owner reads the range from the
+changelog, not from the number.
+
+## Task Breakdown
+
+- [ ] Bump `package.json` and `assets/skill-version.json` to 0.19.1 with a
+      `breakingChanges` entry describing the range.
+- [ ] Write the `docs/CHANGELOG.md` 0.19.1 entry, folding in the two 0.19.x
+      follow-up fixes that merged after the 0.19.0 tag.
+- [ ] File `deploy/release-checklists/260912-repo-harness-0.19.1.md` with the
+      merged-PR table, upgrade notes, and the verification ledger.
+- [ ] Run the release gate, merge, tag `v0.19.1`, publish, and record the
+      publish readback in the filing.
+
+## Verification
+
+`bun run check:release` is the explicit release gate and runs the full suite; it
+also proves `repo-harness@0.19.1` is unpublished. The release PR's CI is the
+authoritative run on the exact merge candidate. Version consistency is covered by
+`check-skill-version`, and the three projection gates cover the generated trees.
+
+## Rollback
+
+Before publish, the release is a branch and a tag that can be deleted. After
+publish an npm version is immutable; the recovery path is a follow-up patch
+release, not a revert.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [ ] Bump `package.json` and `assets/skill-version.json` to 0.19.1 with a
+- [ ] Write the `docs/CHANGELOG.md` 0.19.1 entry, folding in the two 0.19.x
+- [ ] File `deploy/release-checklists/260912-repo-harness-0.19.1.md` with the
+- [ ] Run the release gate, merge, tag `v0.19.1`, publish, and record the

--- a/tasks/contracts/20260912-1123-release-0-19-1.contract.md
+++ b/tasks/contracts/20260912-1123-release-0-19-1.contract.md
@@ -1,0 +1,264 @@
+# Task Contract: release-0-19-1
+
+> **Status**: Active
+> **Plan**: plans/plan-20260912-1123-release-0-19-1.md
+> **Task Profile**: code-change
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: ancienttwo
+> **Capability ID**: root
+> **Last Updated**: 2026-09-12 11:24
+> **Review File**: `tasks/reviews/20260912-1123-release-0-19-1.review.md`
+> **Notes File**: `tasks/notes/20260912-1123-release-0-19-1.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+Ten PRs have merged into `main` since `v0.19.0` and none of them reach a
+downstream repository. The globally installed runtime is 0.19.0, so Stop never
+applies run-summary retention and `repo-harness run evidence-gc` does not
+resolve. Checkpoint retention exists in 0.19.0 but runs only inside a successful
+publish, so a repository whose evidence ledger was reset, or one that stopped
+running the harness, has no operator exit for a multi-gigabyte backlog until
+this release ships.
+
+If the stamp ships wrong, generated project stamps and `check-skill-version`
+disagree with the published package, and a downstream `repo-harness update`
+installs a version whose templates claim a different one.
+
+## Goal
+
+Publish `repo-harness@0.19.1` from `2bea52c1` as a patch, with no product code
+change on the release branch.
+
+1. `package.json` and `assets/skill-version.json` carry 0.19.1 as both `version`
+   and `templateVersion`, with a `breakingChanges` entry describing the range.
+2. `docs/CHANGELOG.md` has a 0.19.1 section covering the ten merged PRs,
+   including the two 0.19.x follow-up fixes that merged after the 0.19.0 tag.
+3. `deploy/release-checklists/260912-repo-harness-0.19.1.md` records the
+   merged-PR table, the upgrade notes for an existing checkpoint backlog, and
+   the verification ledger, updated with the publish readback after npm accepts.
+
+## Scope
+
+- In scope: the version stamp, the changelog entry, the release filing, the
+  five README "Current Release" lines that `tests/readme-dx.test.ts` asserts
+  literally, and this contract's own workflow artifacts.
+- Out of scope: any change under `src/`, `scripts/`, `assets/hooks/`, or
+  `tests/`. The product tree on this branch must stay byte-identical to
+  `2bea52c1`, whose CI is green; a code change here would make the release PR's
+  CI the first and only run over it.
+- Taste constraints: the changelog states what changed and what an operator must
+  do, from the merged diffs. No marketing, no roadmap.
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+
+## Falsifier
+
+The direction is wrong if the branch carries a product diff against `2bea52c1`,
+or if `repo-harness@0.19.1` already exists on npm. Cheapest proof point:
+`git diff --stat 2bea52c1..HEAD -- src scripts assets/hooks tests` must be
+empty, and `bun run check:release` proves the version is unpublished before it
+runs anything else.
+
+## Root Cause Evidence
+
+Required when Task Profile is `bugfix`; leave as-is otherwise.
+
+- root_cause: one sentence naming file:line/condition (testable, not "a state issue").
+- repro: the command or UI path that reproduces the symptom.
+- regression_guard: path to a test that fails on the unfixed code and passes after the fix (must also appear as a `package_test` check in Verification Plan).
+- pre_fix_failure_artifact: path to a captured run of regression_guard on the UNFIXED code. Capture with `bun test <regression_guard> > <artifact> 2>&1; echo "PRE_FIX_EXIT=$?" >> <artifact>` (no pipes — pipes swallow the exit status). The gate requires a non-zero `PRE_FIX_EXIT=` line plus the regression_guard path string in the artifact (see the Root Cause Evidence Gate section in docs/reference-configs/sprint-contracts.md).
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260912-1123-release-0-19-1.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260912-1123-release-0-19-1.review.md`
+- Notes file: `tasks/notes/20260912-1123-release-0-19-1.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Change Assessment
+
+```json
+{"protocol":1,"oracles":[{"id":"version-stamp-consistency","kind":"deterministic_test","paths":["*"]},{"id":"published-release-readback","kind":"runtime_readback","paths":["package.json","assets/skill-version.json","deploy/release-checklists/260912-repo-harness-0.19.1.md"]}]}
+```
+
+## Acceptance Policy
+
+```json
+{"protocol":2,"reviewer":"Codex","source":"codex-plugin","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - plans/
+  - tasks/todos.md
+  - tasks/contracts/20260912-1123-release-0-19-1.contract.md
+  - tasks/reviews/20260912-1123-release-0-19-1.review.md
+  - tasks/notes/20260912-1123-release-0-19-1.notes.md
+  - package.json
+  - assets/skill-version.json
+  - docs/CHANGELOG.md
+  - README.md
+  - README.zh-CN.md
+  - README.ja.md
+  - README.fr.md
+  - README.es.md
+  - deploy/release-checklists/
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+    fallback: null
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+This block contains only non-executable artifact requirements. Define every
+executable check once in the canonical Verification Plan below. Each check must
+state its phase, cost, evidence policy, necessity, and input environment; a
+missing or malformed plan fails closed.
+
+```yaml
+exit_criteria:
+  files_exist:
+    - docs/spec.md
+  artifacts_exist:
+    - .ai/harness/checks/latest.json
+    - tasks/notes/20260912-1123-release-0-19-1.notes.md
+```
+
+## Verification Plan
+
+```json
+{
+  "protocol": 1,
+  "checks": [
+    {
+      "id": "release-gate",
+      "kind": "command",
+      "command": "bun run check:release",
+      "cwd": ".",
+      "phase": "acceptance",
+      "cost": "expensive",
+      "evidence_policy": "current_exact",
+      "necessity": "The explicit release gate. It proves repo-harness@0.19.1 is unpublished and runs scripts/check-ci.sh over the candidate tree; no narrower check establishes the unpublished precondition.",
+      "inputs": { "env": ["NPM_RELEASE_REGISTRY"] }
+    },
+    {
+      "id": "readme-dx",
+      "kind": "package_test",
+      "path": "tests/readme-dx.test.ts",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Asserts the literal release-version strings this contract rewrites across five locales.",
+      "inputs": { "env": [] }
+    },
+    {
+      "id": "skill-version",
+      "kind": "command",
+      "command": "bun scripts/check-skill-version.ts",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Proves package.json and assets/skill-version.json agree on the bumped 0.19.1 stamp.",
+      "inputs": { "env": [] }
+    },
+    {
+      "id": "task-workflow",
+      "kind": "command",
+      "command": "bash scripts/check-task-workflow.sh --strict",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository-integrity check for the workflow artifacts this contract adds.",
+      "inputs": { "env": [] }
+    },
+    {
+      "id": "reference-config-projection-drift",
+      "kind": "command",
+      "command": "bun run check:reference-configs",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Generated docs must match their authoring source on a release candidate.",
+      "inputs": { "env": [] }
+    },
+    {
+      "id": "init-dry-run",
+      "kind": "command",
+      "command": "bun src/cli/index.ts init --repo . --dry-run",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository-integrity check; proves the bumped stamp does not change the adoption plan.",
+      "inputs": { "env": [] }
+    }
+  ]
+}
+```
+
+This is the sole executable verification authority. Use `baseline_with_delta`
+only when a referenced immutable baseline plus named current delta checks prove
+the intended coverage; do not infer that choice from paths or command text.
+
+## Acceptance Notes (Human Review)
+
+- Functional behavior:
+- Edge cases:
+- Regression risks:
+
+## Rollback Point
+
+- Commit / checkpoint:
+- Revert strategy:

--- a/tasks/notes/20260912-1123-release-0-19-1.notes.md
+++ b/tasks/notes/20260912-1123-release-0-19-1.notes.md
@@ -1,0 +1,42 @@
+# Notes: release-0-19-1
+
+## Why this branch carries no product diff
+
+`git diff --stat 2bea52c1..HEAD -- src scripts assets/hooks tests` is empty by
+design. The product tree is exactly `main`, whose CI is green at `2bea52c1`, so
+the release PR's CI re-runs the same suite over an unchanged tree rather than
+becoming the first run over new code. A code change landing here would make the
+release the only gate over it.
+
+## Version choice
+
+Patch, by release-owner decision. The range does add public surface --
+`repo-harness run evidence-gc`, `fleet` registry pruning, the `auto-campaign`
+skill, a repository-scoped operator board -- and moves architecture projection
+execution settings from repository policy to
+`~/.repo-harness/config.json#architecture`, which changes where an operator
+edits them. A strict semver reading puts that in a minor; the owner read the
+range as additive on top of 0.19.0 rather than a new layer. Recorded here and in
+the release filing so the next owner reads the scope from the changelog rather
+than inferring it from the number.
+
+## Changelog composition
+
+The `[Unreleased]` section held two fixes from #399 that merged after the
+0.19.0 tag was cut. They belong to 0.19.1 and were folded into its `### Fixed`
+block rather than left pending.
+
+## README version stamps
+
+`tests/readme-dx.test.ts` asserts the release version literally in all five
+locale READMEs ("Current Release": npm package and generated workflow stamp).
+A version bump that skips them fails the functional CI phase, not a projection
+check, so it surfaces late.
+
+## Publish path on this machine
+
+npm publish has no TOTP configured here; a non-TTY invocation fails with EOTP.
+Use `script -q /dev/null npm publish --auth-type=web --browser=false` and open
+the printed authorization URL.
+
+> **Substantive Change SHA256**: `sha256:77df4b44f485467d2138d5d7f6f5bc93a141712f362426c5e77868d8de6d7df9`

--- a/tasks/reviews/20260912-1123-release-0-19-1.review.md
+++ b/tasks/reviews/20260912-1123-release-0-19-1.review.md
@@ -1,0 +1,84 @@
+# Task Review: release-0-19-1
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260912-1123-release-0-19-1.md
+> **Contract**: tasks/contracts/20260912-1123-release-0-19-1.contract.md
+> **Notes File**: tasks/notes/20260912-1123-release-0-19-1.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-09-12 11:24
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Commands passed:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+- Waza `/check` run:
+- Commands run:
+- Manual checks:
+- Supporting artifacts:
+- Implementation notes reviewed:
+- Run snapshot:
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -1,7 +1,7 @@
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: 2026-09-11 02:38
+> **Updated**: 2026-09-12 11:24
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.


### PR DESCRIPTION
v0.19.0 之後合入 10 個 PR，但下游一個都拿不到：全域安裝的 runtime 還是 0.19.0，Stop 不會套用 run summary retention，`repo-harness run evidence-gc` 也不存在。Checkpoint retention 雖然在 0.19.0 裡，但只在一次成功的 publish 內執行，所以 ledger 被重置或已停用 harness 的 repo，在這版發出去之前對數 GB 的積壓沒有任何操作員出口。

版號取 patch，由發布者決定。這個範圍確實新增了公開 CLI 面（`run evidence-gc`、`fleet` registry pruning）並把 architecture projection 執行設定搬到 `~/.repo-harness/config.json`，嚴格 semver 會判 minor；release filing 與 notes 都記了這個選擇，後面接手的人看 changelog 而不是看號碼。

**分支上沒有產品碼改動**——`git diff 2bea52c1..HEAD -- src scripts assets/hooks tests` 是空的。樹就是 main，CI 在 `2bea52c1` 已經綠過。

## 內容

| PR | 改動 |
| --- | --- |
| #399 | 升級時的安裝所有權；Herdr repo pin 播種 |
| #400 | Architecture projection manifest rebind |
| #402 | `auto-campaign` 有邊界的標準輪 skill |
| #403 | Operator board 按 repo 範圍化 |
| #404 | 顯式 fleet registry pruning |
| #405 | Stop run summary retention 與 `run evidence-gc` |
| #406 | Campaign preparation 在任何 runtime effect 前可重試 |
| #407 | BRC native host execution checkpoint（文件） |
| #401 | Architecture projection 改為全域設定 |
| #408 | 主動提出有量測依據的 refactor 建議 |
| #410 | Evidence retention 契約記錄修正 |

## 驗證

`bun run check:release`（含全量 `scripts/check-ci.sh`）：5328 測試 / 423 檔，3 個失敗全部查明為非回歸——

- `campaign-finish-failure-audit.test.ts` ×2：全量下 per-test 20 秒預算被信號終止（`status=null`）。單獨跑 43 秒、3 pass 0 fail。
- `harness-benchmark-matrix.test.ts` ×1：`tar failed`，測試內硬編 30 秒逾時。在 `main`（不含本 PR 任何改動）上同樣失敗，本機預存問題。

`check-ci.sh governance` 全綠：三個 projection、workflow checks、deploy-sql、ContextScan SAFE、architecture sync `blocking=0`、context map、task-sync digest 已綁。`check-skill-version` 回報 0.19.1／0.19.1。`tests/readme-dx.test.ts` 8 pass。