### PR TITLE
test(cli): run the chatgpt browser CLI tests in-process

### DIFF
--- a/plans/plan-20260913-0038-chatgpt-inprocess.md
+++ b/plans/plan-20260913-0038-chatgpt-inprocess.md
@@ -1,0 +1,150 @@
+# Plan: Run chatgpt browser CLI tests in-process
+
+> **Status**: Executing
+> **Created**: 20260913-0038
+> **Slug**: chatgpt-inprocess
+> **Planning Source**: codex-plan-or-waza-think
+> **Orchestration Kind**: host-plan
+> **Source Ref**: (none)
+> **Substantive Change SHA256**: `sha256:695292620362ead9c1252788c2ad21852ecca7e948f1f127552efa84879d46ba`
+> **Artifact Level**: work-package
+> **Promotion Reason**: verification_boundary
+> **Verification Boundary**: Changed test file plus new helper consumers, measured against a recorded baseline and a JUnit test-name multiset.
+> **Rollback Surface**: tests/cli/chatgpt-browser.test.ts and tests/helpers/cli-in-process.ts only.
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260913-0038-chatgpt-inprocess.contract.md`
+> **Task Review**: `tasks/reviews/20260913-0038-chatgpt-inprocess.review.md`
+> **Implementation Notes**: `tasks/notes/20260913-0038-chatgpt-inprocess.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from codex-plan-or-waza-think planning output.
+- Source ref: (none)
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260913-0038-chatgpt-inprocess.md`
+- Sprint contract: `tasks/contracts/20260913-0038-chatgpt-inprocess.contract.md`
+- Sprint review: `tasks/reviews/20260913-0038-chatgpt-inprocess.review.md`
+- Implementation notes: `tasks/notes/20260913-0038-chatgpt-inprocess.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260913-0038-chatgpt-inprocess.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260913-0038-chatgpt-inprocess.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260913-0038-chatgpt-inprocess.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260913-0038-chatgpt-inprocess.contract.md`
+- Review file: `tasks/reviews/20260913-0038-chatgpt-inprocess.review.md`
+- Implementation notes file: `tasks/notes/20260913-0038-chatgpt-inprocess.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260913-0038-chatgpt-inprocess.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260913-0038-chatgpt-inprocess.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: tests/cli/chatgpt-browser.test.ts and tests/helpers/cli-in-process.ts only.
+- **Verification boundary**: Changed test file plus new helper consumers, measured against a recorded baseline and a JUnit test-name multiset.
+- **Review/acceptance boundary**: `tasks/reviews/20260913-0038-chatgpt-inprocess.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: verification_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260913-0038-chatgpt-inprocess.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260913-0038-chatgpt-inprocess.contract.md`, `tasks/reviews/20260913-0038-chatgpt-inprocess.review.md`, and `tasks/notes/20260913-0038-chatgpt-inprocess.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260913-0038-chatgpt-inprocess.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: tests/cli/chatgpt-browser.test.ts and tests/helpers/cli-in-process.ts only.
+
+## Captured Planning Output
+
+# Plan: Run chatgpt browser CLI tests in-process
+
+## Promotion Gate
+
+- **Merge/PR unit**: One independently reviewable test-runtime change to `tests/cli/chatgpt-browser.test.ts` and one new test helper.
+- **Rollback surface**: Revert this slice; no product source, script, or workflow file changes.
+- **Verification boundary**: The changed test file plus the new helper's consumers, measured against a recorded per-file baseline and a JUnit test-name multiset.
+- **Review/acceptance boundary**: Local focused runs plus repository-integrity checks recorded here.
+- **High-risk surface**: A silently early-returning in-process runner could make assertions read stale output, so the runner needs an explicit completion barrier and a zero-loss test-name check.
+- **Why not checklist row**: It is an independent verification boundary with its own before/after measurement and its own merge unit.
+
+## Evidence Contract
+
+- **State/progress path**: This plan's Task Breakdown.
+- **Verification evidence**: Recorded baseline and post-change elapsed time for the changed file, JUnit `<testcase name>` multiset equality, and repository-integrity command results.
+- **Evaluator rubric**: Same 55 test names before and after, all passing, with measurably lower elapsed time.
+- **Stop condition**: Either the file runs green in-process with identical names, or a semantic blocker is reported without changing `src/`.
+- **Rollback surface**: `tests/cli/chatgpt-browser.test.ts` and `tests/helpers/cli-in-process.ts` only.
+
+## Decision
+
+P1: `src/cli/index.ts` exports `buildProgram()` and `runCli(argv)`; the module-level body is guarded by `import.meta.main`, so importing it has no side effects. `src/cli/commands/chatgpt.ts` owns the whole `chatgpt` command group. `src/cli/chatgpt-browser/**` holds no module-level mutable state, registers no `process` listeners, and never writes to stdout.
+
+P2: `runChatgpt()` paid a full Bun cold start per call. Measured directly: 20 `spawnSync` CLI calls cost 4054 ms (~203 ms each) while 20 in-process `runCli` calls cost 38 ms (~1.9 ms each) after a one-time 166 ms module import. With 77 call sites, process startup is roughly 15 s of the file's runtime.
+
+P3: The in-process runner must reproduce three process-boundary semantics. Environment: `oracle-provider.buildOracleEnv` and `secret-scan.scannerEnv` both build the child environment from a `process.env` snapshot, and Bun 1.4.0 propagates runtime `process.env` mutation and deletion to bare `spawnSync` children, so replacing `process.env` in place preserves fake-oracle and fake-gitleaks behavior. Working directory: `resolveRepoRoot` resolves against `process.cwd()`, so the runner chdirs and restores. Exit: commander's own exits become thrown `CommanderError`s through `exitOverride`, and every chatgpt action funnels through `runChatgptAction`, whose only failure exit is a `process.exit(2)` in the last statement of its catch, so a patched `process.exit` that records the code and returns reproduces the status without an unhandled rejection. The one property the CLI does not expose in-process is completion: all ten chatgpt actions discard the work promise (`void runChatgptAction(...)`), so commander's `parseAsync` resolves before the action finishes. Each action's terminal statement is a stdout write or that exit, so the runner's completion barrier is "first stdout write, or recorded exit", which is an observable contract of the command group rather than a change to it. At 10x scale the first thing to fail is a new chatgpt action that keeps working after its terminal log; the barrier is documented at the helper boundary so that contract is explicit.
+
+## Scope
+
+Add `tests/helpers/cli-in-process.ts` with a `runCliInProcess` runner that snapshots and restores `process.env`, `process.cwd()`, stdout/stderr writers, the console writers, and `process.exit`, and returns `{ status, stdout, stderr }`. Point `runChatgpt()` at it and await the result at every call site, converting the enclosing test bodies and `withRepo` to async. Do not change assertions, test titles, `src/`, `scripts/`, or `.github/`.
+
+## Verification
+
+Run the changed file isolated and together with sibling `tests/cli/chatgpt*.test.ts`, compare the JUnit `<testcase name>` multiset against the recorded baseline, and run the repository-integrity checks plus `bun run check:type` and the init dry-run. No full suite: the change is confined to one test file and one new test helper.
+
+## Task Breakdown
+
+- [x] Add the in-process CLI runner helper with env/cwd/stdout/exit restoration and a documented completion barrier.
+- [x] Convert `runChatgpt()` and its 77 call sites to the in-process runner without touching assertions or titles.
+- [x] Prove zero test loss with a JUnit test-name multiset comparison and record before/after elapsed time.
+- [x] Complete focused and repository-integrity verification.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [x] Add the in-process CLI runner helper with env/cwd/stdout/exit restoration and a documented completion barrier.
+- [x] Convert `runChatgpt()` and its 77 call sites to the in-process runner without touching assertions or titles.
+- [x] Prove zero test loss with a JUnit test-name multiset comparison and record before/after elapsed time.
+- [x] Complete focused and repository-integrity verification.

--- a/tasks/contracts/20260913-0038-chatgpt-inprocess.contract.md
+++ b/tasks/contracts/20260913-0038-chatgpt-inprocess.contract.md
@@ -1,0 +1,340 @@
+# Task Contract: chatgpt-inprocess
+
+> **Status**: Active
+> **Plan**: plans/plan-20260913-0038-chatgpt-inprocess.md
+> **Task Profile**: code-change
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: ancienttwo
+> **Capability ID**: root
+> **Last Updated**: 2026-09-13 00:38
+> **Review File**: `tasks/reviews/20260913-0038-chatgpt-inprocess.review.md`
+> **Notes File**: `tasks/notes/20260913-0038-chatgpt-inprocess.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+`tests/cli/chatgpt-browser.test.ts` spends roughly 15 seconds of its runtime on Bun cold
+starts: 77 call sites each spawn a fresh `bun src/cli/index.ts`, and every one of those
+re-parses the entire CLI module tree. If this ships wrong the failure is silent rather
+than slow: an in-process runner that returns before the command finished would let
+assertions read stale output, and this file is the only coverage of the chatgpt browser
+command surface, secret scanning and Oracle provider behavior.
+
+## Goal
+
+`runChatgpt()` executes the CLI in the test process through `runCli`, preserving the
+`{ status, stdout, stderr }` shape, the per-call `cwd` and `env` semantics and the exit
+codes. Every test title, count and assertion in the file is unchanged, proven by a
+before/after JUnit `testcase name` multiset comparison, and the measured per-file elapsed
+time drops.
+
+## Scope
+
+- In scope:
+  - `tests/helpers/cli-in-process.ts`: new `runCliInProcess` runner.
+  - `tests/cli/chatgpt-browser.test.ts`: `runChatgpt`, `withRepo`, `bindChromeProfile` and
+    the call sites that must await them.
+- Out of scope:
+  - `src/`, `scripts/`, `.github/`.
+  - Every assertion and test title.
+  - Tests that call `runBrowserConsult`/`runBrowserFollowup` or the CDP helpers directly:
+    they already run in-process.
+- Taste constraints: the completion barrier belongs in the helper with its reason stated
+  at that boundary, not spread across call sites.
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+
+## Falsifier
+
+What observable evidence would prove this task's direction wrong, and the cheapest proof point to check first. Leave as-is if not applicable.
+
+## Root Cause Evidence
+
+Required when Task Profile is `bugfix`; leave as-is otherwise.
+
+- root_cause: one sentence naming file:line/condition (testable, not "a state issue").
+- repro: the command or UI path that reproduces the symptom.
+- regression_guard: path to a test that fails on the unfixed code and passes after the fix (must also appear as a `package_test` check in Verification Plan).
+- pre_fix_failure_artifact: path to a captured run of regression_guard on the UNFIXED code. Capture with `bun test <regression_guard> > <artifact> 2>&1; echo "PRE_FIX_EXIT=$?" >> <artifact>` (no pipes — pipes swallow the exit status). The gate requires a non-zero `PRE_FIX_EXIT=` line plus the regression_guard path string in the artifact (see the Root Cause Evidence Gate section in docs/reference-configs/sprint-contracts.md).
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260913-0038-chatgpt-inprocess.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260913-0038-chatgpt-inprocess.review.md`
+- Notes file: `tasks/notes/20260913-0038-chatgpt-inprocess.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Change Assessment
+
+```json
+{"protocol":1,"oracles":[{"id":"chatgpt-browser-suite","kind":"deterministic_test","paths":["tests/cli/chatgpt-browser.test.ts","tests/helpers/cli-in-process.ts"]}]}
+```
+
+## Acceptance Policy
+
+```json
+{"protocol":2,"reviewer":"Codex","source":"codex-plugin","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - docs/spec.md
+  - plans/
+  - tasks/todos.md
+  - tasks/contracts/20260913-0038-chatgpt-inprocess.contract.md
+  - tasks/reviews/20260913-0038-chatgpt-inprocess.review.md
+  - tasks/notes/20260913-0038-chatgpt-inprocess.notes.md
+  - .ai/context/capabilities.json
+  - .claude/templates/
+  - src/
+  - tests/
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+    fallback: null
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+This block contains only non-executable artifact requirements. Define every
+executable check once in the canonical Verification Plan below. Each check must
+state its phase, cost, evidence policy, necessity, and input environment; a
+missing or malformed plan fails closed. Populate artifact requirements only
+for deliverables this task actually owns; do not create a spec, notes or report
+merely to fill this template.
+
+```yaml
+exit_criteria:
+  files_exist: []
+  artifacts_exist: []
+```
+
+## Verification Plan
+
+```json
+{
+  "protocol": 1,
+  "checks": [
+    {
+      "id": "chatgpt-browser",
+      "kind": "package_test",
+      "path": "tests/cli/chatgpt-browser.test.ts",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "The only consumer of the new in-process runner and the subject of this change.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "global-runtime-init",
+      "kind": "package_test",
+      "path": "tests/cli/global-runtime-init.test.ts",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "The other in-process runCli consumer; it shares the process the runner now patches.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "check-type",
+      "kind": "command",
+      "command": "bun run check:type",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "The new helper's exported types must check against its call sites.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "check-hooks",
+      "kind": "command",
+      "command": "bun run check:hooks",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository integrity check for substantive changes.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "check-helpers",
+      "kind": "command",
+      "command": "bun run check:helpers",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository integrity check for substantive changes.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "check-reference-configs",
+      "kind": "command",
+      "command": "bun run check:reference-configs",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository integrity check for substantive changes.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "check-architecture-sync",
+      "kind": "command",
+      "command": "bash scripts/check-architecture-sync.sh",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository integrity check for substantive changes.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "check-task-workflow",
+      "kind": "command",
+      "command": "bash scripts/check-task-workflow.sh --strict",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository integrity check for substantive changes.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "check-task-sync",
+      "kind": "command",
+      "command": "bash scripts/check-task-sync.sh",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository integrity check; the digest is bound to the merge base.",
+      "inputs": {
+        "env": [
+          "REPO_HARNESS_DIFF_BASE",
+          "REPO_HARNESS_DIFF_MODE"
+        ]
+      }
+    },
+    {
+      "id": "init-dry-run",
+      "kind": "command",
+      "command": "bun src/cli/index.ts init --repo . --dry-run",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository integrity check for substantive changes.",
+      "inputs": {
+        "env": []
+      }
+    }
+  ]
+}
+```
+
+Author the actual checks using [Testing Policy and Artifact Standards](../../docs/reference-configs/sprint-contracts.md#testing-policy-and-artifact-standards).
+The empty array is not permission to omit required repository checks: retain it
+only when no executable criterion applies and explain why in Acceptance Notes.
+Prefer existing covering tests; creating a task-named test or adding typecheck
+is not a template requirement. For each selected check declare `id`, `kind`,
+`cwd`, `phase`, `cost`, `evidence_policy`, `necessity`, `inputs.env`, and its
+`command` or `path`. Declare the same execution once, including checks nested
+inside aggregate scripts. Use `baseline_with_delta` only with an immutable
+baseline and named current delta checks; never infer it from paths or command text.
+
+## Acceptance Notes (Human Review)
+
+- Changed behavior/boundary, existing covering tests and remaining gap: only the test
+  runtime changed. `tests/cli/chatgpt-browser.test.ts` now drives the CLI in-process
+  through `runCliInProcess`; every assertion, title and count is unchanged, proven by an
+  identical 55-entry JUnit `testcase name` multiset and 553 `expect()` calls before and
+  after. One call site keeps a real child process because `Bun.which` resolves against the
+  process's startup PATH; the reason is recorded at that call site and in the notes.
+- New test case/file rationale, or why existing coverage is sufficient: no new test cases.
+  The new file is a helper, and the changed file is its only consumer.
+- Selected check IDs and why their coverage is sufficient; omitted coverage:
+  `chatgpt-browser` is the changed file; `global-runtime-init` is the other in-process
+  `runCli` consumer and shares the process this runner patches; `check-type` covers the new
+  helper's signatures; the remaining ids are the required repository-integrity checks.
+- Full/expensive check justification and expected cost, if applicable: none. The change is
+  confined to one test file and one new test helper, with no product source touched.
+- Execution/baseline references, subject, current delta and disposition: baseline
+  `tests/cli/chatgpt-browser.test.ts` at 58.36 s wall / 40.27 s CPU on `origin/main`;
+  current 39.54 s wall / 9.23 s CPU. Both runs shared the machine with a parallel test
+  load, so the wall figures are noisy and the CPU figure carries the result.
+- Residual risks and incomplete observations: the completion barrier assumes each
+  `chatgpt` action's terminal statement writes to stdout or reaches its error exit. An
+  action that keeps working after its final log would let a test read early; the assumption
+  is stated at the helper boundary, and a command that produces neither signal fails with a
+  named error instead of returning a wrong result.
+
+## Rollback Point
+
+- Commit / checkpoint: `origin/main` at 95eddaa9.
+- Revert strategy: revert this commit; it touches only the two test paths.

--- a/tasks/notes/20260913-0038-chatgpt-inprocess.notes.md
+++ b/tasks/notes/20260913-0038-chatgpt-inprocess.notes.md
@@ -1,0 +1,90 @@
+# Implementation Notes: chatgpt-inprocess
+
+> **Status**: Active
+> **Plan**: plans/plan-20260913-0038-chatgpt-inprocess.md
+> **Contract**: tasks/contracts/20260913-0038-chatgpt-inprocess.contract.md
+> **Review**: tasks/reviews/20260913-0038-chatgpt-inprocess.review.md
+> **Last Updated**: 2026-09-13 00:38
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- The runner calls `buildProgram()` and applies `exitOverride()` to the whole command
+  tree, so commander's own exits (`--help`, unknown option, missing required option)
+  arrive as thrown `CommanderError`s after the text has been written.
+- A command body's own `process.exit` is recorded instead of thrown. Throwing would leave
+  an unhandled rejection, because every `chatgpt` action discards the work promise
+  (`void runChatgptAction(...)`), and Bun's test runner fails a test on an unhandled
+  rejection even when a `process.on('unhandledRejection')` listener consumes it. The only
+  `process.exit` this command group reaches is the last statement of `runChatgptAction`'s
+  error funnel, so recording and returning ends the action exactly where exiting did.
+- The same discarded promise means commander resolves `parseAsync` before an action
+  finishes, so the runner needs an explicit completion barrier. Each of the ten `chatgpt`
+  actions ends by writing its result to stdout or by reaching that error exit, and nothing
+  under `src/cli/chatgpt-browser/` writes to stdout, so the first stdout write or the
+  recorded exit is the terminal step. Both run synchronously to the end of the action, so
+  when the runner observes one, the action's remaining work has already run.
+- `process.env` is replaced in place (including deletions) rather than passed as an
+  argument: `oracle-provider.buildOracleEnv` and `secret-scan.scannerEnv` build their
+  child environments from a `process.env` snapshot, and Bun 1.4.0 propagates runtime
+  `process.env` mutation and deletion to bare `spawnSync` children, so the fake oracle and
+  fake Gitleaks binaries observe exactly the variables a test sets. `process.cwd()` is
+  changed and restored for `resolveRepoRoot`, which resolves relative paths against it.
+
+## Deviations From Plan Or Spec
+
+- One call site keeps a real child process: the `pathDoctor` doctor run inside `oracle
+  rejects unsupported versions uniformly before consultation side effects`. It asserts
+  `oracle.resolvedFrom === 'PATH'`, and the resolver uses `Bun.which('oracle')`, which
+  resolves against the environment the process started with rather than a runtime
+  `process.env.PATH` assignment. In-process the test resolved the machine's real
+  `~/.bun/bin/oracle` instead of the fixture binary. `runChatgptSpawnedForPath` covers that
+  one call; the other four CLI calls in the same test run in-process. Nothing else in the
+  file depends on signals, stdin, `process.execPath`, or a real exit path.
+- No test kept spawning for timing reasons. `oracle timeout kills its POSIX process group
+  and cleans staged egress` asserts a wall-clock bound of 8 s; back-to-back A/B runs of the
+  pre-change file and this one measured 7.05 s / 6.61 s and 6.98 s / 7.12 s, so the bound
+  behaves the same either way. It does fail under heavy parallel machine load, which it
+  also did before this change.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| Throw a sentinel from the patched `process.exit` | Rejected | The action's discarded promise turns it into an unhandled rejection, which fails the test in Bun. |
+| Detect completion by event-loop quiescence | Rejected | Bun returns an empty `process.getActiveResourcesInfo()` even with a live child process and a pending timer, and `async_hooks` promise tracking is a no-op. |
+| Spawn a smaller test-only CLI entry instead of going in-process | Rejected | It keeps a process per call and stops covering how `src/cli/index.ts` wires the command group. |
+| Fix `Bun.which` to read `process.env.PATH` | Rejected | That is a `src/` change made to suit a test; the one affected call site keeps a real child process instead. |
+
+## Open Questions
+
+- None.
+
+## Measurements
+
+| Run | Wall | CPU (user + sys) |
+|-----|------|------------------|
+| Before, `tests/cli/chatgpt-browser.test.ts` | 58.36 s | 40.27 s |
+| After, same file | 39.54 s | 9.23 s |
+
+77 CLI invocations became 76 in-process calls plus one retained child process. Measured in
+isolation, 20 `spawnSync` CLI calls cost 4054 ms against 38 ms for 20 in-process calls after
+a one-time 166 ms module import. Both suite numbers were taken while a parallel session was
+running its own test load, so the wall-clock figures are noisy; the CPU drop is not.
+Zero test loss: the JUnit `testcase name` multiset is identical at 55 entries, with 553
+`expect()` calls before and after.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/reviews/20260913-0038-chatgpt-inprocess.review.md
+++ b/tasks/reviews/20260913-0038-chatgpt-inprocess.review.md
@@ -1,0 +1,98 @@
+# Task Review: chatgpt-inprocess
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260913-0038-chatgpt-inprocess.md
+> **Contract**: tasks/contracts/20260913-0038-chatgpt-inprocess.contract.md
+> **Notes File**: tasks/notes/20260913-0038-chatgpt-inprocess.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-09-13 00:38
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Check IDs and evidence disposition:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+Follow [Testing Policy and Artifact Standards](../../docs/reference-configs/sprint-contracts.md#testing-policy-and-artifact-standards).
+Consume canonical evidence; do not rerun checks to populate this review or
+copy the executable plan. Return missing/stale evidence to its execution owner.
+
+- Waza `/check` review reference, when required:
+- Check IDs and disposition (executed / exact reuse / baseline with delta / failed / missing / not run):
+- Verified subject, relevant environment and immutable execution references:
+- Historical baseline and current delta references, if applicable:
+- Manual observations, failures and coverage limitations:
+- Implementation notes reviewed, if present:
+- Run snapshot:
+
+## Manual Check Evidence
+
+Copy each non-built-in contract `manual_checks` requirement exactly. Check it only after
+the observation is complete and replace the placeholder with concrete command output,
+screenshot/artifact path, or reviewer observation.
+
+- [ ] Exact manual_checks requirement
+  - Evidence: concrete observation, command output, screenshot path, or reviewer note
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -1,7 +1,7 @@
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: 2026-09-12 23:03
+> **Updated**: 2026-09-13 00:38
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.

--- a/tests/cli/chatgpt-browser.test.ts
+++ b/tests/cli/chatgpt-browser.test.ts
@@ -9,6 +9,7 @@ import { buildRuntimeAcceptanceProbeArgs } from '../../src/cli/chatgpt-browser/o
 import { createCdpClient, waitForVerifiedAssistantText } from '../../src/cli/chatgpt-browser/native-provider';
 import { DEFAULT_SESSION_ROOT, listBrowserSessions, writeBrowserSession } from '../../src/cli/chatgpt-browser/session-store';
 import { assertChatGptMcpContract } from '../helpers/chatgpt-mcp-contract';
+import { runCliInProcess } from '../helpers/cli-in-process';
 
 const ROOT = join(import.meta.dir, '../..');
 const CLI = join(ROOT, 'src/cli/index.ts');
@@ -16,11 +17,13 @@ const CLI = join(ROOT, 'src/cli/index.ts');
 setDefaultTimeout(180000);
 
 function runChatgpt(args: string[], cwd = ROOT, env: NodeJS.ProcessEnv = process.env) {
-  return spawnSync('bun', [CLI, 'chatgpt', ...args], {
-    cwd,
-    encoding: 'utf-8',
-    env,
-  });
+  return runCliInProcess(['chatgpt', ...args], cwd, env);
+}
+
+// `Bun.which` resolves against the environment the process started with, so a
+// PATH entry assigned at runtime is only visible to a real child process.
+function runChatgptSpawnedForPath(args: string[], env: NodeJS.ProcessEnv) {
+  return spawnSync('bun', [CLI, 'chatgpt', ...args], { cwd: ROOT, encoding: 'utf-8', env });
 }
 
 async function runBrowserOutputRace(repoRoot: string, relativePath: string): Promise<Array<{ ok: boolean; output?: string; error?: string }>> {
@@ -65,7 +68,7 @@ async function runBrowserOutputRace(repoRoot: string, relativePath: string): Pro
   return records;
 }
 
-function withRepo<T>(fn: (repoRoot: string) => T): T {
+async function withRepo<T>(fn: (repoRoot: string) => T | Promise<T>): Promise<T> {
   const repoRoot = mkdtempSync(join(tmpdir(), 'repo-harness-chatgpt-browser-'));
   try {
     mkdirSync(join(repoRoot, 'plans/sprints'), { recursive: true });
@@ -73,7 +76,7 @@ function withRepo<T>(fn: (repoRoot: string) => T): T {
     writeFileSync(join(repoRoot, 'plans/sprints/example.sprint.md'), '# Sprint\n\n- [ ] Task\n');
     writeFileSync(join(repoRoot, 'docs/example.md'), '# Docs\n');
     writeFileSync(join(repoRoot, '.env'), 'SECRET=value\n');
-    return fn(repoRoot);
+    return await fn(repoRoot);
   } finally {
     rmSync(repoRoot, { recursive: true, force: true });
   }
@@ -165,13 +168,13 @@ function writeFakeOracle(path: string, opts: { help?: string; sessionLine?: stri
   return path;
 }
 
-function bindChromeProfile(repoRoot: string, opts: { profileDirectory?: string } = {}): { userDataDir: string; profileDir: string } {
+async function bindChromeProfile(repoRoot: string, opts: { profileDirectory?: string } = {}): Promise<{ userDataDir: string; profileDir: string }> {
   const userDataDir = join(repoRoot, 'Chrome/User Data');
   const profileDir = join(userDataDir, opts.profileDirectory ?? 'Profile 1');
   mkdirSync(profileDir, { recursive: true });
   writeFileSync(join(userDataDir, 'Local State'), '{}\n');
   writeFileSync(join(profileDir, 'Preferences'), '{}\n');
-  const setup = runChatgpt([
+  const setup = await runChatgpt([
     'browser-setup',
     '--repo',
     repoRoot,
@@ -187,8 +190,8 @@ function bindChromeProfile(repoRoot: string, opts: { profileDirectory?: string }
 }
 
 describe('chatgpt browser command', () => {
-  test('prints help for browser command group', () => {
-    const root = runChatgpt(['--help']);
+  test('prints help for browser command group', async () => {
+    const root = await runChatgpt(['--help']);
     expect(root.status).toBe(0);
     expect(root.stdout).toContain('browser-consult');
     expect(root.stdout).toContain('browser-followup');
@@ -200,18 +203,18 @@ describe('chatgpt browser command', () => {
     expect(root.stdout).toContain('browser-open');
     expect(root.stdout).toContain('browser-cleanup');
 
-    const setup = runChatgpt(['browser-setup', '--help']);
+    const setup = await runChatgpt(['browser-setup', '--help']);
     expect(setup.status).toBe(0);
     expect(setup.stdout).toContain('--profile-dir');
     expect(setup.stdout).toContain('--profile-directory');
     expect(setup.stdout).not.toContain('--open');
 
-    const doctor = runChatgpt(['browser-doctor', '--help']);
+    const doctor = await runChatgpt(['browser-doctor', '--help']);
     expect(doctor.status).toBe(0);
     expect(doctor.stdout).toContain('--validate-session');
     expect(doctor.stdout).toContain('--profile-directory');
 
-    const consult = runChatgpt(['browser-consult', '--help']);
+    const consult = await runChatgpt(['browser-consult', '--help']);
     expect(consult.status).toBe(0);
     expect(consult.stdout).toContain('ChatGPT Web');
     expect(consult.stdout).toContain('--dry-run');
@@ -224,8 +227,8 @@ describe('chatgpt browser command', () => {
     expect(consult.stdout).toContain('--gitleaks-bin');
   }, 30_000);
 
-  test('secret scan covers the exact prompt bundle and follow-ups fail closed before a new session', () => {
-    withRepo((repoRoot) => {
+  test('secret scan covers the exact prompt bundle and follow-ups fail closed before a new session', async () => {
+    await withRepo(async (repoRoot) => {
       const binDir = mkdtempSync(join(tmpdir(), 'repo-harness-fake-gitleaks-'));
       try {
         const gitleaksPath = writeFakeGitleaks(binDir);
@@ -237,7 +240,7 @@ describe('chatgpt browser command', () => {
           FAKE_GITLEAKS_REPO_ROOT: repoRoot,
         };
         writeFileSync(join(repoRoot, '.gitleaks.toml'), '[allowlist]\n');
-        const clean = runChatgpt([
+        const clean = await runChatgpt([
           'browser-consult',
           '--repo',
           repoRoot,
@@ -268,7 +271,7 @@ describe('chatgpt browser command', () => {
 
         const sessionsRoot = join(repoRoot, '.ai/harness/chatgpt/sessions');
         const before = readdirSync(sessionsRoot).sort();
-        const rejectedFollowup = runChatgpt([
+        const rejectedFollowup = await runChatgpt([
           'browser-followup',
           '--repo',
           repoRoot,
@@ -317,13 +320,13 @@ describe('chatgpt browser command', () => {
     });
   });
 
-  test('secret scan rejects findings, missing binaries, and incompatible versions before session creation', () => {
-    withRepo((repoRoot) => {
+  test('secret scan rejects findings, missing binaries, and incompatible versions before session creation', async () => {
+    await withRepo(async (repoRoot) => {
       const binDir = mkdtempSync(join(tmpdir(), 'repo-harness-fake-gitleaks-errors-'));
       try {
         const scanner = writeFakeGitleaks(binDir);
         writeFileSync(join(repoRoot, 'docs/example.md'), 'SYNTHETIC_DELEGATE_SECRET # gitleaks:allow\n');
-        const finding = runChatgpt([
+        const finding = await runChatgpt([
           'browser-consult',
           '--repo',
           repoRoot,
@@ -341,7 +344,7 @@ describe('chatgpt browser command', () => {
         expect(finding.stderr).not.toContain('SYNTHETIC_DELEGATE_SECRET');
         expect(existsSync(join(repoRoot, '.ai/harness/chatgpt/sessions'))).toBe(false);
 
-        const unboundBinary = runChatgpt([
+        const unboundBinary = await runChatgpt([
           'browser-consult',
           '--repo',
           repoRoot,
@@ -355,7 +358,7 @@ describe('chatgpt browser command', () => {
         expect(unboundBinary.stderr).toContain('--gitleaks-bin requires --secret-scan');
         expect(existsSync(join(repoRoot, '.ai/harness/chatgpt/sessions'))).toBe(false);
 
-        const missing = runChatgpt([
+        const missing = await runChatgpt([
           'browser-consult',
           '--repo',
           repoRoot,
@@ -371,7 +374,7 @@ describe('chatgpt browser command', () => {
         expect(existsSync(join(repoRoot, '.ai/harness/chatgpt/sessions'))).toBe(false);
 
         const incompatible = writeFakeGitleaks(binDir, '8.18.4');
-        const old = runChatgpt([
+        const old = await runChatgpt([
           'browser-consult',
           '--repo',
           repoRoot,
@@ -391,8 +394,8 @@ describe('chatgpt browser command', () => {
     });
   }, 30_000);
 
-  test('scan-bound Oracle sends immutable captured file bytes instead of a post-scan source mutation', () => {
-    withRepo((repoRoot) => {
+  test('scan-bound Oracle sends immutable captured file bytes instead of a post-scan source mutation', async () => {
+    await withRepo(async (repoRoot) => {
       const binDir = mkdtempSync(join(tmpdir(), 'repo-harness-scan-bound-oracle-'));
       try {
         const sourcePath = join(repoRoot, 'docs/example.md');
@@ -420,7 +423,7 @@ describe('chatgpt browser command', () => {
         ].join('\n') + '\n');
         chmodSync(oraclePath, 0o755);
 
-        const result = runChatgpt([
+        const result = await runChatgpt([
           'browser-consult',
           '--repo',
           repoRoot,
@@ -452,11 +455,11 @@ describe('chatgpt browser command', () => {
     });
   }, 30_000);
 
-  test('explicit skill projection is canonical, idempotent, reversible, and refuses unowned destinations', () => {
+  test('explicit skill projection is canonical, idempotent, reversible, and refuses unowned destinations', async () => {
     const testHome = mkdtempSync(join(tmpdir(), 'repo-harness-chatgpt-skill-home-'));
     try {
       const env = { ...process.env, HOME: testHome, REPO_HARNESS_SOURCE_ROOT: ROOT };
-      const install = runChatgpt(['install-skill', '--target', 'both'], ROOT, env);
+      const install = await runChatgpt(['install-skill', '--target', 'both'], ROOT, env);
       expect(install.status).toBe(0);
       const canonical = realpathSync(join(ROOT, 'assets/skills/repo-harness-chatgpt'));
       const claudeSkill = join(testHome, '.claude/skills/repo-harness-chatgpt');
@@ -466,18 +469,18 @@ describe('chatgpt browser command', () => {
         expect(realpathSync(destination)).toBe(canonical);
       }
 
-      const reinstall = runChatgpt(['install-skill', '--target', 'both'], ROOT, env);
+      const reinstall = await runChatgpt(['install-skill', '--target', 'both'], ROOT, env);
       expect(reinstall.status).toBe(0);
       expect(reinstall.stdout).toContain('[claude] already installed');
       expect(reinstall.stdout).toContain('[codex] already installed');
 
-      const uninstall = runChatgpt(['uninstall-skill', '--target', 'both'], ROOT, env);
+      const uninstall = await runChatgpt(['uninstall-skill', '--target', 'both'], ROOT, env);
       expect(uninstall.status).toBe(0);
       expect(existsSync(claudeSkill)).toBe(false);
       expect(existsSync(codexSkill)).toBe(false);
 
       mkdirSync(codexSkill, { recursive: true });
-      const refused = runChatgpt(['uninstall-skill', '--target', 'both'], ROOT, env);
+      const refused = await runChatgpt(['uninstall-skill', '--target', 'both'], ROOT, env);
       expect(refused.status).toBe(2);
       expect(refused.stderr).toContain('refusing unowned ChatGPT Skill destination');
       expect(existsSync(codexSkill)).toBe(true);
@@ -487,9 +490,9 @@ describe('chatgpt browser command', () => {
     }
   }, 30_000);
 
-  test('dry-run consult writes a repo-local session with inline files', () => {
-    withRepo((repoRoot) => {
-      const result = runChatgpt([
+  test('dry-run consult writes a repo-local session with inline files', async () => {
+    await withRepo(async (repoRoot) => {
+      const result = await runChatgpt([
         'browser-consult',
         '--repo',
         repoRoot,
@@ -525,15 +528,15 @@ describe('chatgpt browser command', () => {
       expect(payload.dryRun.command).toContain('--browser-app');
       expect(payload.dryRun.command).toContain('team-review-mcp');
 
-      const read = runChatgpt(['browser-session', '--repo', repoRoot, payload.sessionId]);
+      const read = await runChatgpt(['browser-session', '--repo', repoRoot, payload.sessionId]);
       expect(read.status).toBe(0);
       expect(read.stdout).toContain('Dry run only');
 
-      const listed = runChatgpt(['browser-list', '--repo', repoRoot, '--json']);
+      const listed = await runChatgpt(['browser-list', '--repo', repoRoot, '--json']);
       expect(listed.status).toBe(0);
       expect(JSON.parse(listed.stdout).sessions[0].sessionId).toBe(payload.sessionId);
 
-      const followup = runChatgpt([
+      const followup = await runChatgpt([
         'browser-followup',
         '--repo',
         repoRoot,
@@ -550,15 +553,15 @@ describe('chatgpt browser command', () => {
       expect(followupMeta.sourceSessionId).toBe(payload.sessionId);
       expect(followupMeta.browser.chatgptApp).toBe('team-review-mcp');
 
-      const cleanupPlan = runChatgpt(['browser-cleanup', '--repo', repoRoot, '--status', 'dry_run', '--limit', '1', '--json']);
+      const cleanupPlan = await runChatgpt(['browser-cleanup', '--repo', repoRoot, '--status', 'dry_run', '--limit', '1', '--json']);
       expect(cleanupPlan.status).toBe(0);
       expect(JSON.parse(cleanupPlan.stdout).dryRun).toBe(true);
     });
   }, 30_000);
 
-  test('denies secret files before writing a session', () => {
-    withRepo((repoRoot) => {
-      const result = runChatgpt([
+  test('denies secret files before writing a session', async () => {
+    await withRepo(async (repoRoot) => {
+      const result = await runChatgpt([
         'browser-consult',
         '--repo',
         repoRoot,
@@ -574,13 +577,13 @@ describe('chatgpt browser command', () => {
     });
   }, 30_000);
 
-  test('denies allowed-path symlink escapes before writing a session', () => {
-    withRepo((repoRoot) => {
+  test('denies allowed-path symlink escapes before writing a session', async () => {
+    await withRepo(async (repoRoot) => {
       const outside = mkdtempSync(join(tmpdir(), 'repo-harness-chatgpt-browser-outside-'));
       try {
         writeFileSync(join(outside, 'secret.md'), '# outside\n');
         symlinkSync(join(outside, 'secret.md'), join(repoRoot, 'plans/sprints/linked.md'));
-        const result = runChatgpt([
+        const result = await runChatgpt([
           'browser-consult',
           '--repo',
           repoRoot,
@@ -599,9 +602,9 @@ describe('chatgpt browser command', () => {
     });
   }, 30_000);
 
-  test('validates write-output path and overwrite policy before writing a session', () => {
-    withRepo((repoRoot) => {
-      const denied = runChatgpt([
+  test('validates write-output path and overwrite policy before writing a session', async () => {
+    await withRepo(async (repoRoot) => {
+      const denied = await runChatgpt([
         'browser-consult',
         '--repo',
         repoRoot,
@@ -616,7 +619,7 @@ describe('chatgpt browser command', () => {
       expect(readFileSync(join(repoRoot, '.env'), 'utf-8')).toBe('SECRET=value\n');
       expect(existsSync(join(repoRoot, '.ai/harness/chatgpt/sessions'))).toBe(false);
 
-      const absolute = runChatgpt([
+      const absolute = await runChatgpt([
         'browser-consult',
         '--repo',
         repoRoot,
@@ -631,7 +634,7 @@ describe('chatgpt browser command', () => {
 
       mkdirSync(join(repoRoot, 'tasks/reviews'), { recursive: true });
       writeFileSync(join(repoRoot, 'tasks/reviews/existing.md'), 'old\n');
-      const noOverwrite = runChatgpt([
+      const noOverwrite = await runChatgpt([
         'browser-consult',
         '--repo',
         repoRoot,
@@ -647,8 +650,8 @@ describe('chatgpt browser command', () => {
     });
   }, 30_000);
 
-  test('rejects imported artifact basename collisions before creating a session', () => {
-    withRepo((repoRoot) => {
+  test('rejects imported artifact basename collisions before creating a session', async () => {
+    await withRepo(async (repoRoot) => {
       const sourceRoot = mkdtempSync(join(tmpdir(), 'repo-harness-chatgpt-browser-artifacts-'));
       try {
         const sourceA = join(sourceRoot, 'reports');
@@ -690,8 +693,8 @@ describe('chatgpt browser command', () => {
     });
   }, 30_000);
 
-  test('lists session output and transcript paths from the configured session root', () => {
-    withRepo((repoRoot) => {
+  test('lists session output and transcript paths from the configured session root', async () => {
+    await withRepo(async (repoRoot) => {
       const absoluteRoot = mkdtempSync(join(tmpdir(), 'repo-harness-chatgpt-browser-custom-root-'));
       try {
         const cases: Array<{ customRoot?: string; expectedRoot: string }> = [
@@ -759,9 +762,9 @@ describe('chatgpt browser command', () => {
     });
   }, 30_000);
 
-  test('native provider readiness and dry-run are wired without opening a browser', () => {
-    withRepo((repoRoot) => {
-      const doctor = runChatgpt(['browser-doctor', '--repo', repoRoot, '--provider', 'native', '--json']);
+  test('native provider readiness and dry-run are wired without opening a browser', async () => {
+    await withRepo(async (repoRoot) => {
+      const doctor = await runChatgpt(['browser-doctor', '--repo', repoRoot, '--provider', 'native', '--json']);
       expect(doctor.status).toBe(0);
       const readiness = JSON.parse(doctor.stdout);
       expect(readiness.provider).toBe('native');
@@ -774,7 +777,7 @@ describe('chatgpt browser command', () => {
       expect(readiness.native.defaultChannel).toBe('chrome');
       expect(readiness.native.productSession.status).toBe('not_configured');
 
-      const result = runChatgpt([
+      const result = await runChatgpt([
         'browser-consult',
         '--repo',
         repoRoot,
@@ -791,7 +794,7 @@ describe('chatgpt browser command', () => {
       expect(meta.status).toBe('dry_run');
       expect(meta.browser.profileDir).toBeUndefined();
 
-      const appPreselectDryRun = runChatgpt([
+      const appPreselectDryRun = await runChatgpt([
         'browser-consult',
         '--repo',
         repoRoot,
@@ -808,7 +811,7 @@ describe('chatgpt browser command', () => {
       expect(appPreselectPayload.status).toBe('failed');
       expect(appPreselectPayload.error.code).toBe('CHATGPT_APP_PRESELECT_PROVIDER_UNSUPPORTED');
 
-      const unsupported = runChatgpt([
+      const unsupported = await runChatgpt([
         'browser-consult',
         '--repo',
         repoRoot,
@@ -824,7 +827,7 @@ describe('chatgpt browser command', () => {
       expect(unsupportedPayload.status).toBe('failed');
       expect(unsupportedPayload.error.code).toBe('NATIVE_MODEL_SELECTION_UNSUPPORTED');
 
-      const unbound = runChatgpt([
+      const unbound = await runChatgpt([
         'browser-consult',
         '--repo',
         repoRoot,
@@ -840,30 +843,30 @@ describe('chatgpt browser command', () => {
     });
   }, 30_000);
 
-  test('rejects removed bridge provider and browser-bind command surfaces', () => {
-    withRepo((repoRoot) => {
-      const doctor = runChatgpt(['browser-doctor', '--repo', repoRoot, '--provider', 'bridge']);
+  test('rejects removed bridge provider and browser-bind command surfaces', async () => {
+    await withRepo(async (repoRoot) => {
+      const doctor = await runChatgpt(['browser-doctor', '--repo', repoRoot, '--provider', 'bridge']);
       expect(doctor.status).toBe(2);
       expect(doctor.stderr).toContain('invalid --provider "bridge" (expected: oracle, native)');
 
-      const consult = runChatgpt(['browser-consult', '--repo', repoRoot, '--provider', 'bridge', '--prompt', 'Reply OK']);
+      const consult = await runChatgpt(['browser-consult', '--repo', repoRoot, '--provider', 'bridge', '--prompt', 'Reply OK']);
       expect(consult.status).toBe(2);
       expect(consult.stderr).toContain('invalid --provider "bridge" (expected: oracle, native)');
 
-      const bind = runChatgpt(['browser-bind', '--repo', repoRoot]);
+      const bind = await runChatgpt(['browser-bind', '--repo', repoRoot]);
       expect(bind.status).not.toBe(0);
       expect(bind.stderr).toContain("unknown command 'browser-bind'");
     });
   }, 30_000);
 
-  test('browser setup binds a user-selected ChatGPT profile and native dry-run uses it', () => {
-    withRepo((repoRoot) => {
+  test('browser setup binds a user-selected ChatGPT profile and native dry-run uses it', async () => {
+    await withRepo(async (repoRoot) => {
       const userDataDir = join(repoRoot, 'Chrome/User Data');
       const profileDir = join(userDataDir, 'Profile 1');
       mkdirSync(profileDir, { recursive: true });
       writeFileSync(join(userDataDir, 'Local State'), '{}\n');
       writeFileSync(join(profileDir, 'Preferences'), '{}\n');
-      const setup = runChatgpt([
+      const setup = await runChatgpt([
         'browser-setup',
         '--repo',
         repoRoot,
@@ -892,7 +895,7 @@ describe('chatgpt browser command', () => {
       const retiredPageKeys = ['bind' + 'PagePath', 'bind' + 'PageUrl'];
       expect(Object.keys(binding)).not.toEqual(expect.arrayContaining(retiredPageKeys));
 
-      const doctor = runChatgpt(['browser-doctor', '--repo', repoRoot, '--provider', 'native', '--json']);
+      const doctor = await runChatgpt(['browser-doctor', '--repo', repoRoot, '--provider', 'native', '--json']);
       expect(doctor.status).toBe(0);
       const readiness = JSON.parse(doctor.stdout);
       expect(readiness.native.productSession.status).toBe('bound');
@@ -907,7 +910,7 @@ describe('chatgpt browser command', () => {
         expect(readiness.next).toContain('Install Google Chrome before native provider execution.');
       }
 
-      const result = runChatgpt([
+      const result = await runChatgpt([
         'browser-consult',
         '--repo',
         repoRoot,
@@ -928,14 +931,14 @@ describe('chatgpt browser command', () => {
     });
   }, 30_000);
 
-  test('native provider blocks the default Chrome profile before CDP launch', () => {
+  test('native provider blocks the default Chrome profile before CDP launch', async () => {
     if (process.platform !== 'darwin') {
       expect(process.platform).not.toBe('darwin');
       return;
     }
-    withRepo((repoRoot) => {
+    await withRepo(async (repoRoot) => {
       const defaultChromeDir = join(homedir(), 'Library/Application Support/Google/Chrome');
-      const doctor = runChatgpt([
+      const doctor = await runChatgpt([
         'browser-doctor',
         '--repo',
         repoRoot,
@@ -956,7 +959,7 @@ describe('chatgpt browser command', () => {
       expect(readiness.native.productSession.validation).toBeUndefined();
       expect(readiness.browser.opensBrowser).toBe(false);
 
-      const result = runChatgpt([
+      const result = await runChatgpt([
         'browser-consult',
         '--repo',
         repoRoot,
@@ -978,7 +981,7 @@ describe('chatgpt browser command', () => {
     });
   }, 30_000);
 
-  test('native CDP starts Chrome on an atomically assigned port', () => {
+  test('native CDP starts Chrome on an atomically assigned port', async () => {
     const source = readFileSync(join(ROOT, 'src/cli/chatgpt-browser/native-provider.ts'), 'utf-8');
     expect(source).toContain("'--remote-debugging-port=0'");
     expect(source).toContain('DevToolsActivePort');
@@ -1075,8 +1078,8 @@ describe('chatgpt browser command', () => {
     expect(capture).toEqual({ text: 'instant final', completed: true });
   });
 
-  test('oracle rejects unsupported versions uniformly before consultation side effects', () => {
-    withRepo((repoRoot) => {
+  test('oracle rejects unsupported versions uniformly before consultation side effects', async () => {
+    await withRepo(async (repoRoot) => {
       const binDir = mkdtempSync(join(tmpdir(), 'repo-harness-oracle-version-policy-'));
       const withoutConfiguredOracle = { ...process.env };
       delete withoutConfiguredOracle.REPO_HARNESS_ORACLE_BIN;
@@ -1099,7 +1102,7 @@ describe('chatgpt browser command', () => {
         writeOracle(envExact, '0.20.0');
         writeOracle(pathExact, '0.20.0');
 
-        const explicitDoctor = runChatgpt(['browser-doctor', '--repo', repoRoot, '--provider', 'oracle', '--oracle-bin', explicitOld, '--json'], ROOT, withoutConfiguredOracle);
+        const explicitDoctor = await runChatgpt(['browser-doctor', '--repo', repoRoot, '--provider', 'oracle', '--oracle-bin', explicitOld, '--json'], ROOT, withoutConfiguredOracle);
         const explicitReadiness = JSON.parse(explicitDoctor.stdout);
         expect(explicitReadiness).toMatchObject({
           status: 'action_required',
@@ -1110,7 +1113,7 @@ describe('chatgpt browser command', () => {
         expect(explicitReadiness.oracle.error.message).toContain('exactly 0.20.0');
 
         const executed = join(binDir, 'unexpected-execution');
-        const rejectedRun = runChatgpt([
+        const rejectedRun = await runChatgpt([
           'browser-consult',
           '--repo',
           repoRoot,
@@ -1124,7 +1127,7 @@ describe('chatgpt browser command', () => {
         expect(existsSync(executed)).toBe(false);
         expect(existsSync(join(repoRoot, '.ai/harness/chatgpt/oracle-home'))).toBe(false);
 
-        const envDoctor = runChatgpt(['browser-doctor', '--repo', repoRoot, '--provider', 'oracle', '--json'], ROOT, {
+        const envDoctor = await runChatgpt(['browser-doctor', '--repo', repoRoot, '--provider', 'oracle', '--json'], ROOT, {
           ...withoutConfiguredOracle,
           REPO_HARNESS_ORACLE_BIN: envExact,
         });
@@ -1136,7 +1139,7 @@ describe('chatgpt browser command', () => {
         const repoLocalDir = join(repoRoot, 'node_modules/.bin');
         mkdirSync(repoLocalDir, { recursive: true });
         writeOracle(join(repoLocalDir, 'oracle'), '0.20.1');
-        const repoLocalDoctor = runChatgpt(['browser-doctor', '--repo', repoRoot, '--provider', 'oracle', '--json'], ROOT, withoutConfiguredOracle);
+        const repoLocalDoctor = await runChatgpt(['browser-doctor', '--repo', repoRoot, '--provider', 'oracle', '--json'], ROOT, withoutConfiguredOracle);
         expect(JSON.parse(repoLocalDoctor.stdout)).toMatchObject({
           status: 'action_required',
           code: 'ORACLE_VERSION_UNSUPPORTED',
@@ -1144,7 +1147,7 @@ describe('chatgpt browser command', () => {
         });
 
         rmSync(repoLocalDir, { recursive: true, force: true });
-        const pathDoctor = runChatgpt(['browser-doctor', '--repo', repoRoot, '--provider', 'oracle', '--json'], ROOT, {
+        const pathDoctor = runChatgptSpawnedForPath(['browser-doctor', '--repo', repoRoot, '--provider', 'oracle', '--json'], {
           ...withoutConfiguredOracle,
           PATH: `${binDir}:${withoutConfiguredOracle.PATH ?? ''}`,
         });
@@ -1187,7 +1190,7 @@ describe('chatgpt browser command', () => {
         chmodSync(oraclePath, 0o755);
 
         const startedAt = Date.now();
-        const result = runChatgpt([
+        const result = await runChatgpt([
           'browser-consult',
           '--repo',
           repoRoot,
@@ -1227,8 +1230,8 @@ describe('chatgpt browser command', () => {
     });
   }, 15_000);
 
-  test('oracle provider reads the --write-output answer file and treats stdout as logs', () => {
-    withRepo((repoRoot) => {
+  test('oracle provider reads the --write-output answer file and treats stdout as logs', async () => {
+    await withRepo(async (repoRoot) => {
       const binDir = mkdtempSync(join(tmpdir(), 'repo-harness-fake-oracle-bin-'));
       try {
         const oraclePath = join(binDir, 'oracle');
@@ -1267,7 +1270,7 @@ describe('chatgpt browser command', () => {
           join(repoRoot, '.oracle/config.json'),
           '{"promptSuffix":"DO NOT INHERIT","browser":{"manualLogin":true,"modelStrategy":"ignore"}}\n',
         );
-        const result = runChatgpt([
+        const result = await runChatgpt([
           'browser-consult',
           '--repo',
           repoRoot,
@@ -1310,7 +1313,7 @@ describe('chatgpt browser command', () => {
         expect(meta.oracle.captureStatus).toBe('completed');
         expect(meta.output.artifacts).toEqual([]);
 
-        const opened = runChatgpt(['browser-open', '--repo', repoRoot, payload.sessionId]);
+        const opened = await runChatgpt(['browser-open', '--repo', repoRoot, payload.sessionId]);
         expect(opened.status).toBe(0);
         expect(JSON.parse(opened.stdout).url).toBe('https://chatgpt.com/c/fake-conversation');
       } finally {
@@ -1319,14 +1322,14 @@ describe('chatgpt browser command', () => {
     });
   }, 30_000);
 
-  test('oracle provider copies the bound Chrome profile as the only transport', () => {
-    withRepo((repoRoot) => {
-      const { userDataDir } = bindChromeProfile(repoRoot);
+  test('oracle provider copies the bound Chrome profile as the only transport', async () => {
+    await withRepo(async (repoRoot) => {
+      const { userDataDir } = await bindChromeProfile(repoRoot);
 
       const binDir = mkdtempSync(join(tmpdir(), 'repo-harness-fake-oracle-profile-'));
       try {
         const oraclePath = writeFakeOracle(join(binDir, 'oracle'), { sessionLine: 'Session ID: oracle_profile_123' });
-        const result = runChatgpt([
+        const result = await runChatgpt([
           'browser-consult',
           '--repo',
           repoRoot,
@@ -1379,9 +1382,9 @@ describe('chatgpt browser command', () => {
   ];
 
   for (const transportCase of missingTransportFlagCases) {
-    test(`oracle provider fails closed when the resolved binary reports ${transportCase.label}`, () => {
-      withRepo((repoRoot) => {
-        bindChromeProfile(repoRoot);
+    test(`oracle provider fails closed when the resolved binary reports ${transportCase.label}`, async () => {
+      await withRepo(async (repoRoot) => {
+        await bindChromeProfile(repoRoot);
 
         const binDir = mkdtempSync(join(tmpdir(), 'repo-harness-fake-oracle-no-copy-profile-'));
         try {
@@ -1389,7 +1392,7 @@ describe('chatgpt browser command', () => {
             help: transportCase.help,
             body: ['printf "%s\\n" "unexpected oracle execution" >&2', 'exit 99'],
           });
-          const result = runChatgpt([
+          const result = await runChatgpt([
             'browser-consult',
             '--repo',
             repoRoot,
@@ -1413,9 +1416,9 @@ describe('chatgpt browser command', () => {
     }, 30_000);
   }
 
-  test('oracle provider fails closed when the bound Chrome user data directory has no Local State', () => {
-    withRepo((repoRoot) => {
-      const { userDataDir } = bindChromeProfile(repoRoot);
+  test('oracle provider fails closed when the bound Chrome user data directory has no Local State', async () => {
+    await withRepo(async (repoRoot) => {
+      const { userDataDir } = await bindChromeProfile(repoRoot);
       rmSync(join(userDataDir, 'Local State'));
 
       const binDir = mkdtempSync(join(tmpdir(), 'repo-harness-fake-oracle-no-local-state-'));
@@ -1423,7 +1426,7 @@ describe('chatgpt browser command', () => {
         const oraclePath = writeFakeOracle(join(binDir, 'oracle'), {
           body: ['printf "%s\\n" "unexpected oracle execution" >&2', 'exit 99'],
         });
-        const result = runChatgpt([
+        const result = await runChatgpt([
           'browser-consult',
           '--repo',
           repoRoot,
@@ -1446,15 +1449,15 @@ describe('chatgpt browser command', () => {
     });
   }, 30_000);
 
-  test('oracle provider fails closed when the binding names no Chrome profile directory', () => {
-    withRepo((repoRoot) => {
+  test('oracle provider fails closed when the binding names no Chrome profile directory', async () => {
+    await withRepo(async (repoRoot) => {
       // A user data directory bound without a profile subdirectory would leave
       // profile selection to Oracle's Local State last_used, which is not
       // deterministic; repo-harness refuses instead of guessing.
       const userDataDir = join(repoRoot, 'Chrome/User Data');
       mkdirSync(userDataDir, { recursive: true });
       writeFileSync(join(userDataDir, 'Local State'), '{}\n');
-      const setup = runChatgpt([
+      const setup = await runChatgpt([
         'browser-setup',
         '--repo',
         repoRoot,
@@ -1472,7 +1475,7 @@ describe('chatgpt browser command', () => {
         const oraclePath = writeFakeOracle(join(binDir, 'oracle'), {
           body: ['printf "%s\\n" "unexpected oracle execution" >&2', 'exit 99'],
         });
-        const result = runChatgpt([
+        const result = await runChatgpt([
           'browser-consult',
           '--repo',
           repoRoot,
@@ -1491,7 +1494,7 @@ describe('chatgpt browser command', () => {
         expect(output).not.toContain('unexpected oracle execution');
 
         // A dry run must not preview a half transport either.
-        const dryRun = runChatgpt([
+        const dryRun = await runChatgpt([
           'browser-consult',
           '--repo',
           repoRoot,
@@ -1510,9 +1513,9 @@ describe('chatgpt browser command', () => {
     });
   }, 30_000);
 
-  test('oracle provider maps a running same-prompt session to a reattach failure', () => {
-    withRepo((repoRoot) => {
-      bindChromeProfile(repoRoot);
+  test('oracle provider maps a running same-prompt session to a reattach failure', async () => {
+    await withRepo(async (repoRoot) => {
+      await bindChromeProfile(repoRoot);
 
       const binDir = mkdtempSync(join(tmpdir(), 'repo-harness-fake-oracle-session-running-'));
       const argvLog = join(binDir, 'argv.txt');
@@ -1527,7 +1530,7 @@ describe('chatgpt browser command', () => {
             'exit 1',
           ],
         });
-        const result = runChatgpt([
+        const result = await runChatgpt([
           'browser-consult',
           '--repo',
           repoRoot,
@@ -1555,10 +1558,10 @@ describe('chatgpt browser command', () => {
     });
   }, 30_000);
 
-  test('oracle dry run renders the copy-profile transport and records it in session meta', () => {
-    withRepo((repoRoot) => {
-      const { userDataDir } = bindChromeProfile(repoRoot);
-      const dryRun = runChatgpt([
+  test('oracle dry run renders the copy-profile transport and records it in session meta', async () => {
+    await withRepo(async (repoRoot) => {
+      const { userDataDir } = await bindChromeProfile(repoRoot);
+      const dryRun = await runChatgpt([
         'browser-consult',
         '--repo',
         repoRoot,
@@ -1578,9 +1581,9 @@ describe('chatgpt browser command', () => {
     });
   }, 30_000);
 
-  test('oracle dry run without a profile binding records the oracle session transport', () => {
-    withRepo((repoRoot) => {
-      const dryRun = runChatgpt([
+  test('oracle dry run without a profile binding records the oracle session transport', async () => {
+    await withRepo(async (repoRoot) => {
+      const dryRun = await runChatgpt([
         'browser-consult',
         '--repo',
         repoRoot,
@@ -1598,8 +1601,8 @@ describe('chatgpt browser command', () => {
     });
   }, 30_000);
 
-  test('oracle provider keeps the answer file authoritative when a clean exit logs the stale-session sentence', () => {
-    withRepo((repoRoot) => {
+  test('oracle provider keeps the answer file authoritative when a clean exit logs the stale-session sentence', async () => {
+    await withRepo(async (repoRoot) => {
       const binDir = mkdtempSync(join(tmpdir(), 'repo-harness-fake-oracle-clean-stale-log-'));
       try {
         const oraclePath = join(binDir, 'oracle');
@@ -1624,7 +1627,7 @@ describe('chatgpt browser command', () => {
           ].join('\n'),
         );
         chmodSync(oraclePath, 0o755);
-        const result = runChatgpt([
+        const result = await runChatgpt([
           'browser-consult',
           '--repo',
           repoRoot,
@@ -1644,8 +1647,8 @@ describe('chatgpt browser command', () => {
     });
   }, 30_000);
 
-  test('the deprecated native provider records its own profile transport', () => {
-    withRepo((repoRoot) => {
+  test('the deprecated native provider records its own profile transport', async () => {
+    await withRepo(async (repoRoot) => {
       const result = writeBrowserSession({
         input: {
           repoRoot,
@@ -1673,8 +1676,8 @@ describe('chatgpt browser command', () => {
     });
   }, 30_000);
 
-  test('oracle provider downgrades an empty answer file to recoverable, not completed', () => {
-    withRepo((repoRoot) => {
+  test('oracle provider downgrades an empty answer file to recoverable, not completed', async () => {
+    await withRepo(async (repoRoot) => {
       const binDir = mkdtempSync(join(tmpdir(), 'repo-harness-fake-oracle-empty-'));
       try {
         const oraclePath = join(binDir, 'oracle');
@@ -1691,7 +1694,7 @@ describe('chatgpt browser command', () => {
           ].join('\n'),
         );
         chmodSync(oraclePath, 0o755);
-        const result = runChatgpt([
+        const result = await runChatgpt([
           'browser-consult',
           '--repo',
           repoRoot,
@@ -1713,8 +1716,8 @@ describe('chatgpt browser command', () => {
     });
   }, 30_000);
 
-  test('oracle provider maps thinking to Oracle browser thinking time', () => {
-    withRepo((repoRoot) => {
+  test('oracle provider maps thinking to Oracle browser thinking time', async () => {
+    await withRepo(async (repoRoot) => {
       const binDir = mkdtempSync(join(tmpdir(), 'repo-harness-fake-oracle-thinking-'));
       try {
         const oraclePath = join(binDir, 'oracle');
@@ -1736,7 +1739,7 @@ describe('chatgpt browser command', () => {
           ].join('\n'),
         );
         chmodSync(oraclePath, 0o755);
-        const result = runChatgpt([
+        const result = await runChatgpt([
           'browser-consult',
           '--repo',
           repoRoot,
@@ -1763,8 +1766,8 @@ describe('chatgpt browser command', () => {
     });
   }, 30_000);
 
-  test('oracle rejection of a thinking value fails closed without a local fallback', () => {
-    withRepo((repoRoot) => {
+  test('oracle rejection of a thinking value fails closed without a local fallback', async () => {
+    await withRepo(async (repoRoot) => {
       const binDir = mkdtempSync(join(tmpdir(), 'repo-harness-fake-oracle-bad-thinking-'));
       try {
         const oraclePath = join(binDir, 'oracle');
@@ -1786,7 +1789,7 @@ describe('chatgpt browser command', () => {
           ].join('\n'),
         );
         chmodSync(oraclePath, 0o755);
-        const result = runChatgpt([
+        const result = await runChatgpt([
           'browser-consult',
           '--repo',
           repoRoot,
@@ -1808,8 +1811,8 @@ describe('chatgpt browser command', () => {
     });
   }, 30_000);
 
-  test('oracle app preselection fails closed when the binary lacks browser-app support', () => {
-    withRepo((repoRoot) => {
+  test('oracle app preselection fails closed when the binary lacks browser-app support', async () => {
+    await withRepo(async (repoRoot) => {
       const binDir = mkdtempSync(join(tmpdir(), 'repo-harness-fake-oracle-no-app-'));
       try {
         const oraclePath = join(binDir, 'oracle');
@@ -1829,7 +1832,7 @@ describe('chatgpt browser command', () => {
           ].join('\n'),
         );
         chmodSync(oraclePath, 0o755);
-        const result = runChatgpt([
+        const result = await runChatgpt([
           'browser-consult',
           '--repo',
           repoRoot,
@@ -1853,8 +1856,8 @@ describe('chatgpt browser command', () => {
     });
   }, 30_000);
 
-  test('oracle provider passes ChatGPT app preselection to Oracle when supported', () => {
-    withRepo((repoRoot) => {
+  test('oracle provider passes ChatGPT app preselection to Oracle when supported', async () => {
+    await withRepo(async (repoRoot) => {
       const binDir = mkdtempSync(join(tmpdir(), 'repo-harness-fake-oracle-app-'));
       try {
         const oraclePath = join(binDir, 'oracle');
@@ -1877,7 +1880,7 @@ describe('chatgpt browser command', () => {
           ].join('\n'),
         );
         chmodSync(oraclePath, 0o755);
-        const result = runChatgpt([
+        const result = await runChatgpt([
           'browser-consult',
           '--repo',
           repoRoot,
@@ -1903,8 +1906,8 @@ describe('chatgpt browser command', () => {
 
   // Regression guard: the pinned oracle surface is 0.20.0 and no longer carries a
   // cookie-path capability, so doctor must report ready on that exact surface.
-  test('oracle doctor reports ready on the pinned 0.20.0 surface without a cookie-path flag', () => {
-    withRepo((repoRoot) => {
+  test('oracle doctor reports ready on the pinned 0.20.0 surface without a cookie-path flag', async () => {
+    await withRepo(async (repoRoot) => {
       const binDir = mkdtempSync(join(tmpdir(), 'repo-harness-fake-oracle-pinned-'));
       try {
         const oraclePath = join(binDir, 'oracle');
@@ -1919,7 +1922,7 @@ describe('chatgpt browser command', () => {
           ].join('\n'),
         );
         chmodSync(oraclePath, 0o755);
-        const doctor = runChatgpt(['browser-doctor', '--repo', repoRoot, '--provider', 'oracle', '--oracle-bin', oraclePath, '--json']);
+        const doctor = await runChatgpt(['browser-doctor', '--repo', repoRoot, '--provider', 'oracle', '--oracle-bin', oraclePath, '--json']);
         expect(doctor.status).toBe(0);
         const readiness = JSON.parse(doctor.stdout);
         expect(readiness.status).toBe('ready');
@@ -1935,8 +1938,8 @@ describe('chatgpt browser command', () => {
     });
   }, 30_000);
 
-  test('oracle doctor probes binary capabilities and reports ready', () => {
-    withRepo((repoRoot) => {
+  test('oracle doctor probes binary capabilities and reports ready', async () => {
+    await withRepo(async (repoRoot) => {
       const binDir = mkdtempSync(join(tmpdir(), 'repo-harness-fake-oracle-doctor-'));
       try {
         const oraclePath = join(binDir, 'oracle');
@@ -1951,7 +1954,7 @@ describe('chatgpt browser command', () => {
           ].join('\n'),
         );
         chmodSync(oraclePath, 0o755);
-        const doctor = runChatgpt(['browser-doctor', '--repo', repoRoot, '--provider', 'oracle', '--oracle-bin', oraclePath, '--json']);
+        const doctor = await runChatgpt(['browser-doctor', '--repo', repoRoot, '--provider', 'oracle', '--oracle-bin', oraclePath, '--json']);
         expect(doctor.status).toBe(0);
         const readiness = JSON.parse(doctor.stdout);
         expect(readiness.status).toBe('ready');
@@ -1980,7 +1983,7 @@ describe('chatgpt browser command', () => {
         });
         expect(readiness.oracle.missingCapabilities).toEqual([]);
 
-        const missing = runChatgpt(['browser-doctor', '--repo', repoRoot, '--provider', 'oracle', '--oracle-bin', join(binDir, 'nope'), '--json'], ROOT, {
+        const missing = await runChatgpt(['browser-doctor', '--repo', repoRoot, '--provider', 'oracle', '--oracle-bin', join(binDir, 'nope'), '--json'], ROOT, {
           ...process.env,
           PATH: `${binDir}:${process.env.PATH ?? ''}`,
         });
@@ -2008,8 +2011,8 @@ describe('chatgpt browser command', () => {
     });
   }, 30_000);
 
-  test('oracle doctor requires every runtime flag before reporting ready', () => {
-    withRepo((repoRoot) => {
+  test('oracle doctor requires every runtime flag before reporting ready', async () => {
+    await withRepo(async (repoRoot) => {
       const binDir = mkdtempSync(join(tmpdir(), 'repo-harness-fake-oracle-incompatible-'));
       try {
         const oraclePath = join(binDir, 'oracle');
@@ -2027,7 +2030,7 @@ describe('chatgpt browser command', () => {
           ].join('\n'),
         );
         chmodSync(oraclePath, 0o755);
-        const doctor = runChatgpt(['browser-doctor', '--repo', repoRoot, '--provider', 'oracle', '--oracle-bin', oraclePath, '--json']);
+        const doctor = await runChatgpt(['browser-doctor', '--repo', repoRoot, '--provider', 'oracle', '--oracle-bin', oraclePath, '--json']);
         expect(doctor.status).toBe(0);
         const readiness = JSON.parse(doctor.stdout);
         expect(readiness.status).toBe('action_required');
@@ -2067,12 +2070,12 @@ describe('chatgpt browser command', () => {
 
   // The session-descriptor and evidence flags live only in the repo-harness Oracle
   // fork. `--help` does not list them, so acceptance is proved by a dry-run probe.
-  test('oracle doctor reports ready when the binary accepts the runtime flag probe', () => {
-    withRepo((repoRoot) => {
+  test('oracle doctor reports ready when the binary accepts the runtime flag probe', async () => {
+    await withRepo(async (repoRoot) => {
       const binDir = mkdtempSync(join(tmpdir(), 'repo-harness-fake-oracle-fork-flags-'));
       try {
         const oraclePath = writeFakeOracle(join(binDir, 'oracle'));
-        const doctor = runChatgpt(['browser-doctor', '--repo', repoRoot, '--provider', 'oracle', '--oracle-bin', oraclePath, '--json']);
+        const doctor = await runChatgpt(['browser-doctor', '--repo', repoRoot, '--provider', 'oracle', '--oracle-bin', oraclePath, '--json']);
         expect(doctor.status).toBe(0);
         const readiness = JSON.parse(doctor.stdout);
         expect(readiness.status).toBe('ready');
@@ -2090,12 +2093,12 @@ describe('chatgpt browser command', () => {
     });
   }, 30_000);
 
-  test('oracle doctor fails closed when the binary rejects the fork session flags', () => {
-    withRepo((repoRoot) => {
+  test('oracle doctor fails closed when the binary rejects the fork session flags', async () => {
+    await withRepo(async (repoRoot) => {
       const binDir = mkdtempSync(join(tmpdir(), 'repo-harness-fake-oracle-upstream-flags-'));
       try {
         const oraclePath = writeFakeOracle(join(binDir, 'oracle'), { rejectWriteSession: true });
-        const doctor = runChatgpt(['browser-doctor', '--repo', repoRoot, '--provider', 'oracle', '--oracle-bin', oraclePath, '--json']);
+        const doctor = await runChatgpt(['browser-doctor', '--repo', repoRoot, '--provider', 'oracle', '--oracle-bin', oraclePath, '--json']);
         expect(doctor.status).toBe(0);
         const readiness = JSON.parse(doctor.stdout);
         expect(readiness.status).toBe('action_required');
@@ -2127,15 +2130,15 @@ describe('chatgpt browser command', () => {
     });
   }, 30_000);
 
-  test('oracle consult refuses before spawning when the binary rejects the fork session flags', () => {
-    withRepo((repoRoot) => {
+  test('oracle consult refuses before spawning when the binary rejects the fork session flags', async () => {
+    await withRepo(async (repoRoot) => {
       const binDir = mkdtempSync(join(tmpdir(), 'repo-harness-fake-oracle-upstream-consult-'));
       try {
         const oraclePath = writeFakeOracle(join(binDir, 'oracle'), {
           rejectWriteSession: true,
           body: ['printf "%s\\n" "unexpected oracle execution" >&2', 'exit 99'],
         });
-        const result = runChatgpt(['browser-consult', '--repo', repoRoot, '--prompt', 'Review this.', '--oracle-bin', oraclePath]);
+        const result = await runChatgpt(['browser-consult', '--repo', repoRoot, '--prompt', 'Review this.', '--oracle-bin', oraclePath]);
         expect(result.status).toBe(0);
         const payload = JSON.parse(result.stdout);
         expect(payload.status).toBe('failed');
@@ -2152,7 +2155,7 @@ describe('chatgpt browser command', () => {
     });
   }, 30_000);
 
-  test('runtime flag probe fails closed when buildOracleCommand stops emitting a mapped flag', () => {
+  test('runtime flag probe fails closed when buildOracleCommand stops emitting a mapped flag', async () => {
     const probeDir = mkdtempSync(join(tmpdir(), 'repo-harness-oracle-probe-sync-'));
     try {
       expect(buildRuntimeAcceptanceProbeArgs(probeDir)).toContain('--write-session');
@@ -2165,8 +2168,8 @@ describe('chatgpt browser command', () => {
     }
   });
 
-  test('oracle doctor is not ready without the copy-profile transport flags', () => {
-    withRepo((repoRoot) => {
+  test('oracle doctor is not ready without the copy-profile transport flags', async () => {
+    await withRepo(async (repoRoot) => {
       const binDir = mkdtempSync(join(tmpdir(), 'repo-harness-fake-oracle-no-transport-'));
       try {
         const oraclePath = join(binDir, 'oracle');
@@ -2181,7 +2184,7 @@ describe('chatgpt browser command', () => {
           ].join('\n'),
         );
         chmodSync(oraclePath, 0o755);
-        const doctor = runChatgpt(['browser-doctor', '--repo', repoRoot, '--provider', 'oracle', '--oracle-bin', oraclePath, '--json']);
+        const doctor = await runChatgpt(['browser-doctor', '--repo', repoRoot, '--provider', 'oracle', '--oracle-bin', oraclePath, '--json']);
         expect(doctor.status).toBe(0);
         const readiness = JSON.parse(doctor.stdout);
         expect(readiness.status).toBe('action_required');
@@ -2197,8 +2200,8 @@ describe('chatgpt browser command', () => {
     });
   }, 30_000);
 
-  test('oracle doctor repairs repo-local and env-selected binaries through source-aware actions', () => {
-    withRepo((repoRoot) => {
+  test('oracle doctor repairs repo-local and env-selected binaries through source-aware actions', async () => {
+    await withRepo(async (repoRoot) => {
       const repoBinDir = join(repoRoot, 'node_modules/.bin');
       mkdirSync(repoBinDir, { recursive: true });
       const repoOracle = join(repoBinDir, 'oracle');
@@ -2214,7 +2217,7 @@ describe('chatgpt browser command', () => {
       );
       chmodSync(repoOracle, 0o755);
 
-      const repoLocal = runChatgpt(['browser-doctor', '--repo', repoRoot, '--provider', 'oracle', '--json']);
+      const repoLocal = await runChatgpt(['browser-doctor', '--repo', repoRoot, '--provider', 'oracle', '--json']);
       expect(repoLocal.status).toBe(0);
       const repoLocalReadiness = JSON.parse(repoLocal.stdout);
       expect(repoLocalReadiness.status).toBe('action_required');
@@ -2224,7 +2227,7 @@ describe('chatgpt browser command', () => {
         command: 'bun add -D @steipete/oracle@0.20.0',
       });
 
-      const envSelected = runChatgpt(['browser-doctor', '--repo', repoRoot, '--provider', 'oracle', '--json'], ROOT, {
+      const envSelected = await runChatgpt(['browser-doctor', '--repo', repoRoot, '--provider', 'oracle', '--json'], ROOT, {
         ...process.env,
         REPO_HARNESS_ORACLE_BIN: join(repoRoot, 'missing-oracle'),
       });
@@ -2239,9 +2242,9 @@ describe('chatgpt browser command', () => {
     });
   }, 30_000);
 
-  test('oracle follow-up uses providerSessionId instead of local sessionId', () => {
-    withRepo((repoRoot) => {
-      const initial = runChatgpt([
+  test('oracle follow-up uses providerSessionId instead of local sessionId', async () => {
+    await withRepo(async (repoRoot) => {
+      const initial = await runChatgpt([
         'browser-consult',
         '--repo',
         repoRoot,
@@ -2261,7 +2264,7 @@ describe('chatgpt browser command', () => {
       writeFileSync(join(userDataDir, 'Local State'), '{}\n');
       writeFileSync(join(profileDir, 'Preferences'), '{}\n');
       writeFileSync(join(profileDir, 'Cookies'), 'fake cookie db\n');
-      const setup = runChatgpt([
+      const setup = await runChatgpt([
         'browser-setup',
         '--repo',
         repoRoot,
@@ -2295,7 +2298,7 @@ describe('chatgpt browser command', () => {
           ].join('\n'),
         );
         chmodSync(oraclePath, 0o755);
-        const followup = runChatgpt([
+        const followup = await runChatgpt([
           'browser-followup',
           '--repo',
           repoRoot,
@@ -2326,9 +2329,9 @@ describe('chatgpt browser command', () => {
     });
   }, 30_000);
 
-  test('rejects invalid session ids for read/open surfaces', () => {
-    withRepo((repoRoot) => {
-      const read = runChatgpt(['browser-session', '--repo', repoRoot, '../secret']);
+  test('rejects invalid session ids for read/open surfaces', async () => {
+    await withRepo(async (repoRoot) => {
+      const read = await runChatgpt(['browser-session', '--repo', repoRoot, '../secret']);
       expect(read.status).toBe(2);
       expect(read.stderr).toContain('invalid ChatGPT browser session id');
     });
@@ -2340,7 +2343,7 @@ describe('chatgpt browser command', () => {
   // both deleted. Their content reconciled into the one canonical
   // repo-harness-chatgpt package (SSD-05); these path-specific assertions
   // migrate to that package's setup/consult/read-back references.
-  test('canonical repo-harness-chatgpt package carries the Oracle setup and GPT Pro consult/read-back content', () => {
+  test('canonical repo-harness-chatgpt package carries the Oracle setup and GPT Pro consult/read-back content', async () => {
     const setup = readFileSync(join(ROOT, 'assets/skills/repo-harness-chatgpt/references/setup.md'), 'utf-8');
     expect(setup).toContain('--provider oracle --json');
     expect(setup).toContain('node >=24');

--- a/tests/helpers/cli-in-process.ts
+++ b/tests/helpers/cli-in-process.ts
@@ -1,0 +1,150 @@
+import { format } from 'node:util';
+import { buildProgram } from '../../src/cli/index';
+import type { Command } from 'commander';
+
+/** The `spawnSync` fields CLI tests assert on, produced without a child process. */
+export interface InProcessCliResult {
+  readonly status: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+const SETTLE_TIMEOUT_MS = 170_000;
+
+function applyEnv(target: NodeJS.ProcessEnv): void {
+  for (const key of Object.keys(process.env)) {
+    if (target[key] === undefined) delete process.env[key];
+  }
+  for (const [key, value] of Object.entries(target)) {
+    if (value !== undefined) process.env[key] = value;
+  }
+}
+
+function overrideExit(command: Command): void {
+  command.exitOverride();
+  for (const child of command.commands) overrideExit(child);
+}
+
+/**
+ * Run the repo-harness CLI inside the test process instead of spawning `bun`.
+ *
+ * The process boundary carried four semantics this runner has to reproduce.
+ *
+ * `env` and `cwd` are replaced in place and restored afterwards, because the
+ * command bodies read them through `process`: `resolveRepoRoot` resolves against
+ * `process.cwd()`, and the oracle and Gitleaks child environments are built from
+ * a `process.env` snapshot, so fixture binaries only observe a test's variables
+ * if the live environment carries them.
+ *
+ * Commander's own exits (`--help`, unknown option, missing required option) are
+ * converted to thrown `CommanderError`s by `exitOverride`, after the help or
+ * error text has already been written.
+ *
+ * A command body's own exit is recorded rather than thrown: the single
+ * `process.exit(2)` the `chatgpt` group can reach is the last statement of its
+ * error funnel, and throwing from it would surface as an unhandled rejection
+ * that Bun's test runner fails on, because the action handlers discard the work
+ * promise (`void runChatgptAction(...)`).
+ *
+ * That discarded promise is also why completion needs its own barrier: commander
+ * resolves `parseAsync` before the action finishes. Every `chatgpt` action ends
+ * by writing its result to stdout or by reaching that error exit, and nothing
+ * under `src/cli/chatgpt-browser/` writes to stdout, so the first stdout write or
+ * the recorded exit marks the command as finished. Both are the action's
+ * terminal statement, so by the time this function observes one, the remaining
+ * synchronous work in that action has already run.
+ */
+export async function runCliInProcess(
+  args: readonly string[],
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+): Promise<InProcessCliResult> {
+  const envSnapshot = { ...process.env };
+  const requestedEnv = { ...env };
+  const cwdSnapshot = process.cwd();
+  const originalStdoutWrite = process.stdout.write;
+  const originalStderrWrite = process.stderr.write;
+  const originalExit = process.exit;
+  const originalConsole = {
+    log: console.log,
+    info: console.info,
+    debug: console.debug,
+    error: console.error,
+    warn: console.warn,
+  };
+
+  let stdout = '';
+  let stderr = '';
+  let exitCode: number | undefined;
+  let settle: (() => void) | undefined;
+  const finished = (): boolean => exitCode !== undefined || stdout.length > 0;
+  const emitOut = (text: string): void => {
+    stdout += text;
+    if (finished()) settle?.();
+  };
+  const emitErr = (text: string): void => {
+    stderr += text;
+  };
+
+  applyEnv(requestedEnv);
+  process.chdir(cwd);
+  process.stdout.write = ((chunk: string | Uint8Array, ...rest: unknown[]) => {
+    emitOut(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf-8'));
+    const callback = rest.find((value) => typeof value === 'function') as (() => void) | undefined;
+    callback?.();
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string | Uint8Array, ...rest: unknown[]) => {
+    emitErr(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf-8'));
+    const callback = rest.find((value) => typeof value === 'function') as (() => void) | undefined;
+    callback?.();
+    return true;
+  }) as typeof process.stderr.write;
+  console.log = (...values: unknown[]) => emitOut(`${format(...values)}\n`);
+  console.info = console.log;
+  console.debug = console.log;
+  console.error = (...values: unknown[]) => emitErr(`${format(...values)}\n`);
+  console.warn = console.error;
+  process.exit = ((code?: number) => {
+    exitCode = code ?? 0;
+    settle?.();
+  }) as typeof process.exit;
+
+  try {
+    const program = buildProgram();
+    overrideExit(program);
+    await program.parseAsync(['bun', 'repo-harness', ...args]);
+    if (!finished()) {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        await new Promise<void>((resolve, reject) => {
+          settle = resolve;
+          timer = setTimeout(
+            () => reject(new Error(`in-process CLI did not finish: repo-harness ${args.join(' ')}`)),
+            SETTLE_TIMEOUT_MS,
+          );
+        });
+      } finally {
+        if (timer) clearTimeout(timer);
+        settle = undefined;
+      }
+    }
+    return { status: exitCode ?? 0, stdout, stderr };
+  } catch (error) {
+    const failure = error as { exitCode?: number; message?: string };
+    if (typeof failure.exitCode === 'number') return { status: failure.exitCode, stdout, stderr };
+    if (failure.message) emitErr(`${failure.message}\n`);
+    return { status: 1, stdout, stderr };
+  } finally {
+    process.exit = originalExit;
+    console.log = originalConsole.log;
+    console.info = originalConsole.info;
+    console.debug = originalConsole.debug;
+    console.error = originalConsole.error;
+    console.warn = originalConsole.warn;
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+    process.chdir(cwdSnapshot);
+    applyEnv(envSnapshot);
+  }
+}


### PR DESCRIPTION
`tests/cli/chatgpt-browser.test.ts` spawned a fresh `bun src/cli/index.ts` at 77 call sites, paying a full CLI module-tree parse each time. Measured in isolation: 20 spawned calls cost 4054 ms, 20 in-process calls cost 38 ms after a one-time 166 ms import.

### Result

| Run | Wall | CPU (user + sys) |
|-----|------|------------------|
| Before | 58.36 s | 40.27 s |
| After | 39.54 s | 9.23 s |

Both runs shared the machine with a parallel test load, so the wall numbers are noisy; the CPU drop is not. A second post-change run under load 16 measured 51.44 s wall / 9.21 s CPU.

Zero test loss: the JUnit `<testcase name>` multiset is identical at 55 entries, with 553 `expect()` calls before and after. No assertion, title, or `src/` file changed.

### How the process boundary is reproduced

`tests/helpers/cli-in-process.ts` drives `buildProgram()` in the test process.

- `process.env` is replaced in place, including deletions, and restored afterwards. `oracle-provider.buildOracleEnv` and `secret-scan.scannerEnv` build their child environments from a `process.env` snapshot, and Bun 1.4.0 propagates runtime mutation and deletion to bare `spawnSync` children, so the fake oracle and fake Gitleaks binaries observe exactly the variables a test sets. `process.cwd()` is changed and restored for `resolveRepoRoot`.
- Commander's own exits become thrown `CommanderError`s through `exitOverride`, after the help or error text has been written.
- A command body's own `process.exit` is recorded rather than thrown. The chatgpt actions discard their work promise (`void runChatgptAction(...)`), so a throw would land as an unhandled rejection, which Bun's test runner fails on even with a listener attached. The only exit this command group reaches is the last statement of its error funnel.
- That discarded promise also means commander resolves `parseAsync` before the action finishes, so completion comes from the action's terminal step: its first stdout write or the recorded exit. Nothing under `src/cli/chatgpt-browser/` writes to stdout, and both signals run synchronously to the end of the action.

### One call site keeps a real child process

The `pathDoctor` run inside `oracle rejects unsupported versions uniformly before consultation side effects` asserts `oracle.resolvedFrom === 'PATH'`. The resolver uses `Bun.which('oracle')`, which resolves against the environment the process started with rather than a runtime `process.env.PATH` assignment, so in-process it found the machine's real `~/.bun/bin/oracle`. `runChatgptSpawnedForPath` covers that one call; the other four CLI calls in the same test run in-process. Fixing the resolver would have been a `src/` change made to suit a test.

No other test needs a child process: nothing in the file depends on signals, stdin, `process.execPath`, or a real exit path. `oracle timeout kills its POSIX process group and cleans staged egress` asserts an 8 s wall-clock bound; back-to-back A/B runs of the pre-change and post-change files measured 7.05 s / 6.61 s and 6.98 s / 7.12 s.

### Verification

`tests/cli/chatgpt-browser.test.ts` (55 pass), the same file together with `tests/cli/global-runtime-init.test.ts` (98 pass), `bun run check:type`, `check:hooks`, `check:helpers`, `check:reference-configs`, `check-deploy-sql-order.sh`, `check-architecture-sync.sh`, `check-task-workflow.sh --strict`, `check-task-sync.sh` bound to the `origin/main` merge base, and `init --repo . --dry-run`.
