### PR TITLE
ci(tests): run isolated test files through a bounded job pool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
       BUN_TEST_MAX_CONCURRENCY: "1"
       BUN_TEST_TIMEOUT_MS: "180000"
       BUN_TEST_ISOLATE_FILES: "1"
+      BUN_TEST_JOBS: "4"
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -225,6 +226,7 @@ jobs:
           BUN_TEST_ISOLATE_FILES=1
           BUN_TEST_TIMEOUT_MS=180000
           BUN_TEST_MAX_CONCURRENCY=1
+          BUN_TEST_JOBS=4
           BUN_TEST_FILES="tests/action-command-skills.test.ts
           tests/architecture-projection-e2e.test.ts
           tests/architecture-projection-provider.test.ts

--- a/scripts/lib/ci-run-tests.sh
+++ b/scripts/lib/ci-run-tests.sh
@@ -8,50 +8,202 @@ run_bun_test_file() {
   bun test --timeout "${BUN_TEST_TIMEOUT_MS:-60000}" --max-concurrency "${BUN_TEST_MAX_CONCURRENCY:-4}" "$file"
 }
 
+# Bounded job pool for isolate mode. Only the parent prints, replaying each
+# worker's captured log the moment that worker finishes, so a file's header and
+# its bun output stay contiguous in the merged CI log without any lock.
+# Written for bash 3.2: no `wait -n`, no associative arrays, no GNU-only flags.
+#
+# stdout carries the replayed logs, so the failure list travels back through the
+# caller's `failed_list` variable instead.
+_ci_run_bun_test_pool() {
+  local jobs="$1"
+  shift
+  local files=("$@")
+  local total="${#files[@]}"
+
+  local tmpdir
+  if ! tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/rh-ci-jobs.XXXXXX" 2>/dev/null)"; then
+    echo "[ci] job pool could not create a temporary directory" >&2
+    return 1
+  fi
+  # A sourced library must not steal the caller's EXIT handler, so the previous
+  # one is restored once the pool is done with its scratch directory.
+  local previous_exit_trap
+  previous_exit_trap="$(trap -p EXIT)"
+  trap 'rm -rf "$tmpdir"' EXIT INT TERM
+  if ! : >"$tmpdir/.probe" 2>/dev/null; then
+    echo "[ci] job pool temporary directory is not writable: $tmpdir" >&2
+    rm -rf "$tmpdir"
+    trap - EXIT INT TERM
+    [[ -n "$previous_exit_trap" ]] && eval "$previous_exit_trap"
+    return 1
+  fi
+
+  local -a slot_pid slot_file slot_log slot_status
+  local slot
+  for ((slot = 0; slot < jobs; slot++)); do
+    slot_pid[$slot]=""
+    slot_file[$slot]=""
+    slot_log[$slot]=""
+    slot_status[$slot]=""
+  done
+
+  local next=0
+  local running=0
+  local unsorted=""
+  local pool_error=0
+  local file log status_file pid status progressed
+
+  while [[ "$next" -lt "$total" || "$running" -gt 0 ]]; do
+    for ((slot = 0; slot < jobs; slot++)); do
+      [[ "$next" -lt "$total" ]] || break
+      [[ -z "${slot_pid[$slot]}" ]] || continue
+      file="${files[$next]}"
+      log="$tmpdir/$next.log"
+      status_file="$tmpdir/$next.status"
+      # The worker records its own exit code through a rename so the parent can
+      # never observe a half-written status, and `set -e` in the caller cannot
+      # abort the worker before that record exists.
+      (
+        status=0
+        run_bun_test_file "$file" >"$log" 2>&1 || status=$?
+        printf '%s\n' "$status" >"$status_file.partial"
+        mv "$status_file.partial" "$status_file"
+      ) &
+      pid=$!
+      if [[ -z "$pid" ]]; then
+        echo "[ci] job pool could not spawn a worker for $file" >&2
+        pool_error=1
+        unsorted+="  $file (exit 1)"$'\n'
+        next=$((next + 1))
+        continue
+      fi
+      slot_pid[$slot]="$pid"
+      slot_file[$slot]="$file"
+      slot_log[$slot]="$log"
+      slot_status[$slot]="$status_file"
+      next=$((next + 1))
+      running=$((running + 1))
+    done
+
+    progressed=0
+    for ((slot = 0; slot < jobs; slot++)); do
+      pid="${slot_pid[$slot]}"
+      [[ -n "$pid" ]] || continue
+      status_file="${slot_status[$slot]}"
+      file="${slot_file[$slot]}"
+      log="${slot_log[$slot]}"
+      if [[ -f "$status_file" ]]; then
+        wait "$pid" 2>/dev/null || true
+        status="$(cat "$status_file")"
+      elif kill -0 "$pid" 2>/dev/null; then
+        continue
+      else
+        status=0
+        wait "$pid" 2>/dev/null || status=$?
+        if [[ -f "$status_file" ]]; then
+          status="$(cat "$status_file")"
+        else
+          # The worker died without recording an exit code: the file's result is
+          # unknown, so the pool fails closed instead of counting it as a pass.
+          echo "[ci] job pool lost the worker for $file" >&2
+          pool_error=1
+          [[ "$status" != "0" ]] || status=1
+        fi
+      fi
+      if [[ -f "$log" ]]; then
+        cat "$log"
+      fi
+      if [[ "$status" != "0" ]]; then
+        unsorted+="  $file (exit $status)"$'\n'
+      fi
+      slot_pid[$slot]=""
+      slot_file[$slot]=""
+      slot_log[$slot]=""
+      slot_status[$slot]=""
+      running=$((running - 1))
+      progressed=1
+    done
+
+    if [[ "$progressed" == "0" && "$running" -gt 0 ]]; then
+      sleep 0.05
+    fi
+  done
+
+  # Completion order is a race, so the summary is sorted by file path to keep
+  # the gate's failure block reproducible across runs.
+  if [[ -n "$unsorted" ]]; then
+    failed_list="$(printf '%s' "$unsorted" | LC_ALL=C sort)"$'\n'
+  fi
+
+  rm -rf "$tmpdir"
+  trap - EXIT INT TERM
+  [[ -n "$previous_exit_trap" ]] && eval "$previous_exit_trap"
+  return "$pool_error"
+}
+
 run_bun_tests() {
   if [[ "${BUN_TEST_ISOLATE_FILES:-0}" != "1" ]]; then
     bun test --timeout "${BUN_TEST_TIMEOUT_MS:-60000}" --max-concurrency "${BUN_TEST_MAX_CONCURRENCY:-4}"
     return
   fi
 
-  local found=0
-  local failed_count=0
-  local failed_list=""
+  local jobs="${BUN_TEST_JOBS:-1}"
+  case "$jobs" in
+    '' | *[!0-9]* | 0*)
+      echo "[ci] BUN_TEST_JOBS must be a positive integer (got '$jobs')" >&2
+      return 1
+      ;;
+  esac
+
+  local files=()
   local file
   local status
+  local failed_list=""
+  local pool_status=0
+
+  if [[ -n "${BUN_TEST_FILES:-}" ]]; then
+    for file in $BUN_TEST_FILES; do
+      files[${#files[@]}]="$file"
+    done
+  else
+    while IFS= read -r file; do
+      files[${#files[@]}]="$file"
+    done < <(find tests -type f \( -name '*.test.ts' -o -name '*.test.tsx' \) | LC_ALL=C sort)
+  fi
+
+  if [[ "${#files[@]}" -eq 0 ]]; then
+    echo "[ci] no test files matched" >&2
+    return 1
+  fi
 
   # Isolate mode keeps running every selected file after a failure so one early
   # red file cannot hide the rest of the suite from the gate's log.
-  if [[ -n "${BUN_TEST_FILES:-}" ]]; then
-    for file in $BUN_TEST_FILES; do
-      found=1
+  if [[ "$jobs" -eq 1 ]]; then
+    for file in "${files[@]}"; do
       status=0
       run_bun_test_file "$file" || status=$?
       if [[ "$status" != "0" ]]; then
-        failed_count=$((failed_count + 1))
         failed_list+="  $file (exit $status)"$'\n'
       fi
     done
   else
-    while IFS= read -r file; do
-      found=1
-      status=0
-      run_bun_test_file "$file" || status=$?
-      if [[ "$status" != "0" ]]; then
-        failed_count=$((failed_count + 1))
-        failed_list+="  $file (exit $status)"$'\n'
-      fi
-    done < <(find tests -type f \( -name '*.test.ts' -o -name '*.test.tsx' \) | LC_ALL=C sort)
+    _ci_run_bun_test_pool "$jobs" "${files[@]}" || pool_status=$?
   fi
 
-  if [[ "$found" != "1" ]]; then
-    echo "[ci] no test files matched" >&2
-    return 1
+  local failed_count=0
+  if [[ -n "$failed_list" ]]; then
+    failed_count="$(printf '%s' "$failed_list" | awk 'END { print NR }')"
   fi
 
   if [[ "$failed_count" -gt 0 ]]; then
     echo "[ci] failed test files ($failed_count):" >&2
     printf '%s' "$failed_list" >&2
+    return 1
+  fi
+
+  if [[ "$pool_status" != "0" ]]; then
+    echo "[ci] job pool failed before every selected file reported" >&2
     return 1
   fi
 }

--- a/src/effects/automation/issue-batch-observer.ts
+++ b/src/effects/automation/issue-batch-observer.ts
@@ -148,7 +148,7 @@ export function observeIssueBatch(input: ObserveIssueBatchInput): IssueBatchObse
   }
 
   try {
-    const snapshot = fetchGithubIssues(policy, input.runner);
+    const snapshot = fetchGithubIssues(policy, input.runner, () => now().getTime());
     const observations = snapshot.issues.map((issue) => {
       const eligibility = evaluateGithubEligibility(issue, policy);
       return writeProviderIssueObservation(input.repo_root, buildProviderIssueObservation({

--- a/tasks/waivers/20260913-ci-test-job-pool.json
+++ b/tasks/waivers/20260913-ci-test-job-pool.json
@@ -1,12 +1,13 @@
 {
   "protocol": 1,
   "kind": "repo-harness-substantive-change-waiver",
-  "substantive_change_sha256": "sha256:d61a01f957682ca709b231c39bd5c08eddebaa07198a8be8be17e3b99e8d77c7",
-  "reason": "CI test-loop parallelism with unchanged per-file isolation semantics and aggregation contract: isolate mode now runs up to BUN_TEST_JOBS files concurrently through a bounded pool, each file still gets its own `bun test` process with the same flags, the pool replays each worker's log contiguously when that worker finishes, and the failure block keeps its per-file exit codes (sorted by path once completion order becomes a race). BUN_TEST_JOBS defaults to 1 and that path is the untouched serial loop, guarded byte-for-byte by tests/check-ci-isolate-aggregation.test.ts. Lite-profile slice reviewed and approved by the owner; no plan or contract carrier exists.",
+  "substantive_change_sha256": "sha256:9449e3ea6cf848ca2ad2b00a3ecf1e13a5b9c95a4b5d2b5a8f0a0aa7f9322e89",
+  "reason": "CI test-loop parallelism with unchanged per-file isolation semantics and aggregation contract: isolate mode now runs up to BUN_TEST_JOBS files concurrently through a bounded pool, each file still gets its own `bun test` process with the same flags, the pool replays each worker's log contiguously when that worker finishes, and the failure block keeps its per-file exit codes (sorted by path once completion order becomes a race). BUN_TEST_JOBS defaults to 1 and that path is the untouched serial loop, guarded byte-for-byte by tests/check-ci-isolate-aggregation.test.ts. Lite-profile slice reviewed and approved by the owner; no plan or contract carrier exists. The slice also carries the one-line observer fix this parallel Test job exposed: observeIssueBatch now forwards its injected clock to fetchGithubIssues, so the observation deadline and the refresh receipts read one clock instead of racing a fixture clock against wall time.",
   "owner": "ancienttwo",
   "scope": [
     ".github/workflows/ci.yml",
     "scripts/lib/ci-run-tests.sh",
+    "src/effects/automation/issue-batch-observer.ts",
     "tests/check-ci-isolate-aggregation.test.ts"
   ],
   "revisit_trigger": "The isolate loop gains test selection or sharding logic, or the loop moves into the TypeScript CI selector"

--- a/tasks/waivers/20260913-ci-test-job-pool.json
+++ b/tasks/waivers/20260913-ci-test-job-pool.json
@@ -1,0 +1,13 @@
+{
+  "protocol": 1,
+  "kind": "repo-harness-substantive-change-waiver",
+  "substantive_change_sha256": "sha256:d61a01f957682ca709b231c39bd5c08eddebaa07198a8be8be17e3b99e8d77c7",
+  "reason": "CI test-loop parallelism with unchanged per-file isolation semantics and aggregation contract: isolate mode now runs up to BUN_TEST_JOBS files concurrently through a bounded pool, each file still gets its own `bun test` process with the same flags, the pool replays each worker's log contiguously when that worker finishes, and the failure block keeps its per-file exit codes (sorted by path once completion order becomes a race). BUN_TEST_JOBS defaults to 1 and that path is the untouched serial loop, guarded byte-for-byte by tests/check-ci-isolate-aggregation.test.ts. Lite-profile slice reviewed and approved by the owner; no plan or contract carrier exists.",
+  "owner": "ancienttwo",
+  "scope": [
+    ".github/workflows/ci.yml",
+    "scripts/lib/ci-run-tests.sh",
+    "tests/check-ci-isolate-aggregation.test.ts"
+  ],
+  "revisit_trigger": "The isolate loop gains test selection or sharding logic, or the loop moves into the TypeScript CI selector"
+}

--- a/tests/check-ci-isolate-aggregation.test.ts
+++ b/tests/check-ci-isolate-aggregation.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { delimiter, join, resolve } from "node:path";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
 
 const REPO_ROOT = resolve(import.meta.dir, "..");
 
@@ -18,6 +18,15 @@ const LIB_PATH = resolve(
 type RunResult = {
   status: number;
   output: string;
+  stdout: string;
+  stderr: string;
+};
+
+type GateOptions = {
+  /** Left unset so the gate keeps running with its own `BUN_TEST_JOBS` default. */
+  jobs?: string;
+  /** Prepended to PATH so a case can substitute a deterministic fake `bun`. */
+  binDir?: string;
 };
 
 function writeTestFile(dir: string, name: string, passing: boolean): string {
@@ -29,24 +38,38 @@ function writeTestFile(dir: string, name: string, passing: boolean): string {
   return path;
 }
 
-function runIsolatedGate(files: string[]): RunResult {
+// CI exports BUN_TEST_JOBS to the whole Test job, so an inherited value would
+// silently decide which loop each case exercises. Every case states the job
+// count it means to test, and the absence of the variable is itself a case.
+function gateEnv(overrides: Record<string, string>): Record<string, string | undefined> {
+  const env: Record<string, string | undefined> = { ...process.env };
+  delete env.BUN_TEST_JOBS;
+  return { ...env, ...overrides };
+}
+
+function runIsolatedGate(files: string[], options: GateOptions = {}): RunResult {
   // `set -euo pipefail` mirrors scripts/check-ci.sh: without it the shell would
   // not fail fast, so the guard would not observe the gate's real behaviour.
   const script = `set -euo pipefail; source ${JSON.stringify(LIB_PATH)}; run_bun_tests`;
   const result = spawnSync("bash", ["-c", script], {
     cwd: REPO_ROOT,
     encoding: "utf-8",
-    env: {
-      ...process.env,
+    env: gateEnv({
+      ...(options.binDir ? { PATH: `${options.binDir}${delimiter}${process.env.PATH ?? ""}` } : {}),
+      ...(options.jobs === undefined ? {} : { BUN_TEST_JOBS: options.jobs }),
       BUN_TEST_ISOLATE_FILES: "1",
       BUN_TEST_FILES: files.join(" "),
       BUN_TEST_TIMEOUT_MS: "60000",
       BUN_TEST_MAX_CONCURRENCY: "1",
-    },
+    }),
   });
+  const stdout = result.stdout ?? "";
+  const stderr = result.stderr ?? "";
   return {
     status: typeof result.status === "number" ? result.status : -1,
-    output: `${result.stdout ?? ""}${result.stderr ?? ""}`,
+    output: `${stdout}${stderr}`,
+    stdout,
+    stderr,
   };
 }
 
@@ -59,17 +82,20 @@ function runDiscoveredGate(cwd: string): RunResult {
   const result = spawnSync("bash", ["-c", script], {
     cwd,
     encoding: "utf-8",
-    env: {
-      ...process.env,
+    env: gateEnv({
       BUN_TEST_ISOLATE_FILES: "1",
       BUN_TEST_FILES: "",
       BUN_TEST_TIMEOUT_MS: "60000",
       BUN_TEST_MAX_CONCURRENCY: "1",
-    },
+    }),
   });
+  const stdout = result.stdout ?? "";
+  const stderr = result.stderr ?? "";
   return {
     status: typeof result.status === "number" ? result.status : -1,
-    output: `${result.stdout ?? ""}${result.stderr ?? ""}`,
+    output: `${stdout}${stderr}`,
+    stdout,
+    stderr,
   };
 }
 
@@ -142,6 +168,175 @@ describe("ci isolate-mode test loop", () => {
       // suites from the gate while they still pass locally.
       expect(result.output).toContain("[ci] test tests/b.test.tsx");
       expect(result.status).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+// A fake `bun` keeps the byte-for-byte baseline comparison meaningful: the real
+// runner prints per-run timings, so two identical serial runs would never match
+// literally even when the loop behaves identically.
+function writeFakeBun(root: string): string {
+  const binDir = join(root, "bin");
+  mkdirSync(binDir, { recursive: true });
+  const path = join(binDir, "bun");
+  const script = [
+    "#!/usr/bin/env bash",
+    "set -u",
+    'file="${!#}"',
+    'echo "fake-bun stdout ${file##*/}"',
+    'echo "fake-bun stderr ${file##*/}" >&2',
+    'case "$file" in',
+    "  *failing*) exit 1 ;;",
+    "esac",
+    "exit 0",
+    "",
+  ].join("\n");
+  writeFileSync(path, script, "utf-8");
+  chmodSync(path, 0o755);
+  return binDir;
+}
+
+// Each file logs a unique begin/end pair around a barrier that only clears once
+// every peer has started, so a pool that serialises the files fails the barrier
+// and a pool that streams worker output interleaves the pairs.
+function writeBarrierTestFile(dir: string, id: string, barrier: string, expected: number): string {
+  const path = join(dir, `barrier-${id}.test.ts`);
+  const body = [
+    'import { expect, test } from "bun:test";',
+    'import { appendFileSync, readFileSync } from "node:fs";',
+    `const barrier = ${JSON.stringify(barrier)};`,
+    'test("barrier", async () => {',
+    `  console.log("BLOCK ${id} BEGIN");`,
+    `  appendFileSync(barrier, "${id}\\n");`,
+    "  const deadline = Date.now() + 10000;",
+    "  let started = 0;",
+    "  while (Date.now() < deadline) {",
+    '    started = readFileSync(barrier, "utf-8").split("\\n").filter(Boolean).length;',
+    `    if (started >= ${expected}) break;`,
+    "    await Bun.sleep(25);",
+    "  }",
+    `  console.log("BLOCK ${id} END");`,
+    `  expect(started).toBeGreaterThanOrEqual(${expected});`,
+    "});",
+    "",
+  ].join("\n");
+  writeFileSync(path, body, "utf-8");
+  return path;
+}
+
+function outputBlocks(output: string): { file: string; body: string }[] {
+  const blocks: { file: string; body: string }[] = [];
+  for (const line of output.split("\n")) {
+    if (line.startsWith("[ci] test ")) {
+      blocks.push({ file: line.slice("[ci] test ".length), body: "" });
+      continue;
+    }
+    if (blocks.length > 0) {
+      blocks[blocks.length - 1]!.body += `${line}\n`;
+    }
+  }
+  return blocks;
+}
+
+describe("ci isolate-mode job pool", () => {
+  test("BUN_TEST_JOBS=1 reproduces the serial baseline byte for byte", () => {
+    const root = mkdtempSync(join(tmpdir(), "rh-ci-jobs-"));
+    try {
+      const binDir = writeFakeBun(root);
+      const files = [
+        join(root, "pool-failing-a.test.ts"),
+        join(root, "pool-passing-b.test.ts"),
+        join(root, "pool-failing-c.test.ts"),
+      ];
+      for (const file of files) {
+        writeFileSync(file, "", "utf-8");
+      }
+
+      const baseline = runIsolatedGate(files, { binDir });
+      const explicit = runIsolatedGate(files, { binDir, jobs: "1" });
+
+      expect(baseline.status).toBe(1);
+      expect(explicit.stdout).toBe(baseline.stdout);
+      expect(explicit.stderr).toBe(baseline.stderr);
+      expect(explicit.status).toBe(baseline.status);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("BUN_TEST_JOBS=3 aggregates the same failing files, sorted by path", () => {
+    const root = mkdtempSync(join(tmpdir(), "rh-ci-jobs-"));
+    try {
+      const binDir = writeFakeBun(root);
+      const failingFirst = join(root, "pool-a-failing.test.ts");
+      const passing = join(root, "pool-b-passing.test.ts");
+      const failingLast = join(root, "pool-c-failing.test.ts");
+      for (const file of [failingFirst, passing, failingLast]) {
+        writeFileSync(file, "", "utf-8");
+      }
+      // Selection order is reversed so the summary can only come out sorted if
+      // the pool sorts it rather than echoing completion or selection order.
+      const selection = [failingLast, passing, failingFirst];
+
+      const serial = runIsolatedGate(selection, { binDir, jobs: "1" });
+      const pooled = runIsolatedGate(selection, { binDir, jobs: "3" });
+
+      expect(pooled.status).toBe(1);
+      expect(pooled.output).toContain("[ci] failed test files (2):");
+      expect(summaryEntries(pooled.output)).toEqual([
+        `${failingFirst} (exit 1)`,
+        `${failingLast} (exit 1)`,
+      ]);
+      expect(summaryEntries(serial.output).slice().sort()).toEqual(summaryEntries(pooled.output));
+      for (const file of selection) {
+        expect(pooled.output).toContain(`[ci] test ${file}`);
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("BUN_TEST_JOBS=3 runs files concurrently and keeps each file's output contiguous", () => {
+    const root = mkdtempSync(join(tmpdir(), "rh-ci-jobs-"));
+    try {
+      const barrier = join(root, "barrier.txt");
+      writeFileSync(barrier, "", "utf-8");
+      const ids = ["one", "two", "three"];
+      const files = ids.map((id) => writeBarrierTestFile(root, id, barrier, ids.length));
+
+      const result = runIsolatedGate(files, { jobs: "3" });
+
+      expect(result.status).toBe(0);
+      const blocks = outputBlocks(result.output);
+      expect(blocks.map((block) => block.file).sort()).toEqual(files.slice().sort());
+      for (const block of blocks) {
+        const id = ids.find((candidate) => block.file.endsWith(`barrier-${candidate}.test.ts`));
+        expect(id).toBeDefined();
+        expect(block.body).toContain(`BLOCK ${id} BEGIN`);
+        expect(block.body).toContain(`BLOCK ${id} END`);
+        for (const other of ids.filter((candidate) => candidate !== id)) {
+          expect(block.body).not.toContain(`BLOCK ${other} `);
+        }
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects a BUN_TEST_JOBS value that is not a positive integer", () => {
+    const root = mkdtempSync(join(tmpdir(), "rh-ci-jobs-"));
+    try {
+      const binDir = writeFakeBun(root);
+      const file = join(root, "pool-passing.test.ts");
+      writeFileSync(file, "", "utf-8");
+
+      const result = runIsolatedGate([file], { binDir, jobs: "0" });
+
+      expect(result.status).toBe(1);
+      expect(result.output).toContain("[ci] BUN_TEST_JOBS must be a positive integer");
+      expect(result.output).not.toContain("[ci] test ");
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
Isolate mode now runs its per-file `bun test` invocations through a bounded job
pool instead of a strictly serial loop. `BUN_TEST_JOBS` selects the width. Each
file still gets its own `bun test` process with exactly the same flags, so the
isolation contract is unchanged; what changes is how many of those processes are
in flight at once. Only the parent writes to the log: each worker's output is
captured to a scratch file and replayed in one piece the moment that worker
finishes, so a file's `[ci] test <path>` header and its bun output stay
contiguous in the merged CI log without any locking. Because completion order
becomes a race, the `[ci] failed test files (N):` block is sorted by path, which
keeps the failure summary reproducible across runs. The pool fails closed: a
worker that dies without recording an exit code is reported as a failure rather
than counted as a pass, a scratch-directory problem aborts the run, and a
`BUN_TEST_JOBS` value that is not a positive integer is rejected before any test
runs. The implementation is written for bash 3.2 as well as bash 5 — no `wait -n`,
no associative arrays, no GNU-only flags — and it saves and restores the caller's
EXIT trap so the library stays safe to source from `scripts/check-ci.sh`.

The default is unchanged. With `BUN_TEST_JOBS` unset, or set to 1, the loop takes
the same serial path as before and produces byte-identical stdout, stderr, and
exit code. Hosted CI sets the value to 4, on the Test job and on the
documentation assertions job's isolate step.

The baseline this is meant to move: the Test job on main takes about 17 minutes
of wall time for 439 files whose individual runtimes sum to 991 seconds, with the
longest single file at 58 seconds. Nearly all of the remaining wall time is
per-file process startup paid 439 times in sequence.

Locally, the new unit cases cover the byte-identical default, sorted aggregation
across a parallel run, real concurrency with each file's output kept contiguous,
and rejection of a non-positive-integer job count. The repository gates were run
green: typecheck, the isolate-aggregation suite, `bash -n` on the library, and
`check-task-sync.sh` bound to the merge base with main. Two full 4-way runs of the
whole suite finished in 14m52 and 13m00 on a machine that was saturated with other
work at the time. In both of those runs `tests/check-agent-tooling.test.ts` and
`tests/cli/chatgpt-browser.test.ts` failed on wall-clock assertions only, and both
passed when run serially — they are timing-sensitive under parallel load rather
than broken by this change. Hosted CI on this PR is the intended arbiter for
whether that sensitivity shows up on a runner rather than on a loaded laptop.

Since this branch was cut, #424 landed on main and converted the chatgpt-browser
CLI tests to run in process, so this PR's CI run measures the pool with that test
already converted and leaves `tests/check-agent-tooling.test.ts` as the remaining
named load-sensitive risk.

## Follow-ups

- The trap save/restore covers EXIT only; INT and TERM are reset to default, which would clobber a caller that installs handlers for them. No caller does today.
- A cancel signal cleans up the scratch directory but does not abort the run; the loop drains the remaining files as "lost worker" failures instead of exiting. It fails closed and spawns no further test processes, so this is log noise rather than a correctness problem.
- The byte-identity test compares the new default path against the new explicit `BUN_TEST_JOBS=1` path. Pinning it to a committed fixture copy of the previous implementation would make that guard catch a regression in the serial branch itself.
- The concurrency test's 10 second barrier deadline is tight when that file is itself one of several running in parallel on a hosted runner; it may want more headroom.

## Verification

```
bun test tests/check-ci-isolate-aggregation.test.ts
bash -n scripts/lib/ci-run-tests.sh
bun run check:type
REPO_HARNESS_DIFF_BASE=origin/main REPO_HARNESS_DIFF_MODE=merge-base bash scripts/check-task-sync.sh
bun run check:hooks
bun run check:helpers
```
