### PR TITLE
test(fixtures): materialize the collaboration delegation fixture from a template

### DIFF
--- a/plans/plan-20260912-2303-delegation-template.md
+++ b/plans/plan-20260912-2303-delegation-template.md
@@ -1,0 +1,151 @@
+# Plan: Template the collaboration delegation fixture
+
+> **Status**: Executing
+> **Created**: 20260912-2303
+> **Slug**: delegation-template
+> **Planning Source**: codex-plan-or-waza-think
+> **Orchestration Kind**: host-plan
+> **Source Ref**: (none)
+> **Artifact Level**: work-package
+> **Promotion Reason**: verification_boundary
+> **Verification Boundary**: Commands named in the captured planning output plus `repo-harness run verify-contract --contract tasks/contracts/20260912-2303-delegation-template.contract.md --strict`.
+> **Rollback Surface**: Before execution remove `plans/plan-20260912-2303-delegation-template.md`; after execution revert branch `codex/delegation-template` or the explicitly reviewed diff.
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260912-2303-delegation-template.contract.md`
+> **Task Review**: `tasks/reviews/20260912-2303-delegation-template.review.md`
+> **Implementation Notes**: `tasks/notes/20260912-2303-delegation-template.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from codex-plan-or-waza-think planning output.
+- Source ref: (none)
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260912-2303-delegation-template.md`
+- Sprint contract: `tasks/contracts/20260912-2303-delegation-template.contract.md`
+- Sprint review: `tasks/reviews/20260912-2303-delegation-template.review.md`
+- Implementation notes: `tasks/notes/20260912-2303-delegation-template.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260912-2303-delegation-template.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260912-2303-delegation-template.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260912-2303-delegation-template.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260912-2303-delegation-template.contract.md`
+- Review file: `tasks/reviews/20260912-2303-delegation-template.review.md`
+- Implementation notes file: `tasks/notes/20260912-2303-delegation-template.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260912-2303-delegation-template.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260912-2303-delegation-template.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: Before execution remove `plans/plan-20260912-2303-delegation-template.md`; after execution revert branch `codex/delegation-template` or the explicitly reviewed diff.
+- **Verification boundary**: Commands named in the captured planning output plus `repo-harness run verify-contract --contract tasks/contracts/20260912-2303-delegation-template.contract.md --strict`.
+- **Review/acceptance boundary**: `tasks/reviews/20260912-2303-delegation-template.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: verification_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260912-2303-delegation-template.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260912-2303-delegation-template.contract.md`, `tasks/reviews/20260912-2303-delegation-template.review.md`, and `tasks/notes/20260912-2303-delegation-template.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260912-2303-delegation-template.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: Before execution remove `plans/plan-20260912-2303-delegation-template.md`; after execution revert branch `codex/delegation-template` or the explicitly reviewed diff.
+
+## Captured Planning Output
+
+## Context
+
+`tests/effects/collaboration-contribution-collector.test.ts` rebuilt the C4
+delegation fixture 17 times per run: each rebuild runs `git init`, two commits,
+a `.codex` copy, and one real `bun src/cli/index.ts delegation capability` child
+process. Baseline isolate run: 87s for 35 tests.
+
+PR #421 already landed `fixtureTemplate()` in `tests/helpers/repo-fixture.ts`,
+but it only accepts an async builder and only snapshots a `{ root, home }`
+workspace. The delegation fixture is a synchronous builder consumed by
+synchronous test bodies, and its workspace field is `repoRoot`.
+
+## Decision
+
+Relax `fixtureTemplate()` rather than add a parallel API:
+
+- an overload pair lets `materialize()` mirror the builder, so a synchronous
+  builder keeps a synchronous call site and the 35 existing test bodies stay
+  synchronous;
+- an optional `workspacePaths` selector names the directories to snapshot, so a
+  fixture that does not use the `{ root, home }` shape is expressible;
+- the store layout becomes index-keyed instead of `root`/`home`-keyed.
+
+The template boundary stops at the expensive builder. Each test still receives
+unshared bytes restored into the fixture's own paths, because
+`repoHarnessRepoIdFor()` hashes the repository root verbatim.
+
+Cleanup ownership moves to the call site: the builder's `roots` argument is
+discarded and `delegationFixture()` registers both directories for `afterEach`,
+because on a cache hit the builder never runs.
+
+## Task Breakdown
+
+- [x] Relax `fixtureTemplate()` to support a synchronous builder and a workspace
+      path selector.
+- [x] Rewire `collaboration-contribution-collector.test.ts` onto the template.
+- [x] Prove zero test loss and no cross-file leakage.
+
+## Verification Plan
+
+- `bun test --timeout 180000 tests/effects/collaboration-contribution-collector.test.ts`
+- `bun test --timeout 180000 tests/effects/campaign-worker.test.ts`
+- `bun test --timeout 180000 tests/effects/collaboration-*.test.ts`
+- `bun run check:type`
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [x] Relax `fixtureTemplate()` to support a synchronous builder and a workspace
+- [x] Rewire `collaboration-contribution-collector.test.ts` onto the template.
+- [x] Prove zero test loss and no cross-file leakage.

--- a/tasks/contracts/20260912-2303-delegation-template.contract.md
+++ b/tasks/contracts/20260912-2303-delegation-template.contract.md
@@ -1,0 +1,385 @@
+# Task Contract: delegation-template
+
+> **Status**: Active
+> **Plan**: plans/plan-20260912-2303-delegation-template.md
+> **Task Profile**: code-change
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: ancienttwo
+> **Capability ID**: root
+> **Last Updated**: 2026-09-12 23:03
+> **Review File**: `tasks/reviews/20260912-2303-delegation-template.review.md`
+> **Notes File**: `tasks/notes/20260912-2303-delegation-template.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+`tests/effects/collaboration-contribution-collector.test.ts` rebuilds the C4 delegation
+fixture 17 times per run, and each rebuild spends a `git init`, two commits and one real
+`bun src/cli/index.ts delegation capability` child process before the first assertion. If
+this ships wrong the failure is silent rather than slow: this file is the only coverage of
+the contribution collector's crash-and-converge matrix and of the actor/destination
+binding, so a fixture that leaked state between tests would let all 35 tests pass for the
+wrong reason.
+
+## Goal
+
+`createCollaborationDelegationFixture` is built once per distinct argument list in that
+file and every later test receives a pristine materialization with the same isolation a
+rebuild gives. `fixtureTemplate` gains a synchronous path and a workspace-path selector
+instead of a second parallel mechanism. Every test title, count and assertion is
+unchanged, proven by a before/after JUnit `testcase name` diff.
+
+## Scope
+
+- In scope:
+  - `tests/helpers/repo-fixture.ts`: `fixtureTemplate` accepts a synchronous builder and an
+    explicit `workspacePaths` selector; the snapshot store becomes index-keyed.
+  - `tests/effects/collaboration-contribution-collector.test.ts`: route the delegation
+    fixture through the template and dispose it in `afterAll`.
+- Out of scope:
+  - `src/`, `scripts/`, `.github/`.
+  - Every assertion, test title and test body.
+  - `tests/helpers/collaboration-delegation-fixture.ts` itself: it stays a synchronous
+    builder with an unchanged signature, so `scripts/c9-collaboration-canary.ts` and the
+    six sibling suites that import it keep working untouched.
+- Taste constraints: one mechanism. A second consumer of the synchronous path would
+  justify extracting more; one consumer justifies only relaxing what exists.
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+
+## Falsifier
+
+What observable evidence would prove this task's direction wrong, and the cheapest proof point to check first. Leave as-is if not applicable.
+
+## Root Cause Evidence
+
+Required when Task Profile is `bugfix`; leave as-is otherwise.
+
+- root_cause: one sentence naming file:line/condition (testable, not "a state issue").
+- repro: the command or UI path that reproduces the symptom.
+- regression_guard: path to a test that fails on the unfixed code and passes after the fix (must also appear as a `package_test` check in Verification Plan).
+- pre_fix_failure_artifact: path to a captured run of regression_guard on the UNFIXED code. Capture with `bun test <regression_guard> > <artifact> 2>&1; echo "PRE_FIX_EXIT=$?" >> <artifact>` (no pipes — pipes swallow the exit status). The gate requires a non-zero `PRE_FIX_EXIT=` line plus the regression_guard path string in the artifact (see the Root Cause Evidence Gate section in docs/reference-configs/sprint-contracts.md).
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260912-2303-delegation-template.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260912-2303-delegation-template.review.md`
+- Notes file: `tasks/notes/20260912-2303-delegation-template.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Change Assessment
+
+```json
+{"protocol":1,"oracles":[{"id":"affected-suites","kind":"deterministic_test","paths":["*"]}]}
+```
+
+## Acceptance Policy
+
+```json
+{"protocol":2,"reviewer":"Codex","source":"codex-plugin","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - tests/helpers/repo-fixture.ts
+  - tests/effects/collaboration-contribution-collector.test.ts
+  - plans/plan-20260912-2303-delegation-template.md
+  - tasks/todos.md
+  - tasks/contracts/20260912-2303-delegation-template.contract.md
+  - tasks/reviews/20260912-2303-delegation-template.review.md
+  - tasks/notes/20260912-2303-delegation-template.notes.md
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+    fallback: null
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+This block contains only non-executable artifact requirements. Define every
+executable check once in the canonical Verification Plan below. Each check must
+state its phase, cost, evidence policy, necessity, and input environment; a
+missing or malformed plan fails closed. Populate artifact requirements only
+for deliverables this task actually owns; do not create a spec, notes or report
+merely to fill this template.
+
+```yaml
+exit_criteria:
+  files_exist:
+    - tests/helpers/repo-fixture.ts
+  artifacts_exist:
+    - tasks/notes/20260912-2303-delegation-template.notes.md
+```
+
+## Verification Plan
+
+```json
+{
+  "protocol": 1,
+  "checks": [
+    {
+      "id": "collaboration-contribution-collector",
+      "kind": "package_test",
+      "path": "tests/effects/collaboration-contribution-collector.test.ts",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "The rewired suite: its 35 tests are the behavioural contract the template must preserve.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "campaign-worker",
+      "kind": "package_test",
+      "path": "tests/effects/campaign-worker.test.ts",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Existing fixtureTemplate consumer; the template's store layout and materialize path changed underneath it.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "brc10-lifecycle",
+      "kind": "package_test",
+      "path": "tests/effects/brc10-lifecycle.test.ts",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Existing fixtureTemplate consumer; the template's store layout and materialize path changed underneath it.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "campaign-authoring-resume",
+      "kind": "package_test",
+      "path": "tests/effects/campaign-authoring-resume.test.ts",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Existing fixtureTemplate consumer; the template's store layout and materialize path changed underneath it.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "campaign-closeout",
+      "kind": "package_test",
+      "path": "tests/effects/campaign-closeout.test.ts",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Existing fixtureTemplate consumer; the template's store layout and materialize path changed underneath it.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "check-type",
+      "kind": "command",
+      "command": "bun run check:type",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "The overloaded template signature must type-check against every existing call site.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "check-hooks",
+      "kind": "command",
+      "command": "bun run check:hooks",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository integrity check for substantive changes.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "check-helpers",
+      "kind": "command",
+      "command": "bun run check:helpers",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository integrity check for substantive changes.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "check-reference-configs",
+      "kind": "command",
+      "command": "bun run check:reference-configs",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository integrity check for substantive changes.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "check-architecture-sync",
+      "kind": "command",
+      "command": "bash scripts/check-architecture-sync.sh",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository integrity check for substantive changes.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "check-task-workflow",
+      "kind": "command",
+      "command": "bash scripts/check-task-workflow.sh --strict",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository integrity check for substantive changes.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "check-task-sync",
+      "kind": "command",
+      "command": "bash scripts/check-task-sync.sh",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository integrity check; the digest is bound to the merge base.",
+      "inputs": {
+        "env": [
+          "REPO_HARNESS_DIFF_BASE",
+          "REPO_HARNESS_DIFF_MODE"
+        ]
+      }
+    },
+    {
+      "id": "init-dry-run",
+      "kind": "command",
+      "command": "bun src/cli/index.ts init --repo . --dry-run",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository integrity check for substantive changes.",
+      "inputs": {
+        "env": []
+      }
+    }
+  ]
+}
+```
+
+Author the actual checks using [Testing Policy and Artifact Standards](../../docs/reference-configs/sprint-contracts.md#testing-policy-and-artifact-standards).
+The empty array is not permission to omit required repository checks: retain it
+only when no executable criterion applies and explain why in Acceptance Notes.
+Prefer existing covering tests; creating a task-named test or adding typecheck
+is not a template requirement. For each selected check declare `id`, `kind`,
+`cwd`, `phase`, `cost`, `evidence_policy`, `necessity`, `inputs.env`, and its
+`command` or `path`. Declare the same execution once, including checks nested
+inside aggregate scripts. Use `baseline_with_delta` only with an immutable
+baseline and named current delta checks; never infer it from paths or command text.
+
+## Acceptance Notes (Human Review)
+
+- Changed behavior/boundary, existing covering tests and remaining gap: test plumbing only.
+  The 35 tests in the rewired suite keep their own assertions as the behavioural coverage,
+  and the four campaign suites cover the template path that already existed.
+- New test case/file rationale, or why existing coverage is sufficient: no new test. The
+  template's only contract is a pristine tree per caller, which is exactly what the five
+  suites assert by passing unchanged.
+- Selected check IDs and why their coverage is sufficient; omitted coverage: the five
+  `package_test` checks are the complete consumer set of `fixtureTemplate` plus the rewired
+  suite. The six other files that import
+  `tests/helpers/collaboration-delegation-fixture.ts` are not in the diff — that helper's
+  signature and body are unchanged — but all six plus `scripts/c9-collaboration-canary.ts`'s
+  suite surface were run green anyway and are recorded in the notes file. The remaining
+  checks are the repository integrity set.
+- Full/expensive check justification and expected cost, if applicable: no full suite. The
+  change touches one test file and one test helper; every consumer of the changed helper
+  exports is named and run directly, and CI runs the full suite on the PR.
+- Execution/baseline references, subject, current delta and disposition: baseline and
+  post-change runs were taken on the same machine in the same session. The JUnit
+  `testcase name` multisets are identical (35 entries), and the suite reports the same
+  35 pass / 0 fail / 355 expect() calls before and after, in 87s before and 62s after.
+- Residual risks and incomplete observations: the template hands every caller the same
+  frozen fixture object, so the shared `role_profile`, `capability` and
+  `claim_actor_receipt` values are shared references rather than copies; only the bytes on
+  disk are unshared. No test in this suite mutates them. A future fixture that baked a
+  third absolute path outside the selector's list would not be restored, and
+  `fixtureTemplate` would not notice.
+
+## Rollback Point
+
+- Commit / checkpoint: `origin/main` at the branch point of `codex/delegation-template`.
+- Revert strategy: revert the single commit; no product code, migration or state is
+  involved.

--- a/tasks/notes/20260912-2303-delegation-template.notes.md
+++ b/tasks/notes/20260912-2303-delegation-template.notes.md
@@ -1,0 +1,87 @@
+# Implementation Notes: delegation-template
+
+> **Status**: Active
+> **Plan**: plans/plan-20260912-2303-delegation-template.md
+> **Contract**: tasks/contracts/20260912-2303-delegation-template.contract.md
+> **Review**: tasks/reviews/20260912-2303-delegation-template.review.md
+> **Last Updated**: 2026-09-12 23:03
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- `materialize()` mirrors the builder instead of always returning a promise. The delegation
+  fixture is a synchronous builder consumed by 35 synchronous test bodies; making the cache
+  async would have forced every one of them to become `async` purely to reach a cache, which
+  is a wider diff than the optimization it pays for.
+- One mechanism, not a synchronous twin. Only one consumer needs the synchronous path, so
+  `fixtureTemplate` got an overload pair and an optional `workspacePaths` selector rather
+  than a parallel API. A second synchronous consumer would be the point to reconsider.
+- `workspacePaths` is an explicit selector, not a widened `FixtureWorkspace` interface. The
+  collaboration fixture names its repository `repoRoot`; teaching the template to accept
+  either field name would make the snapshot set implicit, and the snapshot set is exactly
+  what decides whether a restored fixture is complete.
+- Cleanup ownership moved to the call site. `createCollaborationDelegationFixture` pushes
+  its two directories into the caller's `roots` array, but on a cache hit the builder never
+  runs. The call site passes a discarded array and `delegationFixture()` registers both
+  paths itself, so every test — build or restore — registers exactly once and `afterEach`
+  semantics are unchanged.
+- The template boundary stops at the builder. `setWorkerStdout`, admission, dispatch and
+  the collector transaction still run per test against unshared bytes restored into the
+  fixture's own paths, because `repoHarnessRepoIdFor()` hashes the repository root
+  verbatim and a copied-to-a-new-path fixture would fail closed.
+- No spy or clock seam is installed before fixture construction anywhere in the suite, so
+  the template needs no ordering treatment beyond what PR #421 established.
+
+## Timings (this machine, isolate runs)
+
+| File | Before | After |
+|------|--------|-------|
+| `tests/effects/collaboration-contribution-collector.test.ts` | 87s | 62s |
+| `tests/cli/collaboration.test.ts` | 24s | 25s |
+| `tests/effects/collaboration-context-delivery.test.ts` | 17s | 17s |
+| `tests/effects/collaboration-dispatch-effect-fence.test.ts` | 12s | 10s |
+| `tests/effects/collaboration-admission-bridge.test.ts` | 28s | 21s |
+| `tests/effects/collaboration-dispatch-fence-composed.test.ts` | 9s | 8s |
+| `tests/effects/collaboration-succession.test.ts` | 19s | 13s |
+| `tests/effects/campaign-worker.test.ts` | 53s | 43s |
+
+Only the first row is in the diff's blast radius; the rest import the delegation fixture
+helper, whose signature and body are unchanged, and their movement is machine noise.
+
+## Zero-loss Evidence
+
+JUnit `testcase name` multisets over
+`tests/effects/collaboration-contribution-collector.test.ts`, taken from the pre-change
+file content and the post-change file: 35 names each, identical after sorting. Same-process
+run of `tests/effects/collaboration-*.test.ts`: 137 pass / 0 fail / 915 expect() calls.
+
+## Deviations From Plan Or Spec
+
+- None recorded.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| Move the template inside `createCollaborationDelegationFixture` so all seven importers benefit for free | Rejected | It would pull `bun:test` into `scripts/c9-collaboration-canary.ts` through the helper's import graph, and would hide cleanup ownership inside a helper that cannot see the caller's `afterEach`. |
+| Add a separate `syncFixtureTemplate()` | Rejected | One consumer. A second mechanism would need its own drift check against the async one. |
+| Make every test body `async` and reuse the existing async `materialize` | Rejected | 35 signature edits in a file whose bodies are otherwise untouched, for no behavioural gain. |
+
+## Open Questions
+
+- None.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/reviews/20260912-2303-delegation-template.review.md
+++ b/tasks/reviews/20260912-2303-delegation-template.review.md
@@ -1,0 +1,99 @@
+# Task Review: delegation-template
+
+> **Status**: Pending
+> **Substantive Change SHA256**: `sha256:de66ba0978ca0193a309ccecfee96ec8524fb7136bfca4017e7d9ab49c3a619d`
+> **Plan**: plans/plan-20260912-2303-delegation-template.md
+> **Contract**: tasks/contracts/20260912-2303-delegation-template.contract.md
+> **Notes File**: tasks/notes/20260912-2303-delegation-template.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-09-12 23:03
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Check IDs and evidence disposition:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+Follow [Testing Policy and Artifact Standards](../../docs/reference-configs/sprint-contracts.md#testing-policy-and-artifact-standards).
+Consume canonical evidence; do not rerun checks to populate this review or
+copy the executable plan. Return missing/stale evidence to its execution owner.
+
+- Waza `/check` review reference, when required:
+- Check IDs and disposition (executed / exact reuse / baseline with delta / failed / missing / not run):
+- Verified subject, relevant environment and immutable execution references:
+- Historical baseline and current delta references, if applicable:
+- Manual observations, failures and coverage limitations:
+- Implementation notes reviewed, if present:
+- Run snapshot:
+
+## Manual Check Evidence
+
+Copy each non-built-in contract `manual_checks` requirement exactly. Check it only after
+the observation is complete and replace the placeholder with concrete command output,
+screenshot/artifact path, or reviewer observation.
+
+- [ ] Exact manual_checks requirement
+  - Evidence: concrete observation, command output, screenshot path, or reviewer note
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -1,7 +1,7 @@
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: 2026-09-12 19:48
+> **Updated**: 2026-09-12 23:03
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.

--- a/tests/effects/collaboration-contribution-collector.test.ts
+++ b/tests/effects/collaboration-contribution-collector.test.ts
@@ -8,7 +8,7 @@
  * three invariants that make the boundary safe: one visible commit, one
  * `WorkerResultV1`, and no duplicated signal.
  */
-import { afterEach, describe, expect, test } from 'bun:test';
+import { afterAll, afterEach, describe, expect, test } from 'bun:test';
 import { existsSync, readFileSync, readdirSync, writeFileSync } from 'fs';
 import { join } from 'path';
 
@@ -72,11 +72,34 @@ import {
   type CollaborationDelegationFixture,
 } from '../helpers/collaboration-delegation-fixture';
 import { deliveryPlaneDigest, removeFixtureRoots } from '../helpers/collaboration-store-fixture';
+import { fixtureTemplate } from '../helpers/repo-fixture';
 
 const sourceRoot = process.cwd();
 const roots: string[] = [];
 
+/**
+ * The delegation fixture is built once for this file and restored per test. Its
+ * cost is a git repository plus a real CLI child process that records the
+ * capability receipt, and every test here starts from the same shape.
+ *
+ * The builder's own `roots` argument is discarded because the template, not the
+ * builder, decides when a workspace exists: on a cache hit the builder never
+ * runs, so `delegationFixture()` is the single place that registers the two
+ * directories for `afterEach` removal.
+ */
+const templates = fixtureTemplate(
+  (mode: string) => createCollaborationDelegationFixture(sourceRoot, [], mode),
+  (value) => [value.repoRoot, value.home],
+);
+
+function delegationFixture(mode = 'shadow'): CollaborationDelegationFixture {
+  const value = templates.materialize(mode);
+  roots.push(value.repoRoot, value.home);
+  return value;
+}
+
 afterEach(() => removeFixtureRoots(roots));
+afterAll(() => templates.dispose());
 
 const PROTECTED_PATHS = [
   'common:.repo-harness-read-only-canary-common',
@@ -137,7 +160,7 @@ function completedRun(stdout: string, mode: string | null = 'shadow'): {
   readonly value: CollaborationDelegationFixture;
   readonly dispatchId: string;
 } {
-  const value = createCollaborationDelegationFixture(sourceRoot, roots, mode ?? 'shadow');
+  const value = delegationFixture(mode ?? 'shadow');
   setWorkerStdout(value.repoRoot, stdout);
   const participant = delegationParticipant(value, 0);
   const admitted = admitCollaborationDelegation({
@@ -419,7 +442,7 @@ describe('C4 contribution collector', () => {
   }, 120_000);
 
   test('the collector refuses a run that has not completed', () => {
-    const value = createCollaborationDelegationFixture(sourceRoot, roots);
+    const value = delegationFixture();
     setWorkerStdout(value.repoRoot, framed(draftPayload()));
     const participant = delegationParticipant(value, 0);
     const admitted = admitCollaborationDelegation({

--- a/tests/helpers/repo-fixture.ts
+++ b/tests/helpers/repo-fixture.ts
@@ -42,36 +42,75 @@ export interface FixtureWorkspace {
   readonly home: string;
 }
 
+export interface FixtureTemplate<A extends readonly unknown[], R> {
+  materialize(...args: A): R;
+  dispose(): void;
+}
+
+function isThenable(value: unknown): value is PromiseLike<unknown> {
+  return typeof (value as { then?: unknown } | null | undefined)?.then === "function";
+}
+
 /**
  * Build an expensive repository fixture once per distinct argument list and give
  * every later caller a pristine materialization of it.
  *
- * The snapshot is restored into the original `root` and `home`, never copied to a
- * fresh path: `repoHarnessRepoIdFor` hashes the repository root verbatim, so the
- * sealed authorization, registry entry, campaign intent and publication recorded
- * inside a fixture are all bound to that exact path. Restoring in place therefore
- * keeps the returned value valid while giving each caller unshared bytes, which is
- * the same isolation a rebuild provides.
+ * The snapshot is restored into the workspace directories the fixture already
+ * owns, never copied to a fresh path: `repoHarnessRepoIdFor` hashes the
+ * repository root verbatim, so the sealed authorization, registry entry,
+ * campaign intent and publication recorded inside a fixture are all bound to
+ * that exact path. Restoring in place therefore keeps the returned value valid
+ * while giving each caller unshared bytes, which is the same isolation a rebuild
+ * provides.
+ *
+ * `materialize` mirrors the builder: a synchronous builder keeps a synchronous
+ * call site, because a fixture whose consumers are synchronous must not force
+ * every test body to become async just to reach the cache. `workspacePaths`
+ * names the directories to snapshot when the fixture does not use the
+ * `{ root, home }` shape.
  */
-export function fixtureTemplate<A extends readonly unknown[], T extends FixtureWorkspace>(build: (...args: A) => Promise<T>) {
-  const templates = new Map<string, { readonly value: T; readonly store: string }>();
+export function fixtureTemplate<A extends readonly unknown[], T extends FixtureWorkspace>(
+  build: (...args: A) => Promise<T>,
+): FixtureTemplate<A, Promise<T>>;
+export function fixtureTemplate<A extends readonly unknown[], T extends object>(
+  build: (...args: A) => T,
+  workspacePaths: (value: T) => readonly string[],
+): FixtureTemplate<A, T>;
+export function fixtureTemplate(
+  build: (...args: never[]) => unknown,
+  workspacePaths?: (value: never) => readonly string[],
+): FixtureTemplate<never[], unknown> {
+  const select = (workspacePaths ?? ((value: FixtureWorkspace) => [value.root, value.home])) as (value: unknown) => readonly string[];
+  const templates = new Map<string, { readonly value: unknown; readonly store: string; readonly asynchronous: boolean }>();
+  const capture = (value: unknown): string => {
+    const paths = select(value);
+    const store = tmpWorkspaceIn(dirname(paths[0]!), "fixture-template");
+    paths.forEach((path, index) => cpSync(path, join(store, `${index}`), { recursive: true, verbatimSymlinks: true }));
+    return store;
+  };
+  const restore = (entry: { readonly value: unknown; readonly store: string }): void => {
+    select(entry.value).forEach((path, index) => {
+      rmSync(path, { recursive: true, force: true });
+      cpSync(join(entry.store, `${index}`), path, { recursive: true, verbatimSymlinks: true });
+    });
+  };
   return {
-    async materialize(...args: A): Promise<T> {
+    materialize(...args: never[]): unknown {
       const key = JSON.stringify(args);
       const cached = templates.get(key);
       if (cached) {
-        for (const [name, path] of [["root", cached.value.root], ["home", cached.value.home]] as const) {
-          rmSync(path, { recursive: true, force: true });
-          cpSync(join(cached.store, name), path, { recursive: true, verbatimSymlinks: true });
-        }
-        return cached.value;
+        restore(cached);
+        return cached.asynchronous ? Promise.resolve(cached.value) : cached.value;
       }
-      const value = await build(...args);
-      const store = tmpWorkspaceIn(dirname(value.root), "fixture-template");
-      cpSync(value.root, join(store, "root"), { recursive: true, verbatimSymlinks: true });
-      cpSync(value.home, join(store, "home"), { recursive: true, verbatimSymlinks: true });
-      templates.set(key, { value, store });
-      return value;
+      const built = build(...args);
+      if (isThenable(built)) {
+        return Promise.resolve(built).then((value) => {
+          templates.set(key, { value, store: capture(value), asynchronous: true });
+          return value;
+        });
+      }
+      templates.set(key, { value: built, store: capture(built), asynchronous: false });
+      return built;
     },
     dispose(): void {
       for (const { store } of templates.values()) rmSync(store, { recursive: true, force: true });


### PR DESCRIPTION
## What

`tests/effects/collaboration-contribution-collector.test.ts` rebuilt the C4 delegation
fixture 17 times per run. Each rebuild spends a `git init`, two commits, a `.codex` copy
and one real `bun src/cli/index.ts delegation capability` child process before the first
assertion.

It now materializes from the `fixtureTemplate` PR #421 introduced: the fixture is built
once per file and restored per test into its own `repoRoot`/`home` paths, so every test
still starts from unshared bytes.

## How

`fixtureTemplate` gained two things rather than a parallel API:

- `materialize()` mirrors its builder. A synchronous builder keeps a synchronous call
  site, because the 35 test bodies in this suite are synchronous and making them `async`
  purely to reach a cache would have been a wider diff than the optimization it pays for.
- an explicit `workspacePaths` selector names the directories to snapshot, for a fixture
  that does not use the `{ root, home }` shape. This one calls its repository `repoRoot`.

Cleanup ownership moved to the call site. `createCollaborationDelegationFixture` pushes
its two directories into the caller's `roots` array, but on a cache hit the builder never
runs, so the suite passes a discarded array and registers both paths itself — every test
registers exactly once and `afterEach` semantics are unchanged.

`tests/helpers/collaboration-delegation-fixture.ts` is untouched: its signature and body
are unchanged, so `scripts/c9-collaboration-canary.ts` and the six sibling suites that
import it keep working.

## Timings (isolate runs, same machine and session)

| File | Before | After |
|------|--------|-------|
| `tests/effects/collaboration-contribution-collector.test.ts` | 87s | 62s |
| `tests/cli/collaboration.test.ts` | 24s | 25s |
| `tests/effects/collaboration-context-delivery.test.ts` | 17s | 17s |
| `tests/effects/collaboration-dispatch-effect-fence.test.ts` | 12s | 10s |
| `tests/effects/collaboration-admission-bridge.test.ts` | 28s | 21s |
| `tests/effects/collaboration-dispatch-fence-composed.test.ts` | 9s | 8s |
| `tests/effects/collaboration-succession.test.ts` | 19s | 13s |
| `tests/effects/campaign-worker.test.ts` | 53s | 43s |

Only the first row is in the diff's blast radius. The rest import the delegation fixture
helper, whose signature and body are unchanged, and their movement is machine noise.

## Zero-loss evidence

JUnit `testcase name` multisets over the pre-change file content and the post-change file:
35 names each, identical after sorting. Both runs report `35 pass / 0 fail / 355 expect()
calls`.

Same-process run of `tests/effects/collaboration-*.test.ts`: `137 pass / 0 fail / 915
expect() calls` across 10 files, so the template leaks nothing across files.

## Checks

`bun run check:type`, `check:hooks`, `check:helpers`, `check:reference-configs`,
`scripts/check-deploy-sql-order.sh`, `scripts/check-architecture-sync.sh`,
`scripts/check-task-workflow.sh --strict`, `scripts/check-task-sync.sh` (merge-base bound),
`scripts/inspect-project-state.ts`, `init --repo . --dry-run` — all green. The four
existing `fixtureTemplate` consumers (`campaign-worker`, `brc10-lifecycle`,
`campaign-authoring-resume`, `campaign-closeout`) were run green as the regression surface.
