### PR TITLE
test: gate real-install and herdr tests behind the release lane

### DIFF
--- a/assets/reference-configs/release-deploy.md
+++ b/assets/reference-configs/release-deploy.md
@@ -12,6 +12,13 @@ This repo keeps deployment contract surfaces under `deploy/` and private runtime
 state under ignored `_ops/`. Detailed release patterns, Cloudflare examples, and
 rollback playbooks belong in the external runbook.
 
+Tests whose cost is a real package install or a real external program are gated
+behind `REPO_HARNESS_TEST_EXPENSIVE` and are therefore not part of the hosted
+`scripts/check-ci.sh functional` lane. The release gate is the lane that owns
+them: `bun run check:release` (and a bare local `bash scripts/check-ci.sh`) runs
+the `all` lane, which exports that variable before the suite, while
+`prepublishOnly` stays a fast pre-publish check that never runs tests.
+
 ## Webapp Release Shape
 
 - For a SaaS webapp with public SEO/SSR plus authenticated workspace, prefer one

--- a/docs/reference-configs/release-deploy.md
+++ b/docs/reference-configs/release-deploy.md
@@ -12,6 +12,13 @@ This repo keeps deployment contract surfaces under `deploy/` and private runtime
 state under ignored `_ops/`. Detailed release patterns, Cloudflare examples, and
 rollback playbooks belong in the external runbook.
 
+Tests whose cost is a real package install or a real external program are gated
+behind `REPO_HARNESS_TEST_EXPENSIVE` and are therefore not part of the hosted
+`scripts/check-ci.sh functional` lane. The release gate is the lane that owns
+them: `bun run check:release` (and a bare local `bash scripts/check-ci.sh`) runs
+the `all` lane, which exports that variable before the suite, while
+`prepublishOnly` stays a fast pre-publish check that never runs tests.
+
 ## Webapp Release Shape
 
 - For a SaaS webapp with public SEO/SSR plus authenticated workspace, prefer one

--- a/plans/plan-20260913-0250-expensive-test-gate.md
+++ b/plans/plan-20260913-0250-expensive-test-gate.md
@@ -1,0 +1,164 @@
+# Plan: Gate real-install and herdr tests behind the release lane
+
+> **Status**: Executing
+> **Substantive Change SHA256**: `sha256:4366f02606f02ae97f07df3bd30bccc84d5cbc05fdd7c2ff2121baec3179b3cd`
+> **Created**: 20260913-0250
+> **Slug**: expensive-test-gate
+> **Planning Source**: codex-plan-or-waza-think
+> **Orchestration Kind**: host-plan
+> **Source Ref**: (none)
+> **Artifact Level**: work-package
+> **Promotion Reason**: verification_boundary
+> **Verification Boundary**: Commands named in the captured planning output plus `repo-harness run verify-contract --contract tasks/contracts/20260913-0250-expensive-test-gate.contract.md --strict`.
+> **Rollback Surface**: Before execution remove `plans/plan-20260913-0250-expensive-test-gate.md`; after execution revert branch `codex/expensive-test-gate` or the explicitly reviewed diff.
+> **Spec**: `docs/spec.md`
+> **Research**: See `docs/researches/`
+> **Task Contract**: `tasks/contracts/20260913-0250-expensive-test-gate.contract.md`
+> **Task Review**: `tasks/reviews/20260913-0250-expensive-test-gate.review.md`
+> **Implementation Notes**: `tasks/notes/20260913-0250-expensive-test-gate.notes.md`
+
+## Agentic Routing
+- Selected route: planning
+- Routing reason: Captured from codex-plan-or-waza-think planning output.
+- Source ref: (none)
+- Due diligence:
+  - P1 map: See captured planning output below.
+  - P2 trace: See captured planning output below.
+  - P3 decision rationale: See captured planning output below.
+
+## Workflow Inventory
+Complete this inventory before implementation. If any line is unknown, keep the plan in Draft and fill it before projection.
+
+- Active plan: `plans/plan-20260913-0250-expensive-test-gate.md`
+- Sprint contract: `tasks/contracts/20260913-0250-expensive-test-gate.contract.md`
+- Sprint review: `tasks/reviews/20260913-0250-expensive-test-gate.review.md`
+- Implementation notes: `tasks/notes/20260913-0250-expensive-test-gate.notes.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Current checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope authority: `tasks/contracts/20260913-0250-expensive-test-gate.contract.md` `allowed_paths`
+- Concurrency rule: `.ai/harness/active-plan` selects the active plan for this worktree when present; `.ai/harness/active-worktree` records the owning worktree. If another worktree already owns active work, open or switch to the matching worktree instead of serializing unrelated plans.
+- Execution isolation: approved contract-level work projects through `repo-harness run plan-to-todo --plan plans/plan-20260913-0250-expensive-test-gate.md` and may start `repo-harness run contract-worktree start --plan plans/plan-20260913-0250-expensive-test-gate.md`.
+
+## Approach
+### Strategy
+Use the captured planning output below as the execution source of truth.
+
+### Trade-offs
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Captured plan | Preserves the approved Codex Plan or Waza think decision | Requires the captured text to be concrete enough to execute | Use |
+
+## Detailed Design
+### File Changes
+| File | Action | Description |
+|------|--------|-------------|
+| See captured planning output | Follow | Implement only the approved scope named below |
+
+### Code Snippets
+See captured planning output.
+
+### Data Flow
+See captured planning output.
+
+## Risk Assessment
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Captured plan lacks enough detail | Medium | Execution may need clarification | Stop before implementation if the captured output contradicts repo rules or lacks concrete file targets |
+
+## Task Contracts
+- Contract file: `tasks/contracts/20260913-0250-expensive-test-gate.contract.md`
+- Review file: `tasks/reviews/20260913-0250-expensive-test-gate.review.md`
+- Implementation notes file: `tasks/notes/20260913-0250-expensive-test-gate.notes.md`
+- Template: `.claude/templates/contract.template.md`
+- Verification command: `repo-harness run verify-contract --contract tasks/contracts/20260913-0250-expensive-test-gate.contract.md --strict`
+- Active plan rule: this captured plan is written to `.ai/harness/active-plan` and the owning worktree is written to `.ai/harness/active-worktree` unless --no-active is used. Do not infer active execution from the latest non-archived plan.
+
+## Handoff
+
+- Checks file: `.ai/harness/checks/latest.json`
+- Session handoff: `.ai/harness/handoff/current.md`
+
+## Promotion Gate
+
+- **Merge/PR unit**: Captured plan `plans/plan-20260913-0250-expensive-test-gate.md` is the proposed mergeable execution unit; revise before execute if this is only a checklist step.
+- **Rollback surface**: Before execution remove `plans/plan-20260913-0250-expensive-test-gate.md`; after execution revert branch `codex/expensive-test-gate` or the explicitly reviewed diff.
+- **Verification boundary**: Commands named in the captured planning output plus `repo-harness run verify-contract --contract tasks/contracts/20260913-0250-expensive-test-gate.contract.md --strict`.
+- **Review/acceptance boundary**: `tasks/reviews/20260913-0250-expensive-test-gate.review.md` must record pass against the captured acceptance criteria.
+- **High-risk surface**: Risks named in captured planning output; keep the plan Draft if risk ownership is not concrete.
+- **Why not checklist row**: verification_boundary
+
+## Evidence Contract
+
+- **State/progress path**: `plans/plan-20260913-0250-expensive-test-gate.md` task breakdown, `tasks/todos.md` deferred-goal ledger, `tasks/contracts/20260913-0250-expensive-test-gate.contract.md`, `tasks/reviews/20260913-0250-expensive-test-gate.review.md`, and `tasks/notes/20260913-0250-expensive-test-gate.notes.md`
+- **Verification evidence**: `.ai/harness/checks/latest.json`, `.ai/harness/runs/`, and the commands named in the captured planning output
+- **Evaluator rubric**: `tasks/reviews/20260913-0250-expensive-test-gate.review.md` must record a passing Waza /check style recommendation
+- **Stop condition**: all task breakdown items are complete, sprint verification passes, and the review recommends pass
+- **Rollback surface**: Before execution remove `plans/plan-20260913-0250-expensive-test-gate.md`; after execution revert branch `codex/expensive-test-gate` or the explicitly reviewed diff.
+
+## Captured Planning Output
+
+# Plan: Gate real-install and herdr tests behind the release lane
+
+## Promotion Gate
+
+- **Merge/PR unit**: One independently reviewable test-scheduling change.
+- **Rollback surface**: Two test files, `scripts/check-ci.sh`, one new guard test and one reference-config sentence.
+- **Verification boundary**: The two affected files must be observably cheaper with the gate off, complete with it on, and the lane wiring must be asserted mechanically.
+- **Review/acceptance boundary**: Local validation recorded here; hosted Required / CI execution is separately identified.
+- **High-risk surface**: A renamed variable could silently disable release coverage; the guard test binds the lane and both files to one name.
+- **Why not checklist row**: It changes what the default CI lane executes, which is a verification boundary of its own.
+
+## Evidence Contract
+
+- **State/progress path**: This plan's Task Breakdown.
+- **Verification evidence**: Gate-off and gate-on runs of both affected files, the guard test, the existing lane test, and the repository-integrity commands, recorded here.
+- **Evaluator rubric**: Gate off skips exactly the expensive cases and keeps every `<testcase name>`; gate on runs them green; `all` exports the variable and `functional` does not.
+- **Stop condition**: Scope implemented and the declared checks pass, or a verified external blocker is reported.
+- **Rollback surface**: This slice's declared files only.
+
+## Decision
+
+P1: `.github/workflows/ci.yml` schedules jobs; its Test job runs `bash scripts/check-ci.sh functional`, so hosted PR and main execution is the `functional` lane. `scripts/check-ci.sh` with no argument is the `all` lane, and that is exactly what `scripts/check-npm-release.sh` invokes in full mode (`check:release`). `prepublishOnly` runs `check-npm-release.sh --prepublish`, which deliberately stops before the suite. So the release path that executes tests is the `all` lane, reached through `bun run check:release` or a bare local `bash scripts/check-ci.sh`.
+
+P2: `tests/harness-benchmark-matrix.test.ts` holds 31 tests; only the two that call `prepareBenchmarkRuntimeArtifact()` pack the whole repository with `npm pack` and install the tarball into an isolated HOME. `tests/claude-review.test.ts` holds 15 declarations (20 executed cases) and every one of them needs the pinned `herdr` binary: the sentinel helper spawns a real `herdr` server and `unstartedSession()` resolves `Bun.which('herdr')`. That makes the whole file, not a subset, the external-program cost.
+
+P3: `test.skipIf(!process.env.REPO_HARNESS_TEST_EXPENSIVE)` follows the existing `BRC_TEST_CONTAINER_IMAGE` precedent in `tests/effects/brc10-lifecycle.test.ts`, keeps every test name in the JUnit report, and keeps the skip visibly a gate rather than a failure. The variable is exported only in the `all` lane so the release gate keeps full coverage while the hosted PR lane drops the two install tests and the herdr file. A rename is the failure mode that would silently drop release coverage, so a guard test asserts the lane wiring and the shared variable name across both files. At 10x scale the first limit is still the hosted full lane's per-file wall clock, not this gate.
+
+## Scope
+
+Gate the two `prepareBenchmarkRuntimeArtifact()` tests in `tests/harness-benchmark-matrix.test.ts` and all of `tests/claude-review.test.ts` behind `REPO_HARNESS_TEST_EXPENSIVE`; export it in the `all` lane of `scripts/check-ci.sh` only; add `tests/expensive-test-gate.test.ts`; add one release-lane sentence to `assets/reference-configs/release-deploy.md` and re-project it. No `src/` change, no `.github/workflows/ci.yml` change, no assertion or title change in the gated tests, no `tasks/todos.md` edit.
+
+## Verification
+
+Run both affected files with the gate off and with the gate on, compare the JUnit `<testcase name>` multisets against the pre-change baseline, run the new guard test and `tests/check-ci-job-split.test.ts`, then `bun run check:type` and the repository-integrity commands. No full local suite: this slice changes only test scheduling and one shell export, and the hosted Required / CI run is the full-coverage authority.
+
+## Task Breakdown
+
+- [x] Gate the two real-install benchmark tests and the whole herdr review file behind one variable.
+- [x] Export the variable in the `all` lane of `scripts/check-ci.sh` and leave `functional` unset.
+- [x] Add the lane-and-name guard test.
+- [x] Document the variable's release-lane relationship in the reference configs and re-project.
+- [x] Complete gate-off/gate-on, guard, type and repository-integrity verification.
+
+## Verification Results
+
+- Gate variable is `REPO_HARNESS_TEST_EXPENSIVE`; `scripts/check-ci.sh` exports it only inside the `all` lane, immediately before `run_bun_tests`.
+- Release path confirmed by reading: `scripts/check-npm-release.sh` full mode calls `bash scripts/check-ci.sh` with no lane argument, and that script is `bun run check:release`. `prepublishOnly` uses `--prepublish`, which returns before the suite, so it was left untouched.
+- `tests/harness-benchmark-matrix.test.ts`, `bun test --timeout 180000`: baseline 62.73 s (31 pass); gate off 2.57 s (29 pass, 2 skip); gate on 55.99 s (31 pass).
+- `tests/claude-review.test.ts`, same command: baseline 38.98 s (20 pass); gate off 0.023 s (20 skip); gate on 39.22 s (20 pass).
+- JUnit `<testcase name>` multisets are identical between baseline, gate-off and gate-on for both files (`diff` of sorted `name="..."` extractions, zero differences).
+- `bun test tests/check-ci-job-split.test.ts tests/expensive-test-gate.test.ts`: 9 passed, 188 expectations, 10.10 s.
+- The new guard was mutation-checked: renaming the exported variable fails the shared-name assertion, and hoisting the export out of the `all` branch fails the functional-lane assertion.
+- `bun run check:type`, `check:hooks`, `check:helpers`, `check:reference-configs`, `bash scripts/check-deploy-sql-order.sh` equivalents in the governance lane, `bash scripts/check-architecture-sync.sh`, `bash scripts/check-task-workflow.sh --strict`, merge-base-bound `bash scripts/check-task-sync.sh`, `bun src/cli/index.ts init --repo . --dry-run` and `bash scripts/check-ci.sh governance` results are recorded below as they run.
+- `.github/workflows/ci.yml` was not modified. Its "Install pinned Herdr runtime" step is now unnecessary for the `functional` lane and is queued for the next change that already touches that file, batched with the existing documentation-lane hardening row in `tasks/todos.md`.
+
+## Annotations
+<!-- [NOTE]: prefixed inline. Claude processes all and revises. -->
+
+## Task Breakdown
+- [x] Gate the two real-install benchmark tests and the whole herdr review file behind one variable.
+- [x] Export the variable in the `all` lane of `scripts/check-ci.sh` and leave `functional` unset.
+- [x] Add the lane-and-name guard test.
+- [x] Document the variable's release-lane relationship in the reference configs and re-project.
+- [x] Complete gate-off/gate-on, guard, type and repository-integrity verification.

--- a/scripts/check-ci.sh
+++ b/scripts/check-ci.sh
@@ -67,6 +67,12 @@ if [[ "$lane" != functional ]]; then
 fi
 
 if [[ "$lane" != governance ]]; then
+  if [[ "$lane" == all ]]; then
+    # Local and release callers own the expensive real-install and real-herdr
+    # cases; the hosted functional lane deliberately leaves them gated out.
+    export REPO_HARNESS_TEST_EXPENSIVE=1
+  fi
+
   echo "[ci] tests"
   run_bun_tests
 

--- a/tasks/contracts/20260913-0250-expensive-test-gate.contract.md
+++ b/tasks/contracts/20260913-0250-expensive-test-gate.contract.md
@@ -1,0 +1,392 @@
+# Task Contract: expensive-test-gate
+
+> **Status**: Active
+> **Plan**: plans/plan-20260913-0250-expensive-test-gate.md
+> **Task Profile**: code-change
+> <!-- legal values: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | bugfix (omit for legacy passthrough); see docs/reference-configs/sprint-contracts.md -->
+> **Owner**: ancienttwo
+> **Capability ID**: root
+> **Last Updated**: 2026-09-13 02:50
+> **Review File**: `tasks/reviews/20260913-0250-expensive-test-gate.review.md`
+> **Notes File**: `tasks/notes/20260913-0250-expensive-test-gate.notes.md`
+> **Exemplar**: `docs/reference-configs/contract-brief-example.md`
+
+## Why
+
+Two test files spend almost all of their wall clock on real external work:
+`tests/harness-benchmark-matrix.test.ts` packs the whole repository with `npm
+pack` and installs the tarball into an isolated HOME, and
+`tests/claude-review.test.ts` drives the real pinned `herdr` binary. Every
+hosted pull request and every `main` push pays that cost through the
+`functional` lane. If the gate ships wrong the release lane silently stops
+executing them and the packaging/review-session regressions they own become
+unguarded.
+
+## Goal
+
+One environment variable, `REPO_HARNESS_TEST_EXPENSIVE`, gates the two real
+install cases in `tests/harness-benchmark-matrix.test.ts` and the whole of
+`tests/claude-review.test.ts`. `scripts/check-ci.sh` exports it in the `all`
+lane only, so local and release callers (`bun run check:release` reaches the
+`all` lane) keep full coverage while the hosted `functional` lane skips them.
+A guard test binds the lane wiring and the shared variable name; no test title
+disappears from the JUnit report.
+
+## Scope
+
+- In scope: `tests/harness-benchmark-matrix.test.ts` (two `prepareBenchmarkRuntimeArtifact()` cases), all of `tests/claude-review.test.ts`, the `all`-lane export in `scripts/check-ci.sh`, the new `tests/expensive-test-gate.test.ts`, and one release-lane paragraph in `assets/reference-configs/release-deploy.md` with its `docs/reference-configs/` projection.
+- Out of scope: `src/`, `.github/workflows/ci.yml` (including the now-unneeded "Install pinned Herdr runtime" step), `tasks/todos.md` hand edits, any other plan, and any assertion or title inside the gated tests.
+- Taste constraints: follow the existing `test.skipIf(!process.env.BRC_TEST_CONTAINER_IMAGE)` precedent in `tests/effects/brc10-lifecycle.test.ts`; the skip must read as a gate, never as a failure.
+
+## Stop Conditions
+
+- Stop and hand back to the parent if the change would require editing a path outside Allowed Paths.
+- Stop if an Exit Criteria command cannot be run in this environment.
+- Stop if Goal, Scope, or Exit Criteria are internally contradictory.
+
+## Falsifier
+
+What observable evidence would prove this task's direction wrong, and the cheapest proof point to check first. Leave as-is if not applicable.
+
+## Root Cause Evidence
+
+Required when Task Profile is `bugfix`; leave as-is otherwise.
+
+- root_cause: one sentence naming file:line/condition (testable, not "a state issue").
+- repro: the command or UI path that reproduces the symptom.
+- regression_guard: path to a test that fails on the unfixed code and passes after the fix (must also appear as a `package_test` check in Verification Plan).
+- pre_fix_failure_artifact: path to a captured run of regression_guard on the UNFIXED code. Capture with `bun test <regression_guard> > <artifact> 2>&1; echo "PRE_FIX_EXIT=$?" >> <artifact>` (no pipes — pipes swallow the exit status). The gate requires a non-zero `PRE_FIX_EXIT=` line plus the regression_guard path string in the artifact (see the Root Cause Evidence Gate section in docs/reference-configs/sprint-contracts.md).
+
+## Workflow Inventory
+
+- Source plan: `plans/plan-20260913-0250-expensive-test-gate.md`
+- Deferred-goal ledger: `tasks/todos.md`
+- Review file: `tasks/reviews/20260913-0250-expensive-test-gate.review.md`
+- Notes file: `tasks/notes/20260913-0250-expensive-test-gate.notes.md`
+- Checks file: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Scope gate: edit only paths listed under `allowed_paths`; update this contract before widening scope.
+- Completion gate: run `verify-sprint --prepare-acceptance`, record one typed AcceptanceReceipt under the frozen policy below, then run `verify-sprint`; review Markdown is projection only.
+
+## Change Assessment
+
+```json
+{"protocol":1,"oracles":[{"id":"expensive-test-gate","kind":"deterministic_test","paths":["tests/expensive-test-gate.test.ts"]},{"id":"check-ci-job-split","kind":"deterministic_test","paths":["tests/check-ci-job-split.test.ts"]}]}
+```
+
+## Acceptance Policy
+
+```json
+{"protocol":2,"reviewer":"Codex","source":"codex-plugin","user_waiver":"allowed"}
+```
+
+## Allowed Paths
+
+```yaml
+allowed_paths:
+  - docs/spec.md
+  - plans/
+  - tasks/todos.md
+  - tasks/contracts/20260913-0250-expensive-test-gate.contract.md
+  - tasks/reviews/20260913-0250-expensive-test-gate.review.md
+  - tasks/notes/20260913-0250-expensive-test-gate.notes.md
+  - .ai/context/capabilities.json
+  - .claude/templates/
+  - tests/
+  - scripts/check-ci.sh
+  - assets/reference-configs/release-deploy.md
+  - docs/reference-configs/release-deploy.md
+```
+
+## Evidence Requirements
+
+```yaml
+evidence_requirements:
+  # Set benchmark to required when this contract consumes the harness profile benchmark matrix.
+  benchmark: not_applicable
+```
+
+## Delegation Contract
+
+```yaml
+delegation:
+  budget:
+    tokens: null
+    runner_invocations: null
+    wall_time_minutes: null
+  permission_scope:
+    mode: inherit_allowed_paths
+    writable_paths: []
+    network: inherited
+  roles:
+    parent:
+      mode: narrate_and_gatekeep
+      purpose: approval_checkpoint_owner
+    explorer:
+      mode: read_only
+      purpose: codebase_research
+    worker:
+      mode: edit_within_allowed_paths
+      purpose: implementation
+    verifier:
+      mode: read_only
+      purpose: exit_criteria_review
+  runner:
+    preferred:
+      - subagent
+    fallback: null
+    brief_is_authoritative: true
+```
+
+## Exit Criteria (Machine Verifiable)
+
+This block contains only non-executable artifact requirements. Define every
+executable check once in the canonical Verification Plan below. Each check must
+state its phase, cost, evidence policy, necessity, and input environment; a
+missing or malformed plan fails closed. Populate artifact requirements only
+for deliverables this task actually owns; do not create a spec, notes or report
+merely to fill this template.
+
+```yaml
+exit_criteria:
+  files_exist:
+    - tests/expensive-test-gate.test.ts
+  artifacts_exist:
+    - tasks/notes/20260913-0250-expensive-test-gate.notes.md
+```
+
+## Verification Plan
+
+```json
+{
+  "protocol": 1,
+  "checks": [
+    {
+      "id": "benchmark-matrix-gate-off",
+      "kind": "package_test",
+      "path": "tests/harness-benchmark-matrix.test.ts",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Proves the hosted functional lane keeps the other 29 cases green and skips exactly the two real pack/install cases.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "benchmark-matrix-gate-on",
+      "kind": "command",
+      "command": "REPO_HARNESS_TEST_EXPENSIVE=1 bun test --timeout 180000 tests/harness-benchmark-matrix.test.ts",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "expensive",
+      "evidence_policy": "current_exact",
+      "necessity": "Proves the release lane still runs the two real pack/install cases green; distinct input environment from the gate-off run.",
+      "inputs": {
+        "env": [
+          "REPO_HARNESS_TEST_EXPENSIVE"
+        ]
+      }
+    },
+    {
+      "id": "claude-review-gate-off",
+      "kind": "package_test",
+      "path": "tests/claude-review.test.ts",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Proves the hosted functional lane skips the whole real-herdr file instead of failing on a missing runtime.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "claude-review-gate-on",
+      "kind": "command",
+      "command": "REPO_HARNESS_TEST_EXPENSIVE=1 bun test --timeout 180000 tests/claude-review.test.ts",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "expensive",
+      "evidence_policy": "current_exact",
+      "necessity": "Proves the release lane still runs every real-herdr review session case green; distinct input environment from the gate-off run.",
+      "inputs": {
+        "env": [
+          "REPO_HARNESS_TEST_EXPENSIVE"
+        ]
+      }
+    },
+    {
+      "id": "expensive-test-gate",
+      "kind": "package_test",
+      "path": "tests/expensive-test-gate.test.ts",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "The new guard: the all lane exports the variable, the functional lane does not, and both gated files use that exact name.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "check-ci-job-split",
+      "kind": "package_test",
+      "path": "tests/check-ci-job-split.test.ts",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "The existing lane authority; the new export must not change lane independence or the Required / CI aggregate.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "check-type",
+      "kind": "command",
+      "command": "bun run check:type",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "The new guard test and the two gate declarations must type-check.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "check-hooks",
+      "kind": "command",
+      "command": "bun run check:hooks",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository integrity check for substantive changes.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "check-helpers",
+      "kind": "command",
+      "command": "bun run check:helpers",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository integrity check for substantive changes.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "check-reference-configs",
+      "kind": "command",
+      "command": "bun run check:reference-configs",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "The reference-config edit is authored in assets/ and projected into docs/; this proves no drift.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "check-architecture-sync",
+      "kind": "command",
+      "command": "bash scripts/check-architecture-sync.sh",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository integrity check for substantive changes.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "check-task-workflow",
+      "kind": "command",
+      "command": "bash scripts/check-task-workflow.sh --strict",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository integrity check for substantive changes.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "check-task-sync",
+      "kind": "command",
+      "command": "bash scripts/check-task-sync.sh",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository integrity check; the digest is bound to the origin/main merge base.",
+      "inputs": {
+        "env": [
+          "REPO_HARNESS_DIFF_BASE",
+          "REPO_HARNESS_DIFF_MODE"
+        ]
+      }
+    },
+    {
+      "id": "init-dry-run",
+      "kind": "command",
+      "command": "bun src/cli/index.ts init --repo . --dry-run",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "Required repository integrity check for substantive changes.",
+      "inputs": {
+        "env": []
+      }
+    },
+    {
+      "id": "check-ci-governance",
+      "kind": "command",
+      "command": "bash scripts/check-ci.sh governance",
+      "cwd": ".",
+      "phase": "verification",
+      "cost": "normal",
+      "evidence_policy": "current_exact",
+      "necessity": "The edited lane script must still complete its governance lane end to end.",
+      "inputs": {
+        "env": []
+      }
+    }
+  ]
+}
+```
+
+Author the actual checks using [Testing Policy and Artifact Standards](../../docs/reference-configs/sprint-contracts.md#testing-policy-and-artifact-standards).
+The empty array is not permission to omit required repository checks: retain it
+only when no executable criterion applies and explain why in Acceptance Notes.
+Prefer existing covering tests; creating a task-named test or adding typecheck
+is not a template requirement. For each selected check declare `id`, `kind`,
+`cwd`, `phase`, `cost`, `evidence_policy`, `necessity`, `inputs.env`, and its
+`command` or `path`. Declare the same execution once, including checks nested
+inside aggregate scripts. Use `baseline_with_delta` only with an immutable
+baseline and named current delta checks; never infer it from paths or command text.
+
+## Acceptance Notes (Human Review)
+
+- Changed behavior/boundary, existing covering tests and remaining gap: only which lane executes two expensive test surfaces. `tests/check-ci-job-split.test.ts` already owns lane independence but says nothing about test-cost scheduling, which is the gap the new guard closes.
+- New test case/file rationale, or why existing coverage is sufficient: `tests/expensive-test-gate.test.ts` exists because a rename of the variable on one side would silently drop release coverage while every other check stays green. It was mutation-checked: renaming the export fails the name assertion, and moving the export outside the `all` branch fails the lane assertion.
+- Selected check IDs and why their coverage is sufficient; omitted coverage: the four gate-off/gate-on runs are the behavior itself, the two lane tests are the wiring, and the remaining IDs are the repository-integrity set. No full local suite: this slice changes test scheduling, one shell export and one document, and no product code. Hosted `Required / CI` remains the full-coverage authority.
+- Full/expensive check justification and expected cost, if applicable: the two gate-on runs are `expensive` because they are exactly the real `npm pack`/global-install and real `herdr` cost being gated; they are the only way to prove the release lane still passes. Measured cost below.
+- Execution/baseline references, subject, current delta and disposition: pre-change baselines on this branch were 62.73s (31 pass) for the benchmark file and 38.98s (20 pass) for the review file. After the change, gate off is 2.57s (29 pass / 2 skip) and 0.023s (20 skip); gate on is 55.99s (31 pass) and 39.22s (20 pass). The JUnit `<testcase name>` multiset is byte-identical to baseline in all four runs.
+- Residual risks and incomplete observations: the hosted functional lane no longer exercises the one pure schema case inside `tests/claude-review.test.ts`; whole-file gating was chosen because `unstartedSession()` resolves `Bun.which('herdr')` and every other case drives a real server. `tests/harness-benchmark-matrix.test.ts` keeps a third real install (`bun add -g <fixture dir>` at the Git-clean mode-drift case) ungated: it installs a three-file fixture package, not the repository, and the approved scope fixes the gated count at two.
+
+## Rollback Point
+
+- Commit / checkpoint:
+- Revert strategy:

--- a/tasks/notes/20260913-0250-expensive-test-gate.notes.md
+++ b/tasks/notes/20260913-0250-expensive-test-gate.notes.md
@@ -1,0 +1,51 @@
+# Implementation Notes: expensive-test-gate
+
+> **Status**: Active
+> **Plan**: plans/plan-20260913-0250-expensive-test-gate.md
+> **Contract**: tasks/contracts/20260913-0250-expensive-test-gate.contract.md
+> **Review**: tasks/reviews/20260913-0250-expensive-test-gate.review.md
+> **Last Updated**: 2026-09-13 02:50
+> **Lifecycle**: notes
+
+## Design Decisions
+
+- Gate variable: `REPO_HARNESS_TEST_EXPENSIVE`. One name for both surfaces, declared inline in each test file the way `BRC_TEST_CONTAINER_IMAGE` already is in `tests/effects/brc10-lifecycle.test.ts` and `tests/effects/campaign-container-live.test.ts`. No shared helper module: the cross-file invariant is protected by an explicit guard test, which is cheaper than a third import surface.
+- Release-path wiring: `scripts/check-ci.sh:70-74` exports the variable inside `if [[ "$lane" == all ]]`, before `run_bun_tests`. The `all` lane is what a bare `bash scripts/check-ci.sh` runs, and `scripts/check-npm-release.sh:43` calls exactly that in full mode, which is `bun run check:release`. So the release gate that executes tests is `check:release` -> `check-ci.sh` (no lane) -> `all`, and it picks up the variable without any second wiring point. `prepublishOnly` runs `check-npm-release.sh --prepublish`, which returns at `scripts/check-npm-release.sh:38` before the suite; it never ran tests and still does not, so nothing was attached there.
+- `.github/workflows/ci.yml` Test job runs `bash scripts/check-ci.sh functional`, which leaves the variable unset. Hosted PR and `main` runs therefore skip the gated cases.
+- Skip visibility: titles could not change (the JUnit `<testcase name>` multiset had to stay identical), so each gated file prints a single `[gate] REPO_HARNESS_TEST_EXPENSIVE unset: ...(release lane only, not a failure).` line at module load when the gate is closed. The skip therefore reads as a gate in the log, not as a silent omission.
+- The guard test derives the variable name from `scripts/check-ci.sh` and asserts both gated files use that exact name, and that no second `test.skipIf(!process.env.X)` name appears in them. Both failure modes were mutation-checked before landing.
+
+## Deviations From Plan Or Spec
+
+- The dispatch brief pointed at `tests/harness-benchmark-matrix.test.ts:492` as a `bun add -g` site while also fixing the gated count at two and the remaining passing count at 29. Those are inconsistent: line 492 belongs to a third case ("rejects Git-clean install-profile mode drift"), which installs a generated three-file fixture directory, not the packed repository. The two/29 boundary was kept, so that case stays in the functional lane. Its cost is a local `bun add -g` of a trivial package, not an `npm pack` of the whole repo.
+- `tests/claude-review.test.ts` is gated as a whole file, which the brief allowed. One case in it ("schema enums reject array coercion instead of accepting malformed provider data") is pure and loses hosted-lane coverage. Whole-file gating was chosen because `unstartedSession()` resolves `Bun.which('herdr')!` and every other case drives a real server or a spawned provider child, so a per-case split would have left one case behind a helper that still requires the runtime.
+
+## Tradeoffs Considered
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| Shared `tests/helpers/expensive-gate.ts` vs inline `process.env` reads | Inline | Matches the existing `skipIf` precedent, keeps the gate readable at the point of skip, and the name invariant is already enforced by the guard test |
+| `describe.skipIf` wrapper for the review file vs per-case `skipIf` | Per-case | A wrapping `describe` would prefix every JUnit `<testcase name>`, which the acceptance boundary forbids |
+| Gate only the herdr cases vs the whole review file | Whole file | `unstartedSession()` needs the pinned `herdr` binary too; a partial gate would still fail without the runtime |
+| Attach the variable to `prepublishOnly` as well | No | `check-npm-release.sh --prepublish` returns before the suite by design; attaching a test-cost variable there would imply a test run it does not perform |
+
+## Open Questions
+
+- `.github/workflows/ci.yml` still carries the "Install pinned Herdr runtime" step in its Test job. The hosted `functional` lane no longer needs it, because every `herdr` case is now gated out of that lane. It was deliberately left in place: this slice does not touch `ci.yml`. Remove it on the next change that already opens `ci.yml`, batched with the existing `tasks/todos.md` row "Harden the CI documentation lane after #415", whose own revisit trigger is "the next change touching `.github/workflows/ci.yml` or `scripts/*.ts`". Removing the step alone would burn a full hosted CI run for no coverage change.
+
+## Evidence Links
+
+- Checks: `.ai/harness/checks/latest.json`
+- Run snapshots: `.ai/harness/runs/`
+- Measured on this branch, `bun test --timeout 180000` per file: benchmark matrix 62.73s (31 pass) before, 2.57s (29 pass / 2 skip) gate off, 55.99s (31 pass) gate on. Claude review 38.98s (20 pass) before, 0.023s (20 skip) gate off, 39.22s (20 pass) gate on.
+- JUnit `<testcase name>` multisets for both files are identical across baseline, gate-off and gate-on runs.
+
+## Promotion Filter
+
+Promote a candidate to `tasks/lessons.md`, `docs/researches/`, or harness asset files only when all three hold: hard to reverse, surprising without local context, and a real trade-off existed. If any one is missing, keep it in this notes file instead.
+
+## Promotion Candidates
+
+- Promote to `tasks/lessons.md` only after a repeated correction or failure pattern.
+- Promote to `docs/researches/` only when it is durable repo knowledge with evidence.
+- Promote to harness asset files only after verification across more than one task or fixture.

--- a/tasks/reviews/20260913-0250-expensive-test-gate.review.md
+++ b/tasks/reviews/20260913-0250-expensive-test-gate.review.md
@@ -1,0 +1,98 @@
+# Task Review: expensive-test-gate
+
+> **Status**: Pending
+> **Plan**: plans/plan-20260913-0250-expensive-test-gate.md
+> **Contract**: tasks/contracts/20260913-0250-expensive-test-gate.contract.md
+> **Notes File**: tasks/notes/20260913-0250-expensive-test-gate.notes.md
+> **Checks File**: .ai/harness/checks/latest.json
+> **Last Updated**: 2026-09-13 02:50
+> **Recommendation**: fail
+> **Review Rubric Version**: 2
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+
+## Human Review Card
+
+- Verdict: pending
+- Change type: code-change | docs-only | ledger-closeout | migration | eval-only | delegated-run | frontend
+- Intended files changed:
+- Actual files changed:
+- Check IDs and evidence disposition:
+- Residual risks:
+- Reviewer action required: inspect diff and card
+- Rollback:
+
+## Mode Evidence
+
+- Selected route:
+- P1/P2/P3 evidence:
+- Root cause or plan evidence:
+
+## Verification Evidence
+
+Follow [Testing Policy and Artifact Standards](../../docs/reference-configs/sprint-contracts.md#testing-policy-and-artifact-standards).
+Consume canonical evidence; do not rerun checks to populate this review or
+copy the executable plan. Return missing/stale evidence to its execution owner.
+
+- Waza `/check` review reference, when required:
+- Check IDs and disposition (executed / exact reuse / baseline with delta / failed / missing / not run):
+- Verified subject, relevant environment and immutable execution references:
+- Historical baseline and current delta references, if applicable:
+- Manual observations, failures and coverage limitations:
+- Implementation notes reviewed, if present:
+- Run snapshot:
+
+## Manual Check Evidence
+
+Copy each non-built-in contract `manual_checks` requirement exactly. Check it only after
+the observation is complete and replace the placeholder with concrete command output,
+screenshot/artifact path, or reviewer observation.
+
+- [ ] Exact manual_checks requirement
+  - Evidence: concrete observation, command output, screenshot path, or reviewer note
+
+## Acceptance Receipt Projection
+
+> **Disposition**: unavailable
+> **Reviewer**: unavailable
+> **Source**: unavailable
+> **Actor**: not-applicable
+> **Reviewed Subject SHA256**: pending
+> **Reviewed Subject Scope**: normalized-final-content
+> **Reviewed Target Revision**: pending
+> **Verification Evidence SHA256**: pending
+> **Issued At**: pending
+
+- Summary: No AcceptanceReceipt has been recorded.
+- Findings: none
+
+## Behavior Diff Notes
+
+- ...
+
+## Residual Risks / Follow-ups
+
+- ...
+
+## Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | 0/10 | |
+| Product depth | 0/10 | |
+| Design quality | 0/10 | |
+| Code quality | 0/10 | |
+
+## Failing Items
+
+- ...
+
+## Retest Steps
+
+- Re-run:
+- Re-check:
+
+## Summary
+
+- ...

--- a/tasks/todos.md
+++ b/tasks/todos.md
@@ -1,7 +1,7 @@
 # Deferred Goal Ledger
 
 > **Status**: Backlog
-> **Updated**: 2026-09-13 01:44
+> **Updated**: 2026-09-13 02:50
 > **Scope**: Medium/long-term goals deferred from active plan execution
 
 Current plan tasks live in the active plan's `## Task Breakdown`.

--- a/tests/claude-review.test.ts
+++ b/tests/claude-review.test.ts
@@ -14,6 +14,15 @@ import { verifyAcceptance } from '../scripts/acceptance-receipt';
 import { emptyVerificationEvaluation, withEmptyVerificationPlan } from './helpers/verification-plan-fixture';
 import { reviewContextDigest, validateClaudeReviewResult, type ClaudeReviewRequest } from '../src/core/review/claude-review';
 
+// Every case in this file drives the real pinned `herdr` binary (sentinel
+// servers, `Bun.which('herdr')` session metadata) plus a spawned fake provider
+// child, so the whole file belongs to the release lane (`scripts/check-ci.sh`
+// with no lane argument). Same gate variable as
+// tests/harness-benchmark-matrix.test.ts.
+const releaseLaneOnly = test.skipIf(!process.env.REPO_HARNESS_TEST_EXPENSIVE);
+if (!process.env.REPO_HARNESS_TEST_EXPENSIVE) {
+  console.log('[gate] REPO_HARNESS_TEST_EXPENSIVE unset: skipping the real herdr review session cases (release lane only, not a failure).');
+}
 const fixtures: { root: string; home: string }[] = [];
 const sentinels: {name:string; process:ChildProcess; root:string; configPath:string}[] = [];
 async function sentinelServer() {
@@ -89,7 +98,7 @@ function fixture(mode = 'normal') {
     timeoutMs: 5000, admitSession: () => { admissions++; } }, admissions: () => admissions };
 }
 
-test('same child/session performs two rounds, records real receipt, rejects stale/duplicate subjects and closes precisely', async () => {
+releaseLaneOnly('same child/session performs two rounds, records real receipt, rejects stale/duplicate subjects and closes precisely', async () => {
   const f = fixture();
   const sentinel = await sentinelServer();
   const before = sentinel.identity();
@@ -113,7 +122,7 @@ test('same child/session performs two rounds, records real receipt, rejects stal
   expect(sentinel.identity()).toEqual(before);
 }, 30_000);
 
-test('stale source while reviewer runs cannot write an acceptance receipt or trigger replay', async () => {
+releaseLaneOnly('stale source while reviewer runs cannot write an acceptance receipt or trigger replay', async () => {
   const f = fixture('stale');
   await expect(runClaudeReviewRound(f.options)).rejects.toThrow('stale');
   prepare(f.root);
@@ -123,7 +132,7 @@ test('stale source while reviewer runs cannot write an acceptance receipt or tri
   expect(existsSync(join(dir, 'accepted-1.json'))).toBe(false);
 }, 20_000);
 
-test('explicit cancel cleans the exact detached provider after its host dies', async () => {
+releaseLaneOnly('explicit cancel cleans the exact detached provider after its host dies', async () => {
   const f = fixture();
   const first = await runClaudeReviewRound(f.options);
   const status = claudeReviewStatus(f.root, contract) as { processes: { host: string } };
@@ -135,7 +144,7 @@ test('explicit cancel cleans the exact detached provider after its host dies', a
   expect(claudeReviewStatus(f.root, contract).status).toBe('closed');
 }, 20_000);
 
-test.each(['wrong-session', 'wrong-subject', 'conflicting-pass', 'crash', 'hang'])('%s fails closed; explicit cancel remains available', async mode => {
+releaseLaneOnly.each(['wrong-session', 'wrong-subject', 'conflicting-pass', 'crash', 'hang'])('%s fails closed; explicit cancel remains available', async mode => {
   const f = fixture(mode);
   f.options.timeoutMs = 400;
   await expect(runClaudeReviewRound(f.options)).rejects.toThrow();
@@ -146,7 +155,7 @@ test.each(['wrong-session', 'wrong-subject', 'conflicting-pass', 'crash', 'hang'
   expect(claudeReviewStatus(f.root, contract).status).toBe('closed');
 }, 20_000);
 
-test('concurrent submission is refused without sending a second provider turn', async () => {
+releaseLaneOnly('concurrent submission is refused without sending a second provider turn', async () => {
   const f = fixture('slow');
   const running = runClaudeReviewRound(f.options);
   await Bun.sleep(50);
@@ -158,7 +167,7 @@ test('concurrent submission is refused without sending a second provider turn', 
 }, 20_000);
 
 
-test('a continuation must account for prior findings and cannot be replayed after omission', async () => {
+releaseLaneOnly('a continuation must account for prior findings and cannot be replayed after omission', async () => {
   const f = fixture('omit-finding');
   await runClaudeReviewRound(f.options);
   writeFileSync(join(f.root, 'source.ts'), 'export const value = 2;\n'); prepare(f.root);
@@ -167,7 +176,7 @@ test('a continuation must account for prior findings and cannot be replayed afte
   expect(existsSync(join(reviewSessionLocation(f.root, contract).dir, 'accepted-2.json'))).toBe(false);
 }, 20_000);
 
-test('three rounds share one admission and a fourth changed subject is refused', async () => {
+releaseLaneOnly('three rounds share one admission and a fourth changed subject is refused', async () => {
   const f = fixture();
   const first = await runClaudeReviewRound(f.options);
   for (let round = 2; round <= 3; round++) {
@@ -183,7 +192,7 @@ test('three rounds share one admission and a fourth changed subject is refused',
 }, 20_000);
 
 
-test('schema enums reject array coercion instead of accepting malformed provider data', () => {
+releaseLaneOnly('schema enums reject array coercion instead of accepting malformed provider data', () => {
   const context = { contract_file: contract, contract_sha256: 'contract', goal_sha256: 'goal', subject_sha256: 'subject', verification_evidence_sha256: 'evidence', target_revision: 'target' };
   const request: ClaudeReviewRequest = { round: 1, round_id: 'round', session_id: 'session', context, context_sha256: reviewContextDigest(context), prompt: '', timeout_ms: 1 };
   const output = { round_id: request.round_id, session_id: request.session_id, subject_sha256: context.subject_sha256, context_sha256: request.context_sha256, verdict: 'FAIL', summary: 'Review', findings: [{ id: 'F1', severity: 'P1', status: 'new', message: 'Evidence' }] };
@@ -199,7 +208,7 @@ test('schema enums reject array coercion instead of accepting malformed provider
   }
 });
 
-test('startup spawn failure can be cancelled without process metadata or acceptance', async () => {
+releaseLaneOnly('startup spawn failure can be cancelled without process metadata or acceptance', async () => {
   const f = fixture();
   chmodSync(f.options.providerCommand, 0o600);
   await expect(runClaudeReviewRound(f.options)).rejects.toThrow();
@@ -225,7 +234,7 @@ function unstartedSession() {
   return { ...f, ...location, session };
 }
 
-test('pre-spawn cancel fences a delayed host under real herdr and preserves a sentinel', async () => {
+releaseLaneOnly('pre-spawn cancel fences a delayed host under real herdr and preserves a sentinel', async () => {
   const f = unstartedSession();
   const sentinel = await sentinelServer();
   const before = sentinel.identity();
@@ -248,7 +257,7 @@ test('pre-spawn cancel fences a delayed host under real herdr and preserves a se
   expect(sentinel.identity()).toEqual(before);
 }, 10_000);
 
-test('failed server metadata publication reaps its owned herdr child', async () => {
+releaseLaneOnly('failed server metadata publication reaps its owned herdr child', async () => {
   const f = unstartedSession();
   // A dangling entry survives existsSync but refuses immutable publication.
   symlinkSync(join(f.dir, 'absent-target'), join(f.dir, 'server.json'));
@@ -260,7 +269,7 @@ test('failed server metadata publication reaps its owned herdr child', async () 
   expect(claudeReviewStatus(f.root, contract).status).toBe('closed');
 });
 
-test('ambiguous server startup cannot report successful closure', async () => {
+releaseLaneOnly('ambiguous server startup cannot report successful closure', async () => {
   const f = unstartedSession();
   writeFileSync(join(f.dir, 'server-start-intent.json'), JSON.stringify({ session_id: f.session.session_id }));
   await expect(closeClaudeReview(f.options, true)).rejects.toThrow('server_startup_ownership_unknown');
@@ -271,7 +280,7 @@ test('ambiguous server startup cannot report successful closure', async () => {
   expect(claudeReviewStatus(f.root, contract).status).toBe('cleanup_pending');
 });
 
-test('pre-metadata cancel refuses ambiguous spawn intent and mismatched no-child proof', async () => {
+releaseLaneOnly('pre-metadata cancel refuses ambiguous spawn intent and mismatched no-child proof', async () => {
   const f = unstartedSession();
   writeFileSync(join(f.dir, 'spawn-intent.json'), JSON.stringify({ session_id: f.session.session_id }));
   await expect(closeClaudeReview(f.options, true)).rejects.toThrow('startup_ownership_unknown');
@@ -282,7 +291,7 @@ test('pre-metadata cancel refuses ambiguous spawn intent and mismatched no-child
 });
 
 
-test('pre-metadata cancel refuses sessions without recorded startup serialization', async () => {
+releaseLaneOnly('pre-metadata cancel refuses sessions without recorded startup serialization', async () => {
   const f = unstartedSession();
   const { startup_protocol, ...unrecorded } = f.session;
   writeFileSync(join(f.dir, 'session.json'), JSON.stringify(unrecorded));
@@ -290,7 +299,7 @@ test('pre-metadata cancel refuses sessions without recorded startup serializatio
   expect(existsSync(join(f.dir, 'closed.json'))).toBe(false);
 });
 
-test('server identity mismatch cannot submit another round or signal a replacement server', async () => {
+releaseLaneOnly('server identity mismatch cannot submit another round or signal a replacement server', async () => {
   const f = fixture();
   await runClaudeReviewRound(f.options);
   const dir = reviewSessionLocation(f.root, contract).dir;
@@ -308,7 +317,7 @@ test('server identity mismatch cannot submit another round or signal a replaceme
   } finally { writeFileSync(path, original); }
 }, 20_000);
 
-test('old tmux session metadata is rejected without translation or cleanup', async () => {
+releaseLaneOnly('old tmux session metadata is rejected without translation or cleanup', async () => {
   const f = unstartedSession();
   const path = join(f.dir, 'session.json');
   const original = readFileSync(path, 'utf8');

--- a/tests/expensive-test-gate.test.ts
+++ b/tests/expensive-test-gate.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const ROOT = resolve(import.meta.dir, '..');
+const laneScript = readFileSync(join(ROOT, 'scripts/check-ci.sh'), 'utf8');
+const GATED_FILES = ['tests/harness-benchmark-matrix.test.ts', 'tests/claude-review.test.ts'];
+
+// The lane script is the single authority for the variable name; the gated test
+// files are checked against whatever it exports, so a rename cannot leave one
+// side pointing at a dead name while the release lane silently loses coverage.
+function exportedGateVariable(): string {
+  const matches = [...laneScript.matchAll(/^\s*export\s+([A-Z0-9_]+)=1$/gm)].map(match => match[1]);
+  expect(matches).toHaveLength(1);
+  return matches[0]!;
+}
+
+function runLane(lane: string) {
+  const bin = mkdtempSync(join(tmpdir(), 'rh-expensive-gate-'));
+  try {
+    // The bun stub reports the variable the lane actually handed to `bun test`,
+    // so the assertion reads the real exported environment, not the script text.
+    writeFileSync(join(bin, 'bun'), `#!/bin/bash\nif [[ "$1" == test ]]; then echo "TEST_LANE_GATE=\${${exportedGateVariable()}:-unset}"; fi\nexit 0\n`, { mode: 0o755 });
+    writeFileSync(join(bin, 'npm'), '#!/bin/bash\nexit 0\n', { mode: 0o755 });
+    writeFileSync(join(bin, 'bash'), '#!/bin/bash\nexit 0\n', { mode: 0o755 });
+    return spawnSync('/bin/bash', ['scripts/check-ci.sh', lane], {
+      cwd: ROOT, encoding: 'utf8',
+      env: { ...process.env, PATH: `${bin}:${process.env.PATH}`, BUN_TEST_ISOLATE_FILES: '0', REPO_HARNESS_DIFF_BASE: 'HEAD' },
+    });
+  } finally {
+    rmSync(bin, { recursive: true, force: true });
+  }
+}
+
+test('the release lane enables the expensive test gate and the hosted functional lane does not', () => {
+  const all = runLane('all');
+  const functional = runLane('functional');
+  expect(all.status).toBe(0);
+  expect(all.stdout).toContain('TEST_LANE_GATE=1');
+  expect(functional.status).toBe(0);
+  expect(functional.stdout).toContain('TEST_LANE_GATE=unset');
+});
+
+test('both expensive test files gate on the exact variable the release lane exports', () => {
+  const variable = exportedGateVariable();
+  for (const file of GATED_FILES) {
+    const source = readFileSync(join(ROOT, file), 'utf8');
+    expect(source).toContain(`test.skipIf(!process.env.${variable})`);
+    // No other environment name may gate this file, otherwise the release lane
+    // would enable one gate and leave a second one closed.
+    const referenced = new Set([...source.matchAll(/test\.skipIf\(!process\.env\.([A-Z0-9_]+)\)/g)].map(match => match[1]));
+    expect([...referenced]).toEqual([variable]);
+  }
+});

--- a/tests/harness-benchmark-matrix.test.ts
+++ b/tests/harness-benchmark-matrix.test.ts
@@ -40,6 +40,15 @@ import {
 
 const ROOT = join(import.meta.dir, '..');
 
+// These two cases run `npm pack` over the whole repository and install the
+// resulting tarball into an isolated HOME, so they belong to the release lane
+// (`scripts/check-ci.sh` with no lane argument) rather than the hosted
+// functional lane. Same gate variable as tests/claude-review.test.ts.
+const releaseLaneOnly = test.skipIf(!process.env.REPO_HARNESS_TEST_EXPENSIVE);
+if (!process.env.REPO_HARNESS_TEST_EXPENSIVE) {
+  console.log('[gate] REPO_HARNESS_TEST_EXPENSIVE unset: skipping the real pack/install cases (release lane only, not a failure).');
+}
+
 describe('No Harness / Lite / Strict benchmark authority', () => {
   test('fixes producer cost at two concurrent arms and a 50 minute absolute budget', () => {
     expect(BENCHMARK_MAX_CONCURRENCY).toBe(2);
@@ -284,7 +293,7 @@ describe('No Harness / Lite / Strict benchmark authority', () => {
     expect(env.PATH?.split(':')[0]).toBe('/tmp/benchmark-host/.bun/bin');
   });
 
-  test('packs exactly one external immutable runtime artifact and rejects mutation', () => {
+  releaseLaneOnly('packs exactly one external immutable runtime artifact and rejects mutation', () => {
     const runRoot = mkdtempSync(join(tmpdir(), 'harness-runtime-artifact-'));
     try {
       const artifact = prepareBenchmarkRuntimeArtifact(ROOT, runRoot);
@@ -324,7 +333,7 @@ describe('No Harness / Lite / Strict benchmark authority', () => {
     }
   }, 30_000);
 
-  test('reuses one packed artifact across isolated installs without mutating source authority', () => {
+  releaseLaneOnly('reuses one packed artifact across isolated installs without mutating source authority', () => {
     const runRoot = mkdtempSync(join(tmpdir(), 'harness-runtime-install-'));
     const manifest = join(ROOT, 'evals/harness/scenarios.json');
     const seed = resolve(ROOT, 'evals/fixtures/harness-matrix');


### PR DESCRIPTION
## What

Move two "real install / real external program" test surfaces out of the default CI lane and into the release lane, behind one environment variable.

**Gate variable: `REPO_HARNESS_TEST_EXPENSIVE`**

| Surface | Why it is expensive | Gated |
| --- | --- | --- |
| `tests/harness-benchmark-matrix.test.ts` — the two `prepareBenchmarkRuntimeArtifact()` cases | `npm pack` of the whole repository plus a global install of the tarball into an isolated HOME | 2 of 31 cases; the other 29 still run in every lane |
| `tests/claude-review.test.ts` | Every case drives the real pinned `herdr` binary (sentinel servers, `Bun.which('herdr')` session metadata) plus a spawned fake provider child | whole file |

Both follow the existing `test.skipIf(!process.env.BRC_TEST_CONTAINER_IMAGE)` precedent in `tests/effects/brc10-lifecycle.test.ts`. Each file prints one `[gate] ... (release lane only, not a failure).` line when the gate is closed, so a skip reads as a gate and not as a silent omission.

## Measured cost, per file, `bun test --timeout 180000`

| File | Before | Gate off (hosted lane) | Gate on (release lane) |
| --- | --- | --- | --- |
| `tests/harness-benchmark-matrix.test.ts` | 62.73 s, 31 pass | **2.57 s**, 29 pass / 2 skip | 55.99 s, 31 pass |
| `tests/claude-review.test.ts` | 38.98 s, 20 pass | **0.023 s**, 20 skip | 39.22 s, 20 pass |

No test title is lost: the sorted JUnit `<testcase name>` multiset is identical across baseline, gate-off and gate-on for both files (skipped cases still appear).

## Release lane wiring

`scripts/check-ci.sh` exports the variable inside `if [[ "$lane" == all ]]`, immediately before `run_bun_tests`. That is the whole wiring, because:

- `.github/workflows/ci.yml` Test job runs `bash scripts/check-ci.sh functional` → variable unset → hosted PR and `main` runs skip the expensive cases.
- `scripts/check-npm-release.sh` in full mode (`bun run check:release`, and a bare local `bash scripts/check-ci.sh`) runs the `all` lane → variable set → the release gate still executes them.
- `prepublishOnly` runs `check-npm-release.sh --prepublish`, which returns before the suite by design. It never ran tests, so nothing was attached there.

## Guard test

`tests/expensive-test-gate.test.ts` asserts that the `all` lane exports the variable, that the `functional` lane does not, and that both gated files gate on the exact name the lane script exports (and on no second name). Both failure modes were mutation-checked before landing: renaming the export fails the shared-name assertion, hoisting the export out of the `all` branch fails the lane assertion.

## Deliberately not in this PR

`.github/workflows/ci.yml` still carries its "Install pinned Herdr runtime" step. The hosted `functional` lane no longer needs it, but removing it alone would burn a full hosted run for zero coverage change. It is queued for the next change that already opens `ci.yml`, batched with the existing `tasks/todos.md` row "Harden the CI documentation lane after #415", whose revisit trigger is exactly that. Recorded in `tasks/notes/20260913-0250-expensive-test-gate.notes.md`.

## Verification

Gate-off and gate-on runs of both files, `tests/expensive-test-gate.test.ts` + `tests/check-ci-job-split.test.ts` (9 passed, 188 expectations), `check:type`, `check:hooks`, `check:helpers`, `check:reference-configs`, `check-architecture-sync.sh`, `check-task-workflow.sh --strict`, merge-base-bound `check-task-sync.sh`, `init --repo . --dry-run`, and `bash scripts/check-ci.sh governance`. No full local suite: this slice changes test scheduling, one shell export and one document, with no product code touched; hosted `Required / CI` is the full-coverage authority.
