### PR TITLE
fix(external-sources): forward the injected clock to the GitHub fetcher in refresh

### DIFF
--- a/src/effects/external-sources/refresh.ts
+++ b/src/effects/external-sources/refresh.ts
@@ -75,7 +75,7 @@ export function refreshExternalSource(input: {
   let pages = 0;
   let issuesSeen = 0;
   try {
-    const fetched = fetchGithubIssues(policy, input.runner);
+    const fetched = fetchGithubIssues(policy, input.runner, () => now().getTime());
     identity = fetched.repository;
     pages = fetched.pages_fetched;
     issuesSeen = fetched.issues_seen;

--- a/tasks/waivers/20260913-refresh-clock-forward.json
+++ b/tasks/waivers/20260913-refresh-clock-forward.json
@@ -1,0 +1,12 @@
+{
+  "protocol": 1,
+  "kind": "repo-harness-substantive-change-waiver",
+  "substantive_change_sha256": "sha256:8f2e97c454b4873ee3340d0249b4d4a203ace69a09ab2389f0368016dc887302",
+  "reason": "refreshExternalSource now forwards its injected clock to fetchGithubIssues, so the fetch deadline and the receipt/observation timestamps are measured on one clock instead of racing a fixture clock against wall time; the refresh fixture's deadline_ms is raised to 60000 so the test's one-second tick clock stays consistent with the deadline it now drives, and a new case proves the deadline is measured on the injected clock. This is the sibling of the observer fix in #425. Lite-profile slice reviewed and approved by the owner; no plan or contract carrier exists.",
+  "owner": "ancienttwo",
+  "scope": [
+    "src/effects/external-sources/refresh.ts",
+    "tests/effects/external-source-github.test.ts"
+  ],
+  "revisit_trigger": "A new caller of fetchGithubIssues appears, or its clock parameter changes shape"
+}

--- a/tests/effects/external-source-github.test.ts
+++ b/tests/effects/external-source-github.test.ts
@@ -30,7 +30,7 @@ function refreshRepository(): string {
   execFileSync('git', ['init', '-q'], { cwd: root });
   mkdirSync(join(root, '.ai', 'harness'), { recursive: true });
   writeFileSync(join(root, '.ai', 'harness', 'policy.json'), JSON.stringify({
-    external_sources: { version: 1, mode: 'manual', github: { enabled: true, repository: 'acme/widgets', selection: { kind: 'labels', labels_all: ['ready'], assignees_any: [] }, limits: { max_pages: 2, max_issues: 20, max_body_bytes: 256, max_total_bytes: 4096, deadline_ms: 1000 } } },
+    external_sources: { version: 1, mode: 'manual', github: { enabled: true, repository: 'acme/widgets', selection: { kind: 'labels', labels_all: ['ready'], assignees_any: [] }, limits: { max_pages: 2, max_issues: 20, max_body_bytes: 256, max_total_bytes: 4096, deadline_ms: 60000 } } },
   }));
   return root;
 }
@@ -166,6 +166,19 @@ describe('GitHub external-source adapter', () => {
       expect(() => refreshExternalSource({ policy: readExternalSourcesPolicy(root), repo_root: root, registered_repository_id: 'repo_1', runner: () => { throw new GithubAdapterError('rate_limit', '429', 'unavailable'); }, now })).toThrow(ExternalSourceRefreshError);
       try { refreshExternalSource({ policy: readExternalSourcesPolicy(root), repo_root: root, registered_repository_id: 'repo_1', runner: () => { throw new GithubAdapterError('rate_limit', '429', 'unavailable'); }, now }); }
       catch (error) { expect((error as ExternalSourceRefreshError).receipt?.outcome).toBe('unavailable'); }
+    } finally { rmSync(root, { recursive: true, force: true }); }
+  });
+
+  test('refresh measures the fetch deadline on its injected clock', () => {
+    const root = refreshRepository();
+    let tick = 0;
+    const now = () => new Date(Date.parse('2026-08-31T00:00:00.000Z') + (tick++ * 120_000));
+    try {
+      refreshExternalSource({ policy: readExternalSourcesPolicy(root), repo_root: root, registered_repository_id: 'repo_1', runner: snapshot('first'), now });
+      throw new Error('expected the injected clock to exceed deadline_ms');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ExternalSourceRefreshError);
+      expect((error as ExternalSourceRefreshError).receipt?.failure?.class).toBe('deadline');
     } finally { rmSync(root, { recursive: true, force: true }); }
   });
 });


### PR DESCRIPTION
`refreshExternalSource` resolves one clock (`input.now`, defaulting to real time) and stamps every receipt and observation with it, but it called `fetchGithubIssues` without a clock, so the fetcher fell back to its `Date.now` default. The fetch deadline was therefore measured on wall time while the receipt timestamps came from the caller's clock: two clocks for one attempt. Under the now-parallel CI Test job the wall clock advances with machine load, so a refresh whose logical time never moved could still trip `deadline_ms` and fail as `unavailable` purely because the box was busy. #425 fixed exactly this on the batch-observer path; this is the same one-line fix on the refresh path, so both callers of the fetcher now measure the deadline on the clock that stamps their receipts.

The refresh fixture's `deadline_ms` moves from 1000 to 60000. With the deadline now driven by the injected clock, the existing persistence test's one-second-per-read tick clock would consume a one-second budget within a single attempt; 60000 keeps that fixture measuring what it is about (immutable observations and attempt receipts) rather than the deadline. The fixture is local to this test file and no assertion reads it. The existing deadline test, `enforces one deadline across repository identity and every exact Issue request`, keeps its own policy at `deadline_ms: 100` with its own explicit clock and is untouched.

A new case, `refresh measures the fetch deadline on its injected clock`, drives refresh with a clock that advances 120s per read against the 60s fixture deadline and asserts an `ExternalSourceRefreshError` whose receipt failure class is `deadline`. It is load-independent: it never consults wall time, and it fails on the base revision (verified by restoring the pre-change `refresh.ts` and rerunning the file: that single case fails, the other six pass).

Production behaviour is unchanged. Neither production caller — `src/cli/commands/external-source.ts` nor `src/effects/automation/campaign-planning.ts` — injects a clock, so `now` stays `() => new Date()` and `() => now().getTime()` is the fetcher's `Date.now` default.

Verification

- `bun test tests/effects/external-source-github.test.ts tests/effects/campaign-step.test.ts tests/effects/issue-batch-observer.test.ts` — 37 pass, 0 fail
- Revert check: base `refresh.ts` restored over the worktree, `bun test tests/effects/external-source-github.test.ts` — 6 pass, 1 fail (the new deadline case); working tree restored clean afterwards
- `bun run check:type` — clean
- `REPO_HARNESS_DIFF_BASE=origin/main REPO_HARNESS_DIFF_MODE=merge-base bash scripts/check-task-sync.sh` — bound waiver admitted (`sha256:8f2e97c4...`), exit 0
- `bash scripts/check-task-workflow.sh --strict` — `[workflow] OK`
