### PR TITLE
test(auto-campaign): build the skill install fixture once per profile

### DIFF
--- a/plans/plan-20260913-0144-auto-campaign-template.md
+++ b/plans/plan-20260913-0144-auto-campaign-template.md
@@ -1,0 +1,157 @@
+# Plan: Template the auto-campaign skill fixture
+
+> **Status**: Executing
+> **Created**: 20260913-0144
+> **Slug**: auto-campaign-template
+> **Planning Source**: codex-plan-or-waza-think
+> **Orchestration Kind**: host-plan
+> **Source Ref**: (none)
+> **Artifact Level**: work-package
+> **Promotion Reason**: verification_boundary
+> **Verification Boundary**: Commands named in the captured planning output plus `repo-harness run verify-contract --contract tasks/contracts/20260913-0144-auto-campaign-template.contract.md --strict`.
+> **Rollback Surface**: Before execution remove `plans/plan-20260913-0144-auto-campaign-template.md`; after execution revert branch `codex/auto-campaign-template` or the explicitly reviewed diff.
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260913-0144-auto-campaign-template.contract.md`
+> **Task Review**: `tasks/reviews/20260913-0144-auto-campaign-template.review.md`
+> **Implementation Notes**: `tasks/notes/20260913-0144-auto-campaign-template.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from codex-plan-or-waza-think planning output.
+- Source ref: (none)
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260913-0144-auto-campaign-template.md`
+- Sprint contract: `tasks/contracts/20260913-0144-auto-campaign-template.contract.md`
+- Sprint review: `tasks/reviews/20260913-0144-auto-campaign-template.review.md`
+- Implementation notes: `tasks/notes/20260913-0144-auto-campaign-template.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260913-0144-auto-campaign-template.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260913-0144-auto-campaign-template.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260913-0144-auto-campaign-template.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260913-0144-auto-campaign-template.contract.md`
+- Review file: `tasks/reviews/20260913-0144-auto-campaign-template.review.md`
+- Implementation notes file: `tasks/notes/20260913-0144-auto-campaign-template.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260913-0144-auto-campaign-template.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260913-0144-auto-campaign-template.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: Before execution remove `plans/plan-20260913-0144-auto-campaign-template.md`; after execution revert branch `codex/auto-campaign-template` or the explicitly reviewed diff.
+- **Verification boundary**: Commands named in the captured planning output plus `repo-harness run verify-contract --contract tasks/contracts/20260913-0144-auto-campaign-template.contract.md --strict`.
+- **Review/acceptance boundary**: `tasks/reviews/20260913-0144-auto-campaign-template.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: verification_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260913-0144-auto-campaign-template.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260913-0144-auto-campaign-template.contract.md`, `tasks/reviews/20260913-0144-auto-campaign-template.review.md`, and `tasks/notes/20260913-0144-auto-campaign-template.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260913-0144-auto-campaign-template.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: Before execution remove `plans/plan-20260913-0144-auto-campaign-template.md`; after execution revert branch `codex/auto-campaign-template` or the explicitly reviewed diff.
+
+## Captured Planning Output
+
+## Goal
+
+Remove the repeated expensive fixture build in `tests/auto-campaign-skill.test.ts` by routing
+`fixture()` through the existing `fixtureTemplate` helper in `tests/helpers/repo-fixture.ts`.
+
+## Problem
+
+`fixture(profile)` runs, per test:
+
+- `git init` plus an empty `git commit` in a fresh mkdtemp repository,
+- `bash scripts/sync-codex-installed-copies.sh`, which starts three Bun child processes
+  (`scripts/check-managed-runtime.ts` conditionally, `skill-surface-select.ts` twice) and
+  rsyncs the whole package into two skill roots.
+
+Three tests pay that cost three times. The local baseline for the file is 81.86s
+(`bun test --timeout 180000 tests/auto-campaign-skill.test.ts`); the CI per-file baseline is 44.10s.
+
+## Approach
+
+Wrap the existing builder in the synchronous `fixtureTemplate` overload added by PR #423,
+keyed by the install profile, with `workspacePaths` selecting the single mkdtemp directory
+that owns every byte the fixture writes:
+
+- `repo` (git repository), `bin` (CLI shim), `runtime` (`REPO_HARNESS_HOME`),
+  `codex-skills` and `claude-skills` (`CODEX_SKILLS_ROOT` / `CLAUDE_SKILLS_ROOT`, the only
+  destinations `sync-codex-installed-copies.sh` writes to) all live under that directory,
+  and `HOME` is that directory itself.
+
+The two `full` tests then share one build; `minimal` keeps its own. `draft()` still spawns a
+real `prepare-grant.ts` child process every call, because that is the behaviour under test.
+Snapshot restore happens in place, so the sealed grant paths and repo id stay valid, and the
+per-test `afterEach` removal keeps each test's bytes unshared.
+
+## Task Breakdown
+
+- [ ] Route `fixture()` in `tests/auto-campaign-skill.test.ts` through `fixtureTemplate`, register the
+      directory for `afterEach` removal at the call site, and dispose templates in `afterAll`.
+- [ ] Verify the file isolated and co-resident with an existing `fixtureTemplate` consumer, and prove
+      the JUnit testcase-name multiset is unchanged.
+
+## Verification
+
+- `bun test --timeout 180000 tests/auto-campaign-skill.test.ts`
+- `bun test --timeout 180000 tests/auto-campaign-skill.test.ts tests/effects/campaign-worker.test.ts`
+- repository-integrity checks (`check:type`, `check:hooks`, `check:helpers`, `check:reference-configs`,
+  architecture sync, task workflow, task sync, `init --repo . --dry-run`)
+
+## Risks
+
+No product source changes; scope is one test file. If snapshot restore ever conflicted with the
+installed-copy owner markers the tests would fail closed on the ownership hash, not silently pass.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [ ] Route `fixture()` in `tests/auto-campaign-skill.test.ts` through `fixtureTemplate`, register the
+- [ ] Verify the file isolated and co-resident with an existing `fixtureTemplate` consumer, and prove

--- a/tasks/contracts/20260913-0144-auto-campaign-template.contract.md
+++ b/tasks/contracts/20260913-0144-auto-campaign-template.contract.md
@@ -1,0 +1,318 @@
+# Task Contract: auto-campaign-template
+
+> **Status**: Active
+> **Plan**: plans/plan-20260913-0144-auto-campaign-template.md
+> **Task Profile**: code-change
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: ancienttwo
+> **Capability ID**: root
+> **Last Updated**: 2026-09-13 01:44
+> **Review File**: `tasks/reviews/20260913-0144-auto-campaign-template.review.md`
+> **Notes File**: `tasks/notes/20260913-0144-auto-campaign-template.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+`tests/auto-campaign-skill.test.ts` rebuilds a git repository plus a full
+`scripts/sync-codex-installed-copies.sh` install (three Bun child processes and two
+package rsyncs) once per test. That fixture cost dominates the file's runtime and is
+paid three times for two distinct install profiles. If it stays, every CI run keeps
+buying the same install twice.
+
+## Goal
+
+Route `fixture()` in `tests/auto-campaign-skill.test.ts` through the existing
+`fixtureTemplate` helper so the expensive install is built once per install profile and
+restored per test, with identical test names, assertions and isolation.
+
+## Scope
+
+- In scope: `tests/auto-campaign-skill.test.ts` only.
+- Out of scope: `src/`, `scripts/`, `.github/`, `tests/helpers/repo-fixture.ts`, any test assertion or test title, and the per-call `draft()` child process that is the behaviour under test.
+- Taste constraints: <!-- advisory only, no run gate; default style/taste lives in AGENTS.md and the minimal-change policy, use this to record a per-task override -->
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+
+## Falsifier
+
+If the snapshot did not carry the complete fixture state, a later test would observe
+leftover or missing install state: the cheapest proof point is the third test, which
+asserts the `minimal` profile installs no `auto-campaign` directory, together with the
+second test's assertion that no authorization is stored after the first test minted one.
+Both pass, so in-place restore carries the full state.
+
+## Root Cause Evidence
+
+Required when Task Profile is `bugfix`; leave as-is otherwise.
+
+- root_cause: one sentence naming file:line/condition (testable, not "a state issue").
+- repro: the command or UI path that reproduces the symptom.
+- regression_guard: path to a test that fails on the unfixed code and passes after the fix (must also appear as a `package_test` check in Verification Plan).
+- pre_fix_failure_artifact: path to a captured run of regression_guard on the UNFIXED code. Capture with `bun test <regression_guard> > <artifact> 2>&1; echo "PRE_FIX_EXIT=$?" >> <artifact>` (no pipes — pipes swallow the exit status). The gate requires a non-zero `PRE_FIX_EXIT=` line plus the regression_guard path string in the artifact (see the Root Cause Evidence Gate section in docs/reference-configs/sprint-contracts.md).
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260913-0144-auto-campaign-template.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260913-0144-auto-campaign-template.review.md`
+- Notes file: `tasks/notes/20260913-0144-auto-campaign-template.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Change Assessment
+
+```json
+{"protocol":1,"oracles":[{"id":"auto-campaign-skill","kind":"deterministic_test","paths":["tests/auto-campaign-skill.test.ts"]}]}
+```
+
+## Acceptance Policy
+
+```json
+{"protocol":2,"reviewer":"Codex","source":"codex-plugin","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - docs/spec.md
+  - plans/
+  - tasks/todos.md
+  - tasks/contracts/20260913-0144-auto-campaign-template.contract.md
+  - tasks/reviews/20260913-0144-auto-campaign-template.review.md
+  - tasks/notes/20260913-0144-auto-campaign-template.notes.md
+  - .ai/context/capabilities.json
+  - .claude/templates/
+  - src/
+  - tests/
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+    fallback: null
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+This block contains only non-executable artifact requirements. Define every
+executable check once in the canonical Verification Plan below. Each check must
+state its phase, cost, evidence policy, necessity, and input environment; a
+missing or malformed plan fails closed. Populate artifact requirements only
+for deliverables this task actually owns; do not create a spec, notes or report
+merely to fill this template.
+
+```yaml
+exit_criteria:
+  files_exist:
+    - tests/auto-campaign-skill.test.ts
+  artifacts_exist:
+    - tasks/notes/20260913-0144-auto-campaign-template.notes.md
+```
+
+## Verification Plan
+
+```json
+{
+  "protocol": 1,
+  "checks": [
+    {
+      "id": "auto-campaign-skill",
+      "kind": "package_test",
+      "path": "tests/auto-campaign-skill.test.ts",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "The only changed file; proves the templated fixture keeps every assertion and the per-profile isolation.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "campaign-worker",
+      "kind": "package_test",
+      "path": "tests/effects/campaign-worker.test.ts",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Existing fixtureTemplate consumer, run co-resident to prove the shared template registry stays per-file correct in one process.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "check-type",
+      "kind": "command",
+      "command": "bun run check:type",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "The new synchronous template call site must type-check against the helper's overloads.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "check-hooks",
+      "kind": "command",
+      "command": "bun run check:hooks",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository integrity check for substantive changes.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "check-helpers",
+      "kind": "command",
+      "command": "bun run check:helpers",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository integrity check for substantive changes.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "check-reference-configs",
+      "kind": "command",
+      "command": "bun run check:reference-configs",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository integrity check for substantive changes.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "check-architecture-sync",
+      "kind": "command",
+      "command": "bash scripts/check-architecture-sync.sh",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository integrity check for substantive changes.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "check-task-workflow",
+      "kind": "command",
+      "command": "bash scripts/check-task-workflow.sh --strict",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository integrity check for substantive changes.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "check-task-sync",
+      "kind": "command",
+      "command": "bash scripts/check-task-sync.sh",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository integrity check; the digest is bound to the merge base.",
+      "inputs": {
+        "env": [
+          "REPO_HARNESS_DIFF_BASE",
+          "REPO_HARNESS_DIFF_MODE"
+        ]
+      }
+    },
+    {
+      "id": "init-dry-run",
+      "kind": "command",
+      "command": "bun src/cli/index.ts init --repo . --dry-run",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository integrity check for substantive changes.",
+      "inputs": {
+        "env": []
+      }
+    }
+  ]
+}
+```
+
+Author the actual checks using [Testing Policy and Artifact Standards](../../docs/reference-configs/sprint-contracts.md#testing-policy-and-artifact-standards).
+The empty array is not permission to omit required repository checks: retain it
+only when no executable criterion applies and explain why in Acceptance Notes.
+Prefer existing covering tests; creating a task-named test or adding typecheck
+is not a template requirement. For each selected check declare `id`, `kind`,
+`cwd`, `phase`, `cost`, `evidence_policy`, `necessity`, `inputs.env`, and its
+`command` or `path`. Declare the same execution once, including checks nested
+inside aggregate scripts. Use `baseline_with_delta` only with an immutable
+baseline and named current delta checks; never infer it from paths or command text.
+
+## Acceptance Notes (Human Review)
+
+- Changed behavior/boundary, existing covering tests and remaining gap: test-only change in one file; the file's own three tests are the complete coverage of the fixture they build.
+- New test case/file rationale, or why existing coverage is sufficient: no new test. The change must be invisible to assertions, so the existing file plus an unchanged JUnit testcase-name multiset is the correct proof.
+- Selected check IDs and why their coverage is sufficient; omitted coverage: `auto-campaign-skill` isolated and co-resident with `campaign-worker`, plus the required repository-integrity checks. No product source changed, so no other suite is affected and no full-suite run is justified.
+- Full/expensive check justification and expected cost, if applicable: none; no expensive criterion applies.
+- Execution/baseline references, subject, current delta and disposition: paired local runs of the same worktree, `bun test --timeout 180000 tests/auto-campaign-skill.test.ts`: 77.69s before, 61.36s after (an earlier pair measured 81.86s -> 69.87s). Co-resident with `tests/effects/campaign-worker.test.ts`: 18 pass in 98.36s.
+- Residual risks and incomplete observations: the snapshot copies two full package installs, so part of the saved rsync/Bun-startup cost returns as a directory copy; the win is the removed duplicate build for the `full` profile, not a linear 3x reduction.
+
+## Rollback Point
+
+- Commit / checkpoint: `b9628876` (origin/main at branch creation).
+- Revert strategy: revert the single commit; the change is confined to one test file plus workflow artifacts.

--- a/tasks/notes/20260913-0144-auto-campaign-template.notes.md
+++ b/tasks/notes/20260913-0144-auto-campaign-template.notes.md
@@ -1,0 +1,70 @@
+# Implementation Notes: auto-campaign-template
+
+> **Status**: Active
+> **Plan**: plans/plan-20260913-0144-auto-campaign-template.md
+> **Contract**: tasks/contracts/20260913-0144-auto-campaign-template.contract.md
+> **Review**: tasks/reviews/20260913-0144-auto-campaign-template.review.md
+> **Last Updated**: 2026-09-13 01:44
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- The template boundary stops at the install: the builder keeps `git init`, the empty
+  commit, the CLI shim and `scripts/sync-codex-installed-copies.sh`, while `draft()` still
+  spawns a real `prepare-grant.ts` child process on every call because that spawn is the
+  behaviour the file asserts on.
+- One workspace path (`value.dir`) is snapshotted rather than a `{ root, home }` pair. The
+  fixture's mkdtemp directory is simultaneously `HOME`, the parent of `REPO_HARNESS_HOME`,
+  and the parent of `CODEX_SKILLS_ROOT` / `CLAUDE_SKILLS_ROOT`; `sync-codex-installed-copies.sh`
+  writes only to those two skill roots, so nothing the fixture produces lives outside it.
+- Registration for `afterEach` removal moved from the builder into the `fixture()` wrapper,
+  because on a cache hit the builder never runs. This mirrors the existing consumer in
+  `tests/effects/collaboration-contribution-collector.test.ts`.
+- The template key is the install profile, so `full` is built once for two tests and
+  `minimal` keeps its own build. Three builds become two.
+
+## Deviations From Plan Or Spec
+
+- None recorded.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| Share one template across both install profiles | Rejected | The profile is exactly what the install output differs by; the third test asserts `minimal` installs nothing. |
+| Also template the `draft()` child process | Rejected | `prepare-grant.ts` sealing and minting is the behaviour under test, not fixture cost. |
+| Snapshot `repo` and the skill roots separately | Rejected | They share one mkdtemp parent that is also `HOME`; snapshotting the parent is both simpler and complete. |
+
+## Open Questions
+
+- None.
+
+## Measured Effect
+
+Paired runs in this worktree, `bun test --timeout 180000 tests/auto-campaign-skill.test.ts`:
+
+| Run | Before | After |
+|-----|--------|-------|
+| pair 1 | 81.86s | 69.87s |
+| pair 2 | 77.69s | 61.36s |
+
+Co-resident with `tests/effects/campaign-worker.test.ts`: 18 pass, 0 fail, 98.36s.
+JUnit `<testcase name>` multiset is byte-identical before and after (three names).
+
+Part of the saved rsync and Bun-startup cost returns as the snapshot directory copy, which
+carries two full package installs; the net win is the removed duplicate `full` build.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/reviews/20260913-0144-auto-campaign-template.review.md
+++ b/tasks/reviews/20260913-0144-auto-campaign-template.review.md
@@ -1,0 +1,98 @@
+# Task Review: auto-campaign-template
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260913-0144-auto-campaign-template.md
+> **Contract**: tasks/contracts/20260913-0144-auto-campaign-template.contract.md
+> **Notes File**: tasks/notes/20260913-0144-auto-campaign-template.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-09-13 01:44
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Check IDs and evidence disposition:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+Follow [Testing Policy and Artifact Standards](../../docs/reference-configs/sprint-contracts.md#testing-policy-and-artifact-standards).
+Consume canonical evidence; do not rerun checks to populate this review or
+copy the executable plan. Return missing/stale evidence to its execution owner.
+
+- Waza `/check` review reference, when required:
+- Check IDs and disposition (executed / exact reuse / baseline with delta / failed / missing / not run):
+- Verified subject, relevant environment and immutable execution references:
+- Historical baseline and current delta references, if applicable:
+- Manual observations, failures and coverage limitations:
+- Implementation notes reviewed, if present:
+- Run snapshot:
+
+## Manual Check Evidence
+
+Copy each non-built-in contract `manual_checks` requirement exactly. Check it only after
+the observation is complete and replace the placeholder with concrete command output,
+screenshot/artifact path, or reviewer observation.
+
+- [ ] Exact manual_checks requirement
+  - Evidence: concrete observation, command output, screenshot path, or reviewer note
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -1,7 +1,7 @@
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: 2026-09-13 00:38
+> **Updated**: 2026-09-13 01:44
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.

--- a/tests/auto-campaign-skill.test.ts
+++ b/tests/auto-campaign-skill.test.ts
@@ -1,19 +1,19 @@
-import { afterEach, expect, test } from 'bun:test';
+import { afterAll, afterEach, expect, test } from 'bun:test';
 import { execFileSync, spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { automationDigest, canonicalAutomationJson, validateProgramAuthorization } from '../src/core/automation/budget';
 import { listStoredProgramAuthorizations, mintProgramAuthorization, readStoredProgramAuthorization } from '../src/effects/automation/grant-store';
+import { fixtureTemplate } from './helpers/repo-fixture';
 
 const root = resolve(import.meta.dir, '..');
 const source = join(root, 'assets/skills/auto-campaign');
 const temporary: string[] = [];
 afterEach(() => { for (const path of temporary.splice(0)) rmSync(path, { recursive: true, force: true }); });
 
-function fixture(profile: 'minimal' | 'full') {
+function buildFixture(profile: 'minimal' | 'full') {
   const dir = mkdtempSync(join(tmpdir(), 'auto-campaign-'));
-  temporary.push(dir);
   const repo = join(dir, 'repo');
   mkdirSync(repo);
   execFileSync('git', ['init', '-q', '-b', 'main', repo]);
@@ -39,6 +39,29 @@ function fixture(profile: 'minimal' | 'full') {
     return spawnSync(process.execPath, [join(env.CODEX_SKILLS_ROOT, 'auto-campaign/scripts/prepare-grant.ts'), path], { cwd: repo, env, encoding: 'utf8', timeout: 15000 });
   }
   return { dir, repo, env, input, draft };
+}
+
+/**
+ * The install is built once per profile and restored per test. Its cost is a git
+ * repository plus `scripts/sync-codex-installed-copies.sh`, which starts three Bun
+ * child processes and rsyncs the package into both skill roots; every test here
+ * starts from that same shape.
+ *
+ * One workspace path is enough because the fixture's mkdtemp directory owns every
+ * byte written: it is `HOME`, and `REPO_HARNESS_HOME`, `CODEX_SKILLS_ROOT` and
+ * `CLAUDE_SKILLS_ROOT` -- the sync script's only destinations -- are all inside it.
+ * `draft()` still spawns a real `prepare-grant.ts` per call, because that is the
+ * behaviour under test.
+ */
+const templates = fixtureTemplate(buildFixture, (value) => [value.dir]);
+afterAll(() => templates.dispose());
+
+// The template, not the builder, decides when a workspace exists: on a cache hit
+// the builder never runs, so registration for `afterEach` removal belongs here.
+function fixture(profile: 'minimal' | 'full') {
+  const value = templates.materialize(profile);
+  temporary.push(value.dir);
+  return value;
 }
 
 test('full installs complete portable skill on both hosts; draft seals and mints through existing authority', () => {


### PR DESCRIPTION
## What

`tests/auto-campaign-skill.test.ts` rebuilt its whole fixture for each of three tests: a
`git init` plus empty commit, and `bash scripts/sync-codex-installed-copies.sh`, which
starts three Bun child processes and rsyncs the package into two skill roots. Only two
distinct install profiles (`full`, `minimal`) exist, so one of those installs was pure
duplicate cost.

`fixture()` now goes through the existing `fixtureTemplate` helper, keyed by profile. The
snapshot path is the fixture's mkdtemp directory: it is `HOME`, and it contains
`REPO_HARNESS_HOME` and both `CODEX_SKILLS_ROOT` / `CLAUDE_SKILLS_ROOT`, which are the sync
script's only write destinations. Restore happens in place, so the repo path the grant
store hashes stays valid, and the per-test `afterEach` removal keeps each test's bytes
unshared. `draft()` still spawns a real `prepare-grant.ts` per call, because that spawn is
the behaviour under test.

## Timing

Paired runs in the same worktree, `bun test --timeout 180000 tests/auto-campaign-skill.test.ts`:

| Run | Before | After |
|-----|--------|-------|
| pair 1 | 81.86s | 69.87s |
| pair 2 | 77.69s | 61.36s |

Co-resident with an existing `fixtureTemplate` consumer
(`tests/effects/campaign-worker.test.ts`): 18 pass, 0 fail, 98.36s.

## No lost tests

`bun test --reporter=junit` on both revisions, `<testcase name>` multiset sorted and
diffed: identical, three names, zero diff lines.

```
testcase name="draft rejects absent authority, malformed identity and nonstandard overrides without minting"
testcase name="full installs complete portable skill on both hosts; draft seals and mints through existing authority"
testcase name="minimal does not discover or install auto-campaign"
```

No assertion, test title, `src/`, `scripts/` or CI file changed.

## Checks

`check:type`, `check:hooks`, `check:helpers`, `check:reference-configs`,
`scripts/check-architecture-sync.sh`, `scripts/check-task-workflow.sh --strict`,
`scripts/check-task-sync.sh` (merge-base bound), `init --repo . --dry-run` -- all exit 0.