### PR TITLE
test: build the historical campaign fixture once per file and materialize it per test

### DIFF
--- a/plans/plan-20260912-1948-fixture-template.md
+++ b/plans/plan-20260912-1948-fixture-template.md
@@ -1,0 +1,189 @@
+# Plan: Share the historical campaign fixture by template clone
+
+> **Status**: Executing
+> **Created**: 20260912-1948
+> **Slug**: fixture-template
+> **Planning Source**: codex-plan-or-waza-think
+> **Orchestration Kind**: host-plan
+> **Source Ref**: (none)
+> **Artifact Level**: work-package
+> **Promotion Reason**: verification_boundary
+> **Verification Boundary**: Commands named in the captured planning output plus `repo-harness run verify-contract --contract tasks/contracts/20260912-1948-fixture-template.contract.md --strict`.
+> **Rollback Surface**: Before execution remove `plans/plan-20260912-1948-fixture-template.md`; after execution revert branch `codex/fixture-template` or the explicitly reviewed diff.
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260912-1948-fixture-template.contract.md`
+> **Task Review**: `tasks/reviews/20260912-1948-fixture-template.review.md`
+> **Implementation Notes**: `tasks/notes/20260912-1948-fixture-template.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from codex-plan-or-waza-think planning output.
+- Source ref: (none)
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260912-1948-fixture-template.md`
+- Sprint contract: `tasks/contracts/20260912-1948-fixture-template.contract.md`
+- Sprint review: `tasks/reviews/20260912-1948-fixture-template.review.md`
+- Implementation notes: `tasks/notes/20260912-1948-fixture-template.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260912-1948-fixture-template.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260912-1948-fixture-template.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260912-1948-fixture-template.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260912-1948-fixture-template.contract.md`
+- Review file: `tasks/reviews/20260912-1948-fixture-template.review.md`
+- Implementation notes file: `tasks/notes/20260912-1948-fixture-template.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260912-1948-fixture-template.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260912-1948-fixture-template.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: Before execution remove `plans/plan-20260912-1948-fixture-template.md`; after execution revert branch `codex/fixture-template` or the explicitly reviewed diff.
+- **Verification boundary**: Commands named in the captured planning output plus `repo-harness run verify-contract --contract tasks/contracts/20260912-1948-fixture-template.contract.md --strict`.
+- **Review/acceptance boundary**: `tasks/reviews/20260912-1948-fixture-template.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: verification_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260912-1948-fixture-template.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260912-1948-fixture-template.contract.md`, `tasks/reviews/20260912-1948-fixture-template.review.md`, and `tasks/notes/20260912-1948-fixture-template.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260912-1948-fixture-template.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: Before execution remove `plans/plan-20260912-1948-fixture-template.md`; after execution revert branch `codex/fixture-template` or the explicitly reviewed diff.
+
+## Captured Planning Output
+
+## Goal
+
+Four campaign-lifecycle suites rebuild the same expensive repository fixture once per
+test. Build each distinct fixture once per file and give every later test a pristine
+materialization of it, without weakening per-test isolation and without changing a
+single assertion or test title.
+
+## P1 Map
+
+- `tests/helpers/historical-campaign-lifecycle.ts#historicalPlanningFixture` builds a
+  disposable repository plus a disposable `REPO_HARNESS_HOME`, through
+  `tests/helpers/campaign-adoption-repository.ts#createAdoptionRepository`: two
+  `mkdtemp` roots, `git init`, several `git add`/`git commit` rounds, an Issue-batch
+  adoption and publication, and two planning admissions with a real contract preflight.
+- Consumers: `tests/effects/campaign-closeout.test.ts`,
+  `tests/effects/brc10-lifecycle.test.ts`, `tests/effects/campaign-worker.test.ts`.
+  `tests/effects/campaign-authoring-resume.test.ts` builds the sibling shape directly
+  from `createAdoptionRepository` plus `adoptIssueBatch` and a verified revision
+  observation.
+- `tests/helpers/repo-fixture.ts` already owns disposable repository workspaces after
+  the previous slice, so it is the one place a shared-template mechanism belongs.
+
+## P2 Trace
+
+A fixture is not path-independent. `src/effects/repo-registry.ts#repoHarnessRepoIdFor`
+hashes the repository root path verbatim, and that id is sealed into the program
+authorization, the campaign intent, the registry entry in `registered-repos.json`, the
+work envelope and the publication receipt. `readRegisteredRepos` fails closed when a
+stored id does not re-derive from the canonical path. A template copied to a *new*
+directory would therefore be rejected by the first authority read.
+
+## P3 Decision
+
+Restore the template into the fixture's original `root` and `home` instead of copying
+it to a fresh path. Each test still receives unshared bytes — the previous test's tree
+is removed and rewritten from the pristine snapshot — so isolation is identical to a
+rebuild, while every sealed path-bound digest stays valid. The snapshot is taken
+immediately after the builder returns, before any test mutates it, and is keyed by the
+builder's argument list so variants stay separate.
+
+Rejected alternatives:
+
+- Copy to a fresh path and rewrite absolute paths: impossible, the paths are inside
+  sha256-sealed records.
+- Classify read-only tests and share one fixture among them: needs a per-test audit that
+  rots on the next edit, and it is only necessary when in-place restore does not work.
+
+Trade-off: the restore is one directory copy per test instead of a rebuild, and the
+fixture's recorded timestamps are those of the template build rather than of the test.
+No consumer asserts on fixture build time. At 10x more tests per file the copy cost
+grows linearly while the rebuild cost it replaces grows linearly too, so the ratio holds.
+
+## Scope
+
+- `tests/helpers/repo-fixture.ts`: add `tmpWorkspaceIn` and `fixtureTemplate`.
+- `tests/effects/campaign-closeout.test.ts`, `tests/effects/brc10-lifecycle.test.ts`,
+  `tests/effects/campaign-worker.test.ts`, `tests/effects/campaign-authoring-resume.test.ts`:
+  route the fixture builders through the template and dispose the templates in `afterAll`.
+- Out of scope: `src/`, `scripts/`, `.github/`, every assertion and test title, and
+  `tests/helpers/collaboration-delegation-fixture.ts`.
+
+## Promotion Gate
+
+- **Merge/PR unit**: one PR that changes only test helpers and test plumbing.
+- **Rollback surface**: revert the commit; no product code is touched.
+- **Verification boundary**: the four affected suites, each in isolation and all four in
+  one process, compared test-title by test-title against the pre-change baseline.
+- **Review/acceptance boundary**: zero test loss and unchanged assertions are the
+  acceptance condition, not the timing win.
+- **High-risk surface**: cross-test leakage through a shared fixture directory.
+- **Why not checklist row**: it changes shared test-fixture ownership and needs its own
+  before/after evidence run, which is an independent verification boundary.
+
+## Verification
+
+- `bun test --timeout 180000 <file>` for each of the four files.
+- `bun test --timeout 180000 <all four files>` in one process.
+- `bun test --reporter=junit` before and after, with the `testcase name` multisets diffed.
+- `bun run check:type`, `bun run check:hooks`, `bun run check:helpers`,
+  `bun run check:reference-configs`, `bash scripts/check-architecture-sync.sh`,
+  `bash scripts/check-task-workflow.sh --strict`, `bash scripts/check-task-sync.sh`,
+  `bun src/cli/index.ts init --repo . --dry-run`.
+- No full suite: the change touches four test files and one test helper, every consumer
+  of that helper is named above, and each is run directly.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [ ] Execute captured plan: Share the historical campaign fixture by template clone

--- a/tasks/contracts/20260912-1948-fixture-template.contract.md
+++ b/tasks/contracts/20260912-1948-fixture-template.contract.md
@@ -1,0 +1,381 @@
+# Task Contract: fixture-template
+
+> **Status**: Active
+> **Plan**: plans/plan-20260912-1948-fixture-template.md
+> **Task Profile**: code-change
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: ancienttwo
+> **Capability ID**: root
+> **Last Updated**: 2026-09-12 19:48
+> **Review File**: `tasks/reviews/20260912-1948-fixture-template.review.md`
+> **Notes File**: `tasks/notes/20260912-1948-fixture-template.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+Four campaign-lifecycle suites rebuild the same disposable repository fixture once per
+test, which is the dominant cost of each file. If this ships wrong the failure is not a
+slow suite but a silent one: a fixture shared across tests that leaks state would make
+these suites pass for the wrong reason, and they are the only coverage of campaign
+closeout, recovery, worker settlement and authoring resume.
+
+## Goal
+
+`historicalPlanningFixture` and the authoring-resume fixture are built once per distinct
+argument list per file, and every later test receives a pristine materialization with the
+same isolation a rebuild gives. Every test title, count and assertion in the four files is
+unchanged, proven by a before/after JUnit `testcase name` diff.
+
+## Scope
+
+- In scope:
+  - `tests/helpers/repo-fixture.ts`: `tmpWorkspaceIn` and `fixtureTemplate`.
+  - `tests/effects/campaign-closeout.test.ts`, `tests/effects/brc10-lifecycle.test.ts`,
+    `tests/effects/campaign-worker.test.ts`,
+    `tests/effects/campaign-authoring-resume.test.ts`: route the fixture builders through
+    the template and dispose the templates in `afterAll`.
+- Out of scope:
+  - `src/`, `scripts/`, `.github/`.
+  - Every assertion, test title and test body.
+  - `tests/helpers/collaboration-delegation-fixture.ts`: its builder is synchronous and
+    names its workspace `repoRoot`, so it needs a second mechanism rather than this one.
+- Taste constraints: no per-test read-only/read-write classification; isolation stays
+  structural, not a maintained list.
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+
+## Falsifier
+
+What observable evidence would prove this task's direction wrong, and the cheapest proof point to check first. Leave as-is if not applicable.
+
+## Root Cause Evidence
+
+Required when Task Profile is `bugfix`; leave as-is otherwise.
+
+- root_cause: one sentence naming file:line/condition (testable, not "a state issue").
+- repro: the command or UI path that reproduces the symptom.
+- regression_guard: path to a test that fails on the unfixed code and passes after the fix (must also appear as a `package_test` check in Verification Plan).
+- pre_fix_failure_artifact: path to a captured run of regression_guard on the UNFIXED code. Capture with `bun test <regression_guard> > <artifact> 2>&1; echo "PRE_FIX_EXIT=$?" >> <artifact>` (no pipes — pipes swallow the exit status). The gate requires a non-zero `PRE_FIX_EXIT=` line plus the regression_guard path string in the artifact (see the Root Cause Evidence Gate section in docs/reference-configs/sprint-contracts.md).
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260912-1948-fixture-template.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260912-1948-fixture-template.review.md`
+- Notes file: `tasks/notes/20260912-1948-fixture-template.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Change Assessment
+
+```json
+{"protocol":1,"oracles":[{"id":"affected-suites","kind":"deterministic_test","paths":["*"]}]}
+```
+
+## Acceptance Policy
+
+```json
+{"protocol":2,"reviewer":"Codex","source":"codex-plugin","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - tests/helpers/repo-fixture.ts
+  - tests/effects/campaign-closeout.test.ts
+  - tests/effects/brc10-lifecycle.test.ts
+  - tests/effects/campaign-worker.test.ts
+  - tests/effects/campaign-authoring-resume.test.ts
+  - plans/plan-20260912-1948-fixture-template.md
+  - tasks/todos.md
+  - tasks/contracts/20260912-1948-fixture-template.contract.md
+  - tasks/reviews/20260912-1948-fixture-template.review.md
+  - tasks/notes/20260912-1948-fixture-template.notes.md
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+    fallback: null
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+This block contains only non-executable artifact requirements. Define every
+executable check once in the canonical Verification Plan below. Each check must
+state its phase, cost, evidence policy, necessity, and input environment; a
+missing or malformed plan fails closed. Populate artifact requirements only
+for deliverables this task actually owns; do not create a spec, notes or report
+merely to fill this template.
+
+```yaml
+exit_criteria:
+  files_exist:
+    - tests/helpers/repo-fixture.ts
+  artifacts_exist:
+    - tasks/notes/20260912-1948-fixture-template.notes.md
+```
+
+## Verification Plan
+
+```json
+{
+  "protocol": 1,
+  "checks": [
+    {
+      "id": "campaign-closeout",
+      "kind": "package_test",
+      "path": "tests/effects/campaign-closeout.test.ts",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Fixture consumer whose builders now materialize from a template.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "brc10-lifecycle",
+      "kind": "package_test",
+      "path": "tests/effects/brc10-lifecycle.test.ts",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Fixture consumer whose builders now materialize from a template.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "campaign-worker",
+      "kind": "package_test",
+      "path": "tests/effects/campaign-worker.test.ts",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Fixture consumer whose builders now materialize from a template.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "campaign-authoring-resume",
+      "kind": "package_test",
+      "path": "tests/effects/campaign-authoring-resume.test.ts",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Fixture consumer whose builders now materialize from a template.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "new-plan",
+      "kind": "package_test",
+      "path": "tests/new-plan.test.ts",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Existing tmpWorkspace consumer, covering the repo-fixture refactor that moved its body into tmpWorkspaceIn.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "check-type",
+      "kind": "command",
+      "command": "bun run check:type",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "The new generic template signature must type-check against every call site.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "check-hooks",
+      "kind": "command",
+      "command": "bun run check:hooks",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository integrity check for substantive changes.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "check-helpers",
+      "kind": "command",
+      "command": "bun run check:helpers",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository integrity check for substantive changes.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "check-reference-configs",
+      "kind": "command",
+      "command": "bun run check:reference-configs",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository integrity check for substantive changes.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "check-architecture-sync",
+      "kind": "command",
+      "command": "bash scripts/check-architecture-sync.sh",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository integrity check for substantive changes.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "check-task-workflow",
+      "kind": "command",
+      "command": "bash scripts/check-task-workflow.sh --strict",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository integrity check for substantive changes.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "check-task-sync",
+      "kind": "command",
+      "command": "bash scripts/check-task-sync.sh",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository integrity check; the digest is bound to the merge base.",
+      "inputs": {
+        "env": [
+          "REPO_HARNESS_DIFF_BASE",
+          "REPO_HARNESS_DIFF_MODE"
+        ]
+      }
+    },
+    {
+      "id": "init-dry-run",
+      "kind": "command",
+      "command": "bun src/cli/index.ts init --repo . --dry-run",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository integrity check for substantive changes.",
+      "inputs": {
+        "env": []
+      }
+    }
+  ]
+}
+```
+
+Author the actual checks using [Testing Policy and Artifact Standards](../../docs/reference-configs/sprint-contracts.md#testing-policy-and-artifact-standards).
+The empty array is not permission to omit required repository checks: retain it
+only when no executable criterion applies and explain why in Acceptance Notes.
+Prefer existing covering tests; creating a task-named test or adding typecheck
+is not a template requirement. For each selected check declare `id`, `kind`,
+`cwd`, `phase`, `cost`, `evidence_policy`, `necessity`, `inputs.env`, and its
+`command` or `path`. Declare the same execution once, including checks nested
+inside aggregate scripts. Use `baseline_with_delta` only with an immutable
+baseline and named current delta checks; never infer it from paths or command text.
+
+## Acceptance Notes (Human Review)
+
+- Changed behavior/boundary, existing covering tests and remaining gap: only test plumbing
+  changes. The four suites keep their own assertions as the behavioral coverage; the new
+  `fixtureTemplate` has no separate unit test because its only contract — a pristine tree
+  per caller — is exactly what those suites assert by passing unchanged.
+- New test case/file rationale, or why existing coverage is sufficient: no new test. Adding
+  one would restate the four suites' isolation requirement in a weaker form.
+- Selected check IDs and why their coverage is sufficient; omitted coverage: the four
+  `package_test` checks are the complete consumer set of the changed fixture path;
+  `new-plan` covers the additive `tmpWorkspace` refactor for the other `repo-fixture.ts`
+  consumers, whose call sites are unchanged and covered by `check-type`. The remaining
+  checks are the repository integrity set.
+- Full/expensive check justification and expected cost, if applicable: no full suite. The
+  change touches four test files and one test helper; every consumer of the changed helper
+  exports is named and run directly, and CI runs the full suite on the PR.
+- Execution/baseline references, subject, current delta and disposition: baseline and
+  post-change runs were taken on the same machine in the same session; the JUnit
+  `testcase name` multisets are byte-identical (171 entries), and the combined four-file
+  run reports the same 77 pass / 4 skip / 0 fail / 493 expect() calls before and after.
+- Residual risks and incomplete observations: a future fixture that bakes a *second*
+  absolute path outside `root` and `home` would need that path added to the template, and
+  `fixtureTemplate` would not notice. `tests/helpers/collaboration-delegation-fixture.ts`
+  is untouched and still rebuilds per test.
+
+## Rollback Point
+
+- Commit / checkpoint: `origin/main` at the branch point of `codex/fixture-template`.
+- Revert strategy: revert the single commit; no product code, migration or state is
+  involved.

--- a/tasks/notes/20260912-1948-fixture-template.notes.md
+++ b/tasks/notes/20260912-1948-fixture-template.notes.md
@@ -1,0 +1,100 @@
+# Implementation Notes: fixture-template
+
+> **Status**: Active
+> **Plan**: plans/plan-20260912-1948-fixture-template.md
+> **Contract**: tasks/contracts/20260912-1948-fixture-template.contract.md
+> **Review**: tasks/reviews/20260912-1948-fixture-template.review.md
+> **Last Updated**: 2026-09-12 19:48
+> **Lifecycle**: notes
+> **Substantive Change SHA256**: `sha256:e865a8acd82b5529483307bdff50915ffe5b7e9f2cd437a53ff504972b86983a`
+
+## Design Decisions
+
+- **Restore in place, do not clone to a new path.** `repoHarnessRepoIdFor`
+  (`src/effects/repo-registry.ts:105`) hashes the repository root path verbatim, and that
+  id is sealed into the program authorization, the campaign intent, the
+  `registered-repos.json` entry, the work envelope and the publication receipt.
+  `readRegisteredRepos` fails closed when a stored id does not re-derive from the
+  canonical path, so a template copied to a fresh directory is rejected by the first
+  authority read. `fixtureTemplate` therefore deletes the fixture's own `root` and `home`
+  and rewrites them from a pristine snapshot taken right after the builder returned. Each
+  test still gets unshared bytes; only the path is reused, and the tests are sequential
+  within a file.
+- **No origin/clone rewrite was needed.** `createAdoptionRepository`
+  (`tests/helpers/campaign-adoption-repository.ts:21`) builds a single `git init`
+  repository with no remote, so there is no remote URL to re-point after a copy. The git
+  worktrees that `installHistoricalBoundDispatch` creates live under `home` and are
+  registered in `root/.git`, and both are replaced together by the restore, so no stale
+  registration survives.
+- **The template boundary is the expensive builder, not the whole per-test setup.**
+  `installHistoricalBoundDispatch` and the closeout budget step stay per test: they are
+  in-process, they mint a fresh `randomUUID` claim, and the suites assert on the lease
+  generations they produce.
+- **Keyed by the builder's argument list.** `campaign-closeout.test.ts` uses three distinct
+  argument tuples and `campaign-authoring-resume.test.ts` five, so one template per file
+  would have been wrong; `JSON.stringify(args)` keeps the variants separate and builds each
+  exactly once.
+- **Templates are materialized lazily inside the first test that needs them, and every call
+  site already builds its fixture before installing any spy or clock seam**, so no template
+  is ever built under a mocked module.
+- **`cpSync` uses `verbatimSymlinks`** so a symlink in the snapshot is restored as a
+  symlink rather than being dereferenced into a copy; file modes are preserved by `cpSync`
+  itself. Timestamps are deliberately *not* preserved, so a restored tree looks as freshly
+  written as a rebuilt one.
+
+## Deviations From Plan Or Spec
+
+- `tests/effects/campaign-closeout.test.ts:313` keeps its direct `historicalPlanningFixture`
+  call. That argument tuple has exactly one consumer, so templating it would pay a snapshot
+  copy for no reuse.
+- `tests/helpers/collaboration-delegation-fixture.ts` is not converted. Its builder
+  `createCollaborationDelegationFixture` is synchronous, so it cannot use the async
+  `materialize`; it names its workspace `repoRoot` rather than `root`; and it pushes into
+  the caller's `roots` array from inside the builder. Converting it needs a synchronous twin
+  of `fixtureTemplate` plus a workspace-path selector, which is a second mechanism for a
+  single consumer. Left as the next slice.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| Clone the template to a fresh path per test | Rejected | The fixture's repository id is a hash of its root path and is sealed into records that cannot be rewritten. |
+| Classify read-only tests and share one fixture among them | Rejected | Needs a per-test audit that rots on the next edit, and it is only necessary when an in-place restore does not work. |
+| Restore the snapshot into the fixture's own paths | Chosen | Keeps every path-bound digest valid while still giving each test unshared bytes. |
+| Template the whole per-test setup including the bound dispatch | Rejected | The dispatch mints a fresh claim id and the suites assert on the lease generations it produces. |
+
+## Open Questions
+
+- None.
+
+## Measured Cost
+
+Same machine, same session, `bun test --timeout 180000` per file. The absolute numbers are
+much higher than CI's because the machine was loaded; the ratio is the subject.
+
+| File | Before | After | Delta |
+|------|--------|-------|-------|
+| `tests/effects/campaign-closeout.test.ts` | 199.62s | 133.80s | -33.0% |
+| `tests/effects/brc10-lifecycle.test.ts` | 199.19s | 109.34s | -45.1% |
+| `tests/effects/campaign-authoring-resume.test.ts` | 159.17s | 94.21s | -40.8% |
+| `tests/effects/campaign-worker.test.ts` | 63.07s | 51.59s | -18.2% |
+| All four in one `bun test` process | 676.33s | 376.25s | -44.4% |
+
+Zero test loss: the JUnit `testcase name` multisets of the combined before/after runs are
+identical (171 entries), and both runs report 77 pass / 4 skip / 0 fail / 493 expect() calls
+across 81 tests.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/reviews/20260912-1948-fixture-template.review.md
+++ b/tasks/reviews/20260912-1948-fixture-template.review.md
@@ -1,0 +1,98 @@
+# Task Review: fixture-template
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260912-1948-fixture-template.md
+> **Contract**: tasks/contracts/20260912-1948-fixture-template.contract.md
+> **Notes File**: tasks/notes/20260912-1948-fixture-template.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-09-12 19:48
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Check IDs and evidence disposition:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+Follow [Testing Policy and Artifact Standards](../../docs/reference-configs/sprint-contracts.md#testing-policy-and-artifact-standards).
+Consume canonical evidence; do not rerun checks to populate this review or
+copy the executable plan. Return missing/stale evidence to its execution owner.
+
+- Waza `/check` review reference, when required:
+- Check IDs and disposition (executed / exact reuse / baseline with delta / failed / missing / not run):
+- Verified subject, relevant environment and immutable execution references:
+- Historical baseline and current delta references, if applicable:
+- Manual observations, failures and coverage limitations:
+- Implementation notes reviewed, if present:
+- Run snapshot:
+
+## Manual Check Evidence
+
+Copy each non-built-in contract `manual_checks` requirement exactly. Check it only after
+the observation is complete and replace the placeholder with concrete command output,
+screenshot/artifact path, or reviewer observation.
+
+- [ ] Exact manual_checks requirement
+  - Evidence: concrete observation, command output, screenshot path, or reviewer note
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -1,7 +1,7 @@
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: (archive-workflow)
+> **Updated**: 2026-09-12 19:48
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.

--- a/tests/effects/brc10-lifecycle.test.ts
+++ b/tests/effects/brc10-lifecycle.test.ts
@@ -1,5 +1,5 @@
 import { readTaskAutomationAttemptCurrent } from '../../src/effects/engineers/automation-attempt-store';
-import { afterEach, expect, test } from 'bun:test';
+import { afterAll, afterEach, expect, test } from 'bun:test';
 import { existsSync, rmSync, writeFileSync, readFileSync, mkdirSync, chmodSync } from 'fs';
 import { join } from 'path';
 import { execFileSync, spawnSync } from 'child_process';
@@ -7,6 +7,7 @@ import { readPlanningRecord } from '../../src/effects/automation/campaign-planni
 import { campaignRuntimeRecordKey } from '../../src/core/automation/campaign-runtime';
 import { historicalPlanningFixture, installHistoricalBoundDispatch, installHistoricalAttempt, installHistoricalChild, installHistoricalFinal } from '../helpers/historical-campaign-lifecycle';
 import { prepareHistoricalCodexInvocation } from '../helpers/historical-campaign-lifecycle';
+import { fixtureTemplate } from '../helpers/repo-fixture';
 import { persistPlanningRecord } from '../../src/effects/automation/campaign-planning-store';
 import { bindCampaignWorker, readCompletedCampaignWorker } from '../../src/effects/automation/campaign-worker';
 import { retireCampaignDispatch, observeCampaignReclaimEligibility, recoverCampaignDispatch } from '../../src/effects/automation/campaign-recovery';
@@ -17,9 +18,11 @@ import { readClaimTokenForTask } from '../../src/effects/state/coordination-clai
 import { readClaimActorReceipt } from '../../src/effects/engineers/claim-actor-store';
 
 const roots: string[] = [];
+const templates = fixtureTemplate(historicalPlanningFixture);
 afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }); });
+afterAll(() => templates.dispose());
 async function acquired() {
-  const f = await historicalPlanningFixture(); roots.push(f.root, f.home);
+  const f = await templates.materialize(); roots.push(f.root, f.home);
   const result = installHistoricalBoundDispatch(f);
   if (!('worker_handoff' in result) || !result.worker_handoff || !result.envelope) throw new Error(JSON.stringify(result));
   roots.push(result.envelope.worktree_path);

--- a/tests/effects/campaign-authoring-resume.test.ts
+++ b/tests/effects/campaign-authoring-resume.test.ts
@@ -1,11 +1,12 @@
 import * as issueStore from '../../src/effects/automation/issue-batch-store';
 import { buildProviderIssueObservation, buildExternalSourceRefreshReceipt } from '../../src/core/external-sources/issue-observation';
-import { afterEach, expect, test, spyOn } from 'bun:test';
+import { afterAll, afterEach, expect, test, spyOn } from 'bun:test';
 import { execFileSync } from 'child_process';
 import { readFileSync, readdirSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { createHash } from 'crypto';
 import { createAdoptionRepository, observeVerifiedFixtureRevision } from '../helpers/campaign-adoption-repository';
+import { fixtureTemplate } from '../helpers/repo-fixture';
 import { campaignBrowserMetadata } from '../helpers/campaign-browser-session';
 import { makeSnapshot } from '../helpers/issue-batch-adoption-fixture';
 import { sealProgramAuthorization } from '../../src/core/automation/budget';
@@ -24,9 +25,8 @@ import { canonicalMessageBytes, canonicalMessageDigest } from '../../src/core/me
 const roots: string[] = [];
 afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }); });
 const git = (root: string, args: string[]) => execFileSync('git', args, { cwd: root, encoding: 'utf8', stdio: ['ignore','pipe','pipe'] }).trim();
-async function fixture(stop = true, usage: 'none' | 'open' | 'acquired' = 'none') {
+async function buildFixture(stop: boolean, usage: 'none' | 'open' | 'acquired') {
   const f = await createAdoptionRepository('active', 1, undefined, {}, {}, { verified_revision: true, max_agent_turns: 30, max_runner_invocations: 30 });
-  roots.push(f.root, f.home);
   const adopted = await adoptIssueBatch(f.input, f.deps);
   git(f.root, ['merge', '--ff-only', adopted.publication!.materialized_commit]);
   if (usage !== 'none') {
@@ -95,6 +95,13 @@ async function fixture(stop = true, usage: 'none' | 'open' | 'acquired' = 'none'
   const adoptionArtifacts = () => Object.fromEntries(readdirSync(join(issueBatchGroupStoreRoot(f.root, f.intent.campaign_id, 1), 'adoption'))
     .sort().map(name => [name, readFileSync(join(issueBatchGroupStoreRoot(f.root, f.intent.campaign_id, 1), 'adoption', name), 'utf8')]));
   return { ...f, adopted, resume, successor, failedSuccessor, readBinding, adoptionPath, adoptSuccessor, adoptionArtifacts };
+}
+const templates = fixtureTemplate(buildFixture);
+afterAll(() => templates.dispose());
+async function fixture(stop = true, usage: 'none' | 'open' | 'acquired' = 'none') {
+  const f = await templates.materialize(stop, usage);
+  roots.push(f.root, f.home);
+  return f;
 }
 
 test.each(['exact', 'replacement', 'partial'] as const)('stopped adopted source enforces %s Issue identities through real admission', async mode => {

--- a/tests/effects/campaign-closeout.test.ts
+++ b/tests/effects/campaign-closeout.test.ts
@@ -11,7 +11,7 @@ import { publicationPointerFromReceipt } from '../../src/core/publication/public
 import { writePublicationReceiptCache } from '../../src/effects/publication/publication-receipt';
 import { resolveGitCommonDirectory } from '../../src/effects/git/common-directory';
 import { readDevelopmentCampaignStatus, appendDevelopmentCampaignEvent } from '../../src/effects/automation/development-campaign-store';
-import { afterEach, expect, test } from 'bun:test';
+import { afterAll, afterEach, expect, test } from 'bun:test';
 import { rmSync, realpathSync, mkdtempSync, writeFileSync, readFileSync, existsSync, mkdirSync, chmodSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -19,14 +19,17 @@ import { execFileSync, spawnSync } from 'child_process';
 import { cleanupExactWorktree, assertWorktreeBinding } from '../../src/effects/state/coordination-worktree-topology';
 import { canonicalMessageDigest, messageSha256 } from '../../src/core/messages/mechanics';
 import { historicalPlanningFixture, installHistoricalBoundDispatch, installHistoricalAttempt, installHistoricalChild, installHistoricalFinal } from '../helpers/historical-campaign-lifecycle';
+import { fixtureTemplate } from '../helpers/repo-fixture';
 import { ensureCampaignAuthoringBudget, beginCampaignBudgetStep, readCampaignBudgetLedger } from '../../src/effects/automation/budget-store';
 import { readPlanningRecord, persistPlanningRecord, withCampaignPlanningLock } from '../../src/effects/automation/campaign-planning-store';
 import { runCampaignCloseoutProviderAttempt } from '../../src/effects/automation/campaign-closeout-provider';
 
 const roots: string[] = [];
+const templates = fixtureTemplate(historicalPlanningFixture);
 afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }); });
+afterAll(() => templates.dispose());
 async function fixture(recoveryBudget = false) {
-  const f = await historicalPlanningFixture(false, false, undefined, true, recoveryBudget ? { max_provider_failures: 10 } : {}); roots.push(f.root, f.home);
+  const f = await templates.materialize(false, false, undefined, true, recoveryBudget ? { max_provider_failures: 10 } : {}); roots.push(f.root, f.home);
   const budget = ensureCampaignAuthoringBudget({ repo_root: f.root, authorization: f.authorization, env: f.env }).budget;
   const step = { repo_root: f.root, automation_run_id: budget.automation_run_id, expected_budget_sha256: budget.budget_sha256,
     campaign_id: f.intent.campaign_id, group_number: 1 as const, intent_sha256: f.intent.intent_sha256, idempotency_key: 'closeout-fixture', env: f.env };
@@ -109,7 +112,7 @@ test('shared lifecycle refuses audit while published Tasks lack cleanup receipts
 }, 60_000);
 
 async function acquired(recoveryBudget = false) {
-  const f = await historicalPlanningFixture(false, false, undefined, true, { max_agent_turns: 40, max_runner_invocations: 40, ...(recoveryBudget ? { max_provider_failures: 10 } : {}) }); roots.push(f.root, f.home);
+  const f = await templates.materialize(false, false, undefined, true, { max_agent_turns: 40, max_runner_invocations: 40, ...(recoveryBudget ? { max_provider_failures: 10 } : {}) }); roots.push(f.root, f.home);
   const result = installHistoricalBoundDispatch(f);
   if (!('worker_handoff' in result) || !result.worker_handoff || !result.envelope) throw new Error(JSON.stringify(result));
   roots.push(result.envelope.worktree_path);

--- a/tests/effects/campaign-worker.test.ts
+++ b/tests/effects/campaign-worker.test.ts
@@ -1,10 +1,11 @@
 import * as revisionAdmission from '../../src/effects/automation/campaign-revision-admission';
 import * as campaignRuntime from '../../src/effects/automation/campaign-runtime';
-import { afterEach, expect, test, spyOn } from 'bun:test';
+import { afterAll, afterEach, expect, test, spyOn } from 'bun:test';
 import { spawnSync } from 'child_process';
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { historicalPlanningFixture, installHistoricalBoundDispatch, installHistoricalAttempt, installHistoricalFinal } from '../helpers/historical-campaign-lifecycle';
+import { fixtureTemplate } from '../helpers/repo-fixture';
 import { ensureCampaignAuthoringBudget, readAutomationBudgetStatus, appendAutomationUsage, readAutomationUsageForResult } from '../../src/effects/automation/budget-store';
 import { bindCampaignWorker, createCampaignWorkerHandoff } from '../../src/effects/automation/campaign-worker';
 import { recoverCampaignDispatch } from '../../src/effects/automation/campaign-recovery';
@@ -18,9 +19,11 @@ import { campaignRuntimeRecordKey } from '../../src/core/automation/campaign-run
 import { campaignContainerDirectory } from '../../src/effects/automation/campaign-container';
 import { resolveGitCommonDirectory } from '../../src/effects/git/common-directory';
 const roots: string[] = [];
+const templates = fixtureTemplate(historicalPlanningFixture);
 afterEach(() => roots.splice(0).forEach(root => rmSync(root, { recursive: true, force: true })));
+afterAll(() => templates.dispose());
 async function acquired() {
-  const f = await historicalPlanningFixture(); roots.push(f.root, f.home);
+  const f = await templates.materialize(); roots.push(f.root, f.home);
   const result = installHistoricalBoundDispatch(f);
   return { ...f, result, worktree: result.envelope.worktree_path };
 }

--- a/tests/helpers/repo-fixture.ts
+++ b/tests/helpers/repo-fixture.ts
@@ -1,8 +1,8 @@
 import { afterAll, expect } from "bun:test";
 import { spawnSync } from "child_process";
-import { mkdtempSync, realpathSync, rmSync } from "fs";
+import { cpSync, mkdtempSync, realpathSync, rmSync } from "fs";
 import { tmpdir } from "os";
-import { join } from "path";
+import { dirname, join } from "path";
 
 const homes = new Map<string, string>();
 function fixtureHome(cwd: string): string {
@@ -30,7 +30,54 @@ const SANDBOX_ENV_BLOCKLIST = [
 ];
 
 export function tmpWorkspace(prefix: string): string {
-  return realpathSync(mkdtempSync(join(tmpdir(), `${prefix}-`)));
+  return tmpWorkspaceIn(tmpdir(), prefix);
+}
+
+export function tmpWorkspaceIn(parent: string, prefix: string): string {
+  return realpathSync(mkdtempSync(join(parent, `${prefix}-`)));
+}
+
+export interface FixtureWorkspace {
+  readonly root: string;
+  readonly home: string;
+}
+
+/**
+ * Build an expensive repository fixture once per distinct argument list and give
+ * every later caller a pristine materialization of it.
+ *
+ * The snapshot is restored into the original `root` and `home`, never copied to a
+ * fresh path: `repoHarnessRepoIdFor` hashes the repository root verbatim, so the
+ * sealed authorization, registry entry, campaign intent and publication recorded
+ * inside a fixture are all bound to that exact path. Restoring in place therefore
+ * keeps the returned value valid while giving each caller unshared bytes, which is
+ * the same isolation a rebuild provides.
+ */
+export function fixtureTemplate<A extends readonly unknown[], T extends FixtureWorkspace>(build: (...args: A) => Promise<T>) {
+  const templates = new Map<string, { readonly value: T; readonly store: string }>();
+  return {
+    async materialize(...args: A): Promise<T> {
+      const key = JSON.stringify(args);
+      const cached = templates.get(key);
+      if (cached) {
+        for (const [name, path] of [["root", cached.value.root], ["home", cached.value.home]] as const) {
+          rmSync(path, { recursive: true, force: true });
+          cpSync(join(cached.store, name), path, { recursive: true, verbatimSymlinks: true });
+        }
+        return cached.value;
+      }
+      const value = await build(...args);
+      const store = tmpWorkspaceIn(dirname(value.root), "fixture-template");
+      cpSync(value.root, join(store, "root"), { recursive: true, verbatimSymlinks: true });
+      cpSync(value.home, join(store, "home"), { recursive: true, verbatimSymlinks: true });
+      templates.set(key, { value, store });
+      return value;
+    },
+    dispose(): void {
+      for (const { store } of templates.values()) rmSync(store, { recursive: true, force: true });
+      templates.clear();
+    },
+  };
 }
 
 export function sandboxEnv(env?: NodeJS.ProcessEnv): NodeJS.ProcessEnv {


### PR DESCRIPTION
## What changed

Four campaign-lifecycle suites rebuilt the same disposable repository and
`REPO_HARNESS_HOME` once per test. `fixtureTemplate` (`tests/helpers/repo-fixture.ts`)
now builds each distinct fixture once per file and gives every later caller a pristine
materialization of it.

The snapshot is restored into the fixture's **own** `root` and `home`, not copied to a
fresh directory. `repoHarnessRepoIdFor` (`src/effects/repo-registry.ts:105`) hashes the
repository root path verbatim, and that id is sealed into the program authorization, the
campaign intent, the `registered-repos.json` entry, the work envelope and the publication
receipt; `readRegisteredRepos` fails closed when a stored id does not re-derive from the
canonical path. Restoring in place keeps every one of those digests valid while each test
still receives unshared bytes, so isolation is exactly what a rebuild gave.

Templates are keyed by the builder's argument list, because `campaign-closeout.test.ts`
uses three distinct tuples and `campaign-authoring-resume.test.ts` five.

No product code, no assertion, no test title and no test body changed.

## Cost, before and after

Same machine, same session, `bun test --timeout 180000`. Absolute numbers run high because
the machine was loaded; the ratio is the subject.

| File | Before | After | Delta |
|------|--------|-------|-------|
| `tests/effects/campaign-closeout.test.ts` | 199.62s | 133.80s | -33.0% |
| `tests/effects/brc10-lifecycle.test.ts` | 199.19s | 109.34s | -45.1% |
| `tests/effects/campaign-authoring-resume.test.ts` | 159.17s | 94.21s | -40.8% |
| `tests/effects/campaign-worker.test.ts` | 63.07s | 51.59s | -18.2% |
| All four in one `bun test` process | 676.33s | 376.25s | -44.4% |

## Zero test loss

`bun test --reporter=junit` over the four files, before and after:

- `testcase name` multisets are byte-identical: `diff` over 171 sorted `name="..."`
  attributes reports no difference.
- Both runs: `Ran 81 tests across 4 files`, `77 pass`, `4 skip`, `0 fail`,
  `493 expect() calls`.
- Each file also passes on its own, which is the cross-file-leak check paired with the
  single-process run above.

## Verification

`bun run check:type`, `bun run check:hooks`, `bun run check:helpers`,
`bun run check:reference-configs`, `bash scripts/check-architecture-sync.sh`,
`bash scripts/check-task-workflow.sh --strict`,
`REPO_HARNESS_DIFF_BASE=origin/main REPO_HARNESS_DIFF_MODE=merge-base bash scripts/check-task-sync.sh`,
`bun src/cli/index.ts init --repo . --dry-run`, plus `tests/new-plan.test.ts` as an
existing `tmpWorkspace` consumer covering the additive `repo-fixture.ts` refactor.

No local full suite: the change touches four test files and one test helper, every
consumer of the changed helper exports is named and run directly, and CI runs the full
suite here.

## Not in this PR

`tests/helpers/collaboration-delegation-fixture.ts` still rebuilds per test. Its builder is
synchronous, names its workspace `repoRoot`, and pushes into the caller's `roots` array from
inside the builder, so it needs a synchronous twin of `fixtureTemplate` plus a workspace-path
selector rather than this mechanism. Left as the next slice.
